### PR TITLE
docs(rfc): expand attachment, session, and context RFCs

### DIFF
--- a/RFCs/RFC-014-File-Attachment-Processing.md
+++ b/RFCs/RFC-014-File-Attachment-Processing.md
@@ -1,0 +1,783 @@
+# RFC-014: File Attachment Processing
+
+**Status:** Pending
+**Priority:** MUST
+**Complexity:** Medium
+**Phase:** 2
+
+---
+
+## Summary
+
+Implement file attachment processing for GitHub comment triggers. This RFC defines detection, download, validation, and prompt injection of user-uploaded files (images, documents) attached to GitHub issues and PR comments.
+
+## Dependencies
+
+- **Builds Upon:** RFC-003 (GitHub Client), RFC-013 (SDK Execution Mode)
+- **Enables:** Enhanced multi-modal agent interactions
+
+## Features Addressed
+
+| Feature ID | Feature Name              | Priority |
+| ---------- | ------------------------- | -------- |
+| NEW        | File Attachment Detection | P0       |
+| NEW        | Attachment Download       | P0       |
+| NEW        | MIME Type Validation      | P0       |
+| NEW        | SDK File Part Injection   | P0       |
+
+## Technical Specification
+
+### 1. File Structure
+
+```
+src/lib/
+├── attachments/
+│   ├── types.ts          # Attachment-related types
+│   ├── parser.ts         # URL detection from comment body
+│   ├── downloader.ts     # Download with auth
+│   ├── validator.ts      # MIME type and size validation
+│   ├── injector.ts       # Transform to SDK file parts
+│   └── index.ts          # Public exports
+```
+
+### 2. Attachment Types (`src/lib/attachments/types.ts`)
+
+```typescript
+import type {Logger} from "../types.js"
+
+/**
+ * Parsed attachment URL from comment body.
+ */
+export interface AttachmentUrl {
+  readonly url: string
+  readonly originalMarkdown: string
+  readonly altText: string
+  readonly type: "image" | "file"
+}
+
+/**
+ * Downloaded attachment with metadata.
+ */
+export interface DownloadedAttachment {
+  readonly url: string
+  readonly filename: string
+  readonly mimeType: string
+  readonly sizeBytes: number
+  readonly content: Buffer
+}
+
+/**
+ * Validated attachment ready for prompt injection.
+ */
+export interface ValidatedAttachment {
+  readonly filename: string
+  readonly mimeType: string
+  readonly sizeBytes: number
+  readonly base64Content: string
+}
+
+/**
+ * SDK-compatible file part.
+ */
+export interface FilePart {
+  readonly type: "file"
+  readonly filename: string
+  readonly mimeType: string
+  readonly content: string // base64
+}
+
+/**
+ * Attachment processing result.
+ */
+export interface AttachmentResult {
+  readonly processed: readonly ValidatedAttachment[]
+  readonly skipped: readonly SkippedAttachment[]
+  readonly modifiedBody: string
+}
+
+export interface SkippedAttachment {
+  readonly url: string
+  readonly reason: string
+}
+
+/**
+ * Attachment limits configuration.
+ */
+export interface AttachmentLimits {
+  readonly maxFiles: number // Default: 5
+  readonly maxFileSizeBytes: number // Default: 5MB
+  readonly maxTotalSizeBytes: number // Default: 15MB
+  readonly allowedMimeTypes: readonly string[]
+}
+
+export const DEFAULT_ATTACHMENT_LIMITS: AttachmentLimits = {
+  maxFiles: 5,
+  maxFileSizeBytes: 5 * 1024 * 1024, // 5MB
+  maxTotalSizeBytes: 15 * 1024 * 1024, // 15MB
+  allowedMimeTypes: [
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "image/svg+xml",
+    "text/plain",
+    "text/markdown",
+    "text/csv",
+    "application/json",
+    "application/pdf",
+  ],
+}
+```
+
+### 3. URL Parser (`src/lib/attachments/parser.ts`)
+
+```typescript
+import type {AttachmentUrl} from "./types.js"
+
+/**
+ * GitHub user-attachment URL patterns.
+ *
+ * Supported formats:
+ * - Markdown images: ![alt](https://github.com/user-attachments/assets/...)
+ * - HTML images: <img ... src="https://github.com/user-attachments/assets/..." />
+ * - File links: [filename](https://github.com/user-attachments/files/...)
+ */
+const ATTACHMENT_PATTERNS = {
+  // Markdown image: ![alt](url)
+  markdownImage: /!\[([^\]]*)\]\((https:\/\/github\.com\/user-attachments\/assets\/[^)]+)\)/gi,
+
+  // Markdown link: [text](url) - for files
+  markdownLink: /\[([^\]]+)\]\((https:\/\/github\.com\/user-attachments\/files\/[^)]+)\)/gi,
+
+  // HTML image: <img src="url" ...>
+  htmlImage: /<img[^>]*src=["'](https:\/\/github\.com\/user-attachments\/assets\/[^"']+)["'][^>]*>/gi,
+}
+
+/**
+ * Parse comment body for GitHub user-attachment URLs.
+ *
+ * Only extracts URLs from github.com/user-attachments/ for security.
+ */
+export function parseAttachmentUrls(body: string): readonly AttachmentUrl[] {
+  const attachments: AttachmentUrl[] = []
+  const seenUrls = new Set<string>()
+
+  // Parse markdown images
+  let match: RegExpExecArray | null
+  while ((match = ATTACHMENT_PATTERNS.markdownImage.exec(body)) != null) {
+    const url = match[2]
+    if (!seenUrls.has(url)) {
+      seenUrls.add(url)
+      attachments.push({
+        url,
+        originalMarkdown: match[0],
+        altText: match[1],
+        type: "image",
+      })
+    }
+  }
+
+  // Reset regex lastIndex
+  ATTACHMENT_PATTERNS.markdownImage.lastIndex = 0
+
+  // Parse markdown file links
+  while ((match = ATTACHMENT_PATTERNS.markdownLink.exec(body)) != null) {
+    const url = match[2]
+    if (!seenUrls.has(url)) {
+      seenUrls.add(url)
+      attachments.push({
+        url,
+        originalMarkdown: match[0],
+        altText: match[1],
+        type: "file",
+      })
+    }
+  }
+
+  ATTACHMENT_PATTERNS.markdownLink.lastIndex = 0
+
+  // Parse HTML images
+  while ((match = ATTACHMENT_PATTERNS.htmlImage.exec(body)) != null) {
+    const url = match[1]
+    if (!seenUrls.has(url)) {
+      seenUrls.add(url)
+      // Extract alt from alt attribute if present
+      const altMatch = /alt=["']([^"']*)["']/i.exec(match[0])
+      attachments.push({
+        url,
+        originalMarkdown: match[0],
+        altText: altMatch?.[1] ?? "",
+        type: "image",
+      })
+    }
+  }
+
+  ATTACHMENT_PATTERNS.htmlImage.lastIndex = 0
+
+  return attachments
+}
+
+/**
+ * Validate that a URL is from the allowed GitHub user-attachments domain.
+ *
+ * Security: Only allows github.com/user-attachments/* URLs.
+ */
+export function isValidAttachmentUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return (
+      parsed.protocol === "https:" &&
+      parsed.hostname === "github.com" &&
+      parsed.pathname.startsWith("/user-attachments/")
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Extract filename from attachment URL or use fallback.
+ */
+export function extractFilename(url: string, altText: string, index: number): string {
+  try {
+    const parsed = new URL(url)
+    const pathParts = parsed.pathname.split("/")
+    const lastPart = pathParts[pathParts.length - 1]
+
+    // If URL has a recognizable filename, use it
+    if (lastPart != null && /\.[a-z0-9]+$/i.test(lastPart)) {
+      return lastPart
+    }
+
+    // Use alt text if available
+    if (altText.length > 0) {
+      // Sanitize alt text for use as filename
+      const sanitized = altText.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 50)
+      return sanitized.length > 0 ? sanitized : `attachment_${index + 1}`
+    }
+
+    return `attachment_${index + 1}`
+  } catch {
+    return `attachment_${index + 1}`
+  }
+}
+```
+
+### 4. Downloader (`src/lib/attachments/downloader.ts`)
+
+```typescript
+import type {AttachmentUrl, DownloadedAttachment, Logger} from "./types.js"
+import {extractFilename} from "./parser.js"
+
+/**
+ * Download attachment with GitHub token authentication.
+ *
+ * Uses fetch with Authorization header for private repo attachments.
+ */
+export async function downloadAttachment(
+  attachment: AttachmentUrl,
+  index: number,
+  token: string,
+  logger: Logger,
+): Promise<DownloadedAttachment | null> {
+  logger.debug("Downloading attachment", {url: attachment.url})
+
+  try {
+    const response = await fetch(attachment.url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "*/*",
+        "User-Agent": "fro-bot-agent",
+      },
+      redirect: "follow",
+    })
+
+    if (!response.ok) {
+      logger.warning("Attachment download failed", {
+        url: attachment.url,
+        status: response.status,
+      })
+      return null
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer())
+    const contentType = response.headers.get("content-type") ?? "application/octet-stream"
+    const filename = extractFilename(attachment.url, attachment.altText, index)
+
+    logger.debug("Attachment downloaded", {
+      filename,
+      mimeType: contentType,
+      sizeBytes: buffer.length,
+    })
+
+    return {
+      url: attachment.url,
+      filename,
+      mimeType: contentType.split(";")[0].trim(),
+      sizeBytes: buffer.length,
+      content: buffer,
+    }
+  } catch (error) {
+    logger.warning("Attachment download error", {
+      url: attachment.url,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}
+
+/**
+ * Download multiple attachments in parallel.
+ */
+export async function downloadAttachments(
+  attachments: readonly AttachmentUrl[],
+  token: string,
+  logger: Logger,
+): Promise<readonly (DownloadedAttachment | null)[]> {
+  return Promise.all(attachments.map((attachment, index) => downloadAttachment(attachment, index, token, logger)))
+}
+```
+
+### 5. Validator (`src/lib/attachments/validator.ts`)
+
+```typescript
+import type {DownloadedAttachment, ValidatedAttachment, SkippedAttachment, AttachmentLimits, Logger} from "./types.js"
+import {DEFAULT_ATTACHMENT_LIMITS} from "./types.js"
+
+interface ValidationResult {
+  readonly validated: readonly ValidatedAttachment[]
+  readonly skipped: readonly SkippedAttachment[]
+}
+
+/**
+ * Validate downloaded attachments against limits.
+ */
+export function validateAttachments(
+  downloaded: readonly (DownloadedAttachment | null)[],
+  limits: AttachmentLimits = DEFAULT_ATTACHMENT_LIMITS,
+  logger: Logger,
+): ValidationResult {
+  const validated: ValidatedAttachment[] = []
+  const skipped: SkippedAttachment[] = []
+  let totalSize = 0
+
+  for (const attachment of downloaded) {
+    // Skip failed downloads
+    if (attachment == null) {
+      continue
+    }
+
+    // Check file count limit
+    if (validated.length >= limits.maxFiles) {
+      skipped.push({
+        url: attachment.url,
+        reason: `Exceeds max file count (${limits.maxFiles})`,
+      })
+      logger.debug("Attachment skipped: max count", {url: attachment.url})
+      continue
+    }
+
+    // Check individual file size
+    if (attachment.sizeBytes > limits.maxFileSizeBytes) {
+      skipped.push({
+        url: attachment.url,
+        reason: `File too large (${formatBytes(attachment.sizeBytes)} > ${formatBytes(limits.maxFileSizeBytes)})`,
+      })
+      logger.debug("Attachment skipped: too large", {
+        url: attachment.url,
+        size: attachment.sizeBytes,
+      })
+      continue
+    }
+
+    // Check total size limit
+    if (totalSize + attachment.sizeBytes > limits.maxTotalSizeBytes) {
+      skipped.push({
+        url: attachment.url,
+        reason: `Would exceed total size limit (${formatBytes(limits.maxTotalSizeBytes)})`,
+      })
+      logger.debug("Attachment skipped: total size exceeded", {url: attachment.url})
+      continue
+    }
+
+    // Check MIME type
+    if (!isMimeTypeAllowed(attachment.mimeType, limits.allowedMimeTypes)) {
+      skipped.push({
+        url: attachment.url,
+        reason: `MIME type not allowed: ${attachment.mimeType}`,
+      })
+      logger.debug("Attachment skipped: MIME type", {
+        url: attachment.url,
+        mimeType: attachment.mimeType,
+      })
+      continue
+    }
+
+    // Attachment validated
+    totalSize += attachment.sizeBytes
+    validated.push({
+      filename: attachment.filename,
+      mimeType: attachment.mimeType,
+      sizeBytes: attachment.sizeBytes,
+      base64Content: attachment.content.toString("base64"),
+    })
+
+    logger.info("Attachment validated", {
+      filename: attachment.filename,
+      mimeType: attachment.mimeType,
+      sizeBytes: attachment.sizeBytes,
+    })
+  }
+
+  return {validated, skipped}
+}
+
+/**
+ * Check if MIME type is in allowed list.
+ *
+ * Supports wildcards (e.g., "image/*").
+ */
+function isMimeTypeAllowed(mimeType: string, allowedTypes: readonly string[]): boolean {
+  const [category, subtype] = mimeType.split("/")
+
+  for (const allowed of allowedTypes) {
+    if (allowed === mimeType) {
+      return true
+    }
+
+    // Check wildcard (e.g., "image/*")
+    if (allowed.endsWith("/*")) {
+      const allowedCategory = allowed.slice(0, -2)
+      if (category === allowedCategory) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+/**
+ * Format bytes for human-readable display.
+ */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
+}
+```
+
+### 6. Prompt Injector (`src/lib/attachments/injector.ts`)
+
+```typescript
+import type {
+  AttachmentUrl,
+  ValidatedAttachment,
+  FilePart,
+  AttachmentResult,
+  SkippedAttachment,
+  Logger,
+} from "./types.js"
+
+/**
+ * Transform validated attachments to SDK file parts.
+ */
+export function toFileParts(attachments: readonly ValidatedAttachment[]): readonly FilePart[] {
+  return attachments.map(attachment => ({
+    type: "file" as const,
+    filename: attachment.filename,
+    mimeType: attachment.mimeType,
+    content: attachment.base64Content,
+  }))
+}
+
+/**
+ * Modify comment body to replace attachment markdown with @filename references.
+ *
+ * This allows the agent to understand which files are being referenced.
+ */
+export function modifyBodyForAttachments(
+  originalBody: string,
+  parsedUrls: readonly AttachmentUrl[],
+  validated: readonly ValidatedAttachment[],
+): string {
+  let modifiedBody = originalBody
+
+  // Build URL -> filename mapping
+  const urlToFilename = new Map<string, string>()
+  for (const attachment of validated) {
+    // Find the parsed URL that matches this filename
+    const parsedUrl = parsedUrls.find(p => validated.some(v => v.filename === attachment.filename))
+    if (parsedUrl != null) {
+      urlToFilename.set(parsedUrl.originalMarkdown, `@${attachment.filename}`)
+    }
+  }
+
+  // Replace markdown with @filename references
+  for (const [originalMarkdown, reference] of urlToFilename) {
+    modifiedBody = modifiedBody.replace(originalMarkdown, reference)
+  }
+
+  return modifiedBody
+}
+
+/**
+ * Process attachments and return complete result.
+ */
+export function buildAttachmentResult(
+  originalBody: string,
+  parsedUrls: readonly AttachmentUrl[],
+  validated: readonly ValidatedAttachment[],
+  skipped: readonly SkippedAttachment[],
+): AttachmentResult {
+  const modifiedBody = modifyBodyForAttachments(originalBody, parsedUrls, validated)
+
+  return {
+    processed: validated,
+    skipped,
+    modifiedBody,
+  }
+}
+```
+
+### 7. Public Exports (`src/lib/attachments/index.ts`)
+
+```typescript
+export {parseAttachmentUrls, isValidAttachmentUrl, extractFilename} from "./parser.js"
+export {downloadAttachment, downloadAttachments} from "./downloader.js"
+export {validateAttachments} from "./validator.js"
+export {toFileParts, modifyBodyForAttachments, buildAttachmentResult} from "./injector.js"
+export type {
+  AttachmentUrl,
+  DownloadedAttachment,
+  ValidatedAttachment,
+  FilePart,
+  AttachmentResult,
+  SkippedAttachment,
+  AttachmentLimits,
+} from "./types.js"
+export {DEFAULT_ATTACHMENT_LIMITS} from "./types.js"
+```
+
+### 8. Integration with Main Action
+
+Add to `src/main.ts` after context collection:
+
+```typescript
+import {
+  parseAttachmentUrls,
+  downloadAttachments,
+  validateAttachments,
+  buildAttachmentResult,
+  toFileParts,
+} from "./lib/attachments/index.js"
+
+// ... in run() function, after collecting agent context ...
+
+// Process attachments from comment body
+const attachmentLogger = createLogger({phase: "attachments"})
+const parsedUrls = parseAttachmentUrls(agentContext.commentBody ?? "")
+
+let attachmentResult: AttachmentResult | null = null
+let fileParts: FilePart[] = []
+
+if (parsedUrls.length > 0) {
+  attachmentLogger.info("Processing attachments", {count: parsedUrls.length})
+
+  const token = inputs.githubToken
+  const downloaded = await downloadAttachments(parsedUrls, token, attachmentLogger)
+  const {validated, skipped} = validateAttachments(downloaded, undefined, attachmentLogger)
+
+  attachmentResult = buildAttachmentResult(agentContext.commentBody ?? "", parsedUrls, validated, skipped)
+
+  fileParts = toFileParts(validated)
+
+  attachmentLogger.info("Attachments processed", {
+    processed: validated.length,
+    skipped: skipped.length,
+  })
+}
+
+// Use attachmentResult.modifiedBody in prompt if attachments were processed
+const promptBody = attachmentResult?.modifiedBody ?? agentContext.commentBody ?? ""
+```
+
+### 9. SDK Prompt with File Parts
+
+Update `executeOpenCode()` to accept file parts:
+
+```typescript
+// In opencode.ts, update prompt call to include file parts
+const promptResponse = await client.session.prompt<true>({
+  path: {id: session.id},
+  body: {
+    ...(model != null && {
+      model: {
+        providerID: model.providerID,
+        modelID: model.modelID,
+      },
+    }),
+    agent: agent ?? undefined,
+    parts: [
+      {type: "text", text: prompt},
+      ...fileParts, // File parts added here
+    ],
+  },
+})
+```
+
+## Acceptance Criteria
+
+- [ ] Markdown image URLs parsed from comment body
+- [ ] HTML image URLs parsed from comment body
+- [ ] Markdown file link URLs parsed from comment body
+- [ ] Only `github.com/user-attachments/` URLs accepted (security)
+- [ ] Attachments downloaded with GitHub token authentication
+- [ ] MIME type determined from response headers
+- [ ] File size validated against 5MB limit per file
+- [ ] Total size validated against 15MB limit
+- [ ] Max 5 attachments per comment
+- [ ] Only allowed MIME types accepted
+- [ ] Validated attachments converted to base64
+- [ ] File parts passed to SDK `prompt()` call
+- [ ] Original markdown replaced with `@filename` in prompt body
+- [ ] Attachments NOT persisted to cache
+- [ ] Attachment metadata logged (filename, size, type)
+
+## Test Cases
+
+### URL Parsing Tests
+
+```typescript
+describe("parseAttachmentUrls", () => {
+  it("parses markdown image URLs", () => {
+    const body = "Check this: ![screenshot](https://github.com/user-attachments/assets/abc123)"
+    const result = parseAttachmentUrls(body)
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe("image")
+    expect(result[0].url).toContain("user-attachments/assets")
+  })
+
+  it("parses markdown file links", () => {
+    const body = "See [log.txt](https://github.com/user-attachments/files/xyz789)"
+    const result = parseAttachmentUrls(body)
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe("file")
+  })
+
+  it("parses HTML image tags", () => {
+    const body = '<img src="https://github.com/user-attachments/assets/img123" alt="error">'
+    const result = parseAttachmentUrls(body)
+    expect(result).toHaveLength(1)
+    expect(result[0].altText).toBe("error")
+  })
+
+  it("ignores non-GitHub URLs", () => {
+    const body = "![img](https://example.com/image.png)"
+    const result = parseAttachmentUrls(body)
+    expect(result).toHaveLength(0)
+  })
+
+  it("deduplicates same URL appearing multiple times", () => {
+    const url = "https://github.com/user-attachments/assets/same123"
+    const body = `![a](${url}) and ![b](${url})`
+    const result = parseAttachmentUrls(body)
+    expect(result).toHaveLength(1)
+  })
+})
+```
+
+### Validation Tests
+
+```typescript
+describe("validateAttachments", () => {
+  it("accepts attachments within limits", () => {
+    const downloaded = [createMockDownload({sizeBytes: 1024, mimeType: "image/png"})]
+    const result = validateAttachments(downloaded, DEFAULT_ATTACHMENT_LIMITS, mockLogger)
+    expect(result.validated).toHaveLength(1)
+    expect(result.skipped).toHaveLength(0)
+  })
+
+  it("rejects files exceeding size limit", () => {
+    const downloaded = [createMockDownload({sizeBytes: 10 * 1024 * 1024, mimeType: "image/png"})]
+    const result = validateAttachments(downloaded, DEFAULT_ATTACHMENT_LIMITS, mockLogger)
+    expect(result.validated).toHaveLength(0)
+    expect(result.skipped).toHaveLength(1)
+    expect(result.skipped[0].reason).toContain("too large")
+  })
+
+  it("rejects disallowed MIME types", () => {
+    const downloaded = [createMockDownload({sizeBytes: 1024, mimeType: "application/x-executable"})]
+    const result = validateAttachments(downloaded, DEFAULT_ATTACHMENT_LIMITS, mockLogger)
+    expect(result.validated).toHaveLength(0)
+    expect(result.skipped[0].reason).toContain("MIME type not allowed")
+  })
+
+  it("enforces max file count", () => {
+    const downloaded = Array.from({length: 10}, () => createMockDownload({sizeBytes: 1024, mimeType: "image/png"}))
+    const result = validateAttachments(downloaded, DEFAULT_ATTACHMENT_LIMITS, mockLogger)
+    expect(result.validated).toHaveLength(5)
+    expect(result.skipped).toHaveLength(5)
+  })
+
+  it("enforces total size limit", () => {
+    const downloaded = [
+      createMockDownload({sizeBytes: 6 * 1024 * 1024, mimeType: "image/png"}),
+      createMockDownload({sizeBytes: 6 * 1024 * 1024, mimeType: "image/png"}),
+      createMockDownload({sizeBytes: 6 * 1024 * 1024, mimeType: "image/png"}),
+    ]
+    const result = validateAttachments(downloaded, DEFAULT_ATTACHMENT_LIMITS, mockLogger)
+    expect(result.validated).toHaveLength(2)
+    expect(result.skipped).toHaveLength(1)
+    expect(result.skipped[0].reason).toContain("total size")
+  })
+})
+```
+
+### Security Tests
+
+```typescript
+describe("isValidAttachmentUrl", () => {
+  it("accepts github.com/user-attachments URLs", () => {
+    expect(isValidAttachmentUrl("https://github.com/user-attachments/assets/abc")).toBe(true)
+    expect(isValidAttachmentUrl("https://github.com/user-attachments/files/xyz")).toBe(true)
+  })
+
+  it("rejects non-GitHub URLs", () => {
+    expect(isValidAttachmentUrl("https://malicious.com/user-attachments/assets/abc")).toBe(false)
+    expect(isValidAttachmentUrl("https://github.com.evil.com/user-attachments/assets/abc")).toBe(false)
+  })
+
+  it("rejects non-user-attachments GitHub URLs", () => {
+    expect(isValidAttachmentUrl("https://github.com/owner/repo/blob/main/file.png")).toBe(false)
+    expect(isValidAttachmentUrl("https://raw.githubusercontent.com/owner/repo/main/file.png")).toBe(false)
+  })
+
+  it("rejects HTTP URLs", () => {
+    expect(isValidAttachmentUrl("http://github.com/user-attachments/assets/abc")).toBe(false)
+  })
+})
+```
+
+## Security Considerations
+
+1. **URL Allowlist**: Only `github.com/user-attachments/` URLs are processed
+2. **Authentication**: Downloads use GitHub token for private repo access
+3. **Size Limits**: Prevents resource exhaustion (5MB per file, 15MB total)
+4. **MIME Validation**: Only allows safe content types (images, text, JSON, PDF)
+5. **No Persistence**: Attachments are temp-only, never cached
+6. **Log Sanitization**: Only metadata logged, never content
+
+## Implementation Notes
+
+1. **Temp Storage**: Downloaded files stored in temp directory, cleaned up after run
+2. **Parallel Downloads**: All attachments downloaded concurrently for performance
+3. **Graceful Degradation**: Failed downloads logged as warnings, not errors
+4. **Base64 Encoding**: Required by SDK `type: "file"` parts
+5. **Body Modification**: Original URLs replaced with `@filename` for agent context
+
+## Estimated Effort
+
+- **Development**: 6-8 hours
+- **Testing**: 3-4 hours
+- **Total**: 9-12 hours

--- a/RFCs/RFC-015-GraphQL-Context-Hydration.md
+++ b/RFCs/RFC-015-GraphQL-Context-Hydration.md
@@ -1,0 +1,1147 @@
+# RFC-015: GraphQL Context Hydration
+
+**Status:** Pending
+**Priority:** MUST
+**Complexity:** High
+**Phase:** 2
+
+---
+
+## Summary
+
+Implement enhanced GitHub context hydration using GraphQL API to provide the agent with comprehensive issue and pull request context. This replaces limited REST API context with rich, structured data including comments, reviews, commits, and file changes.
+
+## Dependencies
+
+- **Builds Upon:** RFC-003 (GitHub Client), RFC-005 (Triggers)
+- **Enables:** RFC-008 (Comments), RFC-009 (Reviews), improved agent context awareness
+
+## Features Addressed
+
+| Feature ID | Feature Name              | Priority |
+| ---------- | ------------------------- | -------- |
+| NEW        | Issue Context via GraphQL | P0       |
+| NEW        | PR Context via GraphQL    | P0       |
+| NEW        | Context Budgeting         | P0       |
+| NEW        | Fork PR Detection         | P0       |
+| NEW        | REST API Fallback         | P0       |
+
+## Technical Specification
+
+### 1. File Structure
+
+```
+src/lib/
+├── context/
+│   ├── types.ts          # Context-related types
+│   ├── graphql.ts        # GraphQL queries and client
+│   ├── issue.ts          # Issue context hydration
+│   ├── pull-request.ts   # PR context hydration
+│   ├── budget.ts         # Context budgeting/truncation
+│   ├── fallback.ts       # REST API fallback
+│   └── index.ts          # Public exports
+```
+
+### 2. Context Types (`src/lib/context/types.ts`)
+
+```typescript
+import type {Logger} from "../types.js"
+
+/**
+ * Common author information.
+ */
+export interface Author {
+  readonly login: string
+  readonly avatarUrl?: string
+}
+
+/**
+ * Label information.
+ */
+export interface Label {
+  readonly name: string
+  readonly color: string
+}
+
+/**
+ * Comment in issue/PR thread.
+ */
+export interface Comment {
+  readonly id: string
+  readonly author: Author | null
+  readonly body: string
+  readonly createdAt: string
+  readonly isMinimized: boolean
+}
+
+/**
+ * Hydrated issue context.
+ */
+export interface IssueContext {
+  readonly type: "issue"
+  readonly number: number
+  readonly title: string
+  readonly body: string
+  readonly author: Author | null
+  readonly state: "OPEN" | "CLOSED"
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly labels: readonly Label[]
+  readonly assignees: readonly Author[]
+  readonly comments: readonly Comment[]
+  readonly commentCount: number
+  readonly truncated: boolean
+}
+
+/**
+ * Commit in PR.
+ */
+export interface PrCommit {
+  readonly oid: string
+  readonly message: string
+  readonly author: {
+    readonly name: string
+    readonly email: string
+    readonly date: string
+  } | null
+}
+
+/**
+ * Changed file in PR.
+ */
+export interface PrFile {
+  readonly path: string
+  readonly additions: number
+  readonly deletions: number
+  readonly changeType: "ADDED" | "DELETED" | "MODIFIED" | "RENAMED" | "COPIED"
+}
+
+/**
+ * Review on PR.
+ */
+export interface PrReview {
+  readonly id: string
+  readonly author: Author | null
+  readonly state: "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED" | "DISMISSED" | "PENDING"
+  readonly body: string
+  readonly submittedAt: string | null
+  readonly comments: readonly ReviewComment[]
+}
+
+/**
+ * Inline review comment.
+ */
+export interface ReviewComment {
+  readonly id: string
+  readonly path: string
+  readonly line: number | null
+  readonly body: string
+  readonly author: Author | null
+  readonly createdAt: string
+}
+
+/**
+ * Hydrated pull request context.
+ */
+export interface PullRequestContext {
+  readonly type: "pull_request"
+  readonly number: number
+  readonly title: string
+  readonly body: string
+  readonly author: Author | null
+  readonly state: "OPEN" | "CLOSED" | "MERGED"
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly baseRefName: string
+  readonly headRefName: string
+  readonly headRefOid: string
+  readonly additions: number
+  readonly deletions: number
+  readonly changedFiles: number
+  readonly baseRepository: string // owner/repo
+  readonly headRepository: string // owner/repo (different for forks)
+  readonly isFork: boolean
+  readonly labels: readonly Label[]
+  readonly assignees: readonly Author[]
+  readonly comments: readonly Comment[]
+  readonly commits: readonly PrCommit[]
+  readonly files: readonly PrFile[]
+  readonly reviews: readonly PrReview[]
+  readonly commentCount: number
+  readonly commitCount: number
+  readonly fileCount: number
+  readonly reviewCount: number
+  readonly truncated: boolean
+}
+
+export type HydratedContext = IssueContext | PullRequestContext
+
+/**
+ * Context budgeting limits.
+ */
+export interface ContextBudget {
+  readonly maxComments: number // Default: 50
+  readonly maxCommits: number // Default: 100
+  readonly maxFiles: number // Default: 100
+  readonly maxReviews: number // Default: 100
+  readonly maxBodyBytes: number // Default: 10KB
+  readonly maxTotalBytes: number // Default: 100KB
+}
+
+export const DEFAULT_CONTEXT_BUDGET: ContextBudget = {
+  maxComments: 50,
+  maxCommits: 100,
+  maxFiles: 100,
+  maxReviews: 100,
+  maxBodyBytes: 10 * 1024, // 10KB
+  maxTotalBytes: 100 * 1024, // 100KB
+}
+
+/**
+ * Context hydration options.
+ */
+export interface HydrationOptions {
+  readonly budget?: ContextBudget
+  readonly includeDiffs?: boolean // Include file diffs (expensive)
+}
+```
+
+### 3. GraphQL Queries (`src/lib/context/graphql.ts`)
+
+```typescript
+import type {Octokit} from "../github/types.js"
+import type {Logger} from "../types.js"
+
+/**
+ * GraphQL query for issue context.
+ */
+export const ISSUE_QUERY = `
+  query IssueContext($owner: String!, $repo: String!, $number: Int!, $commentCount: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $number) {
+        id
+        number
+        title
+        body
+        state
+        createdAt
+        updatedAt
+        author {
+          login
+          avatarUrl
+        }
+        labels(first: 20) {
+          nodes {
+            name
+            color
+          }
+        }
+        assignees(first: 10) {
+          nodes {
+            login
+            avatarUrl
+          }
+        }
+        comments(first: $commentCount) {
+          totalCount
+          nodes {
+            id
+            author {
+              login
+              avatarUrl
+            }
+            body
+            createdAt
+            isMinimized
+          }
+        }
+      }
+    }
+  }
+`
+
+/**
+ * GraphQL query for pull request context.
+ */
+export const PULL_REQUEST_QUERY = `
+  query PullRequestContext(
+    $owner: String!,
+    $repo: String!,
+    $number: Int!,
+    $commentCount: Int!,
+    $commitCount: Int!,
+    $fileCount: Int!,
+    $reviewCount: Int!
+  ) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        id
+        number
+        title
+        body
+        state
+        createdAt
+        updatedAt
+        baseRefName
+        headRefName
+        headRefOid
+        additions
+        deletions
+        changedFiles
+        baseRepository {
+          nameWithOwner
+        }
+        headRepository {
+          nameWithOwner
+        }
+        author {
+          login
+          avatarUrl
+        }
+        labels(first: 20) {
+          nodes {
+            name
+            color
+          }
+        }
+        assignees(first: 10) {
+          nodes {
+            login
+            avatarUrl
+          }
+        }
+        comments(first: $commentCount) {
+          totalCount
+          nodes {
+            id
+            author {
+              login
+              avatarUrl
+            }
+            body
+            createdAt
+            isMinimized
+          }
+        }
+        commits(last: $commitCount) {
+          totalCount
+          nodes {
+            commit {
+              oid
+              message
+              author {
+                name
+                email
+                date
+              }
+            }
+          }
+        }
+        files(first: $fileCount) {
+          totalCount
+          nodes {
+            path
+            additions
+            deletions
+            changeType
+          }
+        }
+        reviews(first: $reviewCount) {
+          totalCount
+          nodes {
+            id
+            author {
+              login
+              avatarUrl
+            }
+            state
+            body
+            submittedAt
+            comments(first: 20) {
+              nodes {
+                id
+                path
+                line
+                body
+                author {
+                  login
+                  avatarUrl
+                }
+                createdAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+/**
+ * Execute GraphQL query with error handling.
+ */
+export async function executeGraphQL<T>(
+  octokit: Octokit,
+  query: string,
+  variables: Record<string, unknown>,
+  logger: Logger,
+): Promise<T | null> {
+  try {
+    logger.debug("Executing GraphQL query", {variables})
+    const result = await octokit.graphql<T>(query, variables)
+    return result
+  } catch (error) {
+    logger.warning("GraphQL query failed", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}
+```
+
+### 4. Issue Context Hydration (`src/lib/context/issue.ts`)
+
+```typescript
+import type {Octokit} from "../github/types.js"
+import type {IssueContext, ContextBudget, Author, Label, Comment, Logger} from "./types.js"
+import {DEFAULT_CONTEXT_BUDGET} from "./types.js"
+import {ISSUE_QUERY, executeGraphQL} from "./graphql.js"
+import {truncateBody} from "./budget.js"
+
+interface IssueQueryResult {
+  repository: {
+    issue: {
+      id: string
+      number: number
+      title: string
+      body: string
+      state: "OPEN" | "CLOSED"
+      createdAt: string
+      updatedAt: string
+      author: {login: string; avatarUrl: string} | null
+      labels: {nodes: Array<{name: string; color: string}>}
+      assignees: {nodes: Array<{login: string; avatarUrl: string}>}
+      comments: {
+        totalCount: number
+        nodes: Array<{
+          id: string
+          author: {login: string; avatarUrl: string} | null
+          body: string
+          createdAt: string
+          isMinimized: boolean
+        }>
+      }
+    }
+  }
+}
+
+/**
+ * Hydrate issue context via GraphQL.
+ */
+export async function hydrateIssueContext(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+  budget: ContextBudget = DEFAULT_CONTEXT_BUDGET,
+  logger: Logger,
+): Promise<IssueContext | null> {
+  logger.info("Hydrating issue context via GraphQL", {owner, repo, number})
+
+  const result = await executeGraphQL<IssueQueryResult>(
+    octokit,
+    ISSUE_QUERY,
+    {
+      owner,
+      repo,
+      number,
+      commentCount: budget.maxComments,
+    },
+    logger,
+  )
+
+  if (result == null || result.repository?.issue == null) {
+    logger.warning("Failed to fetch issue context via GraphQL")
+    return null
+  }
+
+  const issue = result.repository.issue
+  const truncated = issue.comments.totalCount > budget.maxComments
+
+  const context: IssueContext = {
+    type: "issue",
+    number: issue.number,
+    title: issue.title,
+    body: truncateBody(issue.body, budget.maxBodyBytes),
+    author: issue.author != null ? {login: issue.author.login, avatarUrl: issue.author.avatarUrl} : null,
+    state: issue.state,
+    createdAt: issue.createdAt,
+    updatedAt: issue.updatedAt,
+    labels: issue.labels.nodes.map(l => ({name: l.name, color: l.color})),
+    assignees: issue.assignees.nodes.map(a => ({login: a.login, avatarUrl: a.avatarUrl})),
+    comments: issue.comments.nodes.map(c => ({
+      id: c.id,
+      author: c.author != null ? {login: c.author.login, avatarUrl: c.author.avatarUrl} : null,
+      body: truncateBody(c.body, budget.maxBodyBytes),
+      createdAt: c.createdAt,
+      isMinimized: c.isMinimized,
+    })),
+    commentCount: issue.comments.totalCount,
+    truncated,
+  }
+
+  logger.info("Issue context hydrated", {
+    number: context.number,
+    commentCount: context.commentCount,
+    truncated: context.truncated,
+  })
+
+  return context
+}
+```
+
+### 5. Pull Request Context Hydration (`src/lib/context/pull-request.ts`)
+
+```typescript
+import type {Octokit} from "../github/types.js"
+import type {PullRequestContext, ContextBudget, PrCommit, PrFile, PrReview, ReviewComment, Logger} from "./types.js"
+import {DEFAULT_CONTEXT_BUDGET} from "./types.js"
+import {PULL_REQUEST_QUERY, executeGraphQL} from "./graphql.js"
+import {truncateBody} from "./budget.js"
+
+interface PrQueryResult {
+  repository: {
+    pullRequest: {
+      id: string
+      number: number
+      title: string
+      body: string
+      state: "OPEN" | "CLOSED" | "MERGED"
+      createdAt: string
+      updatedAt: string
+      baseRefName: string
+      headRefName: string
+      headRefOid: string
+      additions: number
+      deletions: number
+      changedFiles: number
+      baseRepository: {nameWithOwner: string}
+      headRepository: {nameWithOwner: string}
+      author: {login: string; avatarUrl: string} | null
+      labels: {nodes: Array<{name: string; color: string}>}
+      assignees: {nodes: Array<{login: string; avatarUrl: string}>}
+      comments: {
+        totalCount: number
+        nodes: Array<{
+          id: string
+          author: {login: string; avatarUrl: string} | null
+          body: string
+          createdAt: string
+          isMinimized: boolean
+        }>
+      }
+      commits: {
+        totalCount: number
+        nodes: Array<{
+          commit: {
+            oid: string
+            message: string
+            author: {name: string; email: string; date: string} | null
+          }
+        }>
+      }
+      files: {
+        totalCount: number
+        nodes: Array<{
+          path: string
+          additions: number
+          deletions: number
+          changeType: string
+        }>
+      }
+      reviews: {
+        totalCount: number
+        nodes: Array<{
+          id: string
+          author: {login: string; avatarUrl: string} | null
+          state: string
+          body: string
+          submittedAt: string | null
+          comments: {
+            nodes: Array<{
+              id: string
+              path: string
+              line: number | null
+              body: string
+              author: {login: string; avatarUrl: string} | null
+              createdAt: string
+            }>
+          }
+        }>
+      }
+    }
+  }
+}
+
+/**
+ * Hydrate pull request context via GraphQL.
+ */
+export async function hydratePullRequestContext(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+  budget: ContextBudget = DEFAULT_CONTEXT_BUDGET,
+  logger: Logger,
+): Promise<PullRequestContext | null> {
+  logger.info("Hydrating PR context via GraphQL", {owner, repo, number})
+
+  const result = await executeGraphQL<PrQueryResult>(
+    octokit,
+    PULL_REQUEST_QUERY,
+    {
+      owner,
+      repo,
+      number,
+      commentCount: budget.maxComments,
+      commitCount: budget.maxCommits,
+      fileCount: budget.maxFiles,
+      reviewCount: budget.maxReviews,
+    },
+    logger,
+  )
+
+  if (result == null || result.repository?.pullRequest == null) {
+    logger.warning("Failed to fetch PR context via GraphQL")
+    return null
+  }
+
+  const pr = result.repository.pullRequest
+  const baseRepo = pr.baseRepository.nameWithOwner
+  const headRepo = pr.headRepository.nameWithOwner
+  const isFork = baseRepo !== headRepo
+
+  const truncated =
+    pr.comments.totalCount > budget.maxComments ||
+    pr.commits.totalCount > budget.maxCommits ||
+    pr.files.totalCount > budget.maxFiles ||
+    pr.reviews.totalCount > budget.maxReviews
+
+  const context: PullRequestContext = {
+    type: "pull_request",
+    number: pr.number,
+    title: pr.title,
+    body: truncateBody(pr.body, budget.maxBodyBytes),
+    author: pr.author != null ? {login: pr.author.login, avatarUrl: pr.author.avatarUrl} : null,
+    state: pr.state,
+    createdAt: pr.createdAt,
+    updatedAt: pr.updatedAt,
+    baseRefName: pr.baseRefName,
+    headRefName: pr.headRefName,
+    headRefOid: pr.headRefOid,
+    additions: pr.additions,
+    deletions: pr.deletions,
+    changedFiles: pr.changedFiles,
+    baseRepository: baseRepo,
+    headRepository: headRepo,
+    isFork,
+    labels: pr.labels.nodes.map(l => ({name: l.name, color: l.color})),
+    assignees: pr.assignees.nodes.map(a => ({login: a.login, avatarUrl: a.avatarUrl})),
+    comments: pr.comments.nodes.map(c => ({
+      id: c.id,
+      author: c.author != null ? {login: c.author.login, avatarUrl: c.author.avatarUrl} : null,
+      body: truncateBody(c.body, budget.maxBodyBytes),
+      createdAt: c.createdAt,
+      isMinimized: c.isMinimized,
+    })),
+    commits: pr.commits.nodes.map(n => ({
+      oid: n.commit.oid,
+      message: n.commit.message,
+      author: n.commit.author,
+    })),
+    files: pr.files.nodes.map(f => ({
+      path: f.path,
+      additions: f.additions,
+      deletions: f.deletions,
+      changeType: f.changeType as PrFile["changeType"],
+    })),
+    reviews: pr.reviews.nodes.map(r => ({
+      id: r.id,
+      author: r.author != null ? {login: r.author.login, avatarUrl: r.author.avatarUrl} : null,
+      state: r.state as PrReview["state"],
+      body: truncateBody(r.body, budget.maxBodyBytes),
+      submittedAt: r.submittedAt,
+      comments: r.comments.nodes.map(c => ({
+        id: c.id,
+        path: c.path,
+        line: c.line,
+        body: truncateBody(c.body, budget.maxBodyBytes),
+        author: c.author != null ? {login: c.author.login, avatarUrl: c.author.avatarUrl} : null,
+        createdAt: c.createdAt,
+      })),
+    })),
+    commentCount: pr.comments.totalCount,
+    commitCount: pr.commits.totalCount,
+    fileCount: pr.files.totalCount,
+    reviewCount: pr.reviews.totalCount,
+    truncated,
+  }
+
+  logger.info("PR context hydrated", {
+    number: context.number,
+    isFork: context.isFork,
+    commentCount: context.commentCount,
+    commitCount: context.commitCount,
+    fileCount: context.fileCount,
+    reviewCount: context.reviewCount,
+    truncated: context.truncated,
+  })
+
+  return context
+}
+```
+
+### 6. Context Budgeting (`src/lib/context/budget.ts`)
+
+```typescript
+import type {HydratedContext, ContextBudget} from "./types.js"
+import {DEFAULT_CONTEXT_BUDGET} from "./types.js"
+
+/**
+ * Truncate body text to max bytes with truncation note.
+ */
+export function truncateBody(body: string | null | undefined, maxBytes: number): string {
+  if (body == null) return ""
+
+  const bytes = Buffer.byteLength(body, "utf8")
+  if (bytes <= maxBytes) return body
+
+  // Find a good cutoff point (don't cut in middle of multi-byte char)
+  let cutoff = maxBytes - 50 // Leave room for truncation note
+  while (cutoff > 0 && (body.charCodeAt(cutoff) & 0xc0) === 0x80) {
+    cutoff--
+  }
+
+  const truncated = body.slice(0, cutoff)
+  return `${truncated}\n\n[... truncated, ${bytes - cutoff} bytes omitted ...]`
+}
+
+/**
+ * Estimate total size of hydrated context in bytes.
+ */
+export function estimateContextSize(context: HydratedContext): number {
+  // Simple estimation: JSON stringify and measure
+  const json = JSON.stringify(context)
+  return Buffer.byteLength(json, "utf8")
+}
+
+/**
+ * Check if context exceeds total budget.
+ */
+export function exceedsBudget(context: HydratedContext, budget: ContextBudget = DEFAULT_CONTEXT_BUDGET): boolean {
+  return estimateContextSize(context) > budget.maxTotalBytes
+}
+
+/**
+ * Format context for prompt injection.
+ *
+ * Produces a markdown-formatted summary of the context.
+ */
+export function formatContextForPrompt(context: HydratedContext): string {
+  const lines: string[] = []
+
+  if (context.type === "issue") {
+    lines.push(`## Issue #${context.number}: ${context.title}`)
+    lines.push("")
+    lines.push(`**State:** ${context.state}`)
+    lines.push(`**Author:** ${context.author?.login ?? "unknown"}`)
+    lines.push(`**Created:** ${context.createdAt}`)
+    lines.push(`**Labels:** ${context.labels.map(l => l.name).join(", ") || "none"}`)
+    lines.push("")
+    lines.push("### Description")
+    lines.push("")
+    lines.push(context.body || "*No description provided*")
+    lines.push("")
+
+    if (context.comments.length > 0) {
+      lines.push(`### Comments (${context.commentCount} total, showing ${context.comments.length})`)
+      lines.push("")
+      for (const comment of context.comments) {
+        if (!comment.isMinimized) {
+          lines.push(`**${comment.author?.login ?? "unknown"}** (${comment.createdAt}):`)
+          lines.push(comment.body)
+          lines.push("")
+        }
+      }
+    }
+
+    if (context.truncated) {
+      lines.push("*Note: Some content was truncated due to size limits.*")
+    }
+  } else {
+    lines.push(`## Pull Request #${context.number}: ${context.title}`)
+    lines.push("")
+    lines.push(`**State:** ${context.state}`)
+    lines.push(`**Author:** ${context.author?.login ?? "unknown"}`)
+    lines.push(`**Branch:** ${context.headRefName} → ${context.baseRefName}`)
+    lines.push(`**Changes:** +${context.additions}/-${context.deletions} in ${context.changedFiles} files`)
+    if (context.isFork) {
+      lines.push(`**Fork:** ${context.headRepository} → ${context.baseRepository}`)
+    }
+    lines.push(`**Labels:** ${context.labels.map(l => l.name).join(", ") || "none"}`)
+    lines.push("")
+    lines.push("### Description")
+    lines.push("")
+    lines.push(context.body || "*No description provided*")
+    lines.push("")
+
+    if (context.files.length > 0) {
+      lines.push(`### Changed Files (${context.fileCount} total, showing ${context.files.length})`)
+      lines.push("")
+      for (const file of context.files) {
+        lines.push(`- \`${file.path}\` (${file.changeType}, +${file.additions}/-${file.deletions})`)
+      }
+      lines.push("")
+    }
+
+    if (context.commits.length > 0) {
+      lines.push(`### Recent Commits (${context.commitCount} total, showing ${context.commits.length})`)
+      lines.push("")
+      for (const commit of context.commits.slice(-10)) {
+        const shortOid = commit.oid.slice(0, 7)
+        const firstLine = commit.message.split("\n")[0]
+        lines.push(`- \`${shortOid}\` ${firstLine}`)
+      }
+      lines.push("")
+    }
+
+    if (context.reviews.length > 0) {
+      lines.push(`### Reviews (${context.reviewCount} total, showing ${context.reviews.length})`)
+      lines.push("")
+      for (const review of context.reviews) {
+        lines.push(`**${review.author?.login ?? "unknown"}** - ${review.state}`)
+        if (review.body.length > 0) {
+          lines.push(review.body)
+        }
+        if (review.comments.length > 0) {
+          lines.push(`  *${review.comments.length} inline comments*`)
+        }
+        lines.push("")
+      }
+    }
+
+    if (context.comments.length > 0) {
+      lines.push(`### Conversation (${context.commentCount} total, showing ${context.comments.length})`)
+      lines.push("")
+      for (const comment of context.comments) {
+        if (!comment.isMinimized) {
+          lines.push(`**${comment.author?.login ?? "unknown"}** (${comment.createdAt}):`)
+          lines.push(comment.body)
+          lines.push("")
+        }
+      }
+    }
+
+    if (context.truncated) {
+      lines.push("*Note: Some content was truncated due to size limits.*")
+    }
+  }
+
+  return lines.join("\n")
+}
+```
+
+### 7. REST API Fallback (`src/lib/context/fallback.ts`)
+
+```typescript
+import type {Octokit} from "../github/types.js"
+import type {IssueContext, PullRequestContext, ContextBudget, Logger} from "./types.js"
+import {DEFAULT_CONTEXT_BUDGET} from "./types.js"
+import {truncateBody} from "./budget.js"
+
+/**
+ * Fallback issue context via REST API.
+ *
+ * Used when GraphQL fails (rate limits, permissions, etc.)
+ */
+export async function fallbackIssueContext(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+  budget: ContextBudget = DEFAULT_CONTEXT_BUDGET,
+  logger: Logger,
+): Promise<IssueContext | null> {
+  logger.info("Falling back to REST API for issue context", {owner, repo, number})
+
+  try {
+    const {data: issue} = await octokit.rest.issues.get({owner, repo, issue_number: number})
+    const {data: comments} = await octokit.rest.issues.listComments({
+      owner,
+      repo,
+      issue_number: number,
+      per_page: budget.maxComments,
+    })
+
+    return {
+      type: "issue",
+      number: issue.number,
+      title: issue.title,
+      body: truncateBody(issue.body, budget.maxBodyBytes),
+      author: issue.user != null ? {login: issue.user.login} : null,
+      state: issue.state === "open" ? "OPEN" : "CLOSED",
+      createdAt: issue.created_at,
+      updatedAt: issue.updated_at,
+      labels: issue.labels
+        .filter((l): l is {name: string; color: string} => typeof l === "object" && l != null && "name" in l)
+        .map(l => ({name: l.name, color: l.color ?? ""})),
+      assignees: (issue.assignees ?? []).map(a => ({login: a.login})),
+      comments: comments.map(c => ({
+        id: String(c.id),
+        author: c.user != null ? {login: c.user.login} : null,
+        body: truncateBody(c.body, budget.maxBodyBytes),
+        createdAt: c.created_at,
+        isMinimized: false,
+      })),
+      commentCount: comments.length,
+      truncated: false,
+    }
+  } catch (error) {
+    logger.error("REST fallback failed for issue", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}
+
+/**
+ * Fallback PR context via REST API.
+ *
+ * Provides reduced context compared to GraphQL.
+ */
+export async function fallbackPullRequestContext(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  number: number,
+  budget: ContextBudget = DEFAULT_CONTEXT_BUDGET,
+  logger: Logger,
+): Promise<PullRequestContext | null> {
+  logger.info("Falling back to REST API for PR context", {owner, repo, number})
+
+  try {
+    const {data: pr} = await octokit.rest.pulls.get({owner, repo, pull_number: number})
+    const {data: comments} = await octokit.rest.issues.listComments({
+      owner,
+      repo,
+      issue_number: number,
+      per_page: budget.maxComments,
+    })
+    const {data: files} = await octokit.rest.pulls.listFiles({
+      owner,
+      repo,
+      pull_number: number,
+      per_page: budget.maxFiles,
+    })
+
+    const baseRepo = `${pr.base.repo.owner.login}/${pr.base.repo.name}`
+    const headRepo = pr.head.repo != null ? `${pr.head.repo.owner.login}/${pr.head.repo.name}` : baseRepo
+
+    return {
+      type: "pull_request",
+      number: pr.number,
+      title: pr.title,
+      body: truncateBody(pr.body, budget.maxBodyBytes),
+      author: pr.user != null ? {login: pr.user.login} : null,
+      state: pr.merged ? "MERGED" : pr.state === "open" ? "OPEN" : "CLOSED",
+      createdAt: pr.created_at,
+      updatedAt: pr.updated_at,
+      baseRefName: pr.base.ref,
+      headRefName: pr.head.ref,
+      headRefOid: pr.head.sha,
+      additions: pr.additions,
+      deletions: pr.deletions,
+      changedFiles: pr.changed_files,
+      baseRepository: baseRepo,
+      headRepository: headRepo,
+      isFork: baseRepo !== headRepo,
+      labels: pr.labels.map(l => ({name: l.name, color: l.color ?? ""})),
+      assignees: (pr.assignees ?? []).map(a => ({login: a.login})),
+      comments: comments.map(c => ({
+        id: String(c.id),
+        author: c.user != null ? {login: c.user.login} : null,
+        body: truncateBody(c.body, budget.maxBodyBytes),
+        createdAt: c.created_at,
+        isMinimized: false,
+      })),
+      commits: [], // Not fetched in fallback
+      files: files.map(f => ({
+        path: f.filename,
+        additions: f.additions,
+        deletions: f.deletions,
+        changeType: mapRestStatus(f.status),
+      })),
+      reviews: [], // Not fetched in fallback
+      commentCount: comments.length,
+      commitCount: pr.commits,
+      fileCount: files.length,
+      reviewCount: 0,
+      truncated: false,
+    }
+  } catch (error) {
+    logger.error("REST fallback failed for PR", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}
+
+function mapRestStatus(status: string): "ADDED" | "DELETED" | "MODIFIED" | "RENAMED" | "COPIED" {
+  switch (status) {
+    case "added":
+      return "ADDED"
+    case "removed":
+      return "DELETED"
+    case "renamed":
+      return "RENAMED"
+    case "copied":
+      return "COPIED"
+    default:
+      return "MODIFIED"
+  }
+}
+```
+
+### 8. Public Exports (`src/lib/context/index.ts`)
+
+```typescript
+export {hydrateIssueContext} from "./issue.js"
+export {hydratePullRequestContext} from "./pull-request.js"
+export {fallbackIssueContext, fallbackPullRequestContext} from "./fallback.js"
+export {truncateBody, estimateContextSize, exceedsBudget, formatContextForPrompt} from "./budget.js"
+export {executeGraphQL, ISSUE_QUERY, PULL_REQUEST_QUERY} from "./graphql.js"
+export type {
+  IssueContext,
+  PullRequestContext,
+  HydratedContext,
+  ContextBudget,
+  HydrationOptions,
+  Author,
+  Label,
+  Comment,
+  PrCommit,
+  PrFile,
+  PrReview,
+  ReviewComment,
+} from "./types.js"
+export {DEFAULT_CONTEXT_BUDGET} from "./types.js"
+```
+
+## Acceptance Criteria
+
+- [ ] Issue context fetched via GraphQL (title, body, comments, labels)
+- [ ] PR context fetched via GraphQL (commits, files, reviews, inline comments)
+- [ ] Context budgeting enforced (50 comments, 100 files, 10KB body truncation)
+- [ ] Total context budget ~100KB before prompt injection
+- [ ] Fork PR detected via `headRepository` vs `baseRepository` comparison
+- [ ] Fallback to REST API on GraphQL failure
+- [ ] Warning logged when context is degraded
+- [ ] Truncation notes added when content is cut
+- [ ] Context formatted for prompt injection
+
+## Test Cases
+
+### GraphQL Context Tests
+
+```typescript
+describe("hydrateIssueContext", () => {
+  it("fetches full issue context via GraphQL", async () => {
+    const context = await hydrateIssueContext(mockOctokit, "owner", "repo", 123, DEFAULT_CONTEXT_BUDGET, mockLogger)
+    expect(context).not.toBeNull()
+    expect(context?.type).toBe("issue")
+    expect(context?.number).toBe(123)
+    expect(context?.comments.length).toBeLessThanOrEqual(50)
+  })
+
+  it("falls back to REST on GraphQL failure", async () => {
+    mockOctokit.graphql.mockRejectedValue(new Error("Rate limit"))
+    const context = await hydrateIssueContext(mockOctokit, "owner", "repo", 123, DEFAULT_CONTEXT_BUDGET, mockLogger)
+    // Should return null (caller handles fallback)
+    expect(context).toBeNull()
+    expect(mockLogger.warning).toHaveBeenCalledWith(expect.stringContaining("GraphQL"))
+  })
+})
+
+describe("hydratePullRequestContext", () => {
+  it("detects fork PRs", async () => {
+    mockOctokit.graphql.mockResolvedValue({
+      repository: {
+        pullRequest: {
+          ...mockPrData,
+          baseRepository: {nameWithOwner: "owner/repo"},
+          headRepository: {nameWithOwner: "fork-owner/repo"},
+        },
+      },
+    })
+    const context = await hydratePullRequestContext(mockOctokit, "owner", "repo", 1, DEFAULT_CONTEXT_BUDGET, mockLogger)
+    expect(context?.isFork).toBe(true)
+  })
+
+  it("includes commits, files, and reviews", async () => {
+    const context = await hydratePullRequestContext(mockOctokit, "owner", "repo", 1, DEFAULT_CONTEXT_BUDGET, mockLogger)
+    expect(context?.commits.length).toBeGreaterThan(0)
+    expect(context?.files.length).toBeGreaterThan(0)
+    expect(context?.reviews.length).toBeGreaterThanOrEqual(0)
+  })
+})
+```
+
+### Budgeting Tests
+
+```typescript
+describe("truncateBody", () => {
+  it("returns unchanged body under limit", () => {
+    const body = "Short body"
+    expect(truncateBody(body, 1000)).toBe(body)
+  })
+
+  it("truncates with note when over limit", () => {
+    const body = "A".repeat(20000)
+    const result = truncateBody(body, 10000)
+    expect(result.length).toBeLessThan(20000)
+    expect(result).toContain("truncated")
+  })
+
+  it("handles null/undefined", () => {
+    expect(truncateBody(null, 1000)).toBe("")
+    expect(truncateBody(undefined, 1000)).toBe("")
+  })
+})
+
+describe("exceedsBudget", () => {
+  it("returns true for large context", () => {
+    const largeContext = createMockIssueContext({body: "X".repeat(200000)})
+    expect(exceedsBudget(largeContext)).toBe(true)
+  })
+})
+```
+
+## Security Considerations
+
+1. **Rate Limiting**: GraphQL has separate rate limits; REST fallback handles exhaustion
+2. **Private Data**: Only fetches data user has access to via provided token
+3. **Body Sanitization**: Truncation prevents prompt injection via oversized content
+4. **Fork Detection**: Enables different handling for untrusted fork code
+
+## Implementation Notes
+
+1. **GraphQL vs REST**: GraphQL fetches more data in fewer requests
+2. **Pagination**: Uses first/last with limits to stay within budget
+3. **Caching**: Consider caching within a run for repeated context access
+4. **Error Handling**: Graceful degradation to REST on any GraphQL failure
+
+## Estimated Effort
+
+- **Development**: 10-14 hours
+- **Testing**: 4-6 hours
+- **Total**: 14-20 hours

--- a/RFCs/RFCS.md
+++ b/RFCs/RFCS.md
@@ -1,7 +1,7 @@
 # Fro Bot Agent - RFC Index
 
-**Generated:** 2026-01-10
-**Total RFCs:** 13
+**Generated:** 2026-01-12
+**Total RFCs:** 15
 **Implementation Strategy:** Sequential (RFC-001 → RFC-013)
 
 ---
@@ -31,6 +31,8 @@ The agent harness enables OpenCode with oMo Sisyphus agent workflow to act as an
 | RFC-011 | Setup Action & Environment Bootstrap | MUST     | High       | 1     | Completed  |
 | RFC-012 | Agent Execution & Main Action        | MUST     | High       | 1     | Superseded |
 | RFC-013 | SDK Execution Mode                   | MUST     | High       | 1     | Completed  |
+| RFC-014 | File Attachment Processing           | MUST     | Medium     | 2     | Pending    |
+| RFC-015 | GraphQL Context Hydration            | MUST     | High       | 2     | Pending    |
 
 ---
 
@@ -65,6 +67,14 @@ RFC-001 (Foundation)
     │       │               │       │
     │       │               │       └── RFC-010 (Delegated Work)
     │       │               │
+    │       ├── RFC-014 (File Attachments) ─────────────────────┐
+    │       │       │                                           │
+    │       │       └── [Detection, download, MIME, SDK inject] │
+    │       │                                                   │
+    │       └── RFC-015 (GraphQL Context) ──────────────────────┤
+    │               │                                           │
+    │               └── [Issue/PR hydration, budgeting, fallback]
+    │       │               │
     │       └───────────────┘
     │
     └── [All RFCs depend on RFC-001]
@@ -93,20 +103,22 @@ RFC-001 (Foundation)
 
 ---
 
-### Phase 2: Core Agent Logic (RFC-004 → RFC-007)
+### Phase 2: Core Agent Logic (RFC-004 → RFC-007, RFC-014, RFC-015)
 
-**Goal:** Session management, event handling, security, observability
+**Goal:** Session management, event handling, security, observability, context hydration
 
-| RFC     | Description                            | Estimated Effort |
-| ------- | -------------------------------------- | ---------------- |
-| RFC-004 | Session list/search/prune, writeback   | 9-12 hours       |
-| RFC-005 | Event routing, trigger classification  | 6-9 hours        |
-| RFC-006 | Permission gating, credential handling | 8-11 hours       |
-| RFC-007 | Run summary, job summary, metrics      | 6-9 hours        |
+| RFC     | Description                                        | Estimated Effort |
+| ------- | -------------------------------------------------- | ---------------- |
+| RFC-004 | Session list/search/prune, writeback               | 9-12 hours       |
+| RFC-005 | Event routing, trigger classification, mock events | 6-9 hours        |
+| RFC-006 | Permission gating, credential handling             | 8-11 hours       |
+| RFC-007 | Run summary, job summary, metrics                  | 6-9 hours        |
+| RFC-014 | File attachment processing                         | 9-12 hours       |
+| RFC-015 | GraphQL context hydration                          | 14-20 hours      |
 
-**Phase 2 Total:** ~29-41 hours
+**Phase 2 Total:** ~52-73 hours
 
-**Milestone:** Agent can detect events, check permissions, search prior sessions, and report summaries.
+**Milestone:** Agent can detect events, check permissions, search prior sessions, report summaries, process file attachments, and hydrate full issue/PR context via GraphQL.
 
 ---
 
@@ -130,10 +142,10 @@ RFC-001 (Foundation)
 
 | Phase     | Effort Range      |
 | --------- | ----------------- |
-| Phase 1   | 51-72 hours       |
-| Phase 2   | 29-41 hours       |
+| Phase 1   | 69-92 hours       |
+| Phase 2   | 52-73 hours       |
 | Phase 3   | 33-42 hours       |
-| **Total** | **113-155 hours** |
+| **Total** | **154-207 hours** |
 
 ---
 
@@ -173,44 +185,66 @@ RFC-001 (Foundation)
 | F7: Delegated Work - Open PRs          | RFC-010          | Pending   |
 | F8: Comment Idempotency                | RFC-008          | Pending   |
 | F9: Anti-Loop Protection               | RFC-005          | Pending   |
-| F11: Session Search on Startup         | RFC-004          | Pending   |
+| F10: Reactions & Labels Acknowledgment | RFC-013          | Completed |
+| F11: Issue vs PR Context Detection     | RFC-013          | Completed |
 | F17: OpenCode Storage Cache Restore    | RFC-002          | Pending   |
 | F18: OpenCode Storage Cache Save       | RFC-002          | Pending   |
-| F20: Run Summary in Comments           | RFC-007          | Pending   |
+| F19: Session Search on Startup         | RFC-004          | Pending   |
 | F21: Close-the-Loop Session Writeback  | RFC-004          | Pending   |
 | F22: Session Pruning                   | RFC-004          | Pending   |
-| F25: auth.json Exclusion               | RFC-002, RFC-006 | Pending   |
-| F26: Fork PR Permission Gating         | RFC-006          | Pending   |
-| F27: Credential Strategy               | RFC-003, RFC-006 | Pending   |
-| F28: Branch-Scoped Caching             | RFC-002          | Pending   |
-| F30: GitHub Actions Job Summary        | RFC-007          | Pending   |
-| F31: Structured Logging                | RFC-001, RFC-007 | Pending   |
-| F32: Token Usage Reporting             | RFC-007          | Pending   |
-| F33: Error Message Format              | RFC-008          | Pending   |
-| F10: Setup Action Entrypoint           | RFC-011          | Pending   |
-| F37: Action Inputs Configuration       | RFC-001, RFC-011 | Pending   |
-| F41: Agent Prompt Context Injection    | RFC-012          | Completed |
-| F42: gh CLI Operation Instructions     | RFC-012          | Completed |
-| F43: Reactions & Labels Acknowledgment | RFC-012          | Completed |
-| F44: Issue vs PR Context Detection     | RFC-012          | Completed |
+| F25: Setup Action Entrypoint           | RFC-011          | Pending   |
+| F26: OpenCode CLI Installation         | RFC-011          | Pending   |
+| F27: oMo Plugin Installation           | RFC-011          | Pending   |
+| F28: GitHub CLI Authentication         | RFC-011          | Pending   |
+| F29: Git Identity Configuration        | RFC-011          | Pending   |
+| F30: auth.json Population              | RFC-011          | Pending   |
+| F31: Cache Restoration in Setup        | RFC-011          | Pending   |
+| F32: SDK-Based Agent Execution         | RFC-013          | Completed |
+| F33: Event Subscription and Processing | RFC-013          | Completed |
+| F34: Completion Detection              | RFC-013          | Completed |
+| F35: Timeout and Cancellation          | RFC-013          | Completed |
+| F36: SDK Cleanup                       | RFC-013          | Completed |
+| F37: Model and Agent Configuration     | RFC-013          | Completed |
+| F38: Mock Event Support                | RFC-005          | Pending   |
+| F39: File Attachment Detection         | RFC-014          | Pending   |
+| F40: File Attachment Download          | RFC-014          | Pending   |
+| F41: File Attachment Prompt Injection  | RFC-014          | Pending   |
+| F42: GraphQL Issue Context Hydration   | RFC-015          | Pending   |
+| F43: GraphQL PR Context Hydration      | RFC-015          | Pending   |
+| F44: Context Budgeting                 | RFC-015          | Pending   |
+| F45: Agent Prompt Construction         | RFC-013          | Completed |
+| F46: auth.json Exclusion               | RFC-002, RFC-006 | Pending   |
+| F47: Fork PR Permission Gating         | RFC-006          | Pending   |
+| F48: Credential Strategy               | RFC-003, RFC-006 | Pending   |
+| F49: Branch-Scoped Caching             | RFC-002          | Pending   |
+| F51: Run Summary in Comments           | RFC-007          | Pending   |
+| F52: GitHub Actions Job Summary        | RFC-007          | Pending   |
+| F53: Structured Logging                | RFC-001, RFC-007 | Pending   |
+| F54: Token Usage Reporting             | RFC-007          | Pending   |
+| F55: Error Message Format              | RFC-008          | Pending   |
+| F56: GitHub API Rate Limit Handling    | RFC-007          | Pending   |
+| F57: LLM API Error Handling            | RFC-007          | Pending   |
+| F59: Action Inputs Configuration       | RFC-001, RFC-011 | Pending   |
 
 ### P1 Features (Should-Have) - Future RFCs
 
-| Feature                     | Description                | Notes                |
-| --------------------------- | -------------------------- | -------------------- |
-| F23: Storage Versioning     | Version marker in storage  | Partially in RFC-002 |
-| F24: Corruption Detection   | Detect & handle corruption | Partially in RFC-002 |
-| F29: Concurrency Handling   | Last-write-wins + warning  | Future RFC           |
-| F34: GitHub API Rate Limit  | Retry with backoff         | Future RFC           |
-| F35: LLM API Error Handling | Retry + error comment      | Future RFC           |
-| F38: Setup Entrypoint       | Separate action for setup  | Future RFC           |
+| Feature                                | Description                        | Notes                |
+| -------------------------------------- | ---------------------------------- | -------------------- |
+| F20: S3 Write-Through Backup           | Cross-runner persistence           | Partially in RFC-002 |
+| F23: Storage Versioning                | Version marker in storage          | Partially in RFC-002 |
+| F24: Corruption Detection              | Detect & handle corruption         | Partially in RFC-002 |
+| F50: Concurrency Handling              | Last-write-wins + warning          | Future RFC           |
+| F63: Pull Request Review Comment       | Handle inline review comment event | Future RFC           |
+| F64: Session Sharing                   | Public session share links         | Future RFC           |
+| F65: Automatic Branch Management       | Branch creation workflows          | Future RFC           |
+| F66: Event Streaming and Progress Logs | Real-time agent progress logging   | Future RFC           |
 
 ### P2 Features (Nice-to-Have) - Future RFCs
 
 | Feature                            | Description              | Notes      |
 | ---------------------------------- | ------------------------ | ---------- |
-| F19: S3 Write-Through Backup       | Cross-runner persistence | Future RFC |
-| F39: Org-Level Memory Partitioning | Multi-repo scoping       | Future RFC |
+| F67: Cross-Runner Portability      | S3 backup cross-platform | Future RFC |
+| F68: Org-Level Memory Partitioning | Multi-repo scoping       | Future RFC |
 
 ### Discord Features - Future RFCs
 
@@ -221,7 +255,7 @@ RFC-001 (Foundation)
 | F14: Discord Daemon Architecture    | Long-running bot     | Future RFC |
 | F15: Discord-GitHub Shared Memory   | S3 sync              | Future RFC |
 | F16: Discord Permission Model       | Role-based access    | Future RFC |
-| F36: Discord API Error Handling     | Graceful degradation | Future RFC |
+| F58: Discord API Error Handling     | Graceful degradation | Future RFC |
 
 ---
 


### PR DESCRIPTION
- document the two-layer session workflow with usage examples, tooling table, and lifecycle diagram
- specify mock event support (env vars, security constraints, tests) in RFC-005
- add RFC-014 for file attachment handling and RFC-015 for GraphQL context hydration with budgeting, prompt builders, and fallbacks
- update the RFC index to include RFC-014/RFC-015, new feature list items, and revised effort totals