### PR TITLE
build(dev): suppress git hooks during bootstrap install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@ post.ts → harness/post.ts
 ## COMMANDS
 
 ```bash
-pnpm bootstrap      # Install dependencies
+pnpm install        # Install dependencies
 pnpm test           # Run all tests (vitest)
 pnpm lint           # ESLint check
 pnpm fix            # ESLint auto-fix

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ If the agent times out before completing:
 
 ```bash
 # Install dependencies
-pnpm bootstrap
+pnpm install
 
 # Run tests
 pnpm test

--- a/RULES.md
+++ b/RULES.md
@@ -714,7 +714,7 @@ function createMockClient(options: {sessionIdle?: boolean; sessionError?: boolea
 
 ```bash
 # Development
-pnpm bootstrap     # Install dependencies
+pnpm install       # Install dependencies
 pnpm build         # Bundle to dist/
 pnpm check-types   # TypeScript validation
 pnpm lint          # ESLint check
@@ -1103,7 +1103,7 @@ docs(readme): add SDK execution configuration
 ### Commands
 
 ```bash
-pnpm bootstrap    # Install deps
+pnpm install      # Install deps
 pnpm build        # Bundle
 pnpm check-types  # Type check
 pnpm lint         # Lint

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "type": "module",
   "main": "dist/main.js",
   "scripts": {
-    "bootstrap": "pnpm install --no-strict-peer-dependencies --prefer-offline --loglevel warn",
+    "bootstrap": "SIMPLE_GIT_HOOKS=0 pnpm install --no-strict-peer-dependencies --prefer-offline --loglevel warn",
     "build": "pnpm check-types && tsdown",
     "check-types": "tsc --noEmit",
     "fix": "eslint --fix",


### PR DESCRIPTION
- prefix bootstrap script with SIMPLE_GIT_HOOKS=0 to prevent simple-git-hooks from running during CI dependency installs
- update install command references in AGENTS.md, README.md, and RULES.md from `pnpm bootstrap` to `pnpm install`