### PR TITLE
ci: extract setup steps to reusable composite action

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,0 +1,38 @@
+---
+name: Setup Node.js and pnpm
+description: Sets up pnpm package manager and Node.js with dependency caching
+
+inputs:
+  node-version:
+    description: Node.js version to use. If not provided, reads from .node-version file.
+    required: false
+  install-dependencies:
+    description: Whether to run pnpm bootstrap after setup
+    required: false
+    default: 'true'
+
+outputs:
+  node-version:
+    description: The resolved Node.js version
+    value: ${{ steps.setup-node.outputs.node-version }}
+
+runs:
+  using: composite
+  steps:
+    - name: 📦 Setup pnpm
+      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+      with:
+        run_install: false
+
+    - name: Setup Node.js
+      id: setup-node
+      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      with:
+        cache: pnpm
+        node-version: ${{ inputs.node-version }}
+        node-version-file: ${{ inputs.node-version == '' && '.node-version' || '' }}
+
+    - name: Install dependencies
+      if: inputs.install-dependencies == 'true'
+      shell: bash
+      run: pnpm bootstrap

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,6 @@ jobs:
   setup:
     name: Setup
     outputs:
-      node-version: ${{ steps.set-node-version.outputs.node-version }}
       should-build: ${{ contains(steps.filter.outputs.changes, 'should-build') }}
       should-lint: ${{ contains(steps.filter.outputs.changes, 'should-lint') }}
     permissions:
@@ -29,16 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - name: 📦 Setup PNPM
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          run_install: false
-      - id: set-node-version
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          cache: pnpm
-          node-version-file: .node-version
-      - run: pnpm bootstrap
+      - name: Setup Node.js and pnpm
+        id: setup
+        uses: ./.github/actions/setup
       - id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:
@@ -70,16 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - name: 📦 Setup PNPM
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          run_install: false
-      - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          cache: pnpm
-          node-version: ${{ needs.setup.outputs.node-version }}
-      - run: pnpm bootstrap
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup
       - run: pnpm lint
 
   build:
@@ -89,17 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - name: 📦 Setup PNPM
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          run_install: false
-      - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          cache: pnpm
-          node-version: ${{ needs.setup.outputs.node-version }}
-      - name: Install dependencies
-        run: pnpm bootstrap
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup
       - name: Rebuild the dist/ directory
         run: pnpm build
       - name: Compare the expected and actual dist/ directories
@@ -123,18 +98,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - name: 📦 Setup PNPM
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          run_install: false
-      - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          cache: pnpm
-          node-version: ${{ needs.setup.outputs.node-version }}
-      - name: Install dependencies
-        run: pnpm bootstrap
-
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup
       - name: Run tests
         run: pnpm test
 
@@ -145,6 +110,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup
 
       - id: get-app-token
         name: Get GitHub App Installation Token
@@ -251,17 +219,8 @@ jobs:
       - if: env.DRY_RUN != 'true'
         name: Push `${{ env.RELEASE_BRANCH }}` release branch
         run: git push origin ${{ env.RELEASE_BRANCH }}:${{ env.RELEASE_BRANCH }}
-      - name: 📦 Setup PNPM
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          run_install: false
-      - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          cache: pnpm
-          node-version: ${{ needs.setup.outputs.node-version }}
-      - name: Install dependencies
-        run: pnpm bootstrap
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup
       - if: env.DRY_RUN != 'true'
         name: Build release
         run: pnpm build


### PR DESCRIPTION
Create .github/actions/setup to consolidate Node.js and pnpm setup logic used throughout CI workflow. Replace 6 instances of duplicated setup steps while maintaining caching support for concurrent jobs.