### PR TITLE
ci(renovate): ignore dist/ in scans

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,11 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['github>fro-bot/.github'],
+  // dist/ is bundled vendor code (committed for the GitHub Action runtime).
+  // Skip it from all Renovate scans, including the hidden-Unicode detector,
+  // which trips on legitimate non-ASCII literals in dependencies like
+  // fast-xml-parser's HTML entity tables and AWS SDK helpers.
+  ignorePaths: ['dist/**'],
   customManagers: [
     {
       customType: 'regex',


### PR DESCRIPTION
Renovate's hidden-Unicode detector trips on bundled vendor code under `dist/`. The flagged characters (`U+0085`, `U+00AD`, `U+FEFF`) live inside string literals in fast-xml-parser's HTML entity tables (via @aws-sdk/client-s3) and AWS SDK helpers — they're intentional Unicode in upstream packages, not smuggled content.

Skip `dist/**` from all Renovate scans. The directory has no managed dependencies anyway; it's tsdown's bundled output.

Resolves the "Hidden Unicode characters" warning on the Dependency Dashboard (#2).