### PR TITLE
fix(settings): drop bypass_pull_request_allowances entirely

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -23,13 +23,6 @@ branches:
         dismiss_stale_reviews: true
         require_code_owner_reviews: true
         require_last_push_approval: true
-        # Explicitly prevent any app, user, or team from bypassing the PR
-        # review requirement on main. This stops automated tools (e.g. the
-        # fro-bot GitHub App used by Renovate automerge) from merging PRs
-        # without a human approving review, which is required to pass the
-        # OpenSSF Scorecard Code-Review check.
-        bypass_pull_request_allowances:
-          apps: []
       required_status_checks:
         strict: true
         contexts:
@@ -56,14 +49,6 @@ branches:
         dismiss_stale_reviews: true
         require_code_owner_reviews: true
         require_last_push_approval: true
-        # Allow the GitHub App to bypass PR reviews when updating the major
-        # version branch ref (e.g. v0) after each release. Human PRs still
-        # require review. This is needed because v? branches are pointer
-        # branches maintained by the auto-release workflow, not development
-        # branches.
-        bypass_pull_request_allowances:
-          apps:
-            - fro-bot
       required_status_checks: null
       restrictions: null
 
@@ -76,8 +61,5 @@ branches:
         dismiss_stale_reviews: true
         require_code_owner_reviews: false
         require_last_push_approval: false
-        bypass_pull_request_allowances:
-          apps:
-            - fro-bot
       required_status_checks: null
       restrictions: null


### PR DESCRIPTION
## Summary

Remove `bypass_pull_request_allowances` from all three branch protection blocks (`main`, `v?`, `release`).

## Why PR #338 didn't fix this

PR #338 only removed `users: []` and `teams: []` from the YAML. The `update-repository-settings` action deep-merges config with the **current GitHub protection state** via `getBranchProtection`. The existing state already has `bypass_pull_request_allowances.users` and `bypass_pull_request_allowances.teams` — those survive the merge and get sent back to the API, which rejects them on user-owned repos.

## Fix

Remove `bypass_pull_request_allowances` entirely so the action doesn't touch it. Manage fro-bot app bypass via GitHub UI until upstream fix lands.

Upstream bug: https://github.com/bfra-me/.github/issues/1837