### PR TITLE
fix(gateway): harden readiness lifecycle and secret validation

### DIFF
--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -221,6 +221,65 @@ describe('readOptionalSecret', () => {
   // fallback, EISDIR throws a clear error. There is no stat-then-read sequence, so no TOCTOU
   // window exists. The directory test below exercises the EISDIR path directly.
 
+  it('throws with a clear message when secret file contains embedded newline mid-value', () => {
+    // #given a file with an embedded newline (copy-paste from a wrapped terminal)
+    const secretFile = join(tmpDir, 'embedded-newline.txt')
+    writeFileSync(secretFile, 'AKIA\nIOSFODNN7EXAMPLE')
+    process.env.MISSING_FILE = secretFile
+
+    // #when / #then
+    expect(() => readOptionalSecret('MISSING')).toThrow(secretFile)
+    expect(() => readOptionalSecret('MISSING')).toThrow('contains embedded line-breaking characters')
+
+    delete process.env.MISSING_FILE
+  })
+
+  it('throws with a clear message when env var contains embedded newline mid-value', () => {
+    // #given an env var with an embedded newline (copy-paste with line-wrapping)
+    process.env.NEWLINE_SECRET = 'AKIA\nIOSFODNN7EXAMPLE'
+
+    // #when / #then
+    expect(() => readOptionalSecret('NEWLINE_SECRET')).toThrow('NEWLINE_SECRET')
+    expect(() => readOptionalSecret('NEWLINE_SECRET')).toThrow('contains embedded line-breaking characters')
+
+    delete process.env.NEWLINE_SECRET
+  })
+
+  it('rejects env var with Unicode next-line character (U+0085)', () => {
+    // #given an env var with U+0085 (NEL) — line-breaking character not in basic [\r\n]
+    process.env.NEL_SECRET = 'AKIA\u0085IOSFODNN7EXAMPLE'
+
+    // #when / #then
+    expect(() => readOptionalSecret('NEL_SECRET')).toThrow('NEL_SECRET')
+    expect(() => readOptionalSecret('NEL_SECRET')).toThrow('contains embedded line-breaking characters')
+
+    delete process.env.NEL_SECRET
+  })
+
+  it('rejects secret file with embedded carriage return (U+000D)', () => {
+    // #given a file with U+000D (\r) — single CR without LF
+    const secretFile = join(tmpDir, 'cr.txt')
+    writeFileSync(secretFile, 'AKIA\rIOSFODNN7EXAMPLE')
+    process.env.CR_SECRET_FILE = secretFile
+
+    // #when / #then
+    expect(() => readOptionalSecret('CR_SECRET')).toThrow('contains embedded line-breaking characters')
+
+    delete process.env.CR_SECRET_FILE
+  })
+
+  it('rejects secret file with Unicode line separator (U+2028)', () => {
+    // #given a file with U+2028 — a character that bypasses the trivial [\r\n] check
+    const secretFile = join(tmpDir, 'u2028.txt')
+    writeFileSync(secretFile, 'AKIA\u2028IOSFODNN7EXAMPLE')
+    process.env.U2028_SECRET_FILE = secretFile
+
+    // #when / #then
+    expect(() => readOptionalSecret('U2028_SECRET')).toThrow('contains embedded line-breaking characters')
+
+    delete process.env.U2028_SECRET_FILE
+  })
+
   it('preserves leading whitespace in file contents', () => {
     // Some operators may legitimately have secrets with leading whitespace
     // (e.g. tokens copied from a UI that quoted with leading padding).

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -72,12 +72,23 @@ export function readOptionalSecret(name: string): string | null {
       // in valid secrets is preserved — matching the env-var path which uses raw process.env[name].
       // Treat whitespace-only or empty files as "not set" (e.g. empty bind-mounted optional secrets).
       const trailingTrimmed = contents.trimEnd()
-      return trailingTrimmed.trim() === '' ? null : trailingTrimmed
+      if (trailingTrimmed.trim() === '') return null
+      if (/[\r\n\u0085\u2028\u2029]/.test(trailingTrimmed)) {
+        throw new Error(
+          `Secret value at ${filePath} contains embedded line-breaking characters — likely a copy-paste with line-wrapping. Remove the line break and rewrite the file as a single line.`,
+        )
+      }
+      return trailingTrimmed
     }
   }
 
   const value = process.env[name]
   if (value !== undefined && value.trim() !== '') {
+    if (/[\r\n\u0085\u2028\u2029]/.test(value)) {
+      throw new Error(
+        `Environment variable ${name} contains embedded line-breaking characters — likely a copy-paste with line-wrapping. Remove the line break and set it as a single line.`,
+      )
+    }
     return value
   }
 

--- a/packages/gateway/src/main.test.ts
+++ b/packages/gateway/src/main.test.ts
@@ -1,3 +1,4 @@
+import type {GatewayConfig} from './config.js'
 import type {GatewayLogger} from './discord/client.js'
 
 import {GatewayIntentBits} from 'discord.js'
@@ -27,7 +28,16 @@ vi.mock('./discord/client.js', async importOriginal => {
   }
 })
 
-const {makeDiscordClientFromConfig} = await import('./main.js')
+// Stub registerSlashCommands so makeGatewayProgram doesn't hit the network.
+vi.mock('./discord/commands/index.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./discord/commands/index.js')>()
+  return {
+    ...actual,
+    registerSlashCommands: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+const {makeDiscordClientFromConfig, makeGatewayProgram} = await import('./main.js')
 const {createDiscordClient} = await import('./discord/client.js')
 const createDiscordClientSpy = vi.mocked(createDiscordClient)
 
@@ -78,5 +88,65 @@ describe('makeDiscordClientFromConfig', () => {
       intents: [GatewayIntentBits.MessageContent, GatewayIntentBits.GuildMembers],
       logger: stubLogger,
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// makeGatewayProgram — startup ordering (Todo 018)
+// ---------------------------------------------------------------------------
+
+describe('makeGatewayProgram', () => {
+  it('calls setupReadinessFlag before login', async () => {
+    // #given
+    const fakeConfig: GatewayConfig = {
+      discordToken: 'test-token',
+      discordApplicationId: 'test-app-id',
+      discordGuildId: null,
+      identity: 'test-gateway',
+      logLevel: 'info',
+      privilegedIntents: [],
+      objectStore: {
+        enabled: true,
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+        prefix: 'test-prefix',
+      },
+    }
+
+    // Minimal fake client — just needs to satisfy the Client shape enough for
+    // setupReadinessFlag (on/once) and the event wiring in makeGatewayProgram.
+    const fakeClient = {
+      on: vi.fn().mockReturnThis(),
+      once: vi.fn().mockReturnThis(),
+      user: null,
+      login: vi.fn().mockResolvedValue('token'),
+    }
+
+    const setupReadinessFlagSpy = vi.fn()
+    const loginSpy = vi.fn().mockResolvedValue(undefined)
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: setupReadinessFlagSpy,
+      login: loginSpy,
+    }
+
+    // #when — run the program with the real Effect runtime (not the mocked runPromise).
+    // vi.importActual bypasses the module mock so we get the real runPromise.
+    const {Effect: ActualEffect} = await vi.importActual<typeof import('effect')>('effect')
+    await ActualEffect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then — setupReadinessFlag must have been called before login
+    expect(setupReadinessFlagSpy).toHaveBeenCalledTimes(1)
+    expect(loginSpy).toHaveBeenCalledTimes(1)
+
+    const setupOrder = setupReadinessFlagSpy.mock.invocationCallOrder[0]
+    const loginOrder = loginSpy.mock.invocationCallOrder[0]
+    expect(setupOrder).toBeDefined()
+    expect(loginOrder).toBeDefined()
+    if (setupOrder === undefined || loginOrder === undefined) {
+      throw new Error('invocationCallOrder missing — toBeDefined() should have caught this')
+    }
+    expect(setupOrder).toBeLessThan(loginOrder)
   })
 })

--- a/packages/gateway/src/main.ts
+++ b/packages/gateway/src/main.ts
@@ -1,4 +1,5 @@
-import type {ChatInputCommandInteraction, GatewayIntentBits, Message} from 'discord.js'
+import type {ChatInputCommandInteraction, Client, GatewayIntentBits, Message} from 'discord.js'
+import type {GatewayConfig} from './config.js'
 import type {GatewayLogger} from './discord/client.js'
 
 import process from 'node:process'
@@ -56,6 +57,77 @@ export function makeDiscordClientFromConfig(
 }
 
 // ---------------------------------------------------------------------------
+// Injectable deps interface — exported so tests can supply spies.
+// ---------------------------------------------------------------------------
+
+export interface GatewayProgramDeps {
+  readonly makeClient: (config: GatewayConfig, logger: GatewayLogger) => Client
+  readonly setupReadinessFlag: (client: Client, logger: GatewayLogger) => void
+  readonly login: (client: Client, token: string) => Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// Extracted program factory — exported for unit testing only.
+// Accepts injectable deps so tests can assert call ordering without touching
+// the network or requiring a real Discord token.
+// ---------------------------------------------------------------------------
+
+export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConfig): Effect.Effect<void, Error> {
+  return Effect.gen(function* () {
+    // b. Create logger
+    const logger = makeLogger(config.logLevel)
+
+    // c. Create Discord client
+    const client = deps.makeClient(config, logger)
+
+    // c2. Set up readiness flag — clears stale flag, registers clientReady listener.
+    //     Must run BEFORE client.login() so the event cannot be missed.
+    yield* Effect.sync(() => deps.setupReadinessFlag(client, logger))
+
+    // d. Build command registry
+    const registry = getCommandRegistry()
+
+    // e. Register slash commands
+    yield* Effect.tryPromise({
+      try: async () =>
+        registerSlashCommands(config.discordToken, config.discordApplicationId, config.discordGuildId, registry),
+      catch: error => (error instanceof Error ? error : new Error(String(error))),
+    })
+
+    // f. Wire client events
+    client.on('interactionCreate', interaction => {
+      if (!interaction.isChatInputCommand()) return
+      // isChatInputCommand() narrows to ChatInputCommandInteraction — cast is safe.
+      const cmd = interaction as unknown as ChatInputCommandInteraction
+      Effect.runPromise(dispatchCommand(cmd, registry)).catch((error: unknown) => {
+        logger.error({err: error, commandName: cmd.commandName}, 'command dispatch failed')
+      })
+    })
+
+    client.on('messageCreate', (message: Message) => {
+      if (message.author.bot) return
+      if (client.user === null) return
+      if (!message.mentions.has(client.user.id)) return
+      Effect.runPromise(handleMention(message, client.user.id)).catch((error: unknown) => {
+        logger.error({err: error}, 'mention handler failed')
+      })
+    })
+
+    // g. Install shutdown handlers
+    installShutdownHandlers(client, logger)
+
+    // h. Login
+    yield* Effect.tryPromise({
+      try: async () => deps.login(client, config.discordToken),
+      catch: error => (error instanceof Error ? error : new Error(String(error))),
+    })
+
+    // i. Log startup
+    logger.info({applicationId: config.discordApplicationId}, 'gateway started')
+  })
+}
+
+// ---------------------------------------------------------------------------
 // Main Effect program
 // ---------------------------------------------------------------------------
 
@@ -66,56 +138,16 @@ const program = Effect.gen(function* () {
     catch: error => (error instanceof Error ? error : new Error(String(error))),
   })
 
-  // b. Create logger
-  const logger = makeLogger(config.logLevel)
-
-  // c. Create Discord client
-  const client = makeDiscordClientFromConfig(config, logger)
-
-  // c2. Set up readiness flag — clears stale flag, registers clientReady listener.
-  //     Must run BEFORE client.login() so the event cannot be missed.
-  yield* Effect.sync(() => setupReadinessFlag(client, logger))
-
-  // d. Build command registry
-  const registry = getCommandRegistry()
-
-  // e. Register slash commands
-  yield* Effect.tryPromise({
-    try: async () =>
-      registerSlashCommands(config.discordToken, config.discordApplicationId, config.discordGuildId, registry),
-    catch: error => (error instanceof Error ? error : new Error(String(error))),
-  })
-
-  // f. Wire client events
-  client.on('interactionCreate', interaction => {
-    if (!interaction.isChatInputCommand()) return
-    // isChatInputCommand() narrows to ChatInputCommandInteraction — cast is safe.
-    const cmd = interaction as unknown as ChatInputCommandInteraction
-    Effect.runPromise(dispatchCommand(cmd, registry)).catch((error: unknown) => {
-      logger.error({err: error, commandName: cmd.commandName}, 'command dispatch failed')
-    })
-  })
-
-  client.on('messageCreate', (message: Message) => {
-    if (message.author.bot) return
-    if (client.user === null) return
-    if (!message.mentions.has(client.user.id)) return
-    Effect.runPromise(handleMention(message, client.user.id)).catch((error: unknown) => {
-      logger.error({err: error}, 'mention handler failed')
-    })
-  })
-
-  // g. Install shutdown handlers
-  installShutdownHandlers(client, logger)
-
-  // h. Login
-  yield* Effect.tryPromise({
-    try: async () => client.login(config.discordToken),
-    catch: error => (error instanceof Error ? error : new Error(String(error))),
-  })
-
-  // i. Log startup
-  logger.info({applicationId: config.discordApplicationId}, 'gateway started')
+  yield* makeGatewayProgram(
+    {
+      makeClient: makeDiscordClientFromConfig,
+      setupReadinessFlag,
+      login: async (client, token) => {
+        await client.login(token)
+      },
+    },
+    config,
+  )
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/readiness.test.ts
+++ b/packages/gateway/src/readiness.test.ts
@@ -25,27 +25,40 @@ function makeLogger(): {logger: GatewayLogger; calls: {method: string; ctx: Reco
 }
 
 /**
- * Minimal ReadinessClient mock that captures the `clientReady` callback so
- * tests can simulate the event by invoking it directly.
+ * Minimal ReadinessClient mock that captures listeners registered via `on`
+ * so tests can simulate events by invoking them directly.
  */
-function makeClient(): {client: ReadinessClient; fireClientReady: () => void} {
-  let capturedCallback: (() => void) | undefined
+function makeClient(): {
+  client: ReadinessClient
+  fireClientReady: () => void
+  fireShardReady: () => void
+  fireShardResume: () => void
+  fireShardDisconnect: () => void
+} {
+  const listeners: {event: string; listener: (...args: unknown[]) => void}[] = []
 
   const client: ReadinessClient = {
-    once: (event: 'clientReady', listener: () => void) => {
-      if (event === 'clientReady') {
-        capturedCallback = listener
-      }
+    on: (
+      event: 'clientReady' | 'shardReady' | 'shardResume' | 'shardDisconnect',
+      listener: (...args: unknown[]) => void,
+    ) => {
+      listeners.push({event, listener})
       return client
     },
   }
 
+  const fire = (event: string) => {
+    for (const entry of listeners) {
+      if (entry.event === event) entry.listener()
+    }
+  }
+
   return {
     client,
-    fireClientReady: () => {
-      if (capturedCallback === undefined) throw new Error('clientReady listener was never registered')
-      capturedCallback()
-    },
+    fireClientReady: () => fire('clientReady'),
+    fireShardReady: () => fire('shardReady'),
+    fireShardResume: () => fire('shardResume'),
+    fireShardDisconnect: () => fire('shardDisconnect'),
   }
 }
 
@@ -96,15 +109,17 @@ describe('setupReadinessFlag', () => {
     // Pre-create a stale flag
     writeFileSync(flagPath, 'stale', {mode: 0o600})
 
-    // Capture filesystem state at the exact moment once() is called
+    // Capture filesystem state at the exact moment on() is called
     let flagExistedAtRegistration: boolean | undefined
 
     const {client} = makeClient()
-    const originalOnce = client.once.bind(client)
-    vi.spyOn(client, 'once').mockImplementation((event, listener) => {
-      // Record whether the flag still exists when the listener is being registered
-      flagExistedAtRegistration = existsSync(flagPath)
-      return originalOnce(event, listener)
+    const originalOn = client.on.bind(client)
+    vi.spyOn(client, 'on').mockImplementation((event, listener) => {
+      // Record whether the flag still exists when the first listener is being registered
+      if (flagExistedAtRegistration === undefined) {
+        flagExistedAtRegistration = existsSync(flagPath)
+      }
+      return originalOn(event, listener)
     })
 
     setupReadinessFlag(client, logger, flagPath)
@@ -130,7 +145,7 @@ describe('setupReadinessFlag', () => {
   })
 
   // #given clientReady fires
-  // #then logger.info is called with 'gateway ready'
+  // #then logger.info is called with 'wrote gateway-ready flag'
   it('logs info when the flag is written successfully', () => {
     const {logger, calls} = makeLogger()
     const {client, fireClientReady} = makeClient()
@@ -138,7 +153,7 @@ describe('setupReadinessFlag', () => {
     setupReadinessFlag(client, logger, flagPath)
     fireClientReady()
 
-    const infoCalls = calls.filter(c => c.method === 'info' && c.msg === 'gateway ready')
+    const infoCalls = calls.filter(c => c.method === 'info' && c.msg === 'wrote gateway-ready flag')
     expect(infoCalls).toHaveLength(1)
   })
 
@@ -157,5 +172,161 @@ describe('setupReadinessFlag', () => {
     const errorCalls = calls.filter(c => c.method === 'error')
     expect(errorCalls).toHaveLength(1)
     expect(errorCalls[0]?.msg).toBe('failed to write gateway-ready flag')
+  })
+
+  // ---------------------------------------------------------------------------
+  // Transition tests (Todo 019)
+  // ---------------------------------------------------------------------------
+
+  // #given clientReady fires (flag written), then shardDisconnect fires
+  // #then flag is deleted after disconnect
+  it('ready → disconnect: writes flag on clientReady, then deletes it on shardDisconnect', () => {
+    const {logger} = makeLogger()
+    const {client, fireClientReady, fireShardDisconnect} = makeClient()
+
+    setupReadinessFlag(client, logger, flagPath)
+
+    // Simulate connection
+    fireClientReady()
+    expect(existsSync(flagPath)).toBe(true)
+
+    // Simulate disconnect
+    fireShardDisconnect()
+    expect(existsSync(flagPath)).toBe(false)
+  })
+
+  // #given clientReady → shardDisconnect → clientReady (reconnect)
+  // #then flag is written both times clientReady fires
+  it('disconnect → ready: re-writes flag on reconnect after disconnect', () => {
+    const {logger} = makeLogger()
+    const {client, fireClientReady, fireShardDisconnect} = makeClient()
+
+    setupReadinessFlag(client, logger, flagPath)
+
+    // First connection
+    fireClientReady()
+    expect(existsSync(flagPath)).toBe(true)
+
+    // Disconnect
+    fireShardDisconnect()
+    expect(existsSync(flagPath)).toBe(false)
+
+    // Reconnect — flag must be re-written
+    fireClientReady()
+    expect(existsSync(flagPath)).toBe(true)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Fix 2: shardReady and shardResume re-arm the healthcheck
+  // ---------------------------------------------------------------------------
+
+  // #given a disconnect followed by shardResume (session resumed)
+  // #when shardResume fires
+  // #then the flag is re-written
+  it('shardResume re-writes the flag after a disconnect', () => {
+    const {logger} = makeLogger()
+    const {client, fireClientReady, fireShardDisconnect, fireShardResume} = makeClient()
+
+    setupReadinessFlag(client, logger, flagPath)
+
+    // Establish initial ready state
+    fireClientReady()
+    expect(existsSync(flagPath)).toBe(true)
+
+    // Disconnect clears the flag
+    fireShardDisconnect()
+    expect(existsSync(flagPath)).toBe(false)
+
+    // Session resumes — flag must be re-written
+    fireShardResume()
+    expect(existsSync(flagPath)).toBe(true)
+  })
+
+  // #given a disconnect followed by shardReady (new session)
+  // #when shardReady fires
+  // #then the flag is re-written
+  it('shardReady re-writes the flag after a disconnect', () => {
+    const {logger} = makeLogger()
+    const {client, fireClientReady, fireShardDisconnect, fireShardReady} = makeClient()
+
+    setupReadinessFlag(client, logger, flagPath)
+
+    // Establish initial ready state
+    fireClientReady()
+    expect(existsSync(flagPath)).toBe(true)
+
+    // Disconnect clears the flag
+    fireShardDisconnect()
+    expect(existsSync(flagPath)).toBe(false)
+
+    // New shard session — flag must be re-written
+    fireShardReady()
+    expect(existsSync(flagPath)).toBe(true)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Cold-start: shardReady / shardResume without a prior clientReady
+  // ---------------------------------------------------------------------------
+
+  // #given no prior clientReady — common in multi-shard setups where shardReady fires first
+  // #when shardReady fires
+  // #then the flag is written
+  it('cold start: shardReady writes the flag without a prior clientReady', () => {
+    // #given no prior clientReady — common in multi-shard setups where shardReady fires first
+    const {logger, calls} = makeLogger()
+    const {client, fireShardReady} = makeClient()
+
+    setupReadinessFlag(client, logger, flagPath)
+
+    // #when
+    fireShardReady()
+
+    // #then flag is written
+    expect(existsSync(flagPath)).toBe(true)
+    const infoCalls = calls.filter(c => c.method === 'info' && c.msg === 'wrote gateway-ready flag')
+    expect(infoCalls).toHaveLength(1)
+    expect(infoCalls[0]?.ctx.origin).toBe('shardReady')
+  })
+
+  // #given no prior clientReady — possible if a resumed session lands before clientReady is emitted
+  // #when shardResume fires
+  // #then the flag is written
+  it('cold start: shardResume writes the flag without a prior clientReady', () => {
+    // #given no prior clientReady — possible if a resumed session lands before clientReady is emitted
+    const {logger, calls} = makeLogger()
+    const {client, fireShardResume} = makeClient()
+
+    setupReadinessFlag(client, logger, flagPath)
+
+    // #when
+    fireShardResume()
+
+    // #then flag is written
+    expect(existsSync(flagPath)).toBe(true)
+    const infoCalls = calls.filter(c => c.method === 'info' && c.msg === 'wrote gateway-ready flag')
+    expect(infoCalls).toHaveLength(1)
+    expect(infoCalls[0]?.ctx.origin).toBe('shardResume')
+  })
+
+  // ---------------------------------------------------------------------------
+  // Fix 5: Disconnect ENOENT branch untested
+  // ---------------------------------------------------------------------------
+
+  // #given the flag does not exist (no prior write)
+  // #when shardDisconnect fires
+  // #then no throw and no error log
+  it('shardDisconnect when flag is already absent: no throw, no error log', () => {
+    const {logger, calls} = makeLogger()
+    const {client, fireShardDisconnect} = makeClient()
+
+    // Flag does not exist (no prior write).
+    setupReadinessFlag(client, logger, flagPath)
+
+    // Fire disconnect — unlink should hit ENOENT and silently return.
+    expect(() => fireShardDisconnect()).not.toThrow()
+
+    // No error-level log should have been emitted.
+    const errorCalls = calls.filter(c => c.method === 'error')
+    expect(errorCalls).toHaveLength(0)
   })
 })

--- a/packages/gateway/src/readiness.ts
+++ b/packages/gateway/src/readiness.ts
@@ -10,6 +10,11 @@ import process from 'node:process'
 // Discord `clientReady` event fires (i.e. the bot is fully connected and
 // ready to receive events). It is cleared at process startup so a stale flag
 // from a prior process cannot mask a current-run failure.
+//
+// Re-arm behaviour: `clientReady`, `shardReady`, and `shardResume` all write
+// the flag so reconnects re-arm the healthcheck. `shardDisconnect` clears the
+// flag so the healthcheck goes red during a disconnect, preventing a stale
+// green from masking an outage.
 // ---------------------------------------------------------------------------
 
 /**
@@ -17,13 +22,20 @@ import process from 'node:process'
  * Avoids importing the full discord.js Client type in tests.
  */
 export interface ReadinessClient {
-  once: (event: 'clientReady', listener: () => void) => this
+  on: (
+    event: 'clientReady' | 'shardReady' | 'shardResume' | 'shardDisconnect',
+    listener: (...args: unknown[]) => void,
+  ) => this
 }
 
 /**
- * Clears any stale readiness flag from a prior process, then registers a
- * one-time `clientReady` listener that writes the flag when Discord confirms
- * the bot is fully connected.
+ * Clears any stale readiness flag from a prior process, then registers
+ * persistent listeners that write the flag on `clientReady`, `shardReady`,
+ * and `shardResume`, and clear it on `shardDisconnect`.
+ *
+ * Using `on` (not `once`) means reconnects re-write the flag and each
+ * disconnect clears it, keeping the healthcheck accurate across the full
+ * session lifetime.
  *
  * Must be called BEFORE `client.login()` so the event cannot be missed.
  *
@@ -48,13 +60,35 @@ export function setupReadinessFlag(
     }
   }
 
-  // Register the listener BEFORE login() so the event cannot be missed.
-  client.once('clientReady', () => {
+  const writeFlag = (origin: string): void => {
     try {
       writeFileSync(flagPath, '', {mode: 0o600})
-      logger.info({}, 'gateway ready')
+      logger.info({origin}, 'wrote gateway-ready flag')
     } catch (error) {
-      logger.error({err: error}, 'failed to write gateway-ready flag')
+      logger.error({err: error, origin}, 'failed to write gateway-ready flag')
     }
-  })
+  }
+
+  const clearFlag = (origin: string): void => {
+    try {
+      unlinkSync(flagPath)
+      logger.info({origin}, 'cleared gateway-ready flag')
+    } catch (error) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+        // Already absent — that's fine.
+        return
+      }
+      // Log and continue. Crashing the gateway during a disconnect is
+      // strictly worse than leaving the flag in place — the next disconnect
+      // or process exit will eventually clear it.
+      logger.error({err: error, origin}, 'failed to clear gateway-ready flag')
+    }
+  }
+
+  // Register listeners BEFORE login() so events cannot be missed.
+  // Use `on` (not `once`) so reconnects re-write the flag.
+  client.on('clientReady', () => writeFlag('clientReady'))
+  client.on('shardReady', () => writeFlag('shardReady'))
+  client.on('shardResume', () => writeFlag('shardResume'))
+  client.on('shardDisconnect', () => clearFlag('shardDisconnect'))
 }


### PR DESCRIPTION
Three reliability improvements that came out of PR #649's review cycle. They share the same scope (gateway lifecycle and config validation) and ship as one PR.

**Readiness flag now re-arms across the full Discord reconnect lifecycle.** Previously the flag was written once on `clientReady` and persisted for the rest of the process. After a permanent disconnect — rate-limit ban, gateway revocation, network partition past discord.js's retry budget — the healthcheck stayed green forever. discord.js v14 also only emits `clientReady` once per session; reconnects emit `shardResume` (session resumed) or `shardReady` (new session) instead. The fix listens on all four events: `clientReady`, `shardReady`, and `shardResume` write the flag; `shardDisconnect` clears it. Each log line includes an `origin` field so operators can tell which event re-armed the healthcheck.

Errors during `shardDisconnect` cleanup now log and continue instead of rethrowing. Crashing the gateway during the very disconnect we're trying to report is strictly worse than leaving a stale flag for one cycle.

**`readOptionalSecret` rejects values containing line-breaking characters.** AWS credentials copy-pasted from a wrapped terminal can carry mid-value newlines that pass `trimEnd` but break S3 request signing later with an opaque AWS signature error. The check applies symmetrically to file-read and env-var paths and covers `\r`, `\n`, U+0085 (NEL), U+2028 (LS), and U+2029 (PS). Errors point operators at the file path or env var name.

**`main.ts` exposes `makeGatewayProgram` as an injectable factory so startup ordering is observable from a unit test.** A reversal of `setupReadinessFlag` and `client.login` would silently reintroduce the stale-flag bug; the new ordering test fails fast if anyone moves the wiring.

Gateway tests grow from 87 to 145 across the three areas.
