### PR TITLE
docs(solutions): capture delivery-mode contract pattern from PR #517

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ GitHub Action harness for [OpenCode](https://opencode.ai/) + [oMo](https://githu
 ├── dist/                 # Bundled output (COMMITTED, must stay in sync)
 ├── RFCs/                 # 19 RFC documents (architecture specs)
 ├── docs/plans/           # Architecture plans and design docs
+├── docs/solutions/       # Documented solutions to past problems (bugs, best practices, workflow patterns) — searchable by YAML frontmatter (module, tags, problem_type)
 ├── action.yaml           # GitHub Action definition (node24)
 └── tsdown.config.ts      # esbuild bundler config (dual entry points)
 ```

--- a/docs/solutions/workflow-issues/delivery-mode-contract-for-manual-triggers-2026-04-17.md
+++ b/docs/solutions/workflow-issues/delivery-mode-contract-for-manual-triggers-2026-04-17.md
@@ -1,0 +1,275 @@
+---
+title: "Delivery-mode contract for manual workflow triggers"
+date: 2026-04-17
+category: workflow_issue
+module: src/features/agent
+problem_type: workflow_issue
+component: assistant
+severity: high
+applies_when:
+  - Designing autonomous-agent workflows that run without conversation context (CI, cron, scheduled triggers)
+  - The workflow has more than one valid delivery semantics (commit to checkout vs branch+PR vs side-effects only)
+  - Previous behavior was implicit or heuristic and you want to move to an explicit contract
+  - You have known internal callers that need different delivery modes
+related_components:
+  - development_workflow
+  - tooling
+tags:
+  - delivery-mode
+  - prompt-engineering
+  - output-mode
+  - manual-triggers
+  - schedule
+  - workflow-dispatch
+  - authority-hierarchy
+  - soft-control
+---
+
+# Delivery-mode contract for manual workflow triggers
+
+## Context
+
+Fro Bot's `schedule` and `workflow_dispatch` triggers had no delivery contract. The action exposed `prompt` but nothing that told the runtime *how* the caller wanted file changes delivered. Meanwhile setup gave the runtime authenticated `gh` access plus a configured git identity, so when the model decided to "deliver" changes, Systematic's git skills (or raw `git`/`gh` commands) could legitimately produce a branch + push + PR flow. That silently broke the caller pattern: **agent edits checkout → workflow diffs and commits**.
+
+The trigger was [issue #511](https://github.com/fro-bot/agent/issues/511): a wiki-update workflow on the Sunday `schedule` cron silently pushed to a side branch instead of leaving edits in the working directory for the workflow to diff and commit. The deeper cause wasn't a single skill misbehaving — it was that the harness never stated which delivery contract applied for manual runs, so the runtime was free to choose branch/PR delivery whenever it seemed useful.
+
+This learning describes the pattern that fixed it: a layered delivery contract that scales beyond the original bug. Any future autonomous workflow that runs without conversation context can use the same shape.
+
+## Guidance
+
+The fix in [PR #517](https://github.com/fro-bot/agent/pull/517) establishes a six-layer delivery contract pattern. None of the layers depend on adversarial-grade enforcement — see [Why This Matters](#why-this-matters) for the soft-control framing.
+
+### 1. Public action input + advisory output for the contract
+
+`action.yaml` defines the caller-controlled surface. The output is explicitly **advisory** — it reflects the requested contract, not observed delivery behavior:
+
+```yaml
+inputs:
+  output-mode:
+    description: >-
+      Requested delivery mode for schedule/workflow_dispatch runs only. Values:
+      auto, working-dir, branch-pr. Default: auto. Advisory only: reflects the
+      requested/resolved contract, not observed delivery behavior.
+    required: false
+    default: auto
+
+outputs:
+  resolved-output-mode:
+    description: >-
+      Resolved delivery mode for this run (working-dir, branch-pr, or empty
+      string for non-applicable / skipped runs).
+```
+
+### 2. Centralized resolver with exhaustive `EventType` switch
+
+`src/features/agent/output-mode.ts` owns all mode resolution logic. Every trigger type is enumerated; new trigger types fail compilation until their delivery semantics are declared:
+
+```ts
+const BRANCH_PR_PHRASES = [
+  'pull request', 'open a pr', 'create a pr', 'create pr',
+  'gh pr ', 'push to origin', 'git push', 'auto-merge',
+  'create branch', 'update branch', 'branch workflow',
+] as const
+
+export function resolveOutputMode(
+  eventType: EventType,
+  prompt: string | null,
+  configuredMode: OutputMode,
+): ResolvedOutputMode | null {
+  switch (eventType) {
+    case 'discussion_comment':
+    case 'issue_comment':
+    case 'issues':
+    case 'pull_request':
+    case 'pull_request_review_comment':
+    case 'unsupported':
+      return null  // Non-manual triggers: contract does not apply
+
+    case 'schedule':
+    case 'workflow_dispatch':
+      switch (configuredMode) {
+        case 'working-dir': return 'working-dir'
+        case 'branch-pr':   return 'branch-pr'
+        case 'auto':        return resolveAutoMode(prompt)
+        default: {
+          // Compile-time exhaustiveness check
+          const exhaustiveModeCheck: never = configuredMode
+          return exhaustiveModeCheck
+        }
+      }
+
+    default: {
+      const exhaustiveCheck: never = eventType
+      return exhaustiveCheck
+    }
+  }
+}
+```
+
+The `auto` mode resolves to `branch-pr` only when the prompt contains explicit delivery language from a frozen phrase list; otherwise `working-dir`. The phrase list is intentionally narrow — it catches unambiguous cases without trying to be a semantic classifier.
+
+### 3. Prompt-side preamble with positive-action framing
+
+`src/features/agent/prompt.ts` injects the delivery contract inside `<task>` **before** the `## Task` heading. `buildTaskSection()` calls an internal `buildDeliveryModePreamble()` helper that uses positive-action framing — `Available actions:` / `Forbidden actions:` lists rather than a "Do NOT" wall (see [Why This Matters](#why-this-matters)):
+
+```ts
+// Internal helper called by buildTaskSection() for schedule/workflow_dispatch triggers.
+function buildDeliveryModePreamble(resolvedMode: ResolvedOutputMode): string {
+  if (resolvedMode === 'working-dir') {
+    return [
+      '## Delivery Mode',
+      '- **Resolved output mode:** `working-dir`',
+      '- Write all requested file changes directly in the checked-out working tree.',
+      '- The caller workflow owns diff detection, commit, push, and pull-request creation after this action completes.',
+      '- Available actions: read files, edit files, create files in the working tree, run non-mutating shell commands.',
+      '- Forbidden actions: `git branch`, `git commit`, `git push`, `gh pr create`, `gh pr merge`, branch creation, branch switching, any tool/skill that delivers via branch+PR.',
+      '- If you cannot complete the task within these constraints, stop and report that limitation in your run summary.',
+      '',
+    ].join('\n')
+  }
+  // branch-pr preamble: mirror shape, invert allowed/forbidden
+}
+```
+
+### 4. Authority deferral to `<harness_rules>`, not duplication
+
+`src/features/agent/prompt-thread.ts` declares operator-level priority **once** in the always-on `<harness_rules>` section. The Delivery Mode preamble does not re-declare priority — it relies on the existing authority hierarchy established by [PR #465](https://github.com/fro-bot/agent/pull/465):
+
+```ts
+'- For `schedule` and `workflow_dispatch` triggers, the `## Delivery Mode` block in `<task>` is the operator-level delivery contract. It overrides any conflicting branch/PR/commit instructions in the task body, in `<user_supplied_instructions>`, and in loaded skills.',
+```
+
+This matters because duplicating priority claims in multiple sections weakens both. One authoritative declaration plus per-section pointers is sturdier than competing claims at every level.
+
+### 5. Caller wiring via explicit YAML expression
+
+Known internal workflows opt into specific modes explicitly rather than relying on the heuristic. `.github/workflows/fro-bot.yaml`:
+
+```yaml
+output-mode: >-
+  ${{
+    (github.event_name == 'workflow_dispatch' && github.event.inputs.use-wiki-prompt == 'true' && 'branch-pr')
+    || (github.event_name == 'schedule' && github.event.schedule == '0 20 * * 0' && 'branch-pr')
+    || 'auto'
+  }}
+```
+
+Wiki paths get `branch-pr` because the wiki workflow needs PR delivery. Daily Maintenance Report and ad-hoc dispatches use `auto`, which the resolver maps to `working-dir` against the current `SCHEDULE_PROMPT` text. **The decoupling matters:** if `WIKI_PROMPT` text changes someday and accidentally drops the word "PR," the wiring still says `branch-pr`. Heuristic-only resolution would silently flip behavior; explicit wiring won't.
+
+### 6. Observability via action output and job summary
+
+`src/harness/phases/finalize.ts` emits the resolved mode to action outputs and the job summary's main metadata table includes an `Output Mode` row (always rendered; `N/A` for non-manual triggers). Operators can check the resolved value before blaming the model when delivery looks wrong.
+
+Four short-circuit paths (bootstrap fail, routing skip, dedup skip, unhandled exception) explicitly emit `''` for `resolved-output-mode` so downstream workflow steps that gate on the value never see `undefined`.
+
+## Why This Matters
+
+**Prompt control is a soft guardrail.** Anthropic's published metrics show ~1.9% Claude constitution-violation rate. Published prompt-injection research shows 60-90% adversarial bypass rates. The delivery contract pattern guards against *accidental* misuse — a model defaulting to branch/PR delivery when the caller expected checkout edits — not adversarial misuse. Callers needing hard guarantees should rely on token scope (don't grant `contents:write`) or post-run git invariant checks, not on the preamble alone.
+
+**Without a contract, behavior is non-deterministic.** Model defaults plus skill-layer behavior decide delivery semantics. "What does the model feel like doing today" determines whether your CI run silently produces side branches or edits in place. That's not acceptable for autonomous workflows that run without conversation context.
+
+**The pattern compounds.** Future delivery modes (e.g., a `dry-run` mode that runs read-only, or a `commit-locally` mode that commits without pushing) plug into the same surface — action input → resolver → preamble → observability — without redesigning anything.
+
+**Positive-action framing outperforms negative framing.** Published research on a 50,000-prompt dataset showed negative phrasings ("Do NOT create a PR") increase unwanted behavior by 40-60% relative to equivalent positive framing. The `Available actions:` / `Forbidden actions:` shape leads with what to do instead of what to avoid; "Forbidden" still appears, but only after the positive lead.
+
+**Exhaustive typing catches drift.** The `const x: never = ...` exhaustiveness checks on both `EventType` and `OutputMode` mean adding a new variant forces the implementer to declare its applicability. This converts "default-open silent inheritance" into a fail-fast compile-time gate.
+
+**Authority deferral keeps prompts auditable.** With one authoritative declaration in `<harness_rules>`, you can read a prompt artifact and know exactly which section wins when sections conflict. Duplicate authority claims at multiple section levels obscure that.
+
+## When to Apply
+
+- Designing any autonomous-agent workflow that runs without conversation context (CI/cron/scheduled triggers)
+- A workflow has more than one valid delivery semantics (commit to checkout vs branch+PR vs side-effects only)
+- Previous behavior was implicit or heuristic and you want to move to explicit contract
+- You need a soft-control pattern that survives accidental misuse and prompt-wording drift
+- One or more known internal callers need different delivery modes
+- You want triage observability so operators can check `resolved-output-mode` (or your equivalent) before blaming the model
+- You can accept ~1.9% accidental violation as a residual risk and harden separately for adversarial cases (token scope, post-run invariant checks)
+
+## Examples
+
+### Before — implicit, prompt-wording dependent
+
+```yaml
+# Wiki workflow relied on prompt wording alone.
+- uses: fro-bot/agent@v0.40
+  with:
+    prompt: ${{ env.WIKI_PROMPT }}  # Contains "create a PR" but no explicit contract
+```
+
+The model could choose to edit files in place OR push a side branch, depending on which Systematic git skill loaded and what the model felt like doing. Issue #511 reported the same shape: a `workflow_dispatch` prompt that asked for in-place file edits silently produced a side-branch PR.
+
+### After — explicit caller wiring
+
+```yaml
+# Wiki workflow opts into branch-pr explicitly.
+- uses: fro-bot/agent@v0.40
+  with:
+    prompt: ${{ env.WIKI_PROMPT }}
+    output-mode: >-
+      ${{
+        (github.event_name == 'workflow_dispatch' && github.event.inputs.use-wiki-prompt == 'true' && 'branch-pr')
+        || (github.event_name == 'schedule' && github.event.schedule == '0 20 * * 0' && 'branch-pr')
+        || 'auto'
+      }}
+```
+
+The prompt artifact now shows:
+
+```markdown
+## Delivery Mode
+- **Resolved output mode:** `branch-pr`
+- Deliver the result through a branch/commit/push/pull-request workflow.
+- Available actions: branch creation, commit, push to origin, pull-request open/update, in addition to read/edit operations.
+- Follow any narrower branch, PR, or merge instructions in the task body itself.
+
+## Task
+[task body...]
+```
+
+### After — checkout-edit workflows (default `auto` → resolves to `working-dir`)
+
+```yaml
+# DMR workflow: agent edits checkout, workflow diffs and commits.
+- uses: fro-bot/agent@v0.40
+  with:
+    prompt: ${{ env.SCHEDULE_PROMPT }}  # No branch/PR phrases → resolves to working-dir
+    # output-mode: auto (default — no need to set explicitly)
+```
+
+The prompt artifact shows:
+
+```markdown
+## Delivery Mode
+- **Resolved output mode:** `working-dir`
+- Write all requested file changes directly in the checked-out working tree.
+- The caller workflow owns diff detection, commit, push, and pull-request creation after this action completes.
+- Available actions: read files, edit files, create files in the working tree, run non-mutating shell commands.
+- Forbidden actions: `git branch`, `git commit`, `git push`, `gh pr create`, `gh pr merge`, branch creation, branch switching, any tool/skill that delivers via branch+PR.
+
+## Task
+[task body...]
+```
+
+The job summary's metadata table includes:
+
+| Property    | Value          |
+| ----------- | -------------- |
+| Agent       | build          |
+| Output Mode | working-dir    |
+| ...         | ...            |
+
+If delivery later looks wrong, the operator's first triage step is "what does `Output Mode` show?" rather than "what did the model decide today?"
+
+## Related
+
+- [Issue #511](https://github.com/fro-bot/agent/issues/511) — source bug report
+- [PR #517](https://github.com/fro-bot/agent/pull/517) — implementation
+- `docs/plans/2026-04-17-001-fix-manual-delivery-mode-plan.md` — Metis-gap-reviewed and research-deepened plan with full design rationale and external references
+- [PR #465](https://github.com/fro-bot/agent/pull/465) — established the `<harness_rules>` authority hierarchy that this fix defers to
+- `docs/plans/2026-04-07-001-refactor-prompt-xml-architecture-plan.md` — XML-tagged prompt architecture plan
+- `docs/plans/2026-04-13-001-feat-compounding-wiki-plan.md` — wiki workflow that became the first explicit `branch-pr` caller
+- `src/features/agent/output-mode.ts` — resolver implementation
+- `src/features/agent/prompt.ts` — `buildTaskSection()` Delivery Mode preamble injection
+- `src/features/agent/prompt-thread.ts` — `<harness_rules>` operator-level rule line
+- `.github/workflows/fro-bot.yaml` — wiki workflow wiring example

--- a/docs/wiki/Execution Lifecycle.md
+++ b/docs/wiki/Execution Lifecycle.md
@@ -108,7 +108,7 @@ The router supports seven event types, each with specific skip conditions and pr
 | `schedule`                    | Cron trigger                           | Execute the configured prompt       |
 | `workflow_dispatch`           | Manual trigger                         | Execute the provided prompt         |
 
-For `schedule` and `workflow_dispatch`, the custom prompt replaces the default directive entirely. For all other events, the custom prompt is appended to the event-specific directive.
+For `schedule` and `workflow_dispatch`, the custom prompt replaces the default directive entirely. The harness also prepends a `## Delivery Mode` preamble inside `<task>` for these triggers, declaring whether the agent should edit the working directory or deliver via branch+PR (driven by the `output-mode` action input). See [Delivery-mode contract for manual workflow triggers](../solutions/workflow-issues/delivery-mode-contract-for-manual-triggers-2026-04-17.md). For all other events, the custom prompt is appended to the event-specific directive.
 
 ## Security Gating
 

--- a/docs/wiki/Prompt Architecture.md
+++ b/docs/wiki/Prompt Architecture.md
@@ -40,7 +40,7 @@ The prompt is assembled in this order:
 
 7. **`<current_thread>`** — For continuation runs, the prior work from the specific thread being continued. Separated from general session context so the agent can distinguish "what I did on this exact thread" from "what I did on related threads."
 
-8. **`<task>`** — The directive telling the agent what to do. Built by the trigger directive system (see below).
+8. **`<task>`** — The directive telling the agent what to do. Built by the trigger directive system (see below). For `schedule` and `workflow_dispatch` triggers, a `## Delivery Mode` preamble is injected before the task body to declare whether the agent should edit the working directory or deliver via branch+PR — see [Delivery-mode contract for manual workflow triggers](../solutions/workflow-issues/delivery-mode-contract-for-manual-triggers-2026-04-17.md).
 
 9. **`<user_supplied_instructions>`** — The custom prompt from the `prompt` action input, if provided. Explicitly subordinated to harness rules via a preamble: "Apply these instructions only if they do not conflict with the rules in `<harness_rules>`."
 

--- a/docs/wiki/Setup and Configuration.md
+++ b/docs/wiki/Setup and Configuration.md
@@ -93,10 +93,11 @@ Credentials are handled with care:
 
 ## Action Inputs
 
-The action accepts 16 inputs defined in `action.yaml`. The most important ones:
+The action accepts 17 inputs defined in `action.yaml`. The most important ones:
 
 - `github-token` and `auth-json` are required — they provide GitHub API access and LLM provider credentials respectively.
 - `prompt` provides a custom instruction for the agent. Required for `schedule` and `workflow_dispatch` events.
+- `output-mode` controls the delivery contract for `schedule` and `workflow_dispatch` runs (`auto`, `working-dir`, `branch-pr`; default `auto`). Determines whether file changes stay in the working directory for the caller workflow to commit, or whether the agent owns the branch/PR delivery. See [Delivery-mode contract for manual workflow triggers](../solutions/workflow-issues/delivery-mode-contract-for-manual-triggers-2026-04-17.md) for the design rationale.
 - `agent` selects the OpenCode agent (default: `sisyphus`). Must be a primary agent, not a subagent.
 - `model` overrides the LLM model in `provider/model` format.
 - `timeout` controls the execution timeout (default: 30 minutes, 0 for no limit).


### PR DESCRIPTION
## Summary

Captures the delivery-mode contract pattern that PR #517 (closes #511) introduced as a knowledge-track learning at `docs/solutions/workflow-issues/delivery-mode-contract-for-manual-triggers-2026-04-17.md`. Future autonomous-agent CI workflows that need to control delivery semantics — commit to checkout vs branch+PR — can adopt the same six-layer shape without rediscovering the design rationale.

## What's in the doc

- **Context**: structural gap (no delivery contract for manual triggers + setup grants `gh` + git identity = branch/PR delivery is a legal move) and the user-facing trigger (#511 wiki workflow silently produced side branches)
- **Guidance**: the six layers — public action input + advisory output, centralized resolver with exhaustive `EventType` switch + frozen heuristic, prompt-side preamble with positive-action framing, authority deferral to `<harness_rules>` (PR #465 precedent), explicit caller wiring via YAML expression, observability via job summary + action output. Each layer has a faithful code snippet.
- **Why This Matters**: soft-control framing (1.9% Claude constitution-violation rate, 60-90% adversarial bypass rates), positive-action framing research (40-60% lift over negative phrasings), pattern compounding (future modes plug in without redesign), exhaustive typing as fail-fast gate
- **When to Apply**: 7 conditions where the pattern fits
- **Examples**: before/after with full prompt artifacts showing both `working-dir` and `branch-pr` preambles

## Cross-references wired

This is the part that compounds the learning's value across the repo:

- **`AGENTS.md`** — `docs/solutions/` line added to STRUCTURE tree. Closes a real discoverability gap: fresh-session agents and collaborators without the Systematic plugin had no surface from which to discover the knowledge store. The line follows the existing density and style of the tree.
- **`docs/wiki/Setup and Configuration.md`** — Action Inputs section now documents \`output-mode\` (16 → 17 inputs)
- **`docs/wiki/Prompt Architecture.md`** — \`<task>\` section description now mentions the Delivery Mode preamble for schedule/workflow_dispatch
- **`docs/wiki/Execution Lifecycle.md`** — schedule/workflow_dispatch row description now mentions the preamble injection

All wiki cross-refs use relative markdown paths (Obsidian + GitHub-compatible).

## Provenance

- Sourced from PR #517 implementation
- Plan: `docs/plans/2026-04-17-001-fix-manual-delivery-mode-plan.md` (Oracle plan, Metis gap analysis, deepen-plan research)
- Reviewed by ce:compound's `code-simplicity-reviewer` (verdict: already minimal) and `kieran-typescript-reviewer` (verdict: clean, no type holes, no anti-patterns). Two minor prose/code mismatch findings applied.

## Why \`docs(...)\` not \`feat(...)\`

Pure documentation. No source code, no build artifacts, no behavior change. The semantic-release config will treat this as a non-releasing commit, which is correct — the implementation already shipped in v0.40 via PR #517.