### PR TITLE
fix(agent): drop unused SessionStatus type and redundant cast

### DIFF
--- a/src/features/agent/session-poll.ts
+++ b/src/features/agent/session-poll.ts
@@ -5,11 +5,6 @@ import {sleep} from '../../shared/async.js'
 import {DEFAULT_TIMEOUT_MS} from '../../shared/constants.js'
 import {toErrorMessage} from '../../shared/errors.js'
 
-type SessionStatus =
-  | {readonly type: 'idle'}
-  | {readonly type: 'retry'; readonly attempt: number; readonly message: string; readonly next: number}
-  | {readonly type: 'busy'}
-
 const POLL_INTERVAL_MS = 500
 const POLL_REQUEST_TIMEOUT_MS = 5_000
 const EVENT_PROCESSOR_SHUTDOWN_TIMEOUT_MS = 2_000
@@ -170,7 +165,7 @@ export async function pollForSessionCompletion(
         'session.status()',
       )
       const statuses = statusResponse.data ?? {}
-      const sessionStatus = statuses[sessionId] as SessionStatus | undefined
+      const sessionStatus = statuses[sessionId]
 
       if (sessionStatus == null) {
         logger.debug('Session status not found in poll response', {sessionId})


### PR DESCRIPTION
The local `SessionStatus` union in `src/features/agent/session-poll.ts` mirrored what the OpenCode SDK already returns from `session.status()`. The `as SessionStatus | undefined` cast on line 173 was structurally redundant — the SDK's inferred type provides the same `type === 'idle'` / `type === 'retry'` / `type === 'busy'` discriminator and narrows the same way.

The new `@typescript-eslint/no-unnecessary-type-assertion` autofix in `@bfra.me/eslint-config@0.51.1` (incoming via Renovate PR #625) correctly flags the cast as redundant and removes it. With the cast gone, the local `SessionStatus` type becomes unused and trips `unused-imports/no-unused-vars` (lint error) and `TS6196` (build error).

This PR removes both — the unused type and the redundant cast — landing the cleanup on main proactively so Renovate's eslint bump merges without surface conflicts. Tested: full tsc passes, all 1548 tests pass, lint has 0 errors (42 pre-existing non-null-assertion warnings remain, unchanged).
