### PR TITLE
ci: simplify GitHub Actions workflows for omo-providers integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,10 +145,11 @@ jobs:
               || ''
             }}
         with:
-          github-token: ${{ secrets.FRO_BOT_PAT }}
           auth-json: ${{ secrets.AUTH_JSON }}
-          model: ${{ vars.FRO_BOT_MODEL }}
+          github-token: ${{ secrets.FRO_BOT_PAT }}
+          omo-providers: ${{ secrets.OMO_PROVIDERS }}
           prompt: ${{ env.PROMPT }}
+
       - if: always()
         name: Introspect main action execution
         run: |

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -70,12 +70,6 @@ jobs:
       )
     name: Fro Bot
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: write
-      discussions: write
-      issues: write
-      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -87,12 +81,7 @@ jobs:
               || github.event.pull_request.head.sha
               || ''
             }}
-          token: >-
-            ${{
-              github.event_name == 'workflow_dispatch'
-              && secrets.GITHUB_TOKEN
-              || secrets.FRO_BOT_PAT
-            }}
+          token: ${{ secrets.FRO_BOT_PAT }}
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup
@@ -109,11 +98,6 @@ jobs:
             }}
         with:
           auth-json: ${{ secrets.AUTH_JSON }}
-          github-token: >-
-            ${{
-              github.event_name == 'workflow_dispatch'
-              && secrets.GITHUB_TOKEN
-              || secrets.FRO_BOT_PAT
-            }}
-          model: ${{ vars.FRO_BOT_MODEL }}
+          github-token: ${{ secrets.FRO_BOT_PAT }}
+          omo-providers: ${{ secrets.OMO_PROVIDERS }}
           prompt: ${{ env.PROMPT }}


### PR DESCRIPTION
- Remove model variable input from both CI and fro-bot workflows
- Add omo-providers secret input to both workflows
- Streamline fro-bot job: remove timeout-minutes constraint
- Simplify token handling in fro-bot job (remove conditional logic)
- Remove explicit permissions block from fro-bot job
- Reorder action inputs in CI test job for consistency