### PR TITLE
fix(ci): add git identity to Prepare Release PR workflow

### DIFF
--- a/.github/workflows/prepare-release-pr.yaml
+++ b/.github/workflows/prepare-release-pr.yaml
@@ -46,6 +46,19 @@ jobs:
             echo 'has-open-pr=false' >> "$GITHUB_OUTPUT"
           fi
 
+      - id: git-user
+        name: Get GitHub App User ID and Setup Git user
+        env:
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+        run: |
+          name="${{ steps.get-app-token.outputs.app-slug }}[bot]"
+          user_id=$(gh api "/users/${name}" --jq .id)
+          email="${user_id}+${name}@users.noreply.github.com"
+          echo "user-email=${email}" >> "$GITHUB_OUTPUT"
+          echo "user-name=${name}" >> "$GITHUB_OUTPUT"
+          git config --global user.email "${email}"
+          git config --global user.name "${name}"
+
       - name: Checkout `release` branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

Adds git user identity setup to the Prepare Release PR workflow, fixing intermittent `fatal: empty ident name` failures on the `git merge --no-ff` step.

## Root Cause

Step 5 ("Reset to last release tag and merge `main`") creates a merge commit via `git merge --no-ff`, which requires a committer identity. The `auto-release.yaml` and `ci.yaml` workflows both configure this via the GitHub App bot identity — this workflow was missing it. Some runner images have a default git config; others don't, making the failure intermittent.

## Fix

Added "Get GitHub App User ID and Setup Git user" step (mirrors `auto-release.yaml` exactly) between the app token step and the checkout step. Uses `fro-bot[bot]` identity derived from the app token.

## Failing run

https://github.com/fro-bot/agent/actions/runs/24315549028/job/71001477773