### PR TITLE
build(pnpm): move overrides to workspace config

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,12 +69,5 @@
     "typescript": "5.9.3",
     "vitest": "4.0.18"
   },
-  "packageManager": "pnpm@10.30.2",
-  "pnpm": {
-    "overrides": {
-      "tar@^7": ">=7.5.11",
-      "undici@^6": ">=6.24.0 <7",
-      "undici@^7": ">=7.24.0"
-    }
-  }
+  "packageManager": "pnpm@10.30.2"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  undici@^6: '>=6.24.0 <7'
-  undici@^7: '>=7.24.0'
   tar@^7: '>=7.5.11'
+  undici@^7: '>=7.24.0'
 
 importers:
 
@@ -5271,8 +5270,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.56.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.57.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,10 @@ onlyBuiltDependencies:
   - simple-git-hooks
   - unrs-resolver
 
+overrides:
+  tar@^7: '>=7.5.11'
+  undici@^7: '>=7.24.0'
+
 savePrefix: ''
 
 shamefullyHoist: true


### PR DESCRIPTION
- remove pnpm.overrides from package.json
- add workspace-level overrides for tar@^7 and undici@^7 in pnpm-workspace.yaml
- drop the previous undici@^6 override from project config
- refresh pnpm-lock.yaml after dependency resolution changes