### PR TITLE
build(deps): update Node.js to 24.16.0-alpine

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,10 +42,10 @@
     {matchFileNames: ['.github/workflows/**'], semanticCommitType: 'ci'},
     {matchDatasources: ['docker'], semanticCommitType: 'build'},
     {
-      // Apply Node.js semver versioning to node Docker images so Renovate
-      // resolves major-alias tags (e.g. 24-alpine) to full semver patch tags
-      // (e.g. 24.15.0-alpine), includes semver in PR titles, and fetches
-      // release-note summaries from nodejs/node into the PR body.
+      // versioning: node + versionCompatibility split "24.16.0-alpine" into
+      // version=24.16.0 / compatibility=-alpine so Renovate compares Node semver
+      // and rebuilds the tag on upgrades. sourceUrl inlines release-note
+      // summaries from nodejs/node into the PR body.
       matchDatasources: ['docker'],
       matchPackageNames: ['/(?:^|/)node$/'],
       versioning: 'node',

--- a/deploy/gateway.Dockerfile
+++ b/deploy/gateway.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
 
 # ── Stage 1: build ────────────────────────────────────────────────────────────
-FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS build
+FROM node:24.16.0-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS build
 
 WORKDIR /workspace
 
@@ -25,7 +25,7 @@ RUN pnpm --filter @fro-bot/runtime build
 RUN pnpm --filter @fro-bot/gateway build
 
 # ── Stage 2: runtime ──────────────────────────────────────────────────────────
-FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS runtime
+FROM node:24.16.0-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS runtime
 
 WORKDIR /app
 

--- a/deploy/workspace.Dockerfile
+++ b/deploy/workspace.Dockerfile
@@ -11,6 +11,6 @@
 #   - mitmproxy CA injected into /usr/local/share/ca-certificates/mitmproxy.crt
 #     followed by update-ca-certificates so all outbound TLS goes through the proxy
 
-FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
+FROM node:24.16.0-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14
 
 CMD ["sh", "-c", "echo 'workspace placeholder — Unit 7 will replace this'; sleep infinity"]


### PR DESCRIPTION
- Update gateway.Dockerfile (build + runtime stages) from node:24-alpine to node:24.16.0-alpine@sha256:2bdb65ed...
- Update workspace.Dockerfile from node:24-alpine to node:24.16.0-alpine @sha256:2bdb65ed...
- Fix renovate.json5 comment to accurately describe versioning behavior

Renovate cannot auto-upgrade from an imprecise tag (24-alpine, precision 1) to a precise one (24.16.0-alpine, precision 3) — this is a documented limitation. Pinning to the full semver tag lets Renovate maintain future updates (e.g. 24.16.0 → 24.17.0) with correct PR titles and inline Node.js release notes via sourceUrl.

Closes #667