### PR TITLE
fix(workflows): correct checkout ref for PR contexts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,6 +114,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event.pull_request.head.sha || '' }}
           token: ${{ secrets.FRO_BOT_PAT }}
 
       - name: Setup Node.js and pnpm

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -77,6 +77,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: >-
+            ${{
+              (github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number))
+              || github.event.pull_request.head.sha
+              || ''
+            }}
           token: >-
             ${{
               github.event_name == 'workflow_dispatch'

--- a/docs/examples/fro-bot.yaml
+++ b/docs/examples/fro-bot.yaml
@@ -159,6 +159,16 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # Check out PR code when:
+          # 1. Issue comment on PR: refs/pull/{number}/head
+          # 2. Direct PR event: pull_request.head.sha
+          # 3. Other events: default to workflow ref
+          ref: >-
+            ${{
+              (github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number))
+              || github.event.pull_request.head.sha
+              || ''
+            }}
           token: >-
             ${{
               github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Ensure checkout uses PR head SHA for pull_request events and refs/pull/{number}/head for issue comments on PRs.