### PR TITLE
fix(settings): use literal branch name v0 instead of glob v?

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -39,7 +39,7 @@ branches:
 
       restrictions: null
 
-  - name: v?
+  - name: v0
     protection:
       enforce_admins: true
       allow_force_pushes: true


### PR DESCRIPTION
The action passes branch names directly to the GitHub API — globs aren't supported. Fixes `Branch not found` error for `v?` in update-repo-settings.