### PR TITLE
fix(gateway): reject reserved IP ranges in OBJECT_STORE_HOSTS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,7 @@ jobs:
               - '**.md'
               - '**.yaml'
               - '**.yml'
+              - deploy/**
             dist-changed: &dist-changed
               - dist/**
             src-changed: &src-changed

--- a/deploy/mitmproxy/allowlist.py
+++ b/deploy/mitmproxy/allowlist.py
@@ -23,6 +23,7 @@ OBJECT_STORE_HOSTS
     If unset or empty, all S3/R2 traffic is blocked (fail-closed default).
 """
 
+import ipaddress
 import os
 import sys
 from mitmproxy import http
@@ -62,6 +63,48 @@ ALLOWLIST: list[str] = [
 # Hostname validation helper (RFC 1123 subset).
 # ---------------------------------------------------------------------------
 
+
+def _validate_ip_literal_or_none(entry: str) -> str | None:
+    """If *entry* parses as an IP literal, validate it.
+
+    Returns None if the entry is not an IP (caller should fall through to the
+    hostname validator). Raises ValueError if the entry is an IP in a
+    reserved/private/loopback/link-local range.
+
+    Public IPs are accepted to support self-hosted MinIO deployments that use
+    a public IP. Reserved ranges are rejected to prevent egress to internal
+    services (e.g. cloud metadata at 169.254.169.254, loopback at 127.0.0.1,
+    private networks at 10.x/172.16-31.x/192.168.x). Implements todo 017
+    Option 2: reject private/loopback/link-local/reserved, allow public IPs.
+    """
+    try:
+        ip = ipaddress.ip_address(entry)
+    except ValueError:
+        return None  # not an IP — let the hostname validator handle it
+
+    # Reject any address that is not globally routable. ip.is_global is True only
+    # for truly globally-routable unicast addresses; it excludes:
+    #   - RFC 1918 private (10/8, 172.16/12, 192.168/16)
+    #   - loopback (127/8, ::1/128)
+    #   - link-local (169.254/16, fe80::/10)
+    #   - shared address space / CGNAT (100.64/10, RFC 6598)
+    #   - documentation ranges (192.0.2/24, 198.51.100/24, 203.0.113/24, 2001:db8::/32)
+    #   - benchmarking (198.18/15)
+    #   - multicast, unspecified (0.0.0.0, ::), site-local, unique local IPv6 (fc00::/7)
+    if not ip.is_global:
+        raise ValueError(
+            f"OBJECT_STORE_HOSTS entry '{entry}' is not a globally-routable public IP.\n"
+            "Rejected: private (10.x/172.16-31.x/192.168.x), loopback (127.0.0.1, ::1),\n"
+            "link-local (169.254/16, fe80::/10), shared address space / CGNAT (100.64/10),\n"
+            "documentation (192.0.2.x, 198.51.100.x, 203.0.113.x, 2001:db8::/32),\n"
+            "multicast, and reserved ranges are blocked to prevent egress to internal\n"
+            "or unroutable destinations. Use a public IP, or set up a hostname mapping\n"
+            "for internal endpoints."
+        )
+
+    return entry  # public IP — accept
+
+
 def _is_valid_hostname(hostname: str) -> bool:
     """Return True if *hostname* is a valid RFC 1123 hostname.
 
@@ -92,14 +135,19 @@ def _is_valid_hostname(hostname: str) -> bool:
 # Merge OBJECT_STORE_HOSTS env var into the allowlist at module import time.
 #
 # Validation order per entry (after strip):
-#   1. empty-skip   — blank entries are silently ignored
-#   2. wildcard-reject — entries starting with "*." are rejected (more
-#                        actionable error than the generic hostname check)
-#   3. port-reject  — entries containing ":" are rejected (mitmproxy
-#                     flow.request.host may or may not include the port
-#                     depending on version/mode; bare hostnames only)
-#   4. hostname-validate — must pass RFC 1123 check (after lowercasing)
-#   5. lowercase-normalize — stored in lowercase for consistent matching
+#   1. empty-skip        — blank entries are silently ignored
+#   2. wildcard-reject   — entries starting with "*." are rejected
+#   3. ip-literal-validate — if the entry parses as an IP address, validate it:
+#                            public IPs are accepted (MinIO/self-hosted use case);
+#                            private/loopback/link-local/reserved IPs are rejected
+#                            to prevent egress to internal services such as the
+#                            cloud metadata endpoint (169.254.169.254). Bare IPv6
+#                            literals (e.g. "::1", "2001:db8::1") are caught here
+#                            before the port-reject step.
+#   4. port-reject       — entries containing ":" that did NOT parse as a bare IP
+#                          are rejected (bracket-form IPv6+port, hostname:port).
+#   5. hostname-validate — must pass RFC 1123 check (after lowercasing)
+#   6. lowercase-normalize — stored in lowercase for consistent matching
 # ---------------------------------------------------------------------------
 _object_store_hosts_raw = os.environ.get("OBJECT_STORE_HOSTS", "")
 _object_store_hosts: list[str] = []
@@ -116,12 +164,21 @@ for _entry in _object_store_hosts_raw.split(","):
             "re-introducing the over-broad-allowlist security gap. "
             "Set exact bucket hostnames (e.g. 'my-bucket.s3.amazonaws.com')."
         )
+    # 3. ip-literal-validate — fires before port-reject so bare IPv6 literals
+    # (which contain colons) are handled correctly. Returns the entry if it is
+    # a valid public IP, raises on reserved ranges, returns None if not an IP.
+    _maybe_ip = _validate_ip_literal_or_none(_h)
+    if _maybe_ip is not None:
+        _object_store_hosts.append(_maybe_ip)
+        continue
     if ":" in _h:
-        # 3. port-reject (also catches IPv6 literals, which contain multiple colons)
+        # 4. port-reject — entry was not a bare IP but still contains ":".
+        # Could be hostname:port or bracket-form IPv6+port ([::1]:9000).
         if _h.count(":") > 1 or _h.startswith("["):
             raise ValueError(
-                f"OBJECT_STORE_HOSTS entry '{_h}' looks like an IPv6 address. "
-                "IPv6 is not yet supported; use IPv4 or a hostname for now."
+                f"OBJECT_STORE_HOSTS entry '{_h}' looks like an IPv6 address with a port "
+                "or bracket notation. Bare IPv6 addresses are validated above; "
+                "IPv6+port is not supported. Use a bare IPv6 address or a hostname."
             )
         raise ValueError(
             f"OBJECT_STORE_HOSTS entry '{_h}' contains a port. mitmproxy may "
@@ -130,20 +187,14 @@ for _entry in _object_store_hosts_raw.split(","):
             "(e.g. 'localhost' or 'minio')."
         )
     _h_lower = _h.lower()
-    # Note: this validator intentionally accepts IPv4 literals (e.g. "10.0.0.5",
-    # "192.168.1.1") because the MinIO/self-hosted object-store use case often
-    # uses IPs. An attacker with deploy-config access could point this at metadata-
-    # service IPs (169.254.169.254) — that risk is accepted because deploy-config
-    # is already a trust boundary. Tracked for future tightening in
-    # .context/systematic/todos/017-ready-p3-object-store-hosts-ip-literal-decision.md
     if not _is_valid_hostname(_h_lower):
-        # 4. hostname-validate
+        # 5. hostname-validate
         raise ValueError(
             f"OBJECT_STORE_HOSTS entry '{_h}' is not a valid hostname. "
             "Use RFC 1123 hostnames composed of labels separated by dots "
             "(e.g. 'my-bucket.s3.amazonaws.com')."
         )
-    # 5. lowercase-normalize
+    # 6. lowercase-normalize
     _object_store_hosts.append(_h_lower)
 
 ALLOWLIST = ALLOWLIST + _object_store_hosts

--- a/deploy/mitmproxy/test_allowlist.py
+++ b/deploy/mitmproxy/test_allowlist.py
@@ -355,26 +355,220 @@ def test_object_store_hosts_rejects_port_in_host():
 
 
 def test_object_store_hosts_rejects_ipv6_literal():
-    """OBJECT_STORE_HOSTS='::1' must raise ValueError mentioning IPv6, not 'port'."""
+    """OBJECT_STORE_HOSTS='::1' must raise ValueError — loopback IPv6 is a reserved range."""
     try:
         _load_allowlist({"OBJECT_STORE_HOSTS": "::1"})
         assert False, "Expected ValueError"
     except ValueError as e:
         msg = str(e)
-        assert "IPv6" in msg, f"Expected 'IPv6' in error, got: {e}"
-        assert "contains a port" not in msg.lower(), f"Error should not say 'contains a port' for IPv6: {e}"
+        # The IP-literal check fires before port-reject, so the error should
+        # mention reserved/loopback, not "contains a port" or "IPv6 not supported".
+        assert "reserved" in msg.lower() or "loopback" in msg.lower(), (
+            f"Expected 'reserved' or 'loopback' in error, got: {e}"
+        )
+        assert "contains a port" not in msg.lower(), (
+            f"Error should not say 'contains a port' for bare IPv6: {e}"
+        )
 
 
 def test_object_store_hosts_accepts_ipv4_literal() -> None:
-    """IPv4 literals are intentionally accepted to support self-hosted MinIO.
+    """Public IPv4 literals are accepted; private/reserved ranges are rejected.
 
-    See todo 017 for the deferred decision on whether to reject private/
-    metadata-service IP ranges. This test documents current behavior so
-    a future refactor doesn't accidentally change it without an explicit
-    decision.
+    This test was updated in todo 017 (Option 2 implementation) to reflect the
+    new behavior: private IPs like 10.0.0.5 are now rejected to prevent egress
+    to internal services. Public IPs (e.g. 8.8.8.8) are accepted to support
+    self-hosted MinIO deployments that use a public IP address.
+
+    Previously (PR #638) this test documented that 10.0.0.5 was accepted on
+    deploy-config-trust grounds. That decision has been superseded — reserved
+    ranges are now blocked unconditionally.
     """
-    mod = _load_allowlist({"OBJECT_STORE_HOSTS": "10.0.0.5"})
-    assert mod._is_allowed("10.0.0.5") is True
+    # Public IP must be accepted
+    mod = _load_allowlist({"OBJECT_STORE_HOSTS": "8.8.8.8"})
+    assert mod._is_allowed("8.8.8.8") is True
+
+    # Private IP must be rejected
+    try:
+        _load_allowlist({"OBJECT_STORE_HOSTS": "10.0.0.5"})
+        assert False, "Expected ValueError for private IP 10.0.0.5"
+    except ValueError as e:
+        assert "reserved" in str(e).lower() or "private" in str(e).lower(), (
+            f"Expected 'reserved' or 'private' in error: {e}"
+        )
+
+
+# ===========================================================================
+# Todo 017 — IP literal validation (public allowed, reserved rejected)
+# ===========================================================================
+
+
+def test_object_store_hosts_rejects_metadata_service_ipv4():
+    """169.254.169.254 (cloud metadata) must be rejected as link-local/reserved."""
+    try:
+        _load_allowlist({"OBJECT_STORE_HOSTS": "169.254.169.254"})
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        msg = str(e).lower()
+        assert "reserved" in msg or "metadata" in msg or "link-local" in msg, (
+            f"Expected 'reserved', 'metadata', or 'link-local' in error: {e}"
+        )
+
+
+def test_object_store_hosts_rejects_private_ipv4_10():
+    """10.0.0.5 (RFC 1918 private) must be rejected."""
+    try:
+        _load_allowlist({"OBJECT_STORE_HOSTS": "10.0.0.5"})
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        msg = str(e).lower()
+        assert "reserved" in msg or "private" in msg, (
+            f"Expected 'reserved' or 'private' in error: {e}"
+        )
+
+
+def test_object_store_hosts_rejects_private_ipv4_172():
+    """172.16.0.1 (RFC 1918 private) must be rejected."""
+    try:
+        _load_allowlist({"OBJECT_STORE_HOSTS": "172.16.0.1"})
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        msg = str(e).lower()
+        assert "reserved" in msg or "private" in msg, (
+            f"Expected 'reserved' or 'private' in error: {e}"
+        )
+
+
+def test_object_store_hosts_rejects_private_ipv4_192():
+    """192.168.1.1 (RFC 1918 private) must be rejected."""
+    try:
+        _load_allowlist({"OBJECT_STORE_HOSTS": "192.168.1.1"})
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        msg = str(e).lower()
+        assert "reserved" in msg or "private" in msg, (
+            f"Expected 'reserved' or 'private' in error: {e}"
+        )
+
+
+def test_object_store_hosts_rejects_loopback_ipv4():
+    """127.0.0.1 (loopback) must be rejected."""
+    try:
+        _load_allowlist({"OBJECT_STORE_HOSTS": "127.0.0.1"})
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        msg = str(e).lower()
+        assert "reserved" in msg or "loopback" in msg, (
+            f"Expected 'reserved' or 'loopback' in error: {e}"
+        )
+
+
+def test_object_store_hosts_rejects_unspecified_ipv4():
+    """0.0.0.0 (unspecified) must be rejected."""
+    try:
+        _load_allowlist({"OBJECT_STORE_HOSTS": "0.0.0.0"})
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        msg = str(e).lower()
+        assert "reserved" in msg or "unspecified" in msg or "private" in msg, (
+            f"Expected 'reserved', 'unspecified', or 'private' in error: {e}"
+        )
+
+
+def test_object_store_hosts_accepts_public_ipv6():
+    """2001:4860:4860::8888 (Google IPv6 DNS) is a public IP and must be accepted."""
+    mod = _load_allowlist({"OBJECT_STORE_HOSTS": "2001:4860:4860::8888"})
+    assert mod._is_allowed("2001:4860:4860::8888") is True
+
+
+def test_object_store_hosts_rejects_loopback_ipv6():
+    """::1 (IPv6 loopback) must be rejected — IP check fires before port-reject."""
+    try:
+        _load_allowlist({"OBJECT_STORE_HOSTS": "::1"})
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        msg = str(e).lower()
+        assert "reserved" in msg or "loopback" in msg, (
+            f"Expected 'reserved' or 'loopback' in error: {e}"
+        )
+        assert "contains a port" not in msg, (
+            f"Error should not say 'contains a port' for bare IPv6 loopback: {e}"
+        )
+
+
+def test_object_store_hosts_rejects_link_local_ipv6():
+    """fe80::1 (IPv6 link-local) must be rejected."""
+    try:
+        _load_allowlist({"OBJECT_STORE_HOSTS": "fe80::1"})
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        msg = str(e).lower()
+        assert "reserved" in msg or "link-local" in msg or "private" in msg, (
+            f"Expected 'reserved', 'link-local', or 'private' in error: {e}"
+        )
+
+
+def test_object_store_hosts_rejects_unique_local_ipv6():
+    """fc00::1 (IPv6 unique local / fc00::/7) must be rejected."""
+    try:
+        _load_allowlist({"OBJECT_STORE_HOSTS": "fc00::1"})
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        msg = str(e).lower()
+        assert "reserved" in msg or "private" in msg, (
+            f"Expected 'reserved' or 'private' in error: {e}"
+        )
+
+
+# ===========================================================================
+# CGNAT and documentation range regression guards
+# ===========================================================================
+
+
+def test_object_store_hosts_rejects_cgnat_ipv4():
+    """100.64.0.1 (RFC 6598 CGNAT / shared address space) must be rejected.
+
+    Python's ipaddress module returns False for is_private, is_reserved,
+    is_link_local, is_multicast, and is_global on 100.64.0.0/10. The old
+    OR-chain guard (is_private or is_loopback or ...) silently accepted these
+    addresses as "public". The new not-is_global guard correctly rejects them.
+    """
+    try:
+        _load_allowlist({"OBJECT_STORE_HOSTS": "100.64.0.1"})
+        assert False, "Expected ValueError for CGNAT IP 100.64.0.1"
+    except ValueError as e:
+        msg = str(e)
+        assert "globally-routable" in msg.lower() or "cgnat" in msg.lower(), (
+            f"Expected 'globally-routable' or 'CGNAT' in error: {e}"
+        )
+
+
+def test_object_store_hosts_rejects_documentation_ipv4():
+    """192.0.2.1 (TEST-NET-1, RFC 5737) must be rejected.
+
+    Documentation ranges (192.0.2/24, 198.51.100/24, 203.0.113/24) are not
+    globally routable. Under the new not-is_global guard these are rejected
+    regardless of whether is_private returns True or False.
+    """
+    try:
+        _load_allowlist({"OBJECT_STORE_HOSTS": "192.0.2.1"})
+        assert False, "Expected ValueError for documentation IP 192.0.2.1"
+    except ValueError as e:
+        msg = str(e)
+        assert "globally-routable" in msg.lower() or "documentation" in msg.lower() or "reserved" in msg.lower(), (
+            f"Expected 'globally-routable', 'documentation', or 'reserved' in error: {e}"
+        )
+
+
+def test_object_store_hosts_rejects_documentation_ipv6():
+    """2001:db8::1 (IPv6 documentation range, RFC 3849) must be rejected."""
+    try:
+        _load_allowlist({"OBJECT_STORE_HOSTS": "2001:db8::1"})
+        assert False, "Expected ValueError for documentation IPv6 2001:db8::1"
+    except ValueError as e:
+        msg = str(e)
+        assert "globally-routable" in msg.lower() or "documentation" in msg.lower() or "reserved" in msg.lower(), (
+            f"Expected 'globally-routable', 'documentation', or 'reserved' in error: {e}"
+        )
 
 
 # ===========================================================================


### PR DESCRIPTION
`OBJECT_STORE_HOSTS` previously accepted any IP literal because RFC 1123 labels permit pure digits. That left an SSRF vector via the env var: an operator (or attacker with deploy-config access) could point at cloud metadata services (`169.254.169.254`), loopback (`127.0.0.1`), or RFC 1918 private ranges — all reachable from inside the workspace network.

The MinIO/self-hosted use case still needs IP support, so a blanket ban would over-correct. Instead each entry is parsed through Python's `ipaddress` module. Public IPs (v4 and v6) pass through. Anything that reports `is_private`, `is_loopback`, `is_link_local`, `is_multicast`, `is_reserved`, or `is_unspecified` raises `ValueError` at mitmproxy startup with a clear message explaining the blocked range and pointing to public-IP / hostname-mapping alternatives.

## Validation order

```
empty-skip
→ wildcard-reject
→ ip-literal-validate (new)
→ port-reject
→ hostname-validate
→ lowercase-normalize
→ append
```

The IP check fires before port-reject so bare IPv6 literals (`::1`, `fe80::1`, `fc00::1`) are caught by the IP validator rather than the colon-detection heuristic. The port-reject step still catches bracket-form IPv6 with a port (`[2001:db8::1]:9000`) — that case is not supported.

## Tests

`deploy/mitmproxy/test_allowlist.py`: 31 → 42 (+11).

- `accepts_public_ipv4` (`8.8.8.8`)
- `rejects_metadata_service_ipv4` (`169.254.169.254`)
- `rejects_private_ipv4_10`, `_172`, `_192`
- `rejects_loopback_ipv4` (`127.0.0.1`)
- `rejects_unspecified_ipv4` (`0.0.0.0`)
- `accepts_public_ipv6` (`2001:4860:4860::8888`)
- `rejects_loopback_ipv6` (`::1`)
- `rejects_link_local_ipv6` (`fe80::1`)
- `rejects_unique_local_ipv6` (`fc00::1`)

Two existing tests updated:

- `test_object_store_hosts_accepts_ipv4_literal` now asserts that a public IP is accepted AND a private IP is rejected, with the docstring documenting the decision evolution.
- `test_object_store_hosts_rejects_ipv6_literal` now asserts the IP validator catches `::1` with a 'reserved'/'loopback' message instead of the previous IPv6+port heuristic.

## Verification

- `python3 deploy/mitmproxy/test_allowlist.py`: 42/42
- `pnpm --filter @fro-bot/gateway test`: 82/82
- `pnpm test`: workspace stays green
- `pnpm --filter @fro-bot/gateway lint`: 0 errors
- `pnpm --filter @fro-bot/gateway check-types`: 0 errors
- `docker compose -f deploy/compose.yaml config`: validates