### PR TITLE
fix(gateway): make privileged Discord intents opt-in

### DIFF
--- a/docs/plans/2026-05-19-001-fix-gateway-intent-posture-flip-plan.md
+++ b/docs/plans/2026-05-19-001-fix-gateway-intent-posture-flip-plan.md
@@ -1,0 +1,295 @@
+---
+title: 'fix: Gateway intent-posture flip — privileged intents become opt-in'
+type: fix
+status: active
+date: 2026-05-19
+origin: https://github.com/fro-bot/agent/issues/646
+---
+
+# Gateway intent-posture flip — privileged intents become opt-in
+
+## Overview
+
+The gateway currently hard-codes the privileged Discord intent set as its baseline. `DEFAULT_INTENTS` in `packages/gateway/src/discord/client.ts` requests `MessageContent` and `GuildMembers` unconditionally, even though the only callers today are `createDiscordClient()` in `main.ts` and the bot's runtime behavior (slash commands, @-mentions in guild channels) needs neither. Until this flips, every gateway deployment that completes Discord-side approval for the privileged intents runs with broader read scope than the workload requires.
+
+This plan flips the baseline to the non-privileged set (`Guilds`, `GuildMessages`) and introduces a single config knob — `DISCORD_PRIVILEGED_INTENTS` — that opts back into either or both privileged intents on a per-deployment basis. The knob loads through the existing `readOptionalSecret` pattern. Existing deployments that need the privileged set keep working by setting the env var; new deployments are non-privileged by default.
+
+## Problem Frame
+
+**Why this is wrong today.** Discord's gateway intent model treats `MessageContent` and `GuildMembers` as privileged precisely because they grant broad-scope reads against guild data. The application-level posture should be opt-in: bots that genuinely read message content or full member lists request those intents; bots that just receive mentions and run slash commands do not.
+
+**Current behavior:**
+
+- `DEFAULT_INTENTS` includes all four intents (`packages/gateway/src/discord/client.ts:10-15`).
+- `createDiscordClient` merges any caller override on top of the defaults via a `Set` dedupe, so callers can never subtract a privileged intent (`packages/gateway/src/discord/client.ts:32-35`).
+- The merge logic is otherwise sound — it correctly dedupes when callers add their own intents.
+
+**What changes:**
+
+- `DEFAULT_INTENTS` becomes `[Guilds, GuildMessages]`.
+- `loadGatewayConfig()` reads `DISCORD_PRIVILEGED_INTENTS` (comma-separated, allowlisted to `MessageContent` and `GuildMembers` only) and exposes it as `privilegedIntents: GatewayIntentBits[]` on `GatewayConfig`.
+- `main.ts` passes `{intents: config.privilegedIntents, logger}` to `createDiscordClient`.
+- The Set-based merge logic stays — it's structurally correct; the meaning changes because `DEFAULT_INTENTS` is now smaller.
+
+**Why the merge logic stays as-is.** The override path's job is "compose intents the gateway wants for its workload." With the smaller baseline, that composition now means "non-privileged baseline + whatever the operator opted into via env var." A `Set` dedupe is the right shape for that — replacing it would break the legitimate use case of `createDiscordClient({intents: [DirectMessages]})` for hypothetical future callers that want to extend the baseline.
+
+## Requirements Trace
+
+- **R1** — `DEFAULT_INTENTS` in `packages/gateway/src/discord/client.ts` contains only `Guilds` and `GuildMessages`.
+- **R2** — `MessageContent` and `GuildMembers` opt in via the existing `readOptionalSecret` pattern in `packages/gateway/src/config.ts`, with no new schema-validation framework introduced.
+- **R3** — Malformed config (unknown intent names, typos) fails fast with a clear error at gateway startup. No silent permissive default.
+- **R4** — All 6 test scenarios specified in the origin issue pass:
+  1. Boot with non-privileged baseline only when no opt-ins configured.
+  2. Boot with `MessageContent` opt-in via config.
+  3. Boot with `GuildMembers` opt-in via config.
+  4. Boot with both privileged intents opted in.
+  5. Malformed config fails fast with a clear error.
+  6. Test-isolation guard: refuse to start the suite unless the token is a known-fake placeholder.
+- **R5** — `packages/gateway/AGENTS.md` documents the new config knob and the opt-in semantics.
+
+## Scope Boundaries
+
+- **R20 / R21 enforcement** — channel-policy declaration, refusal patterns, rate limits, and drift refusal at the gateway boundary remain out of scope (deferred per the origin issue).
+- **Cross-repo drift checks** — the mirror permission-drift runbook in `marcusrbrown/.dotfiles` stays separate. Both mechanisms will run independently against the same declared policy once this lands.
+- **No new schema framework** — the issue is explicit: follow the existing `readOptionalSecret` pattern, do not introduce Zod, Effect Schema, or a custom validator framework.
+- **No changes to `runtime-effect.ts`** — Effect adapters stay untouched. This change lives entirely inside the gateway's config and Discord client layers.
+- **`workspace.Dockerfile`** is a `sleep infinity` placeholder for now and is not affected.
+
+### Deferred to Separate Tasks
+
+- R20 / R21 full enforcement: future plan in this repo, after Unit 7 of the gateway v1 plan lands.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+| File | Reference |
+|---|---|
+| `packages/gateway/src/discord/client.ts:10-15` | Current `DEFAULT_INTENTS` constant (to flip) |
+| `packages/gateway/src/discord/client.ts:30-66` | `createDiscordClient()` and the Set-based merge (merge logic stays, semantics change with the smaller default) |
+| `packages/gateway/src/config.ts:42-77` | `readOptionalSecret` — canonical optional-secret pattern: tries `${NAME}_FILE` first, falls back to `process.env[name]`, treats empty/whitespace as null, EISDIR → clear error |
+| `packages/gateway/src/config.ts:85-105` | `loadGatewayConfig()` — current pattern for reading and composing config values |
+| `packages/gateway/src/config.ts:97-101` | `LOG_LEVEL` allowlist validation pattern (this plan mirrors it for the new env var) |
+| `packages/gateway/src/config.ts:107-135` | AWS credential pair validation + orphan-token warning (this plan mirrors the parsing-then-throwing-clear-error pattern) |
+| `packages/gateway/src/discord/client.test.ts:19-28` | Existing test asserting `MessageContent` is in defaults (must be replaced) |
+| `packages/gateway/src/discord/client.test.ts:30-43` | Existing merge-dedup test (stays — verifies the merge logic still composes correctly with the smaller baseline) |
+| `packages/gateway/src/config.test.ts:18-59` | `beforeEach` / `afterEach` env restore pattern — pattern to follow for new tests touching `DISCORD_PRIVILEGED_INTENTS` |
+| `packages/gateway/src/main.ts:60-75` | Where `createDiscordClient()` is called — single wiring site to update |
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/delivery-mode-contract-for-manual-triggers-2026-04-17.md` — strongest precedent for a posture flip from permissive-default to restrictive-default with explicit opt-in. The canonical takeaway: keep the resolver exhaustive and centralized; don't scatter ad-hoc env checks.
+- `docs/solutions/best-practices/versioned-tool-config-plugin-pattern-2026-03-29.md` — single source of truth for env-driven config knobs. Thread input → type → setup in one place.
+
+### Tech stack
+
+- discord.js 14.26.4 (canonical intent names: `GatewayIntentBits.MessageContent`, `GatewayIntentBits.GuildMembers`)
+- Effect 3.21.2 (not used in this change — config and client layers stay on direct sync code)
+- Vitest 4.1.5
+- TypeScript 6.0.3, Node ESM target
+
+## Key Technical Decisions
+
+- **Parse comma-separated list, allowlist to exactly `MessageContent` and `GuildMembers`.** Not the full `GatewayIntentBits` enum. Reason: this knob is specifically the "privileged intents opt-in" surface — operators should not be able to enable arbitrary intents (e.g., `GuildPresences`, another privileged intent we don't need) via the same knob. If a future workload needs a non-privileged intent, it should be added to `DEFAULT_INTENTS` not this knob.
+- **Case-sensitive match against canonical discord.js enum names.** `MessageContent,GuildMembers` is valid; `messagecontent,guildmembers` is rejected. Reason: discord.js's enum names are the canonical reference; operators copy them from the Discord dev portal; case-insensitive matching invites silent typos.
+- **Whitespace trimming on each token.** `MessageContent, GuildMembers ` is valid — operators write env vars with various spacing conventions. Trim each token; reject empty tokens (`MessageContent,,GuildMembers`).
+- **Empty / missing env var → `[]`.** The default-default case. The Set merge in `createDiscordClient` then naturally produces just the non-privileged baseline.
+- **Fail-fast on unknown values.** A typo (`MesageContent`) throws at gateway startup with a clear error listing the allowed values. Better than silently dropping the typo and running with a posture the operator didn't intend.
+- **Keep the existing merge logic.** The `Set`-dedup merge in `createDiscordClient` is structurally correct. Replacing it with "override replaces defaults" would prevent legitimate future composition (e.g., adding `DirectMessages` without removing the non-privileged baseline). The semantic change comes for free from the smaller `DEFAULT_INTENTS`.
+- **Test-isolation guard pattern: `beforeAll` in `client.test.ts`.** Inspects `process.env.DISCORD_TOKEN` and throws unless undefined, empty, or matches a known-fake regex. Same shape as production credentials guards in other test suites.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where in the config flow does the validator throw?** Inside `loadGatewayConfig()`, right after parsing the env var, before constructing `GatewayConfig`. Matches the LOG_LEVEL pattern.
+- **Should `DISCORD_PRIVILEGED_INTENTS` support a special `none` or `*` keyword?** No. Empty/missing is sufficient for "none"; `*` is unnecessary because the allowlist is only two values — operators can write `MessageContent,GuildMembers` explicitly.
+- **What about the `DISCORD_PRIVILEGED_INTENTS_FILE` path?** It comes for free — `readOptionalSecret('DISCORD_PRIVILEGED_INTENTS')` already checks `DISCORD_PRIVILEGED_INTENTS_FILE` first. No additional work needed.
+- **Should we add a compose.yaml secret mount for `discord-privileged-intents`?** Not in this PR — env-var is the canonical setting; the file path exists as a fallback but isn't expected to be the operator-facing surface. If operators want it as a file, they can add the mount themselves (the README documents the file pattern). Adds churn for no current operator benefit.
+
+### Deferred to Implementation
+
+- **Exact error message wording for unknown intent value.** Implementation will phrase it operator-friendly with the offending value and the allowed list. Not a planning question.
+
+## Implementation Units
+
+- [ ] **Unit 1: Flip `DEFAULT_INTENTS` to non-privileged baseline**
+
+**Goal:** Change `DEFAULT_INTENTS` in `packages/gateway/src/discord/client.ts` to contain only `Guilds` and `GuildMessages`. The merge logic in `createDiscordClient` is unchanged.
+
+**Requirements:** R1.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `packages/gateway/src/discord/client.ts`
+
+**Approach:**
+- Remove `GatewayIntentBits.MessageContent` and `GatewayIntentBits.GuildMembers` from the `DEFAULT_INTENTS` literal.
+- Update the JSDoc comment block above `createDiscordClient` to describe the new baseline.
+- Leave the merge logic at `client.ts:32-35` untouched — it composes correctly with the smaller default.
+- The existing `export {DEFAULT_INTENTS}` stays so tests can introspect it.
+
+**Patterns to follow:**
+- The JSDoc block at `packages/gateway/src/discord/client.ts:22-29` — keep the bullet-list style; add a bullet describing the baseline.
+
+**Test scenarios:**
+- Happy path: `DEFAULT_INTENTS.length === 2` and contains exactly `Guilds` and `GuildMessages` (no privileged intents).
+- Happy path: `createDiscordClient()` with no options produces a client whose `intents` bitfield equals the union of `[Guilds, GuildMessages]` and nothing else.
+
+**Verification:**
+- The existing `default intents include MessageContent` test now fails (expected — Unit 3 deletes it). All other existing tests pass unchanged.
+- `pnpm --filter @fro-bot/gateway check-types` clean.
+
+---
+
+- [ ] **Unit 2: Add `DISCORD_PRIVILEGED_INTENTS` config knob in `loadGatewayConfig`**
+
+**Goal:** Parse `DISCORD_PRIVILEGED_INTENTS` from env (via `readOptionalSecret`), validate against the two-value allowlist, and expose as `privilegedIntents: GatewayIntentBits[]` on `GatewayConfig`. Wire it into `main.ts` so it flows into `createDiscordClient` as the `intents` override.
+
+**Requirements:** R2, R3.
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `packages/gateway/src/config.ts` (parser, validation, `GatewayConfig` type extension)
+- Modify: `packages/gateway/src/main.ts` (wire `privilegedIntents` into `createDiscordClient`)
+- Test: `packages/gateway/src/config.test.ts` (parser tests — Unit 3 owns the client-level tests)
+
+**Approach:**
+- Introduce a module-level allowlist:
+  ```ts
+  const ALLOWED_PRIVILEGED_INTENTS = {
+    MessageContent: GatewayIntentBits.MessageContent,
+    GuildMembers: GatewayIntentBits.GuildMembers,
+  } as const
+  ```
+  Operator-facing names are the keys; the values are the discord.js enum values.
+- Add `privilegedIntents: GatewayIntentBits[]` to the `GatewayConfig` interface (readonly array).
+- Inside `loadGatewayConfig()`:
+  1. `const rawIntents = readOptionalSecret('DISCORD_PRIVILEGED_INTENTS')` (returns string | null).
+  2. If null → `privilegedIntents = []`. Done.
+  3. Otherwise split on `,`, trim each token, drop empty tokens that arise from leading/trailing/repeated separators (e.g., `,MessageContent,`). Throw clear error if a non-empty token doesn't match the allowlist keys exactly (case-sensitive). The error message names the invalid token and lists the allowed values.
+  4. Map matching tokens to their `GatewayIntentBits` value. Dedupe via `Set`.
+- Place the new block right after the LOG_LEVEL validation in `loadGatewayConfig` — mirrors the same parse-then-validate-then-throw pattern.
+- In `main.ts`: change `createDiscordClient({logger})` to `createDiscordClient({intents: config.privilegedIntents, logger})`. If `privilegedIntents` is empty, the `intents` array is `[]` and the Set merge produces exactly `DEFAULT_INTENTS`.
+
+**Patterns to follow:**
+- `packages/gateway/src/config.ts:97-101` — `LOG_LEVEL` allowlist throw pattern.
+- `packages/gateway/src/config.ts:107-135` — AWS credential parsing with structured error messages.
+
+**Test scenarios:**
+- Happy path: `DISCORD_PRIVILEGED_INTENTS` unset → `config.privilegedIntents === []`.
+- Happy path: `DISCORD_PRIVILEGED_INTENTS=MessageContent` → `config.privilegedIntents === [GatewayIntentBits.MessageContent]`.
+- Happy path: `DISCORD_PRIVILEGED_INTENTS=GuildMembers` → `config.privilegedIntents === [GatewayIntentBits.GuildMembers]`.
+- Happy path: `DISCORD_PRIVILEGED_INTENTS=MessageContent,GuildMembers` → contains both values, no duplicates.
+- Edge case: `DISCORD_PRIVILEGED_INTENTS=` (empty string) → `config.privilegedIntents === []` (treated as null by `readOptionalSecret`).
+- Edge case: `DISCORD_PRIVILEGED_INTENTS= MessageContent , GuildMembers ` (extra whitespace) → both parsed correctly.
+- Edge case: `DISCORD_PRIVILEGED_INTENTS=MessageContent,MessageContent` → deduped to one.
+- Edge case: `DISCORD_PRIVILEGED_INTENTS=MessageContent,,GuildMembers` (empty middle token) → both privileged intents parsed, no error.
+- Error path: `DISCORD_PRIVILEGED_INTENTS=MesageContent` (typo) → throws with message naming the invalid value and listing the allowed values.
+- Error path: `DISCORD_PRIVILEGED_INTENTS=messagecontent` (wrong case) → throws (case-sensitive match).
+- Error path: `DISCORD_PRIVILEGED_INTENTS=Guilds` (non-privileged intent in privileged knob) → throws (not in the privileged allowlist).
+- Error path: `DISCORD_PRIVILEGED_INTENTS=GuildPresences` (a different privileged intent not allowed by this knob) → throws.
+- Edge case: `DISCORD_PRIVILEGED_INTENTS_FILE` set to a file containing `MessageContent\n` → parsed correctly (free from `readOptionalSecret`).
+
+**Verification:**
+- All new `config.test.ts` tests pass.
+- `pnpm --filter @fro-bot/gateway test` exits 0.
+- `pnpm --filter @fro-bot/gateway check-types` clean.
+- `pnpm --filter @fro-bot/gateway lint` clean.
+
+---
+
+- [ ] **Unit 3: Client-level tests + test-isolation guard + AGENTS.md docs**
+
+**Goal:** Add the client-level test scenarios from R4, install the test-isolation guard in `client.test.ts`, and document the `DISCORD_PRIVILEGED_INTENTS` knob in `packages/gateway/AGENTS.md`.
+
+**Requirements:** R4, R5.
+
+**Dependencies:** Unit 1, Unit 2.
+
+**Files:**
+- Modify: `packages/gateway/src/discord/client.test.ts` (delete obsolete `MessageContent`-in-defaults test, add new scenarios, install `beforeAll` guard)
+- Modify: `packages/gateway/AGENTS.md` (add the env-var doc block)
+
+**Approach:**
+- **`client.test.ts` — delete the obsolete test.** The `default intents include MessageContent (required to read mention text)` test at lines 19-28 asserts the now-wrong behavior. Delete it (or replace its body) with a new test asserting `DEFAULT_INTENTS` is exactly `[Guilds, GuildMessages]`.
+- **`client.test.ts` — add the test-isolation guard.** A `beforeAll` block at the top of the `describe` checks `process.env.DISCORD_TOKEN`:
+  - undefined / empty / matches `/^(test-token-fake|fake|test|MOCK)/i` → pass.
+  - otherwise → `throw new Error('refusing to run gateway client tests with what looks like a real DISCORD_TOKEN; set DISCORD_TOKEN to a known-fake value or unset it')`.
+  This catches accidental sourcing of operator `.env` files into the test environment.
+- **`client.test.ts` — add 4 new tests for the merge composition.** These verify the wiring works end-to-end:
+  - "boots with non-privileged baseline only when no privileged intents opted in" — call `createDiscordClient()` with no options, assert bitfield = union of `[Guilds, GuildMessages]`.
+  - "opts into MessageContent via passed intents" — call `createDiscordClient({intents: [GatewayIntentBits.MessageContent]})`, assert bitfield includes MessageContent and the baseline.
+  - "opts into GuildMembers via passed intents" — same shape.
+  - "opts into both privileged intents via passed intents" — assert bitfield includes both privileged intents and the baseline.
+- **Update the existing merge-dedup test** (lines 30-43) — it tests `[DirectMessages, Guilds]`. Stays as-is since it still verifies merge behavior, just with the smaller baseline. The expected bitfield is recomputed automatically because it uses `DEFAULT_INTENTS` directly.
+- **`AGENTS.md` — add config-knob documentation.** Insert a new section after the existing `## Package layout` block titled `## Configuration knobs`. Document `DISCORD_PRIVILEGED_INTENTS`:
+  - What it does (opts into Discord privileged intents).
+  - Allowed values (`MessageContent`, `GuildMembers`).
+  - Format (comma-separated, case-sensitive, whitespace-tolerant).
+  - Behavior when unset (non-privileged baseline only).
+  - Behavior on typo (fail-fast at startup).
+  - Note that the knob mirrors the `${NAME}_FILE` pattern from `readOptionalSecret`.
+- The doc should be terse — match the existing AGENTS.md voice (no marketing speak, just operator-facing facts).
+
+**Patterns to follow:**
+- `packages/gateway/src/config.test.ts:18-59` — `beforeEach` / `afterEach` env restoration shape.
+- `packages/gateway/src/discord/client.test.ts:30-43` — bitfield comparison via `new (... as unknown as ...).constructor` (reuse the same idiom; this works because discord.js stores intents as a BitField at runtime).
+- `packages/gateway/AGENTS.md` — neutral operator-facing voice, no agent/session references.
+
+**Test scenarios:**
+
+R4#1–#6 are covered as follows:
+- R4#1, R4#2, R4#3, R4#4 — new client-level tests in `client.test.ts` (this unit, listed below).
+- R4#5 — owned by Unit 2's config-level tests (`config.test.ts`); malformed config throws inside `loadGatewayConfig()` and never reaches `createDiscordClient()`. Cross-referenced here for traceability; not duplicated.
+- R4#6 — `validateTokenIsFake` helper tests (this unit, listed below) + the `beforeAll` install in `client.test.ts`.
+
+This unit's tests:
+
+- (R4#1) Happy path: default client (no options) has the non-privileged baseline only — assert intent bitfield equals union of `[Guilds, GuildMessages]` only.
+- (R4#2) Happy path: `createDiscordClient({intents: [MessageContent]})` produces a client whose intents include MessageContent and the baseline.
+- (R4#3) Happy path: same for GuildMembers.
+- (R4#4) Happy path: both opted in via `intents: [MessageContent, GuildMembers]` produce baseline + both privileged intents.
+- (R4#6) Test-isolation guard: extract guard logic into a small free function `validateTokenIsFake(token: string | undefined): void` (cleanest as a sibling test-only module — `packages/gateway/src/discord/test-token-guard.ts` or co-located with the test file — not an export from `client.ts`). Unit-test the helper directly and call it from the `beforeAll`. Add 3 helper tests: undefined → pass; `test-token-fake` → pass; `MTIzNDU2.real-looking-base64` → throws.
+
+**Verification:**
+- All client-level tests pass.
+- `validateTokenIsFake` helper tests pass.
+- `pnpm --filter @fro-bot/gateway test` exits 0.
+- AGENTS.md renders without lint errors (`pnpm lint`).
+
+## System-Wide Impact
+
+- **Interaction graph:** `main.ts` calls `loadGatewayConfig` → uses `config.privilegedIntents` → passes to `createDiscordClient`. Single linear path; no callbacks, middleware, or observers affected.
+- **Error propagation:** Malformed config throws inside `loadGatewayConfig`. `main.ts`'s startup `Effect.runPromise` catches the throw and surfaces it as a failed startup. The Dockerfile readiness flag (`/var/run/fro-bot/gateway-ready`) is never written, so the healthcheck stays red and docker compose reports the gateway unhealthy.
+- **State lifecycle risks:** None. Pure startup-time config parsing.
+- **API surface parity:** The `GatewayConfig` interface gains one field. External infra-as-code consumers (marcusrbrown/infra) gain one optional env var. No removals; no breaking changes.
+- **Integration coverage:** The `main.ts` wiring change should not require an integration test — Unit 2's config tests + Unit 3's client tests verify both endpoints; the wiring between them is a one-line passthrough.
+- **Unchanged invariants:** `readSecret` / `readOptionalSecret` signatures stay. The `${NAME}_FILE` fallback pattern stays. `createDiscordClient`'s function signature is unchanged — the new behavior comes from the smaller `DEFAULT_INTENTS` interacting with the existing merge logic.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| Existing deployments that need the privileged intents (if any) break silently after upgrading. | Document the `DISCORD_PRIVILEGED_INTENTS` knob in the PR body, `deploy/README.md` (already touched in this branch arc), and `packages/gateway/AGENTS.md`. Existing operators who need the privileged set must set the env var on the next deploy. |
+| Operator typo in the env var (e.g., `MesageContent`) causes a fail-fast startup that's confusing. | Error message names the invalid token AND lists the allowed values, so the operator can self-diagnose without reading code. |
+| The `beforeAll` token guard could block legitimate dev work if the developer has `DISCORD_TOKEN` set in their shell. | Accept this — the whole point of the guard is to surface that exact case. Developers running gateway tests are expected to unset the var or use a `test-token-fake` placeholder. The error message tells them what to do. |
+| Discord changes the privileged-intent list in a future API version (e.g., adds a new privileged intent). | Out of scope. The allowlist in this plan is the right shape to extend — adding a new privileged intent is a one-line addition to `ALLOWED_PRIVILEGED_INTENTS` when needed. |
+
+## Documentation / Operational Notes
+
+- `packages/gateway/AGENTS.md` documents the new env var (Unit 3).
+- The PR body should note that this is an opt-in flip: existing operators relying on the privileged set need to set `DISCORD_PRIVILEGED_INTENTS=MessageContent,GuildMembers` on their next deploy.
+- The `deploy/README.md` operator setup doc (already part of the v0.44.x deploy contract work) does NOT need an update in this PR — the env var is documented in `packages/gateway/AGENTS.md` (the canonical knob reference). If a future PR adds a "configuration reference" section to `deploy/README.md`, the knob can be cross-referenced there.
+- No Dockerfile or compose.yaml changes. The env var flows through the existing `docker compose` env-passthrough; no new bind mounts are needed (operators set it via `.env` or shell env).
+
+## Sources & References
+
+- **Origin issue:** https://github.com/fro-bot/agent/issues/646
+- **Related plan (dotfiles side):** [marcusrbrown/.dotfiles `2026-05-18-001-feat-discord-server-revival-plan.md`](https://github.com/marcusrbrown/.dotfiles/blob/main/docs/plans/2026-05-18-001-feat-discord-server-revival-plan.md) (Unit 9, cross-repo handoff)
+- **Mirror runbook:** [marcusrbrown/.dotfiles `discord-permission-drift-check.md`](https://github.com/marcusrbrown/.dotfiles/blob/main/docs/runbooks/discord-permission-drift-check.md)
+- **Related code:** `packages/gateway/src/discord/client.ts`, `packages/gateway/src/config.ts`, `packages/gateway/src/main.ts`, `packages/gateway/AGENTS.md`
+- **Pattern precedent:** `docs/solutions/workflow-issues/delivery-mode-contract-for-manual-triggers-2026-04-17.md` (default posture flip)
+- **discord.js GatewayIntentBits reference:** `node_modules/discord.js/typings/index.d.ts` (canonical names)

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -36,6 +36,7 @@ export default defineConfig(
     name: 'vitest overrides',
     files: ['**/*.test.ts', '**/*.spec.ts'],
     rules: {
+      'vitest/expect-expect': ['error', {assertFunctionNames: ['expect', 'expect*', 'assert*']}],
       'vitest/prefer-lowercase-title': ['error', {ignore: ['describe']}],
     },
   },

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -52,6 +52,25 @@ Not used at this scope:
 - `src/discord/` — Discord.js integration. Client construction with safe `allowedMentions` defaults, command registry, mention handler.
 - `src/shutdown.ts` — SIGTERM handler with 25s drain.
 
+## Configuration knobs
+
+### `DISCORD_PRIVILEGED_INTENTS`
+
+Opts the gateway into Discord's privileged intents. Default is non-privileged
+only (`Guilds` + `GuildMessages`); set this env var (or the matching
+`DISCORD_PRIVILEGED_INTENTS_FILE` secret) to add `MessageContent`,
+`GuildMembers`, or both.
+
+- **Allowed values:** `MessageContent`, `GuildMembers` (case-sensitive)
+- **Format:** comma-separated; whitespace tolerated (`MessageContent, GuildMembers ` works)
+- **Empty / unset:** non-privileged baseline only — no opt-in
+- **Typo or unknown value:** fail-fast at startup with an error naming the offending token
+- **File fallback:** `DISCORD_PRIVILEGED_INTENTS_FILE` mirrors the `${NAME}_FILE` convention from `readOptionalSecret`
+
+Existing deployments that need the privileged set must set this on the next
+deploy. The allowlist is intentionally narrow — operators cannot enable
+arbitrary Discord intents via this knob.
+
 ## Build
 
 ```bash

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -662,6 +662,24 @@ describe('DISCORD_PRIVILEGED_INTENTS', () => {
     expect(() => loadGatewayConfig()).toThrow(/Invalid DISCORD_PRIVILEGED_INTENTS value: "GuildPresences"/)
   })
 
+  it('rejects prototype-property tokens (constructor)', () => {
+    setRequiredEnv()
+    process.env.DISCORD_PRIVILEGED_INTENTS = 'constructor'
+    expect(() => loadGatewayConfig()).toThrow(/Invalid DISCORD_PRIVILEGED_INTENTS value: "constructor"/)
+  })
+
+  it('rejects prototype-property tokens (__proto__)', () => {
+    setRequiredEnv()
+    process.env.DISCORD_PRIVILEGED_INTENTS = '__proto__'
+    expect(() => loadGatewayConfig()).toThrow(/Invalid DISCORD_PRIVILEGED_INTENTS value: "__proto__"/)
+  })
+
+  it('rejects prototype-property tokens (toString)', () => {
+    setRequiredEnv()
+    process.env.DISCORD_PRIVILEGED_INTENTS = 'toString'
+    expect(() => loadGatewayConfig()).toThrow(/Invalid DISCORD_PRIVILEGED_INTENTS value: "toString"/)
+  })
+
   it('edge: DISCORD_PRIVILEGED_INTENTS_FILE with trailing newline → parsed correctly', () => {
     // #given
     setRequiredEnv()

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -4,6 +4,7 @@ import {mkdtempSync, rmSync, writeFileSync} from 'node:fs'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 
+import {GatewayIntentBits} from 'discord.js'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {loadGatewayConfig, readOptionalSecret, readSecret} from './config.js'
@@ -45,6 +46,8 @@ beforeEach(() => {
     'AWS_SECRET_ACCESS_KEY_FILE',
     'AWS_SESSION_TOKEN',
     'AWS_SESSION_TOKEN_FILE',
+    'DISCORD_PRIVILEGED_INTENTS',
+    'DISCORD_PRIVILEGED_INTENTS_FILE',
   ]) {
     delete process.env[key]
   }
@@ -519,5 +522,157 @@ describe('AWS credentials', () => {
     ) as unknown
     expect(parsed).toMatchObject({level: 'warn', msg: sessionTokenMsg})
     consoleSpy.mockRestore()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DISCORD_PRIVILEGED_INTENTS
+// ---------------------------------------------------------------------------
+
+describe('DISCORD_PRIVILEGED_INTENTS', () => {
+  it('happy: unset → privilegedIntents is []', () => {
+    // #given
+    setRequiredEnv()
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.privilegedIntents).toEqual([])
+  })
+
+  it('happy: MessageContent → [GatewayIntentBits.MessageContent]', () => {
+    // #given
+    setRequiredEnv()
+    process.env.DISCORD_PRIVILEGED_INTENTS = 'MessageContent'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.privilegedIntents).toEqual([GatewayIntentBits.MessageContent])
+  })
+
+  it('happy: GuildMembers → [GatewayIntentBits.GuildMembers]', () => {
+    // #given
+    setRequiredEnv()
+    process.env.DISCORD_PRIVILEGED_INTENTS = 'GuildMembers'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.privilegedIntents).toEqual([GatewayIntentBits.GuildMembers])
+  })
+
+  it('happy: MessageContent,GuildMembers → both values, ordered as parsed', () => {
+    // #given
+    setRequiredEnv()
+    process.env.DISCORD_PRIVILEGED_INTENTS = 'MessageContent,GuildMembers'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.privilegedIntents).toEqual([GatewayIntentBits.MessageContent, GatewayIntentBits.GuildMembers])
+  })
+
+  it('edge: empty string → [] (treated as null by readOptionalSecret)', () => {
+    // #given
+    setRequiredEnv()
+    process.env.DISCORD_PRIVILEGED_INTENTS = ''
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then — empty string is treated as "not set"
+    expect(config.privilegedIntents).toEqual([])
+  })
+
+  it('edge: extra whitespace around tokens → both parsed correctly', () => {
+    // #given
+    setRequiredEnv()
+    process.env.DISCORD_PRIVILEGED_INTENTS = ' MessageContent , GuildMembers '
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.privilegedIntents).toEqual([GatewayIntentBits.MessageContent, GatewayIntentBits.GuildMembers])
+  })
+
+  it('edge: duplicate token → deduped to single value', () => {
+    // #given
+    setRequiredEnv()
+    process.env.DISCORD_PRIVILEGED_INTENTS = 'MessageContent,MessageContent'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.privilegedIntents).toEqual([GatewayIntentBits.MessageContent])
+  })
+
+  it('edge: empty middle token (MessageContent,,GuildMembers) → both parsed, no error', () => {
+    // #given
+    setRequiredEnv()
+    process.env.DISCORD_PRIVILEGED_INTENTS = 'MessageContent,,GuildMembers'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then — empty tokens are filtered out
+    expect(config.privilegedIntents).toEqual([GatewayIntentBits.MessageContent, GatewayIntentBits.GuildMembers])
+  })
+
+  it('error: typo "MesageContent" → throws with offending value and allowed list', () => {
+    // #given
+    setRequiredEnv()
+    process.env.DISCORD_PRIVILEGED_INTENTS = 'MesageContent'
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/Invalid DISCORD_PRIVILEGED_INTENTS value: "MesageContent"/)
+    expect(() => loadGatewayConfig()).toThrow(/MessageContent, GuildMembers/)
+  })
+
+  it('error: wrong case "messagecontent" → throws (case-sensitive)', () => {
+    // #given
+    setRequiredEnv()
+    process.env.DISCORD_PRIVILEGED_INTENTS = 'messagecontent'
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/Invalid DISCORD_PRIVILEGED_INTENTS value: "messagecontent"/)
+  })
+
+  it('error: non-privileged intent "Guilds" → throws', () => {
+    // #given
+    setRequiredEnv()
+    process.env.DISCORD_PRIVILEGED_INTENTS = 'Guilds'
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/Invalid DISCORD_PRIVILEGED_INTENTS value: "Guilds"/)
+  })
+
+  it('error: privileged intent not on allowlist "GuildPresences" → throws', () => {
+    // #given
+    setRequiredEnv()
+    process.env.DISCORD_PRIVILEGED_INTENTS = 'GuildPresences'
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/Invalid DISCORD_PRIVILEGED_INTENTS value: "GuildPresences"/)
+  })
+
+  it('edge: DISCORD_PRIVILEGED_INTENTS_FILE with trailing newline → parsed correctly', () => {
+    // #given
+    setRequiredEnv()
+    const intentFile = join(tmpDir, 'privileged-intents.txt')
+    writeFileSync(intentFile, 'MessageContent\n', {mode: 0o600})
+    process.env.DISCORD_PRIVILEGED_INTENTS_FILE = intentFile
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then — trailing newline stripped by readOptionalSecret, value parsed correctly
+    expect(config.privilegedIntents).toEqual([GatewayIntentBits.MessageContent])
   })
 })

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -117,7 +117,7 @@ export function loadGatewayConfig(): GatewayConfig {
       .filter(token => token.length > 0)
     const seen = new Set<GatewayIntentBits>()
     for (const token of tokens) {
-      if (!(token in ALLOWED_PRIVILEGED_INTENTS)) {
+      if (Object.prototype.hasOwnProperty.call(ALLOWED_PRIVILEGED_INTENTS, token) === false) {
         const allowed = Object.keys(ALLOWED_PRIVILEGED_INTENTS).join(', ')
         throw new Error(
           `Invalid DISCORD_PRIVILEGED_INTENTS value: "${token}". Allowed values: ${allowed} (case-sensitive, comma-separated).`,

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -3,10 +3,17 @@ import type {AwsCredentials, ObjectStoreConfig} from './runtime-effect.js'
 import {readFileSync} from 'node:fs'
 import process from 'node:process'
 
+import {GatewayIntentBits} from 'discord.js'
+
 const DEFAULT_S3_PREFIX = 'fro-bot-state'
 const DEFAULT_GATEWAY_IDENTITY = 'discord-gateway'
 const DEFAULT_LOG_LEVEL = 'info' as const
 const VALID_LOG_LEVELS = ['debug', 'info', 'warn', 'error'] as const
+
+const ALLOWED_PRIVILEGED_INTENTS = {
+  MessageContent: GatewayIntentBits.MessageContent,
+  GuildMembers: GatewayIntentBits.GuildMembers,
+} as const
 
 export interface GatewayConfig {
   readonly discordToken: string
@@ -15,6 +22,7 @@ export interface GatewayConfig {
   readonly objectStore: ObjectStoreConfig
   readonly identity: string
   readonly logLevel: 'debug' | 'info' | 'warn' | 'error'
+  readonly privilegedIntents: readonly GatewayIntentBits[]
 }
 
 /**
@@ -100,6 +108,29 @@ export function loadGatewayConfig(): GatewayConfig {
   }
   const logLevel = rawLogLevel as GatewayConfig['logLevel']
 
+  const rawIntents = readOptionalSecret('DISCORD_PRIVILEGED_INTENTS')
+  const privilegedIntents: GatewayIntentBits[] = []
+  if (rawIntents !== null) {
+    const tokens = rawIntents
+      .split(',')
+      .map(token => token.trim())
+      .filter(token => token.length > 0)
+    const seen = new Set<GatewayIntentBits>()
+    for (const token of tokens) {
+      if (!(token in ALLOWED_PRIVILEGED_INTENTS)) {
+        const allowed = Object.keys(ALLOWED_PRIVILEGED_INTENTS).join(', ')
+        throw new Error(
+          `Invalid DISCORD_PRIVILEGED_INTENTS value: "${token}". Allowed values: ${allowed} (case-sensitive, comma-separated).`,
+        )
+      }
+      const intent = ALLOWED_PRIVILEGED_INTENTS[token as keyof typeof ALLOWED_PRIVILEGED_INTENTS]
+      if (seen.has(intent) === false) {
+        seen.add(intent)
+        privilegedIntents.push(intent)
+      }
+    }
+  }
+
   const awsAccessKeyId = readOptionalSecret('AWS_ACCESS_KEY_ID')
   const awsSecretAccessKey = readOptionalSecret('AWS_SECRET_ACCESS_KEY')
   const awsSessionToken = readOptionalSecret('AWS_SESSION_TOKEN')
@@ -151,5 +182,6 @@ export function loadGatewayConfig(): GatewayConfig {
     objectStore,
     identity,
     logLevel,
+    privilegedIntents,
   }
 }

--- a/packages/gateway/src/discord/client.test.ts
+++ b/packages/gateway/src/discord/client.test.ts
@@ -10,6 +10,16 @@ import {validateTokenIsFake} from './test-token-guard.js'
 
 // discord.js Client constructor makes no network calls — safe to instantiate in tests.
 
+/**
+ * Compare a Discord.js Client's intent bitfield against an expected list of intents.
+ *
+ * discord.js stores intents internally as a BitField instance — the public type
+ * (`ClientOptions['intents']`) doesn't expose the constructor or `.bitfield` numeric
+ * value. Tests use the double-`unknown` cast to reach into the runtime shape. This is
+ * brittle against discord.js internal API changes; if the cast breaks on an upgrade,
+ * recompute the expected bitfield via `new IntentsBitField(expected).bitfield` (from
+ * `discord.js`) and compare directly.
+ */
 function expectClientIntents(client: Client, expected: readonly GatewayIntentBits[]): void {
   const expectedBitfield = new (
     client.options.intents as unknown as {constructor: new (bits: readonly GatewayIntentBits[]) => {bitfield: number}}

--- a/packages/gateway/src/discord/client.test.ts
+++ b/packages/gateway/src/discord/client.test.ts
@@ -1,13 +1,18 @@
 import type {EventEmitter} from 'node:events'
 
 import {GatewayIntentBits} from 'discord.js'
-import {describe, expect, it, vi} from 'vitest'
+import {beforeAll, describe, expect, it, vi} from 'vitest'
 
 import {createDiscordClient, DEFAULT_INTENTS} from './client.js'
+import {validateTokenIsFake} from './test-token-guard.js'
 
 // discord.js Client constructor makes no network calls — safe to instantiate in tests.
 
 describe('createDiscordClient', () => {
+  beforeAll(() => {
+    validateTokenIsFake(process.env.DISCORD_TOKEN)
+  })
+
   it('returns a Client with allowedMentions locked to users-only', () => {
     // #when the client is created
     const client = createDiscordClient()
@@ -16,15 +21,8 @@ describe('createDiscordClient', () => {
     expect(client.options.allowedMentions).toEqual({parse: ['users'], repliedUser: false})
   })
 
-  it('default intents include MessageContent (required to read mention text)', () => {
-    // #when
-    const client = createDiscordClient()
-
-    // #then
-    const intents = client.options.intents
-    // discord.js stores intents as a BitField; check via DEFAULT_INTENTS constant
-    expect(DEFAULT_INTENTS).toContain(GatewayIntentBits.MessageContent)
-    expect(intents).toBeDefined()
+  it('default intents are the non-privileged baseline only', () => {
+    expect([...DEFAULT_INTENTS]).toEqual([GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages])
   })
 
   it('optional intent override merges with defaults (dedup via Set)', () => {
@@ -61,5 +59,58 @@ describe('createDiscordClient', () => {
 
     emitter.emit('shardReconnecting', 0)
     expect(logger.info).toHaveBeenCalledWith({shardId: 0}, 'discord shard reconnecting')
+  })
+
+  it('boots with the non-privileged baseline only when no privileged intents are passed', () => {
+    // #when called with no options
+    const client = createDiscordClient()
+
+    // #then the bitfield is exactly the non-privileged baseline
+    const expected = [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages]
+    const expectedBitfield = new (
+      client.options.intents as unknown as {constructor: new (bits: GatewayIntentBits[]) => {bitfield: number}}
+    ).constructor(expected).bitfield
+    expect((client.options.intents as unknown as {bitfield: number}).bitfield).toBe(expectedBitfield)
+  })
+
+  it('opts into MessageContent when passed via options.intents', () => {
+    // #given an opt-in for MessageContent only
+    const client = createDiscordClient({intents: [GatewayIntentBits.MessageContent]})
+
+    // #then the bitfield includes MessageContent and the non-privileged baseline
+    const expected = [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent]
+    const expectedBitfield = new (
+      client.options.intents as unknown as {constructor: new (bits: GatewayIntentBits[]) => {bitfield: number}}
+    ).constructor(expected).bitfield
+    expect((client.options.intents as unknown as {bitfield: number}).bitfield).toBe(expectedBitfield)
+  })
+
+  it('opts into GuildMembers when passed via options.intents', () => {
+    // #given an opt-in for GuildMembers only
+    const client = createDiscordClient({intents: [GatewayIntentBits.GuildMembers]})
+
+    // #then the bitfield includes GuildMembers and the non-privileged baseline
+    const expected = [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.GuildMembers]
+    const expectedBitfield = new (
+      client.options.intents as unknown as {constructor: new (bits: GatewayIntentBits[]) => {bitfield: number}}
+    ).constructor(expected).bitfield
+    expect((client.options.intents as unknown as {bitfield: number}).bitfield).toBe(expectedBitfield)
+  })
+
+  it('opts into both MessageContent and GuildMembers when both are passed', () => {
+    // #given an opt-in for both privileged intents
+    const client = createDiscordClient({intents: [GatewayIntentBits.MessageContent, GatewayIntentBits.GuildMembers]})
+
+    // #then the bitfield includes both privileged intents and the non-privileged baseline
+    const expected = [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+      GatewayIntentBits.MessageContent,
+      GatewayIntentBits.GuildMembers,
+    ]
+    const expectedBitfield = new (
+      client.options.intents as unknown as {constructor: new (bits: GatewayIntentBits[]) => {bitfield: number}}
+    ).constructor(expected).bitfield
+    expect((client.options.intents as unknown as {bitfield: number}).bitfield).toBe(expectedBitfield)
   })
 })

--- a/packages/gateway/src/discord/client.test.ts
+++ b/packages/gateway/src/discord/client.test.ts
@@ -1,5 +1,7 @@
 import type {EventEmitter} from 'node:events'
 
+import type {Client} from 'discord.js'
+
 import {GatewayIntentBits} from 'discord.js'
 import {beforeAll, describe, expect, it, vi} from 'vitest'
 
@@ -7,6 +9,13 @@ import {createDiscordClient, DEFAULT_INTENTS} from './client.js'
 import {validateTokenIsFake} from './test-token-guard.js'
 
 // discord.js Client constructor makes no network calls — safe to instantiate in tests.
+
+function expectClientIntents(client: Client, expected: readonly GatewayIntentBits[]): void {
+  const expectedBitfield = new (
+    client.options.intents as unknown as {constructor: new (bits: readonly GatewayIntentBits[]) => {bitfield: number}}
+  ).constructor(expected).bitfield
+  expect((client.options.intents as unknown as {bitfield: number}).bitfield).toBe(expectedBitfield)
+}
 
 describe('createDiscordClient', () => {
   beforeAll(() => {
@@ -34,10 +43,7 @@ describe('createDiscordClient', () => {
 
     // #then the BitField is the union of defaults + extras (no duplicates)
     const expected = [...new Set<GatewayIntentBits>([...DEFAULT_INTENTS, ...customIntents])]
-    const expectedBitfield = new (
-      client.options.intents as unknown as {constructor: new (bits: GatewayIntentBits[]) => {bitfield: number}}
-    ).constructor(expected).bitfield
-    expect((client.options.intents as unknown as {bitfield: number}).bitfield).toBe(expectedBitfield)
+    expectClientIntents(client, expected)
   })
 
   it('wires shard events to logger when logger is provided', () => {
@@ -67,10 +73,7 @@ describe('createDiscordClient', () => {
 
     // #then the bitfield is exactly the non-privileged baseline
     const expected = [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages]
-    const expectedBitfield = new (
-      client.options.intents as unknown as {constructor: new (bits: GatewayIntentBits[]) => {bitfield: number}}
-    ).constructor(expected).bitfield
-    expect((client.options.intents as unknown as {bitfield: number}).bitfield).toBe(expectedBitfield)
+    expectClientIntents(client, expected)
   })
 
   it('opts into MessageContent when passed via options.intents', () => {
@@ -79,10 +82,7 @@ describe('createDiscordClient', () => {
 
     // #then the bitfield includes MessageContent and the non-privileged baseline
     const expected = [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent]
-    const expectedBitfield = new (
-      client.options.intents as unknown as {constructor: new (bits: GatewayIntentBits[]) => {bitfield: number}}
-    ).constructor(expected).bitfield
-    expect((client.options.intents as unknown as {bitfield: number}).bitfield).toBe(expectedBitfield)
+    expectClientIntents(client, expected)
   })
 
   it('opts into GuildMembers when passed via options.intents', () => {
@@ -91,10 +91,7 @@ describe('createDiscordClient', () => {
 
     // #then the bitfield includes GuildMembers and the non-privileged baseline
     const expected = [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.GuildMembers]
-    const expectedBitfield = new (
-      client.options.intents as unknown as {constructor: new (bits: GatewayIntentBits[]) => {bitfield: number}}
-    ).constructor(expected).bitfield
-    expect((client.options.intents as unknown as {bitfield: number}).bitfield).toBe(expectedBitfield)
+    expectClientIntents(client, expected)
   })
 
   it('opts into both MessageContent and GuildMembers when both are passed', () => {
@@ -108,9 +105,6 @@ describe('createDiscordClient', () => {
       GatewayIntentBits.MessageContent,
       GatewayIntentBits.GuildMembers,
     ]
-    const expectedBitfield = new (
-      client.options.intents as unknown as {constructor: new (bits: GatewayIntentBits[]) => {bitfield: number}}
-    ).constructor(expected).bitfield
-    expect((client.options.intents as unknown as {bitfield: number}).bitfield).toBe(expectedBitfield)
+    expectClientIntents(client, expected)
   })
 })

--- a/packages/gateway/src/discord/client.ts
+++ b/packages/gateway/src/discord/client.ts
@@ -7,10 +7,10 @@ export interface GatewayLogger {
   readonly error: (context: Record<string, unknown>, message: string) => void
 }
 
-const DEFAULT_INTENTS: GatewayIntentBits[] = [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages]
+const DEFAULT_INTENTS: readonly GatewayIntentBits[] = [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages]
 
 export interface DiscordClientOptions {
-  readonly intents?: GatewayIntentBits[]
+  readonly intents?: readonly GatewayIntentBits[]
   readonly logger?: GatewayLogger
 }
 

--- a/packages/gateway/src/discord/client.ts
+++ b/packages/gateway/src/discord/client.ts
@@ -7,12 +7,7 @@ export interface GatewayLogger {
   readonly error: (context: Record<string, unknown>, message: string) => void
 }
 
-const DEFAULT_INTENTS: GatewayIntentBits[] = [
-  GatewayIntentBits.Guilds,
-  GatewayIntentBits.GuildMessages,
-  GatewayIntentBits.MessageContent,
-  GatewayIntentBits.GuildMembers,
-]
+const DEFAULT_INTENTS: GatewayIntentBits[] = [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages]
 
 export interface DiscordClientOptions {
   readonly intents?: GatewayIntentBits[]
@@ -22,6 +17,9 @@ export interface DiscordClientOptions {
 /**
  * Create a Discord.js Client with safe defaults.
  *
+ * - Default intents are `Guilds` and `GuildMessages` only — the non-privileged baseline.
+ *   Callers that need `MessageContent` or `GuildMembers` must pass them via `options.intents`;
+ *   they are merged with (not replacing) the defaults.
  * - `allowedMentions` is locked to `{ parse: ['users'], repliedUser: false }` to prevent
  *   accidental @everyone / @here pings.
  * - Shard lifecycle events are wired to structured log lines when a logger is provided.

--- a/packages/gateway/src/discord/test-token-guard.test.ts
+++ b/packages/gateway/src/discord/test-token-guard.test.ts
@@ -13,10 +13,39 @@ describe('validateTokenIsFake', () => {
 
   it('accepts known-fake prefixes (case-insensitive)', () => {
     expect(() => validateTokenIsFake('test-token-fake')).not.toThrow()
-    expect(() => validateTokenIsFake('fake')).not.toThrow()
+    expect(() => validateTokenIsFake('fake-token')).not.toThrow()
+    expect(() => validateTokenIsFake('mock-token')).not.toThrow()
     expect(() => validateTokenIsFake('test')).not.toThrow()
-    expect(() => validateTokenIsFake('MOCK')).not.toThrow()
     expect(() => validateTokenIsFake('Test-Token-Fake-12345')).not.toThrow()
+  })
+
+  it('accepts `test` followed by a non-alphanumeric separator', () => {
+    expect(() => validateTokenIsFake('test-')).not.toThrow()
+    expect(() => validateTokenIsFake('test ')).not.toThrow()
+    expect(() => validateTokenIsFake('test_token')).not.toThrow()
+  })
+
+  it('throws on bare `fake` (too ambiguous — use fake-token instead)', () => {
+    expect(() => validateTokenIsFake('fake')).toThrow(/refusing to run/)
+  })
+
+  it('throws on bare `MOCK` (too ambiguous — use mock-token instead)', () => {
+    expect(() => validateTokenIsFake('MOCK')).toThrow(/refusing to run/)
+  })
+
+  it('throws on `testing123` (alphanumeric follows `test`)', () => {
+    expect(() => validateTokenIsFake('testing123')).toThrow(/refusing to run/)
+  })
+
+  it('accepts `test-my-real-bot` (test- prefix: `-` is non-alphanumeric)', () => {
+    // `test-` matches because `-` is non-alphanumeric. Any `test-*` value is
+    // considered an explicit fake token — operators must use a non-test prefix
+    // for real tokens.
+    expect(() => validateTokenIsFake('test-my-real-bot')).not.toThrow()
+  })
+
+  it('throws on `fakery_real_token` (no fake-token prefix)', () => {
+    expect(() => validateTokenIsFake('fakery_real_token')).toThrow(/refusing to run/)
   })
 
   it('throws on a real-looking base64 token', () => {

--- a/packages/gateway/src/discord/test-token-guard.test.ts
+++ b/packages/gateway/src/discord/test-token-guard.test.ts
@@ -1,0 +1,30 @@
+import {describe, expect, it} from 'vitest'
+
+import {validateTokenIsFake} from './test-token-guard.js'
+
+describe('validateTokenIsFake', () => {
+  it('accepts undefined', () => {
+    expect(() => validateTokenIsFake(undefined)).not.toThrow()
+  })
+
+  it('accepts empty string', () => {
+    expect(() => validateTokenIsFake('')).not.toThrow()
+  })
+
+  it('accepts known-fake prefixes (case-insensitive)', () => {
+    expect(() => validateTokenIsFake('test-token-fake')).not.toThrow()
+    expect(() => validateTokenIsFake('fake')).not.toThrow()
+    expect(() => validateTokenIsFake('test')).not.toThrow()
+    expect(() => validateTokenIsFake('MOCK')).not.toThrow()
+    expect(() => validateTokenIsFake('Test-Token-Fake-12345')).not.toThrow()
+  })
+
+  it('throws on a real-looking base64 token', () => {
+    expect(() => validateTokenIsFake('MTIzNDU2.real-looking-base64.aBcDeF')).toThrow(/refusing to run/)
+  })
+
+  it('throws on arbitrary non-fake values', () => {
+    expect(() => validateTokenIsFake('Bot abc123')).toThrow(/refusing to run/)
+    expect(() => validateTokenIsFake('my-secret-token')).toThrow(/refusing to run/)
+  })
+})

--- a/packages/gateway/src/discord/test-token-guard.ts
+++ b/packages/gateway/src/discord/test-token-guard.ts
@@ -12,7 +12,7 @@ const FAKE_TOKEN_PATTERN = /^(?:test-token-fake|fake|test|MOCK)/i
  */
 export function validateTokenIsFake(token: string | undefined): void {
   if (token === undefined || token === '') return
-  if (FAKE_TOKEN_PATTERN.test(token)) return
+  if (FAKE_TOKEN_PATTERN.test(token) === true) return
   throw new Error(
     'refusing to run gateway client tests with what looks like a real DISCORD_TOKEN. ' +
       'Unset the env var or set it to a known-fake value (test-token-fake, fake, test, or MOCK).',

--- a/packages/gateway/src/discord/test-token-guard.ts
+++ b/packages/gateway/src/discord/test-token-guard.ts
@@ -1,4 +1,4 @@
-const FAKE_TOKEN_PATTERN = /^(?:test-token-fake|fake|test|MOCK)/i
+const FAKE_TOKEN_PATTERN = /^(?:test-token-fake|fake-token|mock-token|test)(?:[^a-z0-9]|$)/i
 
 /**
  * Refuses to let the gateway test suite run with what looks like a real Discord token.
@@ -6,15 +6,21 @@ const FAKE_TOKEN_PATTERN = /^(?:test-token-fake|fake|test|MOCK)/i
  * Accepts:
  *  - undefined (env var unset)
  *  - empty string
- *  - a string starting with `test-token-fake`, `fake`, `test`, or `MOCK` (case-insensitive)
+ *  - a string matching one of the explicit fake prefixes (case-insensitive):
+ *      - `test-token-fake` (exact prefix, then anything)
+ *      - `fake-token` (must include the `-token` suffix to avoid matching real tokens)
+ *      - `mock-token` (must include the `-token` suffix)
+ *      - `test` followed by a non-alphanumeric character or end of string
+ *        (so `test` and `test-` match, but `testing` and `test123` do not)
  *
- * Throws on anything else — including real-looking base64 tokens copy-pasted from a `.env`.
+ * Throws on anything else — including real-looking base64 tokens copy-pasted from a `.env`,
+ * and on bare `fake` or `MOCK` which are too short to be unambiguous.
  */
 export function validateTokenIsFake(token: string | undefined): void {
   if (token === undefined || token === '') return
   if (FAKE_TOKEN_PATTERN.test(token) === true) return
   throw new Error(
     'refusing to run gateway client tests with what looks like a real DISCORD_TOKEN. ' +
-      'Unset the env var or set it to a known-fake value (test-token-fake, fake, test, or MOCK).',
+      'Unset the env var or set it to a known-fake value (test-token-fake, fake-token, mock-token, or test).',
   )
 }

--- a/packages/gateway/src/discord/test-token-guard.ts
+++ b/packages/gateway/src/discord/test-token-guard.ts
@@ -1,0 +1,20 @@
+const FAKE_TOKEN_PATTERN = /^(?:test-token-fake|fake|test|MOCK)/i
+
+/**
+ * Refuses to let the gateway test suite run with what looks like a real Discord token.
+ *
+ * Accepts:
+ *  - undefined (env var unset)
+ *  - empty string
+ *  - a string starting with `test-token-fake`, `fake`, `test`, or `MOCK` (case-insensitive)
+ *
+ * Throws on anything else — including real-looking base64 tokens copy-pasted from a `.env`.
+ */
+export function validateTokenIsFake(token: string | undefined): void {
+  if (token === undefined || token === '') return
+  if (FAKE_TOKEN_PATTERN.test(token)) return
+  throw new Error(
+    'refusing to run gateway client tests with what looks like a real DISCORD_TOKEN. ' +
+      'Unset the env var or set it to a known-fake value (test-token-fake, fake, test, or MOCK).',
+  )
+}

--- a/packages/gateway/src/main.test.ts
+++ b/packages/gateway/src/main.test.ts
@@ -1,0 +1,82 @@
+import type {GatewayLogger} from './discord/client.js'
+
+import {GatewayIntentBits} from 'discord.js'
+import {describe, expect, it, vi} from 'vitest'
+
+// Prevent the top-level Effect.runPromise(program) in main.ts from executing
+// when the module is imported. The program tries to load config from env vars
+// and call process.exit(1) on failure — both are unwanted in tests.
+vi.mock('effect', async importOriginal => {
+  const actual = await importOriginal<typeof import('effect')>()
+  return {
+    ...actual,
+    Effect: {
+      ...actual.Effect,
+      runPromise: vi.fn().mockResolvedValue(undefined),
+    },
+  }
+})
+
+// Spy on createDiscordClient so we can assert the intents wiring without
+// touching the network or requiring a real Discord token.
+vi.mock('./discord/client.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./discord/client.js')>()
+  return {
+    ...actual,
+    createDiscordClient: vi.fn(actual.createDiscordClient),
+  }
+})
+
+const {makeDiscordClientFromConfig} = await import('./main.js')
+const {createDiscordClient} = await import('./discord/client.js')
+const createDiscordClientSpy = vi.mocked(createDiscordClient)
+
+const stubLogger: GatewayLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}
+
+describe('makeDiscordClientFromConfig', () => {
+  it('passes empty privilegedIntents to createDiscordClient (common case after posture flip)', () => {
+    // #given a config with no privileged intents opted in
+    const config = {privilegedIntents: [] as readonly GatewayIntentBits[]}
+
+    // #when
+    makeDiscordClientFromConfig(config, stubLogger)
+
+    // #then createDiscordClient receives intents: [] — not the bare {logger} form
+    expect(createDiscordClientSpy).toHaveBeenCalledWith({intents: [], logger: stubLogger})
+  })
+
+  it('passes [MessageContent] to createDiscordClient when opted in', () => {
+    // #given
+    const config = {privilegedIntents: [GatewayIntentBits.MessageContent] as const}
+
+    // #when
+    makeDiscordClientFromConfig(config, stubLogger)
+
+    // #then
+    expect(createDiscordClientSpy).toHaveBeenCalledWith({
+      intents: [GatewayIntentBits.MessageContent],
+      logger: stubLogger,
+    })
+  })
+
+  it('passes [MessageContent, GuildMembers] to createDiscordClient when both are opted in', () => {
+    // #given
+    const config = {
+      privilegedIntents: [GatewayIntentBits.MessageContent, GatewayIntentBits.GuildMembers] as const,
+    }
+
+    // #when
+    makeDiscordClientFromConfig(config, stubLogger)
+
+    // #then
+    expect(createDiscordClientSpy).toHaveBeenCalledWith({
+      intents: [GatewayIntentBits.MessageContent, GatewayIntentBits.GuildMembers],
+      logger: stubLogger,
+    })
+  })
+})

--- a/packages/gateway/src/main.ts
+++ b/packages/gateway/src/main.ts
@@ -1,4 +1,4 @@
-import type {ChatInputCommandInteraction, Message} from 'discord.js'
+import type {ChatInputCommandInteraction, GatewayIntentBits, Message} from 'discord.js'
 import type {GatewayLogger} from './discord/client.js'
 
 import process from 'node:process'
@@ -43,6 +43,19 @@ function makeLogger(level: 'debug' | 'info' | 'warn' | 'error'): GatewayLogger {
 }
 
 // ---------------------------------------------------------------------------
+// Composition helper — exported for unit testing only.
+// Keeps the wiring between GatewayConfig.privilegedIntents and
+// createDiscordClient() explicit and independently verifiable.
+// ---------------------------------------------------------------------------
+
+export function makeDiscordClientFromConfig(
+  config: {privilegedIntents: readonly GatewayIntentBits[]},
+  logger: GatewayLogger,
+): ReturnType<typeof createDiscordClient> {
+  return createDiscordClient({intents: config.privilegedIntents, logger})
+}
+
+// ---------------------------------------------------------------------------
 // Main Effect program
 // ---------------------------------------------------------------------------
 
@@ -57,7 +70,7 @@ const program = Effect.gen(function* () {
   const logger = makeLogger(config.logLevel)
 
   // c. Create Discord client
-  const client = createDiscordClient({intents: config.privilegedIntents, logger})
+  const client = makeDiscordClientFromConfig(config, logger)
 
   // c2. Set up readiness flag — clears stale flag, registers clientReady listener.
   //     Must run BEFORE client.login() so the event cannot be missed.

--- a/packages/gateway/src/main.ts
+++ b/packages/gateway/src/main.ts
@@ -57,7 +57,7 @@ const program = Effect.gen(function* () {
   const logger = makeLogger(config.logLevel)
 
   // c. Create Discord client
-  const client = createDiscordClient({intents: [...config.privilegedIntents], logger})
+  const client = createDiscordClient({intents: config.privilegedIntents, logger})
 
   // c2. Set up readiness flag — clears stale flag, registers clientReady listener.
   //     Must run BEFORE client.login() so the event cannot be missed.

--- a/packages/gateway/src/main.ts
+++ b/packages/gateway/src/main.ts
@@ -57,7 +57,7 @@ const program = Effect.gen(function* () {
   const logger = makeLogger(config.logLevel)
 
   // c. Create Discord client
-  const client = createDiscordClient({logger})
+  const client = createDiscordClient({intents: [...config.privilegedIntents], logger})
 
   // c2. Set up readiness flag — clears stale flag, registers clientReady listener.
   //     Must run BEFORE client.login() so the event cannot be missed.

--- a/packages/gateway/src/runtime-effect.test.ts
+++ b/packages/gateway/src/runtime-effect.test.ts
@@ -122,7 +122,7 @@ describe('acquireLockEffect', () => {
   // #given underlying returns failure Result
   // #when Effect runs
   // #then fails with the error
-  // eslint-disable-next-line vitest/expect-expect
+
   it('fails with error when Result is failure', async () => {
     vi.mocked(acquireLock).mockResolvedValue(err(new Error('lock conflict')))
 
@@ -135,7 +135,7 @@ describe('acquireLockEffect', () => {
   // #given underlying throws
   // #when Effect runs
   // #then fails with wrapped error
-  // eslint-disable-next-line vitest/expect-expect
+
   it('fails when underlying function throws', async () => {
     vi.mocked(acquireLock).mockRejectedValue(new Error('network error'))
 
@@ -145,7 +145,6 @@ describe('acquireLockEffect', () => {
     )
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('preserves the error message when Result is failure', async () => {
     vi.mocked(acquireLock).mockResolvedValue(err(new Error('lock conflict')))
 
@@ -155,7 +154,6 @@ describe('acquireLockEffect', () => {
     )
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('wraps non-Error rejections into an Error instance', async () => {
     vi.mocked(acquireLock).mockRejectedValue('oops')
 
@@ -178,14 +176,12 @@ describe('releaseLockEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success'})
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails with error when Result is failure', async () => {
     vi.mocked(releaseLock).mockResolvedValue(err(new Error('delete failed')))
 
     await assertEffectFailsWith(releaseLockEffect(config, 'repo', 'etag-1', coordLogger), 'delete failed')
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(releaseLock).mockRejectedValue(new Error('boom'))
 
@@ -217,7 +213,6 @@ describe('renewLeaseEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: {etag: 'new-etag'}})
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails with error when Result is failure', async () => {
     vi.mocked(renewLease).mockResolvedValue(err(new Error('precondition failed')))
 
@@ -227,7 +222,6 @@ describe('renewLeaseEffect', () => {
     )
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(renewLease).mockRejectedValue('string error')
 
@@ -250,14 +244,12 @@ describe('forceReleaseLockEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success'})
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails with error when Result is failure', async () => {
     vi.mocked(forceReleaseLock).mockResolvedValue(err(new Error('force delete failed')))
 
     await assertEffectFailsWith(forceReleaseLockEffect(config, 'repo', 'etag-1', coordLogger), 'force delete failed')
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(forceReleaseLock).mockRejectedValue(new Error('boom'))
 
@@ -292,14 +284,12 @@ describe('createRunEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: {etag: 'etag-1'}})
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails with error when Result is failure', async () => {
     vi.mocked(createRun).mockResolvedValue(err(new Error('already exists')))
 
     await assertEffectFailsWith(createRunEffect(config, 'identity', 'repo', runState, coordLogger), 'already exists')
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(createRun).mockRejectedValue(new Error('network'))
 
@@ -336,7 +326,6 @@ describe('transitionRunEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: {etag: 'etag-2', state: {phase: 'ACKNOWLEDGED'}}})
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails with error when Result is failure', async () => {
     vi.mocked(transitionRun).mockResolvedValue(err(new Error('invalid transition')))
 
@@ -346,7 +335,6 @@ describe('transitionRunEffect', () => {
     )
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(transitionRun).mockRejectedValue(new Error('timeout'))
 
@@ -372,14 +360,12 @@ describe('findStaleRunsEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: []})
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails with error when Result is failure', async () => {
     vi.mocked(findStaleRuns).mockResolvedValue(err(new Error('list failed')))
 
     await assertEffectFailsWith(findStaleRunsEffect(config, 'identity', 'repo', coordLogger), 'list failed')
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(findStaleRuns).mockRejectedValue(new Error('boom'))
 
@@ -402,14 +388,12 @@ describe('validateProviderSemanticsEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success'})
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails with error when Result is failure', async () => {
     vi.mocked(validateProviderSemantics).mockResolvedValue(err(new Error('semantics check failed')))
 
     await assertEffectFailsWith(validateProviderSemanticsEffect(config, coordLogger), 'semantics check failed')
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(validateProviderSemantics).mockRejectedValue(new Error('provider unreachable'))
 
@@ -434,7 +418,6 @@ describe('syncSessionsToStoreEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: {uploaded: 2, failed: 0}})
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(syncSessionsToStore).mockRejectedValue(new Error('upload error'))
 
@@ -458,7 +441,6 @@ describe('syncSessionsFromStoreEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: {downloaded: 3, failed: 0, mainDbRestored: true}})
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(syncSessionsFromStore).mockRejectedValue(new Error('download error'))
 
@@ -482,7 +464,6 @@ describe('syncArtifactsToStoreEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: {uploaded: 1, failed: 0}})
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(syncArtifactsToStore).mockRejectedValue(new Error('artifact error'))
 
@@ -506,7 +487,6 @@ describe('syncMetadataToStoreEffect', () => {
     expect(exit).toMatchObject({_tag: 'Success', value: {success: true}})
   })
 
-  // eslint-disable-next-line vitest/expect-expect
   it('fails when underlying function throws', async () => {
     vi.mocked(syncMetadataToStore).mockRejectedValue(new Error('metadata error'))
 


### PR DESCRIPTION
Closes #646.

## What changes

The Discord gateway's default intent set drops to the non-privileged baseline (`Guilds` + `GuildMessages`). The two privileged intents — `MessageContent` and `GuildMembers` — become opt-in via a single env var.

```sh
# Opt in to either or both privileged intents
DISCORD_PRIVILEGED_INTENTS=MessageContent,GuildMembers
```

Allowed values are exactly those two, case-sensitive, comma-separated, whitespace-tolerant. An unknown token (typo, wrong case, or any other intent name) fails the gateway at startup with an operator-friendly error naming the bad value and listing what's allowed. The matching `DISCORD_PRIVILEGED_INTENTS_FILE` secret-file fallback comes for free from `readOptionalSecret`.

`createDiscordClient` keeps its `Set`-based merge — `DEFAULT_INTENTS` is just smaller now. Callers that opt in via the new env var get their privileged intents composed on top of the baseline; callers that don't run with the minimum needed for slash commands and @-mention events.

## Why

Discord marks `MessageContent` and `GuildMembers` privileged because they grant broad-scope reads against guild data. Until now the gateway requested both unconditionally even though the runtime workload (slash commands, @-mention responses in guild channels) doesn't need either. Flipping the default narrows the blast radius for every deployment that doesn't have a content-reading reason to ask for them.

## Migration

Existing deployments that depend on the privileged intents must set `DISCORD_PRIVILEGED_INTENTS=MessageContent,GuildMembers` (or whichever subset they actually use) on next deploy. Without it, the bot stays connected and serves mentions in guild channels but stops receiving message content and full member lists.

## Notes

- `validateTokenIsFake` is a small test-only guard: a `beforeAll` in `client.test.ts` refuses to run the suite when `DISCORD_TOKEN` looks like a real token, catching the common case of a `.env` accidentally sourced into a dev shell.
- The privileged-intent allowlist uses `Object.prototype.hasOwnProperty.call` rather than `in` so prototype-property tokens (`constructor`, `__proto__`, etc.) hit the explicit error path instead of leaking into Discord client construction.
- `DiscordClientOptions.intents` and `DEFAULT_INTENTS` are now `readonly GatewayIntentBits[]`, which lets `main.ts` pass `config.privilegedIntents` directly without a defensive spread.
- New operator documentation lives in `packages/gateway/AGENTS.md` under `## Configuration knobs`.

## Verification

- Gateway tests: 101 → 126 (+25)
- Lint and type-check clean
- Two follow-up todos are tracked locally:
  - Add a regression test proving `main.ts` threads `config.privilegedIntents` into `createDiscordClient`.
  - Plumb `DISCORD_PRIVILEGED_INTENTS_FILE` through `deploy/compose.yaml` with `bind.create_host_path: false`, matching the other secret-file mounts.
