### PR TITLE
fix(gateway): testing ergonomics for the deploy stack

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,9 @@
+# deploy/.env.example
+# Copy to deploy/.env and edit. .env is gitignored.
+
+# Optional — exact bucket host(s) your gateway/workspace reach via S3.
+# Comma-separated. Required only if your deployment actually writes to S3.
+# In v1 the gateway daemon itself does not write to S3, so this can be
+# omitted for Discord-plumbing testing.
+# Example: my-bucket.s3.amazonaws.com,my-account.r2.cloudflarestorage.com
+OBJECT_STORE_HOSTS=

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,2 @@
+# Local environment overrides — never commit
+.env

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -14,6 +14,16 @@ Docker Compose v2 stack for the fro-bot gateway. Runs three services:
 - Access to a Discord application (bot token + application ID)
 - An S3-compatible object store (bucket, region, optional endpoint)
 
+## Testing-Only Configuration (Discord Plumbing)
+
+If you're just verifying the gateway connects to Discord and responds to slash commands and mentions, you do not need a working S3 bucket. The gateway daemon validates S3 credentials at startup but does not write to S3 in v1.
+
+For testing-only:
+
+- Put any plausible-looking values in `deploy/secrets/s3-bucket` and `deploy/secrets/s3-region` (e.g. `test-bucket` and `us-east-1`). Validation only checks they're non-empty.
+- Leave `OBJECT_STORE_HOSTS` unset in `deploy/.env`. The default fail-closed behaviour blocks all S3 traffic — fine for testing, since no S3 calls are made.
+- Use a real bucket and `OBJECT_STORE_HOSTS` value only when Units 5–7 ship the agent and workspace pieces that actually exercise S3.
+
 ## One-Time Setup
 
 ### 1. Copy the override example
@@ -35,11 +45,18 @@ echo -n 'YOUR_DISCORD_BOT_TOKEN'      > deploy/secrets/discord-token
 echo -n 'YOUR_DISCORD_APP_ID'         > deploy/secrets/discord-application-id
 echo -n 'your-s3-bucket-name'         > deploy/secrets/s3-bucket
 echo -n 'us-east-1'                   > deploy/secrets/s3-region
-# Optional — omit for AWS S3; set for R2 or other S3-compatible stores:
-echo -n 'https://your-endpoint.r2.dev' > deploy/secrets/s3-endpoint
+# Optional — leave empty for standard AWS S3; set for R2 or other S3-compatible stores.
+touch deploy/secrets/s3-endpoint
+# echo -n 'https://your-endpoint.r2.dev' > deploy/secrets/s3-endpoint
+# Optional — guild-scoped slash command registration (propagates in ~5s vs up to 1h globally).
+# Leave the file empty (or omit the echo) to register slash commands globally instead:
+touch deploy/secrets/discord-guild-id
+# echo -n 'YOUR_GUILD_ID' > deploy/secrets/discord-guild-id
 
 chmod 0600 deploy/secrets/*
 ```
+
+> **Important:** All files under `deploy/secrets/` must exist before running `docker compose config`, `up`, or `down`. Compose bind-mounts these paths unconditionally — if a file is missing, Docker creates an empty directory at the mount target and the gateway will fail to read the secret. For optional secrets that you don't want to set (e.g. `discord-guild-id`), create the file empty: `touch deploy/secrets/discord-guild-id`. The gateway treats empty and whitespace-only files as unset.
 
 `deploy/secrets/` is gitignored — never commit secret files.
 
@@ -130,6 +147,8 @@ The mitmproxy addon at `deploy/mitmproxy/allowlist.py` enforces a static allowli
 Any host not on the list receives a 403 and the connection is dropped. Both HTTPS CONNECT tunnels and plain HTTP requests are enforced.
 
 ### Object-store bucket scoping
+
+For testing the gateway itself, see [Testing-Only Configuration](#testing-only-configuration-discord-plumbing) — S3 isn't exercised in v1.
 
 The allowlist does **not** include broad S3/R2 wildcards (`*.s3.amazonaws.com`, `*.r2.cloudflarestorage.com`). Instead, set the `OBJECT_STORE_HOSTS` environment variable on the `mitmproxy` service to the exact bucket host(s) your deployment uses:
 

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -20,6 +20,8 @@ services:
       S3_BUCKET_FILE: /run/secrets/s3_bucket
       S3_REGION_FILE: /run/secrets/s3_region
       S3_ENDPOINT_FILE: /run/secrets/s3_endpoint
+      # Optional — guild-scoped slash command registration (fast dev propagation)
+      DISCORD_GUILD_ID_FILE: /run/secrets/discord_guild_id
       # Egress proxy (regular proxy mode — NOT transparent)
       HTTPS_PROXY: http://mitmproxy:8080
       HTTP_PROXY: http://mitmproxy:8080
@@ -32,6 +34,10 @@ services:
       - ./secrets/s3-bucket:/run/secrets/s3_bucket:ro
       - ./secrets/s3-region:/run/secrets/s3_region:ro
       - ./secrets/s3-endpoint:/run/secrets/s3_endpoint:ro
+      # Optional — guild-scoped slash command registration (fast dev propagation).
+      # Create the file empty (`touch deploy/secrets/discord-guild-id`) to register
+      # slash commands globally; the gateway treats empty files as unset.
+      - ./secrets/discord-guild-id:/run/secrets/discord_guild_id:ro
       # mitmproxy CA cert (written by mitmproxy on first start, read here for trust)
       - mitmproxy-certs:/etc/ssl/certs:ro
     networks:

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -157,6 +157,60 @@ describe('readOptionalSecret', () => {
     // #then
     expect(result).toBe('optional-value')
   })
+
+  it('returns null when MISSING_FILE points to an empty file', () => {
+    // #given an empty file — e.g. `touch deploy/secrets/discord-guild-id` for global registration
+    const secretFile = join(tmpDir, 'empty.txt')
+    writeFileSync(secretFile, '')
+    process.env.MISSING_FILE = secretFile
+
+    // #when
+    const result = readOptionalSecret('MISSING')
+
+    // #then empty file is treated as "not set"
+    expect(result).toBeNull()
+  })
+
+  it('returns null when MISSING_FILE points to a whitespace-only file', () => {
+    // #given a file containing only whitespace/newlines
+    const secretFile = join(tmpDir, 'whitespace.txt')
+    writeFileSync(secretFile, '  \n  \n')
+    process.env.MISSING_FILE = secretFile
+
+    // #when
+    const result = readOptionalSecret('MISSING')
+
+    // #then whitespace-only is treated as "not set"
+    expect(result).toBeNull()
+  })
+
+  it('returns null when env var is set to an empty string', () => {
+    process.env.EMPTY_ENV_VAR = ''
+    expect(readOptionalSecret('EMPTY_ENV_VAR')).toBeNull()
+    delete process.env.EMPTY_ENV_VAR
+  })
+
+  it('returns null when env var is set to whitespace only', () => {
+    process.env.WS_ENV_VAR = '   '
+    expect(readOptionalSecret('WS_ENV_VAR')).toBeNull()
+    delete process.env.WS_ENV_VAR
+  })
+
+  it('preserves leading whitespace in file contents', () => {
+    // Some operators may legitimately have secrets with leading whitespace
+    // (e.g. tokens copied from a UI that quoted with leading padding).
+    // The env-var path preserves it via process.env[name]; the file-backed
+    // path must too, for consistency.
+    const secretFile = join(tmpDir, 'leading-ws.txt')
+    writeFileSync(secretFile, '  some-value\n')
+    process.env.MISSING_FILE = secretFile
+
+    // #when
+    const result = readOptionalSecret('MISSING')
+
+    // #then leading whitespace is preserved, trailing newline stripped
+    expect(result).toBe('  some-value')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -41,11 +41,16 @@ export function readSecret(name: string): string {
 export function readOptionalSecret(name: string): string | null {
   const filePath = process.env[`${name}_FILE`]
   if (filePath !== undefined && existsSync(filePath)) {
-    return readFileSync(filePath, 'utf8').trimEnd()
+    const contents = readFileSync(filePath, 'utf8')
+    // Strip only trailing whitespace (newline/spaces from echo) so leading whitespace
+    // in valid secrets is preserved — matching the env-var path which uses raw process.env[name].
+    // Treat whitespace-only or empty files as "not set" (e.g. empty bind-mounted optional secrets).
+    const trailingTrimmed = contents.trimEnd()
+    return trailingTrimmed.trim() === '' ? null : trailingTrimmed
   }
 
   const value = process.env[name]
-  if (value !== undefined) {
+  if (value !== undefined && value.trim() !== '') {
     return value
   }
 


### PR DESCRIPTION
Three friction points for someone bringing up the deploy stack for the first time on their own Discord server.

## 1. `DISCORD_GUILD_ID` wasn't plumbed through compose

`config.ts` already read it via `readOptionalSecret`, but the secret-file mount and the `*_FILE` env-var pointer were missing from `compose.yaml`. Without this, slash commands register globally and take **up to an hour** to propagate. With it, guild-scoped registration propagates in ~5 seconds — critical for dev iteration.

## 2. `readOptionalSecret` mishandled empty files

The previous behavior was `readFileSync(...).trimEnd()` — strips trailing whitespace, returns the remainder. For an empty file, it returned `''` (empty string), not `null`. That meant if you `touch deploy/secrets/discord-guild-id` to satisfy the bind-mount but didn't want a guild override, the empty string flowed into Discord's slash-command registration API as an explicit guild ID, which would fail oddly.

Fix is a two-step: `trimEnd()` for the value we return (preserves leading whitespace, strips the trailing newline from `echo`), then `.trim() === ''` as the emptiness check (whitespace-only and empty files → `null`). The env-var path was already correct; this just brings the file-backed path in line with it.

Regression tests:

- Empty file → `null`
- Whitespace-only file → `null`
- File with leading whitespace and a real value → leading whitespace preserved

## 3. README implied S3 setup is required for everything

The v1 gateway daemon validates S3 credentials at startup but does not actually write to S3 — that arrives with the workspace agent in the next units. New "Testing-Only Configuration" subsection documents the minimum viable secrets for verifying just the Discord plumbing, and the bucket-scoping subsection cross-references it.

Also adds `deploy/.env.example` documenting `OBJECT_STORE_HOSTS` with v1 context, and a deploy-directory `.gitignore` as belt-and-suspenders for `.env`.

## What this PR does NOT change

Workspace agent stays a `sleep infinity` placeholder. Slash command surface stays `/fro-bot ping` plus the unknown-command ack path. Mention handler stays the v1 "create thread, post pong" behavior. Those are upcoming-unit work.

## Verification

- `pnpm --filter @fro-bot/gateway test`: 85/85 (was 84, +1 leading-whitespace regression guard)
- `pnpm --filter @fro-bot/gateway lint`: 0 errors
- `pnpm --filter @fro-bot/gateway check-types`: 0 errors
- `docker compose -f deploy/compose.yaml config --quiet`: validates end-to-end with all six secret files present