### PR TITLE
fix(ci): drop docker/dockerfile frontend directive to avoid smoke flake

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -256,7 +256,15 @@ jobs:
           fi
           echo "OK: no bare @fro-bot/runtime import found in gateway bundle"
       - name: Build gateway Docker image
-        run: docker build -f deploy/gateway.Dockerfile -t fro-bot-gateway:smoke .
+        run: |
+          for attempt in 1 2 3; do
+            if docker build -f deploy/gateway.Dockerfile -t fro-bot-gateway:smoke .; then
+              exit 0
+            fi
+            echo "::warning::docker build attempt ${attempt} failed"
+            [ "${attempt}" -eq 3 ] && { echo "docker build failed after 3 attempts"; exit 1; }
+            sleep $((attempt * 15))
+          done
       - name: Smoke-test gateway image (assert config load, not module crash)
         run: |
           set +e
@@ -292,7 +300,15 @@ jobs:
       - name: Run deploy/scripts unit tests
         run: node --test deploy/scripts/*.test.mjs
       - name: Build workspace Docker image
-        run: docker build -f deploy/workspace.Dockerfile -t fro-bot-workspace:smoke .
+        run: |
+          for attempt in 1 2 3; do
+            if docker build -f deploy/workspace.Dockerfile -t fro-bot-workspace:smoke .; then
+              exit 0
+            fi
+            echo "::warning::docker build attempt ${attempt} failed"
+            [ "${attempt}" -eq 3 ] && { echo "docker build failed after 3 attempts"; exit 1; }
+            sleep $((attempt * 15))
+          done
       - name: Smoke-test workspace image (clone API boots independently of OpenCode)
         run: |
           set -e

--- a/deploy/gateway.Dockerfile
+++ b/deploy/gateway.Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
-
 # ── Stage 1: build ────────────────────────────────────────────────────────────
 FROM node:24.16.0-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS build
 

--- a/deploy/workspace.Dockerfile
+++ b/deploy/workspace.Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
-
 # Workspace executor image.
 #
 # Builds apps/workspace-agent (clone API + OpenCode SDK server + bearer proxy)


### PR DESCRIPTION
The Gateway and Workspace image smoke jobs intermittently fail while resolving the BuildKit external frontend from Docker Hub:

\`\`\`
failed to resolve source metadata for docker.io/docker/dockerfile:1@sha256:...: dial tcp ...:443: i/o timeout
\`\`\`

Both deploy Dockerfiles opened with a \`# syntax=docker/dockerfile:1@sha256:...\` directive, forcing BuildKit to fetch that frontend image from Docker Hub on every build. Neither Dockerfile uses any BuildKit-only syntax (no \`RUN --mount\`, heredocs, \`COPY --link\`, cache/secret/bind mounts), so the directive is unnecessary.

## Changes
- Remove the \`# syntax\` directive from \`deploy/gateway.Dockerfile\` and \`deploy/workspace.Dockerfile\` — builds now use the built-in Dockerfile frontend with no Docker Hub round-trip.
- Wrap both smoke \`docker build\` steps in a 3-attempt retry with backoff, so transient base-image pull blips no longer block unrelated PRs.

## Verification
- Both images build locally with the directive removed; no frontend fetch occurs.
- Workflow YAML validated; retry blocks behave correctly under the job shell.