### PR TITLE
ci(workflows): add fro-bot workflow and simplify CI testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ name: CI
 on:
   merge_group:
   pull_request:
+    branches: [main]
     types: [opened, synchronize, ready_for_review, reopened]
   push:
     branches: [main]
@@ -109,18 +110,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ secrets.FRO_BOT_PAT }}
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup
-
-      - id: get-app-token
-        name: Get GitHub App Installation Token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ secrets.APPLICATION_ID }}
-          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner}}
 
       - name: Test main action
         uses: ./
@@ -128,7 +124,7 @@ jobs:
           SKIP_AGENT_EXECUTION: 'false'
           OPENCODE_PROMPT_ARTIFACT: 'true'
         with:
-          github-token: ${{ steps.get-app-token.outputs.token }}
+          github-token: ${{ secrets.FRO_BOT_PAT }}
           auth-json: ${{ secrets.AUTH_JSON }}
 
       - if: always()

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -1,0 +1,75 @@
+---
+name: Fro Bot
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: Custom prompt for the Fro Bot agent
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fro-bot-${{ github.event.issue.number || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+env:
+  DEFAULT_PROMPT: |
+    You are Fro Bot, an AI assistant for managing GitHub repositories. Your tasks include:
+    - Reviewing new issues and pull requests
+    - Providing feedback and suggestions
+    - Triaging and labeling issues
+    - Assisting with code reviews
+    - Engaging with the community to keep the repository healthy and active
+    You have been triggered by a recent event. Please analyze the context and take appropriate actions to help maintain the repository.
+  SCHEDULE_PROMPT: |
+    Review the repository's open issues and pull requests. For each item, determine if it is:
+    - Stale and needs follow-up
+    - Ready for review
+    - Needs triage
+    Summarize your findings in a comment on the issue or PR, or create a new issue if necessary.
+
+jobs:
+  fro-bot:
+    if: >-
+      (
+        github.event.pull_request == null ||
+        !github.event.pull_request.head.repo.fork
+      ) &&
+      (
+        (github.event_name != 'issue_comment' && github.event_name != 'pull_request_review_comment') ||
+        (
+          contains(github.event.comment.body || '', '@fro-bot') &&
+          (github.event.comment.user.login || '') != 'fro-bot' &&
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || '')
+        )
+      )
+    name: Fro Bot
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.FRO_BOT_PAT }}
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup
+
+      - name: Run Fro Bot
+        uses: fro-bot/agent@9abf823ec5c0723219588188d792395237f5b90c # v0.23.27
+        env:
+          PROMPT: ${{ (github.event_name == 'workflow_dispatch' && (github.event.inputs.prompt || env.DEFAULT_PROMPT)) || (github.event_name == 'schedule' && env.SCHEDULE_PROMPT) || '' }}
+        with:
+          auth-json: ${{ secrets.AUTH_JSON }}
+          github-token: ${{ secrets.FRO_BOT_PAT }}
+          prompt: ${{ env.PROMPT }}


### PR DESCRIPTION
Add new Fro Bot workflow for automated repository management and refactor CI test authentication to use PAT instead of GitHub App token.

Changes:
- Add .github/workflows/fro-bot.yaml with scheduled bot runs, comment triggers, and custom prompts
- Simplify test-actions job authentication by removing GitHub App token generation step
- Use FRO_BOT_PAT directly in CI test instead of generating app token
- Add branches filter to pull_request trigger in CI workflow
- Add explicit name to checkout step in test-actions job