### PR TITLE
ci: split tests into seperate `test-actions` job

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -21,7 +21,7 @@ branches:
       required_pull_request_reviews: null
       required_status_checks:
         strict: false
-        contexts: [Build, Lint, Release, Test, Setup, Renovate / Renovate, Analyze]
+        contexts: [Build, Lint, Release, Test, Test GitHub Actions, Setup, Renovate / Renovate, Analyze]
       restrictions: null
 
   - name: v?

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,7 @@ jobs:
 
   test:
     name: Test
-    needs: [setup]
+    needs: [setup, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -131,11 +131,16 @@ jobs:
           node-version: ${{ needs.setup.outputs.node-version }}
       - name: Install dependencies
         run: pnpm bootstrap
-      - name: Build
-        run: pnpm build
 
       - name: Run tests
         run: pnpm test
+
+  test-actions:
+    name: Test GitHub Actions
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Test setup action
         uses: ./setup/
@@ -143,12 +148,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auth-json: '{"user":"ci-test@example.com","tokens":{"anthropic":"sk-test-key"}}'
           opencode-version: latest
-          skip-cache: 'true'
 
       - name: Test main action
         uses: ./
         env:
-          SKIP_CACHE: 'true'
           SKIP_AGENT_EXECUTION: 'true'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Tests depend on the build in `dist/` so they must run after the build job.