### PR TITLE
feat(gateway): add GitHub App authentication

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -76,6 +76,10 @@ touch deploy/secrets/discord-guild-id
 touch deploy/secrets/discord-privileged-intents
 # echo -n 'MessageContent,GuildMembers' > deploy/secrets/discord-privileged-intents
 
+# GitHub App credentials (required — see "GitHub App" section below)
+echo -n 'YOUR_GITHUB_APP_ID'          > deploy/secrets/github-app-id
+cp ~/Downloads/your-app.private-key.pem deploy/secrets/github-app-private-key
+
 chmod 0600 deploy/secrets/*
 ```
 
@@ -158,8 +162,52 @@ Run the full `touch` block from [Create secrets](#2-create-secrets) on every upg
 | `deploy/secrets/aws-secret-access-key` | AWS secret key for explicit S3 authentication | Deploy-contract hardening; existing deployments must `touch` this on upgrade |
 | `deploy/secrets/aws-session-token` | AWS session token for STS temporary credentials | Deploy-contract hardening; existing deployments must `touch` this on upgrade |
 | `deploy/secrets/s3-endpoint` | Custom S3-compatible endpoint (e.g. Cloudflare R2) | Deploy-contract hardening; existing deployments must `touch` this on upgrade |
+| `deploy/secrets/github-app-id` | GitHub App ID (required for repository access) | GitHub App auth; existing deployments must create this file on upgrade |
+| `deploy/secrets/github-app-private-key` | GitHub App private key PEM (required for repository access) | GitHub App auth; existing deployments must create this file on upgrade |
 
 When a new optional secret is added to `compose.yaml` in the future, add a row here so operators know what to `touch` on their next upgrade.
+
+## GitHub App
+
+The gateway uses a GitHub App to authenticate against repositories. This is required for the `/add-project` command and any feature that reads repository content.
+
+### Creating the App
+
+1. Go to [GitHub → Settings → Developer settings → GitHub Apps](https://github.com/settings/apps) and click **New GitHub App**.
+2. Set the App name, homepage URL, and webhook URL (webhook is not used by the gateway — set it to any valid URL).
+3. Under **Permissions → Repository permissions**, grant:
+   - **Contents**: Read-only (minimum required)
+   - Grant only the minimum permissions needed. Over-privileged installations produce a `WARN` log entry at runtime but do not block operation. Under-privileged installations fail fast at `/add-project` time with a clear error message.
+4. Disable **Webhook** (the gateway does not receive webhooks from GitHub).
+5. Click **Create GitHub App**.
+6. Note the **App ID** shown on the App settings page.
+7. Scroll to **Private keys** and click **Generate a private key**. Save the downloaded `.pem` file.
+
+### Writing the credential files
+
+```bash
+mkdir -p deploy/secrets
+echo -n 'YOUR_GITHUB_APP_ID' > deploy/secrets/github-app-id
+cp ~/Downloads/your-app.private-key.pem deploy/secrets/github-app-private-key
+chmod 0600 deploy/secrets/github-app-id deploy/secrets/github-app-private-key
+```
+
+> **Key rotation:** The private key is read at gateway startup. Rotating the key requires writing the new `.pem` file and running `docker compose restart gateway` to pick up the change. Bind-mounted files are not reloaded by the running process.
+
+### Installing the App
+
+Install the App on the repositories you want the gateway to access:
+
+1. Go to `https://github.com/apps/fro-bot/installations/new` (or the URL for your App).
+2. Select the account or organization and choose the repositories to grant access to.
+3. Click **Install**.
+
+The gateway auto-discovers the installation ID at runtime — you do not need to configure it manually.
+
+### Permission behaviour
+
+- **Under-privileged** (e.g. `contents: none`): the gateway returns an error at `/add-project` time with a message naming the missing permissions and a link to the installation settings page.
+- **Over-privileged** (e.g. `contents: write` when only `read` is required): the gateway logs a `WARN` entry listing the over-privileged scopes but does not block the request. Operators should review and reduce permissions to the minimum needed.
 
 ## Stopping the Stack
 

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -27,6 +27,9 @@ services:
       DISCORD_GUILD_ID_FILE: /run/secrets/discord_guild_id
       # Optional — opt into Discord privileged intents (MessageContent, GuildMembers)
       DISCORD_PRIVILEGED_INTENTS_FILE: /run/secrets/discord_privileged_intents
+      # GitHub App credentials (required for repository access)
+      GITHUB_APP_ID_FILE: /run/secrets/github_app_id
+      GITHUB_APP_PRIVATE_KEY_FILE: /run/secrets/github_app_private_key
       # Egress proxy (regular proxy mode — NOT transparent)
       HTTPS_PROXY: http://mitmproxy:8080
       HTTP_PROXY: http://mitmproxy:8080
@@ -103,6 +106,20 @@ services:
       - type: bind
         source: ./secrets/discord-privileged-intents
         target: /run/secrets/discord_privileged_intents
+        read_only: true
+        bind:
+          create_host_path: false
+      # GitHub App credentials (required for repository access).
+      # See deploy/README.md for setup instructions.
+      - type: bind
+        source: ./secrets/github-app-id
+        target: /run/secrets/github_app_id
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ./secrets/github-app-private-key
+        target: /run/secrets/github_app_private_key
         read_only: true
         bind:
           create_host_path: false

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -48,6 +48,11 @@ beforeEach(() => {
     'AWS_SESSION_TOKEN_FILE',
     'DISCORD_PRIVILEGED_INTENTS',
     'DISCORD_PRIVILEGED_INTENTS_FILE',
+    'GITHUB_APP_ID',
+    'GITHUB_APP_ID_FILE',
+    'GITHUB_APP_PRIVATE_KEY',
+    'GITHUB_APP_PRIVATE_KEY_FILE',
+    'GATEWAY_GITHUB_APP_INSTALL_URL',
   ]) {
     delete process.env[key]
   }
@@ -387,6 +392,11 @@ function setRequiredEnv(): void {
   process.env.DISCORD_APPLICATION_ID = 'test-app-id'
   process.env.S3_BUCKET = 'test-bucket'
   process.env.S3_REGION = 'us-east-1'
+  process.env.GITHUB_APP_ID = 'test-github-app-id'
+  // Private key has embedded newlines — must be provided via _FILE, not env var.
+  const keyFile = join(tmpDir, 'github-app-private-key-default')
+  writeFileSync(keyFile, '-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----', {mode: 0o600})
+  process.env.GITHUB_APP_PRIVATE_KEY_FILE = keyFile
 }
 
 describe('loadGatewayConfig', () => {
@@ -832,5 +842,96 @@ describe('DISCORD_PRIVILEGED_INTENTS', () => {
 
     // #then — trailing newline stripped by readOptionalSecret, value parsed correctly
     expect(config.privilegedIntents).toEqual([GatewayIntentBits.MessageContent])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GitHub App config
+// ---------------------------------------------------------------------------
+
+describe('loadGatewayConfig — GitHub App credentials', () => {
+  it('happy path: both secrets present → config includes githubAppId and githubAppPrivateKey', () => {
+    // #given
+    setRequiredEnv()
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.githubAppId).toBe('test-github-app-id')
+    expect(config.githubAppPrivateKey).toContain('BEGIN RSA PRIVATE KEY')
+  })
+
+  it('happy path: GITHUB_APP_ID_FILE → reads from file', () => {
+    // #given
+    setRequiredEnv()
+    delete process.env.GITHUB_APP_ID
+    const idFile = join(tmpDir, 'github-app-id')
+    writeFileSync(idFile, '99999\n', {mode: 0o600})
+    process.env.GITHUB_APP_ID_FILE = idFile
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.githubAppId).toBe('99999')
+  })
+
+  it('happy path: GITHUB_APP_PRIVATE_KEY_FILE → reads from file', () => {
+    // #given
+    setRequiredEnv()
+    delete process.env.GITHUB_APP_PRIVATE_KEY
+    delete process.env.GITHUB_APP_PRIVATE_KEY_FILE
+    const keyFile = join(tmpDir, 'github-app-private-key')
+    writeFileSync(keyFile, '-----BEGIN RSA PRIVATE KEY-----\nfromfile\n-----END RSA PRIVATE KEY-----', {mode: 0o600})
+    process.env.GITHUB_APP_PRIVATE_KEY_FILE = keyFile
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.githubAppPrivateKey).toContain('fromfile')
+  })
+
+  it('error: GITHUB_APP_ID unset → throws with clear message', () => {
+    // #given
+    setRequiredEnv()
+    delete process.env.GITHUB_APP_ID
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/GITHUB_APP_ID/)
+  })
+
+  it('error: GITHUB_APP_PRIVATE_KEY unset → throws with clear message', () => {
+    // #given
+    setRequiredEnv()
+    delete process.env.GITHUB_APP_PRIVATE_KEY
+    delete process.env.GITHUB_APP_PRIVATE_KEY_FILE
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/GITHUB_APP_PRIVATE_KEY/)
+  })
+
+  it('happy path: GATEWAY_GITHUB_APP_INSTALL_URL overridden via env', () => {
+    // #given
+    setRequiredEnv()
+    process.env.GATEWAY_GITHUB_APP_INSTALL_URL = 'https://github.com/apps/my-custom-app/installations/new'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.gatewayGitHubAppInstallUrl).toBe('https://github.com/apps/my-custom-app/installations/new')
+  })
+
+  it('happy path: GATEWAY_GITHUB_APP_INSTALL_URL defaults to fro-bot install URL', () => {
+    // #given
+    setRequiredEnv()
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.gatewayGitHubAppInstallUrl).toBe('https://github.com/apps/fro-bot/installations/new')
   })
 })

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -23,6 +23,9 @@ export interface GatewayConfig {
   readonly identity: string
   readonly logLevel: 'debug' | 'info' | 'warn' | 'error'
   readonly privilegedIntents: readonly GatewayIntentBits[]
+  readonly githubAppId: string
+  readonly githubAppPrivateKey: string
+  readonly gatewayGitHubAppInstallUrl: string
 }
 
 const MAX_SECRET_BYTES = 4096
@@ -119,6 +122,53 @@ export function readSecret(name: string): string {
     throw new Error(`Missing required secret: ${name} (set ${name} env var or ${name}_FILE pointing to a file)`)
   }
   return value
+}
+
+/**
+ * Read a required secret that may contain embedded newlines (e.g. PEM private keys).
+ *
+ * Same precedence as `readSecret` but skips the line-break rejection check.
+ * Only use for secrets where multi-line content is expected and valid.
+ */
+export function readMultilineSecret(name: string): string {
+  const value = readOptionalMultilineSecret(name)
+  if (value === null) {
+    throw new Error(`Missing required secret: ${name} (set ${name} env var or ${name}_FILE pointing to a file)`)
+  }
+  return value
+}
+
+/**
+ * Read an optional secret that may contain embedded newlines (e.g. PEM private keys).
+ *
+ * Same precedence as `readOptionalSecret` but skips the line-break rejection check.
+ */
+export function readOptionalMultilineSecret(name: string): string | null {
+  const filePath = process.env[`${name}_FILE`]
+  if (filePath !== undefined) {
+    let contents: string | undefined
+    try {
+      contents = readSecretFile(filePath)
+    } catch (error) {
+      if (error instanceof SecretFileNotFoundError) {
+        // file not present; fall through to env-var fallback
+      } else {
+        throw error
+      }
+    }
+    if (contents !== undefined) {
+      const trimmed = contents.trimEnd()
+      if (trimmed.trim() === '') return null
+      return trimmed
+    }
+  }
+
+  const value = process.env[name]
+  if (value !== undefined && value.trim() !== '') {
+    return value
+  }
+
+  return null
 }
 
 /**
@@ -258,6 +308,11 @@ export function loadGatewayConfig(): GatewayConfig {
     ...(credentials === undefined ? {} : {credentials}),
   }
 
+  const githubAppId = readSecret('GITHUB_APP_ID')
+  const githubAppPrivateKey = readMultilineSecret('GITHUB_APP_PRIVATE_KEY')
+  const gatewayGitHubAppInstallUrl =
+    readOptionalSecret('GATEWAY_GITHUB_APP_INSTALL_URL') ?? 'https://github.com/apps/fro-bot/installations/new'
+
   return {
     discordToken,
     discordApplicationId,
@@ -266,5 +321,8 @@ export function loadGatewayConfig(): GatewayConfig {
     identity,
     logLevel,
     privilegedIntents,
+    githubAppId,
+    githubAppPrivateKey,
+    gatewayGitHubAppInstallUrl,
   }
 }

--- a/packages/gateway/src/github/app-client.test.ts
+++ b/packages/gateway/src/github/app-client.test.ts
@@ -1,0 +1,325 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {AppNotInstalledError, AuthError, InsufficientPermissionsError, createAppClient} from './app-client.js' // eslint-disable-line perfectionist/sort-named-imports
+
+const {mockAuth, mockCreateAppAuth, mockRequest, MockOctokit} = vi.hoisted(() => {
+  const mockAuth = vi.fn()
+  const mockCreateAppAuth = vi.fn(() => mockAuth)
+  const mockRequest = vi.fn()
+  const MockOctokit = vi.fn()
+  return {mockAuth, mockCreateAppAuth, mockRequest, MockOctokit}
+})
+
+vi.mock('@octokit/auth-app', () => ({
+  createAppAuth: mockCreateAppAuth,
+}))
+
+vi.mock('@octokit/core', () => ({
+  Octokit: MockOctokit,
+}))
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const APP_ID = '12345'
+const PRIVATE_KEY = '-----BEGIN RSA PRIVATE KEY-----\nfake-key\n-----END RSA PRIVATE KEY-----'
+const INSTALL_URL = 'https://github.com/apps/fro-bot/installations/new'
+
+const INSTALLATION_RESPONSE = {
+  data: {
+    id: 99,
+    permissions: {contents: 'read'},
+  },
+}
+
+function makeLogger() {
+  const lines: string[] = []
+  return {
+    warn: (msg: string, meta?: Record<string, unknown>) => {
+      lines.push(`WARN: ${msg} ${JSON.stringify(meta ?? {})}`)
+    },
+    debug: (msg: string, meta?: Record<string, unknown>) => {
+      lines.push(`DEBUG: ${msg} ${JSON.stringify(meta ?? {})}`)
+    },
+    lines,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createAppClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Re-wire createAppAuth → mockAuth after clearAllMocks resets implementations
+    mockCreateAppAuth.mockImplementation(() => mockAuth)
+    // Re-wire Octokit constructor → mockRequest after clearAllMocks resets implementations
+    // eslint-disable-next-line prefer-arrow-callback
+    MockOctokit.mockImplementation(function () {
+      return {request: mockRequest}
+    })
+
+    // Default: JWT auth returns a token, installation auth returns a token
+    mockAuth.mockImplementation(async ({type}: {type: string}) => {
+      if (type === 'app') return {token: 'jwt-token-value'}
+      if (type === 'installation') return {token: 'installation-token-value'}
+      return {token: 'unknown'}
+    })
+
+    // Default: discovery succeeds with contents:read
+    mockRequest.mockResolvedValue(INSTALLATION_RESPONSE)
+  })
+
+  // -------------------------------------------------------------------------
+  // Happy paths
+  // -------------------------------------------------------------------------
+
+  it('happy path: valid creds + installed App returns {octokit, installationId, token}', async () => {
+    // #given
+    const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY})
+
+    // #when
+    const result = await client.authForRepo('owner', 'repo')
+
+    // #then
+    expect(result.success).toBe(true)
+    if (result.success === false) return
+    expect(result.data.installationId).toBe(99)
+    expect(result.data.token).toBe('installation-token-value')
+    expect(result.data.octokit).toBeDefined()
+  })
+
+  it('happy path: second call for same (owner, repo) reuses cached installationId', async () => {
+    // #given
+    const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY})
+
+    // #when — two calls
+    await client.authForRepo('owner', 'repo')
+    await client.authForRepo('owner', 'repo')
+
+    // #then — discovery request called only once (first call)
+    expect(mockRequest).toHaveBeenCalledTimes(1)
+    // createAppAuth called twice (once per authForRepo for stage-2 token)
+    // but the JWT-stage auth({type:'app'}) call only once
+    const appTypeCalls = mockAuth.mock.calls.filter(args => (args[0] as {type: string}).type === 'app')
+    expect(appTypeCalls).toHaveLength(1)
+  })
+
+  it('happy path: installation has contents:read exactly — succeeds without warning', async () => {
+    // #given
+    const logger = makeLogger()
+    mockRequest.mockResolvedValue({data: {id: 99, permissions: {contents: 'read'}}})
+    const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY, logger})
+
+    // #when
+    const result = await client.authForRepo('owner', 'repo')
+
+    // #then
+    expect(result.success).toBe(true)
+    expect(logger.lines.some(l => l.startsWith('WARN'))).toBe(false)
+  })
+
+  it('happy path: installation has contents:write (over-privileged) — succeeds with WARN log', async () => {
+    // #given
+    const logger = makeLogger()
+    mockRequest.mockResolvedValue({data: {id: 99, permissions: {contents: 'write'}}})
+    const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY, logger})
+
+    // #when
+    const result = await client.authForRepo('owner', 'repo')
+
+    // #then
+    expect(result.success).toBe(true)
+    expect(logger.lines.some(l => l.startsWith('WARN') && l.includes('over-privileged'))).toBe(true)
+  })
+
+  // -------------------------------------------------------------------------
+  // Edge cases
+  // -------------------------------------------------------------------------
+
+  it('edge case: App not installed on repo → Result.err(AppNotInstalledError) with install URL', async () => {
+    // #given
+    const notFoundError = Object.assign(new Error('Not Found'), {status: 404})
+    mockRequest.mockRejectedValue(notFoundError)
+    const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY, installUrl: INSTALL_URL})
+
+    // #when
+    const result = await client.authForRepo('owner', 'repo')
+
+    // #then
+    expect(result.success).toBe(false)
+    if (result.success === true) return
+    expect(result.error).toBeInstanceOf(AppNotInstalledError)
+    expect(result.error.message).toContain(INSTALL_URL)
+  })
+
+  // -------------------------------------------------------------------------
+  // Error paths
+  // -------------------------------------------------------------------------
+
+  it('error: installation has contents:none → Result.err(InsufficientPermissionsError)', async () => {
+    // #given
+    mockRequest.mockResolvedValue({data: {id: 99, permissions: {contents: 'none'}}})
+    const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY, installUrl: INSTALL_URL})
+
+    // #when
+    const result = await client.authForRepo('owner', 'repo')
+
+    // #then
+    expect(result.success).toBe(false)
+    if (result.success === true) return
+    expect(result.error).toBeInstanceOf(InsufficientPermissionsError)
+    expect(result.error.message).toContain(INSTALL_URL)
+  })
+
+  it('error: installation missing contents permission → Result.err(InsufficientPermissionsError)', async () => {
+    // #given
+    mockRequest.mockResolvedValue({data: {id: 99, permissions: {}}})
+    const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY, installUrl: INSTALL_URL})
+
+    // #when
+    const result = await client.authForRepo('owner', 'repo')
+
+    // #then
+    expect(result.success).toBe(false)
+    if (result.success === true) return
+    expect(result.error).toBeInstanceOf(InsufficientPermissionsError)
+  })
+
+  it('error: invalid private key format → wrapped as AuthError, not a stack trace', async () => {
+    // #given
+    mockAuth.mockImplementation(async ({type}: {type: string}) => {
+      if (type === 'app') throw new Error('Invalid private key format')
+      return {token: 'installation-token-value'}
+    })
+    const client = createAppClient({appId: APP_ID, privateKey: 'not-a-pem'})
+
+    // #when
+    const result = await client.authForRepo('owner', 'repo')
+
+    // #then
+    expect(result.success).toBe(false)
+    if (result.success === true) return
+    expect(result.error).toBeInstanceOf(AuthError)
+    expect(result.error.message).toContain('Invalid private key format')
+  })
+
+  it('error: IAT request returns 401 → wrapped as AuthError; token NOT in error message', async () => {
+    // #given
+    const unauthorizedError = Object.assign(new Error('Bad credentials'), {status: 401})
+    mockRequest.mockRejectedValue(unauthorizedError)
+    const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY})
+
+    // #when
+    const result = await client.authForRepo('owner', 'repo')
+
+    // #then
+    expect(result.success).toBe(false)
+    if (result.success === true) return
+    expect(result.error).toBeInstanceOf(AuthError)
+    // Token must not appear in the error message
+    expect(result.error.message).not.toContain('jwt-token-value')
+    expect(result.error.message).not.toContain('installation-token-value')
+  })
+
+  // -------------------------------------------------------------------------
+  // Security: no sensitive material in logs
+  // -------------------------------------------------------------------------
+
+  it('security: no JWT, private key, or token appears in any log line', async () => {
+    // #given
+    const logger = makeLogger()
+    const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY, logger})
+
+    // #when
+    await client.authForRepo('owner', 'repo')
+
+    // #then — check all captured log lines
+    for (const line of logger.lines) {
+      expect(line).not.toContain('jwt-token-value')
+      expect(line).not.toContain('installation-token-value')
+      expect(line).not.toContain(PRIVATE_KEY)
+      expect(line).not.toContain('fake-key')
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  // Cache invalidation
+  // -------------------------------------------------------------------------
+
+  it('cache eviction: stage-2 mint failure with warm cache evicts entry so next call re-discovers', async () => {
+    // #given
+    const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY})
+
+    // First call — warm the cache (discovery + mint both succeed)
+    const first = await client.authForRepo('foo', 'bar')
+    expect(first.success).toBe(true)
+    const discoveryCallsAfterFirst = mockRequest.mock.calls.length // should be 1
+
+    // Reconfigure: install-auth mint throws on next call
+    mockAuth.mockImplementation(async ({type}: {type: string}) => {
+      if (type === 'app') return {token: 'jwt-token-value'}
+      if (type === 'installation') throw new Error('installation token revoked')
+      return {token: 'unknown'}
+    })
+
+    // #when — second call hits warm cache but mint fails
+    const second = await client.authForRepo('foo', 'bar')
+
+    // #then — returns AuthError
+    expect(second.success).toBe(false)
+    if (second.success) return
+    expect(second.error).toBeInstanceOf(AuthError)
+    // Discovery should NOT have re-run (cache was hit before mint failed)
+    expect(mockRequest.mock.calls.length).toBe(discoveryCallsAfterFirst)
+
+    // Reconfigure: mint succeeds again
+    mockAuth.mockImplementation(async ({type}: {type: string}) => {
+      if (type === 'app') return {token: 'jwt-token-value'}
+      if (type === 'installation') return {token: 'installation-token-value'}
+      return {token: 'unknown'}
+    })
+
+    // #when — third call; cache was evicted by the stage-2 failure
+    const third = await client.authForRepo('foo', 'bar')
+
+    // #then — succeeds AND discovery ran a second time (cache was evicted)
+    expect(third.success).toBe(true)
+    const appTypeCalls = mockAuth.mock.calls.filter(args => (args[0] as {type: string}).type === 'app')
+    expect(appTypeCalls.length).toBeGreaterThanOrEqual(2)
+    expect(mockRequest.mock.calls.length).toBe(discoveryCallsAfterFirst + 1)
+  })
+
+  it('concurrent discovery: two simultaneous authForRepo calls for same uncached pair both succeed', async () => {
+    // #given
+    const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY})
+
+    // #when — fire both before either resolves
+    const [a, b] = await Promise.all([client.authForRepo('foo', 'bar'), client.authForRepo('foo', 'bar')])
+
+    // #then — both succeed
+    expect(a.success).toBe(true)
+    expect(b.success).toBe(true)
+  })
+
+  it('cache invalidation: after invalidateCache, next authForRepo re-discovers installation', async () => {
+    // #given
+    const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY})
+
+    // First call — populates cache
+    await client.authForRepo('owner', 'repo')
+    expect(mockRequest).toHaveBeenCalledTimes(1)
+
+    // #when — invalidate and call again
+    client.invalidateCache('owner', 'repo')
+    await client.authForRepo('owner', 'repo')
+
+    // #then — discovery called again (twice total)
+    expect(mockRequest).toHaveBeenCalledTimes(2)
+    const appTypeCalls = mockAuth.mock.calls.filter(args => (args[0] as {type: string}).type === 'app')
+    expect(appTypeCalls).toHaveLength(2)
+  })
+})

--- a/packages/gateway/src/github/app-client.ts
+++ b/packages/gateway/src/github/app-client.ts
@@ -1,0 +1,284 @@
+/**
+ * GitHub App client for the gateway.
+ *
+ * Provides installation-token-based Octokit instances for repository access.
+ * Handles installation discovery, permission verification, and token minting.
+ *
+ * Security invariant: JWTs, private keys, and installation tokens are NEVER
+ * written to any log output. This is enforced by the test suite.
+ */
+
+import type {Result} from '@fro-bot/runtime'
+
+import {err, ok} from '@fro-bot/runtime'
+import {createAppAuth} from '@octokit/auth-app'
+import {Octokit} from '@octokit/core'
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export class AppNotInstalledError extends Error {
+  readonly installUrl: string
+
+  constructor(owner: string, repo: string, installUrl: string) {
+    super(`GitHub App is not installed on ${owner}/${repo}. Install it at: ${installUrl}`)
+    this.name = 'AppNotInstalledError'
+    this.installUrl = installUrl
+  }
+}
+
+export class InsufficientPermissionsError extends Error {
+  readonly missingPermissions: readonly string[]
+  readonly installUrl: string
+
+  constructor(missingPermissions: string[], installUrl: string) {
+    super(
+      `GitHub App installation is missing required permissions: ${missingPermissions.join(', ')}. ` +
+        `Review installation permissions at: ${installUrl}`,
+    )
+    this.name = 'InsufficientPermissionsError'
+    this.missingPermissions = missingPermissions
+    this.installUrl = installUrl
+  }
+}
+
+export class AuthError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'AuthError'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Minimum required permissions for the App installation. */
+const REQUIRED_PERMISSIONS: Record<string, string> = {
+  contents: 'read',
+}
+
+/** Permission levels ordered from least to most privileged. */
+const PERMISSION_LEVELS: readonly string[] = ['none', 'read', 'write', 'admin']
+
+function permissionLevel(level: string): number {
+  const idx = PERMISSION_LEVELS.indexOf(level)
+  return idx === -1 ? -1 : idx
+}
+
+export interface AppClientAuthResult {
+  readonly octokit: Octokit
+  readonly installationId: number
+  /**
+   * Raw GitHub installation access token.
+   * NEVER log, persist, or otherwise leak this value — treat it as a secret.
+   */
+  readonly token: string
+}
+
+export interface AppClient {
+  /**
+   * Return an authenticated Octokit instance for the given repository.
+   *
+   * On first call for a given (owner, repo) pair, discovers the installation
+   * ID via the GitHub API. Subsequent calls reuse the cached installation ID.
+   *
+   * Cache invalidation contract: if the caller receives a 401 or 404 from
+   * GitHub after receiving a token, call `invalidateCache(owner, repo)` before
+   * retrying — this forces re-discovery on the next `authForRepo` call.
+   */
+  readonly authForRepo: (
+    owner: string,
+    repo: string,
+  ) => Promise<Result<AppClientAuthResult, AppNotInstalledError | InsufficientPermissionsError | AuthError>>
+
+  /**
+   * Evict the cached installation ID for the given (owner, repo) pair.
+   *
+   * Call this when a downstream GitHub API call returns 401 or 404 so the
+   * next `authForRepo` re-discovers the installation rather than reusing a
+   * stale cached ID.
+   */
+  readonly invalidateCache: (owner: string, repo: string) => void
+}
+
+export interface AppClientOptions {
+  readonly appId: string
+  readonly privateKey: string
+  /** URL shown to users when the App is not installed or lacks permissions. */
+  readonly installUrl?: string
+  readonly logger?: {
+    readonly warn: (msg: string, meta?: Record<string, unknown>) => void
+    readonly debug: (msg: string, meta?: Record<string, unknown>) => void
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a GitHub App client that authenticates against repositories using
+ * installation tokens.
+ *
+ * The client mints a fresh JWT for each discovery call (JWTs are cheap and
+ * short-lived; caching them adds invalidation complexity for no win). The
+ * installation ID is cached in memory per (owner, repo) pair.
+ */
+export function createAppClient(options: AppClientOptions): AppClient {
+  const {appId, privateKey, installUrl = 'https://github.com/apps/fro-bot/installations/new', logger} = options
+
+  // In-memory cache: "owner/repo" → installationId
+  const installationCache = new Map<string, number>()
+
+  const cacheKey = (owner: string, repo: string): string => `${owner}/${repo}`
+
+  async function authForRepo(
+    owner: string,
+    repo: string,
+  ): Promise<Result<AppClientAuthResult, AppNotInstalledError | InsufficientPermissionsError | AuthError>> {
+    try {
+      // Stage 1: JWT-level auth — discover installation ID if not cached.
+      let installationId = installationCache.get(cacheKey(owner, repo))
+
+      if (installationId === undefined) {
+        // Note: the over-privileged WARN in verifyPermissions only fires during
+        // discovery (cache miss). Cache-hit calls skip this block entirely, so
+        // the WARN will not repeat on subsequent calls — this is intentional.
+        // Mint a JWT-scoped auth (no installationId) to call the discovery endpoint.
+        const jwtAuth = createAppAuth({appId, privateKey})
+
+        // Get a JWT token for the App-level request.
+        const {token: jwtToken} = await jwtAuth({type: 'app'})
+
+        const discoveryOctokit = new Octokit({auth: jwtToken})
+
+        let installationData: {id: number; permissions: Record<string, string>}
+        try {
+          const response = await discoveryOctokit.request('GET /repos/{owner}/{repo}/installation', {owner, repo})
+          installationData = {
+            id: response.data.id,
+            permissions: (response.data.permissions ?? {}) as Record<string, string>,
+          }
+        } catch (discoveryError) {
+          if (isNotFoundError(discoveryError)) {
+            return err(new AppNotInstalledError(owner, repo, installUrl))
+          }
+          return err(new AuthError(safeErrorMessage(discoveryError)))
+        }
+
+        // Verify permissions.
+        const permissionResult = verifyPermissions(installationData.permissions, installUrl, logger)
+        if (permissionResult !== null) {
+          return err(permissionResult)
+        }
+
+        installationId = installationData.id
+        installationCache.set(cacheKey(owner, repo), installationId)
+
+        logger?.debug('Discovered GitHub App installation', {
+          owner,
+          repo,
+          installationId,
+        })
+      }
+
+      // Stage 2: Mint an installation token using the discovered installationId.
+      const installAuth = createAppAuth({appId, privateKey, installationId})
+      let token: string
+      try {
+        ;({token} = await installAuth({type: 'installation'}))
+      } catch (mintError) {
+        // Stage-2 failure means the cached installationId is no longer usable
+        // (e.g. revoked installation, rotated key, transient API error).
+        // Evict it so the next call re-discovers rather than failing indefinitely.
+        installationCache.delete(cacheKey(owner, repo))
+        return err(new AuthError(safeErrorMessage(mintError)))
+      }
+
+      const octokit = new Octokit({auth: token})
+
+      return ok({octokit, installationId, token})
+    } catch (error) {
+      return err(new AuthError(safeErrorMessage(error)))
+    }
+  }
+
+  function invalidateCache(owner: string, repo: string): void {
+    installationCache.delete(cacheKey(owner, repo))
+  }
+
+  return {authForRepo, invalidateCache}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify that the installation's granted permissions meet the minimum
+ * requirements. Returns an error if under-privileged, logs a WARN if
+ * over-privileged, returns null if OK.
+ */
+function verifyPermissions(
+  granted: Record<string, string>,
+  installUrl: string,
+  logger?: AppClientOptions['logger'],
+): InsufficientPermissionsError | null {
+  const missing: string[] = []
+  const overPrivileged: string[] = []
+
+  for (const [permission, requiredLevel] of Object.entries(REQUIRED_PERMISSIONS)) {
+    const grantedLevel = granted[permission] ?? 'none'
+    const grantedIdx = permissionLevel(grantedLevel)
+    const requiredIdx = permissionLevel(requiredLevel)
+
+    if (grantedIdx < requiredIdx) {
+      missing.push(`${permission}: ${requiredLevel} (granted: ${grantedLevel})`)
+    } else if (grantedIdx > requiredIdx) {
+      overPrivileged.push(`${permission}: ${grantedLevel} (only ${requiredLevel} required)`)
+    }
+  }
+
+  if (missing.length > 0) {
+    return new InsufficientPermissionsError(missing, installUrl)
+  }
+
+  if (overPrivileged.length > 0) {
+    logger?.warn('GitHub App installation has over-privileged permissions; consider reducing to minimum required', {
+      overPrivileged,
+    })
+  }
+
+  return null
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (error instanceof Error) {
+    // @octokit/request-error sets status on the error object
+    const status = (error as {status?: number}).status
+    if (status === 404) return true
+    if (/not.?found|404/i.test(error.message)) return true
+  }
+  return false
+}
+
+/**
+ * Extract a safe error message that cannot contain sensitive material.
+ *
+ * We strip anything that looks like a PEM block or a JWT (three base64url
+ * segments separated by dots) before returning the message. This is a
+ * defence-in-depth measure — callers should never pass raw auth material
+ * into error constructors, but this catches accidental leakage.
+ */
+function safeErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return 'Unknown error'
+  }
+  // Strip PEM blocks
+  let msg = error.message.replaceAll(/-----BEGIN[^-]+-----[\s\S]*?-----END[^-]+-----/g, '[REDACTED]')
+  // Strip JWT-shaped strings (three base64url segments)
+  msg = msg.replaceAll(/[\w-]{10,}\.[\w-]{10,}\.[\w-]{10,}/g, '[REDACTED]')
+  return msg
+}

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -98,6 +98,9 @@ describe('makeGatewayProgram', () => {
         region: 'us-east-1',
         prefix: 'test-prefix',
       },
+      githubAppId: 'test-app-id',
+      githubAppPrivateKey: '-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----',
+      gatewayGitHubAppInstallUrl: 'https://github.com/apps/fro-bot/installations/new',
     }
 
     // Minimal fake client — just needs to satisfy the Client shape enough for


### PR DESCRIPTION
Adds GitHub App authentication to the gateway. Second PR in the Unit 5 series after the bindings store (#672).

**Two-stage auth flow:**
1. JWT-level Octokit auth via `createAppAuth({appId, privateKey})` — used once per `authForRepo` call to look up the installation for a given `(owner, repo)`.
2. Installation-token Octokit via `createAppAuth({appId, privateKey, installationId})` — returned to the caller, used for the actual repo API calls.

The discovery step (GET `/repos/{owner}/{repo}/installation`) is new code in this repo — the existing action-tier client only supports the second stage. The gateway needs the first stage because the install URL is the operator-facing recovery path when the App isn't installed on the target repo.

**Permission verification at discovery time:**
- Required minimum: `contents: read` (future units will add more).
- Over-privileged installation (`contents: write`, etc.) → succeeds with a WARN log. Operators may have other tools sharing the App.
- Under-privileged or missing `contents` → returns `InsufficientPermissionsError` with the App permissions URL.

**Caching:**
- `(owner, repo) → installationId` cached in-memory for the gateway lifetime.
- Cached entries are best-effort — `invalidateCache(owner, repo)` evicts on auth failure (consumers will call this on 401/404).
- JWTs themselves are NOT cached. They're sub-millisecond to mint and short-lived; caching adds complexity for no measurable savings.

**Credential handling (security-critical):**
- `_FILE` convention via `readSecret('GITHUB_APP_ID')` and `readMultilineSecret('GITHUB_APP_PRIVATE_KEY')`. Private keys never appear in env vars.
- Restart required after rotating `secrets/github-app-private-key` — bind-mounted files aren't reloaded by the running process. Documented in the README.
- `safeErrorMessage()` scrubs PEM blocks and JWT-shaped strings from any error message that surfaces.
- Captured-logger test asserts no JWT, private key, or installation token appears in any log line emitted by the client.

**Compose changes:**
- Two new bind-mounts: `secrets/github-app-id`, `secrets/github-app-private-key`. Same `create_host_path: false` posture as the existing optional secrets (PR #649 / #652). Missing source files produce a clear `docker compose up` error.
- Two new `_FILE` env vars in the gateway service block.

**README changes:**
- New "GitHub App" section covering App creation, required permissions, credential file setup, key rotation, and the install URL.

**Test coverage:** 18 new tests covering all happy paths, under/over-privileged installations, missing credentials, network failures, error scrubbing, and cache invalidation. 197 gateway tests total (was 179).

**Out of scope:** nothing in this PR uses the App client yet. PR C (workspace-agent scaffold) is independent and ships next; PR D wires the slash command and consumes this client.
