### PR TITLE
fix(gateway): validate secret file paths before reading

### DIFF
--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -1,6 +1,6 @@
 import type {GatewayConfig} from './config.js'
 
-import {mkdtempSync, rmSync, writeFileSync} from 'node:fs'
+import {mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync} from 'node:fs'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 
@@ -212,14 +212,14 @@ describe('readOptionalSecret', () => {
     process.env.FAKE_DIR_FILE = dirPath
 
     // #when / #then
-    expect(() => readOptionalSecret('FAKE_DIR')).toThrow('Secret path is a directory, not a file:')
+    expect(() => readOptionalSecret('FAKE_DIR')).toThrow('not a regular file')
+    expect(() => readOptionalSecret('FAKE_DIR')).toThrow('directory')
 
     delete process.env.FAKE_DIR_FILE
   })
 
-  // readOptionalSecret uses a single readFileSync call — ENOENT falls through to the env-var
-  // fallback, EISDIR throws a clear error. There is no stat-then-read sequence, so no TOCTOU
-  // window exists. The directory test below exercises the EISDIR path directly.
+  // readOptionalSecret uses readSecretFile which lstat-checks before reading — ENOENT falls
+  // through to the env-var fallback; all other non-regular-file types throw immediately.
 
   it('throws with a clear message when secret file contains embedded newline mid-value', () => {
     // #given a file with an embedded newline (copy-paste from a wrapped terminal)
@@ -294,6 +294,87 @@ describe('readOptionalSecret', () => {
 
     // #then leading whitespace is preserved, trailing newline stripped
     expect(result).toBe('  some-value')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// readOptionalSecret — path validation (hardened readSecretFile)
+// ---------------------------------------------------------------------------
+
+describe('readOptionalSecret — path validation', () => {
+  let testDir: string
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'gateway-secret-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(testDir, {recursive: true, force: true})
+    delete process.env.PATH_TEST_FILE
+    delete process.env.PATH_TEST
+  })
+
+  it('rejects symlink to another file (does not follow)', () => {
+    // #given a symlink to a real file
+    const realFile = join(testDir, 'real.txt')
+    const symlinkPath = join(testDir, 'link.txt')
+    writeFileSync(realFile, 'AKIA-real-secret')
+    symlinkSync(realFile, symlinkPath)
+    process.env.PATH_TEST_FILE = symlinkPath
+
+    // #when / #then
+    expect(() => readOptionalSecret('PATH_TEST')).toThrow('not a regular file')
+    expect(() => readOptionalSecret('PATH_TEST')).toThrow('symlink')
+  })
+
+  it('rejects directory pointed at by _FILE env var', () => {
+    // #given a directory at the secret path
+    const dirPath = join(testDir, 'a-dir')
+    mkdirSync(dirPath)
+    process.env.PATH_TEST_FILE = dirPath
+
+    // #when / #then
+    expect(() => readOptionalSecret('PATH_TEST')).toThrow('not a regular file')
+    expect(() => readOptionalSecret('PATH_TEST')).toThrow('directory')
+  })
+
+  it('rejects file exceeding size limit', () => {
+    // #given a file > 4096 bytes
+    const largePath = join(testDir, 'large.txt')
+    writeFileSync(largePath, 'x'.repeat(5000))
+    process.env.PATH_TEST_FILE = largePath
+
+    // #when / #then
+    expect(() => readOptionalSecret('PATH_TEST')).toThrow('too large')
+    expect(() => readOptionalSecret('PATH_TEST')).toThrow('5000 bytes')
+  })
+
+  it('accepts file at exactly the size limit', () => {
+    // #given a file at exactly 4096 bytes
+    const limitPath = join(testDir, 'limit.txt')
+    writeFileSync(limitPath, 'x'.repeat(4096))
+    process.env.PATH_TEST_FILE = limitPath
+
+    // #when / #then
+    expect(readOptionalSecret('PATH_TEST')).toBe('x'.repeat(4096))
+  })
+
+  it('reports ENOENT through readOptionalSecret as null (env var fallback)', () => {
+    // #given a path that does not exist
+    process.env.PATH_TEST_FILE = join(testDir, 'missing.txt')
+    delete process.env.PATH_TEST
+
+    // #when / #then — falls through to env-var fallback, which is also unset → null
+    expect(readOptionalSecret('PATH_TEST')).toBe(null)
+  })
+
+  it('falls through to env-var fallback when _FILE points to nonexistent file but env var is set', () => {
+    // #given _FILE missing but env var set
+    process.env.PATH_TEST_FILE = join(testDir, 'missing.txt')
+    process.env.PATH_TEST = 'env-var-value'
+
+    // #when / #then — uses env var
+    expect(readOptionalSecret('PATH_TEST')).toBe('env-var-value')
   })
 })
 

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -1,6 +1,6 @@
 import type {AwsCredentials, ObjectStoreConfig} from './runtime-effect.js'
 
-import {readFileSync} from 'node:fs'
+import {closeSync, constants, fstatSync, openSync, readFileSync} from 'node:fs'
 import process from 'node:process'
 
 import {GatewayIntentBits} from 'discord.js'
@@ -23,6 +23,86 @@ export interface GatewayConfig {
   readonly identity: string
   readonly logLevel: 'debug' | 'info' | 'warn' | 'error'
   readonly privilegedIntents: readonly GatewayIntentBits[]
+}
+
+const MAX_SECRET_BYTES = 4096
+
+class SecretFileNotFoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SecretFileNotFoundError'
+  }
+}
+
+/**
+ * Read a secret file with hardened path validation. Uses `openSync` with
+ * `O_NOFOLLOW` so symlinks fail at open (no TOCTOU window between validation
+ * and read), then `fstatSync` on the already-open file descriptor to confirm
+ * the file is a regular file under the size limit.
+ *
+ * Throws on:
+ * - ENOENT: file does not exist (SecretFileNotFoundError — callers can catch
+ *   this specifically to fall through to env-var fallbacks)
+ * - Symlink (ELOOP from openSync with O_NOFOLLOW)
+ * - Not a regular file: FIFOs, devices, directories (rejected after fstat)
+ * - Size > MAX_SECRET_BYTES: prevents memory exhaustion
+ *
+ * The 4096-byte limit is generous for any reasonable secret. AWS keys are
+ * typically <50 bytes; Discord tokens are <100; OAuth refresh tokens are
+ * occasionally larger but well under 4KB.
+ *
+ * Note: O_NOFOLLOW is a POSIX extension supported on Linux and macOS. On
+ * Windows (where Node's openSync silently ignores the flag), symlinks fall
+ * through to the fstat-based rejection — same outcome, just at a later check.
+ */
+function readSecretFile(filePath: string): string {
+  let fd: number
+  try {
+    // O_NOFOLLOW: open fails immediately if path is a symlink (Linux/macOS).
+    // This removes the lstat-then-read TOCTOU window — we can never race on a
+    // symlink swap because the open() syscall itself refuses to follow.
+    fd = openSync(filePath, constants.O_RDONLY | constants.O_NOFOLLOW)
+  } catch (error) {
+    if (error instanceof Error && 'code' in error) {
+      if (error.code === 'ENOENT') {
+        throw new SecretFileNotFoundError(`Secret file does not exist: ${filePath}`)
+      }
+      if (error.code === 'ELOOP') {
+        // O_NOFOLLOW path-is-symlink rejection on Linux/macOS
+        throw new Error(
+          `Secret path is not a regular file: ${filePath} (got symlink). Symlinks are not supported — bind-mount a real file.`,
+        )
+      }
+    }
+    throw error
+  }
+  try {
+    const stat = fstatSync(fd)
+    if (stat.isFile() === false) {
+      const kind = describeStatKind(stat)
+      throw new Error(
+        `Secret path is not a regular file: ${filePath} (got ${kind}). FIFOs, devices, and directories are not supported — bind-mount a real file.`,
+      )
+    }
+    if (stat.size > MAX_SECRET_BYTES) {
+      throw new Error(
+        `Secret file is too large: ${filePath} (${stat.size} bytes > ${MAX_SECRET_BYTES} byte limit). Secrets should be a single value on a single line.`,
+      )
+    }
+    return readFileSync(fd, 'utf8')
+  } finally {
+    closeSync(fd)
+  }
+}
+
+function describeStatKind(stat: import('node:fs').Stats): string {
+  if (stat.isSymbolicLink()) return 'symlink'
+  if (stat.isFIFO()) return 'FIFO/pipe'
+  if (stat.isCharacterDevice()) return 'character device'
+  if (stat.isBlockDevice()) return 'block device'
+  if (stat.isDirectory()) return 'directory'
+  if (stat.isSocket()) return 'socket'
+  return 'unknown non-file'
 }
 
 /**
@@ -51,18 +131,10 @@ export function readOptionalSecret(name: string): string | null {
   if (filePath !== undefined) {
     let contents: string | undefined
     try {
-      contents = readFileSync(filePath, 'utf8')
+      contents = readSecretFile(filePath)
     } catch (error) {
-      if (error instanceof Error && 'code' in error) {
-        if (error.code === 'ENOENT') {
-          // file not present; fall through to env-var fallback
-        } else if (error.code === 'EISDIR') {
-          throw new Error(
-            `Secret path is a directory, not a file: ${filePath} (the bind-mount source likely doesn't exist on the host)`,
-          )
-        } else {
-          throw error
-        }
+      if (error instanceof SecretFileNotFoundError) {
+        // file not present; fall through to env-var fallback
       } else {
         throw error
       }


### PR DESCRIPTION
`readOptionalSecret` previously called `readFileSync` on whatever path operators pointed `_FILE` env vars at, with no path validation. Three failure modes the gateway is now hardened against:

- **Symlink redirection** — pointing `DISCORD_TOKEN_FILE` at a symlink to `/etc/passwd` or another sensitive file leaks its contents into config silently. `lstatSync` (not `statSync`) is used so symlinks are detected without following them.
- **FIFO/pipe hang** — pointing at a named pipe makes `readFileSync` block forever, hanging gateway startup with no diagnostic.
- **Memory exhaustion** — character devices like `/dev/zero` or oversized regular files exhaust memory before any size check.

The new `readSecretFile` helper validates the path is a regular file under a 4 KB limit before reading. 4 KB is generous: Discord bot tokens are ~70 bytes, AWS access keys are ~20 bytes, OAuth refresh tokens are occasionally a few hundred bytes but well under the ceiling. The size cap means hostile paths fail fast with a clear error instead of consuming resources.

Error messages name the offending path and describe what kind of non-file was found (symlink, directory, FIFO, etc.), so operators can fix bind-mount mistakes without guessing.

ENOENT still falls through to the env-var fallback so an absent optional `_FILE` doesn't shadow a present env var.

Gateway test count: 148 → 154 (+6 path-validation tests).
