### PR TITLE
fix(gateway): detect mitmproxy loss in healthcheck

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -132,12 +132,15 @@ This checks:
 
 ## Gateway Readiness
 
-The gateway container is considered healthy only after two conditions are both true:
+The gateway container is considered healthy only after three conditions are all true:
 
 1. The Discord `clientReady` event has fired — the bot is fully connected and ready to receive events. At that point the process writes `/var/run/fro-bot/gateway-ready`.
 2. The daemon process (PID 1) is still alive (`kill -0 1`).
+3. mitmproxy is reachable via TCP (`nc -z mitmproxy 8080`) — makes mitmproxy loss visible: if mitmproxy crashes but leaves its CA cert file on disk, the gateway shows `unhealthy` in `docker ps` so the problem is immediately apparent.
 
 The flag is cleared at process startup, so a stale `/var/run/fro-bot/gateway-ready` from a prior container run cannot mask a current-run failure. `docker compose up --wait` blocks until the gateway is genuinely connected to Discord before returning.
+
+The healthcheck is baked into `deploy/gateway.Dockerfile` — there is no override in `compose.yaml`. Note that `restart: unless-stopped` only acts on process exit, not healthcheck failure; an `unhealthy` gateway requires operator intervention (restart the stack or investigate logs). Automatic restart on healthcheck failure would require an autoheal sidecar or an in-process probe that exits the gateway — both are out of scope here.
 
 ## Upgrading existing deployments
 

--- a/deploy/gateway.Dockerfile
+++ b/deploy/gateway.Dockerfile
@@ -43,12 +43,18 @@ WORKDIR /app/packages/gateway
 # future tmpfs-mount changes to /tmp.
 RUN mkdir -p /var/run/fro-bot && chmod 0700 /var/run/fro-bot
 
-# Readiness healthcheck — passes when the Discord `clientReady` event has
-# fired (writes /var/run/fro-bot/gateway-ready) AND PID 1 is alive. Cleared
-# at process startup so a stale flag from a prior process cannot mask a
-# current-run failure. A real liveness probe (HTTP /healthz) lands alongside
-# the workspace agent.
-HEALTHCHECK --interval=10s --timeout=3s --retries=12 --start-period=45s \
-  CMD test -f /var/run/fro-bot/gateway-ready && kill -0 1
+# nc is used by the healthcheck TCP probe below.
+RUN apk add --no-cache netcat-openbsd
+
+# Layered healthcheck:
+#   1. Readiness flag — written by the Discord `clientReady` handler.
+#   2. PID 1 alive — catches silent process death.
+#   3. TCP probe to mitmproxy:8080 — catches mitmproxy crashes that leave the
+#      cert file on disk but the proxy unreachable. "mitmproxy" is the compose
+#      service name defined in deploy/compose.yaml; rename both together.
+# The flag is cleared at process startup so a stale file from a prior run
+# cannot mask a current-run failure.
+HEALTHCHECK --interval=10s --timeout=3s --retries=4 --start-period=45s \
+  CMD test -f /var/run/fro-bot/gateway-ready && kill -0 1 && nc -z mitmproxy 8080
 
 CMD ["node", "dist/main.mjs"]


### PR DESCRIPTION
Replaces the placeholder TCP-readiness-only healthcheck with a layered probe.

**Before:**
```
HEALTHCHECK ... CMD test -f /var/run/fro-bot/gateway-ready && kill -0 1
```

**After:**
```
HEALTHCHECK ... CMD test -f /var/run/fro-bot/gateway-ready && kill -0 1 && nc -z mitmproxy 8080
```

The cert-readability check that landed in PR #638 catches "mitmproxy never started", but **not** "mitmproxy crashed after gateway startup with the cert file still on disk". The new TCP probe makes the latter visible in `docker ps`.

**Layered checks:**
1. Readiness flag — written by the Discord `clientReady` handler at `/var/run/fro-bot/gateway-ready`
2. PID 1 alive — catches silent process death
3. TCP probe to `mitmproxy:8080` — catches mitmproxy crashes that leave the cert file but break the proxy

Adds `netcat-openbsd` to the runner stage. README updated. `compose.yaml` has no override — the Dockerfile healthcheck is now authoritative for the gateway service.

Note: this is observability, not auto-recovery. Docker only restarts containers on process exit, not healthcheck failure. An `unhealthy` gateway still requires operator intervention. Wiring real auto-restart would need an autoheal sidecar or an in-process probe that exits the gateway — out of scope here. Documented in the README.
