### PR TITLE
fix(gateway): inline runtime into bundle to fix image crash-loop

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,6 +228,51 @@ jobs:
           echo "OpenCode state files:"
           ls -lA ~/.local/state/opencode || true
 
+  gateway-smoke:
+    if: ${{ github.event_name == 'push' || needs.setup.outputs.should-build == 'true' }}
+    name: Gateway Image Smoke Test
+    needs: [setup]
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup
+      - name: Build runtime
+        run: pnpm --filter @fro-bot/runtime build
+      - name: Build gateway
+        run: pnpm --filter @fro-bot/gateway build
+      - name: Assert no bare @fro-bot/runtime import in gateway bundle
+        run: |
+          if grep -q 'from "@fro-bot/runtime"' packages/gateway/dist/main.mjs; then
+            echo "REGRESSION: gateway dist has bare @fro-bot/runtime import"
+            exit 1
+          fi
+          echo "OK: no bare @fro-bot/runtime import found in gateway bundle"
+      - name: Build gateway Docker image
+        run: docker build -f deploy/gateway.Dockerfile -t fro-bot-gateway:smoke .
+      - name: Smoke-test gateway image (assert config load, not module crash)
+        run: |
+          set +e
+          output="$(timeout 60s docker run --rm fro-bot-gateway:smoke 2>&1)"
+          status=$?
+          set -e
+          echo "--- docker run output ---"
+          echo "$output"
+          echo "--- exit status: $status ---"
+          if [ "$status" -eq 124 ]; then
+            echo "REGRESSION: gateway image hung on boot (timed out)"
+            exit 1
+          fi
+          test "$status" -ne 0
+          echo "$output" | grep -q "Missing required secret: DISCORD_TOKEN"
+          if echo "$output" | grep -q "ERR_MODULE_NOT_FOUND"; then
+            echo "REGRESSION: module resolution failed (ERR_MODULE_NOT_FOUND)"
+            exit 1
+          fi
+          echo "OK: gateway reached config loading (DISCORD_TOKEN check), no module-resolution crash"
+
   dependency-review:
     if: ${{ github.event_name == 'pull_request' }}
     name: Dependency Review

--- a/deploy/gateway.Dockerfile
+++ b/deploy/gateway.Dockerfile
@@ -31,8 +31,6 @@ WORKDIR /app
 
 # Copy production node_modules from build stage
 COPY --from=build /workspace/node_modules ./node_modules
-COPY --from=build /workspace/packages/runtime/package.json ./packages/runtime/package.json
-COPY --from=build /workspace/packages/runtime/dist/ ./packages/runtime/dist/
 COPY --from=build /workspace/packages/gateway/package.json ./packages/gateway/package.json
 COPY --from=build /workspace/packages/gateway/dist/ ./packages/gateway/dist/
 

--- a/packages/gateway/tsdown.config.ts
+++ b/packages/gateway/tsdown.config.ts
@@ -4,4 +4,8 @@ export default defineConfig({
   entry: ['src/main.ts'],
   format: 'esm',
   outDir: 'dist',
+  noExternal: id => {
+    if (id === '@fro-bot/runtime' || id.startsWith('@fro-bot/runtime/')) return true
+    return false
+  },
 })


### PR DESCRIPTION
## Summary

The gateway Docker image crash-looped on boot with `ERR_MODULE_NOT_FOUND` for `@fro-bot/runtime`. The gateway bundle imported the runtime as an external bare specifier that resolved to its `src/index.ts` entry — a file absent from the runtime image, which ships only `dist/`.

## Changes

- **Inline the runtime into the gateway bundle** (`packages/gateway/tsdown.config.ts`) via `noExternal`, matching how the action tier already bundles the runtime. The gateway bundle is now self-contained.
- **Drop the now-dead runtime copy** from the gateway image's final stage in `deploy/gateway.Dockerfile` — the inlined bundle no longer references `@fro-bot/runtime` at runtime.
- **Add a gateway image smoke test** to CI: build the image, boot it with no secrets, and assert it reaches config loading without a module-resolution crash. A build-time check also asserts the bundle contains no bare `@fro-bot/runtime` import. This catches the packaging regression class that previously shipped undetected.

## Verification

- Gateway bundle contains zero bare `@fro-bot/runtime` imports after build.
- Local image smoke: boots, exits cleanly on missing secrets, no `ERR_MODULE_NOT_FOUND`.
- Gateway tests, lint, and type-check pass.

Fixes #707