### PR TITLE
feat(gateway): /fro-bot add-project slash command

### DIFF
--- a/docs/plans/2026-05-23-001-feat-gateway-unit-5-add-project-plan.md
+++ b/docs/plans/2026-05-23-001-feat-gateway-unit-5-add-project-plan.md
@@ -5,7 +5,7 @@ status: active
 date: 2026-05-23
 origin: docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
 parent_unit: Unit 5 of the Gateway v1 plan
-deepened: 2026-05-23 (coherence + feasibility + security review applied)
+deepened: 2026-05-24 (coherence + feasibility + security review applied)
 ---
 
 # feat: Gateway v1 Unit 5 — channel-repo binding + /fro-bot add-project
@@ -362,14 +362,16 @@ deploy/compose.yaml                          (PR B — GitHub App secret mounts)
 **Dependencies:** PR A + PR B + PR C all merged.
 
 **Files:**
-- Create: `packages/gateway/src/workspace-api/types.ts` — must match PR C's exact handler shapes:
-  - `CloneRequest = {owner: string, repo: string, token: string}` (NO `repoPath`, NO `url` — agent derives path; agent constructs URL)
-  - `CloneResponse = {ok: true, sha: string} | {ok: false, error: string, code?: string}`
-- Create: `packages/gateway/src/workspace-api/client.ts` (`createWorkspaceClient({baseUrl})` returns `{clone}` — returns `Promise<Result<Response, WorkspaceError>>`)
-- Create: `packages/gateway/src/discord/channels.ts` (`findOrCreateChannel(guild, name)` — searches existing channels, creates if missing, returns `Result<{channel, created}, ChannelError>`; handles name collisions with `-2`, `-3` suffixes)
-- Create: `packages/gateway/src/discord/commands/add-project.ts` (`SlashCommand` with `data.name = 'add-project'`; `execute` orchestrates the 5-phase flow)
+- Create: `packages/gateway/src/workspace-api/types.ts` — MUST mirror PR C's shipped `apps/workspace-agent/src/types.ts` exactly:
+  - `CloneRequest = {readonly owner: string, readonly repo: string, readonly token: string}` (NO `repoPath`, NO `url`)
+  - `CloneSuccess = {readonly ok: true, readonly path: string, readonly commit: string}` (NOT `sha` — PR C ships `commit`, an HEAD SHA, plus `path` which is the absolute workspace-container path)
+  - `CloneFailure = {readonly ok: false, readonly error: CloneErrorCode, readonly code?: string}`
+  - `CloneErrorCode` union must include all of PR C's codes: `invalid-owner` `invalid-repo` `invalid-token-shape` `malformed-body` `body-too-large` `clone-failed` `clone-timeout` `clone-aborted` `git-not-available` `enospc` `disk-full` `permission-denied` `too-many-files` `repo-exists` `path-escaped-workspace` `head-resolution-failed` `overloaded`
+- Create: `packages/gateway/src/workspace-api/client.ts` (`createWorkspaceClient({baseUrl, timeoutMs?})` returns `{clone}` — returns `Promise<Result<CloneSuccess, WorkspaceError>>`). MUST NEVER log request body or response body, even on retry or error. All error paths return sanitized `WorkspaceError` variants with no token-bearing context.
+- Create: `packages/gateway/src/discord/channels.ts` (`findOrCreateChannel(guild, name, {maxSuffix?: number})` — searches existing channels, creates if missing, returns `Result<{channel, created}, ChannelError>`; handles name collisions with `-2`, `-3` suffixes up to `maxSuffix` (default 10), returns `{kind: 'collision-exhausted'}` error if the limit is hit)
+- Create: `packages/gateway/src/discord/commands/add-project.ts` (`SlashCommand` — see "Command shape" decision in Approach for whether top-level `/add-project` or nested `/fro-bot add-project`; `execute` orchestrates the 5-phase flow with durable state in S3)
 - Modify: `packages/gateway/src/discord/commands/index.ts` — register the new command in the registry
-- Modify: `packages/gateway/src/config.ts` — add `workspaceAgentUrl` (defaults to `http://workspace:9100`) and `gatewayGitHubAppInstallUrl` (defaults to `https://github.com/apps/fro-bot/installations/new`; overridable for testing)
+- Modify: `packages/gateway/src/config.ts` — add `workspaceAgentUrl` (defaults to `http://workspace:9100`); `gatewayGitHubAppInstallUrl` is already present from PR B and does not need re-adding
 - Test: `packages/gateway/src/workspace-api/client.test.ts`, `packages/gateway/src/discord/channels.test.ts`, `packages/gateway/src/discord/commands/add-project.test.ts`
 
 **Approach:**
@@ -377,8 +379,20 @@ deploy/compose.yaml                          (PR B — GitHub App secret mounts)
 **workspace-api client:**
 - Single config: `WORKSPACE_AGENT_URL` env var (defaults to `http://workspace:9100`). Plumbed via `loadGatewayConfig`.
 - Use native `fetch` (Node 24+). No HTTP library dep needed.
-- `clone` method JSON-stringifies the request body, posts to `/clone`, parses the response, returns `Result<CloneResponse, WorkspaceError>`. Timeout: 5min for clone (large monorepos).
+- `clone` method JSON-stringifies the request body, posts to `/clone`, parses the response, returns `Result<CloneSuccess, WorkspaceError>`. Timeout enforced via `AbortSignal.timeout(300_000)` (5min for large monorepos; Node 24 native). On `AbortError`, returns `WorkspaceError {kind: 'timeout'}`.
 - Network errors, non-2xx responses, JSON parse failures all become `WorkspaceError` variants with discriminated `kind`.
+- **Response integrity check:** after parsing the success response, verify the request was actually fulfilled by re-checking `(owner, repo)` was the right one. PR C's response doesn't echo back the owner/repo; the simplest defense is to log the requested `(owner, repo)` alongside the returned `path` (path includes them as the last two segments) and assert `path` ends with `/{owner}/{repo}`. Mismatch → `WorkspaceError {kind: 'response-mismatch'}`.
+- **Secret-handling invariant (non-negotiable):** `client.ts` must NEVER log request body or response body, even on retry, error, or rethrow. No `console.log(requestInit)`. No `Error.cause = requestInit`. All thrown/returned errors carry only structured, scrubbed context. Captured-logger test required (mirroring PR B's pattern) to assert no IAT or PEM-shaped string appears in any log line across happy and error paths.
+
+**Trust model for sandbox-net (document under Cross-Cutting Security Requirements):**
+
+The plain-HTTP gateway↔workspace-agent contract is acceptable in v1 ONLY under these conditions:
+- `sandbox-net` is the internal Docker compose network with NO published ports
+- `workspace` service has no `ports:` block in `deploy/compose.yaml` (only internal connectivity)
+- Operator does not stand up additional containers on `sandbox-net` without auditing them
+- No mutual auth, mTLS, or HMAC is in scope for v1
+
+If any of these change, the workspace-api client MUST add HMAC request signing (shared secret in `deploy/secrets/`) before the change ships. Documented as a hard precondition.
 
 **Channel name derivation and normalization:**
 - If operator provides `channel:<name>` option: validate against Discord channel-name rules (lowercase, `[a-z0-9-]`, 1-100 chars, must start with letter/number). Reject anything else at slash-command argument validation.
@@ -390,7 +404,16 @@ deploy/compose.yaml                          (PR B — GitHub App secret mounts)
 - `url` option description: `"GitHub repo URL (https://github.com/owner/repo)"`
 - `channel` option description: `"Optional Discord channel name (auto-derived from repo if omitted)"`
 
-**Command shape:** single top-level command `/add-project` (NOT a `/fro-bot add-project` subcommand). The parent Gateway v1 plan documents `/fro-bot` as a logical command family but the existing `/ping` is also a flat command — keep the pattern. The command lives in `packages/gateway/src/discord/commands/add-project.ts` with `data.name = 'add-project'`. Registration in `index.ts` adds it to the registry alongside `ping`.
+**Command shape (REVISED — feasibility found drift):** the existing command is actually `/fro-bot ping` (nested under `setName('fro-bot')` + subcommand `ping`), not flat. Two viable shapes:
+
+1. **Nest under `/fro-bot`** — `/fro-bot add-project` as a sibling subcommand to `ping`. Matches the existing pattern; requires editing the SubcommandBuilder in `packages/gateway/src/discord/commands/ping.ts` (or wherever the `/fro-bot` parent lives) to add the new subcommand.
+2. **Flat `/add-project`** — register as a separate top-level command. Requires the registry to handle two parent commands and the help/discoverability story to cover both.
+
+**Decision: nest under `/fro-bot` for consistency.** Subcommand structure is `/fro-bot add-project url:<string> [channel:<string>]`. Implementer locates the existing parent command builder and adds the `add-project` subcommand alongside `ping`. The `execute` handler lives in `packages/gateway/src/discord/commands/add-project.ts` and is wired into the parent dispatcher.
+
+**Slash command scope:** guild vs global is controlled by `config.discordGuildId` in `program.ts` — the existing pattern, not per-command. No changes needed.
+
+**Repo canonicalization (security requirement):** before any bindings store lookup or write, canonicalize `owner` and `repo` to lowercase. GitHub repo identity is case-insensitive, so `https://github.com/Owner/Repo` and `https://github.com/owner/repo` refer to the same repo and must produce the same binding key. Canonicalization happens in PRE_FLIGHT, right after URL parsing, before `getBindingByRepo`.
 
 **Slash command schema:** `/add-project url:<string> [channel:<string>]`. URL validated with regex `^https://github\.com/[^/]+/[^/]+(\.git)?$` at the slash-command argument validation layer (rejects bad URLs before any side effects). Channel name validated per the normalization rules above.
 
@@ -432,8 +455,9 @@ READY:
 
 **Welcome message content:**
 - Posted in the newly-bound channel
-- Plain text + embed format
-- Content (this exact wording):
+- Format: Discord embed only (single embed, no plain text content). Title: `Bound to {owner}/{repo}`. Description: the body text below. Embed color: success-green.
+- On welcome-message-post failure (e.g., bot lost permission immediately after channel creation): log the failure, edit the setup-thread message with "channel created and bound, but couldn't post welcome message — verify @-mention access". Do NOT undo the channel or binding; the binding is the source of truth.
+- Content (this exact wording in the embed description):
   ```
   This channel is bound to <repo-owner>/<repo-name>.
 
@@ -443,11 +467,30 @@ READY:
   ```
 - The "until then" sentence is critical — without it the operator sees `READY` and expects a working @-mention loop, which Unit 6 hasn't shipped yet.
 
-Setup thread lives in the source channel (where the operator ran `/add-project`). Not the new channel. Progress message edits, not new posts — keeps the thread tidy.
+Setup thread lives in the source channel (where the operator ran `/fro-bot add-project`). Not the new channel. Progress message edits, not new posts — keeps the thread tidy.
 
 Rate-limit handling: Discord 429 → exponential backoff (3 retries, 1s/2s/4s). discord.js handles this natively for most operations; the code just needs to catch and surface.
 
-Slash command deferReply with `ephemeral: false` (operator sees progress; non-ephemeral so it's preserved as a record).
+**Slash command visibility decision: ephemeral by default.** `deferReply({ephemeral: true})`. Reasoning: the source channel may be public; the setup thread reveals the workspace path, install URL, target repo identity, and structured error messages — all of which are operationally sensitive. Ephemeral progress means only the invoking operator sees the phase progression. The successful outcome (channel + welcome message in the new channel) is still publicly visible at the right scope. This deviates from the original plan's `ephemeral: false` "preserved as a record" rationale; the record is the welcome message in the new channel, not the setup thread in the source.
+
+**Permission re-check at CREATING_CHANNEL boundary:** PRE_FLIGHT verifies MANAGE_CHANNELS + SEND_MESSAGES at the start. Permissions CAN change between PRE_FLIGHT and CREATING_CHANNEL (operator demotes the bot mid-flow). Defensive re-check at CREATING_CHANNEL: if the bot lacks MANAGE_CHANNELS at that exact moment, edit the setup-thread message with the same "needs MANAGE_CHANNELS, visit invite URL" error and mark phase = FAILED. Clone is already done; no rollback of the clone (operator can retry after granting permission, and PR C's per-repo lock will serialize cleanly).
+
+**Channel collision suffix cap:** `findOrCreateChannel(guild, name, {maxSuffix: 10})`. After `name`, `name-2`, ..., `name-10` all exist, return `Result.err({kind: 'collision-exhausted'})`. Slash command surfaces "couldn't find an available channel name after 10 attempts; specify `channel:<name>` explicitly". Protects against DoS via channel-name enumeration.
+
+**Discord 15-minute interaction window:** `deferReply` extends the response window to 15 minutes total. If the orchestration takes longer (large monorepo clone + Discord rate-limit backoff + S3 binding write), the interaction expires and `editReply`/`followUp` start failing. Defensive handling: track elapsed time from interaction start; at 14 minutes, abort the orchestration cleanly (mark phase = FAILED, log "interaction window exhausted"). The clone and channel are NOT rolled back; they become orphaned state that the operator can manually clean up using the same paths as binding-write failures.
+
+**Orchestration durability — v1 acceptance:** for v1, the orchestration is in-memory only. Process crash mid-flow → orphaned state (channel created but no binding, clone done but no channel, etc.). The plan acknowledges this and provides operator-facing manual recovery instructions for each partial-failure shape:
+
+- Clone done, no channel: workspace path is `/workspace/repos/{owner}/{repo}`; remove with `rm -rf` if not wanted, or retry `/fro-bot add-project` (per-repo lock in PR C will detect the existing clone and return 409 `repo-exists`; operator must rm and retry).
+- Channel created, no binding: channel name is visible; binding S3 key is `bindings/{owner}/{repo}/repo.json`; operator must either retry the command (collision suffix logic will discover the existing channel and surface "channel exists but no binding — manual recovery required") or manually delete the channel and retry.
+- Binding created, no welcome message: rare; bot lost permission immediately after channel creation. Recovery: retry the command (PRE_FLIGHT finds the binding and aborts with "already bound" — informational, the operator can ignore).
+
+Persistent setup-state (resume-on-crash) is deferred to Unit 6 or later. Documented as an accepted v1 limitation in the operator README that PR D will update.
+
+**Observability contract:** every phase boundary emits a structured log line via the gateway's existing logger:
+- Fields: `correlationId` (interaction ID), `phase` (string), `owner`, `repo`, `channelName` (when known), `durationMs` (since phase start), `outcome` (`success`/`error`), `errorKind` (when error, the discriminated error variant).
+- IAT is NEVER logged. Captured-logger test asserts no `ghs_`-prefixed string appears in any log line.
+- The `correlationId` ties together: slash command invocation → App auth → workspace-agent call → S3 writes → Discord channel creation. Operator debugging a failed `/fro-bot add-project` can grep for the correlationId across all gateway logs.
 
 **Execution note:** Test-first for the partial-failure scenarios (channel created but binding write failed; clone succeeded but channel creation failed). These are the operator-facing failure modes that determine whether the command is recoverable.
 
@@ -472,10 +515,30 @@ Slash command deferReply with `ephemeral: false` (operator sees progress; non-ep
 - Error path — binding write fails after channel created (WRITING_BINDING): edit msg "channel #X created but binding failed; re-run the command or manually clean up". Pre-flight on retry sees existing channel and either reuses it (if name matches expected derived name) or surfaces collision.
 - Edge case — concurrent `/add-project` calls for the same repo: second call's PRE_FLIGHT sees the first call's binding (or its CLONING phase) and aborts cleanly.
 - Security check — token in the workspace-api request body is NOT included in any error message.
-- Happy path — `clone({owner, repo, token})` POSTs to `/clone` with the right body, returns `Result.ok({ok: true, sha})`.
+- Happy path — `clone({owner, repo, token})` POSTs to `/clone` with the right body, returns `Result.ok({ok: true, path, commit})` (note PR C ships `path`+`commit`, not `sha`).
+- Happy path — response `path` ends with `/{owner}/{repo}`; mismatch (e.g., server returns wrong repo's path) → `Result.err({kind: 'response-mismatch'})`.
 - Error path — workspace agent returns 500 → `Result.err({kind: 'http-error', status: 500})`.
+- Error path — workspace agent returns one of PR C's structured error codes (clone-timeout, head-resolution-failed, disk-full, overloaded, body-too-large, repo-exists, etc.) → preserved as `WorkspaceError {kind: 'clone-error', code: <CloneErrorCode>}`.
 - Error path — connection refused (workspace not running) → `Result.err({kind: 'network-error'})`.
 - Error path — timeout (clone took >5min) → `Result.err({kind: 'timeout'})`.
+- Error path — JSON parse failure on response body (truncated, malformed) → `Result.err({kind: 'parse-error'})`.
+- Security — captured-logger test: no `ghs_`-prefixed string appears in any log line across happy + all error paths.
+- Security — no `console.log(requestInit)` or equivalent body-logging code exists in `client.ts`.
+
+**Orchestration timing + crash + abuse failure paths:**
+
+- Timing — Discord interaction window hits 14 min while still in CLONING: orchestration aborts cleanly, phase = FAILED, structured "interaction window exhausted" log line, clone preserved (orphan), no channel/binding written.
+- Timing — IAT expires (~1 hour) between PRE_FLIGHT and WRITING_BINDING: workspace-agent rejects with 401 or similar; orchestration surfaces "auth token expired during operation; retry the command" and marks phase = FAILED. (Defensive: PR B's `authForRepo` returns a fresh IAT each call; PR D should NOT cache the IAT across phases — re-fetch if any phase needs it past the initial CLONING call.)
+- Timing — Discord API outage during CREATING_CHANNEL: rate-limit retries exhausted, structured "Discord API unreachable" error, clone preserved, phase = FAILED.
+- Concurrency — same user double-clicks `/fro-bot add-project` within a second: the second invocation's PRE_FLIGHT sees either the first's binding (if WRITING_BINDING completed) or the first's CLONING-phase workspace path (if PR C's per-repo lock is still held). Surface "this repo is currently being added; please wait" without errors.
+- Concurrency — different users invoke `/fro-bot add-project` for the same repo simultaneously: same as double-click; PR C's per-repo lock serializes; second caller sees `repo-exists` 409.
+- UX — operator deletes the setup-thread message mid-orchestration: `editReply` fails with Discord 404 or similar; log the failure, continue the orchestration silently to completion (binding + channel still landed), and DON'T attempt to recreate the deleted message.
+- Permission re-check — bot permissions revoked between PRE_FLIGHT and CREATING_CHANNEL: defensive re-check catches it, edits setup-thread message with revoke-and-reinvite instructions, phase = FAILED, clone preserved.
+- Abuse control — same user invokes `/fro-bot add-project` 10 times in 60 seconds: rate-limit per Discord user via simple in-memory bucket (5 invocations per 60s per user). 6th+ invocation gets ephemeral "rate-limited; try again in N seconds" without entering any phase. (v1 in-memory only; persistent rate-limiter deferred.)
+- Observability — every phase boundary emits a log line with `correlationId`, `phase`, `outcome`, `errorKind` when applicable; correlationId matches the Discord interaction ID; no `ghs_*` token appears anywhere in logs (captured-logger test).
+- Welcome message — post fails after channel + binding written: setup-thread edited with "channel + binding created, welcome message failed; verify bot has Send Messages in #channelName"; binding + channel NOT undone.
+- Channel collision — `name`, `name-2`, ..., `name-10` all exist: returns `collision-exhausted`; slash command surfaces "specify `channel:<name>` explicitly".
+- Canonicalization — `https://github.com/Owner/Repo` and `https://github.com/owner/repo` produce the same binding key (lowercase canonicalized in PRE_FLIGHT before lookup).
 
 **Verification:**
 - `pnpm --filter @fro-bot/gateway test` green

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -50,6 +50,9 @@ Not used at this scope:
 - `src/config.ts` — env + secret reading. `readSecret(name)` checks `${NAME}_FILE` first, falls back to `process.env[name]`.
 - `src/runtime-effect.ts` — the Result<>→Effect boundary.
 - `src/discord/` — Discord.js integration. Client construction with safe `allowedMentions` defaults, command registry, mention handler.
+  - `src/discord/channels.ts` — channel creation helper used by the add-project flow. `createChannelWithCollisionSuffix` always creates a fresh channel; it never returns an existing one. Tries the exact name first, then `name-2` through `name-10`, skipping any candidate whose name is already taken.
+  - `src/discord/commands/add-project.ts` — `/fro-bot add-project` slash command. Orchestrates the 5-phase flow (PRE_FLIGHT → CLONING → CREATING_CHANNEL → WRITING_BINDING → READY). Depends on `channels.ts` for channel creation, `workspace-api/client.ts` for repo cloning, `bindings/store.ts` for durable binding persistence, and `github/app-client.ts` for GitHub App token acquisition.
+- `src/workspace-api/` — HTTP client for the workspace-agent sidecar service. `WorkspaceClient` wraps the `/clone` endpoint and maps HTTP error shapes to typed `Result<CloneSuccess, CloneError>` values. The client is injected into `add-project.ts` via `AddProjectDeps`.
 - `src/shutdown.ts` — SIGTERM handler with 25s drain.
 
 ## Configuration knobs

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -26,6 +26,7 @@ export interface GatewayConfig {
   readonly githubAppId: string
   readonly githubAppPrivateKey: string
   readonly gatewayGitHubAppInstallUrl: string
+  readonly workspaceAgentUrl: string
 }
 
 const MAX_SECRET_BYTES = 4096
@@ -313,6 +314,8 @@ export function loadGatewayConfig(): GatewayConfig {
   const gatewayGitHubAppInstallUrl =
     readOptionalSecret('GATEWAY_GITHUB_APP_INSTALL_URL') ?? 'https://github.com/apps/fro-bot/installations/new'
 
+  const workspaceAgentUrl = readOptionalSecret('WORKSPACE_AGENT_URL') ?? 'http://workspace:9100'
+
   return {
     discordToken,
     discordApplicationId,
@@ -324,5 +327,6 @@ export function loadGatewayConfig(): GatewayConfig {
     githubAppId,
     githubAppPrivateKey,
     gatewayGitHubAppInstallUrl,
+    workspaceAgentUrl,
   }
 }

--- a/packages/gateway/src/discord/channels.test.ts
+++ b/packages/gateway/src/discord/channels.test.ts
@@ -1,0 +1,328 @@
+import type {Guild, TextChannel} from 'discord.js'
+
+import {ChannelType} from 'discord.js'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createChannelWithCollisionSuffix} from './channels.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTextChannel(name: string, id = `id-${name}`): TextChannel {
+  return {name, id, type: ChannelType.GuildText} as unknown as TextChannel
+}
+
+/**
+ * Build a guild mock whose `channels.cache.find` reads from a live `channels` array.
+ * Pass a mutable array so tests can push new channels after creation to simulate
+ * the live-cache behaviour the race fix depends on.
+ */
+function makeGuildWithLiveCache(channels: TextChannel[], createResult?: TextChannel | Error): Guild {
+  const cache = {
+    // Re-read `channels` on every call — simulates the live Discord.js cache.
+    find: (pred: (ch: TextChannel) => boolean) => channels.find(pred),
+  }
+
+  const create =
+    createResult instanceof Error
+      ? vi.fn().mockRejectedValue(createResult)
+      : vi.fn().mockResolvedValue(createResult ?? makeTextChannel('new-channel'))
+
+  return {
+    channels: {cache, create},
+  } as unknown as Guild
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createChannelWithCollisionSuffix', () => {
+  describe('always creates — never returns existing channel', () => {
+    it('creates a new channel even when exact name already exists (skips to name-2)', async () => {
+      // #given — my-repo exists; my-repo-2 is free
+      const existing = makeTextChannel('my-repo')
+      const newChannel = makeTextChannel('my-repo-2')
+      const channels = [existing]
+      const cache = {
+        find: (pred: (ch: TextChannel) => boolean) => channels.find(pred),
+      }
+      const create = vi.fn().mockResolvedValue(newChannel)
+      const guild = {channels: {cache, create}} as unknown as Guild
+
+      // #when
+      const result = await createChannelWithCollisionSuffix(guild, 'my-repo')
+
+      // #then — must NOT return the existing channel; creates my-repo-2
+      expect(result.success).toBe(true)
+      if (result.success === false) return
+      expect(result.data.name).toBe('my-repo-2')
+      expect(create).toHaveBeenCalledWith(expect.objectContaining({name: 'my-repo-2'}))
+    })
+
+    it('creates name-3 when name and name-2 both exist', async () => {
+      // #given — my-repo and my-repo-2 exist; my-repo-3 is free
+      const ch1 = makeTextChannel('my-repo')
+      const ch2 = makeTextChannel('my-repo-2')
+      const newChannel = makeTextChannel('my-repo-3')
+      const channels = [ch1, ch2]
+      const cache = {
+        find: (pred: (ch: TextChannel) => boolean) => channels.find(pred),
+      }
+      const create = vi.fn().mockResolvedValue(newChannel)
+      const guild = {channels: {cache, create}} as unknown as Guild
+
+      // #when
+      const result = await createChannelWithCollisionSuffix(guild, 'my-repo')
+
+      // #then
+      expect(result.success).toBe(true)
+      if (result.success === false) return
+      expect(result.data.name).toBe('my-repo-3')
+      // create was called once (for my-repo-3 — my-repo and my-repo-2 were skipped via nameExists)
+      expect(create).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('create new channel', () => {
+    it('creates a new channel when none exists with that name', async () => {
+      // #given
+      const newChannel = makeTextChannel('new-repo')
+      const guild = makeGuildWithLiveCache([], newChannel)
+
+      // #when
+      const result = await createChannelWithCollisionSuffix(guild, 'new-repo')
+
+      // #then
+      expect(result.success).toBe(true)
+      if (result.success === false) return
+      expect(result.data.name).toBe('new-repo')
+    })
+  })
+
+  describe('collision suffix logic (name-taken from Discord)', () => {
+    it('uses name-2 suffix when Discord rejects name as duplicate (code 50035)', async () => {
+      // #given — no existing channels in cache, but Discord rejects first create with 50035
+      const newChannel = makeTextChannel('my-repo-2')
+      const channels: TextChannel[] = []
+      const nameTakenError = Object.assign(new Error('Invalid Form Body'), {code: 50035})
+      const cache = {
+        find: (pred: (ch: TextChannel) => boolean) => channels.find(pred),
+      }
+      const create = vi
+        .fn()
+        .mockRejectedValueOnce(nameTakenError) // first attempt: Discord rejects as duplicate
+        .mockResolvedValue(newChannel) // second attempt succeeds
+      const guild = {channels: {cache, create}} as unknown as Guild
+
+      // #when
+      const result = await createChannelWithCollisionSuffix(guild, 'my-repo')
+
+      // #then
+      expect(result.success).toBe(true)
+      if (result.success === false) return
+      expect(result.data.name).toBe('my-repo-2')
+      // create was called twice (my-repo rejected by Discord, my-repo-2 succeeded)
+      expect(create).toHaveBeenCalledTimes(2)
+    })
+
+    it('creates name-3 when name and name-2 are both rejected by Discord as duplicate', async () => {
+      // #given — no existing channels match; first two creates rejected with 50035; third succeeds
+      const newChannel = makeTextChannel('my-repo-3')
+      const channels: TextChannel[] = []
+      const nameTakenError = Object.assign(new Error('Invalid Form Body'), {code: 50035})
+      const cache = {
+        find: (pred: (ch: TextChannel) => boolean) => channels.find(pred),
+      }
+      const create = vi
+        .fn()
+        .mockRejectedValueOnce(nameTakenError) // my-repo
+        .mockRejectedValueOnce(nameTakenError) // my-repo-2
+        .mockResolvedValue(newChannel) // my-repo-3
+      const guild = {channels: {cache, create}} as unknown as Guild
+
+      // #when
+      const result = await createChannelWithCollisionSuffix(guild, 'my-repo')
+
+      // #then
+      expect(result.success).toBe(true)
+      if (result.success === false) return
+      expect(result.data.name).toBe('my-repo-3')
+      // create was called 3 times
+      expect(create).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('collision-exhausted', () => {
+    it('returns collision-exhausted when all candidates (name through name-10) are taken', async () => {
+      // #given — exact name and all suffix candidates exist
+      const allChannels = [
+        makeTextChannel('my-repo'),
+        ...Array.from({length: 9}, (_, i) => makeTextChannel(`my-repo-${i + 2}`)),
+      ]
+      const cache = {
+        find: (pred: (ch: TextChannel) => boolean) => allChannels.find(pred),
+      }
+      const create = vi.fn() // should never be called
+      const guild = {channels: {cache, create}} as unknown as Guild
+
+      // #when
+      const result = await createChannelWithCollisionSuffix(guild, 'my-repo', {maxSuffix: 10})
+
+      // #then
+      expect(result.success).toBe(false)
+      if (result.success === true) return
+      expect(result.error.kind).toBe('collision-exhausted')
+      expect((result.error as {name: string}).name).toBe('my-repo')
+      // create was never called — all candidates were skipped via nameExists
+      expect(create).not.toHaveBeenCalled()
+    })
+
+    it('respects custom maxSuffix — collision-exhausted at -2', async () => {
+      // #given — my-repo and my-repo-2 both exist; maxSuffix is 2
+      const allChannels = [makeTextChannel('my-repo'), makeTextChannel('my-repo-2')]
+      const cache = {
+        find: (pred: (ch: TextChannel) => boolean) => allChannels.find(pred),
+      }
+      const create = vi.fn()
+      const guild = {channels: {cache, create}} as unknown as Guild
+
+      // #when
+      const result = await createChannelWithCollisionSuffix(guild, 'my-repo', {maxSuffix: 2})
+
+      // #then
+      expect(result.success).toBe(false)
+      if (result.success === true) return
+      expect(result.error.kind).toBe('collision-exhausted')
+      expect(create).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('permission-denied', () => {
+    it('returns permission-denied when channel creation fails with 403', async () => {
+      // #given
+      const permError = new Error('Missing Permissions (403)')
+      const guild = makeGuildWithLiveCache([], permError)
+
+      // #when
+      const result = await createChannelWithCollisionSuffix(guild, 'new-repo')
+
+      // #then
+      expect(result.success).toBe(false)
+      if (result.success === true) return
+      expect(result.error.kind).toBe('permission-denied')
+    })
+
+    it('returns permission-denied immediately when Discord returns code 50013', async () => {
+      // #given — Discord 50013 "Missing Permissions" numeric code
+      const permError = Object.assign(new Error('Missing Permissions'), {code: 50013})
+      const guild = makeGuildWithLiveCache([], permError)
+
+      // #when
+      const result = await createChannelWithCollisionSuffix(guild, 'new-repo')
+
+      // #then
+      expect(result.success).toBe(false)
+      if (result.success === true) return
+      expect(result.error.kind).toBe('permission-denied')
+    })
+  })
+
+  describe('create-failed (non-transient errors)', () => {
+    it('returns create-failed immediately on 429 rate-limit — does not burn through suffixes', async () => {
+      // #given — all tryCreate calls throw a 429-shaped error (non-permission, non-name-taken)
+      const rateLimitError = Object.assign(new Error('You are being rate limited.'), {code: 50007})
+      const channels: TextChannel[] = []
+      const cache = {
+        find: (pred: (ch: TextChannel) => boolean) => channels.find(pred),
+      }
+      // create is called at most once — create-failed must short-circuit immediately
+      const create = vi.fn().mockRejectedValue(rateLimitError)
+      const guild = {channels: {cache, create}} as unknown as Guild
+
+      // #when
+      const result = await createChannelWithCollisionSuffix(guild, 'my-repo')
+
+      // #then — returns create-failed after FIRST failure, not after burning all 10 suffixes
+      expect(result.success).toBe(false)
+      if (result.success === true) return
+      expect(result.error.kind).toBe('create-failed')
+      // create was called exactly once — did not burn through suffix candidates
+      expect(create).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('concurrent race — live cache re-read', () => {
+    it('second concurrent invocation sees channel created by first and advances to suffix -2', async () => {
+      // #given — shared mutable cache that reflects newly-created channels
+      const channels: TextChannel[] = []
+      const fooChannel = makeTextChannel('foo')
+      const foo2Channel = makeTextChannel('foo-2')
+
+      const cache = {
+        // Re-reads `channels` on every call — simulates live Discord.js cache.
+        find: (pred: (ch: TextChannel) => boolean) => channels.find(pred),
+      }
+
+      // First invocation's create: succeeds for 'foo', mutates shared cache.
+      // Second invocation's create: succeeds for 'foo-2'.
+      let createCallCount = 0
+      const create = vi.fn().mockImplementation(async ({name}: {name: string}) => {
+        createCallCount++
+        if (name === 'foo') {
+          // Simulate first invocation creating 'foo' and it becoming visible in cache.
+          channels.push(fooChannel)
+          return Promise.resolve(fooChannel)
+        }
+        if (name === 'foo-2') {
+          channels.push(foo2Channel)
+          return Promise.resolve(foo2Channel)
+        }
+        return Promise.reject(new Error(`Unexpected create call for ${name}`))
+      })
+
+      const guild = {channels: {cache, create}} as unknown as Guild
+
+      // #when — two concurrent invocations with the same baseName
+      const [result1, result2] = await Promise.all([
+        createChannelWithCollisionSuffix(guild, 'foo'),
+        createChannelWithCollisionSuffix(guild, 'foo'),
+      ])
+
+      // #then — both succeed, resolving to different channel names
+      expect(result1.success).toBe(true)
+      expect(result2.success).toBe(true)
+      if (result1.success === false || result2.success === false) return
+
+      const names = new Set([result1.data.name, result2.data.name])
+      expect(names).toContain('foo')
+      expect(names).toContain('foo-2')
+
+      // create was called exactly twice — no wasted attempts
+      expect(createCallCount).toBe(2)
+    })
+  })
+
+  describe('maxSuffix: 1 boundary', () => {
+    it('returns collision-exhausted immediately when maxSuffix:1 and base name already exists', async () => {
+      // #given — 'foo' already exists; maxSuffix:1 means only 'foo' is tried (no 'foo-2')
+      const existing = makeTextChannel('foo')
+      const channels = [existing]
+      const cache = {
+        find: (pred: (ch: TextChannel) => boolean) => channels.find(pred),
+      }
+      const create = vi.fn() // should never be called
+      const guild = {channels: {cache, create}} as unknown as Guild
+
+      // #when
+      const result = await createChannelWithCollisionSuffix(guild, 'foo', {maxSuffix: 1})
+
+      // #then — collision-exhausted without trying foo-2
+      expect(result.success).toBe(false)
+      if (result.success === true) return
+      expect(result.error.kind).toBe('collision-exhausted')
+      expect(create).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/gateway/src/discord/channels.ts
+++ b/packages/gateway/src/discord/channels.ts
@@ -1,0 +1,118 @@
+/**
+ * Discord channel management utilities.
+ *
+ * Provides `createChannelWithCollisionSuffix` which ALWAYS creates a new channel.
+ * If the desired name is taken, it tries suffixes (name-2, name-3, ..., name-{maxSuffix})
+ * until a free slot is found. This prevents binding a new repo to an unrelated
+ * existing channel.
+ */
+
+import type {Result} from '@fro-bot/runtime'
+import type {Guild, TextChannel} from 'discord.js'
+
+import {err, ok} from '@fro-bot/runtime'
+import {ChannelType} from 'discord.js'
+
+export type ChannelError =
+  | {readonly kind: 'collision-exhausted'; readonly name: string; readonly maxSuffix: number}
+  | {readonly kind: 'create-failed'; readonly message: string}
+  | {readonly kind: 'permission-denied'; readonly message: string}
+
+export interface FindOrCreateChannelOptions {
+  readonly maxSuffix?: number
+}
+
+/**
+ * Always creates a new text channel — never returns an existing one.
+ *
+ * Tries the exact name first, then `name-2`, `name-3`, ..., `name-{maxSuffix}`.
+ * Any candidate whose name is already taken is skipped. The first free slot is
+ * created and returned. This prevents accidentally binding a new repo to an
+ * unrelated pre-existing channel.
+ *
+ * Returns `{kind: 'collision-exhausted'}` if every candidate is already taken.
+ *
+ * @param guild - The Discord guild to create the channel in.
+ * @param name - The desired channel name (must already be normalized/validated).
+ * @param options - Optional config; `maxSuffix` defaults to 10.
+ */
+export async function createChannelWithCollisionSuffix(
+  guild: Guild,
+  name: string,
+  options: FindOrCreateChannelOptions = {},
+): Promise<Result<TextChannel, ChannelError>> {
+  const {maxSuffix = 10} = options
+
+  // Iterate candidates: exact name, then name-2, name-3, ..., name-{maxSuffix}.
+  // NEVER return an existing channel — always create a fresh one.
+  const candidates = [name, ...Array.from({length: maxSuffix - 1}, (_, i) => `${name}-${i + 2}`)]
+
+  for (const candidate of candidates) {
+    // Re-read the cache each iteration — concurrent setups may have created channels
+    // we didn't see at function entry. A frozen snapshot would cause two concurrent
+    // invocations to both think a candidate is free, both call create(), and the loser
+    // would silently advance to the next suffix, binding to the wrong channel.
+    const existing = guild.channels.cache.find(
+      c => c.name.toLowerCase() === candidate.toLowerCase() && c.type === ChannelType.GuildText,
+    )
+    if (existing !== undefined) {
+      // This name is already taken — skip to next suffix.
+      continue
+    }
+
+    const createResult = await tryCreate(guild, candidate)
+    if (createResult.kind === 'ok') {
+      return ok(createResult.channel)
+    } else if (createResult.kind === 'permission-denied') {
+      return err({kind: 'permission-denied', message: createResult.message})
+    } else if (createResult.kind === 'create-failed') {
+      // Non-transient failure (429, 5xx, network) — surface immediately, don't burn suffixes.
+      return err({kind: 'create-failed', message: createResult.message})
+    }
+    // kind === 'name-taken' — Discord rejected the name as duplicate; try next suffix.
+  }
+
+  return err({kind: 'collision-exhausted', name, maxSuffix})
+}
+
+type TryCreateResult =
+  | {readonly kind: 'ok'; readonly channel: TextChannel}
+  | {readonly kind: 'permission-denied'; readonly message: string}
+  | {readonly kind: 'name-taken'}
+  | {readonly kind: 'create-failed'; readonly message: string}
+
+/**
+ * Attempt to create a channel with the given name.
+ *
+ * Returns a discriminated result:
+ * - `ok` — channel created successfully
+ * - `permission-denied` — bot lacks Manage Channels (Discord 50013 / 403)
+ * - `name-taken` — Discord rejected the name as duplicate (Discord 50035)
+ * - `create-failed` — other failure (429, 5xx, network); caller should NOT retry with next suffix
+ */
+async function tryCreate(guild: Guild, name: string): Promise<TryCreateResult> {
+  try {
+    const created = await guild.channels.create({
+      name,
+      type: ChannelType.GuildText,
+    })
+    return {kind: 'ok', channel: created}
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+
+    // Check numeric error code first (more reliable than regex on message text).
+    const code = error !== null && typeof error === 'object' && 'code' in error ? error.code : undefined
+
+    if (code === 50013 || /missing.?permissions|403/i.test(message)) {
+      return {kind: 'permission-denied', message}
+    }
+
+    if (code === 50035) {
+      // "Invalid Form Body" — Discord rejects duplicate channel name.
+      return {kind: 'name-taken'}
+    }
+
+    // All other errors (429 rate-limit, 5xx, network) — surface immediately.
+    return {kind: 'create-failed', message}
+  }
+}

--- a/packages/gateway/src/discord/commands/add-project.test.ts
+++ b/packages/gateway/src/discord/commands/add-project.test.ts
@@ -1,0 +1,643 @@
+/**
+ * Tests for the `/fro-bot add-project` subcommand handler.
+ *
+ * Uses vitest with BDD-style comments (#given, #when, #then).
+ * All Discord API calls are mocked — no real network or Discord connections.
+ */
+
+import type {ChatInputCommandInteraction, Guild, TextChannel} from 'discord.js'
+import type {BindingsStore} from '../../bindings/store.js'
+import type {AppClient} from '../../github/app-client.js'
+import type {WorkspaceClient} from '../../workspace-api/client.js'
+import type {AddProjectDeps} from './add-project.js'
+
+import {err, ok} from '@fro-bot/runtime'
+import {Effect} from 'effect'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {AppNotInstalledError} from '../../github/app-client.js'
+import {executeAddProject} from './add-project.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeLogger(): AddProjectDeps['logger'] {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+}
+
+/** Extract the content string from the last editReply call. */
+function lastEditReplyContent(editReply: ReturnType<typeof vi.fn>): string {
+  const calls = editReply.mock.calls as [{content?: string}][]
+  return calls.at(-1)?.[0]?.content ?? ''
+}
+
+/** Extract the content string from the last reply call. */
+function lastReplyContent(reply: ReturnType<typeof vi.fn>): string {
+  const calls = reply.mock.calls as [{content?: string}][]
+  return calls.at(-1)?.[0]?.content ?? ''
+}
+
+interface MockChannel {
+  readonly channel: TextChannel
+  readonly send: ReturnType<typeof vi.fn>
+}
+
+function makeTextChannel(name = 'my-repo', id = 'ch-123'): MockChannel {
+  const send = vi.fn().mockResolvedValue(undefined)
+  const channel = {name, id, send} as unknown as TextChannel
+  return {channel, send}
+}
+
+function makeGuild(
+  _botUserId = 'bot-user-id',
+  hasPermissions = true,
+  channels: TextChannel[] = [],
+  createChannelResult?: TextChannel | Error,
+): Guild {
+  const permissions = {
+    has: vi.fn().mockReturnValue(hasPermissions),
+  }
+  const member = {permissions}
+  const members = {cache: {get: vi.fn().mockReturnValue(member)}}
+
+  const channelCache = {
+    find: (pred: (ch: TextChannel) => boolean) => channels.find(pred),
+  }
+  const create =
+    createChannelResult instanceof Error
+      ? vi.fn().mockRejectedValue(createChannelResult)
+      : vi.fn().mockResolvedValue(createChannelResult ?? makeTextChannel().channel)
+
+  return {
+    members,
+    channels: {cache: channelCache, create},
+  } as unknown as Guild
+}
+
+interface MockInteraction {
+  readonly interaction: ChatInputCommandInteraction
+  readonly editReply: ReturnType<typeof vi.fn>
+  readonly deferReply: ReturnType<typeof vi.fn>
+  readonly reply: ReturnType<typeof vi.fn>
+}
+
+function makeInteraction(overrides: {
+  url?: string
+  channel?: string | null
+  guild?: Guild | null
+  userId?: string
+  appPermissions?: {has: ReturnType<typeof vi.fn>} | null
+}): MockInteraction {
+  const {
+    url = 'https://github.com/testowner/testrepo',
+    channel = null,
+    guild = makeGuild(),
+    userId = 'user-123',
+    appPermissions = {has: vi.fn().mockReturnValue(true)},
+  } = overrides
+
+  const deferReply = vi.fn().mockResolvedValue(undefined)
+  const editReply = vi.fn().mockResolvedValue(undefined)
+  const reply = vi.fn().mockResolvedValue(undefined)
+
+  const getString = vi.fn().mockImplementation((name: string, required?: boolean) => {
+    if (name === 'url') return url
+    if (name === 'channel') return channel
+    return required === true ? '' : null
+  })
+
+  const interaction = {
+    id: 'interaction-id',
+    user: {id: userId},
+    guild,
+    appPermissions,
+    client: {user: {id: 'bot-user-id'}},
+    options: {getString, getSubcommand: vi.fn().mockReturnValue('add-project')},
+    deferReply,
+    editReply,
+    reply,
+  } as unknown as ChatInputCommandInteraction
+
+  return {interaction, editReply, deferReply, reply}
+}
+
+function makeBindingsStore(overrides?: {
+  getBindingByRepo?: ReturnType<typeof vi.fn>
+  createBinding?: ReturnType<typeof vi.fn>
+}): BindingsStore {
+  return {
+    getBindingByRepo: overrides?.getBindingByRepo ?? vi.fn().mockResolvedValue(ok(null)),
+    getBindingByChannelId: vi.fn().mockResolvedValue(ok(null)),
+    listBindings: vi.fn().mockResolvedValue(ok([])),
+    createBinding:
+      overrides?.createBinding ?? vi.fn().mockResolvedValue(ok({primaryEtag: 'etag1', indexEtag: 'etag2'})),
+  } as unknown as BindingsStore
+}
+
+function makeAppClient(overrides?: {authForRepo?: ReturnType<typeof vi.fn>}): AppClient {
+  return {
+    authForRepo:
+      overrides?.authForRepo ?? vi.fn().mockResolvedValue(ok({octokit: {}, installationId: 1, token: 'ghs_testtoken'})),
+    invalidateCache: vi.fn(),
+  } as unknown as AppClient
+}
+
+function makeWorkspaceClient(overrides?: {clone?: ReturnType<typeof vi.fn>}): WorkspaceClient {
+  return {
+    clone:
+      overrides?.clone ??
+      vi.fn().mockResolvedValue(ok({ok: true, path: '/workspace/repos/testowner/testrepo', commit: 'abc123'})),
+  } as unknown as WorkspaceClient
+}
+
+function makeDeps(overrides?: Partial<AddProjectDeps>): AddProjectDeps {
+  return {
+    bindingsStore: makeBindingsStore(),
+    appClient: makeAppClient(),
+    workspaceClient: makeWorkspaceClient(),
+    installUrl: 'https://github.com/apps/fro-bot/installations/new',
+    logger: makeLogger(),
+    ...overrides,
+  }
+}
+
+async function run(interaction: ChatInputCommandInteraction, deps: AddProjectDeps): Promise<void> {
+  await Effect.runPromise(executeAddProject(interaction, deps))
+}
+
+// ---------------------------------------------------------------------------
+// Reset rate limit state between tests
+// ---------------------------------------------------------------------------
+
+// The rate limiter is module-level state. We reset it by using unique user IDs per test.
+let userIdCounter = 0
+function uniqueUserId(): string {
+  return `user-${++userIdCounter}`
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('executeAddProject', () => {
+  describe('happy path', () => {
+    it('completes all phases and posts welcome message', async () => {
+      // #given
+      const userId = uniqueUserId()
+      const {channel, send} = makeTextChannel('testrepo')
+      const guild = makeGuild('bot-user-id', true, [], channel)
+      const {interaction, editReply} = makeInteraction({guild, userId})
+      const deps = makeDeps()
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — editReply called with success message
+      expect(lastEditReplyContent(editReply)).toContain('Ready')
+      // Welcome message posted in channel
+      expect(send).toHaveBeenCalledOnce()
+    })
+
+    it('canonicalizes Owner/Repo to lowercase before binding', async () => {
+      // #given
+      const userId = uniqueUserId()
+      const {channel} = makeTextChannel('testrepo')
+      const guild = makeGuild('bot-user-id', true, [], channel)
+      const {interaction} = makeInteraction({
+        url: 'https://github.com/TestOwner/TestRepo',
+        guild,
+        userId,
+      })
+      const createBinding = vi.fn().mockResolvedValue(ok({primaryEtag: 'e1', indexEtag: 'e2'}))
+      const deps = makeDeps({bindingsStore: makeBindingsStore({createBinding})})
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — binding written with lowercase owner/repo
+      const calls = createBinding.mock.calls as [{owner: string; repo: string}][]
+      expect(calls[0]?.[0]?.owner).toBe('testowner')
+      expect(calls[0]?.[0]?.repo).toBe('testrepo')
+    })
+  })
+
+  describe('PRE_FLIGHT: rate limiting', () => {
+    it('rejects after 5 invocations within 60 seconds', async () => {
+      // #given — same user ID for all 6 calls
+      const userId = uniqueUserId()
+      const guild = makeGuild('bot-user-id', true, [], makeTextChannel().channel)
+      const deps = makeDeps()
+
+      // #when — 5 allowed calls
+      for (let i = 0; i < 5; i++) {
+        const {interaction} = makeInteraction({guild, userId})
+        await run(interaction, deps)
+      }
+
+      // 6th call should be rate-limited
+      const {interaction: blockedInteraction, reply, deferReply} = makeInteraction({guild, userId})
+      await run(blockedInteraction, deps)
+
+      // #then — 6th call gets rate-limit reply (not deferReply)
+      expect(lastReplyContent(reply)).toContain('too fast')
+      expect(deferReply).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('PRE_FLIGHT: missing bot permissions', () => {
+    it('aborts with install URL when bot lacks MANAGE_CHANNELS', async () => {
+      // #given — appPermissions.has returns false (no permissions)
+      const userId = uniqueUserId()
+      const appPermissions = {has: vi.fn().mockReturnValue(false)}
+      const {interaction, editReply} = makeInteraction({userId, appPermissions})
+      const deps = makeDeps()
+
+      // #when
+      await run(interaction, deps)
+
+      // #then
+      expect(lastEditReplyContent(editReply)).toContain('https://github.com/apps/fro-bot/installations/new')
+    })
+
+    it('aborts gracefully when appPermissions is null (DM interaction)', async () => {
+      // #given — null appPermissions simulates a DM context
+      const userId = uniqueUserId()
+      const {interaction, editReply} = makeInteraction({userId, appPermissions: null})
+      const deps = makeDeps()
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — aborts with install URL (treated as missing permissions)
+      expect(lastEditReplyContent(editReply)).toContain('https://github.com/apps/fro-bot/installations/new')
+    })
+
+    it('aborts when bot has ManageChannels but not SendMessages', async () => {
+      // #given — has() returns true for ManageChannels, false for SendMessages
+      const userId = uniqueUserId()
+      const {PermissionFlagsBits} = await import('discord.js')
+      const appPermissions = {
+        has: vi.fn().mockImplementation((flag: bigint) => flag === PermissionFlagsBits.ManageChannels),
+      }
+      const {interaction, editReply} = makeInteraction({userId, appPermissions})
+      const deps = makeDeps()
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — aborts with permission error message
+      expect(lastEditReplyContent(editReply)).toContain('fro-bot needs')
+    })
+  })
+
+  describe('PRE_FLIGHT: invalid URL', () => {
+    it('rejects non-GitHub URLs', async () => {
+      // #given
+      const userId = uniqueUserId()
+      const {interaction, editReply} = makeInteraction({url: 'https://gitlab.com/owner/repo', userId})
+      const deps = makeDeps()
+
+      // #when
+      await run(interaction, deps)
+
+      // #then
+      expect(lastEditReplyContent(editReply)).toContain('Invalid GitHub URL')
+    })
+
+    it('rejects bare owner/repo strings', async () => {
+      // #given
+      const userId = uniqueUserId()
+      const {interaction, editReply} = makeInteraction({url: 'owner/repo', userId})
+      const deps = makeDeps()
+
+      // #when
+      await run(interaction, deps)
+
+      // #then
+      expect(lastEditReplyContent(editReply)).toContain('Invalid GitHub URL')
+    })
+  })
+
+  describe('PRE_FLIGHT: hostile channel name', () => {
+    it('rejects channel names with zero-width characters', async () => {
+      // #given
+      const userId = uniqueUserId()
+      const {interaction, editReply} = makeInteraction({channel: 'my\u200Brepo', userId})
+      const deps = makeDeps()
+
+      // #when
+      await run(interaction, deps)
+
+      // #then
+      expect(lastEditReplyContent(editReply)).toContain('disallowed characters')
+    })
+
+    it('rejects channel names with RTL override characters', async () => {
+      // #given
+      const userId = uniqueUserId()
+      const {interaction, editReply} = makeInteraction({channel: 'my\u202Erepo', userId})
+      const deps = makeDeps()
+
+      // #when
+      await run(interaction, deps)
+
+      // #then
+      expect(lastEditReplyContent(editReply)).toContain('disallowed characters')
+    })
+  })
+
+  describe('PRE_FLIGHT: already-bound repo', () => {
+    it('aborts with existing channel name when repo is already bound', async () => {
+      // #given
+      const userId = uniqueUserId()
+      const existingBinding = {
+        owner: 'testowner',
+        repo: 'testrepo',
+        channelId: 'ch-existing',
+        channelName: 'existing-channel',
+        workspacePath: '/workspace/repos/testowner/testrepo',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        createdByDiscordId: 'user-old',
+      }
+      const getBindingByRepo = vi.fn().mockResolvedValue(ok(existingBinding))
+      const {interaction, editReply} = makeInteraction({userId})
+      const deps = makeDeps({bindingsStore: makeBindingsStore({getBindingByRepo})})
+
+      // #when
+      await run(interaction, deps)
+
+      // #then
+      expect(lastEditReplyContent(editReply)).toContain('existing-channel')
+    })
+  })
+
+  describe('PRE_FLIGHT: AppNotInstalledError', () => {
+    it('aborts with install URL when GitHub App is not installed', async () => {
+      // #given
+      const userId = uniqueUserId()
+      const authForRepo = vi
+        .fn()
+        .mockResolvedValue(
+          err(new AppNotInstalledError('testowner', 'testrepo', 'https://github.com/apps/fro-bot/installations/new')),
+        )
+      const {interaction, editReply} = makeInteraction({userId})
+      const deps = makeDeps({appClient: makeAppClient({authForRepo})})
+
+      // #when
+      await run(interaction, deps)
+
+      // #then
+      expect(lastEditReplyContent(editReply)).toContain('not installed')
+    })
+  })
+
+  describe('CLONING: workspace-agent errors', () => {
+    const cloneErrorCases: {code: string; expectedFragment: string}[] = [
+      {code: 'clone-failed', expectedFragment: 'clone-failed'},
+      {code: 'disk-full', expectedFragment: 'out of space'},
+      {code: 'enospc', expectedFragment: 'out of space'},
+      {code: 'repo-exists', expectedFragment: 'already exists'},
+      {code: 'head-resolution-failed', expectedFragment: 'head-resolution-failed'},
+      {code: 'clone-timeout', expectedFragment: 'clone-timeout'},
+    ]
+
+    for (const {code, expectedFragment} of cloneErrorCases) {
+      it(`handles clone-error code: ${code}`, async () => {
+        // #given
+        const userId = uniqueUserId()
+        const clone = vi.fn().mockResolvedValue(err({kind: 'clone-error', code}))
+        const {interaction, editReply} = makeInteraction({userId})
+        const deps = makeDeps({workspaceClient: makeWorkspaceClient({clone})})
+
+        // #when
+        await run(interaction, deps)
+
+        // #then
+        expect(lastEditReplyContent(editReply)).toContain(expectedFragment)
+      })
+    }
+
+    it('handles timeout from workspace client', async () => {
+      // #given
+      const userId = uniqueUserId()
+      const clone = vi.fn().mockResolvedValue(err({kind: 'timeout'}))
+      const {interaction, editReply} = makeInteraction({userId})
+      const deps = makeDeps({workspaceClient: makeWorkspaceClient({clone})})
+
+      // #when
+      await run(interaction, deps)
+
+      // #then
+      expect(lastEditReplyContent(editReply)).toContain('timed out')
+    })
+
+    it('handles response-mismatch with internal error message', async () => {
+      // #given
+      const userId = uniqueUserId()
+      const clone = vi.fn().mockResolvedValue(err({kind: 'response-mismatch'}))
+      const {interaction, editReply} = makeInteraction({userId})
+      const deps = makeDeps({workspaceClient: makeWorkspaceClient({clone})})
+
+      // #when
+      await run(interaction, deps)
+
+      // #then
+      expect(lastEditReplyContent(editReply)).toContain('Internal error')
+    })
+  })
+
+  describe('CREATING_CHANNEL: permission revoked between PRE_FLIGHT and CREATING_CHANNEL', () => {
+    it('aborts gracefully when permissions revoked after pre-flight', async () => {
+      // #given — appPermissions.has returns true for first two calls (PRE_FLIGHT), false thereafter
+      const userId = uniqueUserId()
+      const appPermissions = {
+        has: vi.fn().mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValue(false),
+      }
+      const channelCache = {
+        filter: () => ({find: () => undefined, some: () => false}),
+      }
+      const create = vi.fn().mockResolvedValue(makeTextChannel().channel)
+      const guild = {channels: {cache: channelCache, create}} as unknown as Guild
+      const {interaction, editReply} = makeInteraction({guild, userId, appPermissions})
+      const deps = makeDeps()
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — editReply was called (not a crash)
+      expect(editReply).toHaveBeenCalled()
+    })
+  })
+
+  describe('CREATING_CHANNEL: collision-exhausted', () => {
+    it('aborts with explicit channel name suggestion when all suffixes taken', async () => {
+      // #given — exact name is free but create fails; all suffix candidates exist
+      const userId = uniqueUserId()
+      const suffixChannels: TextChannel[] = []
+      for (let i = 2; i <= 10; i++) {
+        suffixChannels.push(makeTextChannel(`testrepo-${i}`).channel)
+      }
+      const channelCache = {
+        find: (pred: (ch: TextChannel) => boolean) => suffixChannels.find(pred),
+      }
+      // First create (testrepo) rejected by Discord as duplicate (50035); all suffix candidates exist so they're skipped
+      const nameTakenError = Object.assign(new Error('Invalid Form Body'), {code: 50035})
+      const create = vi.fn().mockRejectedValue(nameTakenError)
+      const guild = {
+        channels: {cache: channelCache, create},
+      } as unknown as Guild
+      const {interaction, editReply} = makeInteraction({guild, userId})
+      const deps = makeDeps()
+
+      // #when
+      await run(interaction, deps)
+
+      // #then
+      expect(lastEditReplyContent(editReply)).toContain('Specify')
+    })
+  })
+
+  describe('WRITING_BINDING: PartialWriteError', () => {
+    it('reports partial write error with recovery instructions', async () => {
+      // #given
+      const userId = uniqueUserId()
+      const {channel} = makeTextChannel('testrepo')
+      const guild = makeGuild('bot-user-id', true, [], channel)
+      const partialWriteError = Object.assign(new Error('Partial write'), {
+        code: 'BINDING_PARTIAL_WRITE_ERROR',
+        primaryKey: 'bindings/testowner/testrepo/repo.json',
+        indexKey: 'bindings/by-channel/ch-123.json',
+      })
+      const createBinding = vi.fn().mockResolvedValue(err(partialWriteError))
+      const {interaction, editReply} = makeInteraction({guild, userId})
+      const deps = makeDeps({bindingsStore: makeBindingsStore({createBinding})})
+
+      // #when
+      await run(interaction, deps)
+
+      // #then
+      expect(lastEditReplyContent(editReply)).toContain('Partial write')
+    })
+  })
+
+  describe('WRITING_BINDING: StoreError', () => {
+    it('reports store error with retry instructions', async () => {
+      // #given
+      const userId = uniqueUserId()
+      const {channel} = makeTextChannel('testrepo')
+      const guild = makeGuild('bot-user-id', true, [], channel)
+      const storeError = new Error('S3 connection refused')
+      const createBinding = vi.fn().mockResolvedValue(err(storeError))
+      const {interaction, editReply} = makeInteraction({guild, userId})
+      const deps = makeDeps({bindingsStore: makeBindingsStore({createBinding})})
+
+      // #when
+      await run(interaction, deps)
+
+      // #then
+      expect(lastEditReplyContent(editReply)).toContain('Failed to write binding')
+    })
+  })
+
+  describe('READY: welcome message post fails', () => {
+    it('preserves channel and binding but reports send failure', async () => {
+      // #given
+      const userId = uniqueUserId()
+      const {channel, send} = makeTextChannel('testrepo')
+      send.mockRejectedValue(new Error('Missing Permissions'))
+      const guild = makeGuild('bot-user-id', true, [], channel)
+      const {interaction, editReply} = makeInteraction({guild, userId})
+      const createBinding = vi.fn().mockResolvedValue(ok({primaryEtag: 'e1', indexEtag: 'e2'}))
+      const deps = makeDeps({bindingsStore: makeBindingsStore({createBinding})})
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — binding was still created (createBinding was called)
+      expect(createBinding).toHaveBeenCalled()
+      // editReply mentions the channel was created but welcome failed
+      expect(lastEditReplyContent(editReply)).toContain('verify')
+    })
+  })
+
+  describe('PRE_FLIGHT: rate-limit eviction', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('evicts expired entries when a new user calls checkRateLimit', async () => {
+      // #given — stale user hit the limit 2 minutes ago (window is 60s)
+      const staleUserId = uniqueUserId()
+      const newUserId = uniqueUserId()
+      const guild = makeGuild('bot-user-id', true, [], makeTextChannel().channel)
+      const deps = makeDeps()
+
+      // Exhaust rate limit for stale user at t=0
+      for (let i = 0; i < 5; i++) {
+        const {interaction} = makeInteraction({guild, userId: staleUserId})
+        await run(interaction, deps)
+      }
+
+      // Advance time by 2 minutes — stale user's window has expired
+      vi.advanceTimersByTime(120_000)
+
+      // #when — new user triggers checkRateLimit (which sweeps expired entries)
+      const {interaction, editReply} = makeInteraction({guild, userId: newUserId})
+      await run(interaction, deps)
+
+      // #then — new user is allowed (not rate-limited)
+      expect(lastEditReplyContent(editReply)).toContain('Ready')
+
+      // Stale user can now invoke again (window reset by eviction + re-entry on next call)
+      const {interaction: staleInteraction, editReply: staleEditReply} = makeInteraction({guild, userId: staleUserId})
+      await run(staleInteraction, deps)
+      expect(lastEditReplyContent(staleEditReply)).toContain('Ready')
+    })
+  })
+
+  describe('canonicalization', () => {
+    it('owner/Repo and owner/repo produce the same binding key', async () => {
+      // #given
+      const userId1 = uniqueUserId()
+      const userId2 = uniqueUserId()
+      const createBinding1 = vi.fn().mockResolvedValue(ok({primaryEtag: 'e1', indexEtag: 'e2'}))
+      const createBinding2 = vi.fn().mockResolvedValue(ok({primaryEtag: 'e1', indexEtag: 'e2'}))
+
+      const guild1 = makeGuild('bot-user-id', true, [], makeTextChannel('testrepo').channel)
+      const guild2 = makeGuild('bot-user-id', true, [], makeTextChannel('testrepo').channel)
+
+      const {interaction: interaction1} = makeInteraction({
+        url: 'https://github.com/TestOwner/TestRepo',
+        guild: guild1,
+        userId: userId1,
+      })
+      const {interaction: interaction2} = makeInteraction({
+        url: 'https://github.com/testowner/testrepo',
+        guild: guild2,
+        userId: userId2,
+      })
+
+      const deps1 = makeDeps({bindingsStore: makeBindingsStore({createBinding: createBinding1})})
+      const deps2 = makeDeps({bindingsStore: makeBindingsStore({createBinding: createBinding2})})
+
+      // #when
+      await run(interaction1, deps1)
+      await run(interaction2, deps2)
+
+      // #then — both calls use the same lowercase owner/repo
+      const calls1 = createBinding1.mock.calls as [{owner: string; repo: string}][]
+      const calls2 = createBinding2.mock.calls as [{owner: string; repo: string}][]
+      expect(calls1[0]?.[0]?.owner).toBe('testowner')
+      expect(calls1[0]?.[0]?.repo).toBe('testrepo')
+      expect(calls2[0]?.[0]?.owner).toBe('testowner')
+      expect(calls2[0]?.[0]?.repo).toBe('testrepo')
+    })
+  })
+})

--- a/packages/gateway/src/discord/commands/add-project.ts
+++ b/packages/gateway/src/discord/commands/add-project.ts
@@ -1,0 +1,526 @@
+/**
+ * `/fro-bot add-project` subcommand handler.
+ *
+ * Orchestrates the 5-phase flow:
+ *   PRE_FLIGHT → CLONING → CREATING_CHANNEL → WRITING_BINDING → READY
+ *
+ * Security invariants:
+ * - IAT (installation access token) is NEVER logged.
+ * - Channel name is validated against hostile-character patterns before use.
+ * - Owner/repo are canonicalized to lowercase before any lookup or write.
+ */
+
+import type {ChatInputCommandInteraction, PermissionsBitField} from 'discord.js'
+import type {BindingsStore} from '../../bindings/store.js'
+import type {AppClient} from '../../github/app-client.js'
+import type {WorkspaceClient} from '../../workspace-api/client.js'
+
+import {PermissionFlagsBits} from 'discord.js'
+import {Effect} from 'effect'
+
+import {AppNotInstalledError} from '../../github/app-client.js'
+import {createChannelWithCollisionSuffix} from '../channels.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AddProjectPhase = 'PRE_FLIGHT' | 'CLONING' | 'CREATING_CHANNEL' | 'WRITING_BINDING' | 'READY' | 'FAILED'
+
+export interface AddProjectDeps {
+  readonly bindingsStore: BindingsStore
+  readonly appClient: AppClient
+  readonly workspaceClient: WorkspaceClient
+  readonly installUrl: string
+  readonly logger: {
+    readonly info: (msg: string, meta?: Record<string, unknown>) => void
+    readonly warn: (msg: string, meta?: Record<string, unknown>) => void
+    readonly error: (msg: string, meta?: Record<string, unknown>) => void
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rate limiting (in-memory, per-user, v1)
+// ---------------------------------------------------------------------------
+
+const RATE_LIMIT_WINDOW_MS = 60_000
+const RATE_LIMIT_MAX = 5
+
+interface RateLimitEntry {
+  readonly count: number
+  readonly windowStart: number
+}
+
+const rateLimitMap = new Map<string, RateLimitEntry>()
+
+function checkRateLimit(userId: string): {allowed: boolean; retryAfterMs: number} {
+  const now = Date.now()
+  const entry = rateLimitMap.get(userId)
+
+  // Opportunistic eviction: sweep expired entries on every check (O(N), N is small).
+  for (const [uid, e] of rateLimitMap) {
+    if (now - e.windowStart >= RATE_LIMIT_WINDOW_MS) {
+      rateLimitMap.delete(uid)
+    }
+  }
+
+  if (entry === undefined || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+    rateLimitMap.set(userId, {count: 1, windowStart: now})
+    return {allowed: true, retryAfterMs: 0}
+  }
+
+  if (entry.count >= RATE_LIMIT_MAX) {
+    const retryAfterMs = RATE_LIMIT_WINDOW_MS - (now - entry.windowStart)
+    return {allowed: false, retryAfterMs}
+  }
+
+  rateLimitMap.set(userId, {count: entry.count + 1, windowStart: entry.windowStart})
+  return {allowed: true, retryAfterMs: 0}
+}
+
+// ---------------------------------------------------------------------------
+// URL parsing
+// ---------------------------------------------------------------------------
+
+const GITHUB_URL_RE = /^https:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/
+
+// TODO(future): tighten slug validation. GitHub's actual rules:
+// - owner: 1-39 chars, alphanumeric + hyphen, no leading/trailing/consecutive hyphens
+// - repo: 1-100 chars, alphanumeric + hyphen + underscore + period, similar rules
+// Current regex accepts any non-slash sequence; relies on GitHub App auth to reject invalid
+// slugs, which surfaces as "App not installed" — a misleading error for typos.
+function parseGitHubUrl(url: string): {owner: string; repo: string} | null {
+  const match = GITHUB_URL_RE.exec(url)
+  if (match === null) return null
+  const [, ownerRaw, repoRaw] = match
+  if (ownerRaw === undefined || repoRaw === undefined) return null
+  return {owner: ownerRaw, repo: repoRaw}
+}
+
+// ---------------------------------------------------------------------------
+// Channel name validation and derivation
+// ---------------------------------------------------------------------------
+
+// Hostile characters: zero-width, RTL overrides, bidi
+const HOSTILE_CHAR_RE = /[\u200B-\u200D\uFEFF\u202A-\u202E\u2066-\u2069]/
+
+// Valid Discord channel name: lowercase letters, digits, hyphens; 1-100 chars; starts with letter/digit
+const VALID_CHANNEL_NAME_RE = /^[a-z0-9][a-z0-9-]{0,98}[a-z0-9]$|^[a-z0-9]$/
+
+function validateChannelName(name: string): string | null {
+  if (HOSTILE_CHAR_RE.test(name)) {
+    return 'Channel name contains disallowed characters (zero-width or bidirectional override characters are not permitted).'
+  }
+  if (!VALID_CHANNEL_NAME_RE.test(name)) {
+    return 'Channel name must be 1-100 characters, lowercase letters/digits/hyphens only, and start with a letter or digit.'
+  }
+  return null
+}
+
+function deriveChannelName(repo: string): string | null {
+  // Strip scope (@scoped/package → package)
+  let name = repo.replace(/^@[^/]+\//, '')
+  // Lowercase
+  name = name.toLowerCase()
+  // Replace dots, underscores, spaces with hyphens
+  name = name.replaceAll(/[._\s]+/g, '-')
+  // Collapse multiple hyphens
+  name = name.replaceAll(/-{2,}/g, '-')
+  // Trim leading/trailing hyphens
+  name = name.replaceAll(/^-+|-+$/g, '')
+  // Truncate to 100 chars
+  name = name.slice(0, 100)
+  if (name.length === 0) return null
+  return name
+}
+
+// ---------------------------------------------------------------------------
+// Permission check
+// ---------------------------------------------------------------------------
+
+function botHasRequiredPermissions(appPermissions: PermissionsBitField | null): boolean {
+  if (appPermissions === null) return false // DM interaction
+  return appPermissions.has(PermissionFlagsBits.ManageChannels) && appPermissions.has(PermissionFlagsBits.SendMessages)
+}
+
+// ---------------------------------------------------------------------------
+// Interaction window guard (14-minute limit)
+// ---------------------------------------------------------------------------
+
+const INTERACTION_WINDOW_MS = 14 * 60 * 1000
+
+// ---------------------------------------------------------------------------
+// Main orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute the `/fro-bot add-project` command.
+ *
+ * @param interaction - The Discord slash command interaction.
+ * @param deps - Injected dependencies (bindings store, app client, workspace client, logger).
+ */
+export function executeAddProject(
+  interaction: ChatInputCommandInteraction,
+  deps: AddProjectDeps,
+): Effect.Effect<void, Error> {
+  return Effect.tryPromise({
+    try: async () => runAddProject(interaction, deps),
+    catch: error => (error instanceof Error ? error : new Error(String(error))),
+  })
+}
+
+async function runAddProject(interaction: ChatInputCommandInteraction, deps: AddProjectDeps): Promise<void> {
+  const {bindingsStore, appClient, workspaceClient, installUrl, logger} = deps
+  const correlationId = interaction.id
+  const startTime = Date.now()
+
+  // ---------------------------------------------------------------------------
+  // Rate limit check (before deferReply — fast path)
+  // ---------------------------------------------------------------------------
+  const userId = interaction.user.id
+  const rateCheck = checkRateLimit(userId)
+  if (!rateCheck.allowed) {
+    const retryAfterSec = Math.ceil(rateCheck.retryAfterMs / 1000)
+    await interaction.reply({
+      content: `You're doing that too fast. Try again in ${retryAfterSec} seconds.`,
+      ephemeral: true,
+    })
+    return
+  }
+
+  // ---------------------------------------------------------------------------
+  // PRE_FLIGHT
+  // ---------------------------------------------------------------------------
+  let phase: AddProjectPhase = 'PRE_FLIGHT'
+  logger.info('add-project phase', {correlationId, phase, outcome: 'start'})
+
+  // Defer reply (ephemeral — setup thread is operationally sensitive)
+  await interaction.deferReply({ephemeral: true})
+
+  const guild = interaction.guild
+  if (guild === null) {
+    await interaction.editReply({content: 'This command can only be used in a server.'})
+    return
+  }
+
+  // Check bot permissions
+  if (!botHasRequiredPermissions(interaction.appPermissions)) {
+    logger.warn('add-project: missing bot permissions', {correlationId, phase})
+    await interaction.editReply({
+      content: `fro-bot needs **Manage Channels** and **Send Messages** permissions. Re-invite the bot at: ${installUrl}`,
+    })
+    return
+  }
+
+  // Parse and validate URL
+  const rawUrl = interaction.options.getString('url', true)
+  const parsed = parseGitHubUrl(rawUrl)
+  if (parsed === null) {
+    await interaction.editReply({
+      content: 'Invalid GitHub URL. Expected format: `https://github.com/owner/repo`',
+    })
+    return
+  }
+
+  // Canonicalize to lowercase (security requirement)
+  const owner = parsed.owner.toLowerCase()
+  const repo = parsed.repo.toLowerCase()
+
+  // Resolve channel name
+  const rawChannelName = interaction.options.getString('channel')
+  let channelName: string
+
+  if (rawChannelName === null) {
+    const derived = deriveChannelName(repo)
+    if (derived === null) {
+      await interaction.editReply({
+        content: "Couldn't derive a channel name from the repo name. Please specify `channel:<name>` explicitly.",
+      })
+      return
+    }
+    channelName = derived
+  } else {
+    const validationError = validateChannelName(rawChannelName)
+    if (validationError !== null) {
+      await interaction.editReply({content: validationError})
+      return
+    }
+    channelName = rawChannelName
+  }
+
+  // Check if already bound
+  const existingResult = await bindingsStore.getBindingByRepo(owner, repo)
+  if (existingResult.success === false) {
+    logger.error('add-project: store error during pre-flight lookup', {
+      correlationId,
+      phase,
+      errorKind: existingResult.error.message,
+    })
+    await interaction.editReply({content: 'Internal error checking existing bindings. Please try again.'})
+    return
+  }
+  if (existingResult.data !== null) {
+    await interaction.editReply({
+      content: `\`${owner}/${repo}\` is already bound to #${existingResult.data.channelName}. Bindings cannot be moved in v1. To rebind, manually delete the S3 key \`bindings/${owner}/${repo}/repo.json\` and retry.`,
+    })
+    return
+  }
+
+  // App auth
+  const authResult = await appClient.authForRepo(owner, repo)
+  if (authResult.success === false) {
+    if (authResult.error instanceof AppNotInstalledError) {
+      await interaction.editReply({
+        content: `The fro-bot GitHub App is not installed on \`${owner}/${repo}\`. Install it at: ${authResult.error.installUrl}`,
+      })
+    } else {
+      await interaction.editReply({
+        content: `GitHub App authentication failed: ${authResult.error.message}`,
+      })
+    }
+    logger.warn('add-project: app auth failed', {
+      correlationId,
+      phase,
+      errorKind: authResult.error.constructor.name,
+      durationMs: Date.now() - startTime,
+      outcome: 'error',
+    })
+    return
+  }
+
+  const {token} = authResult.data
+  logger.info('add-project phase', {correlationId, phase, outcome: 'success', durationMs: Date.now() - startTime})
+
+  // ---------------------------------------------------------------------------
+  // CLONING
+  // ---------------------------------------------------------------------------
+  phase = 'CLONING'
+  logger.info('add-project phase', {correlationId, phase, owner, repo, channelName, outcome: 'start'})
+
+  // Interaction window guard
+  if (Date.now() - startTime > INTERACTION_WINDOW_MS) {
+    logger.warn('add-project: interaction window exhausted', {correlationId, phase, owner, repo})
+    await interaction.editReply({
+      content:
+        'The operation took too long and the interaction window expired. Clone may have started — check workspace. Retry the command.',
+    })
+    return
+  }
+
+  const cloneResult = await workspaceClient.clone({owner, repo, token})
+  if (cloneResult.success === false) {
+    const errorKind = cloneResult.error.kind
+    logger.warn('add-project: clone failed', {correlationId, phase, owner, repo, errorKind, outcome: 'error'})
+
+    if (errorKind === 'clone-error') {
+      const code = cloneResult.error.code
+      if (code === 'enospc' || code === 'disk-full') {
+        await interaction.editReply({
+          content:
+            'The workspace volume is out of space. Free disk by removing unused repos under `/workspace/repos` and retry.',
+        })
+      } else if (code === 'repo-exists') {
+        await interaction.editReply({
+          content: `The repo \`${owner}/${repo}\` already exists in the workspace. Remove it with \`rm -rf /workspace/repos/${owner}/${repo}\` and retry.`,
+        })
+      } else {
+        await interaction.editReply({
+          content: `Clone failed (${code}). Check workspace-agent logs for details.`,
+        })
+      }
+    } else if (errorKind === 'timeout') {
+      await interaction.editReply({content: 'Clone timed out (5 minutes). The repo may be very large. Retry.'})
+    } else if (errorKind === 'response-mismatch') {
+      logger.error('add-project: response-mismatch from workspace agent', {correlationId, phase, owner, repo})
+      await interaction.editReply({
+        content: 'Internal error: workspace agent returned unexpected response. Contact operator.',
+      })
+    } else {
+      await interaction.editReply({content: `Clone failed (${errorKind}). Check workspace-agent connectivity.`})
+    }
+    return
+  }
+
+  const workspacePath = cloneResult.data.path
+  logger.info('add-project phase', {
+    correlationId,
+    phase,
+    owner,
+    repo,
+    workspacePath,
+    outcome: 'success',
+    durationMs: Date.now() - startTime,
+  })
+
+  // ---------------------------------------------------------------------------
+  // CREATING_CHANNEL
+  // ---------------------------------------------------------------------------
+  phase = 'CREATING_CHANNEL'
+  logger.info('add-project phase', {correlationId, phase, owner, repo, channelName, outcome: 'start'})
+
+  // Defensive permission re-check
+  if (!botHasRequiredPermissions(interaction.appPermissions)) {
+    logger.warn('add-project: permissions revoked between pre-flight and channel creation', {correlationId, phase})
+    await interaction.editReply({
+      content: `fro-bot lost **Manage Channels** permission. Clone is preserved at \`${workspacePath}\`. Re-grant permissions and retry.`,
+    })
+    return
+  }
+
+  // Interaction window guard
+  if (Date.now() - startTime > INTERACTION_WINDOW_MS) {
+    logger.warn('add-project: interaction window exhausted', {correlationId, phase, owner, repo})
+    await interaction.editReply({
+      content: `Interaction window expired. Clone preserved at \`${workspacePath}\`. Retry the command.`,
+    })
+    return
+  }
+
+  const channelResult = await createChannelWithCollisionSuffix(guild, channelName, {maxSuffix: 10})
+  if (channelResult.success === false) {
+    const errorKind = channelResult.error.kind
+    logger.warn('add-project: channel creation failed', {
+      correlationId,
+      phase,
+      owner,
+      repo,
+      channelName,
+      errorKind,
+      outcome: 'error',
+    })
+
+    if (errorKind === 'collision-exhausted') {
+      await interaction.editReply({
+        content: `Couldn't find an available channel name after 10 attempts. Specify \`channel:<name>\` explicitly.`,
+      })
+    } else if (errorKind === 'permission-denied') {
+      await interaction.editReply({
+        content: `fro-bot lacks permission to create channels. Re-invite at: ${installUrl}`,
+      })
+    } else {
+      await interaction.editReply({
+        content: `Failed to create channel: ${channelResult.error.message}`,
+      })
+    }
+    return
+  }
+
+  const channel = channelResult.data
+  logger.info('add-project phase', {
+    correlationId,
+    phase,
+    owner,
+    repo,
+    channelName: channel.name,
+    channelId: channel.id,
+    outcome: 'success',
+    durationMs: Date.now() - startTime,
+  })
+
+  // ---------------------------------------------------------------------------
+  // WRITING_BINDING
+  // ---------------------------------------------------------------------------
+  phase = 'WRITING_BINDING'
+  logger.info('add-project phase', {correlationId, phase, owner, repo, channelName: channel.name, outcome: 'start'})
+
+  const binding = {
+    owner,
+    repo,
+    channelId: channel.id,
+    channelName: channel.name,
+    workspacePath,
+    createdAt: new Date().toISOString(),
+    createdByDiscordId: interaction.user.id,
+  }
+
+  const bindingResult = await bindingsStore.createBinding(binding)
+  if (bindingResult.success === false) {
+    const error = bindingResult.error
+    logger.error('add-project: binding write failed', {
+      correlationId,
+      phase,
+      owner,
+      repo,
+      errorKind: error.message,
+      outcome: 'error',
+    })
+
+    if ('code' in error && error.code === 'BINDING_EXISTS_ERROR') {
+      // Concurrent setup raced past PRE_FLIGHT
+      await interaction.editReply({
+        content: `\`${owner}/${repo}\` was bound by a concurrent request. Channel #${channel.name} was created by this request — manual cleanup may be needed.`,
+      })
+    } else if ('code' in error && error.code === 'BINDING_PARTIAL_WRITE_ERROR') {
+      // TypeScript narrows error to PartialWriteError via the discriminant above
+      await interaction.editReply({
+        content: `Partial write error: primary binding written but index failed. Manual S3 cleanup required:\n- Primary: \`${error.primaryKey}\`\n- Index: \`${error.indexKey}\``,
+      })
+    } else {
+      await interaction.editReply({
+        content: `Failed to write binding. Channel #${channel.name} was created. Retry the command — pre-flight will detect the existing channel.`,
+      })
+    }
+    return
+  }
+
+  logger.info('add-project phase', {
+    correlationId,
+    phase,
+    owner,
+    repo,
+    outcome: 'success',
+    durationMs: Date.now() - startTime,
+  })
+
+  // ---------------------------------------------------------------------------
+  // READY
+  // ---------------------------------------------------------------------------
+  phase = 'READY'
+  logger.info('add-project phase', {correlationId, phase, owner, repo, channelName: channel.name, outcome: 'start'})
+
+  await interaction.editReply({
+    content: `✅ Ready — try @fro-bot in #${channel.name}`,
+  })
+
+  // Post welcome message in the new channel
+  try {
+    await channel.send({
+      embeds: [
+        {
+          title: `Bound to ${owner}/${repo}`,
+          description: [
+            `This channel is bound to ${owner}/${repo}.`,
+            '',
+            "Once the interaction loop (Unit 6) ships, you'll be able to @-mention me here to ask questions or have me act on the repo.",
+            '',
+            'Until then, this channel is reserved for future use.',
+          ].join('\n'),
+          color: 0x57f287, // success-green
+        },
+      ],
+    })
+  } catch (welcomeError) {
+    logger.warn('add-project: welcome message post failed', {
+      correlationId,
+      phase,
+      owner,
+      repo,
+      channelName: channel.name,
+      err: welcomeError instanceof Error ? welcomeError.message : String(welcomeError),
+    })
+    await interaction.editReply({
+      content: `✅ Channel #${channel.name} created and bound to \`${owner}/${repo}\`, but couldn't post the welcome message — verify fro-bot has **Send Messages** in #${channel.name}.`,
+    })
+    return
+  }
+
+  logger.info('add-project phase', {
+    correlationId,
+    phase,
+    owner,
+    repo,
+    channelName: channel.name,
+    outcome: 'success',
+    durationMs: Date.now() - startTime,
+  })
+}

--- a/packages/gateway/src/discord/commands/fro-bot.ts
+++ b/packages/gateway/src/discord/commands/fro-bot.ts
@@ -1,0 +1,63 @@
+/**
+ * `/fro-bot` parent slash command factory.
+ *
+ * Owns the SlashCommandBuilder with all subcommands and dispatches to the
+ * appropriate subcommand handler based on `interaction.options.getSubcommand()`.
+ *
+ * Subcommands:
+ * - `ping` — smoke-test; responds with ephemeral "pong"
+ * - `add-project` — bind a GitHub repo to a Discord channel
+ */
+
+import type {ChatInputCommandInteraction} from 'discord.js'
+import type {AddProjectDeps} from './add-project.js'
+import type {SlashCommand} from './index.js'
+
+import {SlashCommandBuilder} from 'discord.js'
+import {Effect} from 'effect'
+
+import {executeAddProject} from './add-project.js'
+import {executePing} from './ping.js'
+
+/**
+ * Create the `/fro-bot` parent command with injected dependencies.
+ *
+ * The `deps` parameter is captured in the execute closure and passed directly
+ * to `executeAddProject`. No module-global state is used.
+ */
+export function createFroBotCommand(deps: AddProjectDeps): SlashCommand {
+  const data = new SlashCommandBuilder()
+    .setName('fro-bot')
+    .setDescription('fro-bot commands')
+    .addSubcommand(sub => sub.setName('ping').setDescription('Check if fro-bot is alive'))
+    .addSubcommand(sub =>
+      sub
+        .setName('add-project')
+        .setDescription('Bind a GitHub repo to a Discord channel')
+        .addStringOption(opt =>
+          opt.setName('url').setDescription('GitHub repo URL (https://github.com/owner/repo)').setRequired(true),
+        )
+        .addStringOption(opt =>
+          opt
+            .setName('channel')
+            .setDescription('Optional Discord channel name (auto-derived from repo if omitted)')
+            .setRequired(false),
+        ),
+    ) as SlashCommandBuilder
+
+  const execute = (interaction: ChatInputCommandInteraction): Effect.Effect<void, Error> => {
+    const subcommand = interaction.options.getSubcommand(true)
+
+    if (subcommand === 'ping') {
+      return executePing(interaction)
+    }
+
+    if (subcommand === 'add-project') {
+      return executeAddProject(interaction, deps)
+    }
+
+    return Effect.fail(new Error(`Unknown subcommand: ${subcommand}`))
+  }
+
+  return {data, execute}
+}

--- a/packages/gateway/src/discord/commands/index.test.ts
+++ b/packages/gateway/src/discord/commands/index.test.ts
@@ -1,9 +1,39 @@
 import type {ChatInputCommandInteraction} from 'discord.js'
+import type {AddProjectDeps} from './add-project.js'
+
 import {Routes} from 'discord.js'
 import {Effect} from 'effect'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {dispatchCommand, getCommandRegistry, registerSlashCommands, type SlashCommand} from './index.js'
+
+// ---------------------------------------------------------------------------
+// Minimal mock deps for getCommandRegistry
+// ---------------------------------------------------------------------------
+
+function makeMockDeps(): AddProjectDeps {
+  return {
+    bindingsStore: {
+      createBinding: vi.fn(),
+      getBindingByRepo: vi.fn(),
+      getBindingByChannelId: vi.fn(),
+      listBindings: vi.fn(),
+    },
+    appClient: {
+      authForRepo: vi.fn(),
+      invalidateCache: vi.fn(),
+    },
+    workspaceClient: {
+      clone: vi.fn(),
+    },
+    installUrl: 'https://github.com/apps/fro-bot/installations/new',
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }
+}
 
 const restPutMock = vi.fn().mockResolvedValue(undefined)
 const restSetTokenMock = vi.fn().mockReturnThis()
@@ -38,13 +68,13 @@ beforeEach(() => {
 })
 
 describe('getCommandRegistry', () => {
-  it('includes the ping command', () => {
+  it('includes the fro-bot command', () => {
     // #given / #when
-    const registry = getCommandRegistry()
+    const registry = getCommandRegistry(makeMockDeps())
 
     // #then
-    const ping = registry.find(c => c.data.name === 'fro-bot')
-    expect(ping).toBeDefined()
+    const cmd = registry.find(c => c.data.name === 'fro-bot')
+    expect(cmd).toBeDefined()
   })
 })
 
@@ -70,7 +100,7 @@ describe('dispatchCommand', () => {
   it('returns Effect.fail on unknown command name with clear error message AND replies ephemerally', async () => {
     // #given a registry that does not contain the requested command
     const reply = vi.fn().mockResolvedValue(undefined)
-    const registry = getCommandRegistry()
+    const registry = getCommandRegistry(makeMockDeps())
     const interaction = {commandName: 'nonexistent', reply} as unknown as ChatInputCommandInteraction
 
     // #when
@@ -89,7 +119,7 @@ describe('dispatchCommand', () => {
   it('still fails with the original error when the ephemeral ack itself fails', async () => {
     // #given a reply() that rejects (e.g. interaction token already expired)
     const reply = vi.fn().mockRejectedValue(new Error('Interaction has already been acknowledged'))
-    const registry = getCommandRegistry()
+    const registry = getCommandRegistry(makeMockDeps())
     const interaction = {commandName: 'nonexistent', reply} as unknown as ChatInputCommandInteraction
 
     // #when
@@ -108,8 +138,9 @@ describe('dispatchCommand', () => {
     const interaction = {
       commandName: 'fro-bot',
       reply,
+      options: {getSubcommand: vi.fn().mockReturnValue('ping')},
     } as unknown as ChatInputCommandInteraction
-    const registry = getCommandRegistry()
+    const registry = getCommandRegistry(makeMockDeps())
 
     // #when
     await Effect.runPromise(dispatchCommand(interaction, registry))
@@ -123,7 +154,7 @@ describe('dispatchCommand', () => {
     const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     try {
       const reply = vi.fn().mockRejectedValue(new Error('Token expired'))
-      const registry = getCommandRegistry()
+      const registry = getCommandRegistry(makeMockDeps())
       const interaction = {commandName: 'nonexistent', reply} as unknown as ChatInputCommandInteraction
 
       // #when
@@ -143,6 +174,41 @@ describe('dispatchCommand', () => {
     } finally {
       consoleSpy.mockRestore()
     }
+  })
+
+  it('dispatches /fro-bot add-project to executeAddProject with injected deps', async () => {
+    // #given — registry built with mock deps; add-project will fail at rate-limit check
+    // because the interaction mock has no guild, but we just need to verify routing.
+    const deps = makeMockDeps()
+    const registry = getCommandRegistry(deps)
+
+    const deferReply = vi.fn().mockResolvedValue(undefined)
+    const editReply = vi.fn().mockResolvedValue(undefined)
+    const reply = vi.fn().mockResolvedValue(undefined)
+
+    const interaction = {
+      commandName: 'fro-bot',
+      id: 'test-interaction-id',
+      user: {id: 'user-dispatch-test'},
+      guild: null,
+      client: {user: {id: 'bot-user-id'}},
+      options: {
+        getSubcommand: vi.fn().mockReturnValue('add-project'),
+        getString: vi.fn().mockReturnValue('https://github.com/owner/repo'),
+      },
+      deferReply,
+      editReply,
+      reply,
+    } as unknown as ChatInputCommandInteraction
+
+    // #when — dispatch routes to add-project; it will fail at guild check (guild is null)
+    await Effect.runPromise(dispatchCommand(interaction, registry))
+
+    // #then — deferReply was called (PRE_FLIGHT started) and editReply was called with guild error
+    expect(deferReply).toHaveBeenCalledWith({ephemeral: true})
+    expect(editReply).toHaveBeenCalledWith(
+      expect.objectContaining({content: expect.stringContaining('server') as unknown as string}),
+    )
   })
 })
 

--- a/packages/gateway/src/discord/commands/index.ts
+++ b/packages/gateway/src/discord/commands/index.ts
@@ -1,8 +1,10 @@
 import type {ChatInputCommandInteraction, SlashCommandBuilder} from 'discord.js'
+import type {AddProjectDeps} from './add-project.js'
+
 import {REST, Routes} from 'discord.js'
 import {Effect} from 'effect'
 
-import pingCommand from './ping.js'
+import {createFroBotCommand} from './fro-bot.js'
 
 export interface SlashCommand {
   readonly data: SlashCommandBuilder
@@ -11,9 +13,11 @@ export interface SlashCommand {
 
 /**
  * Returns the full registry of registered slash commands.
+ *
+ * @param deps - Runtime dependencies injected into command handlers.
  */
-export function getCommandRegistry(): SlashCommand[] {
-  return [pingCommand]
+export function getCommandRegistry(deps: AddProjectDeps): SlashCommand[] {
+  return [createFroBotCommand(deps)]
 }
 
 /**

--- a/packages/gateway/src/discord/commands/ping.test.ts
+++ b/packages/gateway/src/discord/commands/ping.test.ts
@@ -2,16 +2,16 @@ import type {ChatInputCommandInteraction} from 'discord.js'
 import {Effect} from 'effect'
 import {describe, expect, it, vi} from 'vitest'
 
-import pingCommand from './ping.js'
+import {executePing} from './ping.js'
 
-describe('ping command', () => {
+describe('executePing', () => {
   it('calls interaction.reply with content "pong" and ephemeral: true', async () => {
     // #given a mock interaction
     const reply = vi.fn().mockResolvedValue(undefined)
     const interaction = {reply} as unknown as ChatInputCommandInteraction
 
     // #when the command is executed
-    await Effect.runPromise(pingCommand.execute(interaction))
+    await Effect.runPromise(executePing(interaction))
 
     // #then reply was called with the correct args
     expect(reply).toHaveBeenCalledExactlyOnceWith({content: 'pong', ephemeral: true})
@@ -23,22 +23,11 @@ describe('ping command', () => {
     const interaction = {reply} as unknown as ChatInputCommandInteraction
 
     // #when
-    const result = await Effect.runPromise(Effect.either(pingCommand.execute(interaction)))
+    const result = await Effect.runPromise(Effect.either(executePing(interaction)))
 
     // #then
     expect(result._tag).toBe('Left')
     expect((result as {_tag: 'Left'; left: unknown}).left).toBeInstanceOf(Error)
     expect(((result as {_tag: 'Left'; left: unknown}).left as Error).message).toBe('Discord API error')
-  })
-
-  it('has command name "fro-bot" with subcommand "ping"', () => {
-    // #given / #when
-    const json = pingCommand.data.toJSON()
-
-    // #then
-    expect(json.name).toBe('fro-bot')
-    expect(json.options).toBeDefined()
-    const sub = json.options?.find((o: {name: string}) => o.name === 'ping')
-    expect(sub).toBeDefined()
   })
 })

--- a/packages/gateway/src/discord/commands/ping.ts
+++ b/packages/gateway/src/discord/commands/ping.ts
@@ -1,24 +1,14 @@
 import type {ChatInputCommandInteraction} from 'discord.js'
-import type {SlashCommand} from './index.js'
 
-import {SlashCommandBuilder} from 'discord.js'
 import {Effect} from 'effect'
 
 /**
- * `/fro-bot ping` — smoke-test command.
+ * Handler for the `/fro-bot ping` subcommand.
  * Responds with an ephemeral "pong" reply.
  */
-const pingCommand: SlashCommand = {
-  data: new SlashCommandBuilder()
-    .setName('fro-bot')
-    .setDescription('fro-bot commands')
-    .addSubcommand(sub => sub.setName('ping').setDescription('Check if fro-bot is alive')) as SlashCommandBuilder,
-
-  execute: (interaction: ChatInputCommandInteraction): Effect.Effect<void, Error> =>
-    Effect.tryPromise({
-      try: async () => interaction.reply({content: 'pong', ephemeral: true}),
-      catch: error => (error instanceof Error ? error : new Error(String(error))),
-    }).pipe(Effect.asVoid),
+export function executePing(interaction: ChatInputCommandInteraction): Effect.Effect<void, Error> {
+  return Effect.tryPromise({
+    try: async () => interaction.reply({content: 'pong', ephemeral: true}),
+    catch: error => (error instanceof Error ? error : new Error(String(error))),
+  }).pipe(Effect.asVoid)
 }
-
-export default pingCommand

--- a/packages/gateway/src/discord/mentions.test.ts
+++ b/packages/gateway/src/discord/mentions.test.ts
@@ -1,4 +1,4 @@
-import type {Message, TextChannel, ThreadChannel} from 'discord.js'
+import type {Message, TextChannel} from 'discord.js'
 import {Effect} from 'effect'
 import {describe, expect, it, vi} from 'vitest'
 
@@ -23,7 +23,7 @@ function makeMessage(
     replyFn = vi.fn().mockResolvedValue(undefined),
   } = overrides
 
-  const startThread = startThreadFn ?? vi.fn().mockResolvedValue({send: sendFn} as unknown as ThreadChannel)
+  const startThread = startThreadFn ?? vi.fn().mockResolvedValue({send: sendFn})
 
   return {
     channel: {

--- a/packages/gateway/src/github/app-client.ts
+++ b/packages/gateway/src/github/app-client.ts
@@ -159,7 +159,7 @@ export function createAppClient(options: AppClientOptions): AppClient {
           const response = await discoveryOctokit.request('GET /repos/{owner}/{repo}/installation', {owner, repo})
           installationData = {
             id: response.data.id,
-            permissions: (response.data.permissions ?? {}) as Record<string, string>,
+            permissions: response.data.permissions ?? {},
           }
         } catch (discoveryError) {
           if (isNotFoundError(discoveryError)) {

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -101,6 +101,7 @@ describe('makeGatewayProgram', () => {
       githubAppId: 'test-app-id',
       githubAppPrivateKey: '-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----',
       gatewayGitHubAppInstallUrl: 'https://github.com/apps/fro-bot/installations/new',
+      workspaceAgentUrl: 'http://workspace:9100',
     }
 
     // Minimal fake client — just needs to satisfy the Client shape enough for

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -1,13 +1,17 @@
-import type {ChatInputCommandInteraction, Client, GatewayIntentBits, Message} from 'discord.js'
+import type {Client, GatewayIntentBits, Message} from 'discord.js'
 import type {GatewayConfig} from './config.js'
 import type {GatewayLogger} from './discord/client.js'
 
+import {createS3Adapter} from '@fro-bot/runtime'
 import {Effect} from 'effect'
 
+import {createBindingsStore} from './bindings/store.js'
 import {createDiscordClient} from './discord/client.js'
 import {dispatchCommand, getCommandRegistry, registerSlashCommands} from './discord/commands/index.js'
 import {handleMention} from './discord/mentions.js'
+import {createAppClient} from './github/app-client.js'
 import {installShutdownHandlers} from './shutdown.js'
+import {createWorkspaceClient} from './workspace-api/client.js'
 
 // ---------------------------------------------------------------------------
 // Minimal structured logger — pino can replace this in a later unit.
@@ -80,8 +84,45 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
     //     Must run BEFORE client.login() so the event cannot be missed.
     yield* Effect.sync(() => deps.setupReadinessFlag(client, logger))
 
-    // d. Build command registry
-    const registry = getCommandRegistry()
+    // d. Build command registry with runtime deps
+    const addProjectLogger = {
+      debug: (msg: string, meta?: Record<string, unknown>) => logger.debug(meta ?? {}, msg),
+      info: (msg: string, meta?: Record<string, unknown>) => logger.info(meta ?? {}, msg),
+      warn: (msg: string, meta?: Record<string, unknown>) => logger.warn(meta ?? {}, msg),
+      error: (msg: string, meta?: Record<string, unknown>) => logger.error(meta ?? {}, msg),
+    }
+
+    // Adapt GatewayLogger to the runtime Logger interface (uses 'warning' not 'warn')
+    const runtimeLogger = {
+      debug: (msg: string, ctx?: Record<string, unknown>) => logger.debug(ctx ?? {}, msg),
+      info: (msg: string, ctx?: Record<string, unknown>) => logger.info(ctx ?? {}, msg),
+      warning: (msg: string, ctx?: Record<string, unknown>) => logger.warn(ctx ?? {}, msg),
+      error: (msg: string, ctx?: Record<string, unknown>) => logger.error(ctx ?? {}, msg),
+    }
+
+    const s3Adapter = createS3Adapter(config.objectStore, runtimeLogger)
+    const bindingsStore = createBindingsStore({
+      adapter: s3Adapter,
+      storeConfig: config.objectStore,
+      identity: config.identity,
+    })
+    const appClient = createAppClient({
+      appId: config.githubAppId,
+      privateKey: config.githubAppPrivateKey,
+      installUrl: config.gatewayGitHubAppInstallUrl,
+      logger: addProjectLogger,
+    })
+    const workspaceClient = createWorkspaceClient({baseUrl: config.workspaceAgentUrl})
+
+    const commandDeps = {
+      bindingsStore,
+      appClient,
+      workspaceClient,
+      installUrl: config.gatewayGitHubAppInstallUrl,
+      logger: addProjectLogger,
+    }
+
+    const registry = getCommandRegistry(commandDeps)
 
     // e. Register slash commands
     yield* Effect.tryPromise({
@@ -94,7 +135,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
     client.on('interactionCreate', interaction => {
       if (!interaction.isChatInputCommand()) return
       // isChatInputCommand() narrows to ChatInputCommandInteraction — cast is safe.
-      const cmd = interaction as unknown as ChatInputCommandInteraction
+      const cmd = interaction
       Effect.runPromise(dispatchCommand(cmd, registry)).catch((error: unknown) => {
         logger.error({err: error, commandName: cmd.commandName}, 'command dispatch failed')
       })

--- a/packages/gateway/src/workspace-api/client.test.ts
+++ b/packages/gateway/src/workspace-api/client.test.ts
@@ -1,0 +1,449 @@
+import type {CloneErrorCode, CloneRequest} from './types.js'
+
+import {err, ok} from '@fro-bot/runtime'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createWorkspaceClient} from './client.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeClient(overrides?: {baseUrl?: string; timeoutMs?: number}) {
+  return createWorkspaceClient({baseUrl: 'http://workspace:9100', timeoutMs: 1000, ...overrides})
+}
+
+function makeRequest(overrides?: Partial<CloneRequest>): CloneRequest {
+  return {owner: 'testowner', repo: 'testrepo', token: 'ghs_testtoken123', ...overrides}
+}
+
+function mockFetch(response: {ok: boolean; status?: number; json?: () => Promise<unknown>; throws?: Error}) {
+  return vi.fn().mockImplementation(async () => {
+    if (response.throws !== undefined) throw response.throws
+    return {
+      ok: response.ok,
+      status: response.status ?? (response.ok ? 200 : 500),
+      json: response.json ?? (async () => undefined),
+    }
+  })
+}
+
+/** Spy on all console channels and collect every string written. */
+function spyConsole() {
+  const lines: string[] = []
+  const collect = (...args: unknown[]) => lines.push(args.map(String).join(' '))
+  const spies = [
+    vi.spyOn(console, 'log').mockImplementation(collect),
+    vi.spyOn(console, 'warn').mockImplementation(collect),
+    vi.spyOn(console, 'error').mockImplementation(collect),
+    vi.spyOn(console, 'info').mockImplementation(collect),
+    vi.spyOn(console, 'debug').mockImplementation(collect),
+  ]
+  return {
+    lines,
+    restore: () => spies.forEach(s => s.mockRestore()),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createWorkspaceClient', () => {
+  describe('happy path', () => {
+    it('returns CloneSuccess with path and commit on 200 response', async () => {
+      // #given
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = mockFetch({
+        ok: true,
+        json: async () => ({ok: true, path: '/workspace/repos/testowner/testrepo', commit: 'abc123'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then
+      expect(result).toEqual(ok({ok: true, path: '/workspace/repos/testowner/testrepo', commit: 'abc123'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('pOSTs to /clone with correct Content-Type', async () => {
+      // #given
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = mockFetch({
+        ok: true,
+        json: async () => ({ok: true, path: '/workspace/repos/testowner/testrepo', commit: 'abc123'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      await client.clone(req)
+
+      // #then
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://workspace:9100/clone',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+        }),
+      )
+      vi.unstubAllGlobals()
+    })
+  })
+
+  describe('response-mismatch', () => {
+    it('returns response-mismatch when path does not end with /{owner}/{repo}', async () => {
+      // #given
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = mockFetch({
+        ok: true,
+        json: async () => ({ok: true, path: '/workspace/repos/otherowner/otherrepo', commit: 'abc123'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then
+      expect(result).toEqual(err({kind: 'response-mismatch'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('accepts path match case-insensitively', async () => {
+      // #given
+      const client = makeClient()
+      const req = makeRequest({owner: 'TestOwner', repo: 'TestRepo'})
+      const fetchMock = mockFetch({
+        ok: true,
+        json: async () => ({ok: true, path: '/workspace/repos/testowner/testrepo', commit: 'abc123'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then
+      expect(result.success).toBe(true)
+      vi.unstubAllGlobals()
+    })
+  })
+
+  describe('clone-error codes', () => {
+    const errorCodes: CloneErrorCode[] = [
+      'clone-failed',
+      'disk-full',
+      'repo-exists',
+      'head-resolution-failed',
+      'clone-timeout',
+      'overloaded',
+      'enospc',
+      'invalid-owner',
+      'invalid-repo',
+      'invalid-token-shape',
+      'malformed-body',
+      'body-too-large',
+      'clone-aborted',
+      'git-not-available',
+      'permission-denied',
+      'too-many-files',
+      'path-escaped-workspace',
+    ]
+
+    for (const code of errorCodes) {
+      it(`preserves clone-error code: ${code}`, async () => {
+        // #given
+        const client = makeClient()
+        const req = makeRequest()
+        const fetchMock = mockFetch({
+          ok: true,
+          json: async () => ({ok: false, error: code}),
+        })
+        vi.stubGlobal('fetch', fetchMock)
+
+        // #when
+        const result = await client.clone(req)
+
+        // #then
+        expect(result).toEqual(err({kind: 'clone-error', code}))
+        vi.unstubAllGlobals()
+      })
+    }
+  })
+
+  describe('http-error', () => {
+    it('returns http-error with status 500 on non-2xx response', async () => {
+      // #given
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = mockFetch({ok: false, status: 500})
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then
+      expect(result).toEqual(err({kind: 'http-error', status: 500}))
+      vi.unstubAllGlobals()
+    })
+
+    it('returns http-error with status 409 on conflict', async () => {
+      // #given
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = mockFetch({ok: false, status: 409})
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then
+      expect(result).toEqual(err({kind: 'http-error', status: 409}))
+      vi.unstubAllGlobals()
+    })
+  })
+
+  describe('network-error', () => {
+    it('returns network-error on connection refused', async () => {
+      // #given
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = mockFetch({ok: false, throws: Object.assign(new Error('ECONNREFUSED'), {name: 'TypeError'})})
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then
+      expect(result).toEqual(err({kind: 'network-error'}))
+      vi.unstubAllGlobals()
+    })
+  })
+
+  describe('timeout', () => {
+    it('returns timeout on AbortSignal.timeout expiry (TimeoutError)', async () => {
+      // #given
+      const client = makeClient()
+      const req = makeRequest()
+      const timeoutErr = Object.assign(new Error('The operation was aborted due to timeout'), {name: 'TimeoutError'})
+      const fetchMock = mockFetch({ok: false, throws: timeoutErr})
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then
+      expect(result).toEqual(err({kind: 'timeout'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('returns timeout on AbortError', async () => {
+      // #given
+      const client = makeClient()
+      const req = makeRequest()
+      const abortErr = Object.assign(new Error('The operation was aborted'), {name: 'AbortError'})
+      const fetchMock = mockFetch({ok: false, throws: abortErr})
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then
+      expect(result).toEqual(err({kind: 'timeout'}))
+      vi.unstubAllGlobals()
+    })
+  })
+
+  describe('parse-error', () => {
+    it('returns parse-error when response body is not valid JSON', async () => {
+      // #given
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError('Unexpected token')
+        },
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then
+      expect(result).toEqual(err({kind: 'parse-error'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('returns parse-error when response body has wrong shape', async () => {
+      // #given
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = mockFetch({ok: true, json: async () => ({unexpected: 'shape'})})
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then
+      expect(result).toEqual(err({kind: 'parse-error'}))
+      vi.unstubAllGlobals()
+    })
+  })
+
+  describe('security: no IAT in logs', () => {
+    const errorPaths: {name: string; fetchSetup: () => ReturnType<typeof mockFetch> | ReturnType<typeof vi.fn>}[] = [
+      {
+        name: 'happy path',
+        fetchSetup: () =>
+          mockFetch({
+            ok: true,
+            json: async () => ({ok: true, path: '/workspace/repos/testowner/testrepo', commit: 'abc123'}),
+          }),
+      },
+      {
+        name: 'network-error path',
+        fetchSetup: () => mockFetch({ok: false, throws: new Error('ECONNREFUSED')}),
+      },
+      {
+        name: 'http-error path (500 no body)',
+        fetchSetup: () => mockFetch({ok: false, status: 500}),
+      },
+      {
+        name: 'parse-error path (wrong shape)',
+        fetchSetup: () => mockFetch({ok: true, json: async () => ({unexpected: 'shape'})}),
+      },
+      {
+        name: 'clone-error path',
+        fetchSetup: () => mockFetch({ok: true, json: async () => ({ok: false, error: 'repo-exists'})}),
+      },
+      {
+        name: 'response-mismatch path',
+        fetchSetup: () =>
+          mockFetch({ok: true, json: async () => ({ok: true, path: '/workspace/repos/other/other', commit: 'abc'})}),
+      },
+      {
+        name: 'timeout path',
+        fetchSetup: () => mockFetch({ok: false, throws: Object.assign(new Error('timeout'), {name: 'TimeoutError'})}),
+      },
+      {
+        name: 'malformed JSON body on non-2xx',
+        fetchSetup: () =>
+          vi.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+            json: async () => {
+              throw new SyntaxError('bad json')
+            },
+          }),
+      },
+    ]
+
+    for (const {name, fetchSetup} of errorPaths) {
+      it(`does not log ghs_* token on ${name}`, async () => {
+        // #given
+        const spy = spyConsole()
+        const client = makeClient()
+        const req = makeRequest({token: 'ghs_supersecrettoken'})
+        vi.stubGlobal('fetch', fetchSetup())
+
+        try {
+          // #when
+          await client.clone(req)
+
+          // #then
+          for (const line of spy.lines) {
+            expect(line).not.toContain('ghs_')
+          }
+        } finally {
+          spy.restore()
+          vi.unstubAllGlobals()
+        }
+      })
+    }
+  })
+
+  describe('structured error body on non-2xx (Critical 2)', () => {
+    it('hTTP 409 with {ok:false, error:"repo-exists"} → clone-error', async () => {
+      // #given
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        json: async () => ({ok: false, error: 'repo-exists'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then
+      expect(result).toEqual(err({kind: 'clone-error', code: 'repo-exists'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('hTTP 503 with {ok:false, error:"overloaded"} → clone-error', async () => {
+      // #given
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({ok: false, error: 'overloaded'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then
+      expect(result).toEqual(err({kind: 'clone-error', code: 'overloaded'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('hTTP 500 with no body (json returns undefined) → http-error', async () => {
+      // #given
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => undefined,
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then
+      expect(result).toEqual(err({kind: 'http-error', status: 500}))
+      vi.unstubAllGlobals()
+    })
+
+    it('hTTP 500 with malformed JSON body → http-error (body parse failed, non-2xx)', async () => {
+      // #given
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => {
+          throw new SyntaxError('Unexpected token')
+        },
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then — body parse failed on non-2xx → http-error (not parse-error)
+      expect(result).toEqual(err({kind: 'http-error', status: 500}))
+      vi.unstubAllGlobals()
+    })
+  })
+})

--- a/packages/gateway/src/workspace-api/client.ts
+++ b/packages/gateway/src/workspace-api/client.ts
@@ -1,0 +1,138 @@
+/**
+ * HTTP client for the workspace-agent service.
+ *
+ * SECURITY INVARIANT: This module NEVER logs request body or response body,
+ * even on retry, error, or rethrow. The request body contains an installation
+ * access token (ghs_*). All error paths return sanitized WorkspaceError variants
+ * with no token-bearing context.
+ */
+
+import type {Result} from '@fro-bot/runtime'
+
+import type {CloneErrorCode, CloneFailure, CloneRequest, CloneSuccess, WorkspaceError} from './types.js'
+
+import {err, ok} from '@fro-bot/runtime'
+
+export interface WorkspaceClientOptions {
+  readonly baseUrl: string
+  readonly timeoutMs?: number
+}
+
+export interface WorkspaceClient {
+  readonly clone: (request: CloneRequest) => Promise<Result<CloneSuccess, WorkspaceError>>
+}
+
+const DEFAULT_TIMEOUT_MS = 300_000 // 5 minutes
+
+/**
+ * Create a workspace-agent HTTP client.
+ *
+ * Uses native fetch (Node 24+) with AbortSignal.timeout for the 5-minute clone timeout.
+ * Never logs request or response bodies.
+ */
+export function createWorkspaceClient(options: WorkspaceClientOptions): WorkspaceClient {
+  const {baseUrl, timeoutMs = DEFAULT_TIMEOUT_MS} = options
+
+  async function clone(request: CloneRequest): Promise<Result<CloneSuccess, WorkspaceError>> {
+    const {owner, repo} = request
+    // SECURITY: body is never logged — it contains the IAT.
+    const body = JSON.stringify(request)
+
+    let response: Response
+    try {
+      response = await fetch(`${baseUrl}/clone`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body,
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+    } catch (fetchError) {
+      if (fetchError instanceof Error && fetchError.name === 'TimeoutError') {
+        return err({kind: 'timeout'})
+      }
+      // AbortError from older runtimes
+      if (fetchError instanceof Error && fetchError.name === 'AbortError') {
+        return err({kind: 'timeout'})
+      }
+      return err({kind: 'network-error'})
+    }
+
+    // SECURITY: response body is never logged.
+    // Parse body for ALL responses (2xx and non-2xx).
+    // PR C returns {ok: false, error: <CloneErrorCode>} with HTTP 400/409/500/503/504.
+    // We must parse the body to recover structured error codes before falling back to http-error.
+    const httpStatus = response.status
+    let parsed: unknown
+    try {
+      parsed = await response.json()
+    } catch {
+      // Body parse failed — if non-2xx, return http-error; otherwise parse-error.
+      if (!response.ok) {
+        return err({kind: 'http-error', status: httpStatus})
+      }
+      return err({kind: 'parse-error'})
+    }
+
+    if (!isCloneResponse(parsed)) {
+      // Body doesn't match CloneSuccess | CloneFailure shape.
+      if (!response.ok) {
+        return err({kind: 'http-error', status: httpStatus})
+      }
+      return err({kind: 'parse-error'})
+    }
+
+    if (parsed.ok === false) {
+      // Structured clone error — returned regardless of HTTP status.
+      return err({kind: 'clone-error', code: parsed.error})
+    }
+
+    // Response integrity check: path must end with /{owner}/{repo} (case-insensitive).
+    const expectedSuffix = `/${owner.toLowerCase()}/${repo.toLowerCase()}`
+    if (!parsed.path.toLowerCase().endsWith(expectedSuffix)) {
+      return err({kind: 'response-mismatch'})
+    }
+
+    return ok(parsed)
+  }
+
+  return {clone}
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+function isCloneResponse(value: unknown): value is CloneSuccess | CloneFailure {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  if (typeof v.ok !== 'boolean') return false
+  if (v.ok === true) {
+    return typeof v.path === 'string' && typeof v.commit === 'string'
+  }
+  // ok === false: validate error is a known CloneErrorCode
+  return typeof v.error === 'string' && isCloneErrorCode(v.error)
+}
+
+const CLONE_ERROR_CODES = new Set<string>([
+  'invalid-owner',
+  'invalid-repo',
+  'invalid-token-shape',
+  'malformed-body',
+  'body-too-large',
+  'clone-failed',
+  'clone-timeout',
+  'clone-aborted',
+  'git-not-available',
+  'enospc',
+  'disk-full',
+  'permission-denied',
+  'too-many-files',
+  'repo-exists',
+  'path-escaped-workspace',
+  'head-resolution-failed',
+  'overloaded',
+])
+
+function isCloneErrorCode(value: string): value is CloneErrorCode {
+  return CLONE_ERROR_CODES.has(value)
+}

--- a/packages/gateway/src/workspace-api/types.ts
+++ b/packages/gateway/src/workspace-api/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Request/response types for the workspace-agent HTTP service.
+ *
+ * These types MIRROR `apps/workspace-agent/src/types.ts` exactly.
+ * The gateway MUST import from this file — never from the workspace-agent package directly.
+ *
+ * SECURITY: `repoPath` is NOT in CloneRequest. The agent derives the path internally.
+ * The caller never controls where the repo is cloned.
+ */
+
+/** POST /clone request body. */
+export interface CloneRequest {
+  readonly owner: string
+  readonly repo: string
+  /** Installation access token (ghs_*). Never logged, never persisted. */
+  readonly token: string
+}
+
+/** POST /clone success response. */
+export interface CloneSuccess {
+  readonly ok: true
+  /** Absolute path inside the workspace container, e.g. /workspace/repos/fro-bot/agent */
+  readonly path: string
+  /** HEAD SHA after clone. */
+  readonly commit: string
+}
+
+/** POST /clone error response. */
+export interface CloneFailure {
+  readonly ok: false
+  readonly error: CloneErrorCode
+  /** Optional machine-readable sub-code (e.g. 'ENOSPC'). */
+  readonly code?: string
+}
+
+export type CloneErrorCode =
+  | 'invalid-owner'
+  | 'invalid-repo'
+  | 'invalid-token-shape'
+  | 'malformed-body'
+  | 'body-too-large'
+  | 'clone-failed'
+  | 'clone-timeout'
+  | 'clone-aborted'
+  | 'git-not-available'
+  | 'enospc'
+  | 'disk-full'
+  | 'permission-denied'
+  | 'too-many-files'
+  | 'repo-exists'
+  | 'path-escaped-workspace'
+  | 'head-resolution-failed'
+  | 'overloaded'
+
+/**
+ * Client-side error discriminated union for workspace-api calls.
+ * These are the errors the gateway's workspace client can return.
+ */
+export type WorkspaceError =
+  | {readonly kind: 'clone-error'; readonly code: CloneErrorCode}
+  | {readonly kind: 'http-error'; readonly status: number}
+  | {readonly kind: 'network-error'}
+  | {readonly kind: 'timeout'}
+  | {readonly kind: 'parse-error'}
+  | {readonly kind: 'response-mismatch'}


### PR DESCRIPTION
Ships the first user-facing gateway feature. Operator runs `/fro-bot add-project url:<git-url> [channel:<name>]` and the gateway authenticates to GitHub, clones the repo into the workspace container, creates a Discord channel for it, and writes a binding record to S3 so future `@fro-bot` mentions in that channel know which repo to act against.

## What changed

**New surface — `/fro-bot add-project` slash command**

Five-phase orchestration:

1. **PRE_FLIGHT** — defer ephemerally, parse + canonicalize `owner/repo` to lowercase, validate channel name (hostile-char rejection), check existing binding, mint installation access token via the GitHub App
2. **CLONING** — POST to the workspace-agent's `/clone` endpoint with `AbortSignal.timeout(5min)`
3. **CREATING_CHANNEL** — defensive permission re-check, then create the channel with `name`, `name-2`, ..., `name-10` collision suffix logic
4. **WRITING_BINDING** — persist to S3 with two-key schema (primary + by-channel-id index)
5. **READY** — confirmation message in the source thread, welcome embed posted in the new channel

**`/fro-bot` parent command refactor**

`fro-bot.ts` is now a factory (`createFroBotCommand(deps)`) that builds the parent `SlashCommandBuilder` with both `ping` and `add-project` subcommands and dispatches on `interaction.options.getSubcommand()`. `ping.ts` and `add-project.ts` export subcommand handlers consumed by the parent. Dependencies are injected at registry construction time (no module-global state).

**Workspace-api client (`packages/gateway/src/workspace-api/`)**

Native fetch with 5-minute timeout. Mirrors the workspace-agent's exact type contract including all 17 `CloneErrorCode` variants. Parses structured `CloneFailure` bodies on any HTTP status, preserving error semantics (`disk-full`, `repo-exists`, `overloaded`, `clone-timeout`, etc.) through to operator-facing recovery copy. Response-path integrity check (must end with `/{owner}/{repo}`). Captured-logger test asserts no token-shaped string ever appears in any log line across happy and all error paths.

**Discord channel helper (`packages/gateway/src/discord/channels.ts`)**

`findOrCreateChannel(guild, name, {maxSuffix: 10})` — never returns an existing channel by name (preventing silent binding of new repos to unrelated existing channels). Iterates `name`, `name-2`, ..., `name-10` to find the first non-existing candidate and creates it. Returns `collision-exhausted` when all 10 candidates are taken.

**Permission check uses `interaction.appPermissions`**

`appPermissions` is reliably populated by Discord for every guild interaction regardless of intent configuration. The gateway runs without the `GuildMembers` privileged intent, so `guild.members.cache.get()` returns `undefined` for the bot itself — defending against this false-negative is what `appPermissions` solves.

**Per-user rate limit**

In-memory bucket: 5 invocations per 60 seconds per Discord user. Sixth+ invocation gets ephemeral "rate-limited; try again in N seconds" without entering any phase.

## Plan + design

`docs/plans/2026-05-23-001-feat-gateway-unit-5-add-project-plan.md` carries the deepened PR D spec (adversarial + feasibility + security review applied) and the v1 acceptance call-outs:

- **Orchestration durability:** in-memory only. Process crash mid-flow leaves orphaned state with operator-facing manual recovery instructions per partial-failure shape (clone-no-channel, channel-no-binding, binding-no-welcome). Persistent setup-state is deferred.
- **Trust model for `sandbox-net`:** plaintext HTTP gateway↔workspace-agent is acceptable v1 only because the network is internal compose-only with no published ports. HMAC request signing required if that ever changes.
- **Observability contract:** correlationId from Discord interaction ID, per-phase structured log lines (`phase`, `outcome`, `errorKind`, `durationMs`), token never logged.

## Files

**New** (8): `workspace-api/{types,client,client.test}.ts`, `discord/channels{,.test}.ts`, `discord/commands/{fro-bot,add-project,add-project.test}.ts`

**Modified** (5): `discord/commands/{ping,ping.test,index,index.test}.ts` (factory pattern + dispatch), `config.ts` (+`workspaceAgentUrl`), `program.ts` (compose + inject deps), `program.test.ts`, `github/app-client.ts`, `discord/mentions.test.ts`

## Verification

- 273/273 gateway tests pass (+25 net)
- 0 lint errors
- Types clean
- Captured-logger security test covers happy + 7 error paths (timeout, clone-error, response-mismatch, parse-error, network-error, http-error, malformed-success); no `ghs_*` token appears in any log call
