### PR TITLE
fix(ci): increase timeouts and add model variable injection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,11 +104,11 @@ jobs:
       - name: Run tests
         run: pnpm test
 
-  test-actions:
+  test-action:
     if: ${{ github.event_name != 'push' }}
-    name: Test GitHub Actions
-    needs: build
+    name: Test GitHub Action
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -137,6 +137,7 @@ jobs:
         with:
           github-token: ${{ secrets.FRO_BOT_PAT }}
           auth-json: ${{ secrets.AUTH_JSON }}
+          model: ${{ vars.FRO_BOT_MODEL }}
           prompt: ${{ env.PROMPT }}
       - if: always()
         name: Introspect main action execution
@@ -189,6 +190,9 @@ jobs:
         uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
 
   release:
+    concurrency:
+      group: release
+      cancel-in-progress: false
     env:
       DRY_RUN: ${{ github.ref_name != github.event.repository.default_branch }}
       RELEASE_BRANCH: v0

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -66,7 +66,7 @@ jobs:
       )
     name: Fro Bot
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: write
       discussions: write
@@ -105,4 +105,5 @@ jobs:
               && secrets.GITHUB_TOKEN
               || secrets.FRO_BOT_PAT
             }}
+          model: ${{ vars.FRO_BOT_MODEL }}
           prompt: ${{ env.PROMPT }}

--- a/docs/examples/fro-bot.yaml
+++ b/docs/examples/fro-bot.yaml
@@ -67,7 +67,7 @@
 #    runs don't collide. Adjust if you want stricter or looser grouping.
 #
 # 4. TIMEOUT
-#    Default is 15 minutes. Increase timeout-minutes if your agent tasks
+#    Default is 30 minutes. Increase timeout-minutes if your agent tasks
 #    routinely take longer (e.g. large code reviews or multi-step work).
 ---
 name: Fro Bot
@@ -127,7 +127,7 @@ jobs:
   fro-bot:
     name: Fro Bot
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: write
       discussions: write


### PR DESCRIPTION
- Increase test-action and fro-bot job timeouts from 15 to 30 minutes
  to accommodate longer agent execution for large PRs and complex analysis
- Rename test-actions job to test-action for consistency
- Inject FRO_BOT_MODEL repository variable into action invocations
  via model input instead of hardcoding
- Add explicit release job concurrency control with serialization
  (cancel-in-progress: false) to prevent simultaneous releases
- Update example workflow documentation to reflect 30-minute timeout