### PR TITLE
docs(prd): add v1.2 features (triggers, directives, post-hook)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to the PRD and project requirements will be documented in this file.
 
+## [1.2] - 2026-01-14
+
+### Added
+
+#### P0 (must-have) - Additional Triggers & Directives
+
+- **L. Trigger-Specific Prompt Directives**: Context-aware default behaviors per trigger
+  - `issues` (opened): Automated triage - summarize, reproduce, propose next steps
+  - `issues` (edited with @mention): Respond to specific mention
+  - `pull_request` (opened/synchronize/reopened): Default review behavior
+  - `pull_request_review_comment` (created): Respond with file/line/diff context
+  - `schedule`: Requires `prompt` input (hard fail if empty)
+  - `workflow_dispatch`: Requires `prompt` input (hard fail if empty)
+  - `getTriggerDirective()` function for thin directive layer
+
+- **M. Post-Action Cache Hook**: Reliable cache saving via `runs.post`
+  - New `src/post.ts` entry point bundled to `dist/post.js`
+  - Runs even on main action timeout/cancellation
+  - Best-effort, never fails the job
+  - Independent of setup consolidation
+
+#### New Trigger Events
+
+- **`issues` event**: Support `opened` and `edited` (with @mention) actions
+- **`pull_request` event**: Support `opened`, `synchronize`, `reopened` actions
+- **`pull_request_review_comment` event**: Elevated from P1 to P0, support `created` action
+- **`schedule` event**: Cron-based triggers with required prompt input
+
+### Changed
+
+- **Trigger documentation**: Comprehensive table in section A.1 with actions, prompt requirements, and scope
+- **Skip conditions**: Added per-trigger guards (draft PR skip, mention requirement, prompt validation)
+- **P1 section**: Added "Setup action consolidation (deferred from v1.2)" as future work item
+
+### Deferred
+
+- **Setup action consolidation**: Architectural change requires separate RFC, user research, and migration plan
+- Documented in P1 for future consideration
+
+### Risks Added
+
+- Noisy automated triggers (mitigated by action constraints and @mention requirements)
+- Post-action hook reliability (mitigated by best-effort design and S3 backup)
+
 ## [1.1] - 2026-01-10
 
 ### Added

--- a/RFCs/RFC-016-Additional-Triggers-Directives.md
+++ b/RFCs/RFC-016-Additional-Triggers-Directives.md
@@ -1,0 +1,862 @@
+# RFC-016: Additional Triggers & Directives
+
+**Status:** Pending
+**Priority:** MUST
+**Complexity:** Medium
+**Phase:** 2
+
+---
+
+## Summary
+
+Extend GitHub event handling to support additional triggers (`issues`, `pull_request`, `pull_request_review_comment`, `schedule`) and implement trigger-specific prompt directives via `getTriggerDirective()`. This RFC expands RFC-005's trigger infrastructure to cover all v1.2 P0 trigger requirements.
+
+## Dependencies
+
+- **Builds Upon:** RFC-005 (GitHub Triggers & Event Handling), RFC-013 (SDK Execution Mode), RFC-003 (GitHub API Client)
+- **Enables:** RFC-008 (GitHub Comment Interactions), RFC-009 (PR Review Features)
+
+## Features Addressed
+
+| Feature ID | Feature Name                        | Priority |
+| ---------- | ----------------------------------- | -------- |
+| F69        | Trigger-Specific Prompt Directives  | P0       |
+| F70        | Issues Event Trigger                | P0       |
+| F71        | Pull Request Event Trigger          | P0       |
+| F72        | Schedule Event Trigger              | P0       |
+| F73        | Pull Request Review Comment Trigger | P0       |
+| F75        | Prompt Input Required Validation    | P0       |
+| F76        | Draft PR Skip                       | P0       |
+
+## Technical Specification
+
+### 1. Extended Trigger Types (`src/lib/triggers/types.ts`)
+
+```typescript
+/**
+ * Extended trigger types for v1.2.
+ * Adds issues, pull_request, pull_request_review_comment, and schedule.
+ */
+export const TRIGGER_TYPES = [
+  "issue_comment",
+  "discussion_comment",
+  "workflow_dispatch",
+  "issues",
+  "pull_request",
+  "pull_request_review_comment",
+  "schedule",
+  "unsupported",
+] as const
+
+export type TriggerType = (typeof TRIGGER_TYPES)[number]
+
+/**
+ * Extended skip reasons for v1.2.
+ */
+export const SKIP_REASONS = [
+  "action_not_created",
+  "action_not_supported",
+  "draft_pr",
+  "issue_locked",
+  "no_mention",
+  "prompt_required",
+  "self_comment",
+  "unauthorized_author",
+  "unsupported_event",
+] as const
+
+export type SkipReason = (typeof SKIP_REASONS)[number]
+
+/**
+ * Extended trigger target for PR review comments.
+ */
+export interface TriggerTarget {
+  readonly kind: "discussion" | "issue" | "manual" | "pr" | "review_comment"
+  readonly number: number
+  readonly title: string
+  readonly body: string | null
+  readonly locked: boolean
+  /** For PR review comments: file path */
+  readonly path?: string
+  /** For PR review comments: line number */
+  readonly line?: number
+  /** For PR review comments: diff hunk */
+  readonly diffHunk?: string
+  /** For PR review comments: commit ID */
+  readonly commitId?: string
+  /** For PRs: whether it's a draft */
+  readonly isDraft?: boolean
+}
+
+/**
+ * Extended trigger configuration.
+ */
+export interface TriggerConfig {
+  readonly botLogin: string | null
+  readonly requireMention: boolean
+  readonly allowedAssociations: readonly string[]
+  /** Skip draft PRs by default */
+  readonly skipDraftPRs: boolean
+  /** Custom prompt input (for schedule/workflow_dispatch) */
+  readonly promptInput: string | null
+}
+
+export const DEFAULT_TRIGGER_CONFIG: TriggerConfig = {
+  botLogin: null,
+  requireMention: true,
+  allowedAssociations: ALLOWED_ASSOCIATIONS,
+  skipDraftPRs: true,
+  promptInput: null,
+} as const
+```
+
+### 2. Extended Event Router (`src/lib/triggers/router.ts`)
+
+```typescript
+/**
+ * Classify event name to trigger type.
+ * Extended for v1.2 triggers.
+ */
+export function classifyTrigger(eventName: string): TriggerType {
+  switch (eventName) {
+    case "issue_comment":
+      return "issue_comment"
+    case "discussion":
+    case "discussion_comment":
+      return "discussion_comment"
+    case "workflow_dispatch":
+      return "workflow_dispatch"
+    case "issues":
+      return "issues"
+    case "pull_request":
+      return "pull_request"
+    case "pull_request_review_comment":
+      return "pull_request_review_comment"
+    case "schedule":
+      return "schedule"
+    default:
+      return "unsupported"
+  }
+}
+
+/**
+ * Build context for issues events.
+ */
+function buildIssuesContextData(payload: IssuesPayload, botLogin: string | null): IssuesContextData {
+  const issue = payload.issue
+  const action = payload.action
+
+  const author: AuthorInfo = {
+    login: issue.user.login,
+    association: issue.author_association,
+    isBot: issue.user.login.endsWith("[bot]"),
+  }
+
+  const target: TriggerTarget = {
+    kind: "issue",
+    number: issue.number,
+    title: issue.title,
+    body: issue.body ?? null,
+    locked: issue.locked,
+  }
+
+  // For 'edited' action, check for @mention in body
+  const hasMention = action === "edited" && botLogin != null ? hasBotMention(issue.body ?? "", botLogin) : false
+
+  return {
+    author,
+    target,
+    commentBody: issue.body ?? null,
+    commentId: null,
+    hasMention,
+    command: null,
+    action,
+  }
+}
+
+/**
+ * Build context for pull_request events.
+ */
+function buildPullRequestContextData(payload: PullRequestPayload): PullRequestContextData {
+  const pr = payload.pull_request
+  const action = payload.action
+
+  const author: AuthorInfo = {
+    login: pr.user.login,
+    association: pr.author_association,
+    isBot: pr.user.login.endsWith("[bot]"),
+  }
+
+  const target: TriggerTarget = {
+    kind: "pr",
+    number: pr.number,
+    title: pr.title,
+    body: pr.body ?? null,
+    locked: pr.locked,
+    isDraft: pr.draft,
+  }
+
+  return {
+    author,
+    target,
+    commentBody: pr.body ?? null,
+    commentId: null,
+    hasMention: false,
+    command: null,
+    action,
+    isDraft: pr.draft,
+  }
+}
+
+/**
+ * Build context for pull_request_review_comment events.
+ */
+function buildPRReviewCommentContextData(
+  payload: PRReviewCommentPayload,
+  botLogin: string | null,
+): PRReviewCommentContextData {
+  const comment = payload.comment
+  const pr = payload.pull_request
+
+  const author: AuthorInfo = {
+    login: comment.user.login,
+    association: comment.author_association,
+    isBot: comment.user.login.endsWith("[bot]"),
+  }
+
+  const target: TriggerTarget = {
+    kind: "review_comment",
+    number: pr.number,
+    title: pr.title,
+    body: comment.body,
+    locked: pr.locked,
+    path: comment.path,
+    line: comment.line ?? comment.original_line,
+    diffHunk: comment.diff_hunk,
+    commitId: comment.commit_id,
+  }
+
+  const hasMention = botLogin != null ? hasBotMention(comment.body, botLogin) : false
+  const command = hasMention ? extractCommand(comment.body, botLogin!) : null
+
+  return {
+    author,
+    target,
+    commentBody: comment.body,
+    commentId: comment.id,
+    hasMention,
+    command,
+  }
+}
+
+/**
+ * Build context for schedule events.
+ */
+function buildScheduleContextData(
+  payload: SchedulePayload,
+  actor: string,
+  promptInput: string | null,
+): ScheduleContextData {
+  const target: TriggerTarget = {
+    kind: "manual",
+    number: 0,
+    title: "Scheduled workflow",
+    body: promptInput,
+    locked: false,
+  }
+
+  const author: AuthorInfo = {
+    login: actor,
+    association: "OWNER",
+    isBot: false,
+  }
+
+  return {
+    author,
+    target,
+    commentBody: promptInput,
+    commentId: null,
+    hasMention: false,
+    command: null,
+  }
+}
+```
+
+### 3. Extended Skip Conditions
+
+```typescript
+/**
+ * Check skip conditions for issues events.
+ */
+function checkIssuesSkipConditions(context: TriggerContext, config: TriggerConfig, logger: Logger): SkipCheckResult {
+  const payload = context.raw.payload as IssuesPayload
+  const action = payload.action
+
+  // Only support 'opened' and 'edited' actions
+  if (action !== "opened" && action !== "edited") {
+    logger.debug("Skipping unsupported issues action", {action})
+    return {
+      shouldSkip: true,
+      reason: "action_not_supported",
+      message: `Issues action '${action}' is not supported (only 'opened' and 'edited')`,
+    }
+  }
+
+  // For 'edited', require @mention
+  if (action === "edited" && !context.hasMention) {
+    logger.debug("Skipping issues.edited without bot mention")
+    return {
+      shouldSkip: true,
+      reason: "no_mention",
+      message: "Issue edit does not mention the bot",
+    }
+  }
+
+  return {shouldSkip: false}
+}
+
+/**
+ * Check skip conditions for pull_request events.
+ */
+function checkPullRequestSkipConditions(
+  context: TriggerContext,
+  config: TriggerConfig,
+  logger: Logger,
+): SkipCheckResult {
+  const payload = context.raw.payload as PullRequestPayload
+  const action = payload.action
+
+  // Only support 'opened', 'synchronize', 'reopened' actions
+  const supportedActions = ["opened", "synchronize", "reopened"]
+  if (!supportedActions.includes(action)) {
+    logger.debug("Skipping unsupported pull_request action", {action})
+    return {
+      shouldSkip: true,
+      reason: "action_not_supported",
+      message: `Pull request action '${action}' is not supported`,
+    }
+  }
+
+  // Skip draft PRs if configured
+  if (config.skipDraftPRs && payload.pull_request.draft) {
+    logger.debug("Skipping draft pull request")
+    return {
+      shouldSkip: true,
+      reason: "draft_pr",
+      message: "Pull request is a draft",
+    }
+  }
+
+  return {shouldSkip: false}
+}
+
+/**
+ * Check skip conditions for schedule/workflow_dispatch.
+ * Hard fail if prompt input is empty.
+ */
+function checkPromptRequiredSkipConditions(
+  context: TriggerContext,
+  config: TriggerConfig,
+  logger: Logger,
+): SkipCheckResult {
+  const promptInput = config.promptInput
+
+  if (promptInput == null || promptInput.trim().length === 0) {
+    logger.error("Prompt input required for scheduled/manual triggers")
+    return {
+      shouldSkip: true,
+      reason: "prompt_required",
+      message: "Prompt input is required for schedule/workflow_dispatch triggers",
+    }
+  }
+
+  return {shouldSkip: false}
+}
+
+/**
+ * Extended checkSkipConditions for all trigger types.
+ */
+export function checkSkipConditions(context: TriggerContext, config: TriggerConfig, logger: Logger): SkipCheckResult {
+  if (context.triggerType === "unsupported") {
+    logger.debug("Skipping unsupported event", {eventName: context.eventName})
+    return {
+      shouldSkip: true,
+      reason: "unsupported_event",
+      message: `Unsupported event type: ${context.eventName}`,
+    }
+  }
+
+  switch (context.triggerType) {
+    case "issue_comment":
+      return checkIssueCommentSkipConditions(context, config, logger)
+
+    case "discussion_comment":
+      return checkDiscussionCommentSkipConditions(context, config, logger)
+
+    case "workflow_dispatch":
+      return checkPromptRequiredSkipConditions(context, config, logger)
+
+    case "issues":
+      return checkIssuesSkipConditions(context, config, logger)
+
+    case "pull_request":
+      return checkPullRequestSkipConditions(context, config, logger)
+
+    case "pull_request_review_comment":
+      return checkCommentSkipConditions(context, config, logger, {
+        targetLabel: "Pull Request",
+        actionLabel: "Review comment",
+      })
+
+    case "schedule":
+      return checkPromptRequiredSkipConditions(context, config, logger)
+
+    default:
+      return {shouldSkip: false}
+  }
+}
+```
+
+### 4. Trigger Directives (`src/lib/agent/prompt.ts`)
+
+````typescript
+import type {TriggerContext} from "../triggers/types.js"
+import type {ActionInputs} from "../types.js"
+
+/**
+ * Trigger directive configuration.
+ */
+interface TriggerDirective {
+  /** Default task instruction for this trigger */
+  readonly directive: string
+  /** Whether custom prompt appends (true) or replaces (false) */
+  readonly appendMode: boolean
+}
+
+/**
+ * Get trigger-specific directive for the agent prompt.
+ *
+ * Each trigger type has a default task directive that instructs the agent
+ * on what to do. Custom prompt input can either append to or replace the
+ * default directive depending on the trigger type.
+ *
+ * @param context - Trigger context from event routing
+ * @param inputs - Action inputs including custom prompt
+ * @returns Trigger directive with instruction text
+ */
+export function getTriggerDirective(context: TriggerContext, inputs: ActionInputs): TriggerDirective {
+  const customPrompt = inputs.prompt?.trim() ?? ""
+
+  switch (context.triggerType) {
+    case "issue_comment":
+      return {
+        directive: "Respond to the comment above.",
+        appendMode: true,
+      }
+
+    case "discussion_comment":
+      return {
+        directive: "Respond to the discussion comment above.",
+        appendMode: true,
+      }
+
+    case "pull_request_review_comment":
+      return {
+        directive: buildReviewCommentDirective(context),
+        appendMode: true,
+      }
+
+    case "issues": {
+      const action = (context.raw.payload as {action?: string}).action
+      if (action === "opened") {
+        return {
+          directive: "Triage this issue: summarize, reproduce if possible, propose next steps.",
+          appendMode: true,
+        }
+      }
+      return {
+        directive: "Respond to the mention in this issue.",
+        appendMode: true,
+      }
+    }
+
+    case "pull_request":
+      return {
+        directive: "Review this pull request for code quality, potential bugs, and improvements.",
+        appendMode: true,
+      }
+
+    case "schedule":
+    case "workflow_dispatch":
+      // No default directive - prompt input is required and replaces
+      return {
+        directive: customPrompt,
+        appendMode: false,
+      }
+
+    default:
+      return {
+        directive: "Execute the requested operation.",
+        appendMode: true,
+      }
+  }
+}
+
+/**
+ * Build directive for PR review comments with file/line context.
+ */
+function buildReviewCommentDirective(context: TriggerContext): string {
+  const target = context.target
+  if (target == null) {
+    return "Respond to the review comment with file and code context."
+  }
+
+  const lines: string[] = ["Respond to the review comment with the following context:"]
+  lines.push("")
+  lines.push("<review_comment_context>")
+
+  if (target.path != null) {
+    lines.push(`File: ${target.path}`)
+  }
+  if (target.line != null) {
+    lines.push(`Line: ${target.line}`)
+  }
+  if (target.commitId != null) {
+    lines.push(`Commit: ${target.commitId}`)
+  }
+  if (target.diffHunk != null) {
+    lines.push("")
+    lines.push("Diff hunk:")
+    lines.push("```diff")
+    lines.push(target.diffHunk)
+    lines.push("```")
+  }
+
+  lines.push("</review_comment_context>")
+
+  return lines.join("\n")
+}
+
+/**
+ * Build the final task section with directive and custom prompt.
+ */
+export function buildTaskSection(context: TriggerContext, inputs: ActionInputs): string {
+  const {directive, appendMode} = getTriggerDirective(context, inputs)
+  const customPrompt = inputs.prompt?.trim() ?? ""
+
+  const lines: string[] = ["## Task", ""]
+
+  if (appendMode) {
+    lines.push(directive)
+    if (customPrompt.length > 0) {
+      lines.push("")
+      lines.push("### Additional Instructions")
+      lines.push("")
+      lines.push(customPrompt)
+    }
+  } else {
+    // Replace mode (schedule/workflow_dispatch)
+    lines.push(directive)
+  }
+
+  lines.push("")
+  lines.push("Follow all instructions and requirements listed in this prompt.")
+
+  return lines.join("\n")
+}
+````
+
+### 5. Integration with `buildAgentPrompt`
+
+Update `buildAgentPrompt()` to use the new task section builder:
+
+```typescript
+export function buildAgentPrompt(options: PromptOptions, logger: Logger): string {
+  const {context, customPrompt, cacheStatus, sessionContext, triggerContext, inputs} = options
+  const parts: string[] = []
+
+  // ... existing sections (Agent Context, Issue/PR Context, Trigger Comment, etc.)
+
+  // Replace hardcoded task section with directive-based one
+  if (triggerContext != null && inputs != null) {
+    parts.push(buildTaskSection(triggerContext, inputs))
+  } else {
+    // Fallback for backward compatibility
+    if (context.commentBody == null) {
+      parts.push(`## Task
+
+Execute the requested operation for repository ${context.repo}. Follow all instructions and requirements listed in this prompt.
+`)
+    } else {
+      parts.push(`## Task
+
+Respond to the trigger comment above. Follow all instructions and requirements listed in this prompt.
+`)
+    }
+  }
+
+  const prompt = parts.join("\n")
+  logger.debug("Built agent prompt", {
+    length: prompt.length,
+    hasCustom: customPrompt != null,
+    hasSessionContext: sessionContext != null,
+    hasTriggerDirective: triggerContext != null,
+  })
+  return prompt
+}
+```
+
+### 6. Payload Type Definitions
+
+Add to `src/lib/github/types.ts`:
+
+```typescript
+/**
+ * Issues event payload.
+ */
+export interface IssuesPayload {
+  action: "opened" | "edited" | "closed" | "reopened" | "assigned" | string
+  issue: {
+    number: number
+    title: string
+    body: string | null
+    user: {login: string}
+    author_association: string
+    locked: boolean
+    labels: Array<{name: string}>
+  }
+}
+
+/**
+ * Pull request event payload.
+ */
+export interface PullRequestPayload {
+  action: "opened" | "synchronize" | "reopened" | "closed" | string
+  pull_request: {
+    number: number
+    title: string
+    body: string | null
+    user: {login: string}
+    author_association: string
+    locked: boolean
+    draft: boolean
+    base: {ref: string; repo: {full_name: string}}
+    head: {ref: string; sha: string; repo: {full_name: string}}
+  }
+}
+
+/**
+ * Pull request review comment event payload.
+ */
+export interface PRReviewCommentPayload {
+  action: "created" | "edited" | "deleted"
+  comment: {
+    id: number
+    body: string
+    user: {login: string}
+    author_association: string
+    path: string
+    line: number | null
+    original_line: number | null
+    diff_hunk: string
+    commit_id: string
+  }
+  pull_request: {
+    number: number
+    title: string
+    locked: boolean
+  }
+}
+
+/**
+ * Schedule event payload.
+ */
+export interface SchedulePayload {
+  schedule: string
+}
+```
+
+## Acceptance Criteria
+
+### Trigger Support
+
+- [ ] `issues` event supported with `opened` action (auto-triage behavior)
+- [ ] `issues.edited` triggers only when `@fro-bot` mentioned in body
+- [ ] `pull_request` event supported with `opened`, `synchronize`, `reopened` actions
+- [ ] `pull_request` skips draft PRs by default (configurable via `skipDraftPRs`)
+- [ ] `pull_request_review_comment` event supported with `created` action
+- [ ] `schedule` event supported with required `prompt` input
+- [ ] `workflow_dispatch` hard fails if `prompt` input is empty
+
+### Trigger Directives
+
+- [ ] `getTriggerDirective()` returns appropriate directive for each trigger type
+- [ ] `issue_comment` directive: "Respond to the comment above"
+- [ ] `discussion_comment` directive: "Respond to the discussion comment above"
+- [ ] `issues.opened` directive: "Triage this issue: summarize, reproduce if possible, propose next steps"
+- [ ] `issues.edited` directive: "Respond to the mention in this issue"
+- [ ] `pull_request` directive: "Review this pull request for code quality, potential bugs, and improvements"
+- [ ] `pull_request_review_comment` directive includes file path, line number, diff hunk, commit ID
+- [ ] Custom `prompt` input **appends** to directive for comment-based triggers
+- [ ] Custom `prompt` input **replaces** directive for `schedule`/`workflow_dispatch`
+
+### Skip Conditions
+
+- [ ] Draft PRs skipped with `draft_pr` reason
+- [ ] Empty prompt input fails with `prompt_required` reason for schedule/dispatch
+- [ ] Unsupported actions fail with `action_not_supported` reason
+- [ ] All existing skip conditions (anti-loop, authorization) still work
+
+## Test Cases
+
+### Trigger Classification Tests
+
+```typescript
+describe("classifyTrigger (extended)", () => {
+  it("classifies issues event", () => {
+    expect(classifyTrigger("issues")).toBe("issues")
+  })
+
+  it("classifies pull_request event", () => {
+    expect(classifyTrigger("pull_request")).toBe("pull_request")
+  })
+
+  it("classifies pull_request_review_comment event", () => {
+    expect(classifyTrigger("pull_request_review_comment")).toBe("pull_request_review_comment")
+  })
+
+  it("classifies schedule event", () => {
+    expect(classifyTrigger("schedule")).toBe("schedule")
+  })
+})
+```
+
+### Skip Condition Tests
+
+```typescript
+describe("checkPullRequestSkipConditions", () => {
+  it("skips draft PRs by default", () => {
+    const context = buildMockPRContext({draft: true})
+    const result = checkSkipConditions(context, DEFAULT_TRIGGER_CONFIG, logger)
+    expect(result.shouldSkip).toBe(true)
+    expect(result.reason).toBe("draft_pr")
+  })
+
+  it("allows draft PRs when skipDraftPRs is false", () => {
+    const context = buildMockPRContext({draft: true})
+    const config = {...DEFAULT_TRIGGER_CONFIG, skipDraftPRs: false}
+    const result = checkSkipConditions(context, config, logger)
+    expect(result.shouldSkip).toBe(false)
+  })
+
+  it("skips unsupported actions", () => {
+    const context = buildMockPRContext({action: "closed"})
+    const result = checkSkipConditions(context, DEFAULT_TRIGGER_CONFIG, logger)
+    expect(result.shouldSkip).toBe(true)
+    expect(result.reason).toBe("action_not_supported")
+  })
+})
+
+describe("checkIssuesSkipConditions", () => {
+  it("allows opened action", () => {
+    const context = buildMockIssuesContext({action: "opened"})
+    const result = checkSkipConditions(context, DEFAULT_TRIGGER_CONFIG, logger)
+    expect(result.shouldSkip).toBe(false)
+  })
+
+  it("requires mention for edited action", () => {
+    const context = buildMockIssuesContext({action: "edited", hasMention: false})
+    const result = checkSkipConditions(context, DEFAULT_TRIGGER_CONFIG, logger)
+    expect(result.shouldSkip).toBe(true)
+    expect(result.reason).toBe("no_mention")
+  })
+
+  it("allows edited action with mention", () => {
+    const context = buildMockIssuesContext({action: "edited", hasMention: true})
+    const result = checkSkipConditions(context, DEFAULT_TRIGGER_CONFIG, logger)
+    expect(result.shouldSkip).toBe(false)
+  })
+})
+
+describe("checkPromptRequiredSkipConditions", () => {
+  it("fails when prompt is empty for schedule", () => {
+    const context = buildMockScheduleContext()
+    const config = {...DEFAULT_TRIGGER_CONFIG, promptInput: ""}
+    const result = checkSkipConditions(context, config, logger)
+    expect(result.shouldSkip).toBe(true)
+    expect(result.reason).toBe("prompt_required")
+  })
+
+  it("allows when prompt is provided", () => {
+    const context = buildMockScheduleContext()
+    const config = {...DEFAULT_TRIGGER_CONFIG, promptInput: "Run daily maintenance"}
+    const result = checkSkipConditions(context, config, logger)
+    expect(result.shouldSkip).toBe(false)
+  })
+})
+```
+
+### Trigger Directive Tests
+
+```typescript
+describe("getTriggerDirective", () => {
+  it("returns triage directive for issues.opened", () => {
+    const context = buildMockTriggerContext("issues", {action: "opened"})
+    const inputs = {prompt: ""}
+    const result = getTriggerDirective(context, inputs)
+    expect(result.directive).toContain("Triage this issue")
+    expect(result.appendMode).toBe(true)
+  })
+
+  it("returns review directive for pull_request", () => {
+    const context = buildMockTriggerContext("pull_request", {})
+    const inputs = {prompt: ""}
+    const result = getTriggerDirective(context, inputs)
+    expect(result.directive).toContain("Review this pull request")
+    expect(result.appendMode).toBe(true)
+  })
+
+  it("returns custom prompt for schedule (replace mode)", () => {
+    const context = buildMockTriggerContext("schedule", {})
+    const inputs = {prompt: "Run daily cleanup"}
+    const result = getTriggerDirective(context, inputs)
+    expect(result.directive).toBe("Run daily cleanup")
+    expect(result.appendMode).toBe(false)
+  })
+
+  it("includes file context for review_comment", () => {
+    const context = buildMockTriggerContext("pull_request_review_comment", {
+      path: "src/main.ts",
+      line: 42,
+      diffHunk: "@@ -10,3 +10,5 @@\n+new code",
+    })
+    const inputs = {prompt: ""}
+    const result = getTriggerDirective(context, inputs)
+    expect(result.directive).toContain("src/main.ts")
+    expect(result.directive).toContain("Line: 42")
+    expect(result.directive).toContain("new code")
+  })
+})
+```
+
+## Implementation Notes
+
+1. **Backward Compatibility**: Existing `issue_comment`, `discussion_comment`, and `workflow_dispatch` behavior must remain unchanged
+2. **Payload Typing**: GitHub payloads are complex; types cover common fields but may need runtime validation
+3. **Mention Matching**: Reuse existing `hasBotMention()` function from RFC-005
+4. **Context Builder Pattern**: Follow existing pattern of separate context builders per event type
+5. **Type Alignment**: Update `EventType` in `src/lib/github/types.ts` to include new event names
+
+## Compatibility with Dependencies
+
+- **RFC-005**: Extends, does not contradict. Adds new trigger types and skip reasons to existing infrastructure.
+- **RFC-013**: Uses existing prompt construction patterns. Adds `triggerContext` to `PromptOptions`.
+- **RFC-003**: Uses existing GitHub client. Adds new payload type definitions.
+
+---
+
+## Estimated Effort
+
+- **Development**: 8-12 hours
+- **Testing**: 4-6 hours
+- **Total**: 12-18 hours

--- a/RFCs/RFC-017-Post-Action-Cache-Hook.md
+++ b/RFCs/RFC-017-Post-Action-Cache-Hook.md
@@ -1,0 +1,477 @@
+# RFC-017: Post-Action Cache Hook
+
+**Status:** Pending
+**Priority:** MUST
+**Complexity:** Medium
+**Phase:** 2
+
+---
+
+## Summary
+
+Implement reliable cache persistence via GitHub Actions `post:` lifecycle hook. This RFC adds a third entry point (`src/post.ts`) that runs independently of the main action, ensuring cache is saved even on timeout, cancellation, or failure.
+
+## Dependencies
+
+- **Builds Upon:** RFC-002 (Cache Infrastructure), RFC-001 (Foundation & Core Types)
+- **Relates To:** RFC-013 (SDK Execution Mode) - coordinates via state handoff
+
+## Features Addressed
+
+| Feature ID | Feature Name           | Priority |
+| ---------- | ---------------------- | -------- |
+| F74        | Post-Action Cache Hook | P0       |
+
+## Problem Statement
+
+The current cache save implementation in `src/main.ts` uses a `finally` block, which is vulnerable to:
+
+1. **Hard kills**: GitHub Actions timeout (6 hours max) kills the process
+2. **Cancellation**: User-initiated workflow cancellation
+3. **SIGKILL**: Force-terminated processes
+4. **Unhandled exceptions**: Exceptions outside try/catch
+
+GitHub Actions provides a `post:` lifecycle hook that runs in a separate process after the main action completes (or fails). This hook is more reliable for cleanup operations.
+
+## Technical Specification
+
+### 1. New Entry Point (`src/post.ts`)
+
+```typescript
+/**
+ * Post-action hook for reliable cache persistence.
+ *
+ * This entry point runs after the main action completes (success, failure, or cancellation).
+ * It handles cache saving and session pruning in a best-effort manner.
+ *
+ * Key properties:
+ * - Runs in a SEPARATE process from main action
+ * - ALWAYS runs (even on main action failure/timeout)
+ * - MUST NOT fail the job (best-effort only)
+ * - Uses core.getState() for state handoff from main action
+ */
+
+import * as core from "@actions/core"
+import {createLogger} from "./lib/logger.js"
+import {saveCache} from "./lib/cache.js"
+import {pruneSessions} from "./lib/session/prune.js"
+import {parseActionInputs} from "./lib/inputs.js"
+
+/**
+ * State keys for main -> post handoff.
+ */
+const STATE_KEYS = {
+  /** Whether the main action processed an event (vs skipped) */
+  SHOULD_SAVE_CACHE: "shouldSaveCache",
+  /** Session ID used in this run (for logging) */
+  SESSION_ID: "sessionId",
+  /** Whether main action already saved cache */
+  CACHE_SAVED: "cacheSaved",
+} as const
+
+async function post(): Promise<void> {
+  const logger = createLogger("post")
+
+  try {
+    logger.info("Post-action hook started")
+
+    // Check if we should save cache
+    const shouldSaveCache = core.getState(STATE_KEYS.SHOULD_SAVE_CACHE) !== "false"
+    const cacheSaved = core.getState(STATE_KEYS.CACHE_SAVED) === "true"
+    const sessionId = core.getState(STATE_KEYS.SESSION_ID) || "unknown"
+
+    logger.debug("Post-action state", {shouldSaveCache, cacheSaved, sessionId})
+
+    // Skip if main action already saved cache successfully
+    if (cacheSaved) {
+      logger.info("Cache already saved by main action, skipping")
+      return
+    }
+
+    // Skip if main action determined we shouldn't save (e.g., skipped event)
+    if (!shouldSaveCache) {
+      logger.info("Cache save not required, skipping")
+      return
+    }
+
+    // Parse inputs for cache configuration
+    const inputsResult = parseActionInputs()
+    if (!inputsResult.ok) {
+      logger.warning("Failed to parse inputs, using defaults", {error: inputsResult.error})
+    }
+
+    // Save cache (idempotent, best-effort)
+    try {
+      await saveCache({
+        agentIdentity: "github",
+        logger,
+      })
+      logger.info("Cache saved successfully")
+    } catch (error) {
+      // Log but don't fail - cache save is best-effort
+      logger.warning("Cache save failed (non-fatal)", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+
+    // Session pruning (optional, non-fatal)
+    try {
+      const inputs = inputsResult.ok ? inputsResult.value : null
+      const retention = inputs?.sessionRetention ?? 50
+
+      await pruneSessions({
+        maxSessions: retention,
+        logger,
+      })
+      logger.info("Session pruning completed", {retention})
+    } catch (error) {
+      // Log but don't fail - pruning is best-effort
+      logger.warning("Session pruning failed (non-fatal)", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+
+    logger.info("Post-action hook completed")
+  } catch (error) {
+    // NEVER fail the job from post-action hook
+    logger.warning("Post-action hook error (non-fatal)", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+// Top-level await for ESM entry
+await post()
+```
+
+### 2. State Handoff from Main Action
+
+Update `src/main.ts` to set state for the post-action hook:
+
+```typescript
+import * as core from "@actions/core"
+
+const STATE_KEYS = {
+  SHOULD_SAVE_CACHE: "shouldSaveCache",
+  SESSION_ID: "sessionId",
+  CACHE_SAVED: "cacheSaved",
+} as const
+
+async function run(): Promise<void> {
+  // Early state initialization
+  core.saveState(STATE_KEYS.SHOULD_SAVE_CACHE, "false")
+  core.saveState(STATE_KEYS.CACHE_SAVED, "false")
+
+  try {
+    // ... existing initialization ...
+
+    // After determining we should process this event
+    core.saveState(STATE_KEYS.SHOULD_SAVE_CACHE, "true")
+
+    // After session creation
+    core.saveState(STATE_KEYS.SESSION_ID, sessionId)
+
+    // ... existing agent execution ...
+
+    // After successful cache save in finally block
+    try {
+      await saveCache({agentIdentity: "github", logger})
+      core.saveState(STATE_KEYS.CACHE_SAVED, "true")
+    } catch (error) {
+      // Cache save failed in main - post hook will retry
+      logger.warning("Cache save failed, post-hook will retry", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  } catch (error) {
+    // ... existing error handling ...
+  }
+}
+```
+
+### 3. Action Configuration Update (`action.yaml`)
+
+```yaml
+name: Fro Bot Agent
+description: AI agent with persistent memory for GitHub automation
+author: Fro Bot <agent@fro.bot>
+
+inputs:
+  github-token:
+    description: GitHub token (App installation token or PAT) with write permissions
+    required: true
+  auth-json:
+    description: JSON object mapping provider IDs to auth configs
+    required: true
+  prompt:
+    description: Custom prompt for the agent
+    required: false
+  session-retention:
+    description: Number of sessions to retain (default 50)
+    required: false
+    default: "50"
+  s3-backup:
+    description: Enable S3 write-through backup
+    required: false
+    default: "false"
+  s3-bucket:
+    description: S3 bucket for backup (required if s3-backup is true)
+    required: false
+  aws-region:
+    description: AWS region for S3 bucket
+    required: false
+  agent:
+    description: "Agent to use (default: Sisyphus). Must be a primary agent, not subagent."
+    required: false
+    default: Sisyphus
+  model:
+    description: "Model override (format: provider/model). If not set, uses agent's configured model."
+    required: false
+  timeout:
+    description: "Execution timeout in milliseconds. 0 = no timeout. Default: 1800000 (30 minutes)"
+    required: false
+    default: "1800000"
+
+outputs:
+  session-id:
+    description: OpenCode session ID used for this run
+  cache-status:
+    description: Cache restore status (hit/miss/corrupted)
+  duration:
+    description: Run duration in seconds
+
+runs:
+  using: node24
+  main: dist/main.js
+  post: dist/post.js
+```
+
+### 4. Build Configuration Update (`tsdown.config.ts`)
+
+```typescript
+export default defineConfig({
+  entry: ["src/main.ts", "src/setup.ts", "src/post.ts"],
+  fixedExtension: false,
+  minify: true,
+  plugins: [licenseCollectorPlugin()],
+  noExternal: id => {
+    // Bundle all @bfra.me/es subpaths
+    if (id.startsWith("@bfra.me/es")) return true
+    // Bundle all @actions/* packages
+    if (id.startsWith("@actions/")) return true
+    // Bundle @octokit/auth-app
+    if (id.startsWith("@octokit/auth-app")) return true
+    // Bundle @opencode-ai/sdk (RFC-013)
+    if (id.startsWith("@opencode-ai/sdk")) return true
+    return false
+  },
+})
+```
+
+### 5. State Keys Module (Optional Extraction)
+
+Create `src/lib/state-keys.ts` for shared state key constants:
+
+```typescript
+/**
+ * State keys for main <-> post action handoff.
+ *
+ * These keys are used with core.saveState() in main action
+ * and core.getState() in post action.
+ */
+export const STATE_KEYS = {
+  /** Whether the main action processed an event (vs skipped) */
+  SHOULD_SAVE_CACHE: "shouldSaveCache",
+  /** Session ID used in this run (for logging) */
+  SESSION_ID: "sessionId",
+  /** Whether main action already saved cache */
+  CACHE_SAVED: "cacheSaved",
+} as const
+
+export type StateKey = keyof typeof STATE_KEYS
+```
+
+## Acceptance Criteria
+
+### Post-Action Hook
+
+- [ ] `src/post.ts` entry point exists and bundles to `dist/post.js`
+- [ ] `action.yaml` includes `runs.post: dist/post.js`
+- [ ] Post-hook saves cache idempotently (best-effort, never fails job)
+- [ ] Post-hook runs even on main action failure/timeout
+- [ ] Post-hook skips cache save if main action already saved
+- [ ] Post-hook skips cache save if main action determined event should be skipped
+
+### State Handoff
+
+- [ ] Main action sets `shouldSaveCache` state before processing
+- [ ] Main action sets `sessionId` state after session creation
+- [ ] Main action sets `cacheSaved` state after successful cache save
+- [ ] Post action reads state with `core.getState()`
+
+### Build Configuration
+
+- [ ] `tsdown.config.ts` includes `src/post.ts` in entry array
+- [ ] Build produces `dist/main.js`, `dist/setup.js`, `dist/post.js`
+- [ ] All three bundles pass type checking
+
+### Error Handling
+
+- [ ] Post-hook logs but does not throw on cache save failure
+- [ ] Post-hook logs but does not throw on session pruning failure
+- [ ] Post-hook catches all exceptions at top level
+- [ ] Job status is not affected by post-hook errors
+
+## Test Cases
+
+### Post-Hook Execution Tests
+
+```typescript
+import {describe, it, expect, vi, beforeEach} from "vitest"
+import * as core from "@actions/core"
+
+vi.mock("@actions/core")
+vi.mock("./lib/cache.js")
+vi.mock("./lib/session/prune.js")
+
+describe("post-action hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("saves cache when shouldSaveCache is true and cacheSaved is false", async () => {
+    vi.mocked(core.getState).mockImplementation(key => {
+      if (key === "shouldSaveCache") return "true"
+      if (key === "cacheSaved") return "false"
+      return ""
+    })
+
+    await import("./post.js")
+
+    expect(saveCache).toHaveBeenCalled()
+  })
+
+  it("skips cache save when cacheSaved is true", async () => {
+    vi.mocked(core.getState).mockImplementation(key => {
+      if (key === "cacheSaved") return "true"
+      return ""
+    })
+
+    await import("./post.js")
+
+    expect(saveCache).not.toHaveBeenCalled()
+  })
+
+  it("skips cache save when shouldSaveCache is false", async () => {
+    vi.mocked(core.getState).mockImplementation(key => {
+      if (key === "shouldSaveCache") return "false"
+      return ""
+    })
+
+    await import("./post.js")
+
+    expect(saveCache).not.toHaveBeenCalled()
+  })
+
+  it("does not fail job on cache save error", async () => {
+    vi.mocked(core.getState).mockImplementation(key => {
+      if (key === "shouldSaveCache") return "true"
+      if (key === "cacheSaved") return "false"
+      return ""
+    })
+    vi.mocked(saveCache).mockRejectedValue(new Error("Cache save failed"))
+
+    // Should not throw
+    await expect(import("./post.js")).resolves.not.toThrow()
+    expect(core.setFailed).not.toHaveBeenCalled()
+  })
+
+  it("does not fail job on pruning error", async () => {
+    vi.mocked(core.getState).mockReturnValue("true")
+    vi.mocked(pruneSessions).mockRejectedValue(new Error("Pruning failed"))
+
+    await expect(import("./post.js")).resolves.not.toThrow()
+    expect(core.setFailed).not.toHaveBeenCalled()
+  })
+})
+```
+
+### State Handoff Tests
+
+```typescript
+describe("main action state handoff", () => {
+  it("sets shouldSaveCache to true when processing event", async () => {
+    // ... setup mock event that should be processed ...
+
+    await run()
+
+    expect(core.saveState).toHaveBeenCalledWith("shouldSaveCache", "true")
+  })
+
+  it("keeps shouldSaveCache false when event is skipped", async () => {
+    // ... setup mock event that should be skipped ...
+
+    await run()
+
+    expect(core.saveState).toHaveBeenCalledWith("shouldSaveCache", "false")
+  })
+
+  it("sets cacheSaved to true after successful cache save", async () => {
+    // ... setup successful run ...
+
+    await run()
+
+    expect(core.saveState).toHaveBeenCalledWith("cacheSaved", "true")
+  })
+
+  it("sets sessionId after session creation", async () => {
+    // ... setup run that creates session ...
+
+    await run()
+
+    expect(core.saveState).toHaveBeenCalledWith("sessionId", expect.stringMatching(/^ses_/))
+  })
+})
+```
+
+### Build Output Tests
+
+```typescript
+describe("build configuration", () => {
+  it("produces three entry points", async () => {
+    const files = await glob("dist/*.js")
+    expect(files).toContain("dist/main.js")
+    expect(files).toContain("dist/setup.js")
+    expect(files).toContain("dist/post.js")
+  })
+})
+```
+
+## Implementation Notes
+
+1. **Best-Effort Design**: Post-hook operations are best-effort. Never call `core.setFailed()` from post-hook.
+2. **Idempotent Cache Save**: The `saveCache()` function should handle "cache already exists" gracefully (GitHub Actions cache is immutable per key).
+3. **Double Save Prevention**: Main action sets `cacheSaved=true` after successful save. Post-hook checks this to avoid redundant work.
+4. **Skip Detection**: If main action determines the event should be skipped (e.g., unauthorized author), it sets `shouldSaveCache=false` to prevent post-hook from saving stale cache.
+5. **Session Pruning**: Moved to post-hook for reliability. If main action times out mid-prune, post-hook will complete it.
+6. **State Persistence**: `core.saveState()` writes to a file that persists between main and post processes. State is scoped to the action run.
+
+## Compatibility with Dependencies
+
+- **RFC-002**: Uses existing `saveCache()` function. No changes to cache infrastructure required.
+- **RFC-001**: Uses existing logger and input parsing. Adds new state keys module.
+- **RFC-013**: Main action continues to attempt cache save in finally block; post-hook is a safety net.
+
+## Security Considerations
+
+1. **State Contents**: Only store non-sensitive metadata in state (session IDs, boolean flags). Never store tokens or credentials.
+2. **Post-Hook Permissions**: Post-hook runs with same permissions as main action. No escalation.
+3. **Cache Integrity**: Post-hook only saves to same cache key as main action would. No cross-contamination.
+
+---
+
+## Estimated Effort
+
+- **Development**: 4-6 hours
+- **Testing**: 2-3 hours
+- **Total**: 6-9 hours

--- a/RFCs/RFCS.md
+++ b/RFCs/RFCS.md
@@ -1,6 +1,8 @@
 # Fro Bot Agent - RFC Index
 
-**Generated:** 2026-01-12 **Total RFCs:** 15 **Implementation Strategy:** Sequential (RFC-001 → RFC-013)
+**Generated:** 2026-01-14
+**Total RFCs:** 17
+**Implementation Strategy:** Sequential (RFC-001 → RFC-017)
 
 ---
 
@@ -31,6 +33,8 @@ The agent harness enables OpenCode with oMo Sisyphus agent workflow to act as an
 | RFC-013 | SDK Execution Mode                   | MUST     | High       | 1     | Completed  |
 | RFC-014 | File Attachment Processing           | MUST     | Medium     | 2     | Pending    |
 | RFC-015 | GraphQL Context Hydration            | MUST     | High       | 2     | Pending    |
+| RFC-016 | Additional Triggers & Directives     | MUST     | Medium     | 2     | Pending    |
+| RFC-017 | Post-Action Cache Hook               | MUST     | Medium     | 2     | Pending    |
 
 ---
 
@@ -51,11 +55,15 @@ RFC-001 (Foundation)
     │
     ├── RFC-002 (Cache) ──────────────┐ │
     │       │                         │ │
-    │       └── RFC-004 (Sessions) ───┼─┼── RFC-007 (Observability)
+    │       ├── RFC-004 (Sessions) ───┼─┼── RFC-007 (Observability)
+    │       │                         │ │
+    │       └── RFC-017 (Post-Action Cache Hook) ─── [Reliable cache save]
     │                                 │ │
     ├── RFC-003 (GitHub Client) ──────┤ │
     │       │                         │ │
     │       ├── RFC-005 (Triggers) ───┤ │
+    │       │       │                 │ │
+    │       │       ├── RFC-016 (Additional Triggers) ─── [issues, PR, schedule]
     │       │       │                 │ │
     │       │       └── RFC-006 (Security)
     │       │               │
@@ -113,8 +121,10 @@ RFC-001 (Foundation)
 | RFC-007 | Run summary, job summary, metrics                  | 6-9 hours        |
 | RFC-014 | File attachment processing                         | 9-12 hours       |
 | RFC-015 | GraphQL context hydration                          | 14-20 hours      |
+| RFC-016 | Additional triggers, directives                    | 12-18 hours      |
+| RFC-017 | Post-action cache hook                             | 6-9 hours        |
 
-**Phase 2 Total:** ~52-73 hours
+**Phase 2 Total:** ~70-100 hours
 
 **Milestone:** Agent can detect events, check permissions, search prior sessions, report summaries, process file attachments, and hydrate full issue/PR context via GraphQL.
 
@@ -141,9 +151,9 @@ RFC-001 (Foundation)
 | Phase     | Effort Range      |
 | --------- | ----------------- |
 | Phase 1   | 69-92 hours       |
-| Phase 2   | 52-73 hours       |
+| Phase 2   | 70-100 hours      |
 | Phase 3   | 33-42 hours       |
-| **Total** | **154-207 hours** |
+| **Total** | **172-234 hours** |
 
 ---
 
@@ -172,70 +182,78 @@ RFC-001 (Foundation)
 
 ### P0 Features (Must-Have)
 
-| Feature                                | RFC              | Status    |
-| -------------------------------------- | ---------------- | --------- |
-| F1: GitHub Action Triggers             | RFC-005          | Completed |
-| F2: Issue Comment Interaction          | RFC-008          | Pending   |
-| F3: Discussion Comment Interaction     | RFC-008          | Pending   |
-| F4: PR Conversation Comments           | RFC-008          | Pending   |
-| F5: PR Review Comments                 | RFC-009          | Pending   |
-| F6: Delegated Work - Push Commits      | RFC-010          | Pending   |
-| F7: Delegated Work - Open PRs          | RFC-010          | Pending   |
-| F8: Comment Idempotency                | RFC-008          | Pending   |
-| F9: Anti-Loop Protection               | RFC-005          | Completed |
-| F10: Reactions & Labels Acknowledgment | RFC-013          | Completed |
-| F11: Issue vs PR Context Detection     | RFC-013          | Completed |
-| F17: OpenCode Storage Cache Restore    | RFC-002          | Pending   |
-| F18: OpenCode Storage Cache Save       | RFC-002          | Pending   |
-| F19: Session Search on Startup         | RFC-004          | Pending   |
-| F21: Close-the-Loop Session Writeback  | RFC-004          | Pending   |
-| F22: Session Pruning                   | RFC-004          | Pending   |
-| F25: Setup Action Entrypoint           | RFC-011          | Pending   |
-| F26: OpenCode CLI Installation         | RFC-011          | Pending   |
-| F27: oMo Plugin Installation           | RFC-011          | Pending   |
-| F28: GitHub CLI Authentication         | RFC-011          | Pending   |
-| F29: Git Identity Configuration        | RFC-011          | Pending   |
-| F30: auth.json Population              | RFC-011          | Pending   |
-| F31: Cache Restoration in Setup        | RFC-011          | Pending   |
-| F32: SDK-Based Agent Execution         | RFC-013          | Completed |
-| F33: Event Subscription and Processing | RFC-013          | Completed |
-| F34: Completion Detection              | RFC-013          | Completed |
-| F35: Timeout and Cancellation          | RFC-013          | Completed |
-| F36: SDK Cleanup                       | RFC-013          | Completed |
-| F37: Model and Agent Configuration     | RFC-013          | Completed |
-| F38: Mock Event Support                | RFC-005          | Completed |
-| F39: File Attachment Detection         | RFC-014          | Pending   |
-| F40: File Attachment Download          | RFC-014          | Pending   |
-| F41: File Attachment Prompt Injection  | RFC-014          | Pending   |
-| F42: GraphQL Issue Context Hydration   | RFC-015          | Pending   |
-| F43: GraphQL PR Context Hydration      | RFC-015          | Pending   |
-| F44: Context Budgeting                 | RFC-015          | Pending   |
-| F45: Agent Prompt Construction         | RFC-013          | Completed |
-| F46: auth.json Exclusion               | RFC-002, RFC-006 | Pending   |
-| F47: Fork PR Permission Gating         | RFC-006          | Pending   |
-| F48: Credential Strategy               | RFC-003, RFC-006 | Pending   |
-| F49: Branch-Scoped Caching             | RFC-002          | Pending   |
-| F51: Run Summary in Comments           | RFC-007          | Pending   |
-| F52: GitHub Actions Job Summary        | RFC-007          | Pending   |
-| F53: Structured Logging                | RFC-001, RFC-007 | Pending   |
-| F54: Token Usage Reporting             | RFC-007          | Pending   |
-| F55: Error Message Format              | RFC-008          | Pending   |
-| F56: GitHub API Rate Limit Handling    | RFC-007          | Pending   |
-| F57: LLM API Error Handling            | RFC-007          | Pending   |
-| F59: Action Inputs Configuration       | RFC-001, RFC-011 | Pending   |
+| Feature                                 | RFC              | Status    |
+| --------------------------------------- | ---------------- | --------- |
+| F1: GitHub Action Triggers              | RFC-005, RFC-016 | Completed |
+| F2: Issue Comment Interaction           | RFC-008          | Pending   |
+| F3: Discussion Comment Interaction      | RFC-008          | Pending   |
+| F4: PR Conversation Comments            | RFC-008          | Pending   |
+| F5: PR Review Comments                  | RFC-009          | Pending   |
+| F6: Delegated Work - Push Commits       | RFC-010          | Pending   |
+| F7: Delegated Work - Open PRs           | RFC-010          | Pending   |
+| F8: Comment Idempotency                 | RFC-008          | Pending   |
+| F9: Anti-Loop Protection                | RFC-005          | Completed |
+| F10: Reactions & Labels Acknowledgment  | RFC-013          | Completed |
+| F11: Issue vs PR Context Detection      | RFC-013          | Completed |
+| F17: OpenCode Storage Cache Restore     | RFC-002          | Pending   |
+| F18: OpenCode Storage Cache Save        | RFC-002          | Pending   |
+| F19: Session Search on Startup          | RFC-004          | Pending   |
+| F21: Close-the-Loop Session Writeback   | RFC-004          | Pending   |
+| F22: Session Pruning                    | RFC-004          | Pending   |
+| F25: Setup Action Entrypoint            | RFC-011          | Pending   |
+| F26: OpenCode CLI Installation          | RFC-011          | Pending   |
+| F27: oMo Plugin Installation            | RFC-011          | Pending   |
+| F28: GitHub CLI Authentication          | RFC-011          | Pending   |
+| F29: Git Identity Configuration         | RFC-011          | Pending   |
+| F30: auth.json Population               | RFC-011          | Pending   |
+| F31: Cache Restoration in Setup         | RFC-011          | Pending   |
+| F32: SDK-Based Agent Execution          | RFC-013          | Completed |
+| F33: Event Subscription and Processing  | RFC-013          | Completed |
+| F34: Completion Detection               | RFC-013          | Completed |
+| F35: Timeout and Cancellation           | RFC-013          | Completed |
+| F36: SDK Cleanup                        | RFC-013          | Completed |
+| F37: Model and Agent Configuration      | RFC-013          | Completed |
+| F38: Mock Event Support                 | RFC-005          | Completed |
+| F39: File Attachment Detection          | RFC-014          | Pending   |
+| F40: File Attachment Download           | RFC-014          | Pending   |
+| F41: File Attachment Prompt Injection   | RFC-014          | Pending   |
+| F42: GraphQL Issue Context Hydration    | RFC-015          | Pending   |
+| F43: GraphQL PR Context Hydration       | RFC-015          | Pending   |
+| F44: Context Budgeting                  | RFC-015          | Pending   |
+| F45: Agent Prompt Construction          | RFC-013          | Completed |
+| F46: auth.json Exclusion                | RFC-002, RFC-006 | Pending   |
+| F47: Fork PR Permission Gating          | RFC-006          | Pending   |
+| F48: Credential Strategy                | RFC-003, RFC-006 | Pending   |
+| F49: Branch-Scoped Caching              | RFC-002          | Pending   |
+| F51: Run Summary in Comments            | RFC-007          | Pending   |
+| F52: GitHub Actions Job Summary         | RFC-007          | Pending   |
+| F53: Structured Logging                 | RFC-001, RFC-007 | Pending   |
+| F54: Token Usage Reporting              | RFC-007          | Pending   |
+| F55: Error Message Format               | RFC-008          | Pending   |
+| F56: GitHub API Rate Limit Handling     | RFC-007          | Pending   |
+| F57: LLM API Error Handling             | RFC-007          | Pending   |
+| F59: Action Inputs Configuration        | RFC-001, RFC-011 | Pending   |
+| F69: Trigger-Specific Prompt Directives | RFC-016          | Pending   |
+| F70: Issues Event Trigger               | RFC-016          | Pending   |
+| F71: Pull Request Event Trigger         | RFC-016          | Pending   |
+| F72: Schedule Event Trigger             | RFC-016          | Pending   |
+| F73: Pull Request Review Comment        | RFC-016          | Pending   |
+| F74: Post-Action Cache Hook             | RFC-017          | Pending   |
+| F75: Prompt Input Required Validation   | RFC-016          | Pending   |
+| F76: Draft PR Skip                      | RFC-016          | Pending   |
 
 ### P1 Features (Should-Have) - Future RFCs
 
-| Feature                                | Description                        | Notes                |
-| -------------------------------------- | ---------------------------------- | -------------------- |
-| F20: S3 Write-Through Backup           | Cross-runner persistence           | Partially in RFC-002 |
-| F23: Storage Versioning                | Version marker in storage          | Partially in RFC-002 |
-| F24: Corruption Detection              | Detect & handle corruption         | Partially in RFC-002 |
-| F50: Concurrency Handling              | Last-write-wins + warning          | Future RFC           |
-| F63: Pull Request Review Comment       | Handle inline review comment event | Future RFC           |
-| F64: Session Sharing                   | Public session share links         | Future RFC           |
-| F65: Automatic Branch Management       | Branch creation workflows          | Future RFC           |
-| F66: Event Streaming and Progress Logs | Real-time agent progress logging   | Future RFC           |
+| Feature                                | Description                      | Notes                            |
+| -------------------------------------- | -------------------------------- | -------------------------------- |
+| F20: S3 Write-Through Backup           | Cross-runner persistence         | Partially in RFC-002             |
+| F23: Storage Versioning                | Version marker in storage        | Partially in RFC-002             |
+| F24: Corruption Detection              | Detect & handle corruption       | Partially in RFC-002             |
+| F50: Concurrency Handling              | Last-write-wins + warning        | Future RFC                       |
+| ~~F63: Pull Request Review Comment~~   | ~~Handle inline review comment~~ | **ELEVATED to P0 as F73 (v1.2)** |
+| F64: Session Sharing                   | Public session share links       | Future RFC                       |
+| F65: Automatic Branch Management       | Branch creation workflows        | Future RFC                       |
+| F66: Event Streaming and Progress Logs | Real-time agent progress logging | Future RFC                       |
 
 ### P2 Features (Nice-to-Have) - Future RFCs
 


### PR DESCRIPTION
Add comprehensive v1.2 documentation for additional GitHub triggers, trigger-specific prompt directives, and post-action cache hook:

- CHANGELOG: Document v1.2 additions with features, changes, and risks
- FEATURES: Update feature count (44→52 P0), add Category K with 8 new
  features covering additional triggers and post-hook infrastructure
- PRD: Add trigger table with 7 event types, skip conditions, and
  directives; document post-action hook for reliable cache persistence
- RFC-016: Specify additional triggers (issues, PR, schedule, review
  comments) with extended router, skip conditions, and getTriggerDirective()
- RFC-017: Design post-action cache hook with state handoff and best-effort
  cleanup that survives timeout/cancellation
- RFCS: Add RFC-016 and RFC-017 to index with effort estimates, update
  dependency graph, elevate F63 to P0 as F73
- RULES: Document trigger router patterns, directive behaviors, and post-hook properties for implementation guidance

Effort estimate: RFC-016 (12-18h) + RFC-017 (6-9h) = 18-27 hours Phase 2 total increases from 52-73h to 70-100h