### PR TITLE
fix(gateway): extract program from side-effectful main

### DIFF
--- a/packages/gateway/src/main.ts
+++ b/packages/gateway/src/main.ts
@@ -1,131 +1,10 @@
-import type {ChatInputCommandInteraction, Client, GatewayIntentBits, Message} from 'discord.js'
-import type {GatewayConfig} from './config.js'
-import type {GatewayLogger} from './discord/client.js'
-
 import process from 'node:process'
 
 import {Effect} from 'effect'
 
 import {loadGatewayConfig} from './config.js'
-import {createDiscordClient} from './discord/client.js'
-import {dispatchCommand, getCommandRegistry, registerSlashCommands} from './discord/commands/index.js'
-import {handleMention} from './discord/mentions.js'
+import {makeDiscordClientFromConfig, makeGatewayProgram, makeLogger} from './program.js'
 import {setupReadinessFlag} from './readiness.js'
-import {installShutdownHandlers} from './shutdown.js'
-
-// ---------------------------------------------------------------------------
-// Minimal structured logger — pino can replace this in a later unit.
-// warn and error use the lint-permitted console channels directly.
-// debug and info use console.log with scoped eslint-disable because they are
-// informational, not warnings — routing them through console.warn would
-// poison log-aggregator severity classification.
-// ---------------------------------------------------------------------------
-
-function makeLogger(level: 'debug' | 'info' | 'warn' | 'error'): GatewayLogger {
-  const levels = {debug: 0, info: 1, warn: 2, error: 3} as const
-  const minLevel = levels[level]
-
-  return {
-    debug: (ctx, msg) => {
-      // eslint-disable-next-line no-console
-      if (minLevel <= levels.debug) console.log(JSON.stringify({level: 'debug', ...ctx, msg}))
-    },
-    info: (ctx, msg) => {
-      // eslint-disable-next-line no-console
-      if (minLevel <= levels.info) console.log(JSON.stringify({level: 'info', ...ctx, msg}))
-    },
-    warn: (ctx, msg) => {
-      if (minLevel <= levels.warn) console.warn(JSON.stringify({level: 'warn', ...ctx, msg}))
-    },
-    error: (ctx, msg) => {
-      if (minLevel <= levels.error) console.error(JSON.stringify({level: 'error', ...ctx, msg}))
-    },
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Composition helper — exported for unit testing only.
-// Keeps the wiring between GatewayConfig.privilegedIntents and
-// createDiscordClient() explicit and independently verifiable.
-// ---------------------------------------------------------------------------
-
-export function makeDiscordClientFromConfig(
-  config: {privilegedIntents: readonly GatewayIntentBits[]},
-  logger: GatewayLogger,
-): ReturnType<typeof createDiscordClient> {
-  return createDiscordClient({intents: config.privilegedIntents, logger})
-}
-
-// ---------------------------------------------------------------------------
-// Injectable deps interface — exported so tests can supply spies.
-// ---------------------------------------------------------------------------
-
-export interface GatewayProgramDeps {
-  readonly makeClient: (config: GatewayConfig, logger: GatewayLogger) => Client
-  readonly setupReadinessFlag: (client: Client, logger: GatewayLogger) => void
-  readonly login: (client: Client, token: string) => Promise<void>
-}
-
-// ---------------------------------------------------------------------------
-// Extracted program factory — exported for unit testing only.
-// Accepts injectable deps so tests can assert call ordering without touching
-// the network or requiring a real Discord token.
-// ---------------------------------------------------------------------------
-
-export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConfig): Effect.Effect<void, Error> {
-  return Effect.gen(function* () {
-    // b. Create logger
-    const logger = makeLogger(config.logLevel)
-
-    // c. Create Discord client
-    const client = deps.makeClient(config, logger)
-
-    // c2. Set up readiness flag — clears stale flag, registers clientReady listener.
-    //     Must run BEFORE client.login() so the event cannot be missed.
-    yield* Effect.sync(() => deps.setupReadinessFlag(client, logger))
-
-    // d. Build command registry
-    const registry = getCommandRegistry()
-
-    // e. Register slash commands
-    yield* Effect.tryPromise({
-      try: async () =>
-        registerSlashCommands(config.discordToken, config.discordApplicationId, config.discordGuildId, registry),
-      catch: error => (error instanceof Error ? error : new Error(String(error))),
-    })
-
-    // f. Wire client events
-    client.on('interactionCreate', interaction => {
-      if (!interaction.isChatInputCommand()) return
-      // isChatInputCommand() narrows to ChatInputCommandInteraction — cast is safe.
-      const cmd = interaction as unknown as ChatInputCommandInteraction
-      Effect.runPromise(dispatchCommand(cmd, registry)).catch((error: unknown) => {
-        logger.error({err: error, commandName: cmd.commandName}, 'command dispatch failed')
-      })
-    })
-
-    client.on('messageCreate', (message: Message) => {
-      if (message.author.bot) return
-      if (client.user === null) return
-      if (!message.mentions.has(client.user.id)) return
-      Effect.runPromise(handleMention(message, client.user.id)).catch((error: unknown) => {
-        logger.error({err: error}, 'mention handler failed')
-      })
-    })
-
-    // g. Install shutdown handlers
-    installShutdownHandlers(client, logger)
-
-    // h. Login
-    yield* Effect.tryPromise({
-      try: async () => deps.login(client, config.discordToken),
-      catch: error => (error instanceof Error ? error : new Error(String(error))),
-    })
-
-    // i. Log startup
-    logger.info({applicationId: config.discordApplicationId}, 'gateway started')
-  })
-}
 
 // ---------------------------------------------------------------------------
 // Main Effect program
@@ -151,11 +30,13 @@ const program = Effect.gen(function* () {
 })
 
 // ---------------------------------------------------------------------------
-// Top-level runner — logger may not exist yet if config load fails, so we
-// fall back to console.error for the startup-failure path.
+// Top-level runner — config may not have loaded, so I instantiate the logger
+// at a fixed 'error' level here rather than reading the configured level.
 // ---------------------------------------------------------------------------
 
 Effect.runPromise(program).catch((error: unknown) => {
-  console.error(JSON.stringify({level: 'error', err: String(error), msg: 'gateway startup failed'}))
+  // Config failed to load, so the configured log level is unavailable — use 'error' directly.
+  const startupLogger = makeLogger('error')
+  startupLogger.error({err: String(error)}, 'gateway startup failed')
   process.exit(1)
 })

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -2,21 +2,8 @@ import type {GatewayConfig} from './config.js'
 import type {GatewayLogger} from './discord/client.js'
 
 import {GatewayIntentBits} from 'discord.js'
+import {Effect} from 'effect'
 import {describe, expect, it, vi} from 'vitest'
-
-// Prevent the top-level Effect.runPromise(program) in main.ts from executing
-// when the module is imported. The program tries to load config from env vars
-// and call process.exit(1) on failure — both are unwanted in tests.
-vi.mock('effect', async importOriginal => {
-  const actual = await importOriginal<typeof import('effect')>()
-  return {
-    ...actual,
-    Effect: {
-      ...actual.Effect,
-      runPromise: vi.fn().mockResolvedValue(undefined),
-    },
-  }
-})
 
 // Spy on createDiscordClient so we can assert the intents wiring without
 // touching the network or requiring a real Discord token.
@@ -37,7 +24,7 @@ vi.mock('./discord/commands/index.js', async importOriginal => {
   }
 })
 
-const {makeDiscordClientFromConfig, makeGatewayProgram} = await import('./main.js')
+const {makeDiscordClientFromConfig, makeGatewayProgram} = await import('./program.js')
 const {createDiscordClient} = await import('./discord/client.js')
 const createDiscordClientSpy = vi.mocked(createDiscordClient)
 
@@ -131,10 +118,8 @@ describe('makeGatewayProgram', () => {
       login: loginSpy,
     }
 
-    // #when — run the program with the real Effect runtime (not the mocked runPromise).
-    // vi.importActual bypasses the module mock so we get the real runPromise.
-    const {Effect: ActualEffect} = await vi.importActual<typeof import('effect')>('effect')
-    await ActualEffect.runPromise(makeGatewayProgram(deps, fakeConfig))
+    // #when — run the program with the real Effect runtime.
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
 
     // #then — setupReadinessFlag must have been called before login
     expect(setupReadinessFlagSpy).toHaveBeenCalledTimes(1)

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -1,0 +1,124 @@
+import type {ChatInputCommandInteraction, Client, GatewayIntentBits, Message} from 'discord.js'
+import type {GatewayConfig} from './config.js'
+import type {GatewayLogger} from './discord/client.js'
+
+import {Effect} from 'effect'
+
+import {createDiscordClient} from './discord/client.js'
+import {dispatchCommand, getCommandRegistry, registerSlashCommands} from './discord/commands/index.js'
+import {handleMention} from './discord/mentions.js'
+import {installShutdownHandlers} from './shutdown.js'
+
+// ---------------------------------------------------------------------------
+// Minimal structured logger — pino can replace this in a later unit.
+// warn and error use the lint-permitted console channels directly.
+// debug and info use console.log with scoped eslint-disable because they are
+// informational, not warnings — routing them through console.warn would
+// poison log-aggregator severity classification.
+// ---------------------------------------------------------------------------
+
+export function makeLogger(level: 'debug' | 'info' | 'warn' | 'error'): GatewayLogger {
+  const levels = {debug: 0, info: 1, warn: 2, error: 3} as const
+  const minLevel = levels[level]
+
+  return {
+    debug: (ctx, msg) => {
+      // eslint-disable-next-line no-console
+      if (minLevel <= levels.debug) console.log(JSON.stringify({level: 'debug', ...ctx, msg}))
+    },
+    info: (ctx, msg) => {
+      // eslint-disable-next-line no-console
+      if (minLevel <= levels.info) console.log(JSON.stringify({level: 'info', ...ctx, msg}))
+    },
+    warn: (ctx, msg) => {
+      if (minLevel <= levels.warn) console.warn(JSON.stringify({level: 'warn', ...ctx, msg}))
+    },
+    error: (ctx, msg) => {
+      if (minLevel <= levels.error) console.error(JSON.stringify({level: 'error', ...ctx, msg}))
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Composition helper — exported for unit testing only.
+// Keeps the wiring between GatewayConfig.privilegedIntents and
+// createDiscordClient() explicit and independently verifiable.
+// ---------------------------------------------------------------------------
+
+export function makeDiscordClientFromConfig(
+  config: {privilegedIntents: readonly GatewayIntentBits[]},
+  logger: GatewayLogger,
+): ReturnType<typeof createDiscordClient> {
+  return createDiscordClient({intents: config.privilegedIntents, logger})
+}
+
+// ---------------------------------------------------------------------------
+// Injectable deps interface — exported so tests can supply spies.
+// ---------------------------------------------------------------------------
+
+export interface GatewayProgramDeps {
+  readonly makeClient: (config: GatewayConfig, logger: GatewayLogger) => Client
+  readonly setupReadinessFlag: (client: Client, logger: GatewayLogger) => void
+  readonly login: (client: Client, token: string) => Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// Extracted program factory — exported for unit testing only.
+// Accepts injectable deps so tests can assert call ordering without touching
+// the network or requiring a real Discord token.
+// ---------------------------------------------------------------------------
+
+export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConfig): Effect.Effect<void, Error> {
+  return Effect.gen(function* () {
+    // b. Create logger
+    const logger = makeLogger(config.logLevel)
+
+    // c. Create Discord client
+    const client = deps.makeClient(config, logger)
+
+    // c2. Set up readiness flag — clears stale flag, registers clientReady listener.
+    //     Must run BEFORE client.login() so the event cannot be missed.
+    yield* Effect.sync(() => deps.setupReadinessFlag(client, logger))
+
+    // d. Build command registry
+    const registry = getCommandRegistry()
+
+    // e. Register slash commands
+    yield* Effect.tryPromise({
+      try: async () =>
+        registerSlashCommands(config.discordToken, config.discordApplicationId, config.discordGuildId, registry),
+      catch: error => (error instanceof Error ? error : new Error(String(error))),
+    })
+
+    // f. Wire client events
+    client.on('interactionCreate', interaction => {
+      if (!interaction.isChatInputCommand()) return
+      // isChatInputCommand() narrows to ChatInputCommandInteraction — cast is safe.
+      const cmd = interaction as unknown as ChatInputCommandInteraction
+      Effect.runPromise(dispatchCommand(cmd, registry)).catch((error: unknown) => {
+        logger.error({err: error, commandName: cmd.commandName}, 'command dispatch failed')
+      })
+    })
+
+    client.on('messageCreate', (message: Message) => {
+      if (message.author.bot) return
+      if (client.user === null) return
+      if (!message.mentions.has(client.user.id)) return
+      Effect.runPromise(handleMention(message, client.user.id)).catch((error: unknown) => {
+        logger.error({err: error}, 'mention handler failed')
+      })
+    })
+
+    // g. Install shutdown handlers
+    installShutdownHandlers(client, logger)
+
+    // h. Login
+    yield* Effect.tryPromise({
+      try: async () => deps.login(client, config.discordToken),
+      catch: error => (error instanceof Error ? error : new Error(String(error))),
+    })
+
+    // i. Log startup
+    logger.info({applicationId: config.discordApplicationId}, 'gateway started')
+  })
+}


### PR DESCRIPTION
Moves `makeGatewayProgram`, `GatewayProgramDeps`, and the structured logger into a new `program.ts` module. `main.ts` becomes a thin runner that builds and runs the program. No behavior change.

**Why:** `main.ts` was both the runner (top-level `Effect.runPromise`) and the source of the testable factory exports. `main.test.ts` had to mock `Effect.runPromise` at module load to prevent the gateway from actually starting on import, and any test that wanted the real `Effect` runtime had to escape with `vi.importActual('effect')`.

**What changed:**
- `packages/gateway/src/program.ts` (new) — `makeLogger`, `makeDiscordClientFromConfig`, `GatewayProgramDeps`, `makeGatewayProgram`. Side-effect-free.
- `packages/gateway/src/main.ts` — thin runner. Imports `makeGatewayProgram` from `./program.js`, runs it, handles startup failure via the same `makeLogger` so the startup-failure log line matches every other gateway log.
- `packages/gateway/src/program.test.ts` (renamed from `main.test.ts`) — drops the `Effect.runPromise` mock entirely. Calls `Effect.runPromise(makeGatewayProgram(...))` directly.

154/154 gateway tests pass (same count — no tests added or removed, just relocated). Build still emits `dist/main.mjs` correctly.
