### PR TITLE
chore: reconcile plan statuses + fix release workflow conflict fallback

### DIFF
--- a/.github/workflows/prepare-release-pr.yaml
+++ b/.github/workflows/prepare-release-pr.yaml
@@ -70,11 +70,22 @@ jobs:
 
       - name: Reset to last release tag and merge `main`
         run: |
+          set -euo pipefail
           last_tag=$(git tag --list 'v*' --sort=-version:refname | head -1)
           echo "Resetting to ${last_tag}"
           git reset --hard "${last_tag}"
           git fetch origin main
-          git merge --no-ff -Xtheirs -m 'skip: merge main [skip release]' origin/main
+          if ! git merge --no-ff -Xtheirs -m 'skip: merge main [skip release]' origin/main; then
+            # Typical trigger: rename/rename on dist/artifact-*.js (the bundle hash
+            # changes every commit on main). -Xtheirs handles content conflicts but
+            # cannot resolve rename/rename. Bias fully to main's tree on conflict —
+            # the release branch's purpose is to mirror main.
+            echo "Merge had unresolvable conflicts; taking main's tree verbatim."
+            git merge --abort
+            git checkout origin/main -- .
+            git add -A
+            git commit --no-verify -m 'skip: merge main [skip release] (conflict-resolved)'
+          fi
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup

--- a/docs/plans/2026-03-22-feat-agent-cohesion-session-continuity-plan.md
+++ b/docs/plans/2026-03-22-feat-agent-cohesion-session-continuity-plan.md
@@ -1,9 +1,10 @@
 ---
 title: "feat: Agent Cohesion via Deterministic Session Continuity"
 type: feat
-status: active
+status: completed
 date: 2026-03-22
 origin: docs/brainstorms/2026-03-22-agent-cohesion-session-context-brainstorm.md
+shipped: 2026-03-22 onward (buildLogicalKey + deterministic 'fro-bot: {key}' titles + session continuation are in packages/runtime/src/session/logical-key.ts and src/harness/phases/session-prep.ts)
 ---
 
 ## Enhancement Summary

--- a/docs/plans/2026-04-13-001-feat-compounding-wiki-plan.md
+++ b/docs/plans/2026-04-13-001-feat-compounding-wiki-plan.md
@@ -1,10 +1,11 @@
 ---
 title: "feat: Add compounding project wiki maintained by Fro Bot"
 type: feat
-status: active
+status: completed
 date: 2026-04-13
 origin: docs/brainstorms/2026-04-13-compounding-wiki-requirements.md
 deepened: 2026-04-13
+shipped: 2026-04-14 (PR #489 — workflow scaffold + boolean dispatch inputs; PR #491 — seed wiki pages; PR #494 — eslint/gitignore for Obsidian vault)
 ---
 
 # feat: Add compounding project wiki maintained by Fro Bot
@@ -104,7 +105,7 @@ Fro Bot accumulates deep knowledge through session memory and project memories, 
 
 ## Implementation Units
 
-- [ ] **Unit 1: Scaffold Obsidian vault and .gitignore**
+- [x] **Unit 1: Scaffold Obsidian vault and .gitignore** (shipped in PR #489)
 
   **Goal:** Create the `docs/wiki/` directory structure with Obsidian vault config, `.gitignore` for user-specific files, and a placeholder `index.md`.
 
@@ -150,7 +151,7 @@ Fro Bot accumulates deep knowledge through session memory and project memories, 
   - `.gitignore` excludes user-specific files
   - `index.md` renders in both Obsidian and GitHub (standard markdown links for GitHub navigation)
 
-- [ ] **Unit 2: Add weekly wiki schedule to fro-bot.yaml**
+- [x] **Unit 2: Add weekly wiki schedule to fro-bot.yaml** (shipped in PR #489)
 
   **Goal:** Add a second cron entry for weekly wiki updates and a `WIKI_PROMPT` env var with the wiki maintenance instructions.
 
@@ -207,7 +208,7 @@ Fro Bot accumulates deep knowledge through session memory and project memories, 
   - PROMPT expression correctly discriminates between the two cron strings
   - Existing DMR functionality unchanged
 
-- [ ] **Unit 3: Generate initial seed wiki pages**
+- [x] **Unit 3: Generate initial seed wiki pages** (shipped in PR #491; 6 canonical pages + index live in docs/wiki/)
 
   **Goal:** Create the 6 canonical wiki pages with full content, wikilinks, and frontmatter. This is the initial "seed" generation — all pages from scratch.
 

--- a/docs/plans/2026-04-17-001-fix-manual-delivery-mode-plan.md
+++ b/docs/plans/2026-04-17-001-fix-manual-delivery-mode-plan.md
@@ -1,10 +1,11 @@
 ---
 title: "fix: Add explicit delivery mode for manual file-edit runs"
 type: fix
-status: active
+status: completed
 date: 2026-04-17
 gap_review: 2026-04-17 (Metis — critical + important gaps closed)
 deepened: 2026-04-17 (research-grounded — repo verification, prompt-priority research, system-wide impact, pattern alignment)
+shipped: 2026-04-18 (PR #517 — feat(action): add output-mode input to fix manual-trigger side-branch delivery)
 ---
 
 # fix: Add explicit delivery mode for manual file-edit runs
@@ -131,7 +132,7 @@ resolved mode
 
 ## Implementation Units
 
-- [ ] **Unit 1: Add public input/output surface for delivery mode**
+- [x] **Unit 1: Add public input/output surface for delivery mode** (shipped in PR #517)
 
 **Goal:** Expose a caller-controlled delivery contract and make the resolved mode visible at runtime.
 
@@ -180,7 +181,7 @@ resolved mode
 
 ---
 
-- [ ] **Unit 2: Centralize mode resolution and inject authoritative task guardrails**
+- [x] **Unit 2: Centralize mode resolution and inject authoritative task guardrails** (shipped in PR #517)
 
 **Goal:** Convert the configured mode into a resolved manual-run contract and render that contract into the prompt where the model will see it before taking git actions.
 
@@ -264,7 +265,7 @@ resolved mode
 
 ---
 
-- [ ] **Unit 3: Make the internal wiki caller explicit and lock in regression coverage**
+- [x] **Unit 3: Make the internal wiki caller explicit and lock in regression coverage** (shipped in PR #517)
 
 **Goal:** Preserve known branch/PR-based automation while the new default fixes checkout-edit workflows.
 

--- a/docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
+++ b/docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
@@ -414,7 +414,7 @@ The Action and gateway both import from `@fro-bot/runtime` (the name is internal
 
 ## Implementation Units
 
-- [ ] **Unit 1: Extract shared runtime package**
+- [x] **Unit 1: Extract shared runtime package** (shipped in PR #541, 2026-04-25)
 
 **Goal:** Move agent execution, session storage, prompt assembly, and object-store into `packages/runtime/`. Action keeps working end-to-end on the extracted runtime with zero behavior change.
 
@@ -497,7 +497,7 @@ The Action and gateway both import from `@fro-bot/runtime` (the name is internal
 
 ---
 
-- [ ] **Unit 2: Coordination primitives — run-state lifecycle, per-repo lock, per-thread queue**
+- [x] **Unit 2: Coordination primitives — run-state lifecycle, per-repo lock, per-thread queue** (shipped in PR #547, 2026-04-25)
 
 **Goal:** Build the S3-backed coordination primitives that both surfaces depend on: run-state records with heartbeat, per-repo single-writer locks, and per-thread queue persistence.
 
@@ -550,7 +550,7 @@ The Action and gateway both import from `@fro-bot/runtime` (the name is internal
 
 ---
 
-- [ ] **Unit 3: Action participates in lock protocol**
+- [x] **Unit 3: Action participates in lock protocol** (shipped in PR #548, 2026-04-25)
 
 **Goal:** Add per-repo lock acquisition to the Action's harness so Action runs and Discord runs on the same repo don't collide. Close the cross-surface correctness hole flagged by flow analysis (Q1).
 


### PR DESCRIPTION
Two small changes bundled:

**Plan reconciliation.** Four plans previously marked `status: active` have shipped reality on main. Updates the frontmatter and per-unit checkboxes to reflect what was actually merged:

- `agent-cohesion-session-continuity` → completed (deterministic `fro-bot: {key}` titles + `buildLogicalKey` + session continuation are in source)
- `compounding-wiki` → completed (PRs #489, #491, #494 — vault scaffold, weekly schedule, six seed pages)
- `manual-delivery-mode` → completed (PR #517 — output-mode input)
- `gateway-discord-v1` Units 1-3 → checked (PRs #541, #547, #548); plan stays active for Units 4-8

**Release workflow fix.** `prepare-release-pr.yaml` runs `git merge --no-ff -Xtheirs origin/main` to synthesize the `next` branch from the last release tag. `-Xtheirs` resolves text conflicts in favor of main but cannot resolve `rename/rename` conflicts, which fire every time main's bundle hash changes (`dist/artifact-*.js`). On conflict, take main's tree wholesale via `git checkout origin/main -- .` and commit. Release branch's purpose is to mirror main; biasing fully to main on conflicts preserves that intent without manual intervention.