### PR TITLE
fix(gateway): plumb DISCORD_PRIVILEGED_INTENTS through compose

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -68,6 +68,13 @@ touch deploy/secrets/aws-session-token
 # Leave the file empty (or omit the echo) to register slash commands globally instead:
 touch deploy/secrets/discord-guild-id
 # echo -n 'YOUR_GUILD_ID' > deploy/secrets/discord-guild-id
+# Optional — opt into Discord privileged intents. Leave the file empty
+# to use the non-privileged baseline (Guilds + GuildMessages only). Set
+# the contents to a comma-separated list of `MessageContent` and/or
+# `GuildMembers` to opt in. Operators rotating intents must restart
+# the gateway after writing the new value.
+touch deploy/secrets/discord-privileged-intents
+# echo -n 'MessageContent,GuildMembers' > deploy/secrets/discord-privileged-intents
 
 chmod 0600 deploy/secrets/*
 ```
@@ -131,6 +138,25 @@ The gateway container is considered healthy only after two conditions are both t
 2. The daemon process (PID 1) is still alive (`kill -0 1`).
 
 The flag is cleared at process startup, so a stale `/var/run/fro-bot/gateway-ready` from a prior container run cannot mask a current-run failure. `docker compose up --wait` blocks until the gateway is genuinely connected to Discord before returning.
+
+## Upgrading existing deployments
+
+The compose stack bind-mounts each secret file individually with `create_host_path: false`. A missing source file produces a clear `docker compose up` error instead of silently materializing as a directory. This is the fail-fast diagnostic — but it means **every time the compose stack adds a new optional secret, existing deployments must `touch` the new file before their next `docker compose up`**.
+
+Run the full `touch` block from [Create secrets](#2-create-secrets) on every upgrade. It is idempotent: `touch` on an existing file is a no-op, but a missing file gets created empty. Empty files mean "secret not set", which is the same as the file being absent — the gateway treats both as opt-out.
+
+### Current optional secrets
+
+| Secret file | Purpose | When added |
+| --- | --- | --- |
+| `deploy/secrets/discord-guild-id` | Guild-scoped slash command registration (propagates in ~5 s vs up to 1 h globally) | Initial compose layout |
+| `deploy/secrets/discord-privileged-intents` | Discord privileged intents opt-in (`MessageContent`, `GuildMembers`) | Added later; existing deployments must `touch` this on upgrade |
+| `deploy/secrets/aws-access-key-id` | AWS access key for explicit S3 authentication | Deploy-contract hardening; existing deployments must `touch` this on upgrade |
+| `deploy/secrets/aws-secret-access-key` | AWS secret key for explicit S3 authentication | Deploy-contract hardening; existing deployments must `touch` this on upgrade |
+| `deploy/secrets/aws-session-token` | AWS session token for STS temporary credentials | Deploy-contract hardening; existing deployments must `touch` this on upgrade |
+| `deploy/secrets/s3-endpoint` | Custom S3-compatible endpoint (e.g. Cloudflare R2) | Deploy-contract hardening; existing deployments must `touch` this on upgrade |
+
+When a new optional secret is added to `compose.yaml` in the future, add a row here so operators know what to `touch` on their next upgrade.
 
 ## Stopping the Stack
 

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -25,6 +25,8 @@ services:
       AWS_SESSION_TOKEN_FILE: /run/secrets/aws_session_token
       # Optional — guild-scoped slash command registration (fast dev propagation)
       DISCORD_GUILD_ID_FILE: /run/secrets/discord_guild_id
+      # Optional — opt into Discord privileged intents (MessageContent, GuildMembers)
+      DISCORD_PRIVILEGED_INTENTS_FILE: /run/secrets/discord_privileged_intents
       # Egress proxy (regular proxy mode — NOT transparent)
       HTTPS_PROXY: http://mitmproxy:8080
       HTTP_PROXY: http://mitmproxy:8080
@@ -92,6 +94,15 @@ services:
       - type: bind
         source: ./secrets/discord-guild-id
         target: /run/secrets/discord_guild_id
+        read_only: true
+        bind:
+          create_host_path: false
+      # Optional — Discord privileged intents (MessageContent, GuildMembers).
+      # Leave the file empty to use the non-privileged baseline (Guilds + GuildMessages only).
+      # Set the contents to a comma-separated list of intent names to opt in.
+      - type: bind
+        source: ./secrets/discord-privileged-intents
+        target: /run/secrets/discord_privileged_intents
         read_only: true
         bind:
           create_host_path: false


### PR DESCRIPTION
Completes the deploy-contract surface for the privileged-intents opt-in that landed in #651.

## What changes

The gateway has been reading `DISCORD_PRIVILEGED_INTENTS_FILE` since PR #651, but `deploy/compose.yaml` didn't pass it through. Operators using infra-as-code (the canonical consumer is `marcusrbrown/infra`) had to patch `compose.yaml` themselves or set the var on the host shell that runs `docker compose up`. Both worked but broke the "compose.yaml is the contract surface" expectation that the rest of the deploy contract holds.

This PR adds:

- `DISCORD_PRIVILEGED_INTENTS_FILE: /run/secrets/discord_privileged_intents` in the gateway service `environment:` block.
- A long-syntax bind mount with `create_host_path: false` (matching the pattern from #649), so missing source files cause a clear Compose error at `docker compose up` rather than silently materializing as directories.
- A `touch deploy/secrets/discord-privileged-intents` step in `deploy/README.md`, alongside the other optional Discord secrets.
- A new `## Upgrading existing deployments` section in the README that documents the touch-on-upgrade requirement for new optional secrets, with a current inventory of every optional secret in the stack and when each was introduced.

## Why

Consistency with the rest of the deploy contract. Operators following the README's setup steps now get the env var threaded into the container without extra work.

## Verification

- `docker compose -f deploy/compose.yaml config` validates.
- Gateway tests, lint, and type-check unchanged (no source code touched).

## Migration

Existing deployments must `touch deploy/secrets/discord-privileged-intents` before their next `docker compose up`. Without the file, Compose fails fast with a clear missing-source error. The new README section documents this explicitly so future optional secrets follow the same upgrade pattern.

Operators who never opt into privileged intents leave the file empty; an empty file is the same as the file being absent.
