### PR TITLE
docs: clarify action-side vs agent-side session management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,9 @@ GitHub Action harness for [OpenCode](https://opencode.ai/) + [oMo](https://githu
 - **@bfra.me ecosystem**: ESLint, Prettier, TSConfig all from `@bfra.me/*` packages
 - **Bleeding-edge Node**: Targets Node 24 (`action.yaml`, `.node-version`)
 - **Persistent sessions (planned)**: Cache `~/.local/share/opencode/storage` across runs
-- **Session tools**: Agent must use `session_list`, `session_read`, `session_search`, `session_info`
+- **Two-layer session management**:
+  - **Action-side (RFC-004)**: TypeScript utilities (`listSessions`, `searchSessions`, `pruneSessions`, `writeSessionSummary`) for infrastructure-level operations
+  - **Agent-side (oMo)**: LLM tools (`session_list`, `session_read`, `session_search`, `session_info`) for runtime introspection
 - **RFC-driven development**: All major features documented in `RFCs/` before implementation
 - **Black-box integration test**: `main.test.ts` spawns Node process to test bundled `dist/main.js`
 

--- a/RFCs/RFC-004-Session-Management.md
+++ b/RFCs/RFC-004-Session-Management.md
@@ -9,7 +9,14 @@
 
 ## Summary
 
-Integrate OpenCode's session management tools (`session_list`, `session_read`, `session_search`, `session_info`) to enable memory reuse across runs. This is the core capability that differentiates Fro Bot from stateless agents.
+Implement session management utilities for the Fro Bot agent harness to enable memory reuse across runs. This RFC defines **action-side utilities** for listing, searching, reading, and pruning OpenCode sessions stored in the standard OpenCode storage directory.
+
+**Important Distinction:**
+
+- **This RFC** defines utilities used by the **GitHub Action** to manage sessions (pruning, introspection, startup search)
+- **oMo session tools** (`session_list`, `session_read`, `session_search`, `session_info`) are provided by the Oh My OpenCode plugin to **AI agents** via prompts for runtime session introspection
+
+The action-side utilities must work with the exact OpenCode storage format to ensure compatibility.
 
 ## Dependencies
 
@@ -31,29 +38,268 @@ Integrate OpenCode's session management tools (`session_list`, `session_read`, `
 ```
 src/lib/
 ├── session/
-│   ├── types.ts          # Session-related types
+│   ├── types.ts          # Session-related types (matching OpenCode)
+│   ├── storage.ts        # OpenCode storage access utilities
 │   ├── search.ts         # Session search operations
 │   ├── prune.ts          # Session pruning logic
 │   ├── writeback.ts      # Close-the-loop writeback
 │   └── index.ts          # Public exports
 ```
 
-### 2. Session Types (`src/lib/session/types.ts`)
+### 2. OpenCode Storage Structure
+
+OpenCode uses **JSON files on disk** (NOT SQLite) stored under `$XDG_DATA_HOME/opencode/storage/` (typically `~/.local/share/opencode/storage/`):
+
+```
+~/.local/share/opencode/storage/
+├── .version                           # Storage version marker
+├── migration                          # Migration version number
+├── project/
+│   └── {projectID}.json              # Project metadata (git root hash)
+├── session/
+│   └── {projectID}/
+│       └── {sessionID}.json          # Session info
+├── message/
+│   └── {sessionID}/
+│       └── {messageID}.json          # Message info
+├── part/
+│   └── {messageID}/
+│       └── {partID}.json             # Message content parts (text, tool calls, etc.)
+├── todo/
+│   └── {sessionID}.json              # Todo items for session
+└── session_diff/
+    └── {sessionID}.json              # Session diffs (optional)
+```
+
+### 3. Session Types (`src/lib/session/types.ts`)
+
+Types aligned with OpenCode's actual Zod schemas from `packages/opencode/src/session/index.ts`:
 
 ```typescript
-export interface Session {
-  readonly id: string
-  readonly projectPath: string
-  readonly createdAt: string
-  readonly updatedAt: string
-  readonly messageCount: number
-  readonly agents: readonly string[]
+/**
+ * OpenCode Session.Info - matches the actual schema from OpenCode source.
+ *
+ * @see https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/session/index.ts
+ */
+export interface SessionInfo {
+  readonly id: string // Format: ses_{hex-timestamp}{random-base62}
+  readonly version: string // OpenCode version that created this session
+  readonly projectID: string // Git root commit hash
+  readonly directory: string // Working directory path
+  readonly parentID?: string // For child/branched sessions
+  readonly title: string // Session title
+  readonly time: {
+    readonly created: number // Unix timestamp (ms)
+    readonly updated: number // Unix timestamp (ms)
+    readonly compacting?: number
+    readonly archived?: number
+  }
+  readonly summary?: {
+    readonly additions: number
+    readonly deletions: number
+    readonly files: number
+    readonly diffs?: readonly FileDiff[]
+  }
+  readonly share?: {
+    readonly url: string
+  }
+  readonly permission?: PermissionRuleset
+  readonly revert?: {
+    readonly messageID: string
+    readonly partID?: string
+    readonly snapshot?: string
+    readonly diff?: string
+  }
 }
 
-export interface SessionMessage {
-  readonly role: "user" | "assistant" | "system"
+/**
+ * OpenCode MessageV2.User - user message schema
+ */
+export interface UserMessage {
+  readonly id: string // Format: msg_{hex-timestamp}{random-base62}
+  readonly sessionID: string
+  readonly role: "user"
+  readonly time: {
+    readonly created: number
+  }
+  readonly summary?: {
+    readonly title?: string
+    readonly body?: string
+    readonly diffs: readonly FileDiff[]
+  }
+  readonly agent: string // e.g., "Sisyphus", "coder", "oracle"
+  readonly model: {
+    readonly providerID: string // e.g., "anthropic", "github-copilot"
+    readonly modelID: string // e.g., "claude-sonnet-4"
+  }
+  readonly system?: string
+  readonly tools?: Record<string, boolean>
+  readonly variant?: string
+}
+
+/**
+ * OpenCode MessageV2.Assistant - assistant message schema
+ */
+export interface AssistantMessage {
+  readonly id: string
+  readonly sessionID: string
+  readonly role: "assistant"
+  readonly time: {
+    readonly created: number
+    readonly completed?: number
+  }
+  readonly parentID: string // References user message ID
+  readonly modelID: string
+  readonly providerID: string
+  readonly mode: string // @deprecated but still present
+  readonly agent: string
+  readonly path: {
+    readonly cwd: string
+    readonly root: string
+  }
+  readonly summary?: boolean
+  readonly cost: number // USD cost
+  readonly tokens: {
+    readonly input: number
+    readonly output: number
+    readonly reasoning: number
+    readonly cache: {
+      readonly read: number
+      readonly write: number
+    }
+  }
+  readonly finish?: string // Finish reason: "end_turn", "tool-calls", etc.
+  readonly error?: MessageError
+}
+
+export type Message = UserMessage | AssistantMessage
+
+/**
+ * OpenCode MessageV2.Part - message content parts (discriminated union)
+ */
+export interface PartBase {
+  readonly id: string // Format: prt_{hex-timestamp}{random-base62}
+  readonly sessionID: string
+  readonly messageID: string
+}
+
+export interface TextPart extends PartBase {
+  readonly type: "text"
+  readonly text: string
+  readonly synthetic?: boolean
+  readonly ignored?: boolean
+  readonly time?: {
+    readonly start: number
+    readonly end?: number
+  }
+  readonly metadata?: Record<string, unknown>
+}
+
+export interface ToolPart extends PartBase {
+  readonly type: "tool"
+  readonly callID: string
+  readonly tool: string
+  readonly state: ToolState
+  readonly metadata?: Record<string, unknown>
+}
+
+export interface ToolStateCompleted {
+  readonly status: "completed"
+  readonly input: Record<string, unknown>
+  readonly output: string
+  readonly title: string
+  readonly metadata: Record<string, unknown>
+  readonly time: {
+    readonly start: number
+    readonly end: number
+    readonly compacted?: number
+  }
+  readonly attachments?: readonly FilePart[]
+}
+
+export interface ToolStatePending {
+  readonly status: "pending"
+}
+
+export interface ToolStateRunning {
+  readonly status: "running"
+  readonly input: Record<string, unknown>
+  readonly time: {readonly start: number}
+}
+
+export interface ToolStateError {
+  readonly status: "error"
+  readonly input: Record<string, unknown>
+  readonly error: string
+  readonly time: {readonly start: number; readonly end: number}
+}
+
+export type ToolState = ToolStatePending | ToolStateRunning | ToolStateCompleted | ToolStateError
+
+export interface ReasoningPart extends PartBase {
+  readonly type: "reasoning"
+  readonly reasoning: string
+  readonly time?: {
+    readonly start: number
+    readonly end?: number
+  }
+}
+
+export interface StepFinishPart extends PartBase {
+  readonly type: "step-finish"
+  readonly reason: string
+  readonly snapshot?: string
+  readonly cost: number
+  readonly tokens: {
+    readonly input: number
+    readonly output: number
+    readonly reasoning: number
+    readonly cache: {
+      readonly read: number
+      readonly write: number
+    }
+  }
+}
+
+export type Part = TextPart | ToolPart | ReasoningPart | StepFinishPart
+
+/**
+ * OpenCode Project metadata
+ */
+export interface ProjectInfo {
+  readonly id: string // Git root commit hash
+  readonly worktree: string // Project directory path
+  readonly vcs: "git" | string
+  readonly time: {
+    readonly created: number
+    readonly updated: number
+    readonly initialized?: number
+  }
+}
+
+/**
+ * Todo item (stored in todo/{sessionID}.json)
+ */
+export interface TodoItem {
+  readonly id: string
   readonly content: string
-  readonly timestamp: string
+  readonly status: "pending" | "in_progress" | "completed" | "cancelled"
+  readonly priority: "high" | "medium" | "low"
+}
+
+/**
+ * Simplified types for RFC-004 operations
+ */
+export interface SessionSummary {
+  readonly id: string
+  readonly projectID: string
+  readonly directory: string
+  readonly title: string
+  readonly createdAt: number
+  readonly updatedAt: number
+  readonly messageCount: number
+  readonly agents: readonly string[]
+  readonly isChild: boolean // Has parentID
 }
 
 export interface SessionSearchResult {
@@ -63,21 +309,10 @@ export interface SessionSearchResult {
 
 export interface SessionMatch {
   readonly messageId: string
+  readonly partId: string
   readonly excerpt: string
-  readonly role: string
-}
-
-export interface SessionInfo {
-  readonly id: string
-  readonly messageCount: number
-  readonly dateRange: {
-    readonly first: string
-    readonly last: string
-  }
-  readonly agents: readonly string[]
-  readonly hasTodos: boolean
-  readonly todoCount: number
-  readonly completedTodos: number
+  readonly role: "user" | "assistant"
+  readonly agent?: string
 }
 
 export interface PruneResult {
@@ -86,98 +321,389 @@ export interface PruneResult {
   readonly remainingCount: number
   readonly freedBytes: number
 }
+
+export interface PruningConfig {
+  readonly maxSessions: number // Default: 50
+  readonly maxAgeDays: number // Default: 30
+}
+
+// Re-export Logger from parent types
+export type {Logger} from "../types.js"
+
+// Supporting types
+export interface FileDiff {
+  readonly file: string
+  readonly additions: number
+  readonly deletions: number
+}
+
+export interface FilePart extends PartBase {
+  readonly type: "file"
+  readonly file: string
+  readonly content: string
+}
+
+export interface PermissionRuleset {
+  readonly rules: readonly unknown[]
+}
+
+export interface MessageError {
+  readonly name: string
+  readonly message: string
+}
 ```
 
-### 3. Session Search (`src/lib/session/search.ts`)
+### 4. Storage Utilities (`src/lib/session/storage.ts`)
 
 ```typescript
 import * as fs from "node:fs/promises"
 import * as path from "node:path"
-import type {Session, SessionSearchResult, SessionInfo, Logger} from "./types.js"
-import {getOpenCodeStoragePath} from "../../utils/env.js"
+import * as os from "node:os"
+import type {SessionInfo, ProjectInfo, Message, Part, TodoItem, Logger} from "./types.js"
 
 /**
- * List all sessions for the current project.
+ * Get the OpenCode storage directory path.
+ * Uses XDG_DATA_HOME or falls back to ~/.local/share/opencode/storage
  */
-export async function listSessions(projectPath: string, logger: Logger): Promise<readonly Session[]> {
-  const storagePath = getOpenCodeStoragePath()
-  const sessionsDir = path.join(storagePath, "sessions")
+export function getOpenCodeStoragePath(): string {
+  const xdgDataHome = process.env["XDG_DATA_HOME"]
+  const basePath = xdgDataHome ?? path.join(os.homedir(), ".local", "share")
+  return path.join(basePath, "opencode", "storage")
+}
 
-  logger.debug("Listing sessions", {projectPath, sessionsDir})
-
+/**
+ * Read a JSON file from storage, returning null if not found.
+ */
+async function readJson<T>(filePath: string): Promise<T | null> {
   try {
-    const entries = await fs.readdir(sessionsDir, {withFileTypes: true})
-    const sessions: Session[] = []
+    const content = await fs.readFile(filePath, "utf8")
+    return JSON.parse(content) as T
+  } catch {
+    return null
+  }
+}
+
+/**
+ * List all JSON files in a directory, returning parsed contents.
+ */
+async function listJsonFiles<T>(dirPath: string): Promise<readonly T[]> {
+  try {
+    const entries = await fs.readdir(dirPath, {withFileTypes: true})
+    const results: T[] = []
 
     for (const entry of entries) {
-      if (!entry.isDirectory()) continue
-
-      const sessionPath = path.join(sessionsDir, entry.name)
-      const metaPath = path.join(sessionPath, "meta.json")
-
-      try {
-        const metaContent = await fs.readFile(metaPath, "utf8")
-        const meta = JSON.parse(metaContent) as Record<string, unknown>
-
-        // Filter by project path
-        if (meta["projectPath"] !== projectPath) continue
-
-        sessions.push({
-          id: entry.name,
-          projectPath: String(meta["projectPath"] ?? ""),
-          createdAt: String(meta["createdAt"] ?? ""),
-          updatedAt: String(meta["updatedAt"] ?? ""),
-          messageCount: Number(meta["messageCount"] ?? 0),
-          agents: (meta["agents"] as string[]) ?? [],
-        })
-      } catch {
-        // Skip sessions with unreadable metadata
-        logger.debug("Skipping session with unreadable metadata", {sessionId: entry.name})
+      if (entry.isFile() && entry.name.endsWith(".json")) {
+        const filePath = path.join(dirPath, entry.name)
+        const content = await readJson<T>(filePath)
+        if (content != null) {
+          results.push(content)
+        }
       }
     }
 
-    // Sort by updatedAt descending (most recent first)
-    sessions.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
-
-    logger.info("Listed sessions", {count: sessions.length})
-    return sessions
-  } catch (error) {
-    logger.debug("No sessions found", {error: error instanceof Error ? error.message : String(error)})
+    return results
+  } catch {
     return []
   }
 }
 
 /**
- * Search session history for matching content.
+ * Get all project IDs from storage.
  */
-export async function searchSessions(
-  query: string,
-  projectPath: string,
-  options: {limit?: number; caseSensitive?: boolean},
-  logger: Logger,
-): Promise<readonly SessionSearchResult[]> {
-  const {limit = 20, caseSensitive = false} = options
-  const sessions = await listSessions(projectPath, logger)
-  const results: SessionSearchResult[] = []
+export async function listProjects(logger: Logger): Promise<readonly ProjectInfo[]> {
+  const storagePath = getOpenCodeStoragePath()
+  const projectDir = path.join(storagePath, "project")
 
-  const searchPattern = caseSensitive ? query : query.toLowerCase()
+  logger.debug("Listing projects", {projectDir})
+  return listJsonFiles<ProjectInfo>(projectDir)
+}
 
-  for (const session of sessions) {
-    const matches = await searchSessionContent(session.id, searchPattern, caseSensitive, logger)
+/**
+ * Find project ID by directory path.
+ */
+export async function findProjectByDirectory(directory: string, logger: Logger): Promise<ProjectInfo | null> {
+  const projects = await listProjects(logger)
 
-    if (matches.length > 0) {
-      results.push({
-        sessionId: session.id,
-        matches,
-      })
-
-      // Stop if we've hit the limit
-      const totalMatches = results.reduce((sum, r) => sum + r.matches.length, 0)
-      if (totalMatches >= limit) break
+  for (const project of projects) {
+    if (project.worktree === directory) {
+      return project
     }
   }
 
-  logger.info("Session search complete", {query, resultCount: results.length})
+  return null
+}
+
+/**
+ * Get all sessions for a project.
+ */
+export async function listSessionsForProject(projectID: string, logger: Logger): Promise<readonly SessionInfo[]> {
+  const storagePath = getOpenCodeStoragePath()
+  const sessionDir = path.join(storagePath, "session", projectID)
+
+  logger.debug("Listing sessions for project", {projectID, sessionDir})
+  return listJsonFiles<SessionInfo>(sessionDir)
+}
+
+/**
+ * Get a specific session by ID.
+ */
+export async function getSession(projectID: string, sessionID: string, logger: Logger): Promise<SessionInfo | null> {
+  const storagePath = getOpenCodeStoragePath()
+  const sessionPath = path.join(storagePath, "session", projectID, `${sessionID}.json`)
+
+  logger.debug("Reading session", {projectID, sessionID})
+  return readJson<SessionInfo>(sessionPath)
+}
+
+/**
+ * Get all messages for a session.
+ */
+export async function getSessionMessages(sessionID: string, logger: Logger): Promise<readonly Message[]> {
+  const storagePath = getOpenCodeStoragePath()
+  const messageDir = path.join(storagePath, "message", sessionID)
+
+  logger.debug("Reading session messages", {sessionID, messageDir})
+  const messages = await listJsonFiles<Message>(messageDir)
+
+  // Sort by creation time (ascending)
+  return [...messages].sort((a, b) => a.time.created - b.time.created)
+}
+
+/**
+ * Get all parts for a message.
+ */
+export async function getMessageParts(messageID: string, logger: Logger): Promise<readonly Part[]> {
+  const storagePath = getOpenCodeStoragePath()
+  const partDir = path.join(storagePath, "part", messageID)
+
+  logger.debug("Reading message parts", {messageID, partDir})
+  return listJsonFiles<Part>(partDir)
+}
+
+/**
+ * Get todos for a session.
+ */
+export async function getSessionTodos(sessionID: string, logger: Logger): Promise<readonly TodoItem[]> {
+  const storagePath = getOpenCodeStoragePath()
+  const todoPath = path.join(storagePath, "todo", `${sessionID}.json`)
+
+  logger.debug("Reading session todos", {sessionID})
+  const todos = await readJson<TodoItem[]>(todoPath)
+  return todos ?? []
+}
+
+/**
+ * Delete a session and all its associated data.
+ */
+export async function deleteSession(projectID: string, sessionID: string, logger: Logger): Promise<number> {
+  const storagePath = getOpenCodeStoragePath()
+  let freedBytes = 0
+
+  // Delete message parts first
+  const messages = await getSessionMessages(sessionID, logger)
+  for (const message of messages) {
+    const partDir = path.join(storagePath, "part", message.id)
+    freedBytes += await deleteDirectoryRecursive(partDir, logger)
+  }
+
+  // Delete messages directory
+  const messageDir = path.join(storagePath, "message", sessionID)
+  freedBytes += await deleteDirectoryRecursive(messageDir, logger)
+
+  // Delete session file
+  const sessionPath = path.join(storagePath, "session", projectID, `${sessionID}.json`)
+  freedBytes += await deleteFile(sessionPath, logger)
+
+  // Delete todos file (if exists)
+  const todoPath = path.join(storagePath, "todo", `${sessionID}.json`)
+  freedBytes += await deleteFile(todoPath, logger)
+
+  // Delete session_diff file (if exists)
+  const diffPath = path.join(storagePath, "session_diff", `${sessionID}.json`)
+  freedBytes += await deleteFile(diffPath, logger)
+
+  logger.debug("Deleted session", {sessionID, freedBytes})
+  return freedBytes
+}
+
+/**
+ * Delete a directory recursively, returning bytes freed.
+ */
+async function deleteDirectoryRecursive(dirPath: string, logger: Logger): Promise<number> {
+  let totalSize = 0
+
+  try {
+    const entries = await fs.readdir(dirPath, {withFileTypes: true})
+
+    for (const entry of entries) {
+      const entryPath = path.join(dirPath, entry.name)
+
+      if (entry.isDirectory()) {
+        totalSize += await deleteDirectoryRecursive(entryPath, logger)
+      } else {
+        const stat = await fs.stat(entryPath)
+        totalSize += stat.size
+      }
+    }
+
+    await fs.rm(dirPath, {recursive: true, force: true})
+  } catch {
+    // Directory doesn't exist or can't be deleted
+  }
+
+  return totalSize
+}
+
+/**
+ * Delete a single file, returning bytes freed.
+ */
+async function deleteFile(filePath: string, logger: Logger): Promise<number> {
+  try {
+    const stat = await fs.stat(filePath)
+    await fs.unlink(filePath)
+    return stat.size
+  } catch {
+    return 0
+  }
+}
+```
+
+### 5. Session Search (`src/lib/session/search.ts`)
+
+```typescript
+import type {SessionInfo, SessionSummary, SessionSearchResult, SessionMatch, Message, Part, Logger} from "./types.js"
+import {
+  getOpenCodeStoragePath,
+  listProjects,
+  listSessionsForProject,
+  getSessionMessages,
+  getMessageParts,
+  findProjectByDirectory,
+} from "./storage.js"
+
+/**
+ * List all main sessions (excluding child/branched sessions) for a directory.
+ * Returns sessions sorted by updatedAt descending (most recent first).
+ */
+export async function listSessions(
+  directory: string,
+  options: {limit?: number; fromDate?: Date; toDate?: Date},
+  logger: Logger,
+): Promise<readonly SessionSummary[]> {
+  const {limit, fromDate, toDate} = options
+
+  logger.debug("Listing sessions", {directory, limit})
+
+  // Find project by directory
+  const project = await findProjectByDirectory(directory, logger)
+  if (project == null) {
+    logger.debug("No project found for directory", {directory})
+    return []
+  }
+
+  // Get all sessions for this project
+  const sessions = await listSessionsForProject(project.id, logger)
+
+  // Filter to main sessions only (no parentID) and apply date filters
+  const filtered = sessions.filter(session => {
+    // Exclude child sessions
+    if (session.parentID != null) return false
+
+    // Apply date filters
+    if (fromDate != null && session.time.created < fromDate.getTime()) return false
+    if (toDate != null && session.time.created > toDate.getTime()) return false
+
+    return true
+  })
+
+  // Sort by updatedAt descending
+  const sorted = [...filtered].sort((a, b) => b.time.updated - a.time.updated)
+
+  // Build summaries with message counts
+  const summaries: SessionSummary[] = []
+  const sessionsToProcess = limit != null ? sorted.slice(0, limit) : sorted
+
+  for (const session of sessionsToProcess) {
+    const messages = await getSessionMessages(session.id, logger)
+    const agents = extractAgentsFromMessages(messages)
+
+    summaries.push({
+      id: session.id,
+      projectID: session.projectID,
+      directory: session.directory,
+      title: session.title,
+      createdAt: session.time.created,
+      updatedAt: session.time.updated,
+      messageCount: messages.length,
+      agents,
+      isChild: false,
+    })
+  }
+
+  logger.info("Listed sessions", {count: summaries.length, directory})
+  return summaries
+}
+
+/**
+ * Extract unique agent names from messages.
+ */
+function extractAgentsFromMessages(messages: readonly Message[]): readonly string[] {
+  const agents = new Set<string>()
+
+  for (const message of messages) {
+    if (message.agent != null) {
+      agents.add(message.agent)
+    }
+  }
+
+  return [...agents]
+}
+
+/**
+ * Search session content for matching text.
+ */
+export async function searchSessions(
+  query: string,
+  directory: string,
+  options: {limit?: number; caseSensitive?: boolean; sessionId?: string},
+  logger: Logger,
+): Promise<readonly SessionSearchResult[]> {
+  const {limit = 20, caseSensitive = false, sessionId} = options
+
+  logger.debug("Searching sessions", {query, directory, limit, caseSensitive})
+
+  const searchPattern = caseSensitive ? query : query.toLowerCase()
+  const results: SessionSearchResult[] = []
+  let totalMatches = 0
+
+  // If specific session, search only that one
+  if (sessionId != null) {
+    const matches = await searchSessionContent(sessionId, searchPattern, caseSensitive, logger)
+    if (matches.length > 0) {
+      results.push({sessionId, matches: matches.slice(0, limit)})
+    }
+    return results
+  }
+
+  // Otherwise search all sessions for the directory
+  const sessions = await listSessions(directory, {}, logger)
+
+  for (const session of sessions) {
+    if (totalMatches >= limit) break
+
+    const matches = await searchSessionContent(session.id, searchPattern, caseSensitive, logger)
+
+    if (matches.length > 0) {
+      const remainingLimit = limit - totalMatches
+      results.push({
+        sessionId: session.id,
+        matches: matches.slice(0, remainingLimit),
+      })
+      totalMatches += Math.min(matches.length, remainingLimit)
+    }
+  }
+
+  logger.info("Session search complete", {query, resultCount: results.length, totalMatches})
   return results
 }
 
@@ -190,142 +716,125 @@ async function searchSessionContent(
   caseSensitive: boolean,
   logger: Logger,
 ): Promise<readonly SessionMatch[]> {
-  const storagePath = getOpenCodeStoragePath()
-  const messagesPath = path.join(storagePath, "sessions", sessionId, "messages.json")
+  const messages = await getSessionMessages(sessionId, logger)
+  const matches: SessionMatch[] = []
 
-  try {
-    const content = await fs.readFile(messagesPath, "utf8")
-    const messages = JSON.parse(content) as Array<{id: string; role: string; content: string}>
-    const matches: SessionMatch[] = []
+  for (const message of messages) {
+    const parts = await getMessageParts(message.id, logger)
 
-    for (const msg of messages) {
-      const searchContent = caseSensitive ? msg.content : msg.content.toLowerCase()
+    for (const part of parts) {
+      const text = extractTextFromPart(part)
+      if (text == null) continue
 
-      if (searchContent.includes(pattern)) {
+      const searchText = caseSensitive ? text : text.toLowerCase()
+
+      if (searchText.includes(pattern)) {
         // Extract excerpt around match
-        const index = searchContent.indexOf(pattern)
+        const index = searchText.indexOf(pattern)
         const start = Math.max(0, index - 50)
-        const end = Math.min(msg.content.length, index + pattern.length + 50)
-        const excerpt = msg.content.slice(start, end)
+        const end = Math.min(text.length, index + pattern.length + 50)
+        const excerpt = text.slice(start, end)
 
         matches.push({
-          messageId: msg.id,
+          messageId: message.id,
+          partId: part.id,
           excerpt: `...${excerpt}...`,
-          role: msg.role,
+          role: message.role,
+          agent: message.agent,
         })
       }
     }
+  }
 
-    return matches
-  } catch {
-    return []
+  return matches
+}
+
+/**
+ * Extract searchable text from a message part.
+ */
+function extractTextFromPart(part: Part): string | null {
+  switch (part.type) {
+    case "text":
+      return part.text
+    case "reasoning":
+      return part.reasoning
+    case "tool":
+      if (part.state.status === "completed") {
+        return `${part.tool}: ${part.state.output}`
+      }
+      return null
+    default:
+      return null
   }
 }
 
 /**
- * Get detailed info about a session.
+ * Get detailed info about a specific session.
  */
-export async function getSessionInfo(sessionId: string, logger: Logger): Promise<SessionInfo | null> {
-  const storagePath = getOpenCodeStoragePath()
-  const sessionPath = path.join(storagePath, "sessions", sessionId)
-
-  try {
-    const metaPath = path.join(sessionPath, "meta.json")
-    const metaContent = await fs.readFile(metaPath, "utf8")
-    const meta = JSON.parse(metaContent) as Record<string, unknown>
-
-    const todosPath = path.join(sessionPath, "todos.json")
-    let hasTodos = false
-    let todoCount = 0
-    let completedTodos = 0
-
-    try {
-      const todosContent = await fs.readFile(todosPath, "utf8")
-      const todos = JSON.parse(todosContent) as Array<{status: string}>
-      hasTodos = todos.length > 0
-      todoCount = todos.length
-      completedTodos = todos.filter(t => t.status === "completed").length
-    } catch {
-      // No todos file
-    }
-
-    return {
-      id: sessionId,
-      messageCount: Number(meta["messageCount"] ?? 0),
-      dateRange: {
-        first: String(meta["createdAt"] ?? ""),
-        last: String(meta["updatedAt"] ?? ""),
-      },
-      agents: (meta["agents"] as string[]) ?? [],
-      hasTodos,
-      todoCount,
-      completedTodos,
-    }
-  } catch {
-    logger.debug("Session info not found", {sessionId})
-    return null
-  }
-}
-
-/**
- * Read session messages.
- */
-export async function readSession(
+export async function getSessionInfo(
   sessionId: string,
-  options: {limit?: number},
+  projectID: string,
   logger: Logger,
-): Promise<readonly SessionMessage[]> {
-  const {limit} = options
-  const storagePath = getOpenCodeStoragePath()
-  const messagesPath = path.join(storagePath, "sessions", sessionId, "messages.json")
+): Promise<{
+  session: SessionInfo
+  messageCount: number
+  agents: readonly string[]
+  hasTodos: boolean
+  todoCount: number
+  completedTodos: number
+} | null> {
+  const {getSession, getSessionTodos} = await import("./storage.js")
 
-  try {
-    const content = await fs.readFile(messagesPath, "utf8")
-    const messages = JSON.parse(content) as Array<{role: string; content: string; timestamp?: string}>
+  const session = await getSession(projectID, sessionId, logger)
+  if (session == null) return null
 
-    const result = messages.map(m => ({
-      role: m.role as "user" | "assistant" | "system",
-      content: m.content,
-      timestamp: m.timestamp ?? "",
-    }))
+  const messages = await getSessionMessages(sessionId, logger)
+  const agents = extractAgentsFromMessages(messages)
+  const todos = await getSessionTodos(sessionId, logger)
 
-    if (limit != null && limit > 0) {
-      return result.slice(-limit)
-    }
-
-    return result
-  } catch {
-    logger.debug("Session messages not found", {sessionId})
-    return []
+  return {
+    session,
+    messageCount: messages.length,
+    agents,
+    hasTodos: todos.length > 0,
+    todoCount: todos.length,
+    completedTodos: todos.filter(t => t.status === "completed").length,
   }
 }
 ```
 
-### 4. Session Pruning (`src/lib/session/prune.ts`)
+### 6. Session Pruning (`src/lib/session/prune.ts`)
 
 ```typescript
-import * as fs from "node:fs/promises"
-import * as path from "node:path"
-import type {PruneResult, PruningConfig, Logger, Session} from "./types.js"
-import {getOpenCodeStoragePath} from "../../utils/env.js"
-import {listSessions} from "./search.js"
+import type {PruneResult, PruningConfig, Logger} from "./types.js"
+import {listSessionsForProject, findProjectByDirectory, deleteSession} from "./storage.js"
+
+/**
+ * Default pruning configuration.
+ */
+export const DEFAULT_PRUNING_CONFIG: PruningConfig = {
+  maxSessions: 50,
+  maxAgeDays: 30,
+}
 
 /**
  * Prune old sessions based on retention policy.
  *
- * Default: keep last 50 sessions OR sessions from last 30 days (whichever is larger).
+ * Retention logic: keep sessions that satisfy EITHER condition:
+ * - Within maxAgeDays of the current date
+ * - Within the most recent maxSessions (by updatedAt)
+ *
+ * This ensures we always keep at least maxSessions, even if they're older than maxAgeDays.
  */
-export async function pruneSessions(projectPath: string, config: PruningConfig, logger: Logger): Promise<PruneResult> {
+export async function pruneSessions(directory: string, config: PruningConfig, logger: Logger): Promise<PruneResult> {
   const {maxSessions, maxAgeDays} = config
-  const sessions = await listSessions(projectPath, logger)
 
-  logger.info("Starting session pruning", {
-    totalSessions: sessions.length,
-    maxSessions,
-    maxAgeDays,
-  })
+  logger.info("Starting session pruning", {directory, maxSessions, maxAgeDays})
 
-  if (sessions.length === 0) {
+  // Find project
+  const project = await findProjectByDirectory(directory, logger)
+  if (project == null) {
+    logger.debug("No project found for pruning", {directory})
     return {
       prunedCount: 0,
       prunedSessionIds: [],
@@ -334,144 +843,177 @@ export async function pruneSessions(projectPath: string, config: PruningConfig, 
     }
   }
 
+  // Get all sessions (including child sessions for cleanup)
+  const allSessions = await listSessionsForProject(project.id, logger)
+
+  // Filter to main sessions only for retention calculation
+  const mainSessions = allSessions.filter(s => s.parentID == null)
+
+  if (mainSessions.length === 0) {
+    return {
+      prunedCount: 0,
+      prunedSessionIds: [],
+      remainingCount: 0,
+      freedBytes: 0,
+    }
+  }
+
+  // Sort by updatedAt descending (most recent first)
+  const sortedSessions = [...mainSessions].sort((a, b) => b.time.updated - a.time.updated)
+
   // Calculate cutoff date
   const cutoffDate = new Date()
   cutoffDate.setDate(cutoffDate.getDate() - maxAgeDays)
+  const cutoffTime = cutoffDate.getTime()
 
   // Determine which sessions to keep
   const sessionsToKeep = new Set<string>()
 
   // Keep sessions within age limit
-  for (const session of sessions) {
-    const updatedAt = new Date(session.updatedAt)
-    if (updatedAt >= cutoffDate) {
+  for (const session of sortedSessions) {
+    if (session.time.updated >= cutoffTime) {
       sessionsToKeep.add(session.id)
     }
   }
 
   // Ensure we keep at least maxSessions (most recent)
-  const sortedSessions = [...sessions]
   for (let i = 0; i < Math.min(maxSessions, sortedSessions.length); i++) {
     sessionsToKeep.add(sortedSessions[i].id)
   }
 
-  // Determine sessions to prune
-  const sessionsToPrune = sessions.filter(s => !sessionsToKeep.has(s.id))
+  // Determine sessions to prune (main sessions not in keep set)
+  const mainSessionsToPrune = sortedSessions.filter(s => !sessionsToKeep.has(s.id))
 
-  if (sessionsToPrune.length === 0) {
+  // Also find child sessions of sessions being pruned
+  const allSessionsToPrune = new Set<string>()
+  for (const session of mainSessionsToPrune) {
+    allSessionsToPrune.add(session.id)
+    // Add child sessions
+    for (const child of allSessions) {
+      if (child.parentID === session.id) {
+        allSessionsToPrune.add(child.id)
+      }
+    }
+  }
+
+  if (allSessionsToPrune.size === 0) {
     logger.info("No sessions to prune")
     return {
       prunedCount: 0,
       prunedSessionIds: [],
-      remainingCount: sessions.length,
+      remainingCount: mainSessions.length,
       freedBytes: 0,
     }
   }
 
   // Prune sessions
-  const storagePath = getOpenCodeStoragePath()
-  const sessionsDir = path.join(storagePath, "sessions")
   let freedBytes = 0
   const prunedIds: string[] = []
 
-  for (const session of sessionsToPrune) {
-    const sessionPath = path.join(sessionsDir, session.id)
-
+  for (const sessionId of allSessionsToPrune) {
     try {
-      const size = await getDirectorySize(sessionPath)
-      await fs.rm(sessionPath, {recursive: true, force: true})
-      freedBytes += size
-      prunedIds.push(session.id)
-      logger.debug("Pruned session", {sessionId: session.id, bytes: size})
+      const bytes = await deleteSession(project.id, sessionId, logger)
+      freedBytes += bytes
+      prunedIds.push(sessionId)
+      logger.debug("Pruned session", {sessionId, bytes})
     } catch (error) {
       logger.warning("Failed to prune session", {
-        sessionId: session.id,
+        sessionId,
         error: error instanceof Error ? error.message : String(error),
       })
     }
   }
 
+  const remainingCount = mainSessions.length - mainSessionsToPrune.length
+
   logger.info("Session pruning complete", {
     prunedCount: prunedIds.length,
-    remainingCount: sessions.length - prunedIds.length,
+    remainingCount,
     freedBytes,
   })
 
   return {
     prunedCount: prunedIds.length,
     prunedSessionIds: prunedIds,
-    remainingCount: sessions.length - prunedIds.length,
+    remainingCount,
     freedBytes,
   }
 }
-
-/**
- * Calculate total size of a directory.
- */
-async function getDirectorySize(dirPath: string): Promise<number> {
-  let totalSize = 0
-
-  try {
-    const entries = await fs.readdir(dirPath, {withFileTypes: true})
-
-    for (const entry of entries) {
-      const entryPath = path.join(dirPath, entry.name)
-
-      if (entry.isDirectory()) {
-        totalSize += await getDirectorySize(entryPath)
-      } else {
-        const stat = await fs.stat(entryPath)
-        totalSize += stat.size
-      }
-    }
-  } catch {
-    // Ignore errors
-  }
-
-  return totalSize
-}
 ```
 
-### 5. Session Writeback (`src/lib/session/writeback.ts`)
+### 7. Session Writeback (`src/lib/session/writeback.ts`)
 
 ```typescript
 import * as fs from "node:fs/promises"
 import * as path from "node:path"
 import type {RunSummary, Logger} from "../types.js"
-import {getOpenCodeStoragePath} from "../../utils/env.js"
+import {getOpenCodeStoragePath, getSessionMessages} from "./storage.js"
 
 /**
- * Write a summary message to the current session.
- * This makes the run outcome discoverable in future session searches.
+ * Append a run summary to a session's message history.
+ *
+ * This creates a synthetic "system" message containing the run summary,
+ * making it discoverable in future session searches.
+ *
+ * NOTE: This directly writes to the OpenCode storage format. The message
+ * will appear in session_read and session_search results.
  */
 export async function writeSessionSummary(sessionId: string, summary: RunSummary, logger: Logger): Promise<void> {
   const storagePath = getOpenCodeStoragePath()
-  const messagesPath = path.join(storagePath, "sessions", sessionId, "messages.json")
+  const messageDir = path.join(storagePath, "message", sessionId)
+  const partDir = path.join(storagePath, "part")
 
-  const summaryMessage = formatSummaryForSession(summary)
+  // Generate IDs matching OpenCode format (descending timestamp for recent-first)
+  const timestamp = Date.now()
+  const messageId = `msg_${timestamp.toString(16)}${generateRandomBase62(14)}`
+  const partId = `prt_${timestamp.toString(16)}${generateRandomBase62(14)}`
+
+  // Create message metadata
+  const messageMetadata = {
+    id: messageId,
+    sessionID: sessionId,
+    role: "user",
+    time: {
+      created: timestamp,
+    },
+    summary: {
+      title: "GitHub Action Run Summary",
+      diffs: [],
+    },
+    agent: "fro-bot",
+    model: {
+      providerID: "system",
+      modelID: "run-summary",
+    },
+  }
+
+  // Create text part with summary content
+  const summaryText = formatSummaryForSession(summary)
+  const partMetadata = {
+    id: partId,
+    sessionID: sessionId,
+    messageID: messageId,
+    type: "text",
+    text: summaryText,
+    time: {
+      start: timestamp,
+      end: timestamp,
+    },
+  }
 
   try {
-    // Read existing messages
-    let messages: Array<{role: string; content: string; timestamp: string}> = []
+    // Ensure directories exist
+    await fs.mkdir(messageDir, {recursive: true})
+    await fs.mkdir(path.join(partDir, messageId), {recursive: true})
 
-    try {
-      const content = await fs.readFile(messagesPath, "utf8")
-      messages = JSON.parse(content)
-    } catch {
-      // No existing messages
-    }
+    // Write message and part files
+    const messagePath = path.join(messageDir, `${messageId}.json`)
+    const partPath = path.join(partDir, messageId, `${partId}.json`)
 
-    // Append summary message
-    messages.push({
-      role: "system",
-      content: summaryMessage,
-      timestamp: new Date().toISOString(),
-    })
+    await fs.writeFile(messagePath, JSON.stringify(messageMetadata, null, 2), "utf8")
+    await fs.writeFile(partPath, JSON.stringify(partMetadata, null, 2), "utf8")
 
-    // Write back
-    await fs.writeFile(messagesPath, JSON.stringify(messages, null, 2), "utf8")
-
-    logger.info("Session summary written", {sessionId})
+    logger.info("Session summary written", {sessionId, messageId})
   } catch (error) {
     logger.warning("Failed to write session summary", {
       sessionId,
@@ -485,7 +1027,7 @@ export async function writeSessionSummary(sessionId: string, summary: RunSummary
  */
 function formatSummaryForSession(summary: RunSummary): string {
   const lines = [
-    "--- Run Summary ---",
+    "--- Fro Bot Run Summary ---",
     `Event: ${summary.eventType}`,
     `Repo: ${summary.repo}`,
     `Ref: ${summary.ref}`,
@@ -512,49 +1054,174 @@ function formatSummaryForSession(summary: RunSummary): string {
 
   return lines.join("\n")
 }
+
+/**
+ * Generate random base62 string (matching OpenCode ID format).
+ */
+function generateRandomBase62(length: number): string {
+  const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+  let result = ""
+  for (let i = 0; i < length; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length))
+  }
+  return result
+}
 ```
 
-### 6. Startup Session Search Integration
+### 8. Public Exports (`src/lib/session/index.ts`)
+
+```typescript
+// Storage utilities
+export {
+  getOpenCodeStoragePath,
+  findProjectByDirectory,
+  getSession,
+  getSessionMessages,
+  getMessageParts,
+  getSessionTodos,
+} from "./storage.js"
+
+// Search operations
+export {listSessions, searchSessions, getSessionInfo} from "./search.js"
+
+// Pruning
+export {pruneSessions, DEFAULT_PRUNING_CONFIG} from "./prune.js"
+
+// Writeback
+export {writeSessionSummary} from "./writeback.js"
+
+// Types
+export type {
+  SessionInfo,
+  SessionSummary,
+  SessionSearchResult,
+  SessionMatch,
+  PruneResult,
+  PruningConfig,
+  Message,
+  UserMessage,
+  AssistantMessage,
+  Part,
+  TextPart,
+  ToolPart,
+  TodoItem,
+  ProjectInfo,
+} from "./types.js"
+```
+
+### 9. Startup Session Search Integration
 
 Add to main entry point pattern:
 
 ```typescript
-import {searchSessions, listSessions} from "./lib/session/index.js"
+import {listSessions, searchSessions, findProjectByDirectory} from "./lib/session/index.js"
 
 async function run(): Promise<void> {
   // ... after cache restore
 
+  // Get current project directory (repo root from GitHub context)
+  const projectPath = process.env["GITHUB_WORKSPACE"] ?? process.cwd()
+
   // Search for relevant prior sessions
-  const projectPath = process.env["GITHUB_REPOSITORY"] ?? ""
-  const sessions = await listSessions(projectPath, logger)
+  const sessions = await listSessions(projectPath, {limit: 10}, logger)
 
   if (sessions.length > 0) {
     logger.info("Found prior sessions", {count: sessions.length, mostRecent: sessions[0].id})
 
-    // Search for context-relevant sessions
-    // TODO: Extract search terms from event payload
-    const searchResults = await searchSessions("error|fix|investigation", projectPath, {limit: 5}, logger)
+    // Search for context-relevant sessions based on event payload
+    // Extract search terms from issue title, PR title, or error messages
+    const searchTerms = extractSearchTermsFromEvent(context)
 
-    if (searchResults.length > 0) {
-      logger.info("Found relevant prior work", {matchCount: searchResults.length})
-      // Pass to agent for context
+    if (searchTerms != null) {
+      const searchResults = await searchSessions(searchTerms, projectPath, {limit: 5}, logger)
+
+      if (searchResults.length > 0) {
+        logger.info("Found relevant prior work", {matchCount: searchResults.length})
+        // Pass session context to agent prompt
+      }
     }
   }
 }
 ```
 
+## Session Tools: Action vs Agent
+
+### Action-Side Utilities (This RFC)
+
+The utilities defined in this RFC are used by the **GitHub Action harness** for:
+
+1. **Startup introspection**: List and search sessions to provide context to the agent
+2. **Session pruning**: Clean up old sessions at the end of each run
+3. **Run summary writeback**: Record run outcomes for future discoverability
+4. **Cache management**: Understand what sessions exist in restored cache
+
+These utilities run **before** and **after** the AI agent executes.
+
+### Agent-Side Tools (oMo Plugin)
+
+The `session_*` tools provided by Oh My OpenCode are available to the **AI agent** during runtime:
+
+| Tool             | Description                            | Usage                             |
+| ---------------- | -------------------------------------- | --------------------------------- |
+| `session_list`   | List available sessions with filtering | Agent discovers prior sessions    |
+| `session_read`   | Read session messages and todos        | Agent reviews prior conversations |
+| `session_search` | Full-text search across sessions       | Agent finds relevant prior work   |
+| `session_info`   | Get session metadata and statistics    | Agent assesses session scope      |
+
+**Key Difference**: The agent uses these tools through natural language via the LLM tool-calling interface. The action uses the RFC-004 utilities directly in TypeScript.
+
+### Ensuring Agent Uses Session Tools
+
+The agent prompt (defined in RFC-011) must instruct the agent to use session tools:
+
+```markdown
+## Session Management (REQUIRED)
+
+Before investigating any issue, you MUST use the session management tools to check for prior work:
+
+1. Use `session_search` to find sessions related to the current issue/PR
+2. Use `session_read` to review relevant prior conversations
+3. Only after checking for prior work should you begin new investigation
+
+At the end of your work, leave a searchable summary that future sessions can find.
+```
+
+## Future Enhancement: Custom OpenCode Tools
+
+A future enhancement would expose action-side utilities (like `pruneSessions`) to agents as OpenCode custom tools:
+
+```typescript
+// Example: future custom tool for session pruning
+// See: https://opencode.ai/docs/custom-tools/
+{
+  "name": "fro_prune_sessions",
+  "description": "Prune old sessions per retention policy. Use when requested by user or when cache is full.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "maxSessions": {"type": "number", "description": "Maximum sessions to keep"},
+      "maxAgeDays": {"type": "number", "description": "Maximum age in days"}
+    }
+  }
+}
+```
+
+This would allow the agent to proactively manage storage when instructed.
+
 ## Acceptance Criteria
 
-- [ ] `listSessions` returns sessions sorted by most recent
-- [ ] `searchSessions` finds content across sessions
-- [ ] `getSessionInfo` returns detailed session metadata
-- [ ] `readSession` returns message history with optional limit
+- [ ] `listSessions` returns sessions sorted by most recent, filtering by directory
+- [ ] `listSessions` excludes child/branched sessions (those with `parentID`)
+- [ ] `searchSessions` finds text content across session message parts
+- [ ] `getSessionInfo` returns detailed session metadata including todos
 - [ ] Session pruning respects both count and age limits
 - [ ] Pruning keeps whichever is larger (count or age retention)
-- [ ] Session summary writeback appends to messages
-- [ ] Startup searches for relevant prior sessions
+- [ ] Pruning also removes child sessions of pruned parent sessions
+- [ ] Session summary writeback creates valid OpenCode message format
+- [ ] Writeback messages are discoverable via `session_search`
+- [ ] All operations work with real OpenCode storage at `~/.local/share/opencode/storage/`
 - [ ] All operations log appropriately
-- [ ] Tests cover pruning edge cases
+- [ ] Tests use valid OpenCode data formats
 
 ## Test Cases
 
@@ -563,13 +1230,25 @@ async function run(): Promise<void> {
 ```typescript
 describe("listSessions", () => {
   it("returns sessions sorted by updatedAt descending", async () => {
-    const sessions = await listSessions("/project", logger)
-    expect(sessions[0].updatedAt >= sessions[1].updatedAt).toBe(true)
+    const sessions = await listSessions("/project", {}, mockLogger)
+    if (sessions.length >= 2) {
+      expect(sessions[0].updatedAt >= sessions[1].updatedAt).toBe(true)
+    }
   })
 
-  it("filters by project path", async () => {
-    const sessions = await listSessions("/project-a", logger)
-    expect(sessions.every(s => s.projectPath === "/project-a")).toBe(true)
+  it("excludes child sessions (those with parentID)", async () => {
+    const sessions = await listSessions("/project", {}, mockLogger)
+    expect(sessions.every(s => !s.isChild)).toBe(true)
+  })
+
+  it("filters by directory via project lookup", async () => {
+    const sessions = await listSessions("/project-a", {}, mockLogger)
+    expect(sessions.every(s => s.directory === "/project-a")).toBe(true)
+  })
+
+  it("respects limit parameter", async () => {
+    const sessions = await listSessions("/project", {limit: 5}, mockLogger)
+    expect(sessions.length).toBeLessThanOrEqual(5)
   })
 })
 ```
@@ -579,30 +1258,103 @@ describe("listSessions", () => {
 ```typescript
 describe("pruneSessions", () => {
   it("keeps at least maxSessions even if older than maxAgeDays", async () => {
-    const result = await pruneSessions("/project", {maxSessions: 10, maxAgeDays: 7}, logger)
-    expect(result.remainingCount).toBeGreaterThanOrEqual(10)
+    const result = await pruneSessions("/project", {maxSessions: 10, maxAgeDays: 7}, mockLogger)
+    expect(result.remainingCount).toBeGreaterThanOrEqual(Math.min(10, totalSessions))
   })
 
   it("keeps recent sessions even if count exceeds maxSessions", async () => {
-    const result = await pruneSessions("/project", {maxSessions: 5, maxAgeDays: 30}, logger)
-    // All sessions within 30 days should be kept
+    // All sessions within maxAgeDays should be kept regardless of count
+    const result = await pruneSessions("/project", {maxSessions: 5, maxAgeDays: 30}, mockLogger)
+    // Verify no sessions within 30 days were pruned
+  })
+
+  it("also prunes child sessions of pruned parents", async () => {
+    const result = await pruneSessions("/project", {maxSessions: 1, maxAgeDays: 1}, mockLogger)
+    // Child sessions should be included in prunedSessionIds
   })
 
   it("reports freed bytes accurately", async () => {
-    const result = await pruneSessions("/project", {maxSessions: 1, maxAgeDays: 1}, logger)
+    const result = await pruneSessions("/project", {maxSessions: 1, maxAgeDays: 1}, mockLogger)
     expect(result.freedBytes).toBeGreaterThanOrEqual(0)
+  })
+})
+```
+
+### Search Tests
+
+```typescript
+describe("searchSessions", () => {
+  it("searches text parts for matching content", async () => {
+    const results = await searchSessions("error", "/project", {}, mockLogger)
+    for (const result of results) {
+      expect(result.matches.every(m => m.excerpt.toLowerCase().includes("error"))).toBe(true)
+    }
+  })
+
+  it("respects caseSensitive option", async () => {
+    const caseInsensitive = await searchSessions("Error", "/project", {caseSensitive: false}, mockLogger)
+    const caseSensitive = await searchSessions("Error", "/project", {caseSensitive: true}, mockLogger)
+    // Case-insensitive should find more or equal matches
+    expect(caseInsensitive.length).toBeGreaterThanOrEqual(caseSensitive.length)
+  })
+
+  it("searches tool output in completed tool parts", async () => {
+    const results = await searchSessions("command output", "/project", {}, mockLogger)
+    // Should find matches in tool part output
+  })
+})
+```
+
+### Storage Format Tests
+
+```typescript
+describe("OpenCode storage format compatibility", () => {
+  it("reads real session files from OpenCode storage", async () => {
+    // This test validates against actual OpenCode storage
+    const storagePath = getOpenCodeStoragePath()
+    const projects = await listProjects(mockLogger)
+    expect(projects.length).toBeGreaterThan(0)
+
+    for (const project of projects) {
+      const sessions = await listSessionsForProject(project.id, mockLogger)
+      for (const session of sessions) {
+        // Validate session structure matches SessionInfo type
+        expect(session.id).toMatch(/^ses_/)
+        expect(typeof session.time.created).toBe("number")
+        expect(typeof session.time.updated).toBe("number")
+      }
+    }
+  })
+
+  it("reads real message files with correct structure", async () => {
+    const storagePath = getOpenCodeStoragePath()
+    const projects = await listProjects(mockLogger)
+    if (projects.length > 0) {
+      const sessions = await listSessionsForProject(projects[0].id, mockLogger)
+      if (sessions.length > 0) {
+        const messages = await getSessionMessages(sessions[0].id, mockLogger)
+        for (const message of messages) {
+          expect(message.id).toMatch(/^msg_/)
+          expect(["user", "assistant"]).toContain(message.role)
+        }
+      }
+    }
   })
 })
 ```
 
 ## Implementation Notes
 
-1. **Session storage format**: Assumes OpenCode stores sessions in `storage/sessions/{id}/` with `meta.json` and `messages.json`
-2. **Graceful handling**: All operations handle missing files gracefully
-3. **Performance**: Large session directories may need streaming/pagination
+1. **OpenCode storage format**: Sessions use JSON files, NOT SQLite. The storage is at `~/.local/share/opencode/storage/`
+2. **ID format**: IDs use format `{prefix}_{hex-timestamp}{random-base62}` for monotonic ordering
+3. **Project organization**: Sessions are organized by `projectID` (git root commit hash)
+4. **Child sessions**: Sessions with `parentID` are branches/forks and should be excluded from main session lists
+5. **Message parts**: Message content is stored separately in the `part/` directory, not in the message files
+6. **Graceful handling**: All operations handle missing files gracefully
+7. **Performance**: Large session directories may need streaming/pagination in future versions
 
 ## Estimated Effort
 
-- **Development**: 6-8 hours
-- **Testing**: 3-4 hours
-- **Total**: 9-12 hours
+- **Development**: 8-10 hours
+- **Testing**: 4-5 hours
+- **Total**: 12-15 hours

--- a/RFCs/RFC-011-RESEARCH-SUMMARY.md
+++ b/RFCs/RFC-011-RESEARCH-SUMMARY.md
@@ -1,0 +1,347 @@
+# RFC-011 Research Summary
+
+**Date:** 2025-01-04
+**Status:** Research Complete
+**Purpose:** Document findings, gaps, and spikes from RFC-011 review
+
+---
+
+## Executive Summary
+
+RFC-011 (Setup Action & Environment Bootstrap) is **largely correct** but requires updates to address gaps discovered through research into the oMo Sisyphus workflow, OpenCode SDK, and RFC dependencies.
+
+### Key Decision: RESOLVED
+
+**RFC-003 already provides `createAppClient()` for GitHub App authentication.**
+
+The function at `src/lib/github/client.ts:63-93` implements:
+
+- Takes `appId`, `privateKey`, `installationId?`
+- Dynamic imports `@octokit/auth-app` (avoids bundling when not needed)
+- Returns `Octokit | null` (null on failure or missing credentials)
+- Proper error handling with logging
+
+**Decision:** RFC-011 uses RFC-003's `createAppClient()` directly. `GITHUB_TOKEN` fallback remains for graceful degradation when:
+
+1. App credentials not provided (optional configuration)
+2. App authentication fails (network/permission issues)
+3. Read-only operations (commenting doesn't require elevated permissions)
+
+---
+
+## Research Sources
+
+| Source | Method | Key Findings |
+| --- | --- | --- |
+| oMo Sisyphus Workflow | GitHub fetch via librarian | Version fallback, download validation, stdbuf, provider config |
+| OpenCode SDK | Official docs + source | `@opencode-ai/sdk` provides programmatic control, still spawns CLI |
+| oh-my-opencode package.json | GitHub fetch | Bun-targeted, cannot be direct dependency, use npx/bunx |
+| Existing codebase | explore agent | Uses Result<T,E> pattern, function-based, Logger with redaction |
+| RFC dependencies | Full RFC read | 7 conflicts identified, phase ordering issues |
+
+---
+
+## Gaps in RFC-011
+
+### Critical Gaps (Must Fix Before Implementation)
+
+| Gap | Current State | Required Change |
+| --- | --- | --- |
+| **Version fallback** | Single version attempt | Add fallback: latest → pinned version on failure |
+| **Download validation** | None | Add `file` command check for corruption |
+| ~~**App token generation**~~ | ~~Placeholder returns `""`~~ | ~~Implement or defer to RFC-006~~ **RESOLVED: Use RFC-003's `createAppClient()`** |
+| **stdbuf documentation** | Mentioned but not specified | Document exact command: `stdbuf -oL -eL opencode run "$PROMPT"` |
+
+### Medium Priority Gaps
+
+| Gap                       | Current State   | Required Change                                            |
+| ------------------------- | --------------- | ---------------------------------------------------------- |
+| Provider config injection | Not covered     | Add optional `opencode.json` custom provider config        |
+| oMo config injection      | Not covered     | Add optional `oh-my-opencode.json` `prompt_append` support |
+| oMo failure handling      | Silent continue | Fail setup or document that agent will fail at runtime     |
+| Event context extraction  | Returns nulls   | Move to main action (RFC-005), not setup                   |
+
+### Low Priority Gaps
+
+| Gap                   | Current State | Required Change                                         |
+| --------------------- | ------------- | ------------------------------------------------------- |
+| Bun vs Node runtime   | RFC uses Node | Document that oh-my-opencode works with npx in Node env |
+| Local plugin override | Not covered   | Not needed for production (only dev workflow)           |
+
+---
+
+## Conflicts Between RFCs
+
+### Conflict 1: Dual auth.json Handling
+
+**Problem:** Both RFC-006 and RFC-011 write auth.json with identical logic.
+
+**Files affected:**
+
+- RFC-006: `writeAuthJson()` (lines 406-454)
+- RFC-011: `populateAuthJson()` (lines 436-449)
+
+**Resolution:** RFC-011 should call RFC-006's function when available, or RFC-006 should import from RFC-011.
+
+**Recommendation:** Since RFC-011 is Phase 1 and RFC-006 is Phase 2, RFC-011 owns auth.json writing. RFC-006 should import from RFC-011.
+
+### Conflict 2: Phase Ordering - RESOLVED
+
+**Original Problem:** RFC-011 needs App token generation but RFC-006 is Phase 2.
+
+**Resolution:** RFC-003 (Phase 1) already provides `createAppClient()` at `src/lib/github/client.ts`. RFC-011 imports and uses it directly. No phase reordering needed.
+
+### Conflict 3: Session Tools Assumed Before RFC-004
+
+**Problem:** RFC-011 agent prompt includes session tool instructions:
+
+```
+Use `session_search` to find relevant prior sessions
+Use `session_read` to review prior work
+```
+
+But RFC-004 (Session Management) is Phase 2.
+
+**Resolution:** These instructions document oMo plugin capabilities, not our implementation. The oMo plugin provides these tools when installed. RFC-011 is correct but should clarify this dependency.
+
+---
+
+## SDK vs CLI Decision
+
+### OpenCode SDK (`@opencode-ai/sdk`)
+
+**Advantages:**
+
+- Type-safe API
+- Structured session management (`session.create()`, `session.list()`, etc.)
+- Persistent server (start once, reuse)
+- SSE streaming for real-time output
+
+**Disadvantages:**
+
+- Still spawns CLI binary internally (`opencode serve`)
+- More setup code (server lifecycle)
+- Additional dependency
+
+### CLI (`opencode run`)
+
+**Advantages:**
+
+- Simpler integration
+- Each run is isolated
+- Proven in Sisyphus workflow
+
+**Disadvantages:**
+
+- Process overhead per invocation
+- Output parsing required
+- Less type safety
+
+### Recommendation
+
+**Use CLI for v1.** The Sisyphus workflow proves CLI works. SDK benefits (type safety, persistent server) are valuable but not critical for initial release. Consider SDK for v2 when session management (RFC-004) needs tighter integration.
+
+---
+
+## oh-my-opencode Integration
+
+### Key Finding: Cannot Be Direct Dependency
+
+From package.json analysis:
+
+- **Build target:** Bun (`--target bun`), not Node.js
+- **Native bindings:** `@ast-grep/napi` requires platform-specific compilation
+- **License:** SUL-1.0 (non-standard)
+- **Heavy deps:** MCP SDK, Hono, Zod v4
+
+### Correct Integration
+
+RFC-011's current approach is correct:
+
+```typescript
+await exec.exec("npx", ["oh-my-opencode", "install"])
+```
+
+This runs oMo as a CLI tool, not as an imported library. No changes needed.
+
+---
+
+## Sisyphus Workflow Patterns to Adopt
+
+### 1. Version Fallback
+
+```bash
+# From Sisyphus workflow
+if ! bash /tmp/opencode-install.sh 2>&1; then
+  echo "Default installer failed, trying with pinned version..."
+  bash /tmp/opencode-install.sh --version 1.0.204
+fi
+```
+
+**RFC-011 change:** Update `installOpenCode()` to accept fallback version:
+
+```typescript
+export async function installOpenCode(
+  version: string,
+  fallbackVersion: string,
+  logger: Logger,
+): Promise<OpenCodeInstallResult>
+```
+
+### 2. Download Validation
+
+```bash
+# From Sisyphus workflow
+if file /tmp/opencode-install.sh | grep -q "shell script\|text"; then
+  # proceed
+else
+  echo "Download corrupted..."
+fi
+```
+
+**RFC-011 change:** Add validation after download:
+
+```typescript
+async function validateDownload(path: string): Promise<boolean>
+```
+
+### 3. stdbuf Execution
+
+```bash
+# From Sisyphus workflow
+stdbuf -oL -eL bun run dist/cli/index.js run "$PROMPT"
+```
+
+**RFC-011 change:** Document in "Real-time Log Streaming Requirement" section that the main action (not setup) must use this pattern.
+
+### 4. Non-Fatal GitHub Operations
+
+```bash
+# From Sisyphus workflow
+gh api .../reactions -X POST -f content="eyes" || true
+```
+
+**Already documented:** RFC-011 Appendix shows `try/catch` with warning logs.
+
+---
+
+## Implementation Spikes
+
+### Spike 1: OpenCode Tool Cache Integration
+
+**Question:** Does `@actions/tool-cache` work for OpenCode binary caching across runs?
+
+**Investigation needed:**
+
+- Verify download URL format matches `tc.downloadTool` expectations
+- Test extraction of `.tar.gz` and `.zip` formats
+- Confirm cache key includes version and arch
+
+**Estimated effort:** 2 hours
+
+### Spike 2: oMo Plugin Installation Verification
+
+**Question:** How to verify oMo plugin installed successfully?
+
+**Investigation needed:**
+
+- Check if `opencode --list-plugins` or similar exists
+- Check if config file is written on success
+- Define fallback if verification not possible
+
+**Estimated effort:** 1 hour
+
+### Spike 3: GitHub App Token Generation - RESOLVED
+
+**Resolution:** RFC-003's `createAppClient()` already implements this using `@octokit/auth-app` with dynamic import. RFC-011 uses it directly.
+
+No spike needed.
+
+---
+
+## Recommended RFC-011 Updates
+
+### Section Updates
+
+| Section                    | Change                                                   |
+| -------------------------- | -------------------------------------------------------- |
+| 4. OpenCode Installation   | Add fallback version parameter, add download validation  |
+| 5. oMo Plugin Installation | Add installation verification, document failure behavior |
+| 9. Setup Entry Point       | Handle optional App token gracefully, add error states   |
+| Real-time Log Streaming    | Add explicit command example with stdbuf                 |
+| Dependencies               | Add note about RFC-006 optional dependency for App token |
+
+### New Acceptance Criteria
+
+Add to existing criteria:
+
+- [ ] OpenCode installation has fallback to pinned version
+- [ ] Downloaded archives are validated before extraction
+- [ ] Setup continues if oMo install fails (with warning)
+- [ ] Setup works without GitHub App credentials (fallback to GITHUB_TOKEN)
+- [ ] stdbuf command documented with exact syntax
+
+---
+
+## Updated Phase Assignment Recommendation
+
+### Current (from RFCS.md)
+
+| Phase | RFCs                               |
+| ----- | ---------------------------------- |
+| 1     | RFC-001, RFC-002, RFC-003, RFC-011 |
+| 2     | RFC-004, RFC-005, RFC-006, RFC-007 |
+| 3     | RFC-008, RFC-009, RFC-010          |
+
+### Recommended (no change needed)
+
+The current phase assignment works if:
+
+1. RFC-011 ships without mandatory GitHub App support
+2. App support is added when RFC-006 lands in Phase 2
+
+No RFCS.md update required.
+
+---
+
+## Next Steps
+
+1. **Apply RFC-011 updates** based on this research
+2. **Update AGENTS.md** to reflect RFC-011 research status
+3. **Create implementation tickets** for spikes
+4. **Begin TDD implementation** of RFC-011 after updates
+
+---
+
+## Appendix: Research Agent Results
+
+### oMo Sisyphus Workflow (bg_0dc179a3)
+
+- Environment variables and secrets mapped
+- CLI flags documented
+- Setup sequence identified
+- Fallback patterns extracted
+
+### OpenCode SDK (bg_0adda3c2)
+
+- SDK methods for session management documented
+- Prompt passing approach clarified
+- SDK vs CLI tradeoffs analyzed
+
+### oh-my-opencode Package (bg_b688d583)
+
+- Dependency structure analyzed
+- Runtime compatibility assessed
+- Integration strategy confirmed (npx, not import)
+
+### Existing Codebase Patterns (bg_48ed5e51)
+
+- Architecture mapped
+- Shared component inventory created
+- Build configuration analyzed
+
+### RFC Dependencies (bg_58b62cc6)
+
+- All 11 RFCs read and cross-referenced
+- 7 conflicts/gaps identified
+- Phase ordering validated

--- a/RFCs/RFC-012-Agent-Execution-Main-Action.md
+++ b/RFCs/RFC-012-Agent-Execution-Main-Action.md
@@ -1,0 +1,1185 @@
+# RFC-012: Agent Execution & Main Action Lifecycle
+
+**Status:** Pending
+**Priority:** MUST
+**Complexity:** High
+**Phase:** 1
+
+---
+
+## Summary
+
+Implement the core agent execution lifecycle in the main action: acknowledge receipt with reactions/labels, collect GitHub context, construct the agent prompt, launch OpenCode via CLI with real-time log streaming, handle completion/failure, and update reactions on finish. This RFC bridges RFC-011 (environment bootstrap) with Phase 2 RFCs (session management, event handling, etc.).
+
+## Dependencies
+
+- **Requires:** RFC-001 (Foundation), RFC-002 (Cache), RFC-003 (GitHub Client), RFC-011 (Setup Action)
+- **Enables:** RFC-004 (Sessions), RFC-005 (Triggers), RFC-006 (Security), RFC-007 (Observability)
+- **Consumes:** Setup action outputs (`opencode-path`, `gh-authenticated`, `cache-status`)
+
+## Features Addressed
+
+| Feature ID | Feature Name                      | Priority |
+| ---------- | --------------------------------- | -------- |
+| F41        | Agent Prompt Context Injection    | P0       |
+| F42        | gh CLI Operation Instructions     | P0       |
+| F43        | Reactions & Labels Acknowledgment | P0       |
+| F44        | Issue vs PR Context Detection     | P0       |
+| NEW        | OpenCode CLI Execution            | P0       |
+| NEW        | Real-time Log Streaming           | P0       |
+| NEW        | Agent Completion Handling         | P0       |
+
+## Background: The Gap
+
+RFC-011 defines the **setup action** that:
+
+- Installs OpenCode CLI
+- Installs oMo plugin
+- Configures `gh` CLI authentication
+- Populates `auth.json`
+- Restores session cache
+- Constructs the agent prompt
+
+However, RFC-011 stops at environment preparation. The **main action** (`src/main.ts`) currently only:
+
+- Restores/saves cache
+- Has TODO placeholders for RFC-003 through RFC-006
+
+**Missing:** The actual agent execution - launching OpenCode with the prompt, streaming logs, handling reactions/labels, and managing the execution lifecycle.
+
+---
+
+## Technical Specification
+
+### 1. File Structure
+
+```
+src/
+├── main.ts                    # Updated main entry point
+├── lib/
+│   ├── execution/
+│   │   ├── types.ts           # Execution types
+│   │   ├── opencode.ts        # OpenCode CLI execution
+│   │   ├── context.ts         # GitHub context collection
+│   │   ├── prompt.ts          # Prompt construction
+│   │   ├── reactions.ts       # Reactions & labels
+│   │   └── index.ts           # Public exports
+```
+
+### 2. Execution Types (`src/lib/execution/types.ts`)
+
+```typescript
+export interface ExecutionContext {
+  readonly eventName: string
+  readonly repo: string
+  readonly ref: string
+  readonly actor: string
+  readonly runId: string
+  readonly issueNumber: number | null
+  readonly issueTitle: string | null
+  readonly issueType: "issue" | "pr" | null
+  readonly commentBody: string | null
+  readonly commentAuthor: string | null
+  readonly commentId: number | null
+  readonly defaultBranch: string
+}
+
+export interface ExecutionResult {
+  readonly success: boolean
+  readonly exitCode: number
+  readonly duration: number
+  readonly sessionId: string | null
+  readonly error: string | null
+}
+
+export interface ReactionContext {
+  readonly repo: string
+  readonly commentId: number | null
+  readonly issueNumber: number | null
+  readonly issueType: "issue" | "pr" | null
+  readonly botLogin: string | null
+}
+
+export interface PromptOptions {
+  readonly context: ExecutionContext
+  readonly customPrompt: string | null
+  readonly cacheStatus: "hit" | "miss" | "corrupted"
+}
+
+export type AcknowledgmentState = "pending" | "acknowledged" | "completed" | "failed"
+```
+
+### 3. GitHub Context Collection (`src/lib/execution/context.ts`)
+
+```typescript
+import * as exec from "@actions/exec"
+import type {ExecutionContext, Logger} from "./types.js"
+
+/**
+ * Collect GitHub context from environment and event payload.
+ *
+ * Determines if the trigger is an issue or PR, extracts comment details,
+ * and gathers all context needed for prompt construction.
+ */
+export async function collectExecutionContext(logger: Logger): Promise<ExecutionContext> {
+  const eventName = process.env["GITHUB_EVENT_NAME"] ?? "unknown"
+  const repo = process.env["GITHUB_REPOSITORY"] ?? ""
+  const ref = process.env["GITHUB_REF_NAME"] ?? "main"
+  const actor = process.env["GITHUB_ACTOR"] ?? "unknown"
+  const runId = process.env["GITHUB_RUN_ID"] ?? "0"
+
+  // Event payload provides comment context
+  const commentBody = process.env["COMMENT_BODY"] ?? null
+  const commentAuthor = process.env["COMMENT_AUTHOR"] ?? null
+  const commentId = parseIntOrNull(process.env["COMMENT_ID"])
+  const issueNumber = parseIntOrNull(process.env["ISSUE_NUMBER"])
+
+  // Determine issue vs PR and get title
+  let issueType: "issue" | "pr" | null = null
+  let issueTitle: string | null = null
+  let defaultBranch = "main"
+
+  if (issueNumber != null && repo.length > 0) {
+    const typeInfo = await detectIssueType(repo, issueNumber, logger)
+    issueType = typeInfo.type
+    issueTitle = typeInfo.title
+    defaultBranch = typeInfo.defaultBranch
+  }
+
+  logger.info("Collected execution context", {
+    eventName,
+    repo,
+    issueNumber,
+    issueType,
+    hasComment: commentBody != null,
+  })
+
+  return {
+    eventName,
+    repo,
+    ref,
+    actor,
+    runId,
+    issueNumber,
+    issueTitle,
+    issueType,
+    commentBody,
+    commentAuthor,
+    commentId,
+    defaultBranch,
+  }
+}
+
+interface IssueTypeInfo {
+  type: "issue" | "pr"
+  title: string | null
+  defaultBranch: string
+}
+
+async function detectIssueType(repo: string, issueNumber: number, logger: Logger): Promise<IssueTypeInfo> {
+  try {
+    const {stdout} = await exec.getExecOutput(
+      "gh",
+      ["api", `/repos/${repo}/issues/${issueNumber}`, "--jq", "{title: .title, has_pr: (.pull_request != null)}"],
+      {silent: true},
+    )
+
+    const data = JSON.parse(stdout) as {title: string | null; has_pr: boolean}
+
+    // Also get default branch
+    const {stdout: repoStdout} = await exec.getExecOutput("gh", ["api", `/repos/${repo}`, "--jq", ".default_branch"], {
+      silent: true,
+    })
+
+    return {
+      type: data.has_pr ? "pr" : "issue",
+      title: data.title,
+      defaultBranch: repoStdout.trim() || "main",
+    }
+  } catch (error) {
+    logger.warning("Failed to detect issue/PR type", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return {type: "issue", title: null, defaultBranch: "main"}
+  }
+}
+
+function parseIntOrNull(value: string | undefined): number | null {
+  if (value == null || value.length === 0) return null
+  const parsed = parseInt(value, 10)
+  return Number.isNaN(parsed) ? null : parsed
+}
+```
+
+### 4. Prompt Construction (`src/lib/execution/prompt.ts`)
+
+```typescript
+import type {PromptOptions, Logger} from "./types.js"
+
+/**
+ * Build the complete agent prompt with GitHub context and instructions.
+ *
+ * The prompt includes:
+ * - Environment context (repo, branch, event, actor)
+ * - Issue/PR context when applicable
+ * - Triggering comment when applicable
+ * - Session management instructions
+ * - gh CLI operation examples
+ * - Run summary requirement
+ * - Custom prompt if provided
+ */
+export function buildAgentPrompt(options: PromptOptions, logger: Logger): string {
+  const {context, customPrompt, cacheStatus} = options
+  const parts: string[] = []
+
+  // System context header
+  parts.push(`# Agent Context
+
+You are the Fro Bot Agent running in GitHub Actions.
+
+## Environment
+- **Repository:** ${context.repo}
+- **Branch/Ref:** ${context.ref}
+- **Event:** ${context.eventName}
+- **Actor:** ${context.actor}
+- **Run ID:** ${context.runId}
+- **Cache Status:** ${cacheStatus}
+`)
+
+  // Issue/PR context
+  if (context.issueNumber != null) {
+    const typeLabel = context.issueType === "pr" ? "Pull Request" : "Issue"
+    parts.push(`## ${typeLabel} Context
+- **Number:** #${context.issueNumber}
+- **Title:** ${context.issueTitle ?? "N/A"}
+- **Type:** ${context.issueType ?? "unknown"}
+`)
+  }
+
+  // Triggering comment
+  if (context.commentBody != null) {
+    parts.push(`## Trigger Comment
+**Author:** ${context.commentAuthor ?? "unknown"}
+
+\`\`\`
+${context.commentBody}
+\`\`\`
+`)
+  }
+
+  // Session management instructions (REQUIRED)
+  parts.push(`## Session Management (REQUIRED)
+
+Before investigating any issue:
+1. Use \`session_search\` to find relevant prior sessions for this repository
+2. Use \`session_read\` to review prior work if found
+3. Avoid repeating investigation already completed in previous sessions
+
+Before completing:
+1. Ensure your session contains a summary of work done
+2. Include key decisions, findings, and outcomes
+3. This summary will be searchable in future agent runs
+`)
+
+  // GitHub CLI instructions
+  parts.push(`## GitHub Operations (Use gh CLI)
+
+The \`gh\` CLI is pre-authenticated. Use it for all GitHub operations:
+
+### Commenting
+\`\`\`bash
+# Comment on issue
+gh issue comment ${context.issueNumber ?? "<number>"} --body "Your message"
+
+# Comment on PR
+gh pr comment ${context.issueNumber ?? "<number>"} --body "Your message"
+\`\`\`
+
+### Creating PRs
+\`\`\`bash
+# Create a new PR
+gh pr create --title "feat(scope): description" --body "Details..." --base ${context.defaultBranch} --head feature-branch
+\`\`\`
+
+### Pushing Commits
+\`\`\`bash
+# Commit and push changes
+git add .
+git commit -m "type(scope): description"
+git push origin HEAD
+\`\`\`
+
+### API Calls
+\`\`\`bash
+# Query the GitHub API
+gh api repos/${context.repo}/issues --jq '.[].title'
+gh api repos/${context.repo}/pulls/${context.issueNumber ?? "<number>"}/files --jq '.[].filename'
+\`\`\`
+`)
+
+  // Run summary requirement
+  parts.push(`## Run Summary (REQUIRED)
+
+Every comment you post MUST include a collapsed details block at the end:
+
+\`\`\`markdown
+<details>
+<summary>Run Summary</summary>
+
+| Field | Value |
+|-------|-------|
+| Event | ${context.eventName} |
+| Repository | ${context.repo} |
+| Run ID | ${context.runId} |
+| Cache | ${cacheStatus} |
+| Session | <your_session_id> |
+
+</details>
+\`\`\`
+`)
+
+  // Custom prompt if provided
+  if (customPrompt != null && customPrompt.trim().length > 0) {
+    parts.push(`## Custom Instructions
+
+${customPrompt.trim()}
+`)
+  }
+
+  // Task directive
+  if (context.commentBody != null) {
+    parts.push(`## Task
+
+Respond to the trigger comment above. Follow all instructions and requirements listed in this prompt.
+`)
+  } else {
+    parts.push(`## Task
+
+Execute the requested operation for repository ${context.repo}. Follow all instructions and requirements listed in this prompt.
+`)
+  }
+
+  const prompt = parts.join("\n")
+  logger.debug("Built agent prompt", {length: prompt.length, hasCustom: customPrompt != null})
+  return prompt
+}
+```
+
+### 5. Reactions & Labels (`src/lib/execution/reactions.ts`)
+
+```typescript
+import * as exec from "@actions/exec"
+import type {ReactionContext, AcknowledgmentState, Logger} from "./types.js"
+
+const WORKING_LABEL = "agent: working"
+const WORKING_LABEL_COLOR = "fcf2e1"
+const WORKING_LABEL_DESCRIPTION = "Agent is currently working on this"
+
+/**
+ * Add eyes reaction to acknowledge receipt of the triggering comment.
+ */
+export async function addEyesReaction(ctx: ReactionContext, logger: Logger): Promise<boolean> {
+  if (ctx.commentId == null) {
+    logger.debug("No comment ID, skipping eyes reaction")
+    return false
+  }
+
+  try {
+    await exec.exec(
+      "gh",
+      [
+        "api",
+        "--method",
+        "POST",
+        `/repos/${ctx.repo}/issues/comments/${ctx.commentId}/reactions`,
+        "-f",
+        "content=eyes",
+      ],
+      {silent: true},
+    )
+
+    logger.info("Added eyes reaction", {commentId: ctx.commentId})
+    return true
+  } catch (error) {
+    logger.warning("Failed to add eyes reaction (non-fatal)", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return false
+  }
+}
+
+/**
+ * Add "agent: working" label to the issue/PR.
+ */
+export async function addWorkingLabel(ctx: ReactionContext, logger: Logger): Promise<boolean> {
+  if (ctx.issueNumber == null) {
+    logger.debug("No issue number, skipping working label")
+    return false
+  }
+
+  try {
+    // Ensure label exists (--force updates if exists)
+    await exec.exec(
+      "gh",
+      [
+        "label",
+        "create",
+        WORKING_LABEL,
+        "--color",
+        WORKING_LABEL_COLOR,
+        "--description",
+        WORKING_LABEL_DESCRIPTION,
+        "--force",
+      ],
+      {silent: true},
+    )
+
+    // Add label to issue/PR
+    const cmd = ctx.issueType === "pr" ? "pr" : "issue"
+    await exec.exec("gh", [cmd, "edit", String(ctx.issueNumber), "--add-label", WORKING_LABEL], {silent: true})
+
+    logger.info("Added working label", {issueNumber: ctx.issueNumber})
+    return true
+  } catch (error) {
+    logger.warning("Failed to add working label (non-fatal)", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return false
+  }
+}
+
+/**
+ * Acknowledge receipt by adding eyes reaction and working label.
+ */
+export async function acknowledgeReceipt(ctx: ReactionContext, logger: Logger): Promise<void> {
+  // Run both in parallel - neither is dependent on the other
+  await Promise.all([addEyesReaction(ctx, logger), addWorkingLabel(ctx, logger)])
+}
+
+/**
+ * Select a random peace sign emoji variant for success reaction.
+ * Matches oMo Sisyphus behavior of using peace sign with random skin tone.
+ */
+function getRandomPeaceReaction(): string {
+  // GitHub API reaction options don't include peace sign directly
+  // Available options: +1, -1, laugh, confused, heart, hooray, rocket, eyes
+  // Use 'hooray' (🎉) as the closest celebratory alternative
+  // Note: If peace sign becomes available, this should be updated
+  return "hooray"
+}
+
+/**
+ * Update reaction from eyes to success indicator on successful completion.
+ * Uses hooray (🎉) as GitHub API doesn't support peace sign reactions.
+ */
+export async function updateReactionOnSuccess(ctx: ReactionContext, logger: Logger): Promise<void> {
+  if (ctx.commentId == null || ctx.botLogin == null) {
+    logger.debug("Missing comment ID or bot login, skipping reaction update")
+    return
+  }
+
+  try {
+    // Find and remove eyes reaction
+    const {stdout} = await exec.getExecOutput(
+      "gh",
+      [
+        "api",
+        `/repos/${ctx.repo}/issues/comments/${ctx.commentId}/reactions`,
+        "--jq",
+        `.[] | select(.content=="eyes" and .user.login=="${ctx.botLogin}") | .id`,
+      ],
+      {silent: true},
+    )
+
+    const reactionId = stdout.trim()
+    if (reactionId.length > 0) {
+      await exec.exec("gh", ["api", "--method", "DELETE", `/repos/${ctx.repo}/reactions/${reactionId}`], {silent: true})
+    }
+
+    // Add success reaction (hooray/🎉 - closest to peace sign in available reactions)
+    const successReaction = getRandomPeaceReaction()
+    await exec.exec(
+      "gh",
+      [
+        "api",
+        "--method",
+        "POST",
+        `/repos/${ctx.repo}/issues/comments/${ctx.commentId}/reactions`,
+        "-f",
+        `content=${successReaction}`,
+      ],
+      {silent: true},
+    )
+
+    logger.info("Updated reaction to success indicator", {commentId: ctx.commentId, reaction: successReaction})
+  } catch (error) {
+    logger.warning("Failed to update reaction (non-fatal)", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * Update reaction to confused (😕) on failure.
+ */
+export async function updateReactionOnFailure(ctx: ReactionContext, logger: Logger): Promise<void> {
+  if (ctx.commentId == null || ctx.botLogin == null) {
+    logger.debug("Missing comment ID or bot login, skipping reaction update")
+    return
+  }
+
+  try {
+    // Find and remove eyes reaction
+    const {stdout} = await exec.getExecOutput(
+      "gh",
+      [
+        "api",
+        `/repos/${ctx.repo}/issues/comments/${ctx.commentId}/reactions`,
+        "--jq",
+        `.[] | select(.content=="eyes" and .user.login=="${ctx.botLogin}") | .id`,
+      ],
+      {silent: true},
+    )
+
+    const reactionId = stdout.trim()
+    if (reactionId.length > 0) {
+      await exec.exec("gh", ["api", "--method", "DELETE", `/repos/${ctx.repo}/reactions/${reactionId}`], {silent: true})
+    }
+
+    // Add confused reaction
+    await exec.exec(
+      "gh",
+      [
+        "api",
+        "--method",
+        "POST",
+        `/repos/${ctx.repo}/issues/comments/${ctx.commentId}/reactions`,
+        "-f",
+        "content=confused",
+      ],
+      {silent: true},
+    )
+
+    logger.info("Updated reaction to confused", {commentId: ctx.commentId})
+  } catch (error) {
+    logger.warning("Failed to update failure reaction (non-fatal)", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * Remove "agent: working" label on completion (success or failure).
+ */
+export async function removeWorkingLabel(ctx: ReactionContext, logger: Logger): Promise<void> {
+  if (ctx.issueNumber == null) {
+    logger.debug("No issue number, skipping label removal")
+    return
+  }
+
+  try {
+    const cmd = ctx.issueType === "pr" ? "pr" : "issue"
+    await exec.exec("gh", [cmd, "edit", String(ctx.issueNumber), "--remove-label", WORKING_LABEL], {silent: true})
+
+    logger.info("Removed working label", {issueNumber: ctx.issueNumber})
+  } catch (error) {
+    logger.warning("Failed to remove working label (non-fatal)", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * Complete acknowledgment cycle based on success/failure.
+ */
+export async function completeAcknowledgment(ctx: ReactionContext, success: boolean, logger: Logger): Promise<void> {
+  // Update reaction based on outcome
+  if (success) {
+    await updateReactionOnSuccess(ctx, logger)
+  } else {
+    await updateReactionOnFailure(ctx, logger)
+  }
+
+  // Always remove working label
+  await removeWorkingLabel(ctx, logger)
+}
+```
+
+### 6. OpenCode CLI Execution (`src/lib/execution/opencode.ts`)
+
+```typescript
+import * as exec from "@actions/exec"
+import type {ExecutionResult, Logger} from "./types.js"
+
+/**
+ * Execute OpenCode CLI with the given prompt.
+ *
+ * On Linux, wraps execution with `stdbuf` for real-time log streaming.
+ * This matches the oMo Sisyphus workflow pattern.
+ *
+ * @param prompt - The complete agent prompt
+ * @param opencodePath - Path to OpenCode binary (from setup action)
+ * @param logger - Logger instance
+ * @returns Execution result with exit code and duration
+ */
+export async function executeOpenCode(
+  prompt: string,
+  opencodePath: string | null,
+  logger: Logger,
+): Promise<ExecutionResult> {
+  const startTime = Date.now()
+
+  // Determine OpenCode command - use PATH if not explicitly provided
+  const opencodeCmd = opencodePath ?? "opencode"
+
+  logger.info("Executing OpenCode agent", {
+    promptLength: prompt.length,
+    platform: process.platform,
+    useStdbuf: process.platform === "linux",
+  })
+
+  try {
+    let exitCode: number
+
+    if (process.platform === "linux") {
+      // Use stdbuf for real-time log streaming on Linux
+      // -oL: line-buffered stdout
+      // -eL: line-buffered stderr
+      exitCode = await exec.exec("stdbuf", ["-oL", "-eL", opencodeCmd, "run", prompt])
+    } else {
+      // macOS/Windows: direct execution (buffered output)
+      exitCode = await exec.exec(opencodeCmd, ["run", prompt])
+    }
+
+    const duration = Date.now() - startTime
+
+    logger.info("OpenCode execution completed", {
+      exitCode,
+      durationMs: duration,
+    })
+
+    return {
+      success: exitCode === 0,
+      exitCode,
+      duration,
+      sessionId: null, // Will be populated by RFC-004 session integration
+      error: null,
+    }
+  } catch (error) {
+    const duration = Date.now() - startTime
+    const errorMessage = error instanceof Error ? error.message : String(error)
+
+    logger.error("OpenCode execution failed", {
+      error: errorMessage,
+      durationMs: duration,
+    })
+
+    return {
+      success: false,
+      exitCode: 1,
+      duration,
+      sessionId: null,
+      error: errorMessage,
+    }
+  }
+}
+
+/**
+ * Verify OpenCode is available and working.
+ *
+ * Runs `opencode --version` to ensure the binary is accessible.
+ */
+export async function verifyOpenCodeAvailable(
+  opencodePath: string | null,
+  logger: Logger,
+): Promise<{available: boolean; version: string | null}> {
+  const opencodeCmd = opencodePath ?? "opencode"
+
+  try {
+    let version = ""
+    await exec.exec(opencodeCmd, ["--version"], {
+      listeners: {
+        stdout: (data: Buffer) => {
+          version += data.toString()
+        },
+      },
+      silent: true,
+    })
+
+    const versionMatch = /(\d+\.\d+\.\d+)/.exec(version)
+    const parsedVersion = versionMatch != null ? versionMatch[1] : null
+
+    logger.debug("OpenCode version verified", {version: parsedVersion})
+    return {available: true, version: parsedVersion}
+  } catch {
+    logger.warning("OpenCode not available")
+    return {available: false, version: null}
+  }
+}
+```
+
+### 7. Updated Main Entry Point (`src/main.ts`)
+
+```typescript
+/**
+ * Fro Bot Agent - Main Entry Point
+ *
+ * GitHub Action harness for OpenCode + oMo agents with persistent session state.
+ * This is the entry point that orchestrates the agent workflow.
+ */
+
+import type {CacheKeyComponents} from "./lib/cache-key.js"
+import type {CacheResult} from "./lib/types.js"
+import type {ReactionContext} from "./lib/execution/types.js"
+import * as core from "@actions/core"
+import {restoreCache, saveCache} from "./lib/cache.js"
+import {parseActionInputs} from "./lib/inputs.js"
+import {createLogger} from "./lib/logger.js"
+import {setActionOutputs} from "./lib/outputs.js"
+import {collectExecutionContext} from "./lib/execution/context.js"
+import {buildAgentPrompt} from "./lib/execution/prompt.js"
+import {executeOpenCode, verifyOpenCodeAvailable} from "./lib/execution/opencode.js"
+import {acknowledgeReceipt, completeAcknowledgment} from "./lib/execution/reactions.js"
+import {
+  getGitHubRefName,
+  getGitHubRepository,
+  getGitHubRunId,
+  getOpenCodeAuthPath,
+  getOpenCodeStoragePath,
+  getRunnerOS,
+} from "./utils/env.js"
+
+/**
+ * Main action entry point.
+ * Orchestrates: acknowledge → collect context → execute agent → complete acknowledgment
+ */
+async function run(): Promise<void> {
+  const startTime = Date.now()
+  const bootstrapLogger = createLogger({phase: "bootstrap"})
+
+  // Track execution state for cleanup
+  let reactionCtx: ReactionContext | null = null
+  let executionSuccess = false
+
+  try {
+    bootstrapLogger.info("Starting Fro Bot Agent")
+
+    // 1. Parse and validate action inputs
+    const inputsResult = parseActionInputs()
+
+    if (!inputsResult.success) {
+      core.setFailed(`Invalid inputs: ${inputsResult.error.message}`)
+      return
+    }
+
+    const inputs = inputsResult.data
+    const logger = createLogger({phase: "main"})
+
+    logger.info("Action inputs parsed", {
+      sessionRetention: inputs.sessionRetention,
+      s3Backup: inputs.s3Backup,
+      hasGithubToken: inputs.githubToken.length > 0,
+      hasPrompt: inputs.prompt != null,
+    })
+
+    // 2. Verify OpenCode is available (from setup action)
+    const opencodePath = process.env["OPENCODE_PATH"] ?? null
+    const opencodeCheck = await verifyOpenCodeAvailable(opencodePath, logger)
+
+    if (!opencodeCheck.available) {
+      core.setFailed("OpenCode is not available. Did you run the setup action first?")
+      return
+    }
+
+    logger.info("OpenCode verified", {version: opencodeCheck.version})
+
+    // 3. Collect GitHub context
+    const contextLogger = createLogger({phase: "context"})
+    const executionContext = await collectExecutionContext(contextLogger)
+
+    // 4. Build reaction context for acknowledgment
+    const botLogin = process.env["BOT_LOGIN"] ?? null
+    reactionCtx = {
+      repo: executionContext.repo,
+      commentId: executionContext.commentId,
+      issueNumber: executionContext.issueNumber,
+      issueType: executionContext.issueType,
+      botLogin,
+    }
+
+    // 5. Acknowledge receipt immediately (eyes reaction + working label)
+    const ackLogger = createLogger({phase: "acknowledgment"})
+    await acknowledgeReceipt(reactionCtx, ackLogger)
+
+    // 6. Build cache key components and restore cache
+    const cacheComponents: CacheKeyComponents = {
+      agentIdentity: "github",
+      repo: getGitHubRepository(),
+      ref: getGitHubRefName(),
+      os: getRunnerOS(),
+    }
+
+    const cacheLogger = createLogger({phase: "cache"})
+    const cacheResult: CacheResult = await restoreCache({
+      components: cacheComponents,
+      logger: cacheLogger,
+      storagePath: getOpenCodeStoragePath(),
+      authPath: getOpenCodeAuthPath(),
+    })
+
+    const cacheStatus = cacheResult.corrupted ? "corrupted" : cacheResult.hit ? "hit" : "miss"
+    logger.info("Cache restore completed", {cacheStatus, key: cacheResult.key})
+
+    // 7. Build agent prompt
+    const promptLogger = createLogger({phase: "prompt"})
+    const prompt = buildAgentPrompt(
+      {
+        context: executionContext,
+        customPrompt: inputs.prompt,
+        cacheStatus,
+      },
+      promptLogger,
+    )
+
+    // 8. Execute OpenCode agent
+    const execLogger = createLogger({phase: "execution"})
+    const result = await executeOpenCode(prompt, opencodePath, execLogger)
+
+    executionSuccess = result.success
+
+    // 9. Calculate duration and set outputs
+    const duration = Date.now() - startTime
+
+    setActionOutputs({
+      sessionId: result.sessionId,
+      cacheStatus,
+      duration,
+    })
+
+    if (!result.success) {
+      core.setFailed(`Agent execution failed with exit code ${result.exitCode}`)
+    } else {
+      logger.info("Agent run completed successfully", {durationMs: duration})
+    }
+  } catch (error) {
+    const duration = Date.now() - startTime
+
+    setActionOutputs({
+      sessionId: null,
+      cacheStatus: "miss",
+      duration,
+    })
+
+    if (error instanceof Error) {
+      bootstrapLogger.error("Agent failed", {error: error.message})
+      core.setFailed(error.message)
+    } else {
+      bootstrapLogger.error("Agent failed with unknown error")
+      core.setFailed("An unknown error occurred")
+    }
+  } finally {
+    // Always cleanup: update reactions and save cache
+    try {
+      // Complete acknowledgment (update reaction, remove label)
+      if (reactionCtx != null) {
+        const cleanupLogger = createLogger({phase: "cleanup"})
+        await completeAcknowledgment(reactionCtx, executionSuccess, cleanupLogger)
+      }
+
+      // Save cache
+      const cacheComponents: CacheKeyComponents = {
+        agentIdentity: "github",
+        repo: getGitHubRepository(),
+        ref: getGitHubRefName(),
+        os: getRunnerOS(),
+      }
+
+      const cacheLogger = createLogger({phase: "cache-save"})
+      await saveCache({
+        components: cacheComponents,
+        runId: getGitHubRunId(),
+        logger: cacheLogger,
+        storagePath: getOpenCodeStoragePath(),
+        authPath: getOpenCodeAuthPath(),
+      })
+    } catch {
+      // Cleanup failures should not mask the original error
+    }
+  }
+}
+
+await run()
+```
+
+### 8. Index Exports (`src/lib/execution/index.ts`)
+
+```typescript
+// Types
+export type {ExecutionContext, ExecutionResult, ReactionContext, PromptOptions, AcknowledgmentState} from "./types.js"
+
+// Context collection
+export {collectExecutionContext} from "./context.js"
+
+// Prompt construction
+export {buildAgentPrompt} from "./prompt.js"
+
+// OpenCode execution
+export {executeOpenCode, verifyOpenCodeAvailable} from "./opencode.js"
+
+// Reactions & labels
+export {
+  addEyesReaction,
+  addWorkingLabel,
+  acknowledgeReceipt,
+  updateReactionOnSuccess,
+  updateReactionOnFailure,
+  removeWorkingLabel,
+  completeAcknowledgment,
+} from "./reactions.js"
+```
+
+---
+
+## Acceptance Criteria
+
+### Context Collection
+
+- [ ] Action collects event name, repo, ref, actor, run ID from environment
+- [ ] Action extracts comment body, author, and ID when triggered by comment
+- [ ] Action detects whether trigger is issue or PR using GitHub API
+- [ ] Action retrieves issue/PR title from API
+- [ ] Action gets repository default branch for PR base instructions
+
+### Prompt Construction
+
+- [ ] Prompt includes all environment context (repo, branch, event, actor, run ID)
+- [ ] Prompt includes issue/PR number and title when applicable
+- [ ] Prompt includes triggering comment body when applicable
+- [ ] Prompt includes session management instructions (session_search, session_read)
+- [ ] Prompt includes gh CLI examples for common operations
+- [ ] Prompt includes run summary requirement with template
+- [ ] Prompt includes custom user prompt when provided
+- [ ] Prompt includes cache status
+
+### Acknowledgment (Reactions & Labels)
+
+- [ ] Eyes reaction added to triggering comment immediately on receipt
+- [ ] "agent: working" label added to issue/PR on receipt
+- [ ] Label created with correct color and description if it doesn't exist
+- [ ] Eyes reaction replaced with hooray (🎉) on successful completion (closest available to peace sign)
+- [ ] Eyes reaction replaced with confused on failure
+- [ ] "agent: working" label removed on completion (success or failure)
+- [ ] All reaction/label operations are non-fatal (failures logged as warnings)
+
+### OpenCode Execution
+
+- [ ] OpenCode CLI executed with constructed prompt
+- [ ] `stdbuf -oL -eL` wrapper used on Linux for real-time log streaming
+- [ ] Direct execution on macOS/Windows (best-effort streaming)
+- [ ] Exit code captured and used to determine success/failure
+- [ ] Execution duration tracked
+
+### Main Action Lifecycle
+
+- [ ] Action verifies OpenCode available before proceeding
+- [ ] Action acknowledges receipt before any long-running operations
+- [ ] Action restores cache before agent execution
+- [ ] Action executes agent with constructed prompt
+- [ ] Action completes acknowledgment in finally block (always runs)
+- [ ] Action saves cache in finally block (always runs)
+- [ ] Action sets all outputs even on failure
+
+### Error Handling
+
+- [ ] OpenCode unavailable produces clear error message
+- [ ] Execution failures reported via `core.setFailed()`
+- [ ] Cleanup runs even when main execution fails
+- [ ] Cleanup failures don't mask original errors
+
+---
+
+## Test Cases
+
+### Context Collection
+
+```typescript
+describe("collectExecutionContext", () => {
+  it("extracts all environment variables", async () => {
+    process.env["GITHUB_EVENT_NAME"] = "issue_comment"
+    process.env["GITHUB_REPOSITORY"] = "owner/repo"
+    process.env["COMMENT_BODY"] = "Hello agent"
+
+    const ctx = await collectExecutionContext(mockLogger)
+
+    expect(ctx.eventName).toBe("issue_comment")
+    expect(ctx.repo).toBe("owner/repo")
+    expect(ctx.commentBody).toBe("Hello agent")
+  })
+
+  it("handles missing optional values gracefully", async () => {
+    delete process.env["COMMENT_BODY"]
+    delete process.env["ISSUE_NUMBER"]
+
+    const ctx = await collectExecutionContext(mockLogger)
+
+    expect(ctx.commentBody).toBeNull()
+    expect(ctx.issueNumber).toBeNull()
+  })
+})
+```
+
+### Prompt Construction
+
+```typescript
+describe("buildAgentPrompt", () => {
+  it("includes all context sections", () => {
+    const prompt = buildAgentPrompt(
+      {
+        context: mockContext,
+        customPrompt: null,
+        cacheStatus: "hit",
+      },
+      mockLogger,
+    )
+
+    expect(prompt).toContain("Repository:")
+    expect(prompt).toContain("Session Management")
+    expect(prompt).toContain("gh CLI")
+    expect(prompt).toContain("Run Summary")
+  })
+
+  it("includes custom prompt when provided", () => {
+    const prompt = buildAgentPrompt(
+      {
+        context: mockContext,
+        customPrompt: "Focus on security",
+        cacheStatus: "miss",
+      },
+      mockLogger,
+    )
+
+    expect(prompt).toContain("Custom Instructions")
+    expect(prompt).toContain("Focus on security")
+  })
+})
+```
+
+### Reactions
+
+```typescript
+describe("acknowledgeReceipt", () => {
+  it("adds eyes reaction and working label in parallel", async () => {
+    const ghExecCalls: string[][] = []
+    // Mock exec.exec to capture calls
+
+    await acknowledgeReceipt(mockReactionCtx, mockLogger)
+
+    expect(ghExecCalls).toContainEqual(expect.arrayContaining(["eyes"]))
+    expect(ghExecCalls).toContainEqual(expect.arrayContaining(["agent: working"]))
+  })
+
+  it("handles API failures gracefully", async () => {
+    // Mock exec.exec to throw
+    await expect(acknowledgeReceipt(mockReactionCtx, mockLogger)).resolves.not.toThrow()
+  })
+})
+```
+
+### OpenCode Execution
+
+```typescript
+describe("executeOpenCode", () => {
+  it("uses stdbuf on Linux", async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, "platform", {value: "linux"})
+
+    await executeOpenCode("test prompt", null, mockLogger)
+
+    expect(execCalls[0]).toContain("stdbuf")
+
+    Object.defineProperty(process, "platform", {value: originalPlatform})
+  })
+
+  it("executes directly on non-Linux", async () => {
+    Object.defineProperty(process, "platform", {value: "darwin"})
+
+    await executeOpenCode("test prompt", null, mockLogger)
+
+    expect(execCalls[0]).not.toContain("stdbuf")
+  })
+})
+```
+
+---
+
+## Security Considerations
+
+1. **Prompt injection**: Custom prompts are included verbatim but sandboxed within the agent's system prompt
+2. **Token exposure**: GH_TOKEN is set by setup action, not logged by this action
+3. **Reaction API calls**: Use `silent: true` to avoid leaking repo/comment IDs
+4. **Bot identity**: Bot login used for reaction cleanup must match authenticated user
+
+---
+
+## Platform Considerations
+
+| Platform              | stdbuf Available    | Log Streaming             |
+| --------------------- | ------------------- | ------------------------- |
+| Linux (ubuntu-latest) | Yes (GNU coreutils) | Real-time (line-buffered) |
+| macOS                 | No (BSD coreutils)  | Buffered (block)          |
+| Windows               | No                  | Buffered (block)          |
+
+Real-time streaming is a UX improvement, not a functional requirement. The action works correctly on all platforms.
+
+---
+
+## Integration with Other RFCs
+
+| RFC     | Integration Point                                  |
+| ------- | -------------------------------------------------- |
+| RFC-001 | Uses logger, types                                 |
+| RFC-002 | Restores/saves cache                               |
+| RFC-003 | Uses GitHub client for API calls (if needed)       |
+| RFC-004 | Session ID from agent run (future integration)     |
+| RFC-005 | Event classification determines context collection |
+| RFC-006 | Permission check before execution (future)         |
+| RFC-007 | Metrics from execution result                      |
+| RFC-011 | Consumes setup outputs (opencode-path, bot-login)  |
+
+---
+
+## Environment Variables Consumed
+
+| Variable          | Source       | Purpose                         |
+| ----------------- | ------------ | ------------------------------- |
+| GITHUB_EVENT_NAME | GitHub       | Event type identification       |
+| GITHUB_REPOSITORY | GitHub       | Repository context              |
+| GITHUB_REF_NAME   | GitHub       | Branch/ref context              |
+| GITHUB_ACTOR      | GitHub       | Triggering user                 |
+| GITHUB_RUN_ID     | GitHub       | Run identification              |
+| COMMENT_BODY      | Workflow     | Triggering comment content      |
+| COMMENT_AUTHOR    | Workflow     | Comment author username         |
+| COMMENT_ID        | Workflow     | Comment ID for reactions        |
+| ISSUE_NUMBER      | Workflow     | Issue/PR number                 |
+| DEFAULT_BRANCH    | Workflow     | Repository default branch       |
+| OPENCODE_PATH     | Setup Action | Path to OpenCode binary         |
+| BOT_LOGIN         | Setup Action | Authenticated bot username      |
+| GH_TOKEN          | Setup Action | GitHub CLI authentication token |
+
+---
+
+## Estimated Effort
+
+- **Development**: 12-16 hours
+- **Testing**: 4-6 hours
+- **Total**: 16-22 hours
+
+---
+
+## Implementation Notes
+
+1. **Setup action prerequisite**: Main action assumes setup action has run (OpenCode installed, gh authenticated)
+2. **Parallel operations**: Acknowledge and cache restore could run in parallel for faster startup
+3. **Non-blocking reactions**: All reaction operations are fire-and-forget with warning on failure
+4. **Session integration placeholder**: ExecutionResult.sessionId is null until RFC-004 integration
+5. **Prompt size**: Monitor prompt length - very long custom prompts could exceed model context

--- a/RFCs/RFCS.md
+++ b/RFCs/RFCS.md
@@ -1,8 +1,8 @@
 # Fro Bot Agent - RFC Index
 
-**Generated:** 2026-01-03
-**Total RFCs:** 11
-**Implementation Strategy:** Sequential (RFC-001 → RFC-011)
+**Generated:** 2026-01-04
+**Total RFCs:** 12
+**Implementation Strategy:** Sequential (RFC-001 → RFC-012)
 
 ---
 
@@ -29,6 +29,7 @@ The agent harness enables OpenCode with oMo "Sisyphus-style" workflow to act as 
 | RFC-009 | PR Review Features                   | MUST     | High       | 3     | Pending   |
 | RFC-010 | Delegated Work (Push/PR)             | MUST     | High       | 3     | Pending   |
 | RFC-011 | Setup Action & Environment Bootstrap | MUST     | High       | 1     | Pending   |
+| RFC-012 | Agent Execution & Main Action        | MUST     | High       | 1     | Pending   |
 
 ---
 
@@ -40,7 +41,11 @@ RFC-001 (Foundation)
     ├── RFC-011 (Setup Action) ─────────┐
     │       │                           │
     │       └── [OpenCode, oMo, gh]     │
-    │                                   │
+    │               │                   │
+    │               └── RFC-012 (Agent Execution)
+    │                       │
+    │                       └── [Run OpenCode, reactions, context]
+    │
     ├── RFC-002 (Cache) ──────────────┐ │
     │       │                         │ │
     │       └── RFC-004 (Sessions) ───┼─┼── RFC-007 (Observability)
@@ -76,8 +81,9 @@ RFC-001 (Foundation)
 | RFC-002 | Cache restore/save, auth.json exclusion  | 9-12 hours       |
 | RFC-003 | Octokit client, context parsing          | 6-9 hours        |
 | RFC-011 | Setup action, OpenCode/oMo install, gh   | 14-20 hours      |
+| RFC-012 | Agent execution, reactions, context      | 16-22 hours      |
 
-**Phase 1 Total:** ~35-50 hours
+**Phase 1 Total:** ~51-72 hours
 
 **Milestone:** Action can restore/save cache, parse GitHub context, and bootstrap OpenCode/oMo environment.
 
@@ -118,12 +124,12 @@ RFC-001 (Foundation)
 
 ## Total Estimated Effort
 
-| Phase     | Effort Range     |
-| --------- | ---------------- |
-| Phase 1   | 35-50 hours      |
-| Phase 2   | 29-41 hours      |
-| Phase 3   | 33-42 hours      |
-| **Total** | **97-133 hours** |
+| Phase     | Effort Range      |
+| --------- | ----------------- |
+| Phase 1   | 51-72 hours       |
+| Phase 2   | 29-41 hours       |
+| Phase 3   | 33-42 hours       |
+| **Total** | **113-155 hours** |
 
 ---
 
@@ -144,7 +150,7 @@ RFC-001 (Foundation)
    - Run project-adaptive validation (tests, build, lint)
    - Update this document's Status column to "Completed"
 
-3. **Implement RFCs strictly in numerical order** (001 → 002 → ... → 010)
+3. **Implement RFCs strictly in numerical order** (001 → 002 → ... → 012)
 
 ---
 
@@ -179,10 +185,10 @@ RFC-001 (Foundation)
 | F33: Error Message Format              | RFC-008          | Pending |
 | F10: Setup Action Entrypoint           | RFC-011          | Pending |
 | F37: Action Inputs Configuration       | RFC-001, RFC-011 | Pending |
-| F41: Agent Prompt Context Injection    | RFC-011          | Pending |
-| F42: gh CLI Operation Instructions     | RFC-011          | Pending |
-| F43: Reactions & Labels Acknowledgment | RFC-008          | Pending |
-| F44: Issue vs PR Context Detection     | RFC-005          | Pending |
+| F41: Agent Prompt Context Injection    | RFC-012          | Pending |
+| F42: gh CLI Operation Instructions     | RFC-012          | Pending |
+| F43: Reactions & Labels Acknowledgment | RFC-012          | Pending |
+| F44: Issue vs PR Context Detection     | RFC-012          | Pending |
 
 ### P1 Features (Should-Have) - Future RFCs
 

--- a/RULES.md
+++ b/RULES.md
@@ -650,17 +650,25 @@ pnpm test         # Run tests
 | `FEATURES.md`      | Feature specifications   |
 | `AGENTS.md`        | Project conventions      |
 
-### Session Tools (Required Usage)
+### Session Tools: Action vs Agent
 
-```typescript
-// On startup - search for prior work
-await session_search(query)
-await session_read(sessionId)
+**Two layers of session management exist:**
 
-// On completion - record for future
-await session_info(sessionId)
-await session_list()
-```
+1. **oMo Session Tools (Agent-side)** - LLM tools provided by Oh My OpenCode plugin to AI agents during runtime:
+   - `session_search` - Full-text search across sessions
+   - `session_read` - Read session messages and history
+   - `session_info` - Get session metadata and statistics
+   - `session_list` - List available sessions
+
+   These are invoked by the agent through natural language via the LLM tool-calling interface. The agent prompt MUST instruct use of these tools before re-investigating.
+
+2. **RFC-004 Utilities (Action-side)** - TypeScript functions used by the GitHub Action harness:
+   - `listSessions()` - Startup introspection
+   - `searchSessions()` - Find relevant prior sessions
+   - `pruneSessions()` - Retention policy enforcement
+   - `writeSessionSummary()` - Close-the-loop writeback
+
+   These run before/after agent execution in the action lifecycle.
 
 ### GitHub CLI Authentication
 


### PR DESCRIPTION
Resolves architectural ambiguity between RFC-004 utilities and oMo
session tools by establishing clear boundaries:

MAJOR CHANGES:
- Document two-layer architecture in AGENTS.md, PRD.md, FEATURES.md
- Action-side (RFC-004): listSessions, searchSessions, pruneSessions,
  writeSessionSummary for infrastructure operations
- Agent-side (oMo): session_list, session_read, session_search,
  session_info for runtime introspection
- Both layers operate on same OpenCode storage directory

RFC-004 Updates:
- Rewrite Summary to clarify this RFC defines action utilities, not
  agent tools
- Add OpenCode storage format documentation (JSON files, not SQLite)
- Implement proper types matching OpenCode schemas (SessionInfo,
  Message, Part)
- Add storage.ts with OpenCode-compatible read/write operations
- Update search.ts to work with OpenCode part-based message storage
- Add child session cleanup to pruning logic
- Update writeSessionSummary to write valid OpenCode message format

RFC-011 Updates:
- Clarify GitHub App authentication via RFC-003's createAppClient()
- Add version fallback pattern (latest → 1.0.204)
- Add download validation with `file` command
- Document stdbuf usage for real-time log streaming
- Add oMo installation verification
- Update acceptance criteria for robustness improvements

RFC-012 (NEW):
- Define main action execution lifecycle
- Implement context collection (event, repo, issue/PR detection)
- Implement prompt construction with session management instructions
- Implement reactions & labels (eyes → hooray/confused, working label)
- Implement OpenCode CLI execution with stdbuf wrapper on Linux
- Update src/main.ts with full orchestration flow

FEATURES.md Changes:
- F15: Update session search to document two layers
- F16: Update session summary writeback to show action-side operation
- F17: Update session pruning to clarify action harness responsibility
- F43: Update reactions to use hooray (🎉) instead of unsupported peace

PRD.md Changes:
- Add two-layer session management table
- Clarify action harness uses RFC-004, agent uses oMo tools
- Update session pruning to be action-only operation

RULES.md Changes:
- Replace "Session Tools (Required Usage)" section with two-layer
  architecture explanation
- Document both oMo LLM tools and RFC-004 TypeScript utilities

RFCS.md Updates:
- Add RFC-012 to index
- Update feature mappings (F41-F44 now RFC-012)
- Update total effort estimate (113-155 hours)
- Update dependency graph

Research Documentation:
- Add RFC-011-RESEARCH-SUMMARY.md documenting gaps, Sisyphus patterns,
  and resolution of GitHub App auth via RFC-003