### PR TITLE
fix(ci): remove review_requested trigger to prevent double-fire on PR creation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
   merge_group:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, ready_for_review, reopened, review_requested]
+    types: [opened, synchronize, ready_for_review, reopened]
   push:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Remove `review_requested` from CI pull_request trigger types. When a PR is created with reviewers requested (e.g., via CODEOWNERS or the VS Code PR creation UI), GitHub fires both `opened` and `review_requested` events simultaneously. The concurrency group (`cancel-in-progress: true`) cancels the first run, making it look like CI is broken.

**Before:** PR creation → 2 CI runs → 1 cancelled (confusing)
**After:** PR creation → 1 CI run → completes normally

The `review_requested` trigger was only useful for one edge case: adding a reviewer to a stale PR with no new commits. This is rare enough that the confusing UX isn't worth it.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: workflow trigger change only. Verify by creating the next PR — should see exactly 1 CI run, not a cancelled + successful pair.