### PR TITLE
docs(agents): synchronize knowledge base documentation across modules

### DIFF
--- a/src/lib/agent/AGENTS.md
+++ b/src/lib/agent/AGENTS.md
@@ -16,31 +16,25 @@
 
 ```typescript
 executeOpenCode(prompt, config, logger) // Main SDK execution
-verifyOpenCodeAvailable(path, logger) // Binary validation
-collectAgentContext(client, context, logger) // GitHub event context
+ensureOpenCodeAvailable(options) // Auto-setup if missing
+collectAgentContext(logger) // GitHub event context
 buildAgentPrompt(options, logger) // Multi-section prompt
-acknowledgeReceipt(ctx, logger) // Eyes + working label
-markSuccess(ctx, logger) // Replace with 🎉
-markFailure(ctx, logger) // Replace with 😕
+acknowledgeReceipt(client, ctx, logger) // Eyes + working label
+completeAcknowledgment(client, ctx, success, logger) // Finalize UX
 ```
 
 ## CONVENTIONS
 
 - **Reaction-based UX**:
-  - **Start**: 👀 (Eyes) reaction on triggering comment
-  - **Success**: Replace 👀 with 🎉 (Hooray)
-  - **Failure**: Replace 👀 with 😕 (Confused)
-  - **Non-fatal**: Reaction failures are logged but never crash the agent
-
-- **Working Label**:
-  - `agent: working` (color: `fcf2e1`) added on start
-  - Always removed on completion (success or failure)
-  - Created lazily if missing
+  - **Start**: 👀 (Eyes) on trigger + `agent: working` label (`fcf2e1`)
+  - **Success**: Replace 👀 with 🎉 (Hooray) + remove label
+  - **Failure**: Replace 👀 with 😕 (Confused) + remove label
+  - **Non-fatal**: UX failures logged but never crash execution
 
 - **Execution Safety**:
   - **SDK Mode**: Spawn OpenCode server, connect via SDK client (RFC-013)
-  - **Event Streaming**: SSE subscription for real-time logging (fire-and-forget)
-  - **Connection Retry**: 30 attempts with 1s delay for server startup
+  - **Connection**: 30 retries (1s delay) for server startup
+  - **Event Streaming**: SSE subscription for real-time logging
   - **Timings**: `startTime` / `duration` tracked for all operations
 
 ## ANTI-PATTERNS

--- a/src/lib/github/AGENTS.md
+++ b/src/lib/github/AGENTS.md
@@ -9,6 +9,7 @@
 | Types     | `types.ts`   | Strict interfaces for payloads (IssueComment, Discussion) |
 | Client    | `client.ts`  | `createClient` (PAT) vs `createAppClient` (App auth)      |
 | Context   | `context.ts` | Event parsing, target extraction, PR detection            |
+| API       | `api.ts`     | Helpers for reactions, labels, and user lookups           |
 | Exports   | `index.ts`   | Public API surface                                        |
 
 ## KEY EXPORTS
@@ -16,11 +17,11 @@
 ```typescript
 createClient(options) // Standard token-based Octokit
 createAppClient(options) // Elevated permissions via @octokit/auth-app
-getBotLogin(client) // Auto-detect identity (returns login or fallback)
 parseGitHubContext(logger) // Convert global context to typed GitHubContext
 classifyEventType(name) // Normalize to issue_comment, discussion, etc.
-getCommentTarget(ctx) // Extract {type, number, owner, repo}
-isPullRequest(payload) // Distinguish PR comments from Issue comments
+createCommentReaction(client) // Add emojis (+1, eyes, rocket)
+ensureLabelExists(client) // Idempotent label creation
+getBotLogin(client) // Auto-detect identity (returns login or fallback)
 ```
 
 ## PATTERNS
@@ -29,12 +30,14 @@ isPullRequest(payload) // Distinguish PR comments from Issue comments
 - **Logger Wrapping**: `createOctokitLogger` adapts project `Logger` to Octokit's interface
 - **Dynamic Imports**: `@octokit/auth-app` imported only when needed to save bundle size
 - **Payload Typing**: Specific interfaces (`IssueCommentPayload`) vs generic `any`
+- **Idempotency**: API helpers (`ensureLabelExists`) handle 422/404 explicitly
 
 ## ANTI-PATTERNS
 
-| Pattern            | Why                                                   |
-| ------------------ | ----------------------------------------------------- |
-| **Global Context** | Don't use `github.context` directly; pass parsed type |
-| **Implicit Types** | Don't cast payloads to `any`; use `types.ts`          |
-| **Hardcoded Bots** | Always use `getBotLogin()` instead of assuming name   |
-| **Raw Events**     | Don't check `ctx.eventName` strings; use classifier   |
+| Pattern            | Why                                                      |
+| ------------------ | -------------------------------------------------------- |
+| **Global Context** | Don't use `github.context` directly; pass parsed type    |
+| **Implicit Types** | Don't cast payloads to `any`; use `types.ts`             |
+| **Hardcoded Bots** | Always use `getBotLogin()` instead of assuming name      |
+| **Raw Events**     | Don't check `ctx.eventName` strings; use classifier      |
+| **String Parsing** | Don't split `owner/repo` manually; use `parseRepoString` |


### PR DESCRIPTION
Synchronize AGENTS.md files across root and lib/ subdirectories:
- Add post-action hook (post.ts) documentation
- Update to triple entry points (main/setup/post)
- Document routeEvent and API helper functions
- Clarify patterns and anti-patterns
- Update test count and RFC completion status