### PR TITLE
fix(settings): update action to v4.13.4 and restore bypass_pull_request_allowances

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -23,6 +23,8 @@ branches:
         dismiss_stale_reviews: true
         require_code_owner_reviews: true
         require_last_push_approval: true
+        bypass_pull_request_allowances:
+          apps: []
       required_status_checks:
         strict: true
         contexts:
@@ -49,6 +51,9 @@ branches:
         dismiss_stale_reviews: true
         require_code_owner_reviews: true
         require_last_push_approval: true
+        bypass_pull_request_allowances:
+          apps:
+            - fro-bot
       required_status_checks: null
       restrictions: null
 
@@ -61,5 +66,8 @@ branches:
         dismiss_stale_reviews: true
         require_code_owner_reviews: false
         require_last_push_approval: false
+        bypass_pull_request_allowances:
+          apps:
+            - fro-bot
       required_status_checks: null
       restrictions: null

--- a/.github/workflows/update-repo-settings.yaml
+++ b/.github/workflows/update-repo-settings.yaml
@@ -18,4 +18,4 @@ jobs:
     secrets:
       APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
       APPLICATION_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
-    uses: bfra-me/.github/.github/workflows/update-repo-settings.yaml@7549f97446a7e078ac2edc6641efc2dd9deab66c # v4.13.1
+    uses: bfra-me/.github/.github/workflows/update-repo-settings.yaml@f1fd53cd492c2d7a4f4946cd292af31c0863a928 # v4.13.4


### PR DESCRIPTION
## Summary

- Update `update-repo-settings` workflow to pin `bfra-me/.github@v4.13.4` (includes `update-repository-settings@0.1.3` fix)
- Restore `bypass_pull_request_allowances` to all three branch protection blocks

## Context

[bfra-me/.github#1837](https://github.com/bfra-me/.github/issues/1837) was fixed in `update-repository-settings@0.1.3` — the action now strips `users`/`teams` from `bypass_pull_request_allowances` on user-owned repos before calling the API.

## Changes

| File | Change |
|------|--------|
| `update-repo-settings.yaml` | Pin `bfra-me/.github` from `v4.13.1` → `v4.13.4` |
| `settings.yml` | Restore `bypass_pull_request_allowances` for `main` (apps: []), `v0` (apps: [fro-bot]), `release` (apps: [fro-bot]) |