### PR TITLE
feat(session): implement OpenCode session management (RFC-004)

### DIFF
--- a/RFCs/RFC-004-Session-Management.md
+++ b/RFCs/RFC-004-Session-Management.md
@@ -1,9 +1,6 @@
 # RFC-004: Session Management Integration
 
-**Status:** Pending
-**Priority:** MUST
-**Complexity:** Medium
-**Phase:** 2
+**Status:** Pending **Priority:** MUST **Complexity:** Medium **Phase:** 2
 
 ---
 
@@ -1358,3 +1355,22 @@ describe("OpenCode storage format compatibility", () => {
 - **Development**: 8-10 hours
 - **Testing**: 4-5 hours
 - **Total**: 12-15 hours
+
+---
+
+## Completion Notes
+
+**Date:** 2026-01-06
+
+**Summary:** Implemented session management utilities for the Fro Bot agent harness:
+
+- `src/lib/session/types.ts` - OpenCode-compatible types (SessionInfo, Message, Part, etc.)
+- `src/lib/session/storage.ts` - Storage access utilities (list, read, delete operations)
+- `src/lib/session/search.ts` - Session list and search operations
+- `src/lib/session/prune.ts` - Session pruning with retention policy
+- `src/lib/session/writeback.ts` - Run summary writeback to session storage
+- `src/lib/session/index.ts` - Public exports
+
+**Tests:** 48 new tests covering all acceptance criteria
+
+**Deviations:** None - implementation follows RFC specification exactly

--- a/RFCs/RFCS.md
+++ b/RFCs/RFCS.md
@@ -1,8 +1,6 @@
 # Fro Bot Agent - RFC Index
 
-**Generated:** 2026-01-04
-**Total RFCs:** 12
-**Implementation Strategy:** Sequential (RFC-001 → RFC-012)
+**Generated:** 2026-01-04 **Total RFCs:** 12 **Implementation Strategy:** Sequential (RFC-001 → RFC-012)
 
 ---
 
@@ -21,7 +19,7 @@ The agent harness enables OpenCode with oMo "Sisyphus-style" workflow to act as 
 | RFC-001 | Foundation & Core Types              | MUST     | Medium     | 1     | Completed |
 | RFC-002 | Cache Infrastructure                 | MUST     | High       | 1     | Completed |
 | RFC-003 | GitHub API Client Layer              | MUST     | Medium     | 1     | Completed |
-| RFC-004 | Session Management Integration       | MUST     | Medium     | 2     | Pending   |
+| RFC-004 | Session Management Integration       | MUST     | Medium     | 2     | Completed |
 | RFC-005 | GitHub Triggers & Event Handling     | MUST     | Medium     | 2     | Pending   |
 | RFC-006 | Security & Permission Gating         | MUST     | Medium     | 2     | Pending   |
 | RFC-007 | Observability & Run Summary          | MUST     | Medium     | 2     | Pending   |

--- a/src/lib/session/index.ts
+++ b/src/lib/session/index.ts
@@ -1,0 +1,52 @@
+// Pruning
+export {DEFAULT_PRUNING_CONFIG, pruneSessions} from './prune.js'
+
+// Search operations
+export {getSessionInfo, listSessions, searchSessions} from './search.js'
+
+// Storage utilities
+export {
+  deleteSession,
+  findProjectByDirectory,
+  getMessageParts,
+  getOpenCodeStoragePath,
+  getSession,
+  getSessionMessages,
+  getSessionTodos,
+  listProjects,
+  listSessionsForProject,
+} from './storage.js'
+
+// Types
+export type {
+  AssistantMessage,
+  FileDiff,
+  FilePart,
+  Logger,
+  Message,
+  MessageError,
+  Part,
+  PartBase,
+  PermissionRuleset,
+  ProjectInfo,
+  PruneResult,
+  PruningConfig,
+  ReasoningPart,
+  SessionInfo,
+  SessionMatch,
+  SessionSearchResult,
+  SessionSummary,
+  StepFinishPart,
+  TextPart,
+  TodoItem,
+  ToolPart,
+  ToolState,
+  ToolStateCompleted,
+  ToolStateError,
+  ToolStatePending,
+  ToolStateRunning,
+  UserMessage,
+} from './types.js'
+
+// Writeback
+export {writeSessionSummary} from './writeback.js'

--- a/src/lib/session/prune.test.ts
+++ b/src/lib/session/prune.test.ts
@@ -1,0 +1,336 @@
+import type {Logger} from './types.js'
+
+import * as fs from 'node:fs/promises'
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {DEFAULT_PRUNING_CONFIG, pruneSessions} from './prune.js'
+
+// Mock fs module
+vi.mock('node:fs/promises')
+vi.mock('node:os')
+
+const mockLogger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+}
+
+// Helper to create mock session data
+function createMockSession(id: string, updatedAt: number, parentID?: string) {
+  return {
+    id,
+    version: '1.0.0',
+    projectID: 'proj1',
+    directory: '/path/to/repo',
+    title: `Session ${id}`,
+    time: {created: updatedAt - 1000, updated: updatedAt},
+    parentID,
+  }
+}
+
+// Helper to create mock project data
+function createMockProject(id: string, worktree: string) {
+  return {
+    id,
+    worktree,
+    vcs: 'git',
+    time: {created: 1000, updated: 2000},
+  }
+}
+
+describe('DEFAULT_PRUNING_CONFIG', () => {
+  it('has expected default values', () => {
+    expect(DEFAULT_PRUNING_CONFIG.maxSessions).toBe(50)
+    expect(DEFAULT_PRUNING_CONFIG.maxAgeDays).toBe(30)
+  })
+})
+
+describe('pruneSessions', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env.XDG_DATA_HOME = '/test/data'
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-06-15T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+    delete process.env.XDG_DATA_HOME
+  })
+
+  it('returns empty result when no project found', async () => {
+    // #given
+    vi.mocked(fs.readdir).mockRejectedValue(new Error('ENOENT'))
+
+    // #when
+    const result = await pruneSessions('/nonexistent', DEFAULT_PRUNING_CONFIG, mockLogger)
+
+    // #then
+    expect(result.prunedCount).toBe(0)
+    expect(result.remainingCount).toBe(0)
+    expect(result.freedBytes).toBe(0)
+  })
+
+  it('keeps at least maxSessions even if older than maxAgeDays', async () => {
+    // #given
+    const project = createMockProject('proj1', '/path/to/repo')
+    const now = Date.now()
+    const oldTime = now - 60 * 24 * 60 * 60 * 1000 // 60 days ago
+
+    // Create 5 old sessions
+    const sessions = [
+      createMockSession('ses_1', oldTime),
+      createMockSession('ses_2', oldTime + 1000),
+      createMockSession('ses_3', oldTime + 2000),
+      createMockSession('ses_4', oldTime + 3000),
+      createMockSession('ses_5', oldTime + 4000),
+    ]
+
+    vi.mocked(fs.readdir).mockImplementation(async dirPath => {
+      const pathStr = String(dirPath)
+      if (pathStr.includes('/project')) {
+        return [{name: 'proj1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/session/')) {
+        return sessions.map(s => ({
+          name: `${s.id}.json`,
+          isFile: () => true,
+          isDirectory: () => false,
+        })) as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      if (pathStr.includes('/message/')) {
+        return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(async filePath => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/project/')) return JSON.stringify(project)
+      for (const session of sessions) {
+        if (pathStr.includes(`${session.id}.json`)) return JSON.stringify(session)
+      }
+      throw new Error('ENOENT')
+    })
+
+    vi.mocked(fs.stat).mockResolvedValue({size: 100} as Awaited<ReturnType<typeof fs.stat>>)
+    vi.mocked(fs.unlink).mockResolvedValue(undefined)
+    vi.mocked(fs.rm).mockResolvedValue(undefined)
+
+    // #when - maxSessions=3 should keep 3 most recent even though all are older than 30 days
+    const result = await pruneSessions('/path/to/repo', {maxSessions: 3, maxAgeDays: 30}, mockLogger)
+
+    // #then
+    expect(result.remainingCount).toBe(3)
+    expect(result.prunedCount).toBe(2) // 5 - 3 = 2 pruned
+  })
+
+  it('keeps recent sessions even if count exceeds maxSessions', async () => {
+    // #given
+    const project = createMockProject('proj1', '/path/to/repo')
+    const now = Date.now()
+
+    // Create 5 recent sessions (within 30 days)
+    const sessions = [
+      createMockSession('ses_1', now - 1 * 24 * 60 * 60 * 1000), // 1 day ago
+      createMockSession('ses_2', now - 2 * 24 * 60 * 60 * 1000), // 2 days ago
+      createMockSession('ses_3', now - 3 * 24 * 60 * 60 * 1000), // 3 days ago
+      createMockSession('ses_4', now - 4 * 24 * 60 * 60 * 1000), // 4 days ago
+      createMockSession('ses_5', now - 5 * 24 * 60 * 60 * 1000), // 5 days ago
+    ]
+
+    vi.mocked(fs.readdir).mockImplementation(async dirPath => {
+      const pathStr = String(dirPath)
+      if (pathStr.includes('/project')) {
+        return [{name: 'proj1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/session/')) {
+        return sessions.map(s => ({
+          name: `${s.id}.json`,
+          isFile: () => true,
+          isDirectory: () => false,
+        })) as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      if (pathStr.includes('/message/')) {
+        return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(async filePath => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/project/')) return JSON.stringify(project)
+      for (const session of sessions) {
+        if (pathStr.includes(`${session.id}.json`)) return JSON.stringify(session)
+      }
+      throw new Error('ENOENT')
+    })
+
+    // #when - maxSessions=2 but all are within 30 days, so all should be kept
+    const result = await pruneSessions('/path/to/repo', {maxSessions: 2, maxAgeDays: 30}, mockLogger)
+
+    // #then - all 5 sessions are within 30 days, so none should be pruned
+    expect(result.prunedCount).toBe(0)
+    expect(result.remainingCount).toBe(5)
+  })
+
+  it('also prunes child sessions of pruned parents', async () => {
+    // #given
+    const project = createMockProject('proj1', '/path/to/repo')
+    const now = Date.now()
+    const oldTime = now - 60 * 24 * 60 * 60 * 1000 // 60 days ago
+
+    // Create parent and child sessions
+    const sessions = [
+      createMockSession('ses_parent', oldTime), // Old parent - will be pruned
+      createMockSession('ses_child', oldTime + 1000, 'ses_parent'), // Child of old parent
+      createMockSession('ses_recent', now - 1000), // Recent - will be kept
+    ]
+
+    vi.mocked(fs.readdir).mockImplementation(async dirPath => {
+      const pathStr = String(dirPath)
+      if (pathStr.includes('/project')) {
+        return [{name: 'proj1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/session/')) {
+        return sessions.map(s => ({
+          name: `${s.id}.json`,
+          isFile: () => true,
+          isDirectory: () => false,
+        })) as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      if (pathStr.includes('/message/')) {
+        return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(async filePath => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/project/')) return JSON.stringify(project)
+      for (const session of sessions) {
+        if (pathStr.includes(`${session.id}.json`)) return JSON.stringify(session)
+      }
+      throw new Error('ENOENT')
+    })
+
+    vi.mocked(fs.stat).mockResolvedValue({size: 100} as Awaited<ReturnType<typeof fs.stat>>)
+    vi.mocked(fs.unlink).mockResolvedValue(undefined)
+    vi.mocked(fs.rm).mockResolvedValue(undefined)
+
+    // #when - maxSessions=1 should keep only the most recent
+    const result = await pruneSessions('/path/to/repo', {maxSessions: 1, maxAgeDays: 30}, mockLogger)
+
+    // #then - both parent and child should be pruned
+    expect(result.prunedSessionIds).toContain('ses_parent')
+    expect(result.prunedSessionIds).toContain('ses_child')
+    expect(result.prunedCount).toBe(2)
+    expect(result.remainingCount).toBe(1)
+  })
+
+  it('reports freed bytes accurately', async () => {
+    // #given
+    const project = createMockProject('proj1', '/path/to/repo')
+    const now = Date.now()
+    const oldTime = now - 60 * 24 * 60 * 60 * 1000 // 60 days ago
+
+    const sessions = [createMockSession('ses_old', oldTime), createMockSession('ses_recent', now - 1000)]
+
+    vi.mocked(fs.readdir).mockImplementation(async dirPath => {
+      const pathStr = String(dirPath)
+      if (pathStr.includes('/project')) {
+        return [{name: 'proj1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/session/')) {
+        return sessions.map(s => ({
+          name: `${s.id}.json`,
+          isFile: () => true,
+          isDirectory: () => false,
+        })) as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      if (pathStr.includes('/message/')) {
+        return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(async filePath => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/project/')) return JSON.stringify(project)
+      for (const session of sessions) {
+        if (pathStr.includes(`${session.id}.json`)) return JSON.stringify(session)
+      }
+      throw new Error('ENOENT')
+    })
+
+    vi.mocked(fs.stat).mockResolvedValue({size: 500} as Awaited<ReturnType<typeof fs.stat>>)
+    vi.mocked(fs.unlink).mockResolvedValue(undefined)
+    vi.mocked(fs.rm).mockResolvedValue(undefined)
+
+    // #when
+    const result = await pruneSessions('/path/to/repo', {maxSessions: 1, maxAgeDays: 30}, mockLogger)
+
+    // #then
+    expect(result.freedBytes).toBeGreaterThanOrEqual(0)
+  })
+
+  it('handles deletion errors gracefully', async () => {
+    // #given
+    const project = createMockProject('proj1', '/path/to/repo')
+    const now = Date.now()
+    const oldTime = now - 60 * 24 * 60 * 60 * 1000 // 60 days ago
+
+    const sessions = [createMockSession('ses_old', oldTime), createMockSession('ses_recent', now - 1000)]
+
+    vi.mocked(fs.readdir).mockImplementation(async dirPath => {
+      const pathStr = String(dirPath)
+      if (pathStr.includes('/project')) {
+        return [{name: 'proj1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/session/')) {
+        return sessions.map(s => ({
+          name: `${s.id}.json`,
+          isFile: () => true,
+          isDirectory: () => false,
+        })) as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      if (pathStr.includes('/message/')) {
+        return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(async filePath => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/project/')) return JSON.stringify(project)
+      for (const session of sessions) {
+        if (pathStr.includes(`${session.id}.json`)) return JSON.stringify(session)
+      }
+      throw new Error('ENOENT')
+    })
+
+    vi.mocked(fs.stat).mockRejectedValue(new Error('Permission denied'))
+    vi.mocked(fs.unlink).mockRejectedValue(new Error('Permission denied'))
+    vi.mocked(fs.rm).mockRejectedValue(new Error('Permission denied'))
+
+    // #when
+    const result = await pruneSessions('/path/to/repo', {maxSessions: 1, maxAgeDays: 30}, mockLogger)
+
+    // #then - should complete without throwing, with 0 freed bytes
+    expect(result.prunedCount).toBe(1) // Still counts as pruned even if deletion failed
+    expect(result.freedBytes).toBe(0)
+  })
+})

--- a/src/lib/session/prune.ts
+++ b/src/lib/session/prune.ts
@@ -1,0 +1,137 @@
+import type {Logger, PruneResult, PruningConfig} from './types.js'
+
+import {deleteSession, findProjectByDirectory, listSessionsForProject} from './storage.js'
+
+/**
+ * Default pruning configuration.
+ */
+export const DEFAULT_PRUNING_CONFIG: PruningConfig = {
+  maxSessions: 50,
+  maxAgeDays: 30,
+}
+
+/**
+ * Prune old sessions based on retention policy.
+ *
+ * Retention logic: keep sessions that satisfy EITHER condition:
+ * - Within maxAgeDays of the current date
+ * - Within the most recent maxSessions (by updatedAt)
+ *
+ * This ensures we always keep at least maxSessions, even if they're older than maxAgeDays.
+ */
+export async function pruneSessions(directory: string, config: PruningConfig, logger: Logger): Promise<PruneResult> {
+  const {maxSessions, maxAgeDays} = config
+
+  logger.info('Starting session pruning', {directory, maxSessions, maxAgeDays})
+
+  // Find project
+  const project = await findProjectByDirectory(directory, logger)
+  if (project == null) {
+    logger.debug('No project found for pruning', {directory})
+    return {
+      prunedCount: 0,
+      prunedSessionIds: [],
+      remainingCount: 0,
+      freedBytes: 0,
+    }
+  }
+
+  // Get all sessions (including child sessions for cleanup)
+  const allSessions = await listSessionsForProject(project.id, logger)
+
+  // Filter to main sessions only for retention calculation
+  const mainSessions = allSessions.filter(s => s.parentID == null)
+
+  if (mainSessions.length === 0) {
+    return {
+      prunedCount: 0,
+      prunedSessionIds: [],
+      remainingCount: 0,
+      freedBytes: 0,
+    }
+  }
+
+  // Sort by updatedAt descending (most recent first)
+  const sortedSessions = [...mainSessions].sort((a, b) => b.time.updated - a.time.updated)
+
+  // Calculate cutoff date
+  const cutoffDate = new Date()
+  cutoffDate.setDate(cutoffDate.getDate() - maxAgeDays)
+  const cutoffTime = cutoffDate.getTime()
+
+  // Determine which sessions to keep
+  const sessionsToKeep = new Set<string>()
+
+  // Keep sessions within age limit
+  for (const session of sortedSessions) {
+    if (session.time.updated >= cutoffTime) {
+      sessionsToKeep.add(session.id)
+    }
+  }
+
+  // Ensure we keep at least maxSessions (most recent)
+  for (let i = 0; i < Math.min(maxSessions, sortedSessions.length); i++) {
+    const session = sortedSessions[i]
+    if (session != null) {
+      sessionsToKeep.add(session.id)
+    }
+  }
+
+  // Determine sessions to prune (main sessions not in keep set)
+  const mainSessionsToPrune = sortedSessions.filter(s => !sessionsToKeep.has(s.id))
+
+  // Also find child sessions of sessions being pruned
+  const allSessionsToPrune = new Set<string>()
+  for (const session of mainSessionsToPrune) {
+    allSessionsToPrune.add(session.id)
+    // Add child sessions
+    for (const child of allSessions) {
+      if (child.parentID === session.id) {
+        allSessionsToPrune.add(child.id)
+      }
+    }
+  }
+
+  if (allSessionsToPrune.size === 0) {
+    logger.info('No sessions to prune')
+    return {
+      prunedCount: 0,
+      prunedSessionIds: [],
+      remainingCount: mainSessions.length,
+      freedBytes: 0,
+    }
+  }
+
+  // Prune sessions
+  let freedBytes = 0
+  const prunedIds: string[] = []
+
+  for (const sessionId of allSessionsToPrune) {
+    try {
+      const bytes = await deleteSession(project.id, sessionId, logger)
+      freedBytes += bytes
+      prunedIds.push(sessionId)
+      logger.debug('Pruned session', {sessionId, bytes})
+    } catch (error) {
+      logger.warning('Failed to prune session', {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  const remainingCount = mainSessions.length - mainSessionsToPrune.length
+
+  logger.info('Session pruning complete', {
+    prunedCount: prunedIds.length,
+    remainingCount,
+    freedBytes,
+  })
+
+  return {
+    prunedCount: prunedIds.length,
+    prunedSessionIds: prunedIds,
+    remainingCount,
+    freedBytes,
+  }
+}

--- a/src/lib/session/search.test.ts
+++ b/src/lib/session/search.test.ts
@@ -1,0 +1,578 @@
+import type {Logger} from './types.js'
+
+import * as fs from 'node:fs/promises'
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getSessionInfo, listSessions, searchSessions} from './search.js'
+
+// Mock fs and os modules
+vi.mock('node:fs/promises')
+vi.mock('node:os')
+
+const mockLogger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+}
+
+// Helper to create mock session data
+function createMockSession(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    version: '1.0.0',
+    projectID: 'proj1',
+    directory: '/path/to/repo',
+    title: `Session ${id}`,
+    time: {created: 1000, updated: 2000},
+    ...overrides,
+  }
+}
+
+// Helper to create mock project data
+function createMockProject(id: string, worktree: string) {
+  return {
+    id,
+    worktree,
+    vcs: 'git',
+    time: {created: 1000, updated: 2000},
+  }
+}
+
+// Helper to create mock message data
+function createMockMessage(id: string, role: 'user' | 'assistant', agent: string, created: number) {
+  return {
+    id,
+    sessionID: 'ses_1',
+    role,
+    time: {created},
+    agent,
+    model: {providerID: 'test', modelID: 'test'},
+  }
+}
+
+describe('listSessions', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env.XDG_DATA_HOME = '/test/data'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.XDG_DATA_HOME
+  })
+
+  it('returns empty array when no project found', async () => {
+    // #given
+    vi.mocked(fs.readdir).mockRejectedValue(new Error('ENOENT'))
+
+    // #when
+    const result = await listSessions('/nonexistent', {}, mockLogger)
+
+    // #then
+    expect(result).toEqual([])
+  })
+
+  it('returns sessions sorted by updatedAt descending', async () => {
+    // #given
+    const project = createMockProject('proj1', '/path/to/repo')
+    const session1 = createMockSession('ses_1', {time: {created: 1000, updated: 1000}})
+    const session2 = createMockSession('ses_2', {time: {created: 2000, updated: 3000}})
+
+    // Mock project lookup
+    vi.mocked(fs.readdir).mockImplementation(async dirPath => {
+      const pathStr = String(dirPath)
+      if (pathStr.includes('/project')) {
+        return [{name: 'proj1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/session/')) {
+        return [
+          {name: 'ses_1.json', isFile: () => true, isDirectory: () => false},
+          {name: 'ses_2.json', isFile: () => true, isDirectory: () => false},
+        ] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      if (pathStr.includes('/message/')) {
+        return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(async filePath => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/project/')) return JSON.stringify(project)
+      if (pathStr.includes('ses_1.json')) return JSON.stringify(session1)
+      if (pathStr.includes('ses_2.json')) return JSON.stringify(session2)
+      throw new Error('ENOENT')
+    })
+
+    // #when
+    const result = await listSessions('/path/to/repo', {}, mockLogger)
+
+    // #then
+    expect(result).toHaveLength(2)
+    expect(result[0]?.id).toBe('ses_2') // Higher updatedAt first
+    expect(result[1]?.id).toBe('ses_1')
+  })
+
+  it('excludes child sessions (those with parentID)', async () => {
+    // #given
+    const project = createMockProject('proj1', '/path/to/repo')
+    const mainSession = createMockSession('ses_main', {})
+    const childSession = createMockSession('ses_child', {parentID: 'ses_main'})
+
+    vi.mocked(fs.readdir).mockImplementation(async dirPath => {
+      const pathStr = String(dirPath)
+      if (pathStr.includes('/project')) {
+        return [{name: 'proj1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/session/')) {
+        return [
+          {name: 'ses_main.json', isFile: () => true, isDirectory: () => false},
+          {name: 'ses_child.json', isFile: () => true, isDirectory: () => false},
+        ] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      if (pathStr.includes('/message/')) {
+        return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(async filePath => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/project/')) return JSON.stringify(project)
+      if (pathStr.includes('ses_main.json')) return JSON.stringify(mainSession)
+      if (pathStr.includes('ses_child.json')) return JSON.stringify(childSession)
+      throw new Error('ENOENT')
+    })
+
+    // #when
+    const result = await listSessions('/path/to/repo', {}, mockLogger)
+
+    // #then
+    expect(result).toHaveLength(1)
+    expect(result[0]?.id).toBe('ses_main')
+    expect(result.every(s => !s.isChild)).toBe(true)
+  })
+
+  it('respects limit parameter', async () => {
+    // #given
+    const project = createMockProject('proj1', '/path/to/repo')
+    const sessions = [
+      createMockSession('ses_1', {time: {created: 1000, updated: 1000}}),
+      createMockSession('ses_2', {time: {created: 2000, updated: 2000}}),
+      createMockSession('ses_3', {time: {created: 3000, updated: 3000}}),
+    ]
+
+    vi.mocked(fs.readdir).mockImplementation(async dirPath => {
+      const pathStr = String(dirPath)
+      if (pathStr.includes('/project')) {
+        return [{name: 'proj1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/session/')) {
+        return sessions.map(s => ({
+          name: `${s.id}.json`,
+          isFile: () => true,
+          isDirectory: () => false,
+        })) as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      if (pathStr.includes('/message/')) {
+        return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(async filePath => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/project/')) return JSON.stringify(project)
+      for (const session of sessions) {
+        if (pathStr.includes(`${session.id}.json`)) return JSON.stringify(session)
+      }
+      throw new Error('ENOENT')
+    })
+
+    // #when
+    const result = await listSessions('/path/to/repo', {limit: 2}, mockLogger)
+
+    // #then
+    expect(result).toHaveLength(2)
+  })
+
+  it('includes message count and agents in summary', async () => {
+    // #given
+    const project = createMockProject('proj1', '/path/to/repo')
+    const session = createMockSession('ses_1', {})
+    const messages = [
+      createMockMessage('msg_1', 'user', 'Sisyphus', 1000),
+      createMockMessage('msg_2', 'assistant', 'oracle', 2000),
+    ]
+
+    vi.mocked(fs.readdir).mockImplementation(async dirPath => {
+      const pathStr = String(dirPath)
+      if (pathStr.includes('/project')) {
+        return [{name: 'proj1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/session/')) {
+        return [{name: 'ses_1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/message/')) {
+        return messages.map(m => ({
+          name: `${m.id}.json`,
+          isFile: () => true,
+          isDirectory: () => false,
+        })) as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(async filePath => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/project/')) return JSON.stringify(project)
+      if (pathStr.includes('ses_1.json')) return JSON.stringify(session)
+      for (const msg of messages) {
+        if (pathStr.includes(`${msg.id}.json`)) return JSON.stringify(msg)
+      }
+      throw new Error('ENOENT')
+    })
+
+    // #when
+    const result = await listSessions('/path/to/repo', {}, mockLogger)
+
+    // #then
+    expect(result).toHaveLength(1)
+    expect(result[0]?.messageCount).toBe(2)
+    expect(result[0]?.agents).toContain('Sisyphus')
+    expect(result[0]?.agents).toContain('oracle')
+  })
+})
+
+describe('searchSessions', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env.XDG_DATA_HOME = '/test/data'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.XDG_DATA_HOME
+  })
+
+  it('searches text parts for matching content', async () => {
+    // #given
+    const project = createMockProject('proj1', '/path/to/repo')
+    const session = createMockSession('ses_1', {})
+    const message = createMockMessage('msg_1', 'user', 'test', 1000)
+    const part = {
+      id: 'prt_1',
+      sessionID: 'ses_1',
+      messageID: 'msg_1',
+      type: 'text',
+      text: 'This contains an error message',
+    }
+
+    vi.mocked(fs.readdir).mockImplementation(async dirPath => {
+      const pathStr = String(dirPath)
+      if (pathStr.includes('/project')) {
+        return [{name: 'proj1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/session/')) {
+        return [{name: 'ses_1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/message/')) {
+        return [{name: 'msg_1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/part/')) {
+        return [{name: 'prt_1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(async filePath => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/project/')) return JSON.stringify(project)
+      if (pathStr.includes('ses_1.json')) return JSON.stringify(session)
+      if (pathStr.includes('msg_1.json')) return JSON.stringify(message)
+      if (pathStr.includes('prt_1.json')) return JSON.stringify(part)
+      throw new Error('ENOENT')
+    })
+
+    // #when
+    const results = await searchSessions('error', '/path/to/repo', {}, mockLogger)
+
+    // #then
+    expect(results).toHaveLength(1)
+    expect(results[0]?.sessionId).toBe('ses_1')
+    expect(results[0]?.matches).toHaveLength(1)
+    expect(results[0]?.matches[0]?.excerpt).toContain('error')
+  })
+
+  it('respects caseSensitive option', async () => {
+    // #given
+    const project = createMockProject('proj1', '/path/to/repo')
+    const session = createMockSession('ses_1', {})
+    const message = createMockMessage('msg_1', 'user', 'test', 1000)
+    const part = {
+      id: 'prt_1',
+      sessionID: 'ses_1',
+      messageID: 'msg_1',
+      type: 'text',
+      text: 'This contains an Error message',
+    }
+
+    vi.mocked(fs.readdir).mockImplementation(async dirPath => {
+      const pathStr = String(dirPath)
+      if (pathStr.includes('/project')) {
+        return [{name: 'proj1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/session/')) {
+        return [{name: 'ses_1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/message/')) {
+        return [{name: 'msg_1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/part/')) {
+        return [{name: 'prt_1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(async filePath => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/project/')) return JSON.stringify(project)
+      if (pathStr.includes('ses_1.json')) return JSON.stringify(session)
+      if (pathStr.includes('msg_1.json')) return JSON.stringify(message)
+      if (pathStr.includes('prt_1.json')) return JSON.stringify(part)
+      throw new Error('ENOENT')
+    })
+
+    // #when - case insensitive should find it
+    const caseInsensitive = await searchSessions('error', '/path/to/repo', {caseSensitive: false}, mockLogger)
+
+    // #then
+    expect(caseInsensitive).toHaveLength(1)
+
+    // #when - case sensitive should NOT find 'error' (only 'Error' exists)
+    const caseSensitive = await searchSessions('error', '/path/to/repo', {caseSensitive: true}, mockLogger)
+
+    // #then
+    expect(caseSensitive).toHaveLength(0)
+  })
+
+  it('searches tool output in completed tool parts', async () => {
+    // #given
+    const project = createMockProject('proj1', '/path/to/repo')
+    const session = createMockSession('ses_1', {})
+    const message = createMockMessage('msg_1', 'assistant', 'test', 1000)
+    const part = {
+      id: 'prt_1',
+      sessionID: 'ses_1',
+      messageID: 'msg_1',
+      type: 'tool',
+      callID: 'call_1',
+      tool: 'bash',
+      state: {
+        status: 'completed',
+        input: {command: 'ls'},
+        output: 'command output with special data',
+        title: 'Run bash',
+        metadata: {},
+        time: {start: 1000, end: 2000},
+      },
+    }
+
+    vi.mocked(fs.readdir).mockImplementation(async dirPath => {
+      const pathStr = String(dirPath)
+      if (pathStr.includes('/project')) {
+        return [{name: 'proj1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/session/')) {
+        return [{name: 'ses_1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/message/')) {
+        return [{name: 'msg_1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/part/')) {
+        return [{name: 'prt_1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(async filePath => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/project/')) return JSON.stringify(project)
+      if (pathStr.includes('ses_1.json')) return JSON.stringify(session)
+      if (pathStr.includes('msg_1.json')) return JSON.stringify(message)
+      if (pathStr.includes('prt_1.json')) return JSON.stringify(part)
+      throw new Error('ENOENT')
+    })
+
+    // #when
+    const results = await searchSessions('special data', '/path/to/repo', {}, mockLogger)
+
+    // #then
+    expect(results).toHaveLength(1)
+    expect(results[0]?.matches[0]?.excerpt).toContain('special data')
+  })
+
+  it('respects limit parameter', async () => {
+    // #given
+    const project = createMockProject('proj1', '/path/to/repo')
+    const session = createMockSession('ses_1', {})
+    const message = createMockMessage('msg_1', 'user', 'test', 1000)
+    const parts = [
+      {id: 'prt_1', sessionID: 'ses_1', messageID: 'msg_1', type: 'text', text: 'match one'},
+      {id: 'prt_2', sessionID: 'ses_1', messageID: 'msg_1', type: 'text', text: 'match two'},
+      {id: 'prt_3', sessionID: 'ses_1', messageID: 'msg_1', type: 'text', text: 'match three'},
+    ]
+
+    vi.mocked(fs.readdir).mockImplementation(async dirPath => {
+      const pathStr = String(dirPath)
+      if (pathStr.includes('/project')) {
+        return [{name: 'proj1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/session/')) {
+        return [{name: 'ses_1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/message/')) {
+        return [{name: 'msg_1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/part/')) {
+        return parts.map(p => ({
+          name: `${p.id}.json`,
+          isFile: () => true,
+          isDirectory: () => false,
+        })) as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(async filePath => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/project/')) return JSON.stringify(project)
+      if (pathStr.includes('ses_1.json')) return JSON.stringify(session)
+      if (pathStr.includes('msg_1.json')) return JSON.stringify(message)
+      for (const part of parts) {
+        if (pathStr.includes(`${part.id}.json`)) return JSON.stringify(part)
+      }
+      throw new Error('ENOENT')
+    })
+
+    // #when
+    const results = await searchSessions('match', '/path/to/repo', {limit: 2}, mockLogger)
+
+    // #then
+    expect(results).toHaveLength(1)
+    expect(results[0]?.matches.length).toBeLessThanOrEqual(2)
+  })
+})
+
+describe('getSessionInfo', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env.XDG_DATA_HOME = '/test/data'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.XDG_DATA_HOME
+  })
+
+  it('returns null when session does not exist', async () => {
+    // #given
+    vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT'))
+
+    // #when
+    const result = await getSessionInfo('nonexistent', 'proj1', mockLogger)
+
+    // #then
+    expect(result).toBeNull()
+  })
+
+  it('returns session info with message count and agents', async () => {
+    // #given
+    const session = createMockSession('ses_1', {})
+    const messages = [
+      createMockMessage('msg_1', 'user', 'Sisyphus', 1000),
+      createMockMessage('msg_2', 'assistant', 'oracle', 2000),
+    ]
+    const todos = [
+      {id: '1', content: 'Task 1', status: 'completed', priority: 'high'},
+      {id: '2', content: 'Task 2', status: 'pending', priority: 'low'},
+    ]
+
+    vi.mocked(fs.readdir).mockImplementation(async dirPath => {
+      const pathStr = String(dirPath)
+      if (pathStr.includes('/message/')) {
+        return messages.map(m => ({
+          name: `${m.id}.json`,
+          isFile: () => true,
+          isDirectory: () => false,
+        })) as unknown as Awaited<ReturnType<typeof fs.readdir>>
+      }
+      return [] as unknown as Awaited<ReturnType<typeof fs.readdir>>
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(async filePath => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('ses_1.json') && pathStr.includes('/session/')) return JSON.stringify(session)
+      if (pathStr.includes('/todo/')) return JSON.stringify(todos)
+      for (const msg of messages) {
+        if (pathStr.includes(`${msg.id}.json`)) return JSON.stringify(msg)
+      }
+      throw new Error('ENOENT')
+    })
+
+    // #when
+    const result = await getSessionInfo('ses_1', 'proj1', mockLogger)
+
+    // #then
+    expect(result).not.toBeNull()
+    expect(result?.session.id).toBe('ses_1')
+    expect(result?.messageCount).toBe(2)
+    expect(result?.agents).toContain('Sisyphus')
+    expect(result?.agents).toContain('oracle')
+    expect(result?.hasTodos).toBe(true)
+    expect(result?.todoCount).toBe(2)
+    expect(result?.completedTodos).toBe(1)
+  })
+})

--- a/src/lib/session/search.ts
+++ b/src/lib/session/search.ts
@@ -1,0 +1,230 @@
+import type {Logger, Message, Part, SessionInfo, SessionMatch, SessionSearchResult, SessionSummary} from './types.js'
+
+import {
+  findProjectByDirectory,
+  getMessageParts,
+  getSession,
+  getSessionMessages,
+  getSessionTodos,
+  listSessionsForProject,
+} from './storage.js'
+
+/**
+ * List all main sessions (excluding child/branched sessions) for a directory.
+ * Returns sessions sorted by updatedAt descending (most recent first).
+ */
+export async function listSessions(
+  directory: string,
+  options: {limit?: number; fromDate?: Date; toDate?: Date},
+  logger: Logger,
+): Promise<readonly SessionSummary[]> {
+  const {limit, fromDate, toDate} = options
+
+  logger.debug('Listing sessions', {directory, limit})
+
+  // Find project by directory
+  const project = await findProjectByDirectory(directory, logger)
+  if (project == null) {
+    logger.debug('No project found for directory', {directory})
+    return []
+  }
+
+  // Get all sessions for this project
+  const sessions = await listSessionsForProject(project.id, logger)
+
+  // Filter to main sessions only (no parentID) and apply date filters
+  const filtered = sessions.filter(session => {
+    // Exclude child sessions
+    if (session.parentID != null) return false
+
+    // Apply date filters
+    if (fromDate != null && session.time.created < fromDate.getTime()) return false
+    if (toDate != null && session.time.created > toDate.getTime()) return false
+
+    return true
+  })
+
+  // Sort by updatedAt descending
+  const sorted = [...filtered].sort((a, b) => b.time.updated - a.time.updated)
+
+  // Build summaries with message counts
+  const summaries: SessionSummary[] = []
+  const sessionsToProcess = limit == null ? sorted : sorted.slice(0, limit)
+
+  for (const session of sessionsToProcess) {
+    const messages = await getSessionMessages(session.id, logger)
+    const agents = extractAgentsFromMessages(messages)
+
+    summaries.push({
+      id: session.id,
+      projectID: session.projectID,
+      directory: session.directory,
+      title: session.title,
+      createdAt: session.time.created,
+      updatedAt: session.time.updated,
+      messageCount: messages.length,
+      agents,
+      isChild: false,
+    })
+  }
+
+  logger.info('Listed sessions', {count: summaries.length, directory})
+  return summaries
+}
+
+/**
+ * Extract unique agent names from messages.
+ */
+function extractAgentsFromMessages(messages: readonly Message[]): readonly string[] {
+  const agents = new Set<string>()
+
+  for (const message of messages) {
+    if (message.agent != null) {
+      agents.add(message.agent)
+    }
+  }
+
+  return [...agents]
+}
+
+/**
+ * Search session content for matching text.
+ */
+export async function searchSessions(
+  query: string,
+  directory: string,
+  options: {limit?: number; caseSensitive?: boolean; sessionId?: string},
+  logger: Logger,
+): Promise<readonly SessionSearchResult[]> {
+  const {limit = 20, caseSensitive = false, sessionId} = options
+
+  logger.debug('Searching sessions', {query, directory, limit, caseSensitive})
+
+  const searchPattern = caseSensitive ? query : query.toLowerCase()
+  const results: SessionSearchResult[] = []
+  let totalMatches = 0
+
+  // If specific session, search only that one
+  if (sessionId != null) {
+    const matches = await searchSessionContent(sessionId, searchPattern, caseSensitive, logger)
+    if (matches.length > 0) {
+      results.push({sessionId, matches: matches.slice(0, limit)})
+    }
+    return results
+  }
+
+  // Otherwise search all sessions for the directory
+  const sessions = await listSessions(directory, {}, logger)
+
+  for (const session of sessions) {
+    if (totalMatches >= limit) break
+
+    const matches = await searchSessionContent(session.id, searchPattern, caseSensitive, logger)
+
+    if (matches.length > 0) {
+      const remainingLimit = limit - totalMatches
+      results.push({
+        sessionId: session.id,
+        matches: matches.slice(0, remainingLimit),
+      })
+      totalMatches += Math.min(matches.length, remainingLimit)
+    }
+  }
+
+  logger.info('Session search complete', {query, resultCount: results.length, totalMatches})
+  return results
+}
+
+/**
+ * Search within a single session's content.
+ */
+async function searchSessionContent(
+  sessionId: string,
+  pattern: string,
+  caseSensitive: boolean,
+  logger: Logger,
+): Promise<readonly SessionMatch[]> {
+  const messages = await getSessionMessages(sessionId, logger)
+  const matches: SessionMatch[] = []
+
+  for (const message of messages) {
+    const parts = await getMessageParts(message.id, logger)
+
+    for (const part of parts) {
+      const text = extractTextFromPart(part)
+      if (text == null) continue
+
+      const searchText = caseSensitive ? text : text.toLowerCase()
+
+      if (searchText.includes(pattern)) {
+        // Extract excerpt around match
+        const index = searchText.indexOf(pattern)
+        const start = Math.max(0, index - 50)
+        const end = Math.min(text.length, index + pattern.length + 50)
+        const excerpt = text.slice(start, end)
+
+        matches.push({
+          messageId: message.id,
+          partId: part.id,
+          excerpt: `...${excerpt}...`,
+          role: message.role,
+          agent: message.agent,
+        })
+      }
+    }
+  }
+
+  return matches
+}
+
+/**
+ * Extract searchable text from a message part.
+ */
+function extractTextFromPart(part: Part): string | null {
+  switch (part.type) {
+    case 'text':
+      return part.text
+    case 'reasoning':
+      return part.reasoning
+    case 'tool': {
+      if (part.state.status === 'completed') {
+        return `${part.tool}: ${part.state.output}`
+      }
+      return null
+    }
+    case 'step-finish':
+      return null
+  }
+}
+
+/**
+ * Get detailed info about a specific session.
+ */
+export async function getSessionInfo(
+  sessionId: string,
+  projectID: string,
+  logger: Logger,
+): Promise<{
+  session: SessionInfo
+  messageCount: number
+  agents: readonly string[]
+  hasTodos: boolean
+  todoCount: number
+  completedTodos: number
+} | null> {
+  const session = await getSession(projectID, sessionId, logger)
+  if (session == null) return null
+
+  const messages = await getSessionMessages(sessionId, logger)
+  const agents = extractAgentsFromMessages(messages)
+  const todos = await getSessionTodos(sessionId, logger)
+
+  return {
+    session,
+    messageCount: messages.length,
+    agents,
+    hasTodos: todos.length > 0,
+    todoCount: todos.length,
+    completedTodos: todos.filter(t => t.status === 'completed').length,
+  }
+}

--- a/src/lib/session/storage.test.ts
+++ b/src/lib/session/storage.test.ts
@@ -1,0 +1,485 @@
+import type {Logger} from './types.js'
+import * as fs from 'node:fs/promises'
+
+import * as os from 'node:os'
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {
+  deleteSession,
+  findProjectByDirectory,
+  getMessageParts,
+  getOpenCodeStoragePath,
+  getSession,
+  getSessionMessages,
+  getSessionTodos,
+  listProjects,
+  listSessionsForProject,
+} from './storage.js'
+
+// Mock fs module
+vi.mock('node:fs/promises')
+vi.mock('node:os')
+
+const mockLogger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+}
+
+describe('getOpenCodeStoragePath', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    delete process.env.XDG_DATA_HOME
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses XDG_DATA_HOME when set', () => {
+    // #given
+    process.env.XDG_DATA_HOME = '/custom/data'
+
+    // #when
+    const result = getOpenCodeStoragePath()
+
+    // #then
+    expect(result).toBe('/custom/data/opencode/storage')
+  })
+
+  it('falls back to ~/.local/share when XDG_DATA_HOME is not set', () => {
+    // #given
+    vi.mocked(os.homedir).mockReturnValue('/home/user')
+
+    // #when
+    const result = getOpenCodeStoragePath()
+
+    // #then
+    expect(result).toBe('/home/user/.local/share/opencode/storage')
+  })
+})
+
+describe('listProjects', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env.XDG_DATA_HOME = '/test/data'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.XDG_DATA_HOME
+  })
+
+  it('returns empty array when project directory does not exist', async () => {
+    // #given
+    vi.mocked(fs.readdir).mockRejectedValue(new Error('ENOENT'))
+
+    // #when
+    const result = await listProjects(mockLogger)
+
+    // #then
+    expect(result).toEqual([])
+  })
+
+  it('returns parsed project files', async () => {
+    // #given
+    const projectData = {
+      id: 'abc123',
+      worktree: '/path/to/project',
+      vcs: 'git',
+      time: {created: 1000, updated: 2000},
+    }
+
+    vi.mocked(fs.readdir).mockResolvedValue([
+      {name: 'abc123.json', isFile: () => true, isDirectory: () => false},
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(projectData))
+
+    // #when
+    const result = await listProjects(mockLogger)
+
+    // #then
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(projectData)
+  })
+
+  it('skips non-JSON files', async () => {
+    // #given
+    vi.mocked(fs.readdir).mockResolvedValue([
+      {name: 'readme.txt', isFile: () => true, isDirectory: () => false},
+      {name: 'project.json', isFile: () => true, isDirectory: () => false},
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({id: 'test'}))
+
+    // #when
+    const result = await listProjects(mockLogger)
+
+    // #then
+    expect(result).toHaveLength(1)
+  })
+
+  it('skips directories', async () => {
+    // #given
+    vi.mocked(fs.readdir).mockResolvedValue([
+      {name: 'subdir', isFile: () => false, isDirectory: () => true},
+      {name: 'project.json', isFile: () => true, isDirectory: () => false},
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({id: 'test'}))
+
+    // #when
+    const result = await listProjects(mockLogger)
+
+    // #then
+    expect(result).toHaveLength(1)
+  })
+
+  it('skips files with invalid JSON', async () => {
+    // #given
+    vi.mocked(fs.readdir).mockResolvedValue([
+      {name: 'invalid.json', isFile: () => true, isDirectory: () => false},
+      {name: 'valid.json', isFile: () => true, isDirectory: () => false},
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+
+    vi.mocked(fs.readFile)
+      .mockResolvedValueOnce('not valid json')
+      .mockResolvedValueOnce(JSON.stringify({id: 'valid'}))
+
+    // #when
+    const result = await listProjects(mockLogger)
+
+    // #then
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({id: 'valid'})
+  })
+})
+
+describe('findProjectByDirectory', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env.XDG_DATA_HOME = '/test/data'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.XDG_DATA_HOME
+  })
+
+  it('returns project matching directory', async () => {
+    // #given
+    const project = {
+      id: 'proj1',
+      worktree: '/path/to/repo',
+      vcs: 'git',
+      time: {created: 1000, updated: 2000},
+    }
+
+    vi.mocked(fs.readdir).mockResolvedValue([
+      {name: 'proj1.json', isFile: () => true, isDirectory: () => false},
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(project))
+
+    // #when
+    const result = await findProjectByDirectory('/path/to/repo', mockLogger)
+
+    // #then
+    expect(result).toEqual(project)
+  })
+
+  it('returns null when no project matches', async () => {
+    // #given
+    const project = {
+      id: 'proj1',
+      worktree: '/different/path',
+      vcs: 'git',
+      time: {created: 1000, updated: 2000},
+    }
+
+    vi.mocked(fs.readdir).mockResolvedValue([
+      {name: 'proj1.json', isFile: () => true, isDirectory: () => false},
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(project))
+
+    // #when
+    const result = await findProjectByDirectory('/path/to/repo', mockLogger)
+
+    // #then
+    expect(result).toBeNull()
+  })
+})
+
+describe('listSessionsForProject', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env.XDG_DATA_HOME = '/test/data'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.XDG_DATA_HOME
+  })
+
+  it('returns sessions for project', async () => {
+    // #given
+    const session = {
+      id: 'ses_abc123',
+      version: '1.0.0',
+      projectID: 'proj1',
+      directory: '/path/to/repo',
+      title: 'Test Session',
+      time: {created: 1000, updated: 2000},
+    }
+
+    vi.mocked(fs.readdir).mockResolvedValue([
+      {name: 'ses_abc123.json', isFile: () => true, isDirectory: () => false},
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(session))
+
+    // #when
+    const result = await listSessionsForProject('proj1', mockLogger)
+
+    // #then
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(session)
+  })
+
+  it('returns empty array when session directory does not exist', async () => {
+    // #given
+    vi.mocked(fs.readdir).mockRejectedValue(new Error('ENOENT'))
+
+    // #when
+    const result = await listSessionsForProject('nonexistent', mockLogger)
+
+    // #then
+    expect(result).toEqual([])
+  })
+})
+
+describe('getSession', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env.XDG_DATA_HOME = '/test/data'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.XDG_DATA_HOME
+  })
+
+  it('returns session when file exists', async () => {
+    // #given
+    const session = {
+      id: 'ses_abc123',
+      version: '1.0.0',
+      projectID: 'proj1',
+      directory: '/path/to/repo',
+      title: 'Test Session',
+      time: {created: 1000, updated: 2000},
+    }
+
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(session))
+
+    // #when
+    const result = await getSession('proj1', 'ses_abc123', mockLogger)
+
+    // #then
+    expect(result).toEqual(session)
+    expect(fs.readFile).toHaveBeenCalledWith('/test/data/opencode/storage/session/proj1/ses_abc123.json', 'utf8')
+  })
+
+  it('returns null when file does not exist', async () => {
+    // #given
+    vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT'))
+
+    // #when
+    const result = await getSession('proj1', 'nonexistent', mockLogger)
+
+    // #then
+    expect(result).toBeNull()
+  })
+})
+
+describe('getSessionMessages', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env.XDG_DATA_HOME = '/test/data'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.XDG_DATA_HOME
+  })
+
+  it('returns messages sorted by creation time', async () => {
+    // #given
+    const msg1 = {id: 'msg_1', sessionID: 'ses_1', role: 'user', time: {created: 2000}, agent: 'test', model: {}}
+    const msg2 = {id: 'msg_2', sessionID: 'ses_1', role: 'assistant', time: {created: 1000}, agent: 'test'}
+
+    vi.mocked(fs.readdir).mockResolvedValue([
+      {name: 'msg_1.json', isFile: () => true, isDirectory: () => false},
+      {name: 'msg_2.json', isFile: () => true, isDirectory: () => false},
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+
+    vi.mocked(fs.readFile).mockResolvedValueOnce(JSON.stringify(msg1)).mockResolvedValueOnce(JSON.stringify(msg2))
+
+    // #when
+    const result = await getSessionMessages('ses_1', mockLogger)
+
+    // #then
+    expect(result).toHaveLength(2)
+    expect(result[0]?.id).toBe('msg_2') // Earlier timestamp first
+    expect(result[1]?.id).toBe('msg_1')
+  })
+
+  it('returns empty array when message directory does not exist', async () => {
+    // #given
+    vi.mocked(fs.readdir).mockRejectedValue(new Error('ENOENT'))
+
+    // #when
+    const result = await getSessionMessages('nonexistent', mockLogger)
+
+    // #then
+    expect(result).toEqual([])
+  })
+})
+
+describe('getMessageParts', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env.XDG_DATA_HOME = '/test/data'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.XDG_DATA_HOME
+  })
+
+  it('returns parts for message', async () => {
+    // #given
+    const part = {
+      id: 'prt_1',
+      sessionID: 'ses_1',
+      messageID: 'msg_1',
+      type: 'text',
+      text: 'Hello world',
+    }
+
+    vi.mocked(fs.readdir).mockResolvedValue([
+      {name: 'prt_1.json', isFile: () => true, isDirectory: () => false},
+    ] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(part))
+
+    // #when
+    const result = await getMessageParts('msg_1', mockLogger)
+
+    // #then
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual(part)
+  })
+})
+
+describe('getSessionTodos', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env.XDG_DATA_HOME = '/test/data'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.XDG_DATA_HOME
+  })
+
+  it('returns todos when file exists', async () => {
+    // #given
+    const todos = [
+      {id: '1', content: 'Task 1', status: 'pending', priority: 'high'},
+      {id: '2', content: 'Task 2', status: 'completed', priority: 'low'},
+    ]
+
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(todos))
+
+    // #when
+    const result = await getSessionTodos('ses_1', mockLogger)
+
+    // #then
+    expect(result).toEqual(todos)
+  })
+
+  it('returns empty array when file does not exist', async () => {
+    // #given
+    vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT'))
+
+    // #when
+    const result = await getSessionTodos('nonexistent', mockLogger)
+
+    // #then
+    expect(result).toEqual([])
+  })
+})
+
+describe('deleteSession', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env.XDG_DATA_HOME = '/test/data'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.XDG_DATA_HOME
+  })
+
+  it('deletes session and associated data', async () => {
+    // #given
+    const message = {id: 'msg_1', sessionID: 'ses_1', role: 'user', time: {created: 1000}, agent: 'test', model: {}}
+
+    // Mock getSessionMessages
+    vi.mocked(fs.readdir).mockImplementation(async dirPath => {
+      const pathStr = String(dirPath)
+      if (pathStr.includes('/message/')) {
+        return [{name: 'msg_1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      if (pathStr.includes('/part/')) {
+        return [{name: 'prt_1.json', isFile: () => true, isDirectory: () => false}] as unknown as Awaited<
+          ReturnType<typeof fs.readdir>
+        >
+      }
+      return []
+    })
+
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(message))
+    vi.mocked(fs.stat).mockResolvedValue({size: 100} as Awaited<ReturnType<typeof fs.stat>>)
+    vi.mocked(fs.unlink).mockResolvedValue(undefined)
+    vi.mocked(fs.rm).mockResolvedValue(undefined)
+
+    // #when
+    const result = await deleteSession('proj1', 'ses_1', mockLogger)
+
+    // #then
+    expect(result).toBeGreaterThan(0)
+    expect(mockLogger.debug).toHaveBeenCalledWith('Deleted session', expect.objectContaining({sessionID: 'ses_1'}))
+  })
+
+  it('handles missing files gracefully', async () => {
+    // #given
+    vi.mocked(fs.readdir).mockRejectedValue(new Error('ENOENT'))
+    vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'))
+    vi.mocked(fs.unlink).mockRejectedValue(new Error('ENOENT'))
+    vi.mocked(fs.rm).mockRejectedValue(new Error('ENOENT'))
+
+    // #when
+    const result = await deleteSession('proj1', 'nonexistent', mockLogger)
+
+    // #then
+    expect(result).toBe(0)
+  })
+})

--- a/src/lib/session/storage.ts
+++ b/src/lib/session/storage.ts
@@ -1,0 +1,212 @@
+import type {Logger, Message, Part, ProjectInfo, SessionInfo, TodoItem} from './types.js'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import process from 'node:process'
+
+/**
+ * Get the OpenCode storage directory path.
+ * Uses XDG_DATA_HOME or falls back to ~/.local/share/opencode/storage
+ */
+export function getOpenCodeStoragePath(): string {
+  const xdgDataHome = process.env.XDG_DATA_HOME
+  const basePath = xdgDataHome ?? path.join(os.homedir(), '.local', 'share')
+  return path.join(basePath, 'opencode', 'storage')
+}
+
+/**
+ * Read a JSON file from storage, returning null if not found or invalid.
+ */
+async function readJson<T>(filePath: string): Promise<T | null> {
+  try {
+    const content = await fs.readFile(filePath, 'utf8')
+    return JSON.parse(content) as T
+  } catch {
+    return null
+  }
+}
+
+/**
+ * List all JSON files in a directory, returning parsed contents.
+ */
+async function listJsonFiles<T>(dirPath: string): Promise<readonly T[]> {
+  try {
+    const entries = await fs.readdir(dirPath, {withFileTypes: true})
+    const results: T[] = []
+
+    for (const entry of entries) {
+      if (entry.isFile() && entry.name.endsWith('.json')) {
+        const filePath = path.join(dirPath, entry.name)
+        const content = await readJson<T>(filePath)
+        if (content != null) {
+          results.push(content)
+        }
+      }
+    }
+
+    return results
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Get all projects from storage.
+ */
+export async function listProjects(logger: Logger): Promise<readonly ProjectInfo[]> {
+  const storagePath = getOpenCodeStoragePath()
+  const projectDir = path.join(storagePath, 'project')
+
+  logger.debug('Listing projects', {projectDir})
+  return listJsonFiles<ProjectInfo>(projectDir)
+}
+
+/**
+ * Find project by directory path.
+ */
+export async function findProjectByDirectory(directory: string, logger: Logger): Promise<ProjectInfo | null> {
+  const projects = await listProjects(logger)
+
+  for (const project of projects) {
+    if (project.worktree === directory) {
+      return project
+    }
+  }
+
+  return null
+}
+
+/**
+ * Get all sessions for a project.
+ */
+export async function listSessionsForProject(projectID: string, logger: Logger): Promise<readonly SessionInfo[]> {
+  const storagePath = getOpenCodeStoragePath()
+  const sessionDir = path.join(storagePath, 'session', projectID)
+
+  logger.debug('Listing sessions for project', {projectID, sessionDir})
+  return listJsonFiles<SessionInfo>(sessionDir)
+}
+
+/**
+ * Get a specific session by ID.
+ */
+export async function getSession(projectID: string, sessionID: string, logger: Logger): Promise<SessionInfo | null> {
+  const storagePath = getOpenCodeStoragePath()
+  const sessionPath = path.join(storagePath, 'session', projectID, `${sessionID}.json`)
+
+  logger.debug('Reading session', {projectID, sessionID})
+  return readJson<SessionInfo>(sessionPath)
+}
+
+/**
+ * Get all messages for a session.
+ */
+export async function getSessionMessages(sessionID: string, logger: Logger): Promise<readonly Message[]> {
+  const storagePath = getOpenCodeStoragePath()
+  const messageDir = path.join(storagePath, 'message', sessionID)
+
+  logger.debug('Reading session messages', {sessionID, messageDir})
+  const messages = await listJsonFiles<Message>(messageDir)
+
+  // Sort by creation time (ascending)
+  return [...messages].sort((a, b) => a.time.created - b.time.created)
+}
+
+/**
+ * Get all parts for a message.
+ */
+export async function getMessageParts(messageID: string, logger: Logger): Promise<readonly Part[]> {
+  const storagePath = getOpenCodeStoragePath()
+  const partDir = path.join(storagePath, 'part', messageID)
+
+  logger.debug('Reading message parts', {messageID, partDir})
+  return listJsonFiles<Part>(partDir)
+}
+
+/**
+ * Get todos for a session.
+ */
+export async function getSessionTodos(sessionID: string, logger: Logger): Promise<readonly TodoItem[]> {
+  const storagePath = getOpenCodeStoragePath()
+  const todoPath = path.join(storagePath, 'todo', `${sessionID}.json`)
+
+  logger.debug('Reading session todos', {sessionID})
+  const todos = await readJson<TodoItem[]>(todoPath)
+  return todos ?? []
+}
+
+/**
+ * Delete a single file, returning bytes freed.
+ */
+async function deleteFile(filePath: string): Promise<number> {
+  try {
+    const stat = await fs.stat(filePath)
+    await fs.unlink(filePath)
+    return stat.size
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Delete a directory recursively, returning bytes freed.
+ */
+async function deleteDirectoryRecursive(dirPath: string): Promise<number> {
+  let totalSize = 0
+
+  try {
+    const entries = await fs.readdir(dirPath, {withFileTypes: true})
+
+    for (const entry of entries) {
+      const entryPath = path.join(dirPath, entry.name)
+
+      if (entry.isDirectory()) {
+        totalSize += await deleteDirectoryRecursive(entryPath)
+      } else {
+        const stat = await fs.stat(entryPath)
+        totalSize += stat.size
+      }
+    }
+
+    await fs.rm(dirPath, {recursive: true, force: true})
+  } catch {
+    // Directory doesn't exist or can't be deleted
+  }
+
+  return totalSize
+}
+
+/**
+ * Delete a session and all its associated data.
+ */
+export async function deleteSession(projectID: string, sessionID: string, logger: Logger): Promise<number> {
+  const storagePath = getOpenCodeStoragePath()
+  let freedBytes = 0
+
+  // Delete message parts first
+  const messages = await getSessionMessages(sessionID, logger)
+  for (const message of messages) {
+    const partDir = path.join(storagePath, 'part', message.id)
+    freedBytes += await deleteDirectoryRecursive(partDir)
+  }
+
+  // Delete messages directory
+  const messageDir = path.join(storagePath, 'message', sessionID)
+  freedBytes += await deleteDirectoryRecursive(messageDir)
+
+  // Delete session file
+  const sessionPath = path.join(storagePath, 'session', projectID, `${sessionID}.json`)
+  freedBytes += await deleteFile(sessionPath)
+
+  // Delete todos file (if exists)
+  const todoPath = path.join(storagePath, 'todo', `${sessionID}.json`)
+  freedBytes += await deleteFile(todoPath)
+
+  // Delete session_diff file (if exists)
+  const diffPath = path.join(storagePath, 'session_diff', `${sessionID}.json`)
+  freedBytes += await deleteFile(diffPath)
+
+  logger.debug('Deleted session', {sessionID, freedBytes})
+  return freedBytes
+}

--- a/src/lib/session/types.ts
+++ b/src/lib/session/types.ts
@@ -1,0 +1,291 @@
+/**
+ * Session management types matching OpenCode's storage format.
+ *
+ * @see https://github.com/anomalyco/opencode/blob/main/packages/opencode/src/session/index.ts
+ */
+
+export type {Logger} from '../logger.js'
+
+/**
+ * OpenCode Session.Info - matches the actual schema from OpenCode source.
+ */
+export interface SessionInfo {
+  readonly id: string
+  readonly version: string
+  readonly projectID: string
+  readonly directory: string
+  readonly parentID?: string
+  readonly title: string
+  readonly time: {
+    readonly created: number
+    readonly updated: number
+    readonly compacting?: number
+    readonly archived?: number
+  }
+  readonly summary?: {
+    readonly additions: number
+    readonly deletions: number
+    readonly files: number
+    readonly diffs?: readonly FileDiff[]
+  }
+  readonly share?: {
+    readonly url: string
+  }
+  readonly permission?: PermissionRuleset
+  readonly revert?: {
+    readonly messageID: string
+    readonly partID?: string
+    readonly snapshot?: string
+    readonly diff?: string
+  }
+}
+
+/**
+ * OpenCode MessageV2.User - user message schema
+ */
+export interface UserMessage {
+  readonly id: string
+  readonly sessionID: string
+  readonly role: 'user'
+  readonly time: {
+    readonly created: number
+  }
+  readonly summary?: {
+    readonly title?: string
+    readonly body?: string
+    readonly diffs: readonly FileDiff[]
+  }
+  readonly agent: string
+  readonly model: {
+    readonly providerID: string
+    readonly modelID: string
+  }
+  readonly system?: string
+  readonly tools?: Record<string, boolean>
+  readonly variant?: string
+}
+
+/**
+ * OpenCode MessageV2.Assistant - assistant message schema
+ */
+export interface AssistantMessage {
+  readonly id: string
+  readonly sessionID: string
+  readonly role: 'assistant'
+  readonly time: {
+    readonly created: number
+    readonly completed?: number
+  }
+  readonly parentID: string
+  readonly modelID: string
+  readonly providerID: string
+  readonly mode: string
+  readonly agent: string
+  readonly path: {
+    readonly cwd: string
+    readonly root: string
+  }
+  readonly summary?: boolean
+  readonly cost: number
+  readonly tokens: {
+    readonly input: number
+    readonly output: number
+    readonly reasoning: number
+    readonly cache: {
+      readonly read: number
+      readonly write: number
+    }
+  }
+  readonly finish?: string
+  readonly error?: MessageError
+}
+
+export type Message = UserMessage | AssistantMessage
+
+/**
+ * OpenCode MessageV2.Part - base interface for message content parts
+ */
+export interface PartBase {
+  readonly id: string
+  readonly sessionID: string
+  readonly messageID: string
+}
+
+export interface TextPart extends PartBase {
+  readonly type: 'text'
+  readonly text: string
+  readonly synthetic?: boolean
+  readonly ignored?: boolean
+  readonly time?: {
+    readonly start: number
+    readonly end?: number
+  }
+  readonly metadata?: Record<string, unknown>
+}
+
+export interface ToolPart extends PartBase {
+  readonly type: 'tool'
+  readonly callID: string
+  readonly tool: string
+  readonly state: ToolState
+  readonly metadata?: Record<string, unknown>
+}
+
+export interface ToolStateCompleted {
+  readonly status: 'completed'
+  readonly input: Record<string, unknown>
+  readonly output: string
+  readonly title: string
+  readonly metadata: Record<string, unknown>
+  readonly time: {
+    readonly start: number
+    readonly end: number
+    readonly compacted?: number
+  }
+  readonly attachments?: readonly FilePart[]
+}
+
+export interface ToolStatePending {
+  readonly status: 'pending'
+}
+
+export interface ToolStateRunning {
+  readonly status: 'running'
+  readonly input: Record<string, unknown>
+  readonly time: {readonly start: number}
+}
+
+export interface ToolStateError {
+  readonly status: 'error'
+  readonly input: Record<string, unknown>
+  readonly error: string
+  readonly time: {readonly start: number; readonly end: number}
+}
+
+export type ToolState = ToolStatePending | ToolStateRunning | ToolStateCompleted | ToolStateError
+
+export interface ReasoningPart extends PartBase {
+  readonly type: 'reasoning'
+  readonly reasoning: string
+  readonly time?: {
+    readonly start: number
+    readonly end?: number
+  }
+}
+
+export interface StepFinishPart extends PartBase {
+  readonly type: 'step-finish'
+  readonly reason: string
+  readonly snapshot?: string
+  readonly cost: number
+  readonly tokens: {
+    readonly input: number
+    readonly output: number
+    readonly reasoning: number
+    readonly cache: {
+      readonly read: number
+      readonly write: number
+    }
+  }
+}
+
+export type Part = TextPart | ToolPart | ReasoningPart | StepFinishPart
+
+/**
+ * OpenCode Project metadata
+ */
+export interface ProjectInfo {
+  readonly id: string
+  readonly worktree: string
+  readonly vcs: 'git' | string
+  readonly time: {
+    readonly created: number
+    readonly updated: number
+    readonly initialized?: number
+  }
+}
+
+/**
+ * Todo item (stored in todo/{sessionID}.json)
+ */
+export interface TodoItem {
+  readonly id: string
+  readonly content: string
+  readonly status: 'pending' | 'in_progress' | 'completed' | 'cancelled'
+  readonly priority: 'high' | 'medium' | 'low'
+}
+
+/**
+ * Simplified session summary for RFC-004 operations
+ */
+export interface SessionSummary {
+  readonly id: string
+  readonly projectID: string
+  readonly directory: string
+  readonly title: string
+  readonly createdAt: number
+  readonly updatedAt: number
+  readonly messageCount: number
+  readonly agents: readonly string[]
+  readonly isChild: boolean
+}
+
+/**
+ * Session search result
+ */
+export interface SessionSearchResult {
+  readonly sessionId: string
+  readonly matches: readonly SessionMatch[]
+}
+
+/**
+ * Individual match within a session
+ */
+export interface SessionMatch {
+  readonly messageId: string
+  readonly partId: string
+  readonly excerpt: string
+  readonly role: 'user' | 'assistant'
+  readonly agent?: string
+}
+
+/**
+ * Result of session pruning operation
+ */
+export interface PruneResult {
+  readonly prunedCount: number
+  readonly prunedSessionIds: readonly string[]
+  readonly remainingCount: number
+  readonly freedBytes: number
+}
+
+/**
+ * Configuration for session pruning
+ */
+export interface PruningConfig {
+  readonly maxSessions: number
+  readonly maxAgeDays: number
+}
+
+// Supporting types
+
+export interface FileDiff {
+  readonly file: string
+  readonly additions: number
+  readonly deletions: number
+}
+
+export interface FilePart extends PartBase {
+  readonly type: 'file'
+  readonly file: string
+  readonly content: string
+}
+
+export interface PermissionRuleset {
+  readonly rules: readonly unknown[]
+}
+
+export interface MessageError {
+  readonly name: string
+  readonly message: string
+}

--- a/src/lib/session/writeback.test.ts
+++ b/src/lib/session/writeback.test.ts
@@ -1,0 +1,278 @@
+import type {RunSummary} from '../types.js'
+
+import type {Logger} from './types.js'
+
+import * as fs from 'node:fs/promises'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {writeSessionSummary} from './writeback.js'
+
+// Mock fs module
+vi.mock('node:fs/promises')
+vi.mock('node:os')
+
+const mockLogger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+}
+
+// Helper to create mock run summary
+function createMockRunSummary(overrides: Partial<RunSummary> = {}): RunSummary {
+  return {
+    eventType: 'issue_comment',
+    repo: 'owner/repo',
+    ref: 'main',
+    runId: 12345,
+    cacheStatus: 'hit',
+    sessionIds: ['ses_abc123'],
+    createdPRs: [],
+    createdCommits: [],
+    duration: 45,
+    tokenUsage: {input: 1000, output: 500},
+    ...overrides,
+  }
+}
+
+describe('writeSessionSummary', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env.XDG_DATA_HOME = '/test/data'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.XDG_DATA_HOME
+  })
+
+  it('creates message and part files in correct directories', async () => {
+    // #given
+    const summary = createMockRunSummary()
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined)
+    vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+
+    // #when
+    await writeSessionSummary('ses_test', summary, mockLogger)
+
+    // #then
+    expect(fs.mkdir).toHaveBeenCalledWith(expect.stringContaining('/message/ses_test'), {recursive: true})
+    expect(fs.mkdir).toHaveBeenCalledWith(expect.stringContaining('/part/msg_'), {recursive: true})
+    expect(fs.writeFile).toHaveBeenCalledTimes(2)
+  })
+
+  it('writes valid JSON message metadata', async () => {
+    // #given
+    const summary = createMockRunSummary()
+    let writtenMessage: unknown = null
+
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined)
+    vi.mocked(fs.writeFile).mockImplementation(async (filePath, content) => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/message/') && pathStr.includes('msg_')) {
+        writtenMessage = JSON.parse(String(content))
+      }
+    })
+
+    // #when
+    await writeSessionSummary('ses_test', summary, mockLogger)
+
+    // #then
+    expect(writtenMessage).not.toBeNull()
+    expect(writtenMessage).toMatchObject({
+      sessionID: 'ses_test',
+      role: 'user',
+      agent: 'fro-bot',
+      model: {
+        providerID: 'system',
+        modelID: 'run-summary',
+      },
+    })
+  })
+
+  it('writes valid JSON part with summary text', async () => {
+    // #given
+    const summary = createMockRunSummary({
+      eventType: 'pull_request',
+      repo: 'test/repo',
+      createdPRs: ['#123'],
+    })
+    let writtenPart: unknown = null
+
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined)
+    vi.mocked(fs.writeFile).mockImplementation(async (filePath, content) => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/part/') && pathStr.includes('prt_')) {
+        writtenPart = JSON.parse(String(content))
+      }
+    })
+
+    // #when
+    await writeSessionSummary('ses_test', summary, mockLogger)
+
+    // #then
+    expect(writtenPart).not.toBeNull()
+    const part = writtenPart as {type: string; text: string; sessionID: string}
+    expect(part.type).toBe('text')
+    expect(part.sessionID).toBe('ses_test')
+    expect(part.text).toContain('Fro Bot Run Summary')
+    expect(part.text).toContain('Event: pull_request')
+    expect(part.text).toContain('Repo: test/repo')
+    expect(part.text).toContain('PRs created: #123')
+  })
+
+  it('includes token usage in summary text', async () => {
+    // #given
+    const summary = createMockRunSummary({
+      tokenUsage: {input: 2000, output: 1500},
+    })
+    let writtenPart: unknown = null
+
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined)
+    vi.mocked(fs.writeFile).mockImplementation(async (filePath, content) => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/part/') && pathStr.includes('prt_')) {
+        writtenPart = JSON.parse(String(content))
+      }
+    })
+
+    // #when
+    await writeSessionSummary('ses_test', summary, mockLogger)
+
+    // #then
+    const part = writtenPart as {text: string}
+    expect(part.text).toContain('Tokens: 2000 in / 1500 out')
+  })
+
+  it('includes commits in summary text', async () => {
+    // #given
+    const summary = createMockRunSummary({
+      createdCommits: ['abc1234', 'def5678'],
+    })
+    let writtenPart: unknown = null
+
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined)
+    vi.mocked(fs.writeFile).mockImplementation(async (filePath, content) => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/part/') && pathStr.includes('prt_')) {
+        writtenPart = JSON.parse(String(content))
+      }
+    })
+
+    // #when
+    await writeSessionSummary('ses_test', summary, mockLogger)
+
+    // #then
+    const part = writtenPart as {text: string}
+    expect(part.text).toContain('Commits: abc1234, def5678')
+  })
+
+  it('generates IDs matching OpenCode format', async () => {
+    // #given
+    const summary = createMockRunSummary()
+    let messageId: string | null = null
+    let partId: string | null = null
+
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined)
+    vi.mocked(fs.writeFile).mockImplementation(async (filePath, content) => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/message/') && pathStr.endsWith('.json')) {
+        const parsed = JSON.parse(String(content)) as {id: string}
+        messageId = parsed.id
+      }
+      if (pathStr.includes('/part/') && pathStr.endsWith('.json')) {
+        const parsed = JSON.parse(String(content)) as {id: string}
+        partId = parsed.id
+      }
+    })
+
+    // #when
+    await writeSessionSummary('ses_test', summary, mockLogger)
+
+    // #then
+    expect(messageId).toMatch(/^msg_[0-9a-f][0-9A-Za-z]+$/)
+    expect(partId).toMatch(/^prt_[0-9a-f][0-9A-Za-z]+$/)
+  })
+
+  it('logs success on completion', async () => {
+    // #given
+    const summary = createMockRunSummary()
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined)
+    vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+
+    // #when
+    await writeSessionSummary('ses_test', summary, mockLogger)
+
+    // #then
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'Session summary written',
+      expect.objectContaining({sessionId: 'ses_test'}),
+    )
+  })
+
+  it('handles write errors gracefully', async () => {
+    // #given
+    const summary = createMockRunSummary()
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined)
+    vi.mocked(fs.writeFile).mockRejectedValue(new Error('Permission denied'))
+
+    // #when
+    await writeSessionSummary('ses_test', summary, mockLogger)
+
+    // #then - should not throw, just log warning
+    expect(mockLogger.warning).toHaveBeenCalledWith(
+      'Failed to write session summary',
+      expect.objectContaining({
+        sessionId: 'ses_test',
+        error: 'Permission denied',
+      }),
+    )
+  })
+
+  it('handles mkdir errors gracefully', async () => {
+    // #given
+    const summary = createMockRunSummary()
+    vi.mocked(fs.mkdir).mockRejectedValue(new Error('No space left'))
+
+    // #when
+    await writeSessionSummary('ses_test', summary, mockLogger)
+
+    // #then - should not throw, just log warning
+    expect(mockLogger.warning).toHaveBeenCalledWith(
+      'Failed to write session summary',
+      expect.objectContaining({
+        sessionId: 'ses_test',
+        error: 'No space left',
+      }),
+    )
+  })
+
+  it('omits optional fields when not present', async () => {
+    // #given
+    const summary = createMockRunSummary({
+      sessionIds: [],
+      createdPRs: [],
+      createdCommits: [],
+      tokenUsage: null,
+    })
+    let writtenPart: unknown = null
+
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined)
+    vi.mocked(fs.writeFile).mockImplementation(async (filePath, content) => {
+      const pathStr = String(filePath)
+      if (pathStr.includes('/part/') && pathStr.includes('prt_')) {
+        writtenPart = JSON.parse(String(content))
+      }
+    })
+
+    // #when
+    await writeSessionSummary('ses_test', summary, mockLogger)
+
+    // #then
+    const part = writtenPart as {text: string}
+    expect(part.text).not.toContain('Sessions used:')
+    expect(part.text).not.toContain('PRs created:')
+    expect(part.text).not.toContain('Commits:')
+    expect(part.text).not.toContain('Tokens:')
+  })
+})

--- a/src/lib/session/writeback.ts
+++ b/src/lib/session/writeback.ts
@@ -1,0 +1,125 @@
+import type {RunSummary} from '../types.js'
+import type {Logger} from './types.js'
+
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+
+import {getOpenCodeStoragePath} from './storage.js'
+
+/**
+ * Generate random base62 string (matching OpenCode ID format).
+ */
+function generateRandomBase62(length: number): string {
+  const chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+  let result = ''
+  for (let i = 0; i < length; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length))
+  }
+  return result
+}
+
+/**
+ * Format run summary for session storage.
+ */
+function formatSummaryForSession(summary: RunSummary): string {
+  const lines = [
+    '--- Fro Bot Run Summary ---',
+    `Event: ${summary.eventType}`,
+    `Repo: ${summary.repo}`,
+    `Ref: ${summary.ref}`,
+    `Run ID: ${summary.runId}`,
+    `Cache: ${summary.cacheStatus}`,
+    `Duration: ${summary.duration}s`,
+  ]
+
+  if (summary.sessionIds.length > 0) {
+    lines.push(`Sessions used: ${summary.sessionIds.join(', ')}`)
+  }
+
+  if (summary.createdPRs.length > 0) {
+    lines.push(`PRs created: ${summary.createdPRs.join(', ')}`)
+  }
+
+  if (summary.createdCommits.length > 0) {
+    lines.push(`Commits: ${summary.createdCommits.join(', ')}`)
+  }
+
+  if (summary.tokenUsage != null) {
+    lines.push(`Tokens: ${summary.tokenUsage.input} in / ${summary.tokenUsage.output} out`)
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Append a run summary to a session's message history.
+ *
+ * This creates a synthetic "user" message containing the run summary,
+ * making it discoverable in future session searches.
+ *
+ * NOTE: This directly writes to the OpenCode storage format. The message
+ * will appear in session_read and session_search results.
+ */
+export async function writeSessionSummary(sessionId: string, summary: RunSummary, logger: Logger): Promise<void> {
+  const storagePath = getOpenCodeStoragePath()
+  const messageDir = path.join(storagePath, 'message', sessionId)
+  const partDir = path.join(storagePath, 'part')
+
+  // Generate IDs matching OpenCode format (hex timestamp + random base62)
+  const timestamp = Date.now()
+  const messageId = `msg_${timestamp.toString(16)}${generateRandomBase62(14)}`
+  const partId = `prt_${timestamp.toString(16)}${generateRandomBase62(14)}`
+
+  // Create message metadata
+  const messageMetadata = {
+    id: messageId,
+    sessionID: sessionId,
+    role: 'user',
+    time: {
+      created: timestamp,
+    },
+    summary: {
+      title: 'GitHub Action Run Summary',
+      diffs: [],
+    },
+    agent: 'fro-bot',
+    model: {
+      providerID: 'system',
+      modelID: 'run-summary',
+    },
+  }
+
+  // Create text part with summary content
+  const summaryText = formatSummaryForSession(summary)
+  const partMetadata = {
+    id: partId,
+    sessionID: sessionId,
+    messageID: messageId,
+    type: 'text',
+    text: summaryText,
+    time: {
+      start: timestamp,
+      end: timestamp,
+    },
+  }
+
+  try {
+    // Ensure directories exist
+    await fs.mkdir(messageDir, {recursive: true})
+    await fs.mkdir(path.join(partDir, messageId), {recursive: true})
+
+    // Write message and part files
+    const messagePath = path.join(messageDir, `${messageId}.json`)
+    const partPath = path.join(partDir, messageId, `${partId}.json`)
+
+    await fs.writeFile(messagePath, JSON.stringify(messageMetadata, null, 2), 'utf8')
+    await fs.writeFile(partPath, JSON.stringify(partMetadata, null, 2), 'utf8')
+
+    logger.info('Session summary written', {sessionId, messageId})
+  } catch (error) {
+    logger.warning('Failed to write session summary', {
+      sessionId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}


### PR DESCRIPTION
Add session management utilities for listing, searching, pruning, and
tracking OpenCode sessions. Includes full test coverage (48 tests) and
marks RFC-004 as completed.

- Storage operations: list, read, delete sessions
- Search sessions with text matching
- Prune old sessions with retention policy
- Write run summaries for future discovery