### PR TITLE
refactor(gateway): explicit boolean comparison in webhook timestamp check

### DIFF
--- a/packages/gateway/src/http/hmac.ts
+++ b/packages/gateway/src/http/hmac.ts
@@ -73,7 +73,7 @@ export function checkTimestamp(
   const parsedMs = Date.parse(timestampHeader)
 
   // Date.parse returns NaN for unparseable strings
-  if (!Number.isFinite(parsedMs)) {
+  if (Number.isFinite(parsedMs) === false) {
     return {ok: false, reason: 'timestamp_expired'}
   }
 


### PR DESCRIPTION
Aligns `checkTimestamp` in the gateway HMAC module with the project's strict-boolean convention — `Number.isFinite(parsedMs) === false` instead of `!Number.isFinite(parsedMs)`. No behavior change; the two forms are equivalent. `refactor` scope so it doesn't trigger a release on its own.