### PR TITLE
fix(release): add GH_REPO for pre-checkout gh commands and fix null PR number

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -49,9 +49,10 @@ jobs:
       - id: check-release-pr
         name: Check for release PR
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: |
-          PR_NUMBER=$(gh pr list --head next --base release --state open --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --head next --base release --state open --json number --jq '.[0].number // empty')
           echo "pr-number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           if [ -n "$PR_NUMBER" ] || [ "${{ github.event.inputs.force-release == 'true' }}" = 'true' ]; then
             echo 'should-release=true' >> "$GITHUB_OUTPUT"
@@ -148,6 +149,7 @@ jobs:
       - if: steps.check-release-pr.outputs.should-release == 'true'
         name: Close release PR
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
           PR_NUMBER: ${{ steps.check-release-pr.outputs.pr-number }}
         run: |


### PR DESCRIPTION
## Summary

- Fix the `Check for release PR` step failing with `fatal: not a git repository` on scheduled runs
- Fix a logic bug where `gh pr list` returning `null` was treated as "PR exists"

## Root Cause

The `check-release-pr` step runs `gh pr list` before `actions/checkout`, so there's no `.git` directory. The `gh` CLI needs either git context or `GH_REPO` to resolve the target repository.

## Changes

1. **`GH_REPO: ${{ github.repository }}`** added to `check-release-pr` env — provides repo context without needing `.git`
2. **`// empty` jq filter** — `--jq '.[0].number // empty'` returns empty string (not `null`) when no PR exists, so `[ -n "$PR_NUMBER" ]` correctly evaluates to false
3. **`GH_REPO` added to `Close release PR`** — defensive hardening against future step reordering (Oracle recommendation)

## Verification

- Failed run: https://github.com/fro-bot/agent/actions/runs/23266254165/job/67647724516
- Error: `failed to run git: fatal: not a git repository`
- Fix validated: YAML syntax check passes, all `gh` commands now have repo context