### PR TITLE
fix(ci): tighten renovate workflow event guard

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -32,9 +32,20 @@ permissions:
 jobs:
   renovate:
     if: >-
-      (github.event.action == 'edited' && !contains(github.actor, '[bot]')) ||
       (
-        github.event_name != 'workflow_run' ||
+        github.event_name == 'issues' &&
+        github.event.action == 'edited' &&
+        !contains(github.actor, '[bot]')
+      ) ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.action == 'edited' &&
+        !contains(github.actor, '[bot]')
+      ) ||
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'workflow_run' &&
         github.event.workflow_run.conclusion == 'success'
       )
     name: Renovate


### PR DESCRIPTION
## Summary
- stop bot-authored `issues.edited` and `pull_request.edited` events from running the Renovate workflow
- keep manual dispatches, branch pushes, and successful CI-triggered `workflow_run` executions enabled
- make the job-level guard explicit so non-`workflow_run` events are no longer accepted by accident