### PR TITLE
fix(gateway): make /add-project recoverable and shutdown-aware

### DIFF
--- a/docs/solutions/best-practices/discord-slash-command-orchestration-patterns-2026-05-27.md
+++ b/docs/solutions/best-practices/discord-slash-command-orchestration-patterns-2026-05-27.md
@@ -128,21 +128,41 @@ for (const line of spy.lines) {
 }
 ```
 
-### 4. Multi-phase orchestration with documented partial-failure recovery
+### 4. Multi-phase orchestration with idempotent self-healing recovery
 
-The flow is a five-phase state machine: `PRE_FLIGHT → CLONING → CREATING_CHANNEL → WRITING_BINDING → READY`. For v1, the orchestration is intentionally **in-memory only** — a process crash mid-flow leaves orphaned state. Rather than building durable resume infrastructure prematurely, the accepted v1 contract is **documented manual recovery per partial-failure shape**, plus:
+The flow is a five-phase state machine: `PRE_FLIGHT → CLONING → CREATING_CHANNEL → WRITING_BINDING → READY`. The primary recovery path for the clone-exists/no-binding partial-failure shape is **re-running the command** — `/add-project` is idempotent for this case:
 
+- **Atomic clone guarantee**: the workspace-agent renames the temp dir to the final dest atomically. `repo-exists` from a clone call means the clone is fully complete — not partial.
+- **Resume keyed on confirmed absent binding**: when `repo-exists` is returned, the handler re-reads the bindings store. It only resumes (falls through to `CREATING_CHANNEL`) when the store confirms `data === null`. A store error (thrown or `success === false`) returns an internal-error reply and does **not** resume — resuming on an unreadable store would risk orphan channels if the binding write also fails.
 - **A defensive permission re-check at the side-effect boundary** (`CREATING_CHANNEL`) — permissions can change between `PRE_FLIGHT` and the first mutation.
-- **Preserve expensive prior work** — a failure after `CLONING` keeps the clone on disk; the recovery message names the path so the operator can retry or clean up.
+- **Preserve expensive prior work** — a failure after `CLONING` keeps the clone on disk; retrying the command will detect `repo-exists`, confirm no binding, and resume from `CREATING_CHANNEL`.
+
+Accepted v1 fallout and boundaries:
+
+- **Orphan channel on concurrent resume**: if two invocations both resume simultaneously, both create a channel, then both race to write the binding. The loser's `createBinding` is rejected with `BINDING_EXISTS_ERROR` (atomic IfNoneMatch write). The loser gets a "bound by a concurrent request / manual cleanup may be needed" reply. The orphan channel is a bounded, operator-visible artifact — not a silent data integrity issue.
+- **Shutdown gating**: new invocations are refused during drain (after `deferReply` so Discord gets its mandatory ack). In-flight runs that are hard-cut during a process restart are healed by the next retry via the resume path.
 
 ```ts
-// Defensive re-check before the first side effect:
-if (botHasRequiredPermissions(interaction.appPermissions) === false) {
-  await interaction.editReply({
-    content: `fro-bot lost **Manage Channels**. Clone preserved at \`${workspacePath}\`. Re-grant and retry.`,
-  })
+// Resume only on CONFIRMED absent binding — store errors do NOT resume:
+let existing: Awaited<ReturnType<typeof bindingsStore.getBindingByRepo>>
+try {
+  existing = await bindingsStore.getBindingByRepo(owner, repo)
+} catch {
+  await interaction.editReply({content: 'Internal error checking existing bindings. Please retry in a moment.'})
   return
 }
+if (existing.success === false) {
+  await interaction.editReply({content: 'Internal error checking existing bindings. Please retry in a moment.'})
+  return
+}
+if (existing.data !== null) {
+  // Already bound — redirect.
+  await interaction.editReply({content: `\`${owner}/${repo}\` is already set up in <#${existing.data.channelId}>.`})
+  return
+}
+// Confirmed absent binding — resume from CREATING_CHANNEL.
+workspacePath = workspaceRepoPath(owner, repo)
+// fall through — do NOT return
 
 // Partial-write recovery names both keys for manual cleanup:
 if (error.code === 'BINDING_PARTIAL_WRITE_ERROR') {

--- a/packages/gateway/src/discord/commands/add-project.test.ts
+++ b/packages/gateway/src/discord/commands/add-project.test.ts
@@ -15,6 +15,7 @@ import {err, ok} from '@fro-bot/runtime'
 import {Effect} from 'effect'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {AppNotInstalledError} from '../../github/app-client.js'
+import {__resetShuttingDownForTests} from '../../shutdown.js'
 import {executeAddProject} from './add-project.js'
 
 // ---------------------------------------------------------------------------
@@ -737,74 +738,299 @@ describe('executeAddProject', () => {
       }
     })
 
-    it('repo-exists + no binding found → "currently being added" message, no rm -rf', async () => {
-      // #given — clone fails with repo-exists; binding store returns null (clone in progress)
+    it('repo-exists + NO binding → RESUMES: proceeds to channel creation and binding write', async () => {
+      // #given — clone fails with repo-exists; bindings store returns null (no binding yet)
+      // This is the post-clone partial-failure recovery path.
       const userId = uniqueUserId()
       const clone = vi.fn().mockResolvedValue(err({kind: 'clone-error', code: 'repo-exists'}))
-      // Both PRE_FLIGHT and repo-exists handler see no binding
+      // PRE_FLIGHT returns null; repo-exists handler also returns null (no binding written yet)
       const getBindingByRepo = vi.fn().mockResolvedValue(ok(null))
-      const {interaction, editReply} = makeInteraction({userId})
+      const createBinding = vi.fn().mockResolvedValue(ok({primaryEtag: 'e1', indexEtag: 'e2'}))
+      const {channel, send} = makeTextChannel('owner-repo')
+      const guild = makeGuild('bot-user-id', true, [], channel)
+      const {interaction, editReply} = makeInteraction({
+        url: 'https://github.com/owner/repo',
+        guild,
+        userId,
+      })
       const deps = makeDeps({
         workspaceClient: makeWorkspaceClient({clone}),
-        bindingsStore: makeBindingsStore({getBindingByRepo}),
+        bindingsStore: makeBindingsStore({getBindingByRepo, createBinding}),
       })
 
       // #when
       await run(interaction, deps)
 
-      // #then — "currently being added" safe message; NEVER instructs deletion
-      const reply = lastEditReplyContent(editReply)
-      expect(reply).toContain('currently being added')
+      // #then — channel was created (guild.channels.create was called)
+      const guildCreate = (guild.channels as unknown as {create: ReturnType<typeof vi.fn>}).create
+      expect(guildCreate).toHaveBeenCalled()
+      // #and — binding was written with the canonical workspace path
+      const bindingCall = (createBinding.mock.calls as [{workspacePath: string; owner: string; repo: string}][])[0]
+      expect(bindingCall?.[0]?.workspacePath).toBe('/workspace/repos/owner/repo')
+      expect(bindingCall?.[0]?.owner).toBe('owner')
+      expect(bindingCall?.[0]?.repo).toBe('repo')
+      // #and — READY reply reached
+      expect(lastEditReplyContent(editReply)).toContain('Ready')
+      // #and — welcome message sent
+      expect(send).toHaveBeenCalled()
+      // #and — clone was only called once (not re-run)
+      expect(clone).toHaveBeenCalledOnce()
+      // #and — no rm -rf in any reply
       for (const content of allEditReplies(editReply)) {
         expect(content).not.toContain('rm -rf')
       }
     })
 
-    it('repo-exists + binding store errors → falls back to "currently being added", no rm -rf', async () => {
-      // #given — clone fails with repo-exists; binding store returns error
+    it('repo-exists + binding store ERRORS (success=false) → internal-error reply, channel NOT created', async () => {
+      // #given — clone fails with repo-exists; second binding lookup returns an error result (store error)
+      // Store errors must NOT resume — resuming on a store outage risks orphan channels.
       const userId = uniqueUserId()
       const clone = vi.fn().mockResolvedValue(err({kind: 'clone-error', code: 'repo-exists'}))
       const storeError = new Error('S3 timeout')
-      // PRE_FLIGHT call succeeds with null; second call (repo-exists handler) errors
+      // PRE_FLIGHT returns null (ok); repo-exists handler returns err (store failure Result)
       const getBindingByRepo = vi.fn().mockResolvedValueOnce(ok(null)).mockResolvedValue(err(storeError))
-      const {interaction, editReply} = makeInteraction({userId})
+      const createBinding = vi.fn().mockResolvedValue(ok({primaryEtag: 'e1', indexEtag: 'e2'}))
+      const {channel} = makeTextChannel('owner-repo')
+      const guild = makeGuild('bot-user-id', true, [], channel)
+      const {interaction, editReply} = makeInteraction({
+        url: 'https://github.com/owner/repo',
+        guild,
+        userId,
+      })
       const deps = makeDeps({
         workspaceClient: makeWorkspaceClient({clone}),
-        bindingsStore: makeBindingsStore({getBindingByRepo}),
+        bindingsStore: makeBindingsStore({getBindingByRepo, createBinding}),
       })
 
       // #when
       await run(interaction, deps)
 
-      // #then — safe fallback; NEVER instructs deletion
-      const reply = lastEditReplyContent(editReply)
-      expect(reply).toContain('currently being added')
+      // #then — internal-error reply (not a resume)
+      expect(lastEditReplyContent(editReply)).toContain('Internal error checking existing bindings')
+      // #and — channel was NOT created (no resume on store error)
+      const guildCreate = (guild.channels as unknown as {create: ReturnType<typeof vi.fn>}).create
+      expect(guildCreate).not.toHaveBeenCalled()
+      // #and — createBinding was NOT called
+      expect(createBinding).not.toHaveBeenCalled()
+      // #and — no rm -rf in any reply
       for (const content of allEditReplies(editReply)) {
         expect(content).not.toContain('rm -rf')
       }
     })
 
-    it('repo-exists + getBindingByRepo REJECTS → falls back to "please wait", no rm -rf', async () => {
+    it('repo-exists + getBindingByRepo REJECTS → internal-error reply, channel NOT created', async () => {
       // #given — clone fails with repo-exists; getBindingByRepo throws (network-level rejection)
+      // A store rejection must NOT resume — we cannot confirm binding absence, so resuming risks orphan channels.
       const userId = uniqueUserId()
       const clone = vi.fn().mockResolvedValue(err({kind: 'clone-error', code: 'repo-exists'}))
-      // PRE_FLIGHT call succeeds with null; second call rejects entirely
+      // PRE_FLIGHT returns null; repo-exists handler rejects entirely
       const getBindingByRepo = vi.fn().mockResolvedValueOnce(ok(null)).mockRejectedValue(new Error('connection reset'))
-      const {interaction, editReply} = makeInteraction({userId})
+      const createBinding = vi.fn().mockResolvedValue(ok({primaryEtag: 'e1', indexEtag: 'e2'}))
+      const {channel} = makeTextChannel('owner-repo')
+      const guild = makeGuild('bot-user-id', true, [], channel)
+      const {interaction, editReply} = makeInteraction({
+        url: 'https://github.com/owner/repo',
+        guild,
+        userId,
+      })
       const deps = makeDeps({
         workspaceClient: makeWorkspaceClient({clone}),
-        bindingsStore: makeBindingsStore({getBindingByRepo}),
+        bindingsStore: makeBindingsStore({getBindingByRepo, createBinding}),
       })
 
       // #when — must resolve without throwing even though getBindingByRepo rejects
       await expect(run(interaction, deps)).resolves.toBeUndefined()
 
-      // #then — safe fallback sent; NEVER instructs deletion
-      const reply = lastEditReplyContent(editReply)
-      expect(reply).toContain('currently being added')
+      // #then — internal-error reply (not a resume)
+      expect(lastEditReplyContent(editReply)).toContain('Internal error checking existing bindings')
+      // #and — channel was NOT created (no resume on store rejection)
+      const guildCreate = (guild.channels as unknown as {create: ReturnType<typeof vi.fn>}).create
+      expect(guildCreate).not.toHaveBeenCalled()
+      // #and — createBinding was NOT called
+      expect(createBinding).not.toHaveBeenCalled()
+      // #and — no rm -rf in any reply
       for (const content of allEditReplies(editReply)) {
         expect(content).not.toContain('rm -rf')
       }
+    })
+
+    it('full retry-after-partial-failure: first invocation binding write fails, second invocation resumes successfully', async () => {
+      // #given — first invocation: clone succeeds, binding write fails
+      const userId1 = uniqueUserId()
+      const {channel: channel1, send: send1} = makeTextChannel('owner-repo')
+      const guild1 = makeGuild('bot-user-id', true, [], channel1)
+      const {interaction: interaction1, editReply: editReply1} = makeInteraction({
+        url: 'https://github.com/owner/repo',
+        guild: guild1,
+        userId: userId1,
+      })
+
+      const cloneFresh = vi
+        .fn()
+        .mockResolvedValue(ok({ok: true, path: '/workspace/repos/owner/repo', commit: 'abc123'}))
+      const bindingStoreError = new Error('S3 write failed')
+      const createBindingFail = vi.fn().mockResolvedValue(err(bindingStoreError))
+      const getBindingEmpty = vi.fn().mockResolvedValue(ok(null))
+
+      const deps1 = makeDeps({
+        workspaceClient: makeWorkspaceClient({clone: cloneFresh}),
+        bindingsStore: makeBindingsStore({getBindingByRepo: getBindingEmpty, createBinding: createBindingFail}),
+      })
+
+      // #when — first invocation runs: clone succeeds but binding write fails
+      await run(interaction1, deps1)
+
+      // #then — first invocation fails with a binding error message
+      expect(lastEditReplyContent(editReply1)).toContain('Failed to write binding')
+
+      // #given — second invocation: workspace agent returns repo-exists (clone done), no binding in store
+      const userId2 = uniqueUserId()
+      const {channel: channel2, send: send2} = makeTextChannel('owner-repo')
+      const guild2 = makeGuild('bot-user-id', true, [], channel2)
+      const {interaction: interaction2, editReply: editReply2} = makeInteraction({
+        url: 'https://github.com/owner/repo',
+        guild: guild2,
+        userId: userId2,
+      })
+
+      const cloneRepoExists = vi.fn().mockResolvedValue(err({kind: 'clone-error', code: 'repo-exists'}))
+      const createBindingOk = vi.fn().mockResolvedValue(ok({primaryEtag: 'e1', indexEtag: 'e2'}))
+      const getBindingStillEmpty = vi.fn().mockResolvedValue(ok(null))
+
+      const deps2 = makeDeps({
+        workspaceClient: makeWorkspaceClient({clone: cloneRepoExists}),
+        bindingsStore: makeBindingsStore({getBindingByRepo: getBindingStillEmpty, createBinding: createBindingOk}),
+      })
+
+      // #when — second invocation runs: resumes from CREATING_CHANNEL
+      await run(interaction2, deps2)
+
+      // #then — second invocation reaches READY
+      expect(lastEditReplyContent(editReply2)).toContain('Ready')
+      // #and — binding was written with canonical path
+      const calls = (createBindingOk.mock.calls as [{workspacePath: string}][])[0]
+      expect(calls?.[0]?.workspacePath).toBe('/workspace/repos/owner/repo')
+      // #and — welcome message sent in second invocation
+      expect(send2).toHaveBeenCalled()
+      // #and — clone NOT re-run in second invocation (repo-exists path, not fresh clone)
+      expect(cloneRepoExists).toHaveBeenCalledOnce()
+      // send1 was never reached (binding failed in first invocation) — intentionally unused
+      expect(send1).not.toHaveBeenCalled()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Concurrent resume race coverage (FIX 2)
+  // -------------------------------------------------------------------------
+
+  describe('CLONING: concurrent resume — BINDING_EXISTS_ERROR loser path', () => {
+    it('second concurrent resume hits BINDING_EXISTS_ERROR → bounded error reply, no throw, no re-clone', async () => {
+      // #given — both invocations see repo-exists + no binding (clone done, no binding yet)
+      // First createBinding succeeds; second gets BINDING_EXISTS_ERROR (atomic IfNoneMatch write)
+      const userId1 = uniqueUserId()
+      const userId2 = uniqueUserId()
+
+      const clone = vi.fn().mockResolvedValue(err({kind: 'clone-error', code: 'repo-exists'}))
+      const getBindingByRepo = vi.fn().mockResolvedValue(ok(null))
+
+      const bindingExistsError = Object.assign(new Error('binding already exists'), {code: 'BINDING_EXISTS_ERROR'})
+      let createBindingCallCount = 0
+      const createBinding = vi.fn().mockImplementation(async () => {
+        createBindingCallCount++
+        if (createBindingCallCount === 1) return ok({primaryEtag: 'e1', indexEtag: 'e2'})
+        return err(bindingExistsError)
+      })
+
+      const {channel: channel1} = makeTextChannel('owner-repo')
+      const guild1 = makeGuild('bot-user-id', true, [], channel1)
+      const {interaction: interaction1, editReply: editReply1} = makeInteraction({
+        url: 'https://github.com/owner/repo',
+        guild: guild1,
+        userId: userId1,
+      })
+
+      const {channel: channel2} = makeTextChannel('owner-repo')
+      const guild2 = makeGuild('bot-user-id', true, [], channel2)
+      const {interaction: interaction2, editReply: editReply2} = makeInteraction({
+        url: 'https://github.com/owner/repo',
+        guild: guild2,
+        userId: userId2,
+      })
+
+      const deps1 = makeDeps({
+        workspaceClient: makeWorkspaceClient({clone}),
+        bindingsStore: makeBindingsStore({getBindingByRepo, createBinding}),
+      })
+      const deps2 = makeDeps({
+        workspaceClient: makeWorkspaceClient({clone}),
+        bindingsStore: makeBindingsStore({getBindingByRepo, createBinding}),
+      })
+
+      // #when — first invocation wins the binding race
+      await expect(run(interaction1, deps1)).resolves.toBeUndefined()
+
+      // #when — second invocation loses: createBinding returns BINDING_EXISTS_ERROR
+      await expect(run(interaction2, deps2)).resolves.toBeUndefined()
+
+      // #then — winner reaches READY
+      expect(lastEditReplyContent(editReply1)).toContain('Ready')
+
+      // #then — loser gets the concurrent-bound message (not a throw, not a re-clone)
+      const loserReply = lastEditReplyContent(editReply2)
+      expect(loserReply).toContain('bound by a concurrent request')
+      expect(loserReply).toContain('manual cleanup may be needed')
+
+      // #and — clone was called twice (two independent resume invocations), not re-run internally
+      expect(clone).toHaveBeenCalledTimes(2)
+
+      // #and — createBinding was called twice (both invocations attempted the write)
+      expect(createBinding).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('shutdown gate (Part 2)', () => {
+    afterEach(() => {
+      __resetShuttingDownForTests()
+    })
+
+    it('isShuttingDown returns true → replies "fro-bot is restarting" and does NOT call clone', async () => {
+      // #given — bot is draining shutdown
+      const userId = uniqueUserId()
+      const clone = vi.fn()
+      const {interaction, editReply} = makeInteraction({
+        url: 'https://github.com/owner/repo',
+        userId,
+      })
+      const deps = makeDeps({
+        workspaceClient: makeWorkspaceClient({clone}),
+        isShuttingDown: () => true,
+      })
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — user gets restart message
+      expect(lastEditReplyContent(editReply)).toContain('fro-bot is restarting')
+      // #and — clone was never called (no new work started)
+      expect(clone).not.toHaveBeenCalled()
+    })
+
+    it('isShuttingDown absent (default) → proceeds normally', async () => {
+      // #given — no isShuttingDown dep injected (optional field left absent)
+      const userId = uniqueUserId()
+      const clone = vi.fn().mockResolvedValue(ok({ok: true, path: '/workspace/repos/owner/repo', commit: 'abc123'}))
+      const {interaction} = makeInteraction({
+        url: 'https://github.com/owner/repo',
+        userId,
+      })
+      // makeDeps without isShuttingDown — the dep is optional; absence defaults to () => false
+      const deps = makeDeps({workspaceClient: makeWorkspaceClient({clone})})
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — clone was called (command proceeded normally)
+      expect(clone).toHaveBeenCalled()
     })
   })
 

--- a/packages/gateway/src/discord/commands/add-project.ts
+++ b/packages/gateway/src/discord/commands/add-project.ts
@@ -19,6 +19,7 @@ import {PermissionFlagsBits} from 'discord.js'
 import {Effect} from 'effect'
 
 import {AppNotInstalledError} from '../../github/app-client.js'
+import {workspaceRepoPath} from '../../workspace-api/client.js'
 import {createChannelWithCollisionSuffix} from '../channels.js'
 
 // ---------------------------------------------------------------------------
@@ -37,6 +38,12 @@ export interface AddProjectDeps {
     readonly warn: (msg: string, meta?: Record<string, unknown>) => void
     readonly error: (msg: string, meta?: Record<string, unknown>) => void
   }
+  /**
+   * Optional. Defaults to `() => false` when absent so callers that don't inject it
+   * are unaffected. When present, returning `true` causes the command to bail early
+   * with a user-friendly restart message instead of starting work that will be hard-killed.
+   */
+  readonly isShuttingDown?: () => boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -217,6 +224,16 @@ async function runAddProject(interaction: ChatInputCommandInteraction, deps: Add
   // Defer reply (ephemeral — setup thread is operationally sensitive)
   await interaction.deferReply({ephemeral: true})
 
+  // Shutdown gate — placed after deferReply so Discord gets its mandatory ack (<3s).
+  // Refuse new work during draining shutdown; resume (Part 1) heals any hard-killed run.
+  const shuttingDownCheck = deps.isShuttingDown ?? (() => false)
+  if (shuttingDownCheck() === true) {
+    await interaction.editReply({
+      content: 'fro-bot is restarting. Please try `/fro-bot add-project` again in a moment.',
+    })
+    return
+  }
+
   const guild = interaction.guild
   if (guild === null) {
     await interaction.editReply({content: 'This command can only be used in a server.'})
@@ -339,6 +356,12 @@ async function runAddProject(interaction: ChatInputCommandInteraction, deps: Add
   }
 
   const cloneResult = await workspaceClient.clone({owner, repo, token})
+  // Intentionally uninitialized: TypeScript's definite-assignment analysis enforces that
+  // every path below either assigns workspacePath (fresh clone success, or repo-exists resume)
+  // or returns. A sentinel default would defeat that compile-time guard — if a future edit
+  // drops a return in an error branch, tsc errors here instead of passing an empty path to
+  // channel creation. Do not initialize.
+  let workspacePath: string
   if (cloneResult.success === false) {
     const errorKind = cloneResult.error.kind
     logger.warn('add-project: clone failed', {correlationId, phase, owner, repo, errorKind, outcome: 'error'})
@@ -350,59 +373,69 @@ async function runAddProject(interaction: ChatInputCommandInteraction, deps: Add
           content:
             'The workspace volume is out of space. Free disk by removing unused repos under `/workspace/repos` and retry.',
         })
+        return
       } else if (code === 'repo-exists') {
-        // Never emit deletion instructions. Re-read bindings to distinguish:
-        // (a) repo genuinely bound → redirect to the bound channel
-        // (b) clone in progress by another user → safe "please wait" message
-        // Either way, no rm -rf instruction: user B must not destroy user A's in-flight clone.
-        let repoExistsBinding: Awaited<ReturnType<typeof bindingsStore.getBindingByRepo>>
+        // repo-exists means the workspace-agent completed the clone atomically (temp dir renamed
+        // to destPath). Decide: redirect (already bound), resume (clone exists, no binding), or
+        // error (store unavailable — do NOT resume; orphan risk).
+        //
+        // Never emit deletion instructions — we must never instruct the user to rm -rf.
+        let existing: Awaited<ReturnType<typeof bindingsStore.getBindingByRepo>>
         try {
-          repoExistsBinding = await bindingsStore.getBindingByRepo(owner, repo)
+          existing = await bindingsStore.getBindingByRepo(owner, repo)
         } catch {
-          // Network-level rejection: fall back to the safe "please wait" message.
+          await interaction.editReply({content: 'Internal error checking existing bindings. Please retry in a moment.'})
+          return
+        }
+        if (existing.success === false) {
+          await interaction.editReply({content: 'Internal error checking existing bindings. Please retry in a moment.'})
+          return
+        }
+        if (existing.data !== null) {
+          // Genuinely already bound — redirect to the bound channel. Nothing to resume.
           await interaction.editReply({
-            content: `\`${owner}/${repo}\` is currently being added by another setup. Please wait a moment and try again.`,
+            content: `\`${owner}/${repo}\` is already set up in <#${existing.data.channelId}>.`,
           })
           return
         }
-        if (repoExistsBinding.success === true && repoExistsBinding.data !== null) {
-          await interaction.editReply({
-            content: `\`${owner}/${repo}\` is already set up in <#${repoExistsBinding.data.channelId}>.`,
-          })
-        } else {
-          // Either binding lookup failed or no binding found — clone is in progress.
-          await interaction.editReply({
-            content: `\`${owner}/${repo}\` is currently being added by another setup. Please wait a moment and try again.`,
-          })
-        }
+        // Clone exists but no binding — a prior run failed after CLONING. Resume from CREATING_CHANNEL.
+        // Concurrency: a racing invocation also resuming will have its createBinding rejected with
+        // BINDING_EXISTS_ERROR (atomic IfNoneMatch write), handled below (~line ~500). The losing run
+        // may leave an orphan channel — accepted v1 fallout (see docs/solutions orchestration-patterns).
+        workspacePath = workspaceRepoPath(owner, repo)
+        logger.info('add-project phase', {phase: 'CLONING', outcome: 'resumed', owner, repo, correlationId})
+        // fall through — do NOT return
       } else {
         await interaction.editReply({
           content: `Clone failed (${code}). Check workspace-agent logs for details.`,
         })
+        return
       }
     } else if (errorKind === 'timeout') {
       await interaction.editReply({content: 'Clone timed out (5 minutes). The repo may be very large. Retry.'})
+      return
     } else if (errorKind === 'response-mismatch') {
       logger.error('add-project: response-mismatch from workspace agent', {correlationId, phase, owner, repo})
       await interaction.editReply({
         content: 'Internal error: workspace agent returned unexpected response. Contact operator.',
       })
+      return
     } else {
       await interaction.editReply({content: `Clone failed (${errorKind}). Check workspace-agent connectivity.`})
+      return
     }
-    return
+  } else {
+    workspacePath = cloneResult.data.path
+    logger.info('add-project phase', {
+      correlationId,
+      phase,
+      owner,
+      repo,
+      workspacePath,
+      outcome: 'success',
+      durationMs: Date.now() - startTime,
+    })
   }
-
-  const workspacePath = cloneResult.data.path
-  logger.info('add-project phase', {
-    correlationId,
-    phase,
-    owner,
-    repo,
-    workspacePath,
-    outcome: 'success',
-    durationMs: Date.now() - startTime,
-  })
 
   // ---------------------------------------------------------------------------
   // CREATING_CHANNEL

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -10,7 +10,7 @@ import {createDiscordClient} from './discord/client.js'
 import {dispatchCommand, getCommandRegistry, registerSlashCommands} from './discord/commands/index.js'
 import {handleMention} from './discord/mentions.js'
 import {createAppClient} from './github/app-client.js'
-import {installShutdownHandlers} from './shutdown.js'
+import {installShutdownHandlers, isShuttingDown} from './shutdown.js'
 import {createWorkspaceClient} from './workspace-api/client.js'
 
 // ---------------------------------------------------------------------------
@@ -120,6 +120,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
       workspaceClient,
       installUrl: config.gatewayGitHubAppInstallUrl,
       logger: addProjectLogger,
+      isShuttingDown,
     }
 
     const registry = getCommandRegistry(commandDeps)

--- a/packages/gateway/src/shutdown.test.ts
+++ b/packages/gateway/src/shutdown.test.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
 
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {__resetShuttingDownForTests, DEFAULT_DRAIN_MS, installShutdownHandlers} from './shutdown.js'
+import {__resetShuttingDownForTests, DEFAULT_DRAIN_MS, installShutdownHandlers, isShuttingDown} from './shutdown.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -206,5 +206,41 @@ describe('installShutdownHandlers', () => {
     const destroy1Count = (client1.destroy as ReturnType<typeof vi.fn>).mock.calls.length
     const destroy2Count = (client2.destroy as ReturnType<typeof vi.fn>).mock.calls.length
     expect(destroy1Count + destroy2Count).toBe(1)
+  })
+})
+
+describe('isShuttingDown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    __resetShuttingDownForTests()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    __resetShuttingDownForTests()
+  })
+
+  it('returns false before any signal is received', () => {
+    // #given — no signal fired, module freshly reset
+    // #when / #then
+    expect(isShuttingDown()).toBe(false)
+  })
+
+  it('returns true after SIGTERM handler fires', async () => {
+    // #given — install handlers with a slow destroy so we can observe state mid-shutdown
+    const {logger} = makeLogger()
+    const client = makeClient(100_000) // hangs
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    const cleanup = installShutdownHandlers(client, logger, 200_000)
+
+    // #when — emit SIGTERM
+    process.emit('SIGTERM')
+    await vi.advanceTimersByTimeAsync(1) // let the handler synchronously set shuttingDown
+
+    // #then
+    expect(isShuttingDown()).toBe(true)
+
+    cleanup()
+    exitSpy.mockRestore()
   })
 })

--- a/packages/gateway/src/shutdown.ts
+++ b/packages/gateway/src/shutdown.ts
@@ -33,6 +33,17 @@ export function __resetShuttingDownForTests(): void {
 }
 
 /**
+ * Returns true if a shutdown signal has been received and the gateway is draining.
+ * Intended for command handlers to check before starting long-running work.
+ *
+ * This is a pure getter — production code may call it; only `__resetShuttingDownForTests`
+ * is test-only.
+ */
+export function isShuttingDown(): boolean {
+  return shuttingDown
+}
+
+/**
  * Install SIGTERM and SIGINT handlers that gracefully drain the Discord client.
  *
  * On signal:

--- a/packages/gateway/src/workspace-api/client.ts
+++ b/packages/gateway/src/workspace-api/client.ts
@@ -24,9 +24,20 @@ export interface WorkspaceClient {
 
 const DEFAULT_TIMEOUT_MS = 300_000 // 5 minutes
 
-// Mirrors WORKSPACE_REPOS_ROOT in apps/workspace-agent/src/clone.ts.
-// Intentionally NOT imported from there: separate package/container boundary.
+// Mirrors WORKSPACE_REPOS_ROOT in apps/workspace-agent/src/clone.ts (separate
+// package/container boundary, so not imported). Module-private: callers use
+// workspaceRepoPath() rather than composing the root themselves.
 const EXPECTED_WORKSPACE_ROOT = '/workspace/repos'
+
+/**
+ * Returns the canonical workspace path for a given owner/repo pair.
+ * Single source of truth shared by the client validator and add-project resume logic.
+ *
+ * owner and repo MUST already be lowercased (canonical form) before calling this.
+ */
+export function workspaceRepoPath(owner: string, repo: string): string {
+  return `${EXPECTED_WORKSPACE_ROOT}/${owner}/${repo}`
+}
 
 /**
  * Create a workspace-agent HTTP client.
@@ -94,7 +105,7 @@ export function createWorkspaceClient(options: WorkspaceClientOptions): Workspac
     // The prior suffix-only check accepted adversarial paths like /etc/passwd/owner/repo.
     // owner/repo arrive already lowercased from add-project.ts; lowercasing the response
     // path would let a case-variant root bypass validation.
-    const expectedPath = `${EXPECTED_WORKSPACE_ROOT}/${owner}/${repo}`
+    const expectedPath = workspaceRepoPath(owner, repo)
     if (parsed.path !== expectedPath) {
       return err({kind: 'response-mismatch'})
     }


### PR DESCRIPTION
Makes `/fro-bot add-project` recover cleanly from partial failures and behave correctly during gateway shutdown.

## Idempotent resume
When a repo is already cloned but has no channel binding — the state left behind when a prior run failed after cloning but before writing the binding — re-running `/add-project` now resumes from channel creation instead of dead-ending on `repo-exists`. Clones are atomic (the workspace-agent renames a temp dir onto the final path), so `repo-exists` reliably means a completed clone; the command re-reads the bindings store and only resumes when a binding is confirmed absent. A store-read failure reports an internal error rather than resuming, avoiding orphaned channels during an outage.

## Shutdown awareness
New `/add-project` invocations are refused with a clear retry message while the gateway is draining for shutdown, instead of starting work that gets cut off mid-flight. Any run that is hard-cut is healed by the next retry via the resume path above.

## Also
- Fixed a missing early return on the disk-full clone-error branch.
- Refreshed the orchestration solution doc to describe the idempotent recovery contract.

Gateway test suite: 295 passing.