### PR TITLE
fix(gateway): reliability and test-coverage follow-ups

### DIFF
--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -1,4 +1,4 @@
-import type {ObjectStoreConfig} from '@fro-bot/runtime'
+import type {ObjectStoreConfig} from './runtime-effect.js'
 
 import {existsSync, readFileSync} from 'node:fs'
 import process from 'node:process'

--- a/packages/gateway/src/discord/commands/index.test.ts
+++ b/packages/gateway/src/discord/commands/index.test.ts
@@ -1,8 +1,41 @@
 import type {ChatInputCommandInteraction} from 'discord.js'
+import {Routes} from 'discord.js'
 import {Effect} from 'effect'
-import {describe, expect, it, vi} from 'vitest'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {dispatchCommand, getCommandRegistry} from './index.js'
+import {dispatchCommand, getCommandRegistry, registerSlashCommands, type SlashCommand} from './index.js'
+
+const restPutMock = vi.fn().mockResolvedValue(undefined)
+const restSetTokenMock = vi.fn().mockReturnThis()
+
+// MockREST is a plain constructor function so `new REST()` works inside the production code.
+// It must be declared at module scope to satisfy unicorn/consistent-function-scoping.
+function MockREST(this: {setToken: typeof restSetTokenMock; put: typeof restPutMock}) {
+  this.setToken = restSetTokenMock
+  this.put = restPutMock
+}
+
+// vi.mock is hoisted by Vitest to the top of the module at runtime, so the
+// factory runs before any imports. ESLint sees this as "after imports" but
+// that's fine — the import-x/first rule applies to static imports, not vi.mock.
+vi.mock('discord.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('discord.js')>()
+  return {
+    ...actual,
+    REST: MockREST,
+    Routes: {
+      applicationCommands: vi.fn((appId: string) => `GLOBAL:${appId}`),
+      applicationGuildCommands: vi.fn((appId: string, guildId: string) => `GUILD:${appId}:${guildId}`),
+    },
+  }
+})
+
+beforeEach(() => {
+  restPutMock.mockClear()
+  restSetTokenMock.mockClear()
+  ;(Routes.applicationCommands as ReturnType<typeof vi.fn>).mockClear()
+  ;(Routes.applicationGuildCommands as ReturnType<typeof vi.fn>).mockClear()
+})
 
 describe('getCommandRegistry', () => {
   it('includes the ping command', () => {
@@ -83,5 +116,75 @@ describe('dispatchCommand', () => {
 
     // #then
     expect(reply).toHaveBeenCalledWith({content: 'pong', ephemeral: true})
+  })
+
+  it('logs a console.warn when the ephemeral ack fails for an unknown command', async () => {
+    // #given a reply() that rejects so the ack-failure branch fires
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const reply = vi.fn().mockRejectedValue(new Error('Token expired'))
+      const registry = getCommandRegistry()
+      const interaction = {commandName: 'nonexistent', reply} as unknown as ChatInputCommandInteraction
+
+      // #when
+      const result = await Effect.runPromise(Effect.either(dispatchCommand(interaction, registry)))
+
+      // #then — Effect still fails with unknown-command (existing behavior preserved)
+      expect(result._tag).toBe('Left')
+
+      // #and — console.warn captured the ack failure with the JSON payload shape
+      expect(consoleSpy).toHaveBeenCalledOnce()
+      const arg = consoleSpy.mock.calls[0]?.[0] as string
+      const parsed = JSON.parse(arg) as Record<string, unknown>
+      expect(parsed.level).toBe('warn')
+      expect(parsed.msg).toBe('ack failed for unknown command')
+      expect(parsed.commandName).toBe('nonexistent')
+      expect(String(parsed.err)).toContain('Token expired')
+    } finally {
+      consoleSpy.mockRestore()
+    }
+  })
+})
+
+describe('registerSlashCommands', () => {
+  it('uses Routes.applicationCommands for global registration when guildId is null', async () => {
+    // #given
+    const token = 'test-token'
+    const applicationId = 'app-123'
+    const registry: SlashCommand[] = [
+      {
+        data: {name: 'cmd', toJSON: () => ({name: 'cmd'})} as unknown as import('discord.js').SlashCommandBuilder,
+        execute: () => Effect.void,
+      },
+    ]
+
+    // #when
+    await registerSlashCommands(token, applicationId, null, registry)
+
+    // #then
+    expect(Routes.applicationCommands).toHaveBeenCalledWith(applicationId) // eslint-disable-line @typescript-eslint/unbound-method
+    expect(Routes.applicationGuildCommands).not.toHaveBeenCalled() // eslint-disable-line @typescript-eslint/unbound-method
+    expect(restPutMock).toHaveBeenCalledWith('GLOBAL:app-123', {body: [{name: 'cmd'}]})
+  })
+
+  it('uses Routes.applicationGuildCommands for guild-scoped registration when guildId is provided', async () => {
+    // #given
+    const token = 'test-token'
+    const applicationId = 'app-123'
+    const guildId = 'guild-456'
+    const registry: SlashCommand[] = [
+      {
+        data: {name: 'cmd', toJSON: () => ({name: 'cmd'})} as unknown as import('discord.js').SlashCommandBuilder,
+        execute: () => Effect.void,
+      },
+    ]
+
+    // #when
+    await registerSlashCommands(token, applicationId, guildId, registry)
+
+    // #then
+    expect(Routes.applicationGuildCommands).toHaveBeenCalledWith(applicationId, guildId) // eslint-disable-line @typescript-eslint/unbound-method
+    expect(Routes.applicationCommands).not.toHaveBeenCalled() // eslint-disable-line @typescript-eslint/unbound-method
+    expect(restPutMock).toHaveBeenCalledWith('GUILD:app-123:guild-456', {body: [{name: 'cmd'}]})
   })
 })

--- a/packages/gateway/src/discord/commands/index.ts
+++ b/packages/gateway/src/discord/commands/index.ts
@@ -46,8 +46,26 @@ export function dispatchCommand(
             content: `Unknown command: \`${commandName}\``,
             ephemeral: true,
           }),
-        catch: () => new Error('ack-failed'),
-      }).pipe(Effect.catchAll(() => Effect.void))
+        catch: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.tapError(err =>
+          Effect.sync(() => {
+            // TODO(future): plumb a logger Effect.Service through dispatchCommand so
+            // we can stop using bare console.warn here. The unknown-command ack path
+            // is the only place in the gateway that does this; eliminating it
+            // completes the structured-logging story.
+            // Log the ack failure but don't propagate it — the unknown-command error
+            // is the meaningful signal for the caller. We can't pass a logger Effect.Service
+            // through dispatchCommand without changing its signature, so use console.warn
+            // directly here. This is the only place in dispatchCommand that does so.
+
+            console.warn(
+              JSON.stringify({level: 'warn', msg: 'ack failed for unknown command', commandName, err: String(err)}),
+            )
+          }),
+        ),
+        Effect.catchAll(() => Effect.void),
+      )
       return yield* Effect.fail(new Error(`Unknown command: ${commandName}`))
     })
   }

--- a/packages/gateway/src/discord/mentions.test.ts
+++ b/packages/gateway/src/discord/mentions.test.ts
@@ -5,11 +5,25 @@ import {describe, expect, it, vi} from 'vitest'
 const BOT_USER_ID = 'bot-user-123'
 
 function makeMessage(
-  overrides: Partial<{isThread: boolean; mentionsBot: boolean; sendFn: ReturnType<typeof vi.fn>}>,
+  overrides: Partial<{
+    isThread: boolean
+    mentionsBot: boolean
+    sendFn: ReturnType<typeof vi.fn>
+    startThreadFn: ReturnType<typeof vi.fn>
+    reactFn: ReturnType<typeof vi.fn>
+    replyFn: ReturnType<typeof vi.fn>
+  }>,
 ): Message {
-  const {isThread = false, mentionsBot = true, sendFn = vi.fn().mockResolvedValue(undefined)} = overrides
+  const {
+    isThread = false,
+    mentionsBot = true,
+    sendFn = vi.fn().mockResolvedValue(undefined),
+    startThreadFn,
+    reactFn = vi.fn().mockResolvedValue(undefined),
+    replyFn = vi.fn().mockResolvedValue(undefined),
+  } = overrides
 
-  const startThread = vi.fn().mockResolvedValue({send: sendFn} as unknown as ThreadChannel)
+  const startThread = startThreadFn ?? vi.fn().mockResolvedValue({send: sendFn} as unknown as ThreadChannel)
 
   return {
     channel: {
@@ -19,6 +33,8 @@ function makeMessage(
       has: (id: string) => mentionsBot && id === BOT_USER_ID,
     },
     startThread,
+    react: reactFn,
+    reply: replyFn,
     _startThread: startThread, // expose for assertions
   } as unknown as Message
 }
@@ -62,5 +78,71 @@ describe('handleMention', () => {
 
     // #then — no thread created
     expect((message as unknown as {_startThread: ReturnType<typeof vi.fn>})._startThread).not.toHaveBeenCalled()
+  })
+
+  it('still attempts fallback reply when both startThread and react fail, then fails with the original error', async () => {
+    // #given startThread rejects AND react also rejects (e.g. global rate limit)
+    const {handleMention} = await import('./mentions.js')
+    const startThreadError = new Error('startThread rate limit')
+    const startThreadFn = vi.fn().mockRejectedValue(startThreadError)
+    const reactFn = vi.fn().mockRejectedValue(new Error('react also rate limited'))
+    const replyFn = vi.fn().mockResolvedValue(undefined)
+    const message = makeMessage({startThreadFn, reactFn, replyFn})
+
+    // #when
+    const result = await Effect.runPromise(Effect.either(handleMention(message, BOT_USER_ID)))
+
+    // #then — Effect still fails with the ORIGINAL startThread error
+    expect(result._tag).toBe('Left')
+    expect((result as {_tag: 'Left'; left: unknown}).left).toBeInstanceOf(Error)
+    expect(((result as {_tag: 'Left'; left: unknown}).left as Error).message).toContain('startThread rate limit')
+    // #and — react was attempted (and failed)
+    expect(reactFn).toHaveBeenCalledWith('❌')
+    // #and — fallback reply was still attempted despite react failing
+    expect(replyFn).toHaveBeenCalledOnce()
+  })
+
+  it('preserves the original startThread error when fallback reply also fails', async () => {
+    // #given startThread rejects, react succeeds, reply rejects
+    const {handleMention} = await import('./mentions.js')
+    const startThreadError = new Error('startThread permission denied')
+    const startThreadFn = vi.fn().mockRejectedValue(startThreadError)
+    const reactFn = vi.fn().mockResolvedValue(undefined)
+    const replyFn = vi.fn().mockRejectedValue(new Error('reply also failed'))
+    const message = makeMessage({startThreadFn, reactFn, replyFn})
+
+    // #when
+    const result = await Effect.runPromise(Effect.either(handleMention(message, BOT_USER_ID)))
+
+    // #then — Effect fails with the original startThread error, not the reply error
+    expect(result._tag).toBe('Left')
+    expect((result as {_tag: 'Left'; left: unknown}).left).toBeInstanceOf(Error)
+    expect(((result as {_tag: 'Left'; left: unknown}).left as Error).message).toContain('startThread permission denied')
+    expect(((result as {_tag: 'Left'; left: unknown}).left as Error).message).not.toContain('reply also failed')
+  })
+
+  it('reacts ❌ and sends fallback reply when startThread fails, then fails with the original error', async () => {
+    // #given
+    const {handleMention} = await import('./mentions.js')
+    const threadError = new Error('Missing Permissions')
+    const startThreadFn = vi.fn().mockRejectedValue(threadError)
+    const reactFn = vi.fn().mockResolvedValue(undefined)
+    const replyFn = vi.fn().mockResolvedValue(undefined)
+    const message = makeMessage({isThread: false, mentionsBot: true, startThreadFn, reactFn, replyFn})
+
+    // #when
+    const result = await Effect.runPromise(Effect.either(handleMention(message, BOT_USER_ID)))
+
+    // #then — react was called with ❌
+    expect(reactFn).toHaveBeenCalledWith('❌')
+
+    // #and — fallback reply was sent with the expected content
+    expect(replyFn).toHaveBeenCalledWith({
+      content: 'Could not start a session here — please try again or check channel permissions.',
+    })
+
+    // #and — the Effect still fails with the original startThread error
+    expect(result._tag).toBe('Left')
+    expect((result as {_tag: 'Left'; left: unknown}).left).toBe(threadError)
   })
 })

--- a/packages/gateway/src/discord/mentions.ts
+++ b/packages/gateway/src/discord/mentions.ts
@@ -30,5 +30,44 @@ export function handleMention(message: Message, botUserId: string): Effect.Effec
       await thread.send('pong')
     },
     catch: error => (error instanceof Error ? error : new Error(String(error))),
-  })
+  }).pipe(
+    Effect.catchAll(threadError =>
+      Effect.gen(function* () {
+        console.warn(
+          JSON.stringify({level: 'warn', msg: 'handleMention: startThread failed', err: String(threadError)}),
+        )
+        yield* Effect.tryPromise({
+          try: async () => message.react('❌'),
+          catch: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(
+          Effect.tapError(err =>
+            Effect.sync(() => {
+              console.warn(JSON.stringify({level: 'warn', msg: 'handleMention: react failed', err: String(err)}))
+            }),
+          ),
+          Effect.catchAll(() => Effect.void),
+        )
+        yield* Effect.tryPromise({
+          try: async () =>
+            message.reply({content: 'Could not start a session here — please try again or check channel permissions.'}),
+          catch: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(
+          Effect.tapError(err =>
+            Effect.sync(() => {
+              console.warn(
+                JSON.stringify({level: 'warn', msg: 'handleMention: fallback reply failed', err: String(err)}),
+              )
+            }),
+          ),
+          // Defense-in-depth: the inner Effect.catchAll branches above already
+          // swallow react and reply rejections, so this outer catchAll should
+          // never fire. Kept defensively in case a future refactor changes the
+          // inner shape — it ensures the fallback chain can never re-fail the
+          // outer Effect with a non-original error.
+          Effect.catchAll(() => Effect.void),
+        )
+        return yield* Effect.fail(threadError)
+      }),
+    ),
+  )
 }

--- a/packages/gateway/src/runtime-effect.test.ts
+++ b/packages/gateway/src/runtime-effect.test.ts
@@ -26,7 +26,7 @@ import {
   transitionRun,
   validateProviderSemantics,
 } from '@fro-bot/runtime'
-import {Effect, Exit} from 'effect'
+import {Effect} from 'effect'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {
@@ -86,6 +86,18 @@ function err(error: Error) {
   return {success: false as const, error}
 }
 
+async function assertEffectFailsWith<E extends Error>(
+  effect: Effect.Effect<unknown, E>,
+  expectedMessageSubstring: string,
+): Promise<void> {
+  const result = await Effect.runPromise(Effect.either(effect))
+  expect(result._tag).toBe('Left')
+  if (result._tag === 'Left') {
+    expect(result.left).toBeInstanceOf(Error)
+    expect((result.left as Error).message).toContain(expectedMessageSubstring)
+  }
+}
+
 // ---------------------------------------------------------------------------
 // acquireLockEffect
 // ---------------------------------------------------------------------------
@@ -110,28 +122,44 @@ describe('acquireLockEffect', () => {
   // #given underlying returns failure Result
   // #when Effect runs
   // #then fails with the error
+  // eslint-disable-next-line vitest/expect-expect
   it('fails with error when Result is failure', async () => {
-    const error = new Error('lock conflict')
-    vi.mocked(acquireLock).mockResolvedValue(err(error))
+    vi.mocked(acquireLock).mockResolvedValue(err(new Error('lock conflict')))
 
-    const exit = await Effect.runPromiseExit(
+    await assertEffectFailsWith(
       acquireLockEffect(config, 'repo', 'holder', 'discord', 'run-1', coordLogger),
+      'lock conflict',
     )
-
-    expect(Exit.isFailure(exit)).toBe(true)
   })
 
   // #given underlying throws
   // #when Effect runs
   // #then fails with wrapped error
+  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(acquireLock).mockRejectedValue(new Error('network error'))
 
-    const exit = await Effect.runPromiseExit(
+    await assertEffectFailsWith(
       acquireLockEffect(config, 'repo', 'holder', 'discord', 'run-1', coordLogger),
+      'network error',
     )
+  })
 
-    expect(Exit.isFailure(exit)).toBe(true)
+  // eslint-disable-next-line vitest/expect-expect
+  it('preserves the error message when Result is failure', async () => {
+    vi.mocked(acquireLock).mockResolvedValue(err(new Error('lock conflict')))
+
+    await assertEffectFailsWith(
+      acquireLockEffect(config, 'repo', 'holder', 'discord', 'run-1', coordLogger),
+      'lock conflict',
+    )
+  })
+
+  // eslint-disable-next-line vitest/expect-expect
+  it('wraps non-Error rejections into an Error instance', async () => {
+    vi.mocked(acquireLock).mockRejectedValue('oops')
+
+    await assertEffectFailsWith(acquireLockEffect(config, 'repo', 'holder', 'discord', 'run-1', coordLogger), 'oops')
   })
 })
 
@@ -150,21 +178,18 @@ describe('releaseLockEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success'})
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails with error when Result is failure', async () => {
-    const error = new Error('delete failed')
-    vi.mocked(releaseLock).mockResolvedValue(err(error))
+    vi.mocked(releaseLock).mockResolvedValue(err(new Error('delete failed')))
 
-    const exit = await Effect.runPromiseExit(releaseLockEffect(config, 'repo', 'etag-1', coordLogger))
-
-    expect(Exit.isFailure(exit)).toBe(true)
+    await assertEffectFailsWith(releaseLockEffect(config, 'repo', 'etag-1', coordLogger), 'delete failed')
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(releaseLock).mockRejectedValue(new Error('boom'))
 
-    const exit = await Effect.runPromiseExit(releaseLockEffect(config, 'repo', 'etag-1', coordLogger))
-
-    expect(Exit.isFailure(exit)).toBe(true)
+    await assertEffectFailsWith(releaseLockEffect(config, 'repo', 'etag-1', coordLogger), 'boom')
   })
 })
 
@@ -192,20 +217,21 @@ describe('renewLeaseEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: {etag: 'new-etag'}})
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails with error when Result is failure', async () => {
     vi.mocked(renewLease).mockResolvedValue(err(new Error('precondition failed')))
 
-    const exit = await Effect.runPromiseExit(renewLeaseEffect(config, 'repo', lockRecord, 'old-etag', coordLogger))
-
-    expect(Exit.isFailure(exit)).toBe(true)
+    await assertEffectFailsWith(
+      renewLeaseEffect(config, 'repo', lockRecord, 'old-etag', coordLogger),
+      'precondition failed',
+    )
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(renewLease).mockRejectedValue('string error')
 
-    const exit = await Effect.runPromiseExit(renewLeaseEffect(config, 'repo', lockRecord, 'old-etag', coordLogger))
-
-    expect(Exit.isFailure(exit)).toBe(true)
+    await assertEffectFailsWith(renewLeaseEffect(config, 'repo', lockRecord, 'old-etag', coordLogger), 'string error')
   })
 })
 
@@ -224,20 +250,18 @@ describe('forceReleaseLockEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success'})
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails with error when Result is failure', async () => {
     vi.mocked(forceReleaseLock).mockResolvedValue(err(new Error('force delete failed')))
 
-    const exit = await Effect.runPromiseExit(forceReleaseLockEffect(config, 'repo', 'etag-1', coordLogger))
-
-    expect(Exit.isFailure(exit)).toBe(true)
+    await assertEffectFailsWith(forceReleaseLockEffect(config, 'repo', 'etag-1', coordLogger), 'force delete failed')
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(forceReleaseLock).mockRejectedValue(new Error('boom'))
 
-    const exit = await Effect.runPromiseExit(forceReleaseLockEffect(config, 'repo', 'etag-1', coordLogger))
-
-    expect(Exit.isFailure(exit)).toBe(true)
+    await assertEffectFailsWith(forceReleaseLockEffect(config, 'repo', 'etag-1', coordLogger), 'boom')
   })
 })
 
@@ -268,20 +292,18 @@ describe('createRunEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: {etag: 'etag-1'}})
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails with error when Result is failure', async () => {
     vi.mocked(createRun).mockResolvedValue(err(new Error('already exists')))
 
-    const exit = await Effect.runPromiseExit(createRunEffect(config, 'identity', 'repo', runState, coordLogger))
-
-    expect(Exit.isFailure(exit)).toBe(true)
+    await assertEffectFailsWith(createRunEffect(config, 'identity', 'repo', runState, coordLogger), 'already exists')
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(createRun).mockRejectedValue(new Error('network'))
 
-    const exit = await Effect.runPromiseExit(createRunEffect(config, 'identity', 'repo', runState, coordLogger))
-
-    expect(Exit.isFailure(exit)).toBe(true)
+    await assertEffectFailsWith(createRunEffect(config, 'identity', 'repo', runState, coordLogger), 'network')
   })
 })
 
@@ -314,24 +336,24 @@ describe('transitionRunEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: {etag: 'etag-2', state: {phase: 'ACKNOWLEDGED'}}})
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails with error when Result is failure', async () => {
     vi.mocked(transitionRun).mockResolvedValue(err(new Error('invalid transition')))
 
-    const exit = await Effect.runPromiseExit(
+    await assertEffectFailsWith(
       transitionRunEffect(config, 'identity', 'repo', 'run-1', 'ACKNOWLEDGED', 'etag-1', coordLogger),
+      'invalid transition',
     )
-
-    expect(Exit.isFailure(exit)).toBe(true)
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(transitionRun).mockRejectedValue(new Error('timeout'))
 
-    const exit = await Effect.runPromiseExit(
+    await assertEffectFailsWith(
       transitionRunEffect(config, 'identity', 'repo', 'run-1', 'ACKNOWLEDGED', 'etag-1', coordLogger),
+      'timeout',
     )
-
-    expect(Exit.isFailure(exit)).toBe(true)
   })
 })
 
@@ -350,20 +372,18 @@ describe('findStaleRunsEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: []})
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails with error when Result is failure', async () => {
     vi.mocked(findStaleRuns).mockResolvedValue(err(new Error('list failed')))
 
-    const exit = await Effect.runPromiseExit(findStaleRunsEffect(config, 'identity', 'repo', coordLogger))
-
-    expect(Exit.isFailure(exit)).toBe(true)
+    await assertEffectFailsWith(findStaleRunsEffect(config, 'identity', 'repo', coordLogger), 'list failed')
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(findStaleRuns).mockRejectedValue(new Error('boom'))
 
-    const exit = await Effect.runPromiseExit(findStaleRunsEffect(config, 'identity', 'repo', coordLogger))
-
-    expect(Exit.isFailure(exit)).toBe(true)
+    await assertEffectFailsWith(findStaleRunsEffect(config, 'identity', 'repo', coordLogger), 'boom')
   })
 })
 
@@ -382,20 +402,18 @@ describe('validateProviderSemanticsEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success'})
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails with error when Result is failure', async () => {
     vi.mocked(validateProviderSemantics).mockResolvedValue(err(new Error('semantics check failed')))
 
-    const exit = await Effect.runPromiseExit(validateProviderSemanticsEffect(config, coordLogger))
-
-    expect(Exit.isFailure(exit)).toBe(true)
+    await assertEffectFailsWith(validateProviderSemanticsEffect(config, coordLogger), 'semantics check failed')
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(validateProviderSemantics).mockRejectedValue(new Error('provider unreachable'))
 
-    const exit = await Effect.runPromiseExit(validateProviderSemanticsEffect(config, coordLogger))
-
-    expect(Exit.isFailure(exit)).toBe(true)
+    await assertEffectFailsWith(validateProviderSemanticsEffect(config, coordLogger), 'provider unreachable')
   })
 })
 
@@ -416,14 +434,14 @@ describe('syncSessionsToStoreEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: {uploaded: 2, failed: 0}})
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(syncSessionsToStore).mockRejectedValue(new Error('upload error'))
 
-    const exit = await Effect.runPromiseExit(
+    await assertEffectFailsWith(
       syncSessionsToStoreEffect(adapter, storeConfig, 'identity', 'repo', '/sessions', logger),
+      'upload error',
     )
-
-    expect(Exit.isFailure(exit)).toBe(true)
   })
 })
 
@@ -440,14 +458,14 @@ describe('syncSessionsFromStoreEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: {downloaded: 3, failed: 0, mainDbRestored: true}})
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(syncSessionsFromStore).mockRejectedValue(new Error('download error'))
 
-    const exit = await Effect.runPromiseExit(
+    await assertEffectFailsWith(
       syncSessionsFromStoreEffect(adapter, storeConfig, 'identity', 'repo', '/sessions', logger),
+      'download error',
     )
-
-    expect(Exit.isFailure(exit)).toBe(true)
   })
 })
 
@@ -464,14 +482,14 @@ describe('syncArtifactsToStoreEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: {uploaded: 1, failed: 0}})
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(syncArtifactsToStore).mockRejectedValue(new Error('artifact error'))
 
-    const exit = await Effect.runPromiseExit(
+    await assertEffectFailsWith(
       syncArtifactsToStoreEffect(adapter, storeConfig, 'identity', 'repo', 'run-1', '/logs', logger),
+      'artifact error',
     )
-
-    expect(Exit.isFailure(exit)).toBe(true)
   })
 })
 
@@ -488,13 +506,13 @@ describe('syncMetadataToStoreEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: {success: true}})
   })
 
+  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(syncMetadataToStore).mockRejectedValue(new Error('metadata error'))
 
-    const exit = await Effect.runPromiseExit(
+    await assertEffectFailsWith(
       syncMetadataToStoreEffect(adapter, storeConfig, 'identity', 'repo', 'run-1', {key: 'val'}, logger),
+      'metadata error',
     )
-
-    expect(Exit.isFailure(exit)).toBe(true)
   })
 })

--- a/packages/gateway/src/runtime-effect.ts
+++ b/packages/gateway/src/runtime-effect.ts
@@ -33,6 +33,8 @@ import {
 } from '@fro-bot/runtime'
 import {Effect} from 'effect'
 
+export type {ObjectStoreConfig} from '@fro-bot/runtime'
+
 // ---------------------------------------------------------------------------
 // Shared logger type used by all coordination functions
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/shutdown.test.ts
+++ b/packages/gateway/src/shutdown.test.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
 
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {DEFAULT_DRAIN_MS, installShutdownHandlers} from './shutdown.js'
+import {__resetShuttingDownForTests, DEFAULT_DRAIN_MS, installShutdownHandlers} from './shutdown.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -45,6 +45,8 @@ describe('installShutdownHandlers', () => {
       // branch to fire process.exit(1) again, masking the real exit code.
       return undefined as never
     })
+    // Todo 008: reset module-level shuttingDown so tests don't leak state.
+    __resetShuttingDownForTests()
   })
 
   afterEach(() => {
@@ -156,5 +158,53 @@ describe('installShutdownHandlers', () => {
     // #given the module default export
     // #then the drain timeout is 25 seconds
     expect(DEFAULT_DRAIN_MS).toBe(25_000)
+  })
+
+  // Todo 013: cover client.destroy() rejection path
+  it('logs shutdown failed and exits 1 when client.destroy() rejects', async () => {
+    // #given
+    const {logger, calls} = makeLogger()
+    const client = makeClient(0)
+    ;(client.destroy as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('destroy failed'))
+    const drainMs = 1_000
+    const cleanup = installShutdownHandlers(client, logger, drainMs)
+
+    // #when
+    process.emit('SIGTERM')
+    await vi.runAllTimersAsync()
+    cleanup()
+
+    // #then
+    expect(calls.some(c => c.method === 'info' && c.msg === 'shutdown initiated')).toBe(true)
+    expect(calls.some(c => c.method === 'warn' && c.msg === 'client.destroy() rejected during shutdown')).toBe(true)
+    expect(calls.some(c => c.method === 'warn' && c.msg === 'shutdown failed')).toBe(true)
+    expect(exitCodes).toContain(1)
+    expect(exitCodes).not.toContain(0)
+  })
+
+  // Todo 008: idempotency across multiple installs
+  it('is idempotent across multiple installs', async () => {
+    // #given two separate installShutdownHandlers calls
+    const {logger, calls} = makeLogger()
+    const client1 = makeClient(0)
+    const client2 = makeClient(0)
+    const cleanup1 = installShutdownHandlers(client1, logger, 1_000)
+    const cleanup2 = installShutdownHandlers(client2, logger, 1_000)
+
+    // #when one SIGTERM arrives
+    process.emit('SIGTERM')
+    await vi.runAllTimersAsync()
+    cleanup1()
+    cleanup2()
+
+    // #then exactly one shutdown initiated, exactly one process.exit
+    expect(calls.filter(c => c.method === 'info' && c.msg === 'shutdown initiated')).toHaveLength(1)
+    expect(exitCodes.filter(c => c === 0)).toHaveLength(1)
+    expect(exitCodes).not.toContain(1)
+
+    // #and — only ONE of the two clients had destroy() called total
+    const destroy1Count = (client1.destroy as ReturnType<typeof vi.fn>).mock.calls.length
+    const destroy2Count = (client2.destroy as ReturnType<typeof vi.fn>).mock.calls.length
+    expect(destroy1Count + destroy2Count).toBe(1)
   })
 })

--- a/packages/gateway/src/shutdown.ts
+++ b/packages/gateway/src/shutdown.ts
@@ -6,6 +6,32 @@ import process from 'node:process'
 
 export const DEFAULT_DRAIN_MS = 25_000
 
+// Todo 008: module-level guard so two installShutdownHandlers calls share state.
+// The first handler to see a signal owns the destroy chain; subsequent calls are no-ops.
+let shuttingDown = false
+
+/**
+ * IMPORTANT for future test authors:
+ *
+ * `shuttingDown` is module-level state that persists across the entire
+ * Vitest worker process via ESM module caching. ANY test file that
+ * imports from this module (including indirectly through transitive
+ * imports) MUST call `__resetShuttingDownForTests()` in a `beforeEach`
+ * block, or its shutdown-related assertions may pass vacuously with
+ * stale state from a previous test file.
+ *
+ * The idempotency test in `shutdown.test.ts` is the canonical example
+ * of why this matters: if `shuttingDown` leaks in as `true`, the test
+ * will silently pass with 0 exits instead of 1.
+ *
+ * This export is intentionally prefixed with `__` to flag it as test-
+ * only — production code must never call it.
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function __resetShuttingDownForTests(): void {
+  shuttingDown = false
+}
+
 /**
  * Install SIGTERM and SIGINT handlers that gracefully drain the Discord client.
  *
@@ -14,21 +40,18 @@ export const DEFAULT_DRAIN_MS = 25_000
  * 2. Race `client.destroy()` against a drain timer (default 25 s).
  * 3. If destroy wins → log 'shutdown clean', exit 0.
  * 4. If timer wins → log 'shutdown timeout', exit 1.
+ * 5. If destroy rejects → log 'shutdown failed', exit 1.
  *
  * Returns a cleanup function that removes both signal listeners (useful in tests).
+ *
+ * Idempotent across multiple installs: if two calls are active and a signal
+ * arrives, only the first install's handler runs the destroy chain.
  */
 export function installShutdownHandlers(
   client: Client,
   logger: GatewayLogger,
   drainMs: number = DEFAULT_DRAIN_MS,
 ): () => void {
-  // SIGTERM and SIGINT can arrive in quick succession (e.g. a container
-  // orchestrator that escalates after a few seconds). Without this guard
-  // both signals would race two concurrent destroy chains and call
-  // process.exit twice. The first call wins; subsequent calls log and
-  // return without scheduling new work.
-  let shuttingDown = false
-
   const handler = (signal: string) => {
     if (shuttingDown) {
       logger.debug({signal}, 'shutdown signal received while already shutting down — ignoring')
@@ -44,12 +67,13 @@ export function installShutdownHandlers(
       drainTimer = setTimeout(() => resolve('timeout'), drainMs)
     })
 
+    // Todo 007: return 'failed' on rejection instead of lying with 'clean'.
     const destroyPromise = client
       .destroy()
       .then(() => 'clean' as const)
       .catch((error: unknown) => {
         logger.warn({err: error}, 'client.destroy() rejected during shutdown')
-        return 'clean' as const
+        return 'failed' as const
       })
 
     Promise.race([destroyPromise, drainTimeout])
@@ -59,6 +83,9 @@ export function installShutdownHandlers(
         }
         if (result === 'timeout') {
           logger.warn({}, 'shutdown timeout')
+          process.exit(1)
+        } else if (result === 'failed') {
+          logger.warn({}, 'shutdown failed')
           process.exit(1)
         } else {
           logger.info({}, 'shutdown clean')


### PR DESCRIPTION
Reliability and test-coverage follow-ups to the gateway daemon.

## Shutdown

- `client.destroy()` rejection now returns `failed` instead of being silently coerced to `clean`. The race-result switch has a new `failed` branch that logs `shutdown failed` and exits 1. Operators alerting on non-zero exit codes now see destroy failures.
- The `shuttingDown` guard moved to module scope so two `installShutdownHandlers` calls share it. A single SIGTERM with two installs results in exactly one destroy and one `process.exit`.
- New tests cover the destroy-rejection path end-to-end and the multi-install idempotency case.

## Effect / Result boundary

- `runtime-effect.ts` is the only file in `packages/gateway/src/` that imports from `@fro-bot/runtime`. `config.ts` now picks up `ObjectStoreConfig` through that adapter instead of importing it directly.
- Added an `assertEffectFailsWith` helper. 20 existing failure-path tests refactored to use it so each one pins the preserved error message, not just the failure tag. Added two new coverage tests for preserved error and non-`Error` rejection wrapping.

## Discord

- `registerSlashCommands` is now covered for both the global and guild-scoped branches. Sentinel route strings prove the right `Routes.*` helper is invoked with the right args.
- The unknown-command ack path logs via `Effect.tapError` (structured JSON `console.warn`) before swallowing with `Effect.catchAll`. Real bugs in the reply path are visible in logs; the unknown-command error still wins as the Effect failure.
- `handleMention` reacts ❌ and sends a fallback reply on `startThread` failure, then re-fails the Effect with the original error. Each fallback step is `catchAll`-wrapped so a reaction-API failure doesn't cascade. Tests cover the success path, the react-fails-reply-succeeds path, the react-succeeds-reply-fails path, and the both-fail path.

## Tests

Gateway: 72 → 82 (+10).

- `shutdown.test.ts` 7 → 9
- `runtime-effect.test.ts`: +2 new, 20 existing refactored to assert preserved error messages
- `commands/index.test.ts` 5 → 8 (global routing, guild routing, ack-failure log)
- `mentions.test.ts` 4 → 7 (fallback success + 2 failure-recovery cases)

## Verification

- `pnpm --filter @fro-bot/gateway test`: 82/82
- `pnpm test`: workspace stays green
- `pnpm --filter @fro-bot/gateway lint`: 0 errors
- `pnpm --filter @fro-bot/gateway check-types`: 0 errors
- `pnpm --filter @fro-bot/gateway build`: clean
