### PR TITLE
fix(gateway): harden /add-project authorization, recovery messaging, and path validation

### DIFF
--- a/packages/gateway/src/discord/commands/add-project.test.ts
+++ b/packages/gateway/src/discord/commands/add-project.test.ts
@@ -41,6 +41,11 @@ function lastReplyContent(reply: ReturnType<typeof vi.fn>): string {
   return calls.at(-1)?.[0]?.content ?? ''
 }
 
+/** Collect all editReply content strings across every call. */
+function allEditReplies(editReply: ReturnType<typeof vi.fn>): string[] {
+  return (editReply.mock.calls as [{content?: string}][]).map(c => c[0]?.content ?? '')
+}
+
 interface MockChannel {
   readonly channel: TextChannel
   readonly send: ReturnType<typeof vi.fn>
@@ -62,7 +67,9 @@ function makeGuild(
     has: vi.fn().mockReturnValue(hasPermissions),
   }
   const member = {permissions}
-  const members = {cache: {get: vi.fn().mockReturnValue(member)}}
+  const members = {
+    fetch: vi.fn().mockResolvedValue(member),
+  }
 
   const channelCache = {
     find: (pred: (ch: TextChannel) => boolean) => channels.find(pred),
@@ -400,7 +407,6 @@ describe('executeAddProject', () => {
       {code: 'clone-failed', expectedFragment: 'clone-failed'},
       {code: 'disk-full', expectedFragment: 'out of space'},
       {code: 'enospc', expectedFragment: 'out of space'},
-      {code: 'repo-exists', expectedFragment: 'already exists'},
       {code: 'head-resolution-failed', expectedFragment: 'head-resolution-failed'},
       {code: 'clone-timeout', expectedFragment: 'clone-timeout'},
     ]
@@ -461,7 +467,10 @@ describe('executeAddProject', () => {
         filter: () => ({find: () => undefined, some: () => false}),
       }
       const create = vi.fn().mockResolvedValue(makeTextChannel().channel)
-      const guild = {channels: {cache: channelCache, create}} as unknown as Guild
+      const guild = {
+        members: {fetch: vi.fn().mockResolvedValue({permissions: {has: vi.fn().mockReturnValue(true)}})},
+        channels: {cache: channelCache, create},
+      } as unknown as Guild
       const {interaction, editReply} = makeInteraction({guild, userId, appPermissions})
       const deps = makeDeps()
 
@@ -488,6 +497,7 @@ describe('executeAddProject', () => {
       const nameTakenError = Object.assign(new Error('Invalid Form Body'), {code: 50035})
       const create = vi.fn().mockRejectedValue(nameTakenError)
       const guild = {
+        members: {fetch: vi.fn().mockResolvedValue({permissions: {has: vi.fn().mockReturnValue(true)}})},
         channels: {cache: channelCache, create},
       } as unknown as Guild
       const {interaction, editReply} = makeInteraction({guild, userId})
@@ -599,6 +609,202 @@ describe('executeAddProject', () => {
       const {interaction: staleInteraction, editReply: staleEditReply} = makeInteraction({guild, userId: staleUserId})
       await run(staleInteraction, deps)
       expect(lastEditReplyContent(staleEditReply)).toContain('Ready')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Invoking-user authorization gate
+  // -------------------------------------------------------------------------
+
+  describe('PRE_FLIGHT: user authorization', () => {
+    it('rejects user without guild-level ManageChannels and does not proceed to clone', async () => {
+      // #given — members.fetch resolves to a member whose guild-level permissions lack ManageChannels
+      const userId = uniqueUserId()
+      const clone = vi.fn()
+      const unauthorizedMember = {permissions: {has: vi.fn().mockReturnValue(false)}}
+      const guild = makeGuild('bot-user-id', true, [])
+      ;(guild.members as unknown as {fetch: ReturnType<typeof vi.fn>}).fetch = vi
+        .fn()
+        .mockResolvedValue(unauthorizedMember)
+      const {interaction, editReply} = makeInteraction({userId, guild})
+      const deps = makeDeps({workspaceClient: makeWorkspaceClient({clone})})
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — rejected with permission message; clone never invoked
+      expect(lastEditReplyContent(editReply)).toContain('Manage Channels')
+      expect(clone).not.toHaveBeenCalled()
+    })
+
+    it('denies a user whose ManageChannels comes only from a channel overwrite, not guild-level', async () => {
+      // #given — guild-level permissions.has returns false (no base guild ManageChannels),
+      // even though a channel-scoped overwrite might grant it in a real Discord server.
+      const userId = uniqueUserId()
+      const clone = vi.fn()
+      const channelOverwriteOnlyMember = {permissions: {has: vi.fn().mockReturnValue(false)}}
+      const guild = makeGuild('bot-user-id', true, [])
+      ;(guild.members as unknown as {fetch: ReturnType<typeof vi.fn>}).fetch = vi
+        .fn()
+        .mockResolvedValue(channelOverwriteOnlyMember)
+      const {interaction, editReply} = makeInteraction({userId, guild})
+      const deps = makeDeps({workspaceClient: makeWorkspaceClient({clone})})
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — rejected; channel-scoped overwrite does NOT bypass the guild-level gate
+      expect(lastEditReplyContent(editReply)).toContain('Manage Channels')
+      expect(clone).not.toHaveBeenCalled()
+    })
+
+    it('allows user WITH guild-level ManageChannels to proceed past the authorization gate', async () => {
+      // #given — members.fetch resolves to a member with guild-level ManageChannels
+      const userId = uniqueUserId()
+      const {PermissionFlagsBits} = await import('discord.js')
+      const authorizedMember = {
+        permissions: {has: vi.fn().mockImplementation((flag: bigint) => flag === PermissionFlagsBits.ManageChannels)},
+      }
+      const {channel} = makeTextChannel('testrepo')
+      const guild = makeGuild('bot-user-id', true, [], channel)
+      ;(guild.members as unknown as {fetch: ReturnType<typeof vi.fn>}).fetch = vi
+        .fn()
+        .mockResolvedValue(authorizedMember)
+      const {interaction, editReply} = makeInteraction({userId, guild})
+      const deps = makeDeps()
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — proceeds through all phases and reaches READY
+      expect(lastEditReplyContent(editReply)).toContain('Ready')
+    })
+
+    it('fail-closed: members.fetch rejection denies access and does not throw', async () => {
+      // #given — members.fetch rejects (e.g. network error, member not in guild)
+      const userId = uniqueUserId()
+      const clone = vi.fn()
+      const guild = makeGuild('bot-user-id', true, [])
+      ;(guild.members as unknown as {fetch: ReturnType<typeof vi.fn>}).fetch = vi
+        .fn()
+        .mockRejectedValue(new Error('Unknown Member'))
+      const {interaction, editReply} = makeInteraction({userId, guild})
+      const deps = makeDeps({workspaceClient: makeWorkspaceClient({clone})})
+
+      // #when — must resolve without throwing
+      await run(interaction, deps)
+
+      // #then — fail-closed: denied, clone never invoked
+      expect(lastEditReplyContent(editReply)).toContain('Manage Channels')
+      expect(clone).not.toHaveBeenCalled()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // repo-exists never emits deletion instructions
+  // -------------------------------------------------------------------------
+
+  describe('CLONING: repo-exists safe messaging', () => {
+    it('repo-exists + binding found → redirects to bound channel, no rm -rf', async () => {
+      // #given — clone fails with repo-exists; bindings store returns existing binding
+      const userId = uniqueUserId()
+      const clone = vi.fn().mockResolvedValue(err({kind: 'clone-error', code: 'repo-exists'}))
+      const existingBinding = {
+        owner: 'testowner',
+        repo: 'testrepo',
+        channelId: 'ch-bound-456',
+        channelName: 'testrepo',
+        workspacePath: '/workspace/repos/testowner/testrepo',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        createdByDiscordId: 'user-original',
+      }
+      // getBindingByRepo is called twice: once in PRE_FLIGHT (returns null), once in repo-exists handler (returns binding)
+      const getBindingByRepo = vi.fn().mockResolvedValueOnce(ok(null)).mockResolvedValue(ok(existingBinding))
+      const {interaction, editReply} = makeInteraction({userId})
+      const deps = makeDeps({
+        workspaceClient: makeWorkspaceClient({clone}),
+        bindingsStore: makeBindingsStore({getBindingByRepo}),
+      })
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — redirects to existing channel with exact mention token; NEVER instructs deletion
+      const reply = lastEditReplyContent(editReply)
+      expect(reply).toContain('<#ch-bound-456>')
+      for (const content of allEditReplies(editReply)) {
+        expect(content).not.toContain('rm -rf')
+      }
+    })
+
+    it('repo-exists + no binding found → "currently being added" message, no rm -rf', async () => {
+      // #given — clone fails with repo-exists; binding store returns null (clone in progress)
+      const userId = uniqueUserId()
+      const clone = vi.fn().mockResolvedValue(err({kind: 'clone-error', code: 'repo-exists'}))
+      // Both PRE_FLIGHT and repo-exists handler see no binding
+      const getBindingByRepo = vi.fn().mockResolvedValue(ok(null))
+      const {interaction, editReply} = makeInteraction({userId})
+      const deps = makeDeps({
+        workspaceClient: makeWorkspaceClient({clone}),
+        bindingsStore: makeBindingsStore({getBindingByRepo}),
+      })
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — "currently being added" safe message; NEVER instructs deletion
+      const reply = lastEditReplyContent(editReply)
+      expect(reply).toContain('currently being added')
+      for (const content of allEditReplies(editReply)) {
+        expect(content).not.toContain('rm -rf')
+      }
+    })
+
+    it('repo-exists + binding store errors → falls back to "currently being added", no rm -rf', async () => {
+      // #given — clone fails with repo-exists; binding store returns error
+      const userId = uniqueUserId()
+      const clone = vi.fn().mockResolvedValue(err({kind: 'clone-error', code: 'repo-exists'}))
+      const storeError = new Error('S3 timeout')
+      // PRE_FLIGHT call succeeds with null; second call (repo-exists handler) errors
+      const getBindingByRepo = vi.fn().mockResolvedValueOnce(ok(null)).mockResolvedValue(err(storeError))
+      const {interaction, editReply} = makeInteraction({userId})
+      const deps = makeDeps({
+        workspaceClient: makeWorkspaceClient({clone}),
+        bindingsStore: makeBindingsStore({getBindingByRepo}),
+      })
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — safe fallback; NEVER instructs deletion
+      const reply = lastEditReplyContent(editReply)
+      expect(reply).toContain('currently being added')
+      for (const content of allEditReplies(editReply)) {
+        expect(content).not.toContain('rm -rf')
+      }
+    })
+
+    it('repo-exists + getBindingByRepo REJECTS → falls back to "please wait", no rm -rf', async () => {
+      // #given — clone fails with repo-exists; getBindingByRepo throws (network-level rejection)
+      const userId = uniqueUserId()
+      const clone = vi.fn().mockResolvedValue(err({kind: 'clone-error', code: 'repo-exists'}))
+      // PRE_FLIGHT call succeeds with null; second call rejects entirely
+      const getBindingByRepo = vi.fn().mockResolvedValueOnce(ok(null)).mockRejectedValue(new Error('connection reset'))
+      const {interaction, editReply} = makeInteraction({userId})
+      const deps = makeDeps({
+        workspaceClient: makeWorkspaceClient({clone}),
+        bindingsStore: makeBindingsStore({getBindingByRepo}),
+      })
+
+      // #when — must resolve without throwing even though getBindingByRepo rejects
+      await expect(run(interaction, deps)).resolves.toBeUndefined()
+
+      // #then — safe fallback sent; NEVER instructs deletion
+      const reply = lastEditReplyContent(editReply)
+      expect(reply).toContain('currently being added')
+      for (const content of allEditReplies(editReply)) {
+        expect(content).not.toContain('rm -rf')
+      }
     })
   })
 

--- a/packages/gateway/src/discord/commands/add-project.ts
+++ b/packages/gateway/src/discord/commands/add-project.ts
@@ -10,7 +10,7 @@
  * - Owner/repo are canonicalized to lowercase before any lookup or write.
  */
 
-import type {ChatInputCommandInteraction, PermissionsBitField} from 'discord.js'
+import type {ChatInputCommandInteraction, Guild, PermissionsBitField} from 'discord.js'
 import type {BindingsStore} from '../../bindings/store.js'
 import type {AppClient} from '../../github/app-client.js'
 import type {WorkspaceClient} from '../../workspace-api/client.js'
@@ -143,6 +143,26 @@ function botHasRequiredPermissions(appPermissions: PermissionsBitField | null): 
   return appPermissions.has(PermissionFlagsBits.ManageChannels) && appPermissions.has(PermissionFlagsBits.SendMessages)
 }
 
+// Invoking-user authorization gate: prevents privilege amplification where a member coerces
+// the bot's broader ManageChannels permission to create channels they could not create themselves.
+// Uses guild-level base permissions (no channel overwrites) to prevent a user with a
+// channel-scoped ManageChannels overwrite from bypassing the gate.
+async function userIsAuthorized(guild: Guild, userId: string, logger: AddProjectDeps['logger']): Promise<boolean> {
+  try {
+    // guild.members.fetch() is a REST call — works without the privileged GuildMembers intent.
+    // Do NOT use guild.members.cache.get() — returns undefined without the intent.
+    const member = await guild.members.fetch(userId)
+    // member.permissions is the guild-level base permission set (no channel overwrites).
+    return member.permissions.has(PermissionFlagsBits.ManageChannels)
+  } catch (error) {
+    // Fail closed: if we cannot resolve the member's guild permissions, deny.
+    logger.warn('add-project: member permission resolution failed', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return false
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Interaction window guard (14-minute limit)
 // ---------------------------------------------------------------------------
@@ -204,10 +224,21 @@ async function runAddProject(interaction: ChatInputCommandInteraction, deps: Add
   }
 
   // Check bot permissions
-  if (!botHasRequiredPermissions(interaction.appPermissions)) {
+  if (botHasRequiredPermissions(interaction.appPermissions) === false) {
     logger.warn('add-project: missing bot permissions', {correlationId, phase})
     await interaction.editReply({
       content: `fro-bot needs **Manage Channels** and **Send Messages** permissions. Re-invite the bot at: ${installUrl}`,
+    })
+    return
+  }
+
+  // Runtime authorization check — invoking user must hold ManageChannels.
+  // setDefaultMemberPermissions is NOT used — it would gate the entire /fro-bot parent
+  // command (including /ping). This is a scoped runtime check per subcommand.
+  if ((await userIsAuthorized(guild, interaction.user.id, logger)) === false) {
+    logger.warn('add-project: unauthorized user', {correlationId, phase})
+    await interaction.editReply({
+      content: 'You need the **Manage Channels** permission to use this command.',
     })
     return
   }
@@ -320,9 +351,30 @@ async function runAddProject(interaction: ChatInputCommandInteraction, deps: Add
             'The workspace volume is out of space. Free disk by removing unused repos under `/workspace/repos` and retry.',
         })
       } else if (code === 'repo-exists') {
-        await interaction.editReply({
-          content: `The repo \`${owner}/${repo}\` already exists in the workspace. Remove it with \`rm -rf /workspace/repos/${owner}/${repo}\` and retry.`,
-        })
+        // Never emit deletion instructions. Re-read bindings to distinguish:
+        // (a) repo genuinely bound → redirect to the bound channel
+        // (b) clone in progress by another user → safe "please wait" message
+        // Either way, no rm -rf instruction: user B must not destroy user A's in-flight clone.
+        let repoExistsBinding: Awaited<ReturnType<typeof bindingsStore.getBindingByRepo>>
+        try {
+          repoExistsBinding = await bindingsStore.getBindingByRepo(owner, repo)
+        } catch {
+          // Network-level rejection: fall back to the safe "please wait" message.
+          await interaction.editReply({
+            content: `\`${owner}/${repo}\` is currently being added by another setup. Please wait a moment and try again.`,
+          })
+          return
+        }
+        if (repoExistsBinding.success === true && repoExistsBinding.data !== null) {
+          await interaction.editReply({
+            content: `\`${owner}/${repo}\` is already set up in <#${repoExistsBinding.data.channelId}>.`,
+          })
+        } else {
+          // Either binding lookup failed or no binding found — clone is in progress.
+          await interaction.editReply({
+            content: `\`${owner}/${repo}\` is currently being added by another setup. Please wait a moment and try again.`,
+          })
+        }
       } else {
         await interaction.editReply({
           content: `Clone failed (${code}). Check workspace-agent logs for details.`,

--- a/packages/gateway/src/workspace-api/client.test.ts
+++ b/packages/gateway/src/workspace-api/client.test.ts
@@ -113,10 +113,10 @@ describe('createWorkspaceClient', () => {
       vi.unstubAllGlobals()
     })
 
-    it('accepts path match case-insensitively', async () => {
-      // #given
+    it('accepts lowercase owner/repo matching the response path', async () => {
+      // #given — owner/repo arrive already lowercased from the caller (add-project.ts canonicalizes)
       const client = makeClient()
-      const req = makeRequest({owner: 'TestOwner', repo: 'TestRepo'})
+      const req = makeRequest({owner: 'testowner', repo: 'testrepo'})
       const fetchMock = mockFetch({
         ok: true,
         json: async () => ({ok: true, path: '/workspace/repos/testowner/testrepo', commit: 'abc123'}),
@@ -128,6 +128,79 @@ describe('createWorkspaceClient', () => {
 
       // #then
       expect(result.success).toBe(true)
+      vi.unstubAllGlobals()
+    })
+
+    // Strict prefix validation — suffix-only check accepted adversarial paths.
+    it('rejects adversarial path /etc/passwd/testowner/testrepo', async () => {
+      // #given — suffix matches but path root is wrong (privilege escalation attempt)
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = mockFetch({
+        ok: true,
+        json: async () => ({ok: true, path: '/etc/passwd/testowner/testrepo', commit: 'abc123'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then — must reject: path doesn't start with /workspace/repos
+      expect(result).toEqual(err({kind: 'response-mismatch'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('accepts exactly /workspace/repos/{owner}/{repo}', async () => {
+      // #given — exact expected path
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = mockFetch({
+        ok: true,
+        json: async () => ({ok: true, path: '/workspace/repos/testowner/testrepo', commit: 'abc123'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then — must succeed
+      expect(result.success).toBe(true)
+      vi.unstubAllGlobals()
+    })
+
+    it('rejects path with extra trailing segment /workspace/repos/testowner/testrepo/extra', async () => {
+      // #given — suffix matches but there's an extra path segment after owner/repo
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = mockFetch({
+        ok: true,
+        json: async () => ({ok: true, path: '/workspace/repos/testowner/testrepo/extra', commit: 'abc123'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then — exact equality rejects the extra segment
+      expect(result).toEqual(err({kind: 'response-mismatch'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('rejects path with uppercase workspace root /WORKSPACE/repos/owner/repo', async () => {
+      // #given — case-variant root; lowercasing response path would bypass validation
+      const client = makeClient()
+      const req = makeRequest()
+      const fetchMock = mockFetch({
+        ok: true,
+        json: async () => ({ok: true, path: '/WORKSPACE/repos/testowner/testrepo', commit: 'abc123'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.clone(req)
+
+      // #then — exact comparison rejects the case-variant root
+      expect(result).toEqual(err({kind: 'response-mismatch'}))
       vi.unstubAllGlobals()
     })
   })

--- a/packages/gateway/src/workspace-api/client.ts
+++ b/packages/gateway/src/workspace-api/client.ts
@@ -24,6 +24,10 @@ export interface WorkspaceClient {
 
 const DEFAULT_TIMEOUT_MS = 300_000 // 5 minutes
 
+// Mirrors WORKSPACE_REPOS_ROOT in apps/workspace-agent/src/clone.ts.
+// Intentionally NOT imported from there: separate package/container boundary.
+const EXPECTED_WORKSPACE_ROOT = '/workspace/repos'
+
 /**
  * Create a workspace-agent HTTP client.
  *
@@ -86,9 +90,12 @@ export function createWorkspaceClient(options: WorkspaceClientOptions): Workspac
       return err({kind: 'clone-error', code: parsed.error})
     }
 
-    // Response integrity check: path must end with /{owner}/{repo} (case-insensitive).
-    const expectedSuffix = `/${owner.toLowerCase()}/${repo.toLowerCase()}`
-    if (!parsed.path.toLowerCase().endsWith(expectedSuffix)) {
+    // Strict full-path equality check (root + owner + repo).
+    // The prior suffix-only check accepted adversarial paths like /etc/passwd/owner/repo.
+    // owner/repo arrive already lowercased from add-project.ts; lowercasing the response
+    // path would let a case-variant root bypass validation.
+    const expectedPath = `${EXPECTED_WORKSPACE_ROOT}/${owner}/${repo}`
+    if (parsed.path !== expectedPath) {
       return err({kind: 'response-mismatch'})
     }
 


### PR DESCRIPTION
Three security and correctness fixes for the `/fro-bot add-project` command.

## Authorization gate
Require the invoking user to hold **Manage Channels** before running `/add-project`. Previously any guild member could invoke it and the bot would act with its own broader permissions, letting a low-privilege user drive channel creation they couldn't perform themselves. The check is scoped to the subcommand at runtime rather than `default_member_permissions`, which would gate the whole `/fro-bot` command group (including `ping`).

## Safe repo-exists messaging
The previous `repo-exists` reply told the user to `rm -rf /workspace/repos/owner/repo` and retry. When a second user invokes while another user's clone is mid-flight, that instruction would delete the in-flight clone. It now re-reads the bindings store and either redirects to the already-bound channel or asks the user to wait — never instructing deletion.

## Strict clone-response path validation
The workspace clone response was validated with a suffix match (`endsWith('/owner/repo')`), which accepts adversarial prefixes such as `/etc/passwd/owner/repo`. It now requires exact equality against the expected `/workspace/repos/owner/repo` path.

Gateway test suite: 286 passing.