### PR TITLE
ci: add introspection steps for setup and main action execution

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,8 +169,10 @@ jobs:
           which opencode && opencode --version || true
           bunx oh-my-opencode get-local-version || true
 
-          echo "Installed files:"
+          echo "OpenCode config files:"
           find ~/.config/opencode -type f | sort
+          [ -f ~/.config/opencode/opencode.json ] && cat ~/.config/opencode/opencode.json || true
+          [ -f ~/.config/opencode/oh-my-opencode.json ] && cat ~/.config/opencode/oh-my-opencode.json || true
 
           echo "OpenCode shared files:"
           ls -lA ~/.local/share/opencode || true


### PR DESCRIPTION
- Add steps to introspect installed versions of bun and opencode.
- List installed files and check oh-my-opencode installation.
- Include introspection for OpenCode storage, cache, and state files.