### PR TITLE
fix(settings): remove users/teams from bypass_pull_request_allowances

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -30,8 +30,6 @@ branches:
         # OpenSSF Scorecard Code-Review check.
         bypass_pull_request_allowances:
           apps: []
-          users: []
-          teams: []
       required_status_checks:
         strict: true
         contexts:
@@ -66,8 +64,6 @@ branches:
         bypass_pull_request_allowances:
           apps:
             - fro-bot
-          users: []
-          teams: []
       required_status_checks: null
       restrictions: null
 
@@ -83,7 +79,5 @@ branches:
         bypass_pull_request_allowances:
           apps:
             - fro-bot
-          users: []
-          teams: []
       required_status_checks: null
       restrictions: null


### PR DESCRIPTION
## Summary

Remove `users: []` and `teams: []` from `bypass_pull_request_allowances` in all three branch protection blocks (`main`, `v?`, `release`).

## Root Cause

GitHub API rejects user and team restrictions on user-owned repos — only organization repos support them. Even empty arrays trigger the validation error:

> `Validation Failed: "Only organization repositories can have users and team restrictions"`

## Fix

Removed 6 lines (2 per branch block). The `apps` key is sufficient for user-owned repos.