### PR TITLE
docs(gateway): add Effect setup as Unit 4 step 1

### DIFF
--- a/docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
+++ b/docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
@@ -611,8 +611,17 @@ The Action and gateway both import from `@fro-bot/runtime` (the name is internal
 
 **Dependencies:** None (parallel with Unit 1-3)
 
+**Step 1 — Effect foundation** (per `docs/brainstorms/2026-04-25-effect-adoption-gateway-requirements.md`):
+- Add `effect` (3.x, pinned) as a dependency in `packages/gateway/package.json`.
+- Create `packages/gateway/src/runtime-effect.ts` — adapter wrapping every runtime function the gateway uses (`acquireLock`, `releaseLock`, `renewLease`, `forceReleaseLock`, `createRun`, `transitionRun`, `findStaleRuns`, `validateProviderSemantics`, S3 sync helpers). Each wrapper: `Effect.tryPromise` → flatMap on the Result tag → `Effect.fail(error)` on `success: false`, `Effect.succeed(data)` on `success: true`.
+- Decide during this step: `@effect/vitest` vs vanilla vitest with `Effect.runPromise` wrappers; adapter filename (`runtime-effect.ts` vs `runtime/index.ts`).
+- Document the Effect/Result<> boundary in `packages/gateway/AGENTS.md`.
+- All subsequent gateway code (Discord client, slash commands, queue, approval flow, locking) uses Effect natively. Use `Effect.Schedule` for retries; use `Effect.Schema` for Discord interaction validation and approval-token records.
+
 **Files:**
 - Create: `packages/gateway/package.json`, `packages/gateway/tsconfig.json`
+- Create: `packages/gateway/AGENTS.md` (documents Effect/Result<> boundary)
+- Create: `packages/gateway/src/runtime-effect.ts` (Result<>→Effect adapter for runtime functions)
 - Create: `packages/gateway/src/main.ts` (entry point; connects Discord.js client, registers slash commands, graceful shutdown)
 - Create: `packages/gateway/src/config.ts` (`readSecret` helper, env var parsing, `ObjectStoreConfig` assembly)
 - Create: `packages/gateway/src/discord/client.ts` (Discord.js client with `allowedMentions: { parse: ['users'] }` + shard event logging)


### PR DESCRIPTION
Adds an explicit Effect setup step at the start of Unit 4 in the gateway plan: pin `effect` (3.x) as a dependency in `packages/gateway/`, create a `runtime-effect.ts` adapter that wraps each runtime function in `Effect.tryPromise` + flatMap on the Result tag, and use Effect natively (Core + Schedule + Schema) in subsequent gateway code (Discord client, slash commands, queue, approval flow, locking). The Effect/Result<> boundary is documented in `packages/gateway/AGENTS.md`.

Scope is gateway-only. Runtime and Action keep their Result<> APIs; the adapter sits at the gateway package edge so they don't have to know about Effect.