### PR TITLE
fix(gateway): correct GitHub App install-URL slug to fro-bot-agent

### DIFF
--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -946,7 +946,7 @@ describe('loadGatewayConfig — GitHub App credentials', () => {
     const config = loadGatewayConfig()
 
     // #then
-    expect(config.gatewayGitHubAppInstallUrl).toBe('https://github.com/apps/fro-bot/installations/new')
+    expect(config.gatewayGitHubAppInstallUrl).toBe('https://github.com/apps/fro-bot-agent/installations/new')
   })
 })
 

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -328,7 +328,7 @@ export function loadGatewayConfig(): GatewayConfig {
   const githubAppId = readSecret('GITHUB_APP_ID')
   const githubAppPrivateKey = readMultilineSecret('GITHUB_APP_PRIVATE_KEY')
   const gatewayGitHubAppInstallUrl =
-    readOptionalSecret('GATEWAY_GITHUB_APP_INSTALL_URL') ?? 'https://github.com/apps/fro-bot/installations/new'
+    readOptionalSecret('GATEWAY_GITHUB_APP_INSTALL_URL') ?? 'https://github.com/apps/fro-bot-agent/installations/new'
 
   const workspaceAgentUrl = readOptionalSecret('WORKSPACE_AGENT_URL') ?? 'http://workspace:9100'
 

--- a/packages/gateway/src/discord/commands/add-project.test.ts
+++ b/packages/gateway/src/discord/commands/add-project.test.ts
@@ -167,7 +167,7 @@ function makeDeps(overrides?: Partial<AddProjectDeps>): AddProjectDeps {
     bindingsStore: makeBindingsStore(),
     appClient: makeAppClient(),
     workspaceClient: makeWorkspaceClient(),
-    installUrl: 'https://github.com/apps/fro-bot/installations/new',
+    installUrl: 'https://github.com/apps/fro-bot-agent/installations/new',
     logger: makeLogger(),
     ...overrides,
   }
@@ -268,7 +268,7 @@ describe('executeAddProject', () => {
       await run(interaction, deps)
 
       // #then
-      expect(lastEditReplyContent(editReply)).toContain('https://github.com/apps/fro-bot/installations/new')
+      expect(lastEditReplyContent(editReply)).toContain('https://github.com/apps/fro-bot-agent/installations/new')
     })
 
     it('aborts gracefully when appPermissions is null (DM interaction)', async () => {
@@ -281,7 +281,7 @@ describe('executeAddProject', () => {
       await run(interaction, deps)
 
       // #then — aborts with install URL (treated as missing permissions)
-      expect(lastEditReplyContent(editReply)).toContain('https://github.com/apps/fro-bot/installations/new')
+      expect(lastEditReplyContent(editReply)).toContain('https://github.com/apps/fro-bot-agent/installations/new')
     })
 
     it('aborts when bot has ManageChannels but not SendMessages', async () => {
@@ -390,7 +390,13 @@ describe('executeAddProject', () => {
       const authForRepo = vi
         .fn()
         .mockResolvedValue(
-          err(new AppNotInstalledError('testowner', 'testrepo', 'https://github.com/apps/fro-bot/installations/new')),
+          err(
+            new AppNotInstalledError(
+              'testowner',
+              'testrepo',
+              'https://github.com/apps/fro-bot-agent/installations/new',
+            ),
+          ),
         )
       const {interaction, editReply} = makeInteraction({userId})
       const deps = makeDeps({appClient: makeAppClient({authForRepo})})

--- a/packages/gateway/src/discord/commands/index.test.ts
+++ b/packages/gateway/src/discord/commands/index.test.ts
@@ -26,7 +26,7 @@ function makeMockDeps(): AddProjectDeps {
     workspaceClient: {
       clone: vi.fn(),
     },
-    installUrl: 'https://github.com/apps/fro-bot/installations/new',
+    installUrl: 'https://github.com/apps/fro-bot-agent/installations/new',
     logger: {
       info: vi.fn(),
       warn: vi.fn(),

--- a/packages/gateway/src/github/app-client.test.ts
+++ b/packages/gateway/src/github/app-client.test.ts
@@ -24,7 +24,7 @@ vi.mock('@octokit/core', () => ({
 
 const APP_ID = '12345'
 const PRIVATE_KEY = '-----BEGIN RSA PRIVATE KEY-----\nfake-key\n-----END RSA PRIVATE KEY-----'
-const INSTALL_URL = 'https://github.com/apps/fro-bot/installations/new'
+const INSTALL_URL = 'https://github.com/apps/fro-bot-agent/installations/new'
 
 const INSTALLATION_RESPONSE = {
   data: {

--- a/packages/gateway/src/github/app-client.ts
+++ b/packages/gateway/src/github/app-client.ts
@@ -127,7 +127,7 @@ export interface AppClientOptions {
  * installation ID is cached in memory per (owner, repo) pair.
  */
 export function createAppClient(options: AppClientOptions): AppClient {
-  const {appId, privateKey, installUrl = 'https://github.com/apps/fro-bot/installations/new', logger} = options
+  const {appId, privateKey, installUrl = 'https://github.com/apps/fro-bot-agent/installations/new', logger} = options
 
   // In-memory cache: "owner/repo" → installationId
   const installationCache = new Map<string, number>()

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -99,7 +99,7 @@ function makeFakeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     },
     githubAppId: 'test-app-id',
     githubAppPrivateKey: '-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----',
-    gatewayGitHubAppInstallUrl: 'https://github.com/apps/fro-bot/installations/new',
+    gatewayGitHubAppInstallUrl: 'https://github.com/apps/fro-bot-agent/installations/new',
     workspaceAgentUrl: 'http://workspace:9100',
     workspaceOpencodeUrl: 'http://workspace:9200',
     workspaceOpencodeToken: 'test-opencode-token',


### PR DESCRIPTION
## Summary

The gateway's GitHub App install-URL default pointed at `https://github.com/apps/fro-bot/installations/new`, but the published app slug is **`fro-bot-agent`**. When a repo isn't yet authorized, the `/add-project` "app not installed" reply linked operators to the wrong page.

## Changes

Updates both runtime defaults and the matching test literals to `apps/fro-bot-agent`:
- `packages/gateway/src/config.ts` — `gatewayGitHubAppInstallUrl` default
- `packages/gateway/src/github/app-client.ts` — `installUrl` default
- test literals across `config.test.ts`, `app-client.test.ts`, `program.test.ts`, and the `add-project`/`index` command tests

## Verification

- 545 gateway tests pass; lint and type-check clean.
- The `GATEWAY_GITHUB_APP_INSTALL_URL` env override remains the way operators point at a different slug.