### PR TITLE
feat(gateway): Discord approval prompts for sensitive tool calls

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -282,6 +282,39 @@ Add the proxy host to the egress allowlist (`OBJECT_STORE_HOSTS` is S3-only; pro
 
 Leave both variables unset for a clone-only deployment: the workspace boots and serves `/clone`, but the mention loop has no model until they are configured.
 
+## Enabling tool approval prompts
+
+By default, all OpenCode tools run automatically and no approval prompts appear in Discord. To require a Discord Approve / Deny button-click before a specific tool executes, configure that tool's `permission` mode to `ask` in the workspace OpenCode config.
+
+The workspace OpenCode config is supplied via `WORKSPACE_OPENCODE_CONFIG` (in `deploy/.env`) as a JSON object shallow-merged over the base config. Add a `permission` block to that JSON:
+
+```env
+# deploy/.env — enable approval prompts for the Bash tool
+WORKSPACE_OPENCODE_CONFIG={"provider":{...},"permission":{"bash":{"default":"ask"}}}
+```
+
+### Permission modes
+
+| Mode | Behaviour |
+| ---- | --------- |
+| `allow` (default) | Tool runs immediately; no Discord prompt. |
+| `ask` | Gateway posts an Approve / Deny embed in the run thread; run pauses until a decision is received or the deadline fires. |
+| `deny` | Tool is always blocked; no prompt. |
+
+Set `"default":"ask"` inside the tool's permission block to ask for every invocation. More granular patterns (e.g. per-command) follow the OpenCode `permission` config schema.
+
+### Who can approve
+
+Approvers are gated by the same `userIsAuthorized` rule as trigger mentions: the user must hold the `GATEWAY_TRIGGER_ROLE_ID` role (if configured) or have guild-level `ManageChannels`. Anyone else who clicks the button is silently ignored; the prompt stays open.
+
+### Deadline behaviour (fail-closed)
+
+Each approval prompt has a deadline that is a sub-deadline of the overall run timeout, capped at 13 minutes (Discord interaction-token expiry). If no decision arrives before the deadline fires, the gateway automatically posts `reject` — the tool is blocked, the embed updates to show it was timed out, and the run continues or errors from the rejection. This is fail-closed: no tool runs silently when the gateway is unreachable.
+
+### Restart limitation
+
+A pending approval prompt is held in memory by the per-run coordinator. If the gateway or workspace container restarts while a prompt is open, the approval is abandoned. The run surfaces as interrupted in the thread. Re-mention to retry.
+
 ## Stopping the Stack
 
 ```bash

--- a/docs/plans/2026-06-01-005-feat-gateway-discord-tool-approval-plan.md
+++ b/docs/plans/2026-06-01-005-feat-gateway-discord-tool-approval-plan.md
@@ -1,0 +1,330 @@
+---
+title: "feat: Gateway Discord tool-approval (S5) — probe-first"
+type: feat
+status: active
+date: 2026-06-01
+origin: docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
+---
+
+# feat: Gateway Discord tool-approval (S5) — probe-first
+
+## Overview
+
+The gateway mention loop (Unit 6 MVP, PR #705) runs OpenCode against a bound repo in the workspace container and streams output to Discord. Today it has **no approval gate**: any tool the agent decides to run executes unattended. This plan adds the deferred **S5** capability — surfacing OpenCode tool-permission requests as Discord approval embeds with approve/deny buttons, and replying to OpenCode over its HTTP permission endpoint.
+
+**SSE delivery of `permission.asked` is verified reliable at 1.14.41.** Oracle/Librarian review (session 2026-06-01) confirmed that `permission.asked` is a BusEvent published to `bus.subscribeAll()` → `/event` SSE, and that the 1.14.42+ regression only affected SyncEvents — not bus events. The plan remains **probe-first**, but the probe now **confirms** a known-working round-trip rather than gating on a feared unknown. The risk has shifted from "will the signal arrive?" to lifecycle coordination: SSE drops while a permission is pending, reject cascades, shutdown draining, and sub-deadline discipline.
+
+## Problem Frame
+
+Sensitive actions (file writes, bash, PR creation) currently run with no human gate on the Discord surface — the GitHub Action tier never needed one (its operations are PR-scoped and reviewable), but the gateway drives a live agent in a shared channel. S5 from the Gateway v1 brainstorm requires "sensitive-action approvals." The original Unit 6 plan sketched the design (opaque-token `custom_id`, S3 payload, restart durability) but deferred implementation. The spike confirmed it is buildable on the current remote-attach topology; this plan turns that into executable units — without the S3 token store, which is unnecessary (see Key Technical Decisions).
+
+## Requirements Trace
+
+- R-S5. Sensitive tool/permission requests from OpenCode surface in Discord as an approval prompt; the agent run blocks until approved or denied.
+- R-S5.1. Approve/deny is authorized (only trigger-role / `ManageChannels` users, mirroring mention authorization).
+- R-S5.2. Approval state is held in the in-memory registry for the lifetime of the run. There is **no cross-restart durability**: the blocked run is NOT resumed after gateway restart in v1; pending registry entries are abandoned on restart and surface as a clear "run interrupted, please re-mention" failure.
+- R-S5.3. A response (`"once"` / `"reject"`) is delivered to OpenCode over the HTTP permission reply endpoint so the run resumes or aborts the tool.
+- R-S5.4. Approval activity is observable (who approved/denied, which tool) without logging secrets or request/response bodies.
+
+## Scope Boundaries
+
+- Not building reactions (👀/🎉/😕), the working-message progress editor, the serial per-channel queue, or the `/review`/`/sessions`/`/resume` commands — those are separate deferred Unit 6 items.
+- Not changing the GitHub Action tier's tool handling — Action stays as-is.
+- Not building the `/fro-bot approvals` management command in this plan (deferred to a follow-up); the approval flow itself is the deliverable.
+
+### Deferred to Separate Tasks
+
+- Reactions + progress editor (R9): separate plan.
+- Serial queue + `/clear-queue` (R11): separate plan.
+- `/review`, `/sessions`, `/resume` commands: separate plan.
+- Gateway startup self-test wiring (#7) and stand-alone safety-wins: can ship independently; not blocked by S5.
+- `no-fro-bot` block role (R6): separate small auth-only PR — touches `userIsAuthorized()` independently of S5.
+- `/fro-bot approvals` list/revoke management command: follow-up plan after S5 core lands.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/gateway/src/execute/run-core.ts:155-310` — the OpenCode event loop. Consumes **v2 sync events** (`session.next.text.delta`, `session.next.tool.called`, `session.next.tool.success`, `session.idle`, `session.error`). This is where `permission.asked` and `permission.replied` branches attach. No permission handling exists today.
+- `packages/gateway/src/execute/run.ts:73-243` — orchestration wrapper (concurrency gate, thread creation, sink flush). The run currently runs to `session.idle` uninterrupted; approval introduces a mid-run blocking wait on the coordinator promise.
+- `packages/gateway/src/discord/mentions.ts:69-156` — `userIsAuthorized()` (trigger-role / `ManageChannels`) and run handoff. The approve/deny authorization reuses this.
+- `packages/gateway/src/discord/streaming.ts:117-166` — buffered Discord sink; approval embed posting is adjacent but separate (component message, not the text sink).
+- `packages/gateway/src/discord/commands/fro-bot.ts:28-60` + `commands/index.ts:14-106` — slash-command registry + dispatch; the deferred `/fro-bot approvals` extends this.
+- `packages/gateway/src/program.ts:89-264` — boot/event-handler wiring; the Discord `interactionCreate` button handler registers here and must reach the in-memory coordinator registry.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/discord-slash-command-orchestration-patterns-2026-05-27.md` — `interaction.appPermissions` traps, live cache re-reads, multi-phase partial-failure recovery. Directly applicable to button-interaction handling.
+- `docs/solutions/best-practices/gateway-opencode-mention-loop-best-practices-2026-05-30.md` — remote-attach, EOF/timeout handling, failure-path flush. The approval wait must respect the same dual-finally / flush discipline.
+- `docs/solutions/best-practices/webhook-ingress-security-patterns-2026-05-30.md` — constant-time, never log bodies. The single-winner settle guard mirrors the replay-cache reserve pattern; atomic in-memory state transition before awaiting reply POST is mandatory.
+
+### External References
+
+- Spike findings (memory 4365): `@opencode-ai/sdk@1.14.41` — permission events on `/event` SSE bus; v2 `POST /permission/{requestID}/reply` with body `{ reply: "once" | "always" | "reject", message?: string }` and optional `query: { directory?, workspace? }`.
+- Oracle/Librarian review (memory 4366, session 2026-06-01): `permission.asked` is a BusEvent (not a SyncEvent) — SSE delivery at 1.14.41 is verified reliable; `requestID` = `properties.id` (confirmed); `permission.replied` is a real non-sync event `{ sessionID, requestID, reply }` and is the authoritative settlement signal; reject cascade confirmed (one reject → all same-session pending rejected server-side); `GET /permission` lists pending requests (reconciliation fallback when SSE drops); no server-side timeout — headless `opencode serve` blocks indefinitely on Deferred.await until reply / session-abort / server-shutdown.
+- Config-policy fallback: `allow|deny|ask` via OpenCode config (`permission/evaluate.ts`) — non-interactive, does NOT satisfy S5's live-human-approval intent; kept as last-resort only if BOTH SSE and GET /permission fail.
+
+## Key Technical Decisions
+
+- **Probe confirms, not gates.** Unit 1 is now a **confirmation probe** rather than a binary gate: the full round-trip is expected to work (SSE delivery verified reliable), but the probe must empirically confirm it end-to-end and capture any ordering surprises (especially create-session→subscribe→prompt ordering, since run-core currently prompts before subscribing — at-most-once events may be missed). Decision gate: if round-trip works → proceed; if SSE fails but `GET /permission` works → proceed with a polling watcher; only if BOTH fail → Units 2-4 blocked, replan. Config-policy is non-interactive and does NOT satisfy S5.
+- **Bind to the v2 event surface.** run-core consumes `session.next.*` (v2 sync events), so approval detection binds to **v2 `permission.asked`**, not v1 `permission.updated`. Mismatching the surface means the request is never seen.
+- **HTTP reply is regression-proof.** The reply endpoint is plain HTTP (not SSE), so even if SSE delivery were fragile, the response path is stable.
+- **Verified reply body.** `POST /permission/{requestID}/reply` with body `{ reply: "once" | "always" | "reject", message?: string }` and optional `query: { directory?, workspace? }`. APPROVE maps to `"once"` (default); DENY maps to `"reject"`. Do NOT use `allow|deny` or `response:`.
+- **`requestID` = `properties.id` (confirmed).** The inbound event is `{ id: string, type: "permission.asked", properties: PermissionRequest }`; identity and display fields (sessionID, permission, tool, metadata) live in `properties`; the top-level `id` is the event ID only. The reply route's `{requestID}` path param is `properties.id` — confirmed by Oracle/Librarian review.
+- **`permission.replied` is the authoritative settlement signal.** `{ sessionID, requestID, reply }` arrives as a non-sync bus event. run-core (and the coordinator) must consume it as the canonical "this permission was settled" signal, not just the button-click path alone. This handles auto-approve, policy-settle, and reject cascade sibling reconciliation.
+- **Reject cascade.** A single `"reject"` reply settles ALL pending permissions in the same session server-side. The coordinator must reconcile sibling registry entries from `permission.replied` events — it cannot assume independent settlement.
+- **In-memory registry (no S3 token store).** OpenCode pending permissions are ephemeral in-memory deferreds that die on instance teardown. The plan does not resume blocked runs across gateway restart; therefore, persisting an S3 token that points to a non-resumable run buys nothing. The registry is a module-scoped map keyed by `requestID` (`properties.id`). This is correct for a single-process gateway; it breaks under multi-replica deployments, which are out of scope for v1.
+- **`custom_id = approve:<requestID>` / `deny:<requestID>`.** `requestID` is a UUID-shaped string that fits `approve:<requestID>` well within Discord's 100-char `custom_id` limit directly — no opaque token or additional indirection needed.
+- **Workspace routing on reply.** The reply call MUST include the same workspace-routing `query: { directory }` used by the `/event` SSE subscription; without it the reply may hit the wrong instance or return a 4xx.
+- **Single authoritative deadline — a sub-deadline of `runTimeoutMs`.** There is ONE deadline for an approval wait, set as a sub-deadline of the overall run timeout, also capped below Discord's 15-minute interaction-token expiry. This ensures the approval deadline fires before the run itself is torn down, and heartbeat continues during the wait. On timeout: post a deny (`"reject"`, fail-closed), flush the sink, surface a clear Discord message.
+- **Single-winner settle guard.** A settled registry entry transitions state exactly once: button-click vs. timeout vs. `permission.replied` arrival cannot double-act. The loser path is a no-op, never double-POSTs to OpenCode.
+- **Channel-scoped authorization, reusing mention auth.** Any trigger-role / `ManageChannels` user in the channel can approve; the click handler re-runs `userIsAuthorized()` (live fetch, not cache).
+- **SSE loop must not block.** The coordinator seam (`onPermissionAsked` / `onPermissionReplied`) must be non-blocking in the event-loop switch; emit and return, let the coordinator own the wait.
+- **No bodies in logs.** Approval logs carry tool name + decision + actor ID only — never tool input, never the permission payload contents.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Can a remote client see + respond to permissions at 1.14.41? — Yes (spike, memory 4365).
+- v1 vs v2 permission API? — Use v2 (`permission.asked` + `POST /permission/{requestID}/reply`) to match run-core's v2 event surface.
+- Where does approval state live? — In-memory registry keyed by `requestID`; no S3 token store.
+- Which field is the reply `{requestID}` path param? — `properties.id` (confirmed, Oracle/Librarian review, memory 4366).
+- Does SSE deliver `permission.asked` at 1.14.41? — Yes: it is a BusEvent, not a SyncEvent; survives the 1.14.42+ SyncEvent regression (confirmed, memory 4366).
+- Is `permission.replied` a real event? — Yes: a non-sync bus event `{ sessionID, requestID, reply }`; it is the authoritative settlement signal (confirmed, memory 4366).
+- Does reject cascade exist? — Yes: one `"reject"` settles all same-session pending permissions server-side (confirmed, memory 4366).
+- Is there a server-side timeout? — No: `opencode serve` blocks indefinitely until reply / session-abort / server-shutdown (confirmed, memory 4366).
+
+### Deferred to Implementation (Unit 1 Probe)
+
+- **create-session→subscribe→prompt ordering:** run-core currently prompts before subscribing — at-most-once SSE events may be missed. Unit 1 must observe whether this ordering is a problem in practice and whether subscribe-before-prompt is required.
+- **`session.idle` interleaving while a permission is pending:** observe during the Unit 1 probe; handle in Unit 2's loop integration.
+- **N-concurrent cardinality:** confirm whether a single run can emit multiple concurrent `permission.asked` events; design the registry for N pending (keyed per `requestID`), each settled independently.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+@fro-bot <msg> ──► run.ts (auth, concurrency, thread)
+                     └─► run-core.ts event loop (SSE /event)
+                           │  session.next.text.delta ─► sink
+                           │  permission.asked ─────────► coordinator.onPermissionAsked(request)
+                           │        │  1. insert in-memory registry entry (keyed by requestID = properties.id)
+                           │        │  2. post Discord embed + Approve/Deny buttons
+                           │        │     custom_id = approve:<requestID> / deny:<requestID>
+                           │        │  3. await coordinator promise (sub-deadline of runTimeoutMs; fail-closed "reject")
+                           │        ▼
+                           │  permission.replied ────────► coordinator.onPermissionReplied(event)
+                           │        │  settles registry entry (authoritative signal; handles reject cascade)
+                           │        │  withdraws/updates sibling embeds if cascade-rejected
+                           │        ▼
+                           │   interactionCreate (button) ─► authorize (live fetch)
+                           │        │  verify interaction.channelId === pending.channelID
+                           │        │  single-winner settle guard (loser is no-op)
+                           │        │  POST /permission/{requestID}/reply  { reply: "once" | "reject" }
+                           │        │    with query: { directory }
+                           │        │  settle registry entry
+                           │        ▼
+                           │   run resumes (tool runs or is rejected)
+                           └─ session.idle ─► flush sink, finalize
+```
+
+SSE-drop reconciliation path:
+```
+SSE drop detected while permission is pending
+  ├─ GET /permission → lists pending requests → re-surface or fail-closed
+  └─ (last resort only) config-policy: non-interactive, does NOT satisfy S5
+```
+
+Decision gate after Unit 1:
+```
+Unit 1 probe confirms the full round-trip at 1.14.41?
+  ├─ YES (round-trip works) ─► build interactive approval (Units 2-4 as written)
+  ├─ PARTIAL (SSE fails, GET /permission works) ─► proceed with polling watcher; do NOT pivot to config-policy
+  └─ NO (both fail) ─► Units 2-4 blocked; replan; config-policy is a NON-INTERACTIVE fallback,
+                        does NOT satisfy S5's live-human-approval intent.
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Runtime probe — confirm full permission round-trip at 1.14.41 (low-risk confirmation)** — PASSED 2026-06-01. Against an isolated `--pure` 1.14.41 server (temp HOME/XDG, `opencode/big-pickle`), an `external_directory` read trigger produced `permission.asked` over `/event` SSE; `GET /permission` listed the pending request; the tool was blocked before reply; `POST /permission/{properties.id}/reply` with `{reply:"once"}` unblocked it and `{reply:"reject"}` cancelled it; `permission.replied` arrived over SSE as the authoritative settle. Confirmed `requestID = properties.id`; event order `…permission.asked → permission.replied → …session.idle`. Isolation recipe + full payload shape recorded in memory 4367. Decision gate: YES — interactive S5 buildable; config-policy fallback not needed.
+
+**Goal:** Empirically confirm that `permission.asked` reaches the gateway's `/event` SSE subscriber, that `GET /permission` lists the pending request, that `POST /permission/{requestID}/reply` (with `requestID = properties.id`) unblocks the tool, and capture any ordering or interleaving surprises. Since SSE delivery is verified reliable at this SDK version, the probe is a **confirmation** of the full round-trip, not a binary gate on an unknown.
+
+**Requirements:** R-S5 (feasibility confirmation)
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `packages/gateway/scripts/probe-permission-event.mjs` (or a temporary `*.test.ts` harness) — drives a workspace OpenCode session against a fixture that triggers a permission; subscribes to `/event`; calls `GET /permission`; exercises the reply endpoint.
+- Reference: `packages/gateway/src/execute/run-core.ts` (reuse its attach/subscribe wiring), `apps/workspace-agent/` (workspace server + proxy).
+
+**Approach:**
+- Stand up (or reuse) a workspace OpenCode server at the pinned 1.14.41 with a permission-requiring config (a tool set to `ask`).
+- Subscribe to `/event` using the **exact same path** as run-core: same `directory` query parameter, same bearer proxy — not a bare SDK call without workspace routing.
+- Prompt a session into a tool that requires permission; record: (a) does `permission.asked` arrive over SSE? (b) does `GET /permission` list the pending request (reconciliation fallback)? (c) does `POST /permission/{requestID}/reply { reply: "once" }` actually unblock the tool? (d) confirm `requestID = properties.id`. (e) trigger a `"reject"` reply and confirm the cascade: all same-session pending permissions are rejected server-side. (f) observe whether `session.idle` interleaves while a permission is pending. (g) observe create-session→subscribe→prompt ordering — does prompting before subscribing cause `permission.asked` to be missed?
+- Exercise at least one **concurrent-pending** scenario (two permission requests in the same session) to confirm N-request cardinality and independent settlement.
+- **Decision gate:** if the full round-trip works → proceed to Units 2-4. If SSE fails but `GET /permission` works → proceed with a polling watcher instead of pure SSE. If BOTH fail → stop, mark Units 2-4 blocked, open a replan (config-policy is non-interactive and does NOT satisfy S5).
+
+**Execution note:** This is a throwaway investigation harness, not production code — start by observing real events, not by writing assertions. Capture findings, then delete or convert the harness.
+
+**Test scenarios:**
+- Test expectation: none — this is a runtime probe / investigation harness, not feature-bearing code. Its output is a recorded finding (round-trip confirmed + payload shape + `requestID` field + reject cascade behavior + `session.idle` interleaving + create-subscribe-prompt ordering) that informs Units 2-4.
+
+**Verification:**
+- A documented finding: "full round-trip {confirmed | partially confirmed | failed}; `permission.asked` over SSE = {yes | no}; `GET /permission` lists pending = {yes | no}; `POST /permission/{requestID}/reply` unblocks = {yes | no}; `requestID = properties.id` = {confirmed | contradicted}; reject cascade = {confirmed | contradicted}; `session.idle` interleaving = {…}; create-subscribe-prompt ordering = {…}." The decision gate is resolved and the chosen branch is recorded.
+
+- [ ] **Unit 2: Permission coordinator + run-core integration**
+
+**Goal:** Add a permission coordinator with an explicit seam (`onPermissionAsked` / `onPermissionReplied`) and an in-memory registry keyed by `requestID`. run-core consumes both `permission.asked` (register pending + signal the coordinator) and `permission.replied` (authoritative settle — reconcile sibling embeds on reject cascade). The coordinator owns the blocking wait; run-core stays transport-focused.
+
+**Requirements:** R-S5, R-S5.3
+
+**Dependencies:** Unit 1 (confirmed branch).
+
+**Files:**
+- Modify: `packages/gateway/src/execute/run-core.ts`
+- Create: `packages/gateway/src/approvals/coordinator.ts`
+- Test: `packages/gateway/src/execute/run-core.test.ts`, `packages/gateway/src/approvals/coordinator.test.ts`
+
+**Approach:**
+- Add a `permission.asked` branch to run-core's event loop that calls `coordinator.onPermissionAsked(request)` and returns immediately (do not block the loop; keep the SSE drain running so `permission.replied` and other events are not starved).
+- Add a `permission.replied` branch to run-core's event loop that calls `coordinator.onPermissionReplied(event)` — this is the authoritative settlement signal and must be processed even when no button click has arrived.
+- The coordinator exposes: `onPermissionAsked(request): Promise<"once" | "reject">` (the run-core event loop awaits this promise after registering; the promise resolves when settled by button click, `permission.replied`, or the deadline) and `onPermissionReplied(event): void` (settle the matching registry entry and reconcile any same-session siblings cascade-rejected by the server).
+- The in-memory registry is a module-scoped map keyed by `requestID` (`properties.id`). Each entry tracks: promise resolver, channelID (for channel-binding in Unit 3), settlement state (open / settled), and session ID (for cascade reconciliation). A restart abandons all entries — controlled failure, not a hang.
+- **Reject cascade:** when `permission.replied` arrives with `reply: "reject"`, check for other open registry entries with the same `sessionID` and fail-close them (they were cascade-rejected server-side); their embeds must be updated/withdrawn in Unit 3.
+- **create-session→subscribe→prompt ordering:** if Unit 1 showed that prompting before subscribing drops `permission.asked`, enforce subscribe-before-prompt in the coordinator or run-core wiring.
+
+**Patterns to follow:** the existing `session.next.tool.called`/`success` correlation (cache call info, surface to caller) at `run-core.ts:266-300`.
+
+**Test scenarios:**
+- Happy path: `permission.asked` event with valid `properties` → coordinator registers entry keyed by `properties.id`, returns a pending promise.
+- Happy path: `permission.replied { reply: "once" }` → coordinator settles the matching entry; promise resolves `"once"`.
+- Happy path: `permission.replied { reply: "reject" }` → coordinator settles the matching entry; promise resolves `"reject"`; sibling same-session open entries are also fail-closed (cascade).
+- Edge case: `permission.asked` with a missing/unknown tool field in `properties` → still registers with a safe fallback title, does not throw.
+- Edge case: `permission.replied` for an unknown `requestID` (already settled or never registered) → no-op, no error.
+- Edge case: `session.idle` arriving while a permission is pending → pending signal emitted before idle resolves (ordering preserved); coordinator entry not dropped prematurely.
+- N-concurrent: two `permission.asked` events for the same run → two independent registry entries, each settled independently.
+
+**Verification:** run-core emits structured pending-permission signals on `permission.asked`, processes `permission.replied` as the authoritative settle, and continues to handle all existing event types unchanged.
+
+- [ ] **Unit 3: Discord approval embed/buttons + live auth + channel binding + pause/resume**
+
+**Goal:** When the coordinator signals a pending permission, post a Discord approval embed with Approve/Deny buttons (`custom_id = approve:<requestID>` / `deny:<requestID>`); the run pauses on the coordinator promise. Handle button clicks: verify channel binding, authorize the clicker (live fetch), POST the decision to OpenCode's reply endpoint (with workspace routing), and settle the coordinator registry entry. Single authoritative sub-deadline and single-winner settle guard govern the entire flow.
+
+**Requirements:** R-S5, R-S5.1, R-S5.3, R-S5.4
+
+**Dependencies:** Unit 2.
+
+**Files:**
+- Create: `packages/gateway/src/discord/approvals.ts` (embed builder + button `ActionRow`; `custom_id = approve:<requestID>` / `deny:<requestID>`)
+- Modify: `packages/gateway/src/execute/run.ts` (await coordinator promise between pending signal and continuation; respect failure-path flush; ensure heartbeat continues during wait)
+- Modify: `packages/gateway/src/program.ts` (register `interactionCreate` button routing; reach the coordinator registry)
+- Test: `packages/gateway/src/discord/approvals.test.ts`, `packages/gateway/src/execute/run.test.ts`
+
+**Approach:**
+- On pending signal from coordinator: build embed (tool + title, no input body) + Approve/Deny buttons → post to the run's thread.
+- **`custom_id = approve:<requestID>` / `deny:<requestID>`.** `requestID` is `properties.id`; fits well within Discord's 100-char limit directly — no opaque token or S3 indirection needed.
+- Await the coordinator promise (blocking the run); the promise is settled by button click, `permission.replied`, or the single authoritative deadline.
+- **Single authoritative deadline — a sub-deadline of `runTimeoutMs`.** Set the deadline to expire before the run itself is torn down (and before Discord's 15-min interaction-token expiry). Heartbeat must continue during the wait. On deadline expiry: post a deny (`"reject"`, fail-closed) to OpenCode via `POST /permission/{requestID}/reply`, flush the sink, surface a clear "approval timed out — denied" message, settle the coordinator entry, and resolve the run cleanly. Reuse the dual-finally / flush discipline from the mention-loop best-practices doc.
+- **Channel binding invariant.** `interaction.channelId` MUST equal the `channelID` recorded in the coordinator registry entry (recorded at `permission.asked` time). A mismatch fails closed with an ephemeral denial and no reply POST.
+- **Live authorization.** Re-run `userIsAuthorized()` on every click (live `members.fetch`, not cache). Return ephemeral "not authorized" with no side effects if rejected.
+- **Single-winner settle guard.** Check the coordinator registry entry's settlement state before posting. First settler wins; all others (button-click vs. timeout vs. `permission.replied`) are no-ops — never double-POST to OpenCode.
+- POST `{ reply: "once" }` (approve) or `{ reply: "reject" }` (deny) to `POST /permission/{requestID}/reply` via the SDK, **including `query: { directory }`** matching the workspace routing of the run's SSE subscription.
+- On success: settle the coordinator registry entry, edit the original embed to a resolved state (who decided, decision) — no secret content; log actor ID + tool + decision only.
+- **Reject cascade — update sibling embeds.** When `permission.replied` cascade-rejects sibling same-session permissions, update/withdraw their Discord embeds via the coordinator (Unit 2 signals this; Unit 3 handles the embed side-effect).
+- **Shutdown-triggered fail-closed settle.** `program.ts` awaits `inFlightRuns` on shutdown; a pending approval could stall shutdown until the deadline. Add a shutdown signal path that triggers fail-closed settle on all open coordinator registry entries so shutdown does not hang indefinitely.
+
+**Patterns to follow:** `discord/streaming.ts` safe-send helpers; failure-path flush from `run.ts`; `interaction.appPermissions` / live-fetch lessons from the slash-command solution doc.
+
+**Test scenarios:**
+- Happy path (approve): authorized clicker, channel match, registry entry open → single-winner guard passes → POST `{ reply: "once" }` with `query: { directory }` → run resumes → embed shows "approved by @user".
+- Happy path (deny): authorized clicker, channel match → POST `{ reply: "reject" }` → run rejects the tool.
+- Error path: no resolution within sub-deadline → fail-closed `"reject"` posted to OpenCode, sink flushed, clear Discord message, run finalizes cleanly.
+- Edge case: embed post fails (Discord API error) → run does not hang; falls back to fail-closed `"reject"` + logged reason.
+- Race (click-vs-timeout): click arrives after timeout has already settled the entry → single-winner guard no-ops the click; no double-POST to OpenCode.
+- Race (click-vs-permission.replied): `permission.replied` settles the entry before button click arrives → click is a no-op.
+- Security: `interaction.channelId` ≠ coordinator `channelID` → ephemeral denial, no POST, no state change.
+- Security: unauthorized clicker → ephemeral "not authorized", no POST, run stays pending.
+- Reject cascade: deny one permission → coordinator reconciles sibling embeds for same-session cascade-rejected entries.
+- N-concurrent: two `permission.asked` events for the same run → two independent embeds, each settled independently without cross-contamination.
+- Shutdown: gateway shutdown signal → all open coordinator registry entries fail-closed; embeds updated; shutdown does not hang.
+- Integration: approve click end-to-end settles the exact pending run keyed by `requestID` (no cross-run leakage); OpenCode reply endpoint called exactly once per authorized decision.
+
+**Verification:** a permission-requiring run posts an approval prompt, blocks, and resumes or fail-closes deterministically; the concurrency slot is released within the sub-deadline bound; N-concurrent requests do not interfere; shutdown drains cleanly.
+
+- [ ] **Unit 4: Integration/failure tests + deploy docs**
+
+**Goal:** End-to-end failure-mode tests covering the scenarios that unit mocks cannot prove, plus deploy documentation: the workspace `permission: ask` config knob (the deploy-time switch that activates S5) and `AGENTS.md` permission posture.
+
+**Requirements:** R-S5.1, R-S5.3, R-S5.4
+
+**Dependencies:** Units 2, 3.
+
+**Files:**
+- Create: integration test(s) covering the approve→reply→resume cross-seam path and the key failure modes
+- Modify: `packages/gateway/AGENTS.md` (permission posture; authorize-approver guidance)
+- Modify: `deploy/README.md` (workspace `permission: ask` config knob; how to enable tool prompting)
+
+**Approach:**
+- Integration test: the approve→reply→resume path crosses Discord → coordinator → OpenCode HTTP; assert the reply endpoint is hit exactly once per authorized decision via a seam/mock.
+- Integration test: SSE drop while a permission is pending → `GET /permission` reconciliation path kicks in or run fails closed cleanly (no hang).
+- Integration test: workspace/OpenCode restart while a permission is pending → coordinator registry entry expires/fails; gateway never shows "approved" for a dead deferred; run surfaces as "run interrupted, please re-mention".
+- Integration test: gateway shutdown with an in-flight pending approval → shutdown-triggered fail-closed settle completes; `inFlightRuns` drain unblocks; gateway exits cleanly.
+- Document (in `AGENTS.md` + `deploy/README.md`) how an operator enables tool prompting (the workspace OpenCode `permission` config that makes tools `ask` rather than auto-allow) — this is the deploy-time knob that makes S5 active.
+
+**Test scenarios:**
+- Approve → reply → resume end-to-end: coordinator promise resolves `"once"`, reply endpoint called once, run continues.
+- SSE drop during pending: reconcile via `GET /permission` or fail closed without hanging.
+- OpenCode restart during pending: coordinator entry fails/expires; no "approved" side-effect to a dead deferred.
+- Shutdown drain: pending approval fail-closes; `inFlightRuns` unblocks; no indefinite hang.
+
+**Verification:** all failure modes covered by integration tests; deploy docs explain how to enable the prompt posture and the v1 restart limitation.
+
+## System-Wide Impact
+
+- **Interaction graph:** introduces a Discord `interactionCreate` (button) handler alongside the existing slash-command dispatch; both route through `program.ts` event wiring. The run-core event loop gains `permission.asked` and `permission.replied` branches; the run orchestrator gains a blocking wait on the coordinator promise and a pending-run registry.
+- **Error propagation:** approval failures (deadline, Discord post failure, reply-endpoint non-2xx) must fail-closed (deny) and flush partial output, never silently drop a run or leave the concurrency slot wedged.
+- **Authorization surface:** approve/deny reuses `userIsAuthorized()` so the existing mention auth rules apply uniformly to approvals. The R6 block role is deferred to a separate PR.
+- **Integration coverage:** the approve→reply→resume path crosses Discord → coordinator → OpenCode HTTP; unit mocks alone won't prove it — include a seam test that asserts the reply endpoint is hit exactly once per authorized decision.
+- **Unchanged invariants:** the mention loop's existing run path (no permission requested) is unaffected — when no `permission.asked` arrives, behavior is identical to today. The GitHub Action tier is untouched.
+
+### Named Lifecycle Failure Modes
+
+- **workspace/OpenCode restart while pending.** OpenCode rejects the permission server-side when its process exits (shutdown finalizer rejects all pending deferreds). The coordinator registry entry must fail/expire on this signal; the gateway must never show "approved" for a dead deferred. The run surfaces as "run interrupted, please re-mention."
+- **SSE drop while a permission is pending.** `permission.asked` and `permission.replied` are at-most-once / non-replayable bus events; a dropped SSE connection loses them. Reconcile via `GET /permission` (lists pending requests) or fail closed. Never leave a run hanging on a dropped SSE without a timeout.
+- **Gateway shutdown drain.** `program.ts` awaits `inFlightRuns` on shutdown; a pending approval could stall this indefinitely until the sub-deadline fires. Add a shutdown signal that triggers fail-closed settle on all open coordinator registry entries so the drain unblocks promptly.
+- **Heartbeat/lock liveness.** The approval wait shares the run lifecycle; the heartbeat (if any) must continue during the coordinator await. The approval deadline must be a **sub-deadline of `runTimeoutMs`** so the outer run timeout is never the binding constraint.
+- **Reject cascade.** A single `"reject"` reply (or an always-auto-approve config rule) settles ALL pending permissions in the same session server-side. The coordinator must reconcile sibling registry entries from `permission.replied` events, not assume each permission is settled independently. Discord embeds for cascade-rejected siblings must be updated/withdrawn.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `permission.asked` does not reach `/event` SSE at 1.14.41 despite BusEvent classification | Unit 1 probe confirms the full round-trip. If SSE fails: try polling via `GET /permission` (reconciliation fallback). If both fail: pivot to replan (config-policy is NON-INTERACTIVE and does NOT satisfy S5). |
+| create-session→subscribe→prompt ordering drops at-most-once `permission.asked` | Unit 1 probe observes this directly; enforce subscribe-before-prompt in Unit 2 if needed. |
+| `session.idle` interleaves while a permission is pending, terminating the run prematurely | Observe in Unit 1; handle ordering in Unit 2's event loop integration. |
+| OpenCode times out or restarts server-side before the Discord click arrives | Coordinator registry entry fails/expires on the `permission.replied` cascade or SSE close; gateway never posts a reply to a dead deferred. Sub-deadline fires before run teardown. |
+| Gateway shutdown stalls on a pending approval | Shutdown-triggered fail-closed settle on all open coordinator entries; `inFlightRuns` drain unblocks. Tested in Unit 4. |
+| SSE drop while a permission is pending (events are at-most-once) | Reconcile via `GET /permission`; fail closed if unavailable. Never hang without a deadline. |
+| Reject cascade settles sibling permissions unexpectedly | Coordinator reconciles sibling registry entries from `permission.replied`; their embeds are updated/withdrawn. Tested explicitly. |
+| Double-click or click racing a timeout/permission.replied double-POSTs to OpenCode | Single-winner settle guard on the coordinator registry entry: first settler wins, all others are no-ops. Tested with click-vs-timeout and click-vs-permission.replied race scenarios. |
+| A pending approval wedges the per-channel concurrency slot | Bounded by the single authoritative sub-deadline (fail-closed `"reject"`); tested in Unit 3. Heartbeat continues during wait. |
+| Unauthorized user approves a sensitive action | Approve/deny re-runs live `userIsAuthorized()` on every click; never trusts the original mention author or cache. Channel binding check additionally prevents cross-channel approval. |
+| Secret/tool-input leakage into Discord or logs | Embed shows tool name + title only; logs carry actor ID + tool + decision; no tool input in any registry entry or logged field. |
+
+## Documentation / Operational Notes
+
+- Document the workspace permission-mode knob (OpenCode `permission: ask`) required to make tools prompt — without it, tools auto-allow and no approval is requested. This is the deploy-time switch that activates S5. Covered in Unit 4's `AGENTS.md` + `deploy/README.md` edits.
+- Note the v1 limitation: a gateway restart during a pending approval abandons that run. The blocked run is NOT resumed; pending coordinator registry entries are discarded on restart and surface as "run interrupted, please re-mention."
+- Note the multi-replica limitation: the in-memory coordinator registry is single-process; running multiple gateway replicas would split the registry and break button routing. Multi-replica is out of scope for v1.
+
+## Sources & References
+
+- **Origin document:** [docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md](docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md) (Unit 6 deferred items; approval design sketch at lines 183, 200, 284-286, 764, 769)
+- Spike findings: project memory ID 4365 (S5 remote-attach feasibility at 1.14.41)
+- Oracle architecture review + Librarian source research: project memory ID 4366 (session 2026-06-01) — BusEvent classification confirmed, `requestID = properties.id` confirmed, `permission.replied` authoritative signal confirmed, reject cascade confirmed, no server-side timeout confirmed, `GET /permission` reconciliation endpoint confirmed
+- SDK refs: installed `@opencode-ai/sdk@1.14.41` — `PermissionList` (`GET /permission`), `postPermissionRequestIdReply` (`POST /permission/{requestID}/reply`), `permission.asked` / `permission.replied` event shapes
+- OpenCode source (clonedeps): `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/permission/index.ts` (Deferred.await, bus.subscribeAll, shutdown finalizer), `.../server/routes/instance/httpapi/groups/permission.ts` (reply route, list route)
+- Related solutions: `docs/solutions/best-practices/discord-slash-command-orchestration-patterns-2026-05-27.md`, `gateway-opencode-mention-loop-best-practices-2026-05-30.md`, `webhook-ingress-security-patterns-2026-05-30.md`

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -135,6 +135,21 @@ Releasing is always done in a `finally` block so crashes leave the system in a r
 
 Per-run errors are logged and the sweep continues — one corrupted record does not block recovery for the rest.
 
+### Tool approval
+
+When the workspace OpenCode config sets any tool to `ask` (rather than the default `allow`), OpenCode will pause execution and emit a `permission.asked` event before running that tool. The gateway intercepts these events and presents an interactive Discord approval prompt.
+
+**How it works:**
+
+- Each `permission.asked` event creates a Discord embed with Approve / Deny buttons in the run thread.
+- Approvers must pass the same `userIsAuthorized` gate as trigger mentions: either hold the `GATEWAY_TRIGGER_ROLE_ID` role or have guild-level `ManageChannels`.
+- The first valid button click wins (single-winner). A subsequent click on the same embed is a no-op.
+- While the prompt is open, the agent run is paused. OpenCode resumes only after the reply reaches the workspace.
+- If no decision is received within the approval deadline (a sub-deadline of the overall run timeout, capped at 13 minutes for Discord interaction-token expiry), the gateway fail-closes with `reject`: the tool is blocked, the embed is updated, and the run continues or errors from the rejection.
+- Multiple open approvals from the same session are handled independently; a `reject` decision cascades and closes all sibling prompts in that session.
+- **Default:** if no tool is set to `ask`, no approval prompts appear — all tools auto-run.
+- **Restart limitation:** a pending approval is in-memory only and does not survive a gateway or workspace restart. See [Known limitations](#known-limitations) below.
+
 ## Known limitations
 
 - **`add-project` is Discord-only.** The orchestration runs inside the slash
@@ -154,7 +169,7 @@ Per-run errors are logged and the sweep continues — one corrupted record does 
 
 - **No run queue.** Mentions that arrive while the concurrency cap or repo lock is held are rejected immediately. There is no persistent queue, no back-pressure mechanism, and no retry. Users must manually re-send their message when the system is free.
 
-- **No approval flow.** The authorization gate is a role check or permission check; there is no interactive approval step between an authorized mention and agent execution.
+- **Tool approval does not survive a restart.** A pending approval is held in memory by the per-run coordinator. If the gateway or workspace restarts while a permission prompt is in flight, the pending approval is abandoned: the coordinator's deadline fires (or the process exits fail-closed), the Discord embed is settled with `rejected`, and the run surfaces as interrupted. Re-mention to retry.
 
 - **Fresh session per mention.** Each mention starts a new OpenCode session from scratch. There is no conversational continuity across mentions (session persistence is planned but not yet wired into the Discord surface).
 

--- a/packages/gateway/src/approvals/approval-flow.integration.test.ts
+++ b/packages/gateway/src/approvals/approval-flow.integration.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Cross-seam integration tests for the tool-approval flow
+ *
+ * Wires the REAL coordinator + REAL registry together with fake injected
+ * side-effects (captured calls, no Discord / HTTP) and drives them with
+ * synthesised OpenCode events.
+ *
+ * Fake effects:
+ *   postReply    — records { requestID, directory, decision } per call
+ *   renderSettled — records { request, decision, decidedBy, reason } per call
+ *
+ * All timer-sensitive tests use `vi.useFakeTimers()` to control deadline firing.
+ */
+
+import type {PermissionReplyEvent, PermissionRequest, SettlementReason} from './coordinator.js'
+import type {RegisterParams} from './registry.js'
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {createPermissionCoordinator} from './coordinator.js'
+import {createApprovalRegistry} from './registry.js'
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const DIRECTORY = '/workspace/acme/widget'
+const SESSION_A = 'sess-aaa'
+const SESSION_B = 'sess-bbb'
+
+interface PostReplyCall {
+  requestID: string
+  directory: string
+  decision: string
+}
+
+interface RenderSettledCall {
+  request: PermissionRequest
+  decision: string
+  decidedBy: string | null
+  reason: string
+}
+
+function makeLogger() {
+  return {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+}
+
+/** Build fake side-effects and return call-capture arrays + factory */
+function makeFakeEffects() {
+  const postReplyCalls: PostReplyCall[] = []
+  const renderSettledCalls: RenderSettledCall[] = []
+
+  function makeEffectsFor(_requestID: string) {
+    return {
+      postReply: vi.fn(async (requestID: string, directory: string, decision: string) => {
+        postReplyCalls.push({requestID, directory, decision})
+        return {ok: true}
+      }),
+      renderSettled: vi.fn(
+        async (request: PermissionRequest, decision: string, decidedBy: string | null, reason: string) => {
+          renderSettledCalls.push({request, decision, decidedBy, reason})
+        },
+      ),
+    }
+  }
+
+  return {postReplyCalls, renderSettledCalls, makeEffectsFor}
+}
+
+function makeRequest(id: string, sessionID: string = SESSION_A): PermissionRequest {
+  return {requestID: id, sessionID, permission: 'bash', patterns: ['ls'], title: `Run: ${id}`}
+}
+
+function makeReplyEvent(
+  requestID: string,
+  reply: 'once' | 'always' | 'reject',
+  sessionID = SESSION_A,
+): PermissionReplyEvent {
+  return {sessionID, requestID, reply}
+}
+
+/** Wire coordinator + registry together, return both + fake-effects captures */
+function setup(deadlineMs?: number) {
+  const logger = makeLogger()
+  const {postReplyCalls, renderSettledCalls, makeEffectsFor} = makeFakeEffects()
+
+  const registry = createApprovalRegistry({logger})
+
+  /** Simulate what run.ts's onPending does */
+  function onPending(request: PermissionRequest) {
+    const effects = makeEffectsFor(request.requestID)
+    const params: RegisterParams = {
+      requestID: request.requestID,
+      sessionID: request.sessionID,
+      channelID: 'ch-test',
+      directory: DIRECTORY,
+      request,
+      effects,
+    }
+    registry.register(params)
+  }
+
+  /** Simulate what run.ts's onSettled does */
+  function onSettled(requestID: string, decision: string, reason: string) {
+    registry
+      .applySettlement({
+        requestID,
+        decision: decision as 'once' | 'always' | 'reject',
+        reason: reason as SettlementReason,
+      })
+      .catch(() => undefined)
+  }
+
+  const coordinator = createPermissionCoordinator({
+    logger,
+    onPending,
+    onSettled,
+    deadlineMs,
+  })
+
+  return {coordinator, registry, postReplyCalls, renderSettledCalls}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('approval flow — cross-seam integration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // 1. approve→reply→resume (exactly-once) ───────────────────────────────────
+
+  it('approve path: postReply called exactly once with query.directory; permission.replied settles without second postReply', async () => {
+    // #given
+    const {coordinator, registry, postReplyCalls, renderSettledCalls} = setup()
+    const req = makeRequest('req-1')
+
+    // #when — permission.asked → register into coordinator + registry
+    const replyPromise = coordinator.onPermissionAsked(req)
+
+    expect(registry.pending()).toContain('req-1')
+    expect(postReplyCalls).toHaveLength(0)
+
+    // Authorized button click (approve)
+    const clickResult = await registry.handleButtonDecision({
+      requestID: 'req-1',
+      channelID: 'ch-test',
+      decision: 'once',
+      decidedBy: 'user-approved',
+    })
+    expect(clickResult).toBe('ok')
+
+    // #then — postReply called exactly once with correct directory
+    expect(postReplyCalls).toHaveLength(1)
+    expect(postReplyCalls[0]).toMatchObject({requestID: 'req-1', directory: DIRECTORY, decision: 'once'})
+
+    // permission.replied arrives (authoritative settlement)
+    coordinator.onPermissionReplied(makeReplyEvent('req-1', 'once'))
+
+    // Wait for async settlement
+    await vi.runAllTimersAsync()
+    await replyPromise
+
+    // #then — no second postReply (applySettlement skips postReply for 'replied' reason when entry is claimed)
+    expect(postReplyCalls).toHaveLength(1)
+
+    // renderSettled called once
+    expect(renderSettledCalls).toHaveLength(1)
+    expect(renderSettledCalls[0]).toMatchObject({decision: 'once', reason: 'replied'})
+
+    // Entry is gone
+    expect(registry.pending()).not.toContain('req-1')
+    expect(registry.has('req-1')).toBe(false)
+  })
+
+  // 2. deny→reject ──────────────────────────────────────────────────────────
+
+  it('deny path: postReply once with "reject"; permission.replied{reject} settles once, no second postReply', async () => {
+    // #given
+    const {coordinator, registry, postReplyCalls, renderSettledCalls} = setup()
+    const req = makeRequest('req-2')
+
+    const replyPromise = coordinator.onPermissionAsked(req)
+
+    // Authorized deny click
+    const clickResult = await registry.handleButtonDecision({
+      requestID: 'req-2',
+      channelID: 'ch-test',
+      decision: 'reject',
+      decidedBy: 'user-deny',
+    })
+    expect(clickResult).toBe('ok')
+    expect(postReplyCalls).toHaveLength(1)
+    expect(postReplyCalls[0]).toMatchObject({decision: 'reject', directory: DIRECTORY})
+
+    // permission.replied{reject} arrives
+    coordinator.onPermissionReplied(makeReplyEvent('req-2', 'reject'))
+    await vi.runAllTimersAsync()
+    await replyPromise
+
+    // #then — no second postReply
+    expect(postReplyCalls).toHaveLength(1)
+    expect(renderSettledCalls).toHaveLength(1)
+    expect(renderSettledCalls[0]).toMatchObject({decision: 'reject', reason: 'replied'})
+    expect(registry.pending()).not.toContain('req-2')
+  })
+
+  // 3. single-winner race: permission.replied before button click ───────────
+
+  it('single-winner: permission.replied arrives first → late button click returns not-found or already-claimed, no extra postReply', async () => {
+    // #given
+    const {coordinator, registry, postReplyCalls} = setup()
+    const req = makeRequest('req-3')
+
+    const replyPromise = coordinator.onPermissionAsked(req)
+
+    // permission.replied wins first (no button click yet)
+    coordinator.onPermissionReplied(makeReplyEvent('req-3', 'once'))
+    await vi.runAllTimersAsync()
+    await replyPromise
+
+    // Entry is now settled + unregistered (applySettlement called by onSettled)
+    expect(registry.pending()).not.toContain('req-3')
+
+    // Late button click
+    const lateResult = await registry.handleButtonDecision({
+      requestID: 'req-3',
+      channelID: 'ch-test',
+      decision: 'once',
+      decidedBy: 'user-late',
+    })
+
+    // #then — late click does nothing; no postReply emitted
+    expect(lateResult === 'not-found' || lateResult === 'already-claimed').toBe(true)
+    expect(postReplyCalls).toHaveLength(0)
+  })
+
+  // 4. single-winner race: deadline fires before button click ───────────────
+
+  it('single-winner: deadline fires → fail-closed reject posted once → late click → no second postReply', async () => {
+    // #given — very short deadline
+    const {registry, coordinator, postReplyCalls} = setup(50)
+    const req = makeRequest('req-4')
+
+    const p4 = coordinator.onPermissionAsked(req)
+
+    // Advance past deadline
+    await vi.advanceTimersByTimeAsync(200)
+
+    // Deadline fires: coordinator should have disposed / rejected
+    // Give any pending microtasks a chance to settle
+    await vi.runAllTimersAsync()
+    await p4
+
+    // The deadline path posts a fail-closed reject via onSettled → applySettlement → postReply
+    // (only if entry is not already claimed)
+    // Let's check pending is now empty (entry removed after deadline settlement)
+    expect(registry.has('req-4')).toBe(false)
+
+    const postRepliesAfterDeadline = postReplyCalls.length
+
+    // Late button click after deadline
+    const lateResult = await registry.handleButtonDecision({
+      requestID: 'req-4',
+      channelID: 'ch-test',
+      decision: 'once',
+      decidedBy: 'user-late',
+    })
+    expect(lateResult).toBe('not-found')
+
+    // No extra postReply beyond what deadline already posted
+    expect(postReplyCalls).toHaveLength(postRepliesAfterDeadline)
+  })
+
+  // 5. channel-mismatch security ─────────────────────────────────────────────
+
+  it('channel-mismatch: button from wrong channelId → handleButtonDecision returns channel-mismatch, postReply NOT called, entry still pending', async () => {
+    // #given
+    const {registry, coordinator, postReplyCalls} = setup()
+    const req = makeRequest('req-5')
+
+    const p5 = coordinator.onPermissionAsked(req)
+    expect(registry.pending()).toContain('req-5')
+
+    // #when — button click from a different channel
+    const result = await registry.handleButtonDecision({
+      requestID: 'req-5',
+      channelID: 'ch-WRONG',
+      decision: 'once',
+      decidedBy: 'attacker',
+    })
+
+    // #then
+    expect(result).toBe('channel-mismatch')
+    expect(postReplyCalls).toHaveLength(0)
+    // Entry still open
+    expect(registry.pending()).toContain('req-5')
+    expect(registry.has('req-5')).toBe(true)
+
+    // Cleanup — dispose settles the pending deferred
+    coordinator.dispose('test done')
+    await vi.runAllTimersAsync()
+    await p5
+  })
+
+  // 6. reject cascade ────────────────────────────────────────────────────────
+
+  it('reject cascade: two same-session asks → reject one → both entries settled, both embeds rendered', async () => {
+    // #given
+    const {coordinator, registry, postReplyCalls, renderSettledCalls} = setup()
+    const req6a = makeRequest('req-6a', SESSION_A)
+    const req6b = makeRequest('req-6b', SESSION_A)
+
+    const p6a = coordinator.onPermissionAsked(req6a)
+    const p6b = coordinator.onPermissionAsked(req6b)
+
+    expect(registry.pending()).toContain('req-6a')
+    expect(registry.pending()).toContain('req-6b')
+
+    // #when — permission.replied{reject} for req-6a
+    coordinator.onPermissionReplied(makeReplyEvent('req-6a', 'reject'))
+    await vi.runAllTimersAsync()
+    await Promise.all([p6a, p6b])
+
+    // #then — both entries settled
+    expect(registry.has('req-6a')).toBe(false)
+    expect(registry.has('req-6b')).toBe(false)
+    expect(registry.pending()).toHaveLength(0)
+
+    // renderSettled called for both — one 'replied', one 'cascade'
+    expect(renderSettledCalls).toHaveLength(2)
+    const reasons = renderSettledCalls.map(c => c.reason)
+    expect(reasons).toContain('replied')
+    expect(reasons).toContain('cascade')
+
+    // postReply: req-6a was settled via 'replied' (claimed=false → best-effort postReply).
+    // req-6b: cascade also calls best-effort postReply (claimed=false).
+    // Both should be reject.
+    expect(postReplyCalls.every(c => c.decision === 'reject')).toBe(true)
+  })
+
+  // 7. sse-drop / no reply within deadline ──────────────────────────────────
+
+  it('sse-drop: no permission.replied ever → deadline fires → fail-closed reject, pending() empty', async () => {
+    // #given — very short deadline (100ms)
+    const {coordinator, registry, postReplyCalls} = setup(100)
+    const req = makeRequest('req-7')
+
+    const p7 = coordinator.onPermissionAsked(req)
+    expect(registry.pending()).toContain('req-7')
+
+    // #when — advance past deadline, no reply ever
+    await vi.advanceTimersByTimeAsync(500)
+    await vi.runAllTimersAsync()
+    await p7
+
+    // #then — pending() is empty (no hang)
+    expect(registry.has('req-7')).toBe(false)
+    expect(registry.pending()).toHaveLength(0)
+
+    // Fail-closed: postReply was called with reject
+    expect(postReplyCalls.some(c => c.decision === 'reject')).toBe(true)
+  })
+
+  // 8. shutdown drain ────────────────────────────────────────────────────────
+
+  it('shutdown drain: disposeAll resolves promptly, all entries settled, pending() empty', async () => {
+    // #given — no deadline (infinite), two pending entries
+    const req8a = makeRequest('req-8a', SESSION_A)
+    const req8b = makeRequest('req-8b', SESSION_B)
+    const logger = makeLogger()
+    const reg = createApprovalRegistry({logger})
+
+    const {makeEffectsFor, postReplyCalls: postReplyDrain, renderSettledCalls: renderDrain} = makeFakeEffects()
+    reg.register({
+      requestID: 'req-8a',
+      sessionID: SESSION_A,
+      channelID: 'ch-test',
+      directory: DIRECTORY,
+      request: req8a,
+      effects: makeEffectsFor('req-8a'),
+    })
+    reg.register({
+      requestID: 'req-8b',
+      sessionID: SESSION_B,
+      channelID: 'ch-test',
+      directory: DIRECTORY,
+      request: req8b,
+      effects: makeEffectsFor('req-8b'),
+    })
+
+    expect(reg.pending()).toHaveLength(2)
+
+    // #when — shutdown drain
+    const drainStart = Date.now()
+    await reg.disposeAll('gateway shutdown')
+    const drainMs = Date.now() - drainStart
+
+    // #then — resolved promptly (no await on never-arriving reply)
+    expect(drainMs).toBeLessThan(200)
+
+    // All entries gone
+    expect(reg.pending()).toHaveLength(0)
+    expect(reg.has('req-8a')).toBe(false)
+    expect(reg.has('req-8b')).toBe(false)
+
+    // renderSettled called for each entry (disposed reason)
+    expect(renderDrain).toHaveLength(2)
+    expect(renderDrain.every(c => c.reason === 'disposed')).toBe(true)
+
+    // postReply called with reject for each (best-effort fail-closed)
+    expect(postReplyDrain.every(c => c.decision === 'reject')).toBe(true)
+  })
+})

--- a/packages/gateway/src/approvals/approval-flow.integration.test.ts
+++ b/packages/gateway/src/approvals/approval-flow.integration.test.ts
@@ -5,15 +5,22 @@
  * side-effects (captured calls, no Discord / HTTP) and drives them with
  * synthesised OpenCode events.
  *
+ * ### register-before-send pattern (new)
+ *
+ * `onPending` now:
+ *   1. Calls `registry.register(...)` immediately (before any Discord send).
+ *   2. "Sends" the embed (simulated here by immediately calling `attachMessage`).
+ *   3. Calls `registry.attachMessage(requestID, renderFn)` on success.
+ *
  * Fake effects:
  *   postReply    — records { requestID, directory, decision } per call
- *   renderSettled — records { request, decision, decidedBy, reason } per call
+ *   renderFn     — records { request, decision, decidedBy, reason } per call
  *
  * All timer-sensitive tests use `vi.useFakeTimers()` to control deadline firing.
  */
 
-import type {PermissionReplyEvent, PermissionRequest, SettlementReason} from './coordinator.js'
-import type {RegisterParams} from './registry.js'
+import type {PermissionReply, PermissionReplyEvent, PermissionRequest} from './coordinator.js'
+import type {ApprovalSideEffects, RegisterParams} from './registry.js'
 
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {createPermissionCoordinator} from './coordinator.js'
@@ -33,7 +40,7 @@ interface PostReplyCall {
   decision: string
 }
 
-interface RenderSettledCall {
+interface RenderCall {
   request: PermissionRequest
   decision: string
   decidedBy: string | null
@@ -47,23 +54,27 @@ function makeLogger() {
 /** Build fake side-effects and return call-capture arrays + factory */
 function makeFakeEffects() {
   const postReplyCalls: PostReplyCall[] = []
-  const renderSettledCalls: RenderSettledCall[] = []
+  const renderCalls: RenderCall[] = []
 
-  function makeEffectsFor(_requestID: string) {
-    return {
-      postReply: vi.fn(async (requestID: string, directory: string, decision: string) => {
+  function makeEffectsFor(_requestID: string): {
+    effects: ApprovalSideEffects
+    renderFn: (request: PermissionRequest, decision: string, decidedBy: string | null, reason: string) => Promise<void>
+  } {
+    const effects: ApprovalSideEffects = {
+      postReply: vi.fn(async (requestID: string, directory: string, decision: PermissionReply) => {
         postReplyCalls.push({requestID, directory, decision})
         return {ok: true}
       }),
-      renderSettled: vi.fn(
-        async (request: PermissionRequest, decision: string, decidedBy: string | null, reason: string) => {
-          renderSettledCalls.push({request, decision, decidedBy, reason})
-        },
-      ),
     }
+    const renderFn = vi.fn(
+      async (request: PermissionRequest, decision: string, decidedBy: string | null, reason: string) => {
+        renderCalls.push({request, decision, decidedBy, reason})
+      },
+    )
+    return {effects, renderFn}
   }
 
-  return {postReplyCalls, renderSettledCalls, makeEffectsFor}
+  return {postReplyCalls, renderCalls, makeEffectsFor}
 }
 
 function makeRequest(id: string, sessionID: string = SESSION_A): PermissionRequest {
@@ -81,13 +92,18 @@ function makeReplyEvent(
 /** Wire coordinator + registry together, return both + fake-effects captures */
 function setup(deadlineMs?: number) {
   const logger = makeLogger()
-  const {postReplyCalls, renderSettledCalls, makeEffectsFor} = makeFakeEffects()
+  const {postReplyCalls, renderCalls, makeEffectsFor} = makeFakeEffects()
 
   const registry = createApprovalRegistry({logger})
 
-  /** Simulate what run.ts's onPending does */
+  /**
+   * Simulate what run.ts's onPending does with the register-before-send pattern:
+   * 1. register immediately (with deadlineMs — registry owns the timer)
+   * 2. "send" the embed (instant in test)
+   * 3. attachMessage with the renderFn
+   */
   function onPending(request: PermissionRequest) {
-    const effects = makeEffectsFor(request.requestID)
+    const {effects, renderFn} = makeEffectsFor(request.requestID)
     const params: RegisterParams = {
       requestID: request.requestID,
       sessionID: request.sessionID,
@@ -95,29 +111,29 @@ function setup(deadlineMs?: number) {
       directory: DIRECTORY,
       request,
       effects,
+      deadlineMs, // registry owns the deadline timer
     }
+    // Step 1: register before send
     registry.register(params)
-  }
-
-  /** Simulate what run.ts's onSettled does */
-  function onSettled(requestID: string, decision: string, reason: string) {
-    registry
-      .applySettlement({
-        requestID,
-        decision: decision as 'once' | 'always' | 'reject',
-        reason: reason as SettlementReason,
-      })
-      .catch(() => undefined)
+    // Step 2 & 3: simulate successful embed send → attachMessage
+    registry.attachMessage(request.requestID, renderFn)
   }
 
   const coordinator = createPermissionCoordinator({
     logger,
     onPending,
-    onSettled,
-    deadlineMs,
+    // New API: forward permission.replied to registry.confirmReply (owns rendering + cascade)
+    onReplied: event => {
+      registry.confirmReply(event)
+    },
+    // onDispose: fail-close registry entries for this run
+    onDispose: sessionIDs => {
+      // eslint-disable-next-line no-void
+      void Promise.all(sessionIDs.map(async sid => registry.disposeRun(sid, 'run ended')))
+    },
   })
 
-  return {coordinator, registry, postReplyCalls, renderSettledCalls}
+  return {coordinator, registry, postReplyCalls, renderCalls}
 }
 
 // ---------------------------------------------------------------------------
@@ -137,7 +153,7 @@ describe('approval flow — cross-seam integration', () => {
 
   it('approve path: postReply called exactly once with query.directory; permission.replied settles without second postReply', async () => {
     // #given
-    const {coordinator, registry, postReplyCalls, renderSettledCalls} = setup()
+    const {coordinator, registry, postReplyCalls, renderCalls} = setup()
     const req = makeRequest('req-1')
 
     // #when — permission.asked → register into coordinator + registry
@@ -166,12 +182,12 @@ describe('approval flow — cross-seam integration', () => {
     await vi.runAllTimersAsync()
     await replyPromise
 
-    // #then — no second postReply (applySettlement skips postReply for 'replied' reason when entry is claimed)
+    // #then — no second postReply (applySettlement skips postReply since state is 'confirmed')
     expect(postReplyCalls).toHaveLength(1)
 
-    // renderSettled called once
-    expect(renderSettledCalls).toHaveLength(1)
-    expect(renderSettledCalls[0]).toMatchObject({decision: 'once', reason: 'replied'})
+    // renderFn called once
+    expect(renderCalls).toHaveLength(1)
+    expect(renderCalls[0]).toMatchObject({decision: 'once', reason: 'replied'})
 
     // Entry is gone
     expect(registry.pending()).not.toContain('req-1')
@@ -182,7 +198,7 @@ describe('approval flow — cross-seam integration', () => {
 
   it('deny path: postReply once with "reject"; permission.replied{reject} settles once, no second postReply', async () => {
     // #given
-    const {coordinator, registry, postReplyCalls, renderSettledCalls} = setup()
+    const {coordinator, registry, postReplyCalls, renderCalls} = setup()
     const req = makeRequest('req-2')
 
     const replyPromise = coordinator.onPermissionAsked(req)
@@ -205,8 +221,8 @@ describe('approval flow — cross-seam integration', () => {
 
     // #then — no second postReply
     expect(postReplyCalls).toHaveLength(1)
-    expect(renderSettledCalls).toHaveLength(1)
-    expect(renderSettledCalls[0]).toMatchObject({decision: 'reject', reason: 'replied'})
+    expect(renderCalls).toHaveLength(1)
+    expect(renderCalls[0]).toMatchObject({decision: 'reject', reason: 'replied'})
     expect(registry.pending()).not.toContain('req-2')
   })
 
@@ -249,18 +265,17 @@ describe('approval flow — cross-seam integration', () => {
 
     const p4 = coordinator.onPermissionAsked(req)
 
-    // Advance past deadline
+    // Advance past deadline — registry timer fires (not coordinator)
     await vi.advanceTimersByTimeAsync(200)
-
-    // Deadline fires: coordinator should have disposed / rejected
-    // Give any pending microtasks a chance to settle
     await vi.runAllTimersAsync()
-    await p4
 
-    // The deadline path posts a fail-closed reject via onSettled → applySettlement → postReply
-    // (only if entry is not already claimed)
-    // Let's check pending is now empty (entry removed after deadline settlement)
+    // Registry has handled the deadline (reject + render + delete)
     expect(registry.has('req-4')).toBe(false)
+
+    // Coordinator's promise is still pending (deadline is now in registry, not coordinator).
+    // Dispose to resolve it fail-closed (simulating run end).
+    coordinator.dispose('run ended after deadline')
+    await p4
 
     const postRepliesAfterDeadline = postReplyCalls.length
 
@@ -312,7 +327,7 @@ describe('approval flow — cross-seam integration', () => {
 
   it('reject cascade: two same-session asks → reject one → both entries settled, both embeds rendered', async () => {
     // #given
-    const {coordinator, registry, postReplyCalls, renderSettledCalls} = setup()
+    const {coordinator, registry, postReplyCalls, renderCalls} = setup()
     const req6a = makeRequest('req-6a', SESSION_A)
     const req6b = makeRequest('req-6b', SESSION_A)
 
@@ -323,8 +338,12 @@ describe('approval flow — cross-seam integration', () => {
     expect(registry.pending()).toContain('req-6b')
 
     // #when — permission.replied{reject} for req-6a
+    // Registry cascade settles req-6b (render + POST). Coordinator still has p6b pending.
+    // Simulate the server-side cascade reply for req-6b to resolve the coordinator promise.
     coordinator.onPermissionReplied(makeReplyEvent('req-6a', 'reject'))
     await vi.runAllTimersAsync()
+    // Simulate OpenCode's server-side cascade reply for req-6b (registry entry already gone → no-op in registry)
+    coordinator.onPermissionReplied(makeReplyEvent('req-6b', 'reject'))
     await Promise.all([p6a, p6b])
 
     // #then — both entries settled
@@ -332,14 +351,14 @@ describe('approval flow — cross-seam integration', () => {
     expect(registry.has('req-6b')).toBe(false)
     expect(registry.pending()).toHaveLength(0)
 
-    // renderSettled called for both — one 'replied', one 'cascade'
-    expect(renderSettledCalls).toHaveLength(2)
-    const reasons = renderSettledCalls.map(c => c.reason)
+    // renderFn called for both — one 'replied', one 'cascade'
+    expect(renderCalls).toHaveLength(2)
+    const reasons = renderCalls.map(c => c.reason)
     expect(reasons).toContain('replied')
     expect(reasons).toContain('cascade')
 
-    // postReply: req-6a was settled via 'replied' (claimed=false → best-effort postReply).
-    // req-6b: cascade also calls best-effort postReply (claimed=false).
+    // postReply: req-6a was settled via 'replied' (state=open → best-effort postReply).
+    // req-6b: cascade also calls best-effort postReply (state=open).
     // Both should be reject.
     expect(postReplyCalls.every(c => c.decision === 'reject')).toBe(true)
   })
@@ -357,6 +376,10 @@ describe('approval flow — cross-seam integration', () => {
     // #when — advance past deadline, no reply ever
     await vi.advanceTimersByTimeAsync(500)
     await vi.runAllTimersAsync()
+
+    // Registry deadline has fired and cleaned up the entry.
+    // Coordinator promise is still pending — dispose it (simulating run end/timeout).
+    coordinator.dispose('deadline elapsed, run ended')
     await p7
 
     // #then — pending() is empty (no hang)
@@ -376,23 +399,30 @@ describe('approval flow — cross-seam integration', () => {
     const logger = makeLogger()
     const reg = createApprovalRegistry({logger})
 
-    const {makeEffectsFor, postReplyCalls: postReplyDrain, renderSettledCalls: renderDrain} = makeFakeEffects()
+    const {makeEffectsFor, postReplyCalls: postReplyDrain, renderCalls: renderDrain} = makeFakeEffects()
+
+    const e8a = makeEffectsFor('req-8a')
+    const e8b = makeEffectsFor('req-8b')
+
     reg.register({
       requestID: 'req-8a',
       sessionID: SESSION_A,
       channelID: 'ch-test',
       directory: DIRECTORY,
       request: req8a,
-      effects: makeEffectsFor('req-8a'),
+      effects: e8a.effects,
     })
+    reg.attachMessage('req-8a', e8a.renderFn)
+
     reg.register({
       requestID: 'req-8b',
       sessionID: SESSION_B,
       channelID: 'ch-test',
       directory: DIRECTORY,
       request: req8b,
-      effects: makeEffectsFor('req-8b'),
+      effects: e8b.effects,
     })
+    reg.attachMessage('req-8b', e8b.renderFn)
 
     expect(reg.pending()).toHaveLength(2)
 
@@ -409,11 +439,233 @@ describe('approval flow — cross-seam integration', () => {
     expect(reg.has('req-8a')).toBe(false)
     expect(reg.has('req-8b')).toBe(false)
 
-    // renderSettled called for each entry (disposed reason)
+    // renderFn called for each entry (disposed reason)
     expect(renderDrain).toHaveLength(2)
     expect(renderDrain.every(c => c.reason === 'disposed')).toBe(true)
 
     // postReply called with reject for each (best-effort fail-closed)
     expect(postReplyDrain.every(c => c.decision === 'reject')).toBe(true)
+  })
+
+  // ── REQUIRED CROSS-OWNER RACE TESTS ─────────────────────────────────────────
+
+  // R1. Button approve in-flight → deadline fires → deadline LOSES
+  it('race: button approve in-flight when deadline fires → deadline is no-op; confirmReply renders APPROVED exactly once; reject POST never sent', async () => {
+    // #given — deadline wired into registry; postReply for approve is controllable
+    const logger = makeLogger()
+    const {renderCalls, makeEffectsFor} = makeFakeEffects()
+    const postReplyCalls: PostReplyCall[] = []
+
+    // Use a deferred postReply so we can hold the button approve in-flight
+    let resolvePostReply!: (v: {ok: boolean}) => void
+    const heldPostReply = new Promise<{ok: boolean}>(res => {
+      resolvePostReply = res
+    })
+
+    const registry = createApprovalRegistry({logger})
+
+    const req = makeRequest('req-r1')
+    const {renderFn} = makeEffectsFor('req-r1')
+
+    const heldEffects: ApprovalSideEffects = {
+      postReply: vi.fn(async (requestID: string, directory: string, decision: PermissionReply) => {
+        postReplyCalls.push({requestID, directory, decision})
+        return heldPostReply
+      }),
+    }
+
+    const DEADLINE_MS = 200
+    registry.register({
+      requestID: req.requestID,
+      sessionID: req.sessionID,
+      channelID: 'ch-test',
+      directory: DIRECTORY,
+      request: req,
+      effects: heldEffects,
+      deadlineMs: DEADLINE_MS,
+    })
+    registry.attachMessage(req.requestID, renderFn)
+
+    // #when — button approve claims the entry (postReply is in-flight, not yet resolved)
+    const buttonPromise = registry.handleButtonDecision({
+      requestID: req.requestID,
+      channelID: 'ch-test',
+      decision: 'once',
+      decidedBy: 'user-approved',
+    })
+
+    // Advance past the deadline while button POST is still in-flight
+    await vi.advanceTimersByTimeAsync(DEADLINE_MS + 100)
+
+    // #then — deadline does NOT render denied and does NOT delete entry
+    // (entry is still claimed by the button winner)
+    expect(renderCalls).toHaveLength(0)
+    expect(registry.has(req.requestID)).toBe(true)
+
+    // Reject POSTs: the deadline must not have called postReply (only the button did)
+    const rejectPosts = postReplyCalls.filter(c => c.decision === 'reject')
+    expect(rejectPosts).toHaveLength(0)
+
+    // Now resolve the approve POST — button click succeeds
+    resolvePostReply({ok: true})
+    await buttonPromise
+
+    // Deliver permission.replied('once') — OpenCode's authoritative echo
+    registry.confirmReply({requestID: req.requestID, sessionID: req.sessionID, reply: 'once'})
+    await vi.runAllTimersAsync()
+
+    // #then — renders APPROVED exactly once
+    expect(renderCalls).toHaveLength(1)
+    expect(renderCalls[0]).toMatchObject({decision: 'once'})
+
+    // No reject POST ever sent
+    const finalRejectPosts = postReplyCalls.filter(c => c.decision === 'reject')
+    expect(finalRejectPosts).toHaveLength(0)
+
+    // Entry is cleaned up
+    expect(registry.has(req.requestID)).toBe(false)
+  })
+
+  // R2. Deadline fires on OPEN entry (no button) → renders denied + posts reject once
+  it('race: deadline fires on open entry → rejected via POST + rendered denied + entry deleted', async () => {
+    // #given
+    const logger = makeLogger()
+    const {postReplyCalls, renderCalls, makeEffectsFor} = makeFakeEffects()
+    const registry = createApprovalRegistry({logger})
+
+    const req = makeRequest('req-r2')
+    const {effects, renderFn} = makeEffectsFor('req-r2')
+
+    registry.register({
+      requestID: req.requestID,
+      sessionID: req.sessionID,
+      channelID: 'ch-test',
+      directory: DIRECTORY,
+      request: req,
+      effects,
+      deadlineMs: 100,
+    })
+    registry.attachMessage(req.requestID, renderFn)
+
+    // #when — advance past deadline, no button click
+    await vi.advanceTimersByTimeAsync(500)
+    await vi.runAllTimersAsync()
+
+    // #then — reject POST + denied render + entry deleted
+    expect(postReplyCalls.some(c => c.decision === 'reject')).toBe(true)
+    expect(renderCalls).toHaveLength(1)
+    expect(renderCalls[0]).toMatchObject({decision: 'reject'})
+    expect(registry.has(req.requestID)).toBe(false)
+  })
+
+  // R3. permission.replied swallow regression: deadline must not prevent a later confirmReply from rendering
+  it('swallow regression: after deadline no-ops on claimed entry, confirmReply still renders', async () => {
+    // #given — same as R1 but we just verify the render path after the race
+    const logger = makeLogger()
+    const {renderCalls, makeEffectsFor} = makeFakeEffects()
+    let resolvePost!: (v: {ok: boolean}) => void
+    const heldPost = new Promise<{ok: boolean}>(res => {
+      resolvePost = res
+    })
+    const registry = createApprovalRegistry({logger})
+    const req = makeRequest('req-r3')
+    const {renderFn} = makeEffectsFor('req-r3')
+
+    registry.register({
+      requestID: req.requestID,
+      sessionID: req.sessionID,
+      channelID: 'ch-test',
+      directory: DIRECTORY,
+      request: req,
+      effects: {postReply: vi.fn().mockReturnValue(heldPost)},
+      deadlineMs: 150,
+    })
+    registry.attachMessage(req.requestID, renderFn)
+
+    const buttonPromise = registry.handleButtonDecision({
+      requestID: req.requestID,
+      channelID: 'ch-test',
+      decision: 'once',
+      decidedBy: 'user-approved',
+    })
+
+    // Deadline fires while in-flight
+    await vi.advanceTimersByTimeAsync(300)
+
+    // Deadline must not have rendered
+    expect(renderCalls).toHaveLength(0)
+
+    // Resolve POST and deliver confirmReply
+    resolvePost({ok: true})
+    await buttonPromise
+
+    registry.confirmReply({requestID: req.requestID, sessionID: req.sessionID, reply: 'once'})
+    await vi.runAllTimersAsync()
+
+    // #then — exactly one render (approved), not swallowed
+    expect(renderCalls).toHaveLength(1)
+    expect(renderCalls[0]).toMatchObject({decision: 'once'})
+    expect(registry.has(req.requestID)).toBe(false)
+  })
+
+  // 9. register-before-send: entry is immediately available in registry
+  //    even before the embed "send" completes (async attach)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('register-before-send: entry visible in registry before attachMessage resolves', async () => {
+    // #given a registry + coordinator wired together
+    const logger = makeLogger()
+    const reg = createApprovalRegistry({logger})
+
+    // Capture registrations to assert ordering
+    const registeredBeforeAttach: string[] = []
+
+    const coordinator = createPermissionCoordinator({
+      logger,
+      onPending: request => {
+        const {effects, renderFn} = makeFakeEffects().makeEffectsFor(request.requestID)
+        // Step 1: register immediately — entry should be visible NOW
+        reg.register({
+          requestID: request.requestID,
+          sessionID: request.sessionID,
+          channelID: 'ch-test',
+          directory: DIRECTORY,
+          request,
+          effects,
+        })
+        // Capture state BEFORE attachMessage
+        registeredBeforeAttach.push(request.requestID)
+        expect(reg.has(request.requestID)).toBe(true)
+
+        // Step 2: attach message async (simulated as microtask)
+        Promise.resolve()
+          .then(() => {
+            reg.attachMessage(request.requestID, renderFn)
+          })
+          .catch(() => undefined)
+      },
+      onSettled: (requestID, decision, reason) => {
+        reg
+          .applySettlement({
+            requestID,
+            decision,
+            reason,
+          })
+          .catch(() => undefined)
+      },
+    })
+
+    const req = makeRequest('req-9')
+    // #when onPermissionAsked fires (onPending is invoked synchronously inside)
+    const replyPromise = coordinator.onPermissionAsked(req)
+
+    // #then — entry was registered before the async embed attach
+    expect(registeredBeforeAttach).toContain('req-9')
+    expect(reg.has('req-9')).toBe(true)
+
+    // Cleanup
+    coordinator.onPermissionReplied(makeReplyEvent('req-9', 'once'))
+    await vi.runAllTimersAsync()
+    await replyPromise
   })
 })

--- a/packages/gateway/src/approvals/coordinator.test.ts
+++ b/packages/gateway/src/approvals/coordinator.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for the permission approval coordinator.
+ *
+ * Convention: `as unknown as <Type>` for test doubles is permitted per gateway
+ * test pattern. No real SDK client or Discord client is constructed here.
+ */
+
+import type {GatewayLogger} from '../discord/client.js'
+import type {PermissionReply, PermissionRequest, SettlementReason} from './coordinator.js'
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createPermissionCoordinator, parsePermissionReply, parsePermissionRequest} from './coordinator.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeLogger(): GatewayLogger {
+  return {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+}
+
+function makeRequest(overrides: Partial<PermissionRequest> = {}): PermissionRequest {
+  return {
+    requestID: 'per_1',
+    sessionID: 'ses_1',
+    permission: 'external_directory',
+    patterns: ['/tmp/x/*'],
+    title: 'Access outside workspace: /tmp/x/secret.txt',
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Parsers
+// ---------------------------------------------------------------------------
+
+describe('parsePermissionRequest', () => {
+  it('parses a well-formed permission.asked payload', () => {
+    // #given a real-shaped properties payload (probe 4367)
+    const payload = {
+      id: 'per_e871',
+      sessionID: 'ses_178e',
+      permission: 'external_directory',
+      patterns: ['/tmp/oc-iso-outside/*'],
+      metadata: {filepath: '/tmp/oc-iso-outside/secret.txt', parentDir: '/tmp/oc-iso-outside'},
+    }
+    // #when parsed
+    const result = parsePermissionRequest(payload)
+    // #then all fields map and the title is redaction-safe + descriptive
+    expect(result).not.toBeNull()
+    expect(result?.requestID).toBe('per_e871')
+    expect(result?.sessionID).toBe('ses_178e')
+    expect(result?.permission).toBe('external_directory')
+    expect(result?.patterns).toEqual(['/tmp/oc-iso-outside/*'])
+    expect(result?.title).toContain('/tmp/oc-iso-outside/secret.txt')
+  })
+
+  it('returns null when requestID (id) is missing', () => {
+    const result = parsePermissionRequest({sessionID: 'ses_1', permission: 'bash'})
+    expect(result).toBeNull()
+  })
+
+  it('returns null when sessionID is missing', () => {
+    const result = parsePermissionRequest({id: 'per_1', permission: 'bash'})
+    expect(result).toBeNull()
+  })
+
+  it('falls back to a safe title when metadata/patterns are absent', () => {
+    // #given a request with an unknown gate and no metadata
+    const result = parsePermissionRequest({id: 'per_1', sessionID: 'ses_1', permission: 'webfetch'})
+    // #then it does not throw and yields a bare-category title
+    expect(result?.permission).toBe('webfetch')
+    expect(result?.patterns).toEqual([])
+    expect(result?.title).toBe('webfetch')
+  })
+
+  it('defaults permission to "unknown" when the field is absent', () => {
+    const result = parsePermissionRequest({id: 'per_1', sessionID: 'ses_1'})
+    expect(result?.permission).toBe('unknown')
+  })
+
+  it('builds a command title for the bash gate', () => {
+    const result = parsePermissionRequest({
+      id: 'per_1',
+      sessionID: 'ses_1',
+      permission: 'bash',
+      metadata: {command: 'rm -rf /tmp/x'},
+    })
+    expect(result?.title).toBe('Run command: rm -rf /tmp/x')
+  })
+})
+
+describe('parsePermissionReply', () => {
+  it('parses a well-formed permission.replied payload', () => {
+    const result = parsePermissionReply({sessionID: 'ses_1', requestID: 'per_1', reply: 'once'})
+    expect(result).toEqual({sessionID: 'ses_1', requestID: 'per_1', reply: 'once'})
+  })
+
+  it.each(['once', 'always', 'reject'] as const)('accepts the "%s" reply verb', verb => {
+    const result = parsePermissionReply({sessionID: 'ses_1', requestID: 'per_1', reply: verb})
+    expect(result?.reply).toBe(verb)
+  })
+
+  it('returns null for an out-of-allowlist reply verb', () => {
+    // #given a hostile/invalid verb (the action enum, not OpenCode's)
+    const result = parsePermissionReply({sessionID: 'ses_1', requestID: 'per_1', reply: 'allow'})
+    // #then it is rejected — only once|always|reject are valid
+    expect(result).toBeNull()
+  })
+
+  it('returns null when requestID is missing', () => {
+    const result = parsePermissionReply({sessionID: 'ses_1', reply: 'once'})
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Coordinator — settlement
+// ---------------------------------------------------------------------------
+
+describe('createPermissionCoordinator', () => {
+  it('settles a pending request with "once" on permission.replied', async () => {
+    // #given a registered request
+    const coordinator = createPermissionCoordinator({logger: makeLogger()})
+    const request = makeRequest()
+    const promise = coordinator.onPermissionAsked(request)
+    expect(coordinator.pending()).toEqual(['per_1'])
+    // #when an authoritative reply arrives
+    coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'per_1', reply: 'once'})
+    // #then the promise resolves with the reply and the entry is no longer pending
+    await expect(promise).resolves.toBe('once')
+    expect(coordinator.pending()).toEqual([])
+  })
+
+  it('settles with "reject" on a reject reply', async () => {
+    const coordinator = createPermissionCoordinator({logger: makeLogger()})
+    const promise = coordinator.onPermissionAsked(makeRequest())
+    coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'per_1', reply: 'reject'})
+    await expect(promise).resolves.toBe('reject')
+  })
+
+  it('cascade-rejects sibling open requests in the same session on reject', async () => {
+    // #given two open requests in the same session and one in another
+    const coordinator = createPermissionCoordinator({logger: makeLogger()})
+    const a = coordinator.onPermissionAsked(makeRequest({requestID: 'per_a', sessionID: 'ses_1'}))
+    const b = coordinator.onPermissionAsked(makeRequest({requestID: 'per_b', sessionID: 'ses_1'}))
+    const other = coordinator.onPermissionAsked(makeRequest({requestID: 'per_c', sessionID: 'ses_2'}))
+    // #when one of the same-session requests is rejected
+    coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'per_a', reply: 'reject'})
+    // #then both same-session requests settle reject; the other session is untouched
+    await expect(a).resolves.toBe('reject')
+    await expect(b).resolves.toBe('reject')
+    expect(coordinator.pending()).toEqual(['per_c'])
+    coordinator.onPermissionReplied({sessionID: 'ses_2', requestID: 'per_c', reply: 'once'})
+    await expect(other).resolves.toBe('once')
+  })
+
+  it('does NOT cascade siblings on an "once" reply', async () => {
+    const coordinator = createPermissionCoordinator({logger: makeLogger()})
+    const a = coordinator.onPermissionAsked(makeRequest({requestID: 'per_a', sessionID: 'ses_1'}))
+    // eslint-disable-next-line no-void
+    void coordinator.onPermissionAsked(makeRequest({requestID: 'per_b', sessionID: 'ses_1'}))
+    coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'per_a', reply: 'once'})
+    await expect(a).resolves.toBe('once')
+    // #then the sibling remains open
+    expect(coordinator.pending()).toEqual(['per_b'])
+  })
+
+  it('is a no-op for a reply to an unknown requestID', () => {
+    const logger = makeLogger()
+    const coordinator = createPermissionCoordinator({logger})
+    // #when replying to something never registered
+    coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'ghost', reply: 'once'})
+    // #then nothing throws and nothing is pending
+    expect(coordinator.pending()).toEqual([])
+  })
+
+  it('is a no-op for a duplicate reply to an already-settled request', async () => {
+    const coordinator = createPermissionCoordinator({logger: makeLogger()})
+    const promise = coordinator.onPermissionAsked(makeRequest())
+    coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'per_1', reply: 'once'})
+    await expect(promise).resolves.toBe('once')
+    // #when a second reply arrives for the same id — must not throw or double-settle
+    expect(() =>
+      coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'per_1', reply: 'reject'}),
+    ).not.toThrow()
+  })
+
+  it('tracks N concurrent independent requests', async () => {
+    const coordinator = createPermissionCoordinator({logger: makeLogger()})
+    const a = coordinator.onPermissionAsked(makeRequest({requestID: 'per_a', sessionID: 'ses_1'}))
+    const b = coordinator.onPermissionAsked(makeRequest({requestID: 'per_b', sessionID: 'ses_2'}))
+    expect(coordinator.pending()).toEqual(['per_a', 'per_b'])
+    coordinator.onPermissionReplied({sessionID: 'ses_2', requestID: 'per_b', reply: 'once'})
+    await expect(b).resolves.toBe('once')
+    expect(coordinator.pending()).toEqual(['per_a'])
+    coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'per_a', reply: 'reject'})
+    await expect(a).resolves.toBe('reject')
+  })
+
+  it('reuses the pending promise for a duplicate permission.asked', async () => {
+    // #given the same requestID asked twice while open
+    const coordinator = createPermissionCoordinator({logger: makeLogger()})
+    const first = coordinator.onPermissionAsked(makeRequest())
+    const second = coordinator.onPermissionAsked(makeRequest())
+    // #then only one entry is pending
+    expect(coordinator.pending()).toEqual(['per_1'])
+    // #when settled, BOTH awaiters resolve
+    coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'per_1', reply: 'once'})
+    await expect(first).resolves.toBe('once')
+    await expect(second).resolves.toBe('once')
+  })
+
+  // ── callbacks ──────────────────────────────────────────────────────────────
+
+  it('invokes onPending when a request registers and onSettled when it settles', async () => {
+    const onPending = vi.fn()
+    const settled: [string, PermissionReply, SettlementReason][] = []
+    const coordinator = createPermissionCoordinator({
+      logger: makeLogger(),
+      onPending,
+      onSettled: (id, reply, reason) => settled.push([id, reply, reason]),
+    })
+    const promise = coordinator.onPermissionAsked(makeRequest())
+    expect(onPending).toHaveBeenCalledOnce()
+    coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'per_1', reply: 'once'})
+    await promise
+    expect(settled).toEqual([['per_1', 'once', 'replied']])
+  })
+
+  it('reports "cascade" reason for siblings settled by a reject', async () => {
+    const settled: [string, PermissionReply, SettlementReason][] = []
+    const coordinator = createPermissionCoordinator({
+      logger: makeLogger(),
+      onSettled: (id, reply, reason) => settled.push([id, reply, reason]),
+    })
+    // eslint-disable-next-line no-void
+    void coordinator.onPermissionAsked(makeRequest({requestID: 'per_a', sessionID: 'ses_1'}))
+    // eslint-disable-next-line no-void
+    void coordinator.onPermissionAsked(makeRequest({requestID: 'per_b', sessionID: 'ses_1'}))
+    coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'per_a', reply: 'reject'})
+    await Promise.resolve()
+    expect(settled).toContainEqual(['per_a', 'reject', 'replied'])
+    expect(settled).toContainEqual(['per_b', 'reject', 'cascade'])
+  })
+
+  it('does not let a throwing onPending callback break registration', () => {
+    const logger = makeLogger()
+    const coordinator = createPermissionCoordinator({
+      logger,
+      onPending: () => {
+        throw new Error('render failed')
+      },
+    })
+    expect(async () => coordinator.onPermissionAsked(makeRequest())).not.toThrow()
+    expect(coordinator.pending()).toEqual(['per_1'])
+    expect(logger.error).toHaveBeenCalled()
+  })
+
+  // ── dispose ──────────────────────────────────────────────────────────────
+
+  it('fail-closes all open requests on dispose', async () => {
+    const coordinator = createPermissionCoordinator({logger: makeLogger()})
+    const a = coordinator.onPermissionAsked(makeRequest({requestID: 'per_a', sessionID: 'ses_1'}))
+    const b = coordinator.onPermissionAsked(makeRequest({requestID: 'per_b', sessionID: 'ses_2'}))
+    coordinator.dispose('run teardown')
+    await expect(a).resolves.toBe('reject')
+    await expect(b).resolves.toBe('reject')
+    expect(coordinator.pending()).toEqual([])
+  })
+
+  // ── deadline (fake timers) ───────────────────────────────────────────────
+
+  describe('with a per-request deadline', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it('fail-closes to reject when the deadline expires', async () => {
+      const coordinator = createPermissionCoordinator({logger: makeLogger(), deadlineMs: 60_000})
+      const promise = coordinator.onPermissionAsked(makeRequest())
+      // #when the deadline elapses with no reply
+      await vi.advanceTimersByTimeAsync(60_000)
+      // #then the entry fail-closes to reject
+      await expect(promise).resolves.toBe('reject')
+      expect(coordinator.pending()).toEqual([])
+    })
+
+    it('a reply before the deadline wins and clears the timer', async () => {
+      const onSettled = vi.fn()
+      const coordinator = createPermissionCoordinator({logger: makeLogger(), deadlineMs: 60_000, onSettled})
+      const promise = coordinator.onPermissionAsked(makeRequest())
+      coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'per_1', reply: 'once'})
+      await expect(promise).resolves.toBe('once')
+      // #when the deadline would have fired — no second settlement occurs
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(onSettled).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/gateway/src/approvals/coordinator.test.ts
+++ b/packages/gateway/src/approvals/coordinator.test.ts
@@ -8,7 +8,7 @@
 import type {GatewayLogger} from '../discord/client.js'
 import type {PermissionReply, PermissionRequest, SettlementReason} from './coordinator.js'
 
-import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 
 import {createPermissionCoordinator, parsePermissionReply, parsePermissionRequest} from './coordinator.js'
 
@@ -140,20 +140,17 @@ describe('createPermissionCoordinator', () => {
     await expect(promise).resolves.toBe('reject')
   })
 
-  it('cascade-rejects sibling open requests in the same session on reject', async () => {
-    // #given two open requests in the same session and one in another
+  it('coordinator does NOT cascade siblings — cascade is owned by the registry', async () => {
+    // #given two open requests in the same session
     const coordinator = createPermissionCoordinator({logger: makeLogger()})
     const a = coordinator.onPermissionAsked(makeRequest({requestID: 'per_a', sessionID: 'ses_1'}))
-    const b = coordinator.onPermissionAsked(makeRequest({requestID: 'per_b', sessionID: 'ses_1'}))
-    const other = coordinator.onPermissionAsked(makeRequest({requestID: 'per_c', sessionID: 'ses_2'}))
-    // #when one of the same-session requests is rejected
+    // eslint-disable-next-line no-void
+    void coordinator.onPermissionAsked(makeRequest({requestID: 'per_b', sessionID: 'ses_1'}))
+    // #when one is rejected
     coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'per_a', reply: 'reject'})
-    // #then both same-session requests settle reject; the other session is untouched
     await expect(a).resolves.toBe('reject')
-    await expect(b).resolves.toBe('reject')
-    expect(coordinator.pending()).toEqual(['per_c'])
-    coordinator.onPermissionReplied({sessionID: 'ses_2', requestID: 'per_c', reply: 'once'})
-    await expect(other).resolves.toBe('once')
+    // #then the sibling remains open in the coordinator's local map (registry owns cascade)
+    expect(coordinator.pending()).toEqual(['per_b'])
   })
 
   it('does NOT cascade siblings on an "once" reply', async () => {
@@ -229,20 +226,99 @@ describe('createPermissionCoordinator', () => {
     expect(settled).toEqual([['per_1', 'once', 'replied']])
   })
 
-  it('reports "cascade" reason for siblings settled by a reject', async () => {
-    const settled: [string, PermissionReply, SettlementReason][] = []
-    const coordinator = createPermissionCoordinator({
-      logger: makeLogger(),
-      onSettled: (id, reply, reason) => settled.push([id, reply, reason]),
+  it('invokes onReplied (new API) when a request is replied', async () => {
+    const onReplied = vi.fn()
+    const coordinator = createPermissionCoordinator({logger: makeLogger(), onReplied})
+    const promise = coordinator.onPermissionAsked(makeRequest())
+    coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'per_1', reply: 'once'})
+    await promise
+    expect(onReplied).toHaveBeenCalledExactlyOnceWith({sessionID: 'ses_1', requestID: 'per_1', reply: 'once'})
+  })
+
+  it('invokes onDispose with the collected sessionIDs when dispose is called', () => {
+    // #given a coordinator that has seen requests from two sessions
+    const onDispose = vi.fn()
+    const coordinator = createPermissionCoordinator({logger: makeLogger(), onDispose})
+    // eslint-disable-next-line no-void
+    void coordinator.onPermissionAsked(makeRequest({requestID: 'per_a', sessionID: 'ses_A'}))
+    // eslint-disable-next-line no-void
+    void coordinator.onPermissionAsked(makeRequest({requestID: 'per_b', sessionID: 'ses_B'}))
+    // #when disposed
+    coordinator.dispose('run ended')
+    // #then onDispose is called with the set of sessionIDs seen (NOT the reason string)
+    expect(onDispose).toHaveBeenCalledOnce()
+    const [sessionIDs] = onDispose.mock.calls[0] as [readonly string[]]
+    expect(sessionIDs).toHaveLength(2)
+    expect(sessionIDs).toContain('ses_A')
+    expect(sessionIDs).toContain('ses_B')
+  })
+
+  it('onDispose receives empty array when no requests were ever seen', () => {
+    // #given a coordinator that never saw any requests
+    const onDispose = vi.fn()
+    const coordinator = createPermissionCoordinator({logger: makeLogger(), onDispose})
+    // #when disposed with no prior requests
+    coordinator.dispose('run ended')
+    // #then onDispose is called with an empty array
+    expect(onDispose).toHaveBeenCalledExactlyOnceWith([])
+  })
+
+  it('concurrent-run isolation: disposing run A via coordinator+registry does NOT touch run B entries', async () => {
+    // #given a shared registry (program-scoped) with entries for two runs
+    const {createApprovalRegistry} = await import('./registry.js')
+
+    const logger = makeLogger()
+    const sharedRegistry = createApprovalRegistry({logger})
+
+    // Register run A's entry
+    const reqA: PermissionRequest = makeRequest({requestID: 'per_A', sessionID: 'ses_A'})
+    sharedRegistry.register({
+      requestID: 'per_A',
+      sessionID: 'ses_A',
+      channelID: 'chan_1',
+      directory: '/ws/a',
+      request: reqA,
+      effects: {postReply: vi.fn().mockResolvedValue({ok: true})},
+    })
+    // Register run B's entry (different sessionID, same shared registry)
+    const reqB: PermissionRequest = makeRequest({requestID: 'per_B', sessionID: 'ses_B'})
+    sharedRegistry.register({
+      requestID: 'per_B',
+      sessionID: 'ses_B',
+      channelID: 'chan_2',
+      directory: '/ws/b',
+      request: reqB,
+      effects: {postReply: vi.fn().mockResolvedValue({ok: true})},
+    })
+
+    expect(sharedRegistry.has('per_A')).toBe(true)
+    expect(sharedRegistry.has('per_B')).toBe(true)
+
+    // Build run A's coordinator wired to call disposeRun (the correct fix)
+    const coordinatorA = createPermissionCoordinator({
+      logger,
+      onDispose: sessionIDs => {
+        // eslint-disable-next-line no-void
+        void Promise.all(sessionIDs.map(async sid => sharedRegistry.disposeRun(sid, 'run ended')))
+      },
     })
     // eslint-disable-next-line no-void
-    void coordinator.onPermissionAsked(makeRequest({requestID: 'per_a', sessionID: 'ses_1'}))
-    // eslint-disable-next-line no-void
-    void coordinator.onPermissionAsked(makeRequest({requestID: 'per_b', sessionID: 'ses_1'}))
-    coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'per_a', reply: 'reject'})
-    await Promise.resolve()
-    expect(settled).toContainEqual(['per_a', 'reject', 'replied'])
-    expect(settled).toContainEqual(['per_b', 'reject', 'cascade'])
+    void coordinatorA.onPermissionAsked(reqA) // coordinator sees ses_A
+
+    // #when run A ends and its coordinator disposes
+    coordinatorA.dispose('run ended')
+
+    // Allow the async disposeRun to complete
+    await new Promise(r => setTimeout(r, 0))
+
+    // #then run A's entry is settled and removed
+    expect(sharedRegistry.has('per_A')).toBe(false)
+    // #then run B's entry is NOT touched — isolation holds
+    expect(sharedRegistry.has('per_B')).toBe(true)
+
+    // Cleanup: disposeAll still settles everything (shutdown semantics)
+    await sharedRegistry.disposeAll('gateway shutdown')
+    expect(sharedRegistry.has('per_B')).toBe(false)
   })
 
   it('does not let a throwing onPending callback break registration', () => {
@@ -268,33 +344,5 @@ describe('createPermissionCoordinator', () => {
     await expect(a).resolves.toBe('reject')
     await expect(b).resolves.toBe('reject')
     expect(coordinator.pending()).toEqual([])
-  })
-
-  // ── deadline (fake timers) ───────────────────────────────────────────────
-
-  describe('with a per-request deadline', () => {
-    beforeEach(() => vi.useFakeTimers())
-    afterEach(() => vi.useRealTimers())
-
-    it('fail-closes to reject when the deadline expires', async () => {
-      const coordinator = createPermissionCoordinator({logger: makeLogger(), deadlineMs: 60_000})
-      const promise = coordinator.onPermissionAsked(makeRequest())
-      // #when the deadline elapses with no reply
-      await vi.advanceTimersByTimeAsync(60_000)
-      // #then the entry fail-closes to reject
-      await expect(promise).resolves.toBe('reject')
-      expect(coordinator.pending()).toEqual([])
-    })
-
-    it('a reply before the deadline wins and clears the timer', async () => {
-      const onSettled = vi.fn()
-      const coordinator = createPermissionCoordinator({logger: makeLogger(), deadlineMs: 60_000, onSettled})
-      const promise = coordinator.onPermissionAsked(makeRequest())
-      coordinator.onPermissionReplied({sessionID: 'ses_1', requestID: 'per_1', reply: 'once'})
-      await expect(promise).resolves.toBe('once')
-      // #when the deadline would have fired — no second settlement occurs
-      await vi.advanceTimersByTimeAsync(60_000)
-      expect(onSettled).toHaveBeenCalledTimes(1)
-    })
   })
 })

--- a/packages/gateway/src/approvals/coordinator.ts
+++ b/packages/gateway/src/approvals/coordinator.ts
@@ -3,27 +3,28 @@
  *
  * Bridges OpenCode permission events to the Discord approval UI.
  * run-core registers a pending request on `permission.asked` and settles it on
- * `permission.replied` — the authoritative settlement signal, NOT the button
- * click alone.
+ * `permission.replied` — the authoritative settlement signal.
  *
  * Verified against the installed SDK @ 1.14.41:
  * - `permission.asked`   → `properties.id` IS the requestID; carries
  *   `sessionID`, `permission` (gate category), `patterns`, optional `metadata`.
  * - `permission.replied` → `properties.requestID` + `properties.reply`
  *   (`"once" | "always" | "reject"`).
- * - A `"reject"` reply CASCADES server-side: all other pending permissions in
- *   the SAME session are rejected. The coordinator mirrors that cascade so the
- *   sibling embeds are settled too.
  *
- * Ownership boundary:
- * - Owns: the in-memory registry (keyed by `requestID`), the pending promises,
- *   per-entry deadline timers, and same-session cascade reconciliation.
- * - Does NOT own: Discord rendering, the HTTP reply POST, S3, the lock, or
- *   run-state. The caller wires the embed renderer (`onPending`/`onSettled`) and
- *   posts the reply; run.ts owns run-abort on deadline.
+ * ### Ownership (post-refactor)
  *
- * A process restart abandons all entries — a controlled fail-closed (the
- * deadline / run teardown rejects pending tools), never a silent hang.
+ * The coordinator is now a **thin forwarder** with a minimal local promise map.
+ * ALL ownership of deadline timers, cascade, and settlement rendering has moved
+ * to the registry (`ApprovalRegistry`).
+ *
+ * - `onPermissionAsked`: stores a resolver; calls `onPending`; NO deadline timer.
+ * - `onPermissionReplied`: calls `onReplied` (wired to `registry.confirmReply`);
+ *   resolves the local promise; NO cascade here.
+ * - `dispose`: calls `onDispose` (wired to `registry.disposeRun`); resolves all
+ *   local promises to `'reject'`.
+ *
+ * A process restart abandons all entries — a controlled fail-closed, never a
+ * silent hang.
  */
 
 import type {GatewayLogger} from '../discord/client.js'
@@ -56,7 +57,7 @@ export interface PermissionReplyEvent {
   readonly reply: PermissionReply
 }
 
-/** Why a pending entry settled — surfaced to `onSettled` for embed updates. */
+/** Why a pending entry settled — surfaced to render functions for embed updates. */
 export type SettlementReason = 'replied' | 'cascade' | 'deadline' | 'disposed'
 
 /** Coordinator seam consumed by run-core and the run orchestrator. */
@@ -64,15 +65,15 @@ export interface PermissionCoordinator {
   /**
    * Register a pending request (called by run-core on `permission.asked`).
    * Returns a promise that resolves with the settled reply when
-   * `permission.replied` arrives, the deadline fires, or the run is disposed.
+   * `permission.replied` arrives or the run is disposed.
    * NEVER rejects — resolves `"reject"` on the fail-closed paths.
    * Idempotent: a duplicate requestID returns the existing pending promise.
    */
   onPermissionAsked: (request: PermissionRequest) => Promise<PermissionReply>
   /**
-   * Settle the matching entry (called by run-core on `permission.replied`).
-   * On a `"reject"` reply, cascade-settles every other open entry in the same
-   * session (the server already rejected them). No-op for unknown/settled IDs.
+   * Forward the authoritative reply (called by run-core on `permission.replied`).
+   * Calls `onReplied` (wired to `registry.confirmReply`). No cascade here —
+   * cascade is owned by the registry. No-op for unknown IDs.
    */
   onPermissionReplied: (event: PermissionReplyEvent) => void
   /** Open (unsettled) requestIDs — for SSE-drop reconciliation / debugging. */
@@ -86,20 +87,31 @@ export interface PermissionCoordinatorDeps {
   readonly logger: GatewayLogger
   /**
    * Invoked when a new request is registered. The caller renders the Discord
-   * approval embed here. Must not throw — wrapped defensively.
+   * approval embed here AND registers the entry in the approval registry
+   * (including deadlineMs — deadline ownership has moved to the registry).
+   * Must not throw — wrapped defensively.
    */
   readonly onPending?: (request: PermissionRequest) => void
   /**
-   * Invoked when an entry settles (any reason). The caller updates/withdraws the
-   * embed here. Must not throw — wrapped defensively.
+   * Invoked when `permission.replied` is received. The caller forwards this
+   * to `registry.confirmReply`. Must not throw — wrapped defensively.
+   * Replaces the old `onSettled` callback (settlement rendering is now in the
+   * registry's `confirmReply` path).
+   */
+  readonly onReplied?: (event: PermissionReplyEvent) => void
+  /**
+   * Invoked when `dispose` is called (run teardown). The caller should call
+   * `registry.disposeRun(sessionID, reason)` to fail-close registry entries.
+   * Must not throw — wrapped defensively.
+   */
+  readonly onDispose?: (sessionIDs: readonly string[]) => void
+  /**
+   * @deprecated Use `onReplied` instead. Kept for backward compatibility with
+   * existing call sites that pass `onSettled`. When present, called with
+   * (requestID, reply, reason) on `permission.replied` (reason is always
+   * 'replied' from the coordinator's perspective — cascade is in the registry).
    */
   readonly onSettled?: (requestID: string, reply: PermissionReply, reason: SettlementReason) => void
-  /**
-   * Optional per-request deadline (ms). On expiry the entry fail-closes to
-   * `"reject"`. Must be a sub-deadline of the run wall-clock; run.ts owns the
-   * actual run-abort. Omit to disable per-entry deadlines.
-   */
-  readonly deadlineMs?: number
 }
 
 // ---------------------------------------------------------------------------
@@ -178,23 +190,24 @@ export function parsePermissionReply(payload: unknown): PermissionReplyEvent | n
 }
 
 // ---------------------------------------------------------------------------
-// Coordinator
+// Coordinator (thin forwarder)
 // ---------------------------------------------------------------------------
 
+/** Minimal local entry — just enough to satisfy the pending promise. */
 interface Entry {
   readonly request: PermissionRequest
-  readonly resolve: (reply: PermissionReply) => void
-  settled: boolean
-  timer: ReturnType<typeof setTimeout> | null
+  resolve: (reply: PermissionReply) => void
 }
 
 /**
- * Create a permission coordinator. One instance per run; its registry is
- * scoped to that run (single-process gateway — no cross-replica concern).
+ * Create a permission coordinator. One instance per run; its local promise map
+ * is scoped to that run. Deadline, cascade, and rendering are owned by the registry.
  */
 export function createPermissionCoordinator(deps: PermissionCoordinatorDeps): PermissionCoordinator {
-  const {logger, onPending, onSettled, deadlineMs} = deps
-  const registry = new Map<string, Entry>()
+  const {logger, onPending, onReplied, onDispose, onSettled} = deps
+  const localMap = new Map<string, Entry>()
+  /** SessionIDs seen by this coordinator instance — used by onDispose. */
+  const ownedSessionIDs = new Set<string>()
 
   function notifyPending(request: PermissionRequest): void {
     if (onPending === undefined) return
@@ -208,58 +221,61 @@ export function createPermissionCoordinator(deps: PermissionCoordinatorDeps): Pe
     }
   }
 
-  function notifySettled(requestID: string, reply: PermissionReply, reason: SettlementReason): void {
-    if (onSettled === undefined) return
+  function notifyReplied(event: PermissionReplyEvent): void {
+    // Preferred path: onReplied (wired to registry.confirmReply)
+    if (onReplied !== undefined) {
+      try {
+        onReplied(event)
+      } catch (error) {
+        logger.error(
+          {requestID: event.requestID, detail: error instanceof Error ? error.message : String(error)},
+          'approvals: onReplied callback threw (ignored)',
+        )
+      }
+    }
+    // Legacy compat: onSettled (old API — reason is always 'replied' from coordinator's view)
+    if (onSettled !== undefined) {
+      try {
+        onSettled(event.requestID, event.reply, 'replied')
+      } catch (error) {
+        logger.error(
+          {requestID: event.requestID, detail: error instanceof Error ? error.message : String(error)},
+          'approvals: onSettled callback threw (ignored)',
+        )
+      }
+    }
+  }
+
+  function notifyDispose(): void {
+    if (onDispose === undefined) return
     try {
-      onSettled(requestID, reply, reason)
+      onDispose([...ownedSessionIDs])
     } catch (error) {
       logger.error(
-        {requestID, detail: error instanceof Error ? error.message : String(error)},
-        'approvals: onSettled callback threw (ignored)',
+        {detail: error instanceof Error ? error.message : String(error)},
+        'approvals: onDispose callback threw (ignored)',
       )
     }
   }
 
-  /** Resolve an entry exactly once and run its settlement side effects. */
-  function settle(entry: Entry, reply: PermissionReply, reason: SettlementReason): void {
-    if (entry.settled) return
-    entry.settled = true
-    if (entry.timer !== null) {
-      clearTimeout(entry.timer)
-    }
-    entry.resolve(reply)
-    notifySettled(entry.request.requestID, reply, reason)
-  }
-
   async function onPermissionAsked(request: PermissionRequest): Promise<PermissionReply> {
-    const existing = registry.get(request.requestID)
-    if (existing !== undefined && !existing.settled) {
-      // Duplicate asked for an open request — idempotent: reuse the pending
-      // promise rather than registering a second entry.
+    const existing = localMap.get(request.requestID)
+    if (existing !== undefined) {
+      // Duplicate asked for an open request — idempotent: chain onto the existing promise.
       logger.warn({requestID: request.requestID}, 'approvals: duplicate permission.asked for open request (ignored)')
       return new Promise<PermissionReply>(resolve => {
         const prior = existing.resolve
-        // Chain onto the prior resolver so both awaiters settle together.
-        Object.assign(existing, {
-          resolve: (reply: PermissionReply) => {
-            prior(reply)
-            resolve(reply)
-          },
-        })
+        existing.resolve = (reply: PermissionReply) => {
+          prior(reply)
+          resolve(reply)
+        }
       })
     }
 
     return new Promise<PermissionReply>(resolve => {
-      const entry: Entry = {request, resolve, settled: false, timer: null}
-      if (deadlineMs !== undefined && deadlineMs > 0) {
-        entry.timer = setTimeout(() => {
-          logger.warn({requestID: request.requestID, deadlineMs}, 'approvals: request deadline expired — fail-closed')
-          settle(entry, 'reject', 'deadline')
-        }, deadlineMs)
-        // Do not keep the event loop alive solely for an approval timer.
-        entry.timer.unref?.()
-      }
-      registry.set(request.requestID, entry)
+      const entry: Entry = {request, resolve}
+      localMap.set(request.requestID, entry)
+      ownedSessionIDs.add(request.sessionID)
       logger.info(
         {requestID: request.requestID, sessionID: request.sessionID, permission: request.permission},
         'approvals: permission requested',
@@ -269,46 +285,34 @@ export function createPermissionCoordinator(deps: PermissionCoordinatorDeps): Pe
   }
 
   function onPermissionReplied(event: PermissionReplyEvent): void {
-    const entry = registry.get(event.requestID)
-    if (entry === undefined || entry.settled) {
-      logger.debug(
-        {requestID: event.requestID, reply: event.reply},
-        'approvals: reply for unknown/settled request (no-op)',
-      )
+    const entry = localMap.get(event.requestID)
+    if (entry === undefined) {
+      logger.debug({requestID: event.requestID, reply: event.reply}, 'approvals: reply for unknown request (no-op)')
       return
     }
-    settle(entry, event.reply, 'replied')
-
-    if (event.reply === 'reject') {
-      // Server cascade-rejects all other pending permissions in this session.
-      for (const sibling of registry.values()) {
-        if (!sibling.settled && sibling.request.sessionID === event.sessionID) {
-          logger.info(
-            {requestID: sibling.request.requestID, sessionID: event.sessionID},
-            'approvals: cascade-rejecting sibling permission',
-          )
-          settle(sibling, 'reject', 'cascade')
-        }
-      }
-    }
+    // Resolve local promise and remove from map.
+    localMap.delete(event.requestID)
+    entry.resolve(event.reply)
+    // Forward to registry (which owns rendering + cascade).
+    notifyReplied(event)
   }
 
   function pending(): readonly string[] {
-    const open: string[] = []
-    for (const [requestID, entry] of registry) {
-      if (!entry.settled) open.push(requestID)
-    }
-    return open
+    return Array.from(localMap.keys())
   }
 
   function dispose(reason: string): void {
-    const open = pending()
+    const open = Array.from(localMap.keys())
     if (open.length > 0) {
       logger.warn({reason, count: open.length}, 'approvals: disposing open permission requests — fail-closed')
     }
-    for (const entry of registry.values()) {
-      settle(entry, 'reject', 'disposed')
+    // Resolve all local promises fail-closed.
+    for (const entry of localMap.values()) {
+      entry.resolve('reject')
     }
+    localMap.clear()
+    // Notify registry to dispose its entries.
+    notifyDispose()
   }
 
   return {onPermissionAsked, onPermissionReplied, pending, dispose}

--- a/packages/gateway/src/approvals/coordinator.ts
+++ b/packages/gateway/src/approvals/coordinator.ts
@@ -1,12 +1,12 @@
 /**
  * Permission approval coordinator.
  *
- * Bridges OpenCode permission events to the Discord approval UI (Unit 3).
+ * Bridges OpenCode permission events to the Discord approval UI.
  * run-core registers a pending request on `permission.asked` and settles it on
  * `permission.replied` — the authoritative settlement signal, NOT the button
  * click alone.
  *
- * Verified against the installed SDK @ 1.14.41 (Unit 1 probe — memory 4367):
+ * Verified against the installed SDK @ 1.14.41:
  * - `permission.asked`   → `properties.id` IS the requestID; carries
  *   `sessionID`, `permission` (gate category), `patterns`, optional `metadata`.
  * - `permission.replied` → `properties.requestID` + `properties.reply`
@@ -19,7 +19,7 @@
  * - Owns: the in-memory registry (keyed by `requestID`), the pending promises,
  *   per-entry deadline timers, and same-session cascade reconciliation.
  * - Does NOT own: Discord rendering, the HTTP reply POST, S3, the lock, or
- *   run-state. Unit 3 wires the embed renderer (`onPending`/`onSettled`) and
+ *   run-state. The caller wires the embed renderer (`onPending`/`onSettled`) and
  *   posts the reply; run.ts owns run-abort on deadline.
  *
  * A process restart abandons all entries — a controlled fail-closed (the
@@ -59,7 +59,7 @@ export interface PermissionReplyEvent {
 /** Why a pending entry settled — surfaced to `onSettled` for embed updates. */
 export type SettlementReason = 'replied' | 'cascade' | 'deadline' | 'disposed'
 
-/** Coordinator seam consumed by run-core (Unit 2) and Unit 3. */
+/** Coordinator seam consumed by run-core and the run orchestrator. */
 export interface PermissionCoordinator {
   /**
    * Register a pending request (called by run-core on `permission.asked`).
@@ -85,12 +85,12 @@ export interface PermissionCoordinator {
 export interface PermissionCoordinatorDeps {
   readonly logger: GatewayLogger
   /**
-   * Invoked when a new request is registered. Unit 3 renders the Discord
+   * Invoked when a new request is registered. The caller renders the Discord
    * approval embed here. Must not throw — wrapped defensively.
    */
   readonly onPending?: (request: PermissionRequest) => void
   /**
-   * Invoked when an entry settles (any reason). Unit 3 updates/withdraws the
+   * Invoked when an entry settles (any reason). The caller updates/withdraws the
    * embed here. Must not throw — wrapped defensively.
    */
   readonly onSettled?: (requestID: string, reply: PermissionReply, reason: SettlementReason) => void

--- a/packages/gateway/src/approvals/coordinator.ts
+++ b/packages/gateway/src/approvals/coordinator.ts
@@ -58,7 +58,7 @@ export interface PermissionReplyEvent {
 }
 
 /** Why a pending entry settled — surfaced to render functions for embed updates. */
-export type SettlementReason = 'replied' | 'cascade' | 'deadline' | 'disposed'
+export type SettlementReason = 'replied' | 'cascade' | 'deadline' | 'disposed' | 'superseded'
 
 /** Coordinator seam consumed by run-core and the run orchestrator. */
 export interface PermissionCoordinator {

--- a/packages/gateway/src/approvals/coordinator.ts
+++ b/packages/gateway/src/approvals/coordinator.ts
@@ -1,0 +1,315 @@
+/**
+ * Permission approval coordinator.
+ *
+ * Bridges OpenCode permission events to the Discord approval UI (Unit 3).
+ * run-core registers a pending request on `permission.asked` and settles it on
+ * `permission.replied` — the authoritative settlement signal, NOT the button
+ * click alone.
+ *
+ * Verified against the installed SDK @ 1.14.41 (Unit 1 probe — memory 4367):
+ * - `permission.asked`   → `properties.id` IS the requestID; carries
+ *   `sessionID`, `permission` (gate category), `patterns`, optional `metadata`.
+ * - `permission.replied` → `properties.requestID` + `properties.reply`
+ *   (`"once" | "always" | "reject"`).
+ * - A `"reject"` reply CASCADES server-side: all other pending permissions in
+ *   the SAME session are rejected. The coordinator mirrors that cascade so the
+ *   sibling embeds are settled too.
+ *
+ * Ownership boundary:
+ * - Owns: the in-memory registry (keyed by `requestID`), the pending promises,
+ *   per-entry deadline timers, and same-session cascade reconciliation.
+ * - Does NOT own: Discord rendering, the HTTP reply POST, S3, the lock, or
+ *   run-state. Unit 3 wires the embed renderer (`onPending`/`onSettled`) and
+ *   posts the reply; run.ts owns run-abort on deadline.
+ *
+ * A process restart abandons all entries — a controlled fail-closed (the
+ * deadline / run teardown rejects pending tools), never a silent hang.
+ */
+
+import type {GatewayLogger} from '../discord/client.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Reply verbs accepted by the OpenCode permission reply endpoint @ 1.14.41. */
+export type PermissionReply = 'once' | 'always' | 'reject'
+
+/** Parsed `permission.asked` payload — the request awaiting a decision. */
+export interface PermissionRequest {
+  /** `properties.id` — the requestID used as the reply path param and registry key. */
+  readonly requestID: string
+  /** Owning session — used for the reject cascade. */
+  readonly sessionID: string
+  /** Gate category, e.g. `external_directory`, `bash`. */
+  readonly permission: string
+  /** Patterns the gate matched, e.g. `["/tmp/x/*"]`. May be empty. */
+  readonly patterns: readonly string[]
+  /** Human-readable, redaction-safe summary for the Discord embed. */
+  readonly title: string
+}
+
+/** Parsed `permission.replied` payload — the authoritative settlement. */
+export interface PermissionReplyEvent {
+  readonly sessionID: string
+  readonly requestID: string
+  readonly reply: PermissionReply
+}
+
+/** Why a pending entry settled — surfaced to `onSettled` for embed updates. */
+export type SettlementReason = 'replied' | 'cascade' | 'deadline' | 'disposed'
+
+/** Coordinator seam consumed by run-core (Unit 2) and Unit 3. */
+export interface PermissionCoordinator {
+  /**
+   * Register a pending request (called by run-core on `permission.asked`).
+   * Returns a promise that resolves with the settled reply when
+   * `permission.replied` arrives, the deadline fires, or the run is disposed.
+   * NEVER rejects — resolves `"reject"` on the fail-closed paths.
+   * Idempotent: a duplicate requestID returns the existing pending promise.
+   */
+  onPermissionAsked: (request: PermissionRequest) => Promise<PermissionReply>
+  /**
+   * Settle the matching entry (called by run-core on `permission.replied`).
+   * On a `"reject"` reply, cascade-settles every other open entry in the same
+   * session (the server already rejected them). No-op for unknown/settled IDs.
+   */
+  onPermissionReplied: (event: PermissionReplyEvent) => void
+  /** Open (unsettled) requestIDs — for SSE-drop reconciliation / debugging. */
+  pending: () => readonly string[]
+  /** Fail-close every open entry (called on run teardown). */
+  dispose: (reason: string) => void
+}
+
+/** Dependencies injected at construction. */
+export interface PermissionCoordinatorDeps {
+  readonly logger: GatewayLogger
+  /**
+   * Invoked when a new request is registered. Unit 3 renders the Discord
+   * approval embed here. Must not throw — wrapped defensively.
+   */
+  readonly onPending?: (request: PermissionRequest) => void
+  /**
+   * Invoked when an entry settles (any reason). Unit 3 updates/withdraws the
+   * embed here. Must not throw — wrapped defensively.
+   */
+  readonly onSettled?: (requestID: string, reply: PermissionReply, reason: SettlementReason) => void
+  /**
+   * Optional per-request deadline (ms). On expiry the entry fail-closes to
+   * `"reject"`. Must be a sub-deadline of the run wall-clock; run.ts owns the
+   * actual run-abort. Omit to disable per-entry deadlines.
+   */
+  readonly deadlineMs?: number
+}
+
+// ---------------------------------------------------------------------------
+// Defensive accessors (payloads are untrusted server JSON)
+// ---------------------------------------------------------------------------
+
+function getString(value: unknown, property: string): string | null {
+  if (value == null || typeof value !== 'object') return null
+  const descriptor = Object.getOwnPropertyDescriptor(value, property)
+  return typeof descriptor?.value === 'string' ? descriptor.value : null
+}
+
+function getObject(value: unknown, property: string): unknown {
+  if (value == null || typeof value !== 'object') return null
+  return Object.getOwnPropertyDescriptor(value, property)?.value ?? null
+}
+
+function getStringArray(value: unknown, property: string): string[] {
+  if (value == null || typeof value !== 'object') return []
+  const raw: unknown = Object.getOwnPropertyDescriptor(value, property)?.value
+  if (!Array.isArray(raw)) return []
+  return raw.filter((item): item is string => typeof item === 'string')
+}
+
+/** A reply verb is only the strict allowlist — anything else is rejected input. */
+function asReply(value: unknown): PermissionReply | null {
+  return value === 'once' || value === 'always' || value === 'reject' ? value : null
+}
+
+// ---------------------------------------------------------------------------
+// Parsers (raw `properties` payload → typed shape; null on malformed)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a redaction-safe title from the gate category + metadata/patterns.
+ * Never throws; falls back through metadata → first pattern → bare category.
+ */
+function deriveTitle(permission: string, patterns: readonly string[], metadata: unknown): string {
+  const filepath = getString(metadata, 'filepath')
+  const command = getString(metadata, 'command')
+  const firstPattern = patterns[0] ?? null
+  if (permission === 'external_directory') {
+    return `Access outside workspace: ${filepath ?? firstPattern ?? '(unspecified path)'}`
+  }
+  if (permission === 'bash') {
+    return `Run command: ${command ?? firstPattern ?? '(unspecified command)'}`
+  }
+  const detail = filepath ?? command ?? firstPattern
+  return detail == null ? permission : `${permission}: ${detail}`
+}
+
+/** Parse a `permission.asked` `properties` payload. Returns null if unusable. */
+export function parsePermissionRequest(payload: unknown): PermissionRequest | null {
+  const requestID = getString(payload, 'id')
+  const sessionID = getString(payload, 'sessionID')
+  if (requestID == null || sessionID == null) return null
+  const permission = getString(payload, 'permission') ?? 'unknown'
+  const patterns = getStringArray(payload, 'patterns')
+  const metadata = getObject(payload, 'metadata')
+  return {
+    requestID,
+    sessionID,
+    permission,
+    patterns,
+    title: deriveTitle(permission, patterns, metadata),
+  }
+}
+
+/** Parse a `permission.replied` `properties` payload. Returns null if unusable. */
+export function parsePermissionReply(payload: unknown): PermissionReplyEvent | null {
+  const requestID = getString(payload, 'requestID')
+  const sessionID = getString(payload, 'sessionID')
+  const reply = asReply(getObject(payload, 'reply') ?? getString(payload, 'reply'))
+  if (requestID == null || sessionID == null || reply == null) return null
+  return {requestID, sessionID, reply}
+}
+
+// ---------------------------------------------------------------------------
+// Coordinator
+// ---------------------------------------------------------------------------
+
+interface Entry {
+  readonly request: PermissionRequest
+  readonly resolve: (reply: PermissionReply) => void
+  settled: boolean
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+/**
+ * Create a permission coordinator. One instance per run; its registry is
+ * scoped to that run (single-process gateway — no cross-replica concern).
+ */
+export function createPermissionCoordinator(deps: PermissionCoordinatorDeps): PermissionCoordinator {
+  const {logger, onPending, onSettled, deadlineMs} = deps
+  const registry = new Map<string, Entry>()
+
+  function notifyPending(request: PermissionRequest): void {
+    if (onPending === undefined) return
+    try {
+      onPending(request)
+    } catch (error) {
+      logger.error(
+        {requestID: request.requestID, detail: error instanceof Error ? error.message : String(error)},
+        'approvals: onPending callback threw (ignored)',
+      )
+    }
+  }
+
+  function notifySettled(requestID: string, reply: PermissionReply, reason: SettlementReason): void {
+    if (onSettled === undefined) return
+    try {
+      onSettled(requestID, reply, reason)
+    } catch (error) {
+      logger.error(
+        {requestID, detail: error instanceof Error ? error.message : String(error)},
+        'approvals: onSettled callback threw (ignored)',
+      )
+    }
+  }
+
+  /** Resolve an entry exactly once and run its settlement side effects. */
+  function settle(entry: Entry, reply: PermissionReply, reason: SettlementReason): void {
+    if (entry.settled) return
+    entry.settled = true
+    if (entry.timer !== null) {
+      clearTimeout(entry.timer)
+    }
+    entry.resolve(reply)
+    notifySettled(entry.request.requestID, reply, reason)
+  }
+
+  async function onPermissionAsked(request: PermissionRequest): Promise<PermissionReply> {
+    const existing = registry.get(request.requestID)
+    if (existing !== undefined && !existing.settled) {
+      // Duplicate asked for an open request — idempotent: reuse the pending
+      // promise rather than registering a second entry.
+      logger.warn({requestID: request.requestID}, 'approvals: duplicate permission.asked for open request (ignored)')
+      return new Promise<PermissionReply>(resolve => {
+        const prior = existing.resolve
+        // Chain onto the prior resolver so both awaiters settle together.
+        Object.assign(existing, {
+          resolve: (reply: PermissionReply) => {
+            prior(reply)
+            resolve(reply)
+          },
+        })
+      })
+    }
+
+    return new Promise<PermissionReply>(resolve => {
+      const entry: Entry = {request, resolve, settled: false, timer: null}
+      if (deadlineMs !== undefined && deadlineMs > 0) {
+        entry.timer = setTimeout(() => {
+          logger.warn({requestID: request.requestID, deadlineMs}, 'approvals: request deadline expired — fail-closed')
+          settle(entry, 'reject', 'deadline')
+        }, deadlineMs)
+        // Do not keep the event loop alive solely for an approval timer.
+        entry.timer.unref?.()
+      }
+      registry.set(request.requestID, entry)
+      logger.info(
+        {requestID: request.requestID, sessionID: request.sessionID, permission: request.permission},
+        'approvals: permission requested',
+      )
+      notifyPending(request)
+    })
+  }
+
+  function onPermissionReplied(event: PermissionReplyEvent): void {
+    const entry = registry.get(event.requestID)
+    if (entry === undefined || entry.settled) {
+      logger.debug(
+        {requestID: event.requestID, reply: event.reply},
+        'approvals: reply for unknown/settled request (no-op)',
+      )
+      return
+    }
+    settle(entry, event.reply, 'replied')
+
+    if (event.reply === 'reject') {
+      // Server cascade-rejects all other pending permissions in this session.
+      for (const sibling of registry.values()) {
+        if (!sibling.settled && sibling.request.sessionID === event.sessionID) {
+          logger.info(
+            {requestID: sibling.request.requestID, sessionID: event.sessionID},
+            'approvals: cascade-rejecting sibling permission',
+          )
+          settle(sibling, 'reject', 'cascade')
+        }
+      }
+    }
+  }
+
+  function pending(): readonly string[] {
+    const open: string[] = []
+    for (const [requestID, entry] of registry) {
+      if (!entry.settled) open.push(requestID)
+    }
+    return open
+  }
+
+  function dispose(reason: string): void {
+    const open = pending()
+    if (open.length > 0) {
+      logger.warn({reason, count: open.length}, 'approvals: disposing open permission requests — fail-closed')
+    }
+    for (const entry of registry.values()) {
+      settle(entry, 'reject', 'disposed')
+    }
+  }
+
+  return {onPermissionAsked, onPermissionReplied, pending, dispose}
+}

--- a/packages/gateway/src/approvals/registry.test.ts
+++ b/packages/gateway/src/approvals/registry.test.ts
@@ -841,6 +841,57 @@ describe('FIX 3 — stale timer cleared on duplicate register', () => {
 })
 
 // ---------------------------------------------------------------------------
+// NBC4: superseded render on duplicate register
+// ---------------------------------------------------------------------------
+
+describe('NBC4 — duplicate register renders old entry as superseded', () => {
+  it('calls old renderFn with reason superseded, clears old timer, new entry is active', async () => {
+    // #given a registry with an entry that has a renderFn attached
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects1 = makeEffects()
+    const renderFn1 = makeRenderFn()
+    const request1 = makeRequest({requestID: 'per_1', sessionID: 'ses_1'})
+    registry.register(makeParams({requestID: 'per_1', sessionID: 'ses_1', request: request1, effects: effects1}))
+    registry.attachMessage('per_1', renderFn1)
+
+    // #when the same requestID is re-registered (re-ask)
+    const effects2 = makeEffects()
+    const request2 = makeRequest({requestID: 'per_1', sessionID: 'ses_1'})
+    registry.register(makeParams({requestID: 'per_1', sessionID: 'ses_1', request: request2, effects: effects2}))
+
+    // Allow the best-effort superseded render to settle
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // #then old renderFn was called once with reason 'superseded'
+    expect(renderFn1).toHaveBeenCalledOnce()
+    const [, , , reason] = (renderFn1 as ReturnType<typeof vi.fn>).mock.calls[0] as [unknown, unknown, unknown, string]
+    expect(reason).toBe('superseded')
+
+    // #and new entry is the active one (still pending)
+    expect(registry.has('per_1')).toBe(true)
+    expect(registry.pending()).toContain('per_1')
+  })
+
+  it('does not call old renderFn if no message was attached before re-register', async () => {
+    // #given an entry with NO renderFn attached
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects1 = makeEffects()
+    registry.register(makeParams({requestID: 'per_1', effects: effects1}))
+    // No attachMessage call
+
+    // #when re-registered
+    const effects2 = makeEffects()
+    registry.register(makeParams({requestID: 'per_1', effects: effects2}))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // #then no crash; new entry is active
+    expect(registry.has('per_1')).toBe(true)
+    // effects1.postReply was NOT called (no superseded POST — render only)
+    expect(effects1.postReply).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // P2 bonus: confirmReply sessionID mismatch guard
 // ---------------------------------------------------------------------------
 

--- a/packages/gateway/src/approvals/registry.test.ts
+++ b/packages/gateway/src/approvals/registry.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the program-scoped approval registry bridge (Unit 3b).
+ * Tests for the program-scoped approval registry bridge.
  *
  * Convention: `vi.fn()` for all injected side-effects. No real Discord.js or
  * SDK imports here — pure unit tests. BDD `// #given/#when/#then` per repo convention.

--- a/packages/gateway/src/approvals/registry.test.ts
+++ b/packages/gateway/src/approvals/registry.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Tests for the program-scoped approval registry bridge (Unit 3b).
+ *
+ * Convention: `vi.fn()` for all injected side-effects. No real Discord.js or
+ * SDK imports here — pure unit tests. BDD `// #given/#when/#then` per repo convention.
+ */
+
+import type {GatewayLogger} from '../discord/client.js'
+import type {PermissionRequest} from './coordinator.js'
+import type {ApprovalSideEffects, DecisionOutcome, RegisterParams} from './registry.js'
+
+import {describe, expect, it, vi} from 'vitest'
+
+import {createApprovalRegistry} from './registry.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeLogger(): GatewayLogger {
+  return {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+}
+
+function makeRequest(overrides: Partial<PermissionRequest> = {}): PermissionRequest {
+  return {
+    requestID: 'per_1',
+    sessionID: 'ses_1',
+    permission: 'external_directory',
+    patterns: ['/tmp/x/*'],
+    title: 'Access outside workspace',
+    ...overrides,
+  }
+}
+
+function makeEffects(overrides: Partial<ApprovalSideEffects> = {}): ApprovalSideEffects {
+  return {
+    postReply: vi.fn().mockResolvedValue({ok: true}),
+    renderSettled: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+}
+
+function makeParams(overrides: Partial<RegisterParams> = {}): RegisterParams {
+  const request = overrides.request ?? makeRequest()
+  return {
+    requestID: request.requestID,
+    sessionID: request.sessionID,
+    channelID: 'chan_1',
+    directory: '/workspace/proj',
+    request,
+    effects: makeEffects(),
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// register / has / pending — basic lifecycle
+// ---------------------------------------------------------------------------
+
+describe('register / has / pending', () => {
+  it('registers an entry and reports it via has() and pending()', () => {
+    // #given a fresh registry
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const params = makeParams()
+
+    // #when registered
+    registry.register(params)
+
+    // #then has() and pending() reflect the new entry
+    expect(registry.has('per_1')).toBe(true)
+    expect(registry.pending()).toContain('per_1')
+  })
+
+  it('has() returns false for unknown id', () => {
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    expect(registry.has('unknown')).toBe(false)
+  })
+
+  it('pending() returns empty array when nothing registered', () => {
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    expect(registry.pending()).toEqual([])
+  })
+
+  it('re-registering an existing id overwrites (re-ask scenario)', () => {
+    // #given an entry is already registered
+    const logger = makeLogger()
+    const registry = createApprovalRegistry({logger})
+    registry.register(makeParams())
+
+    // #when re-registered with updated effects
+    const newEffects = makeEffects()
+    registry.register(makeParams({effects: newEffects}))
+
+    // #then still one entry; warn was called; new effects are active
+    expect(registry.pending()).toHaveLength(1)
+    expect(logger.warn).toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleButtonDecision — unknown id
+// ---------------------------------------------------------------------------
+
+describe('handleButtonDecision — unknown id', () => {
+  it("returns 'not-found' and does NOT call postReply", async () => {
+    // #given an empty registry
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects = makeEffects()
+    registry.register(makeParams({effects}))
+
+    // #when clicking a button for an unknown requestID
+    const outcome = await registry.handleButtonDecision({
+      requestID: 'per_UNKNOWN',
+      channelID: 'chan_1',
+      decision: 'once',
+      decidedBy: 'user_A',
+    })
+
+    // #then not-found; no side effects
+    expect(outcome).toBe<DecisionOutcome>('not-found')
+    expect(effects.postReply).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleButtonDecision — channel mismatch
+// ---------------------------------------------------------------------------
+
+describe('handleButtonDecision — channel mismatch', () => {
+  it("returns 'channel-mismatch' and does NOT call postReply", async () => {
+    // #given a registry entry bound to chan_1
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects = makeEffects()
+    registry.register(makeParams({channelID: 'chan_1', effects}))
+
+    // #when a button arrives from a different channel
+    const outcome = await registry.handleButtonDecision({
+      requestID: 'per_1',
+      channelID: 'chan_WRONG',
+      decision: 'once',
+      decidedBy: 'user_A',
+    })
+
+    // #then channel-mismatch; no reply sent
+    expect(outcome).toBe<DecisionOutcome>('channel-mismatch')
+    expect(effects.postReply).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleButtonDecision — happy path
+// ---------------------------------------------------------------------------
+
+describe('handleButtonDecision — happy path', () => {
+  it("returns 'ok', calls postReply once, entry stays registered", async () => {
+    // #given a registered entry
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects = makeEffects()
+    registry.register(makeParams({channelID: 'chan_1', directory: '/workspace/proj', effects}))
+
+    // #when the button is clicked with a valid channel
+    const outcome = await registry.handleButtonDecision({
+      requestID: 'per_1',
+      channelID: 'chan_1',
+      decision: 'once',
+      decidedBy: 'user_A',
+    })
+
+    // #then ok; postReply called once with correct args; entry still exists (not yet settled)
+    expect(outcome).toBe<DecisionOutcome>('ok')
+    expect(effects.postReply).toHaveBeenCalledExactlyOnceWith('per_1', '/workspace/proj', 'once')
+    expect(registry.has('per_1')).toBe(true)
+    expect(effects.renderSettled).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleButtonDecision — second click after claim (single-winner)
+// ---------------------------------------------------------------------------
+
+describe('handleButtonDecision — already-claimed (single-winner)', () => {
+  it("returns 'already-claimed' on second click; postReply called only ONCE total", async () => {
+    // #given first click already settled
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects = makeEffects()
+    registry.register(makeParams({effects}))
+    await registry.handleButtonDecision({
+      requestID: 'per_1',
+      channelID: 'chan_1',
+      decision: 'once',
+      decidedBy: 'user_A',
+    })
+
+    // #when a second click arrives
+    const outcome = await registry.handleButtonDecision({
+      requestID: 'per_1',
+      channelID: 'chan_1',
+      decision: 'always',
+      decidedBy: 'user_B',
+    })
+
+    // #then already-claimed; no second postReply
+    expect(outcome).toBe<DecisionOutcome>('already-claimed')
+    expect(effects.postReply).toHaveBeenCalledOnce()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleButtonDecision — reply-failed → claimed reset → retry works
+// ---------------------------------------------------------------------------
+
+describe('handleButtonDecision — reply-failed', () => {
+  it("returns 'reply-failed' and resets claimed so a subsequent click can retry", async () => {
+    // #given postReply fails on first call, succeeds on retry
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const postReply = vi.fn().mockResolvedValueOnce({ok: false, error: 'timeout'}).mockResolvedValueOnce({ok: true})
+    const effects = makeEffects({postReply})
+    registry.register(makeParams({effects}))
+
+    // #when first click fails
+    const first = await registry.handleButtonDecision({
+      requestID: 'per_1',
+      channelID: 'chan_1',
+      decision: 'once',
+      decidedBy: 'user_A',
+    })
+
+    // #then reply-failed; claimed was reset
+    expect(first).toBe<DecisionOutcome>('reply-failed')
+
+    // #when retry click
+    const retry = await registry.handleButtonDecision({
+      requestID: 'per_1',
+      channelID: 'chan_1',
+      decision: 'once',
+      decidedBy: 'user_A',
+    })
+
+    // #then retry succeeds; postReply called twice total
+    expect(retry).toBe<DecisionOutcome>('ok')
+    expect(postReply).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applySettlement — 'replied' (button already POSTed)
+// ---------------------------------------------------------------------------
+
+describe("applySettlement — reason 'replied'", () => {
+  it('does NOT postReply again; calls renderSettled with stashed decidedBy; unregisters', async () => {
+    // #given a claimed entry (button was clicked)
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects = makeEffects()
+    const request = makeRequest()
+    registry.register(makeParams({request, effects}))
+    await registry.handleButtonDecision({
+      requestID: 'per_1',
+      channelID: 'chan_1',
+      decision: 'once',
+      decidedBy: 'user_A',
+    })
+
+    // #when the coordinator fires settlement with reason 'replied'
+    await registry.applySettlement({requestID: 'per_1', decision: 'once', reason: 'replied'})
+
+    // #then postReply NOT called again (was called once by button); renderSettled called with correct args
+    expect(effects.postReply).toHaveBeenCalledOnce()
+    expect(effects.renderSettled).toHaveBeenCalledExactlyOnceWith(request, 'once', 'user_A', 'replied')
+    expect(registry.has('per_1')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applySettlement — 'deadline' on unclaimed entry
+// ---------------------------------------------------------------------------
+
+describe("applySettlement — reason 'deadline' (unclaimed)", () => {
+  it('calls postReply(reject), renderSettled(null, deadline), then unregisters', async () => {
+    // #given an unclaimed entry (no button click)
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects = makeEffects()
+    const request = makeRequest()
+    registry.register(makeParams({request, effects}))
+
+    // #when deadline fires
+    await registry.applySettlement({requestID: 'per_1', decision: 'reject', reason: 'deadline'})
+
+    // #then postReply called with reject; renderSettled with decidedBy=null
+    expect(effects.postReply).toHaveBeenCalledExactlyOnceWith('per_1', '/workspace/proj', 'reject')
+    expect(effects.renderSettled).toHaveBeenCalledExactlyOnceWith(request, 'reject', null, 'deadline')
+    expect(registry.has('per_1')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applySettlement — 'cascade' with postReply failing → non-fatal
+// ---------------------------------------------------------------------------
+
+describe("applySettlement — reason 'cascade' with failing postReply", () => {
+  it('does NOT throw; still calls renderSettled and unregisters', async () => {
+    // #given an unclaimed entry and a failing postReply
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const postReply = vi.fn().mockResolvedValue({ok: false, error: 'server gone'})
+    const effects = makeEffects({postReply})
+    registry.register(makeParams({effects}))
+
+    // #when cascade settlement arrives
+    await expect(
+      registry.applySettlement({requestID: 'per_1', decision: 'reject', reason: 'cascade'}),
+    ).resolves.not.toThrow()
+
+    // #then renderSettled was still called and entry unregistered
+    expect(effects.renderSettled).toHaveBeenCalledOnce()
+    expect(registry.has('per_1')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applySettlement — idempotent (second call after unregister is a no-op)
+// ---------------------------------------------------------------------------
+
+describe('applySettlement — idempotent', () => {
+  it('second call after unregister is a no-op and does not throw', async () => {
+    // #given entry settled once
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects = makeEffects()
+    registry.register(makeParams({effects}))
+    await registry.applySettlement({requestID: 'per_1', decision: 'reject', reason: 'deadline'})
+
+    // #when called again
+    await expect(
+      registry.applySettlement({requestID: 'per_1', decision: 'reject', reason: 'deadline'}),
+    ).resolves.not.toThrow()
+
+    // #then no additional side effects
+    expect(effects.postReply).toHaveBeenCalledOnce()
+    expect(effects.renderSettled).toHaveBeenCalledOnce()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applySettlement — renderSettled throwing → still unregisters, does not throw
+// ---------------------------------------------------------------------------
+
+describe('applySettlement — renderSettled throws', () => {
+  it('still unregisters and does not propagate the error', async () => {
+    // #given renderSettled throws
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects = makeEffects({
+      renderSettled: vi.fn().mockRejectedValue(new Error('Discord edit failed')),
+    })
+    registry.register(makeParams({effects}))
+
+    // #when settlement fires
+    await expect(
+      registry.applySettlement({requestID: 'per_1', decision: 'reject', reason: 'deadline'}),
+    ).resolves.not.toThrow()
+
+    // #then entry was still removed
+    expect(registry.has('per_1')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// disposeAll
+// ---------------------------------------------------------------------------
+
+describe('disposeAll', () => {
+  it('rejects all open entries, renders settled, empties pending()', async () => {
+    // #given two open entries
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects1 = makeEffects()
+    const effects2 = makeEffects()
+    registry.register(
+      makeParams({
+        requestID: 'per_1',
+        sessionID: 'ses_1',
+        request: makeRequest({requestID: 'per_1', sessionID: 'ses_1'}),
+        effects: effects1,
+      }),
+    )
+    registry.register(
+      makeParams({
+        requestID: 'per_2',
+        sessionID: 'ses_2',
+        request: makeRequest({requestID: 'per_2', sessionID: 'ses_2'}),
+        effects: effects2,
+      }),
+    )
+
+    // #when disposeAll is called
+    await registry.disposeAll('shutdown')
+
+    // #then both entries settled with reject/disposed; pending empty
+    expect(effects1.renderSettled).toHaveBeenCalledOnce()
+    expect(effects2.renderSettled).toHaveBeenCalledOnce()
+    expect(registry.pending()).toHaveLength(0)
+  })
+
+  it('does not throw even if all effects fail', async () => {
+    // #given entries whose effects all throw
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects = makeEffects({
+      postReply: vi.fn().mockRejectedValue(new Error('boom')),
+      renderSettled: vi.fn().mockRejectedValue(new Error('boom')),
+    })
+    registry.register(makeParams({effects}))
+
+    // #when disposeAll
+    await expect(registry.disposeAll('shutdown')).resolves.not.toThrow()
+
+    // #then pending is empty
+    expect(registry.pending()).toHaveLength(0)
+  })
+})

--- a/packages/gateway/src/approvals/registry.test.ts
+++ b/packages/gateway/src/approvals/registry.test.ts
@@ -3,13 +3,25 @@
  *
  * Convention: `vi.fn()` for all injected side-effects. No real Discord.js or
  * SDK imports here — pure unit tests. BDD `// #given/#when/#then` per repo convention.
+ *
+ * ### Core scenarios
+ *
+ * 1. register / has / pending — basic lifecycle
+ * 2. handleButtonDecision — unknown id (not-found)
+ * 3. handleButtonDecision — channel mismatch
+ * 4. handleButtonDecision — happy path (open→claimed→confirmed)
+ * 5. handleButtonDecision — claimed blocks second click while in-flight (single-winner)
+ * 6. handleButtonDecision — reply-failed resets to open, retry works
+ * 7. applySettlement — replied path (renderFn called; no second postReply)
+ * 8. applySettlement — deadline/cascade path on open entry
+ * 9. disposeRun — only settles entries for the matching sessionID
  */
 
 import type {GatewayLogger} from '../discord/client.js'
 import type {PermissionRequest} from './coordinator.js'
-import type {ApprovalSideEffects, DecisionOutcome, RegisterParams} from './registry.js'
+import type {ApprovalSideEffects, DecisionOutcome, RegisterParams, RenderFn} from './registry.js'
 
-import {describe, expect, it, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createApprovalRegistry} from './registry.js'
 
@@ -35,9 +47,12 @@ function makeRequest(overrides: Partial<PermissionRequest> = {}): PermissionRequ
 function makeEffects(overrides: Partial<ApprovalSideEffects> = {}): ApprovalSideEffects {
   return {
     postReply: vi.fn().mockResolvedValue({ok: true}),
-    renderSettled: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   }
+}
+
+function makeRenderFn(): RenderFn {
+  return vi.fn().mockResolvedValue(undefined)
 }
 
 function makeParams(overrides: Partial<RegisterParams> = {}): RegisterParams {
@@ -54,7 +69,7 @@ function makeParams(overrides: Partial<RegisterParams> = {}): RegisterParams {
 }
 
 // ---------------------------------------------------------------------------
-// register / has / pending — basic lifecycle
+// Scenario 1: register / has / pending — basic lifecycle
 // ---------------------------------------------------------------------------
 
 describe('register / has / pending', () => {
@@ -98,7 +113,7 @@ describe('register / has / pending', () => {
 })
 
 // ---------------------------------------------------------------------------
-// handleButtonDecision — unknown id
+// Scenario 2: handleButtonDecision — unknown id
 // ---------------------------------------------------------------------------
 
 describe('handleButtonDecision — unknown id', () => {
@@ -123,7 +138,7 @@ describe('handleButtonDecision — unknown id', () => {
 })
 
 // ---------------------------------------------------------------------------
-// handleButtonDecision — channel mismatch
+// Scenario 3: handleButtonDecision — channel mismatch
 // ---------------------------------------------------------------------------
 
 describe('handleButtonDecision — channel mismatch', () => {
@@ -148,11 +163,11 @@ describe('handleButtonDecision — channel mismatch', () => {
 })
 
 // ---------------------------------------------------------------------------
-// handleButtonDecision — happy path
+// Scenario 4: handleButtonDecision — happy path (open→claimed→confirmed)
 // ---------------------------------------------------------------------------
 
 describe('handleButtonDecision — happy path', () => {
-  it("returns 'ok', calls postReply once, entry stays registered", async () => {
+  it("returns 'ok', calls postReply once, state transitions to confirmed", async () => {
     // #given a registered entry
     const registry = createApprovalRegistry({logger: makeLogger()})
     const effects = makeEffects()
@@ -170,12 +185,35 @@ describe('handleButtonDecision — happy path', () => {
     expect(outcome).toBe<DecisionOutcome>('ok')
     expect(effects.postReply).toHaveBeenCalledExactlyOnceWith('per_1', '/workspace/proj', 'once')
     expect(registry.has('per_1')).toBe(true)
-    expect(effects.renderSettled).not.toHaveBeenCalled()
+  })
+
+  it('confirmed entry does not call postReply on applySettlement(replied)', async () => {
+    // #given a confirmed entry (button clicked → postReply succeeded)
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects = makeEffects()
+    const renderFn = makeRenderFn()
+    registry.register(makeParams({effects}))
+    registry.attachMessage('per_1', renderFn)
+    await registry.handleButtonDecision({
+      requestID: 'per_1',
+      channelID: 'chan_1',
+      decision: 'once',
+      decidedBy: 'user_A',
+    })
+
+    // #when settled with reason 'replied'
+    await registry.applySettlement({requestID: 'per_1', decision: 'once', reason: 'replied'})
+
+    // #then postReply still called only once (no second attempt)
+    expect(effects.postReply).toHaveBeenCalledOnce()
+    // renderFn was called (message was attached)
+    expect(renderFn).toHaveBeenCalledOnce()
+    expect(registry.has('per_1')).toBe(false)
   })
 })
 
 // ---------------------------------------------------------------------------
-// handleButtonDecision — second click after claim (single-winner)
+// Scenario 5: handleButtonDecision — claimed blocks second click (single-winner)
 // ---------------------------------------------------------------------------
 
 describe('handleButtonDecision — already-claimed (single-winner)', () => {
@@ -203,14 +241,50 @@ describe('handleButtonDecision — already-claimed (single-winner)', () => {
     expect(outcome).toBe<DecisionOutcome>('already-claimed')
     expect(effects.postReply).toHaveBeenCalledOnce()
   })
+
+  it("'claimed' state (postReply in-flight) blocks concurrent second click", async () => {
+    // #given postReply is slow (controllable via deferred promise)
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    let resolveReply!: (v: {ok: boolean}) => void
+    const replyPromise = new Promise<{ok: boolean}>(res => {
+      resolveReply = res
+    })
+    const effects = makeEffects({postReply: vi.fn().mockReturnValue(replyPromise)})
+    registry.register(makeParams({effects}))
+
+    // Start first click (in-flight, not yet resolved)
+    const firstClickPromise = registry.handleButtonDecision({
+      requestID: 'per_1',
+      channelID: 'chan_1',
+      decision: 'once',
+      decidedBy: 'user_A',
+    })
+
+    // Second click while first is in-flight
+    const secondOutcome = await registry.handleButtonDecision({
+      requestID: 'per_1',
+      channelID: 'chan_1',
+      decision: 'once',
+      decidedBy: 'user_B',
+    })
+
+    // #then second click is blocked immediately (claimed)
+    expect(secondOutcome).toBe<DecisionOutcome>('already-claimed')
+
+    // Resolve the in-flight reply
+    resolveReply({ok: true})
+    const firstOutcome = await firstClickPromise
+    expect(firstOutcome).toBe<DecisionOutcome>('ok')
+    expect(effects.postReply).toHaveBeenCalledOnce()
+  })
 })
 
 // ---------------------------------------------------------------------------
-// handleButtonDecision — reply-failed → claimed reset → retry works
+// Scenario 6: handleButtonDecision — reply-failed resets to open, retry works
 // ---------------------------------------------------------------------------
 
 describe('handleButtonDecision — reply-failed', () => {
-  it("returns 'reply-failed' and resets claimed so a subsequent click can retry", async () => {
+  it("returns 'reply-failed' and resets to open so a subsequent click can retry", async () => {
     // #given postReply fails on first call, succeeds on retry
     const registry = createApprovalRegistry({logger: makeLogger()})
     const postReply = vi.fn().mockResolvedValueOnce({ok: false, error: 'timeout'}).mockResolvedValueOnce({ok: true})
@@ -225,7 +299,7 @@ describe('handleButtonDecision — reply-failed', () => {
       decidedBy: 'user_A',
     })
 
-    // #then reply-failed; claimed was reset
+    // #then reply-failed; state reset to open
     expect(first).toBe<DecisionOutcome>('reply-failed')
 
     // #when retry click
@@ -243,16 +317,18 @@ describe('handleButtonDecision — reply-failed', () => {
 })
 
 // ---------------------------------------------------------------------------
-// applySettlement — 'replied' (button already POSTed)
+// Scenario 7: applySettlement — 'replied' path (renderFn called; no second postReply)
 // ---------------------------------------------------------------------------
 
 describe("applySettlement — reason 'replied'", () => {
-  it('does NOT postReply again; calls renderSettled with stashed decidedBy; unregisters', async () => {
-    // #given a claimed entry (button was clicked)
+  it('calls renderFn with stashed decidedBy; does NOT call postReply again; unregisters', async () => {
+    // #given a confirmed entry (button was clicked)
     const registry = createApprovalRegistry({logger: makeLogger()})
     const effects = makeEffects()
     const request = makeRequest()
+    const renderFn = makeRenderFn()
     registry.register(makeParams({request, effects}))
+    registry.attachMessage('per_1', renderFn)
     await registry.handleButtonDecision({
       requestID: 'per_1',
       channelID: 'chan_1',
@@ -263,68 +339,77 @@ describe("applySettlement — reason 'replied'", () => {
     // #when the coordinator fires settlement with reason 'replied'
     await registry.applySettlement({requestID: 'per_1', decision: 'once', reason: 'replied'})
 
-    // #then postReply NOT called again (was called once by button); renderSettled called with correct args
+    // #then postReply NOT called again; renderFn called with correct args
     expect(effects.postReply).toHaveBeenCalledOnce()
-    expect(effects.renderSettled).toHaveBeenCalledExactlyOnceWith(request, 'once', 'user_A', 'replied')
+    expect(renderFn).toHaveBeenCalledExactlyOnceWith(request, 'once', 'user_A', 'replied')
+    expect(registry.has('per_1')).toBe(false)
+  })
+
+  it('skips renderFn if no message was attached (embed post failed)', async () => {
+    // #given entry where embed post failed (no attachMessage called)
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects = makeEffects()
+    registry.register(makeParams({effects}))
+    registry.markMessagePostFailed('per_1')
+    await registry.handleButtonDecision({requestID: 'per_1', channelID: 'chan_1', decision: 'once', decidedBy: 'u'})
+
+    // #when settled
+    await registry.applySettlement({requestID: 'per_1', decision: 'once', reason: 'replied'})
+
+    // #then no renderFn called; entry still unregistered
     expect(registry.has('per_1')).toBe(false)
   })
 })
 
 // ---------------------------------------------------------------------------
-// applySettlement — 'deadline' on unclaimed entry
+// Scenario 8: applySettlement — deadline/cascade on open entry
 // ---------------------------------------------------------------------------
 
 describe("applySettlement — reason 'deadline' (unclaimed)", () => {
-  it('calls postReply(reject), renderSettled(null, deadline), then unregisters', async () => {
-    // #given an unclaimed entry (no button click)
+  it('calls postReply(reject), renderFn(null, deadline), then unregisters', async () => {
+    // #given an open entry with a message attached
     const registry = createApprovalRegistry({logger: makeLogger()})
     const effects = makeEffects()
     const request = makeRequest()
+    const renderFn = makeRenderFn()
     registry.register(makeParams({request, effects}))
+    registry.attachMessage('per_1', renderFn)
 
     // #when deadline fires
     await registry.applySettlement({requestID: 'per_1', decision: 'reject', reason: 'deadline'})
 
-    // #then postReply called with reject; renderSettled with decidedBy=null
+    // #then postReply called with reject; renderFn with decidedBy=null
     expect(effects.postReply).toHaveBeenCalledExactlyOnceWith('per_1', '/workspace/proj', 'reject')
-    expect(effects.renderSettled).toHaveBeenCalledExactlyOnceWith(request, 'reject', null, 'deadline')
+    expect(renderFn).toHaveBeenCalledExactlyOnceWith(request, 'reject', null, 'deadline')
     expect(registry.has('per_1')).toBe(false)
   })
-})
 
-// ---------------------------------------------------------------------------
-// applySettlement — 'cascade' with postReply failing → non-fatal
-// ---------------------------------------------------------------------------
-
-describe("applySettlement — reason 'cascade' with failing postReply", () => {
-  it('does NOT throw; still calls renderSettled and unregisters', async () => {
+  it('cascade: postReply failing does not prevent renderFn or unregister', async () => {
     // #given an unclaimed entry and a failing postReply
     const registry = createApprovalRegistry({logger: makeLogger()})
     const postReply = vi.fn().mockResolvedValue({ok: false, error: 'server gone'})
+    const renderFn = makeRenderFn()
     const effects = makeEffects({postReply})
     registry.register(makeParams({effects}))
+    registry.attachMessage('per_1', renderFn)
 
     // #when cascade settlement arrives
     await expect(
       registry.applySettlement({requestID: 'per_1', decision: 'reject', reason: 'cascade'}),
     ).resolves.not.toThrow()
 
-    // #then renderSettled was still called and entry unregistered
-    expect(effects.renderSettled).toHaveBeenCalledOnce()
+    // #then renderFn was still called and entry unregistered
+    expect(renderFn).toHaveBeenCalledOnce()
     expect(registry.has('per_1')).toBe(false)
   })
-})
 
-// ---------------------------------------------------------------------------
-// applySettlement — idempotent (second call after unregister is a no-op)
-// ---------------------------------------------------------------------------
-
-describe('applySettlement — idempotent', () => {
-  it('second call after unregister is a no-op and does not throw', async () => {
+  it('idempotent — second call after unregister is a no-op', async () => {
     // #given entry settled once
     const registry = createApprovalRegistry({logger: makeLogger()})
     const effects = makeEffects()
+    const renderFn = makeRenderFn()
     registry.register(makeParams({effects}))
+    registry.attachMessage('per_1', renderFn)
     await registry.applySettlement({requestID: 'per_1', decision: 'reject', reason: 'deadline'})
 
     // #when called again
@@ -334,22 +419,16 @@ describe('applySettlement — idempotent', () => {
 
     // #then no additional side effects
     expect(effects.postReply).toHaveBeenCalledOnce()
-    expect(effects.renderSettled).toHaveBeenCalledOnce()
+    expect(renderFn).toHaveBeenCalledOnce()
   })
-})
 
-// ---------------------------------------------------------------------------
-// applySettlement — renderSettled throwing → still unregisters, does not throw
-// ---------------------------------------------------------------------------
-
-describe('applySettlement — renderSettled throws', () => {
-  it('still unregisters and does not propagate the error', async () => {
-    // #given renderSettled throws
+  it('renderFn throwing still unregisters and does not propagate', async () => {
+    // #given renderFn throws
     const registry = createApprovalRegistry({logger: makeLogger()})
-    const effects = makeEffects({
-      renderSettled: vi.fn().mockRejectedValue(new Error('Discord edit failed')),
-    })
+    const effects = makeEffects()
+    const renderFn = vi.fn().mockRejectedValue(new Error('Discord edit failed')) as RenderFn
     registry.register(makeParams({effects}))
+    registry.attachMessage('per_1', renderFn)
 
     // #when settlement fires
     await expect(
@@ -362,15 +441,17 @@ describe('applySettlement — renderSettled throws', () => {
 })
 
 // ---------------------------------------------------------------------------
-// disposeAll
+// Scenario 9: disposeRun — only settles entries for the matching sessionID
 // ---------------------------------------------------------------------------
 
-describe('disposeAll', () => {
-  it('rejects all open entries, renders settled, empties pending()', async () => {
-    // #given two open entries
+describe('disposeRun', () => {
+  it('only fail-closes entries with the matching sessionID, leaves others open', async () => {
+    // #given two entries in different sessions
     const registry = createApprovalRegistry({logger: makeLogger()})
     const effects1 = makeEffects()
     const effects2 = makeEffects()
+    const renderFn1 = makeRenderFn()
+    const renderFn2 = makeRenderFn()
     registry.register(
       makeParams({
         requestID: 'per_1',
@@ -379,6 +460,7 @@ describe('disposeAll', () => {
         effects: effects1,
       }),
     )
+    registry.attachMessage('per_1', renderFn1)
     registry.register(
       makeParams({
         requestID: 'per_2',
@@ -387,29 +469,417 @@ describe('disposeAll', () => {
         effects: effects2,
       }),
     )
+    registry.attachMessage('per_2', renderFn2)
+
+    // #when disposeRun for ses_1 only
+    await registry.disposeRun('ses_1', 'run ended')
+
+    // #then ses_1 entry settled with rejected/disposed; ses_2 untouched
+    expect(registry.has('per_1')).toBe(false)
+    expect(renderFn1).toHaveBeenCalledOnce()
+    expect(registry.has('per_2')).toBe(true)
+    expect(renderFn2).not.toHaveBeenCalled()
+  })
+
+  it('no-ops if no entries match the sessionID', async () => {
+    // #given an entry for ses_1
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    registry.register(makeParams())
+
+    // #when disposeRun for a different session
+    await expect(registry.disposeRun('ses_UNKNOWN', 'run ended')).resolves.not.toThrow()
+
+    // #then ses_1 entry untouched
+    expect(registry.has('per_1')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// disposeAll (shutdown path)
+// ---------------------------------------------------------------------------
+
+describe('disposeAll', () => {
+  it('rejects all open entries, renders settled, empties pending()', async () => {
+    // #given two open entries
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects1 = makeEffects()
+    const effects2 = makeEffects()
+    const renderFn1 = makeRenderFn()
+    const renderFn2 = makeRenderFn()
+    registry.register(
+      makeParams({
+        requestID: 'per_1',
+        sessionID: 'ses_1',
+        request: makeRequest({requestID: 'per_1', sessionID: 'ses_1'}),
+        effects: effects1,
+      }),
+    )
+    registry.attachMessage('per_1', renderFn1)
+    registry.register(
+      makeParams({
+        requestID: 'per_2',
+        sessionID: 'ses_2',
+        request: makeRequest({requestID: 'per_2', sessionID: 'ses_2'}),
+        effects: effects2,
+      }),
+    )
+    registry.attachMessage('per_2', renderFn2)
 
     // #when disposeAll is called
     await registry.disposeAll('shutdown')
 
     // #then both entries settled with reject/disposed; pending empty
-    expect(effects1.renderSettled).toHaveBeenCalledOnce()
-    expect(effects2.renderSettled).toHaveBeenCalledOnce()
+    expect(renderFn1).toHaveBeenCalledOnce()
+    expect(renderFn2).toHaveBeenCalledOnce()
     expect(registry.pending()).toHaveLength(0)
   })
 
   it('does not throw even if all effects fail', async () => {
     // #given entries whose effects all throw
     const registry = createApprovalRegistry({logger: makeLogger()})
+    const renderFn = vi.fn().mockRejectedValue(new Error('boom')) as RenderFn
     const effects = makeEffects({
       postReply: vi.fn().mockRejectedValue(new Error('boom')),
-      renderSettled: vi.fn().mockRejectedValue(new Error('boom')),
     })
     registry.register(makeParams({effects}))
+    registry.attachMessage('per_1', renderFn)
 
     // #when disposeAll
     await expect(registry.disposeAll('shutdown')).resolves.not.toThrow()
 
     // #then pending is empty
     expect(registry.pending()).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// attachMessage / markMessagePostFailed
+// ---------------------------------------------------------------------------
+
+describe('attachMessage', () => {
+  it('warns if requestID is not found (already settled)', () => {
+    // #given settled entry
+    const logger = makeLogger()
+    const registry = createApprovalRegistry({logger})
+    // no register — unknown id
+
+    // #when attachMessage called
+    registry.attachMessage('per_GONE', makeRenderFn())
+
+    // #then warns; no throw
+    expect(logger.warn).toHaveBeenCalled()
+  })
+})
+
+describe('markMessagePostFailed', () => {
+  it('warns if requestID is not found; does not throw', () => {
+    const logger = makeLogger()
+    const registry = createApprovalRegistry({logger})
+    registry.markMessagePostFailed('per_GONE')
+    expect(logger.warn).toHaveBeenCalled()
+  })
+
+  it('entry without renderFn skips render on settlement', async () => {
+    // #given entry with no message attached (markMessagePostFailed was called)
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const effects = makeEffects()
+    registry.register(makeParams({effects}))
+    registry.markMessagePostFailed('per_1')
+
+    // #when deadline fires
+    await registry.applySettlement({requestID: 'per_1', decision: 'reject', reason: 'deadline'})
+
+    // #then postReply called (best-effort), entry removed, no render crash
+    expect(effects.postReply).toHaveBeenCalledOnce()
+    expect(registry.has('per_1')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FIX 1: cascadeReject skips claimed siblings
+// ---------------------------------------------------------------------------
+
+describe('FIX 1 — cascadeReject skips claimed siblings', () => {
+  it('cascade from A reject does NOT send reject POST to B when B is claimed (button in-flight)', async () => {
+    // #given two entries in the same session
+    const registry = createApprovalRegistry({logger: makeLogger()})
+
+    // Entry A: open
+    const effectsA = makeEffects()
+    const renderFnA = makeRenderFn()
+    registry.register(
+      makeParams({
+        requestID: 'per_A',
+        sessionID: 'ses_1',
+        request: makeRequest({requestID: 'per_A', sessionID: 'ses_1'}),
+        effects: effectsA,
+      }),
+    )
+    registry.attachMessage('per_A', renderFnA)
+
+    // Entry B: claimed (button approve in-flight — postReply held pending)
+    let resolveB!: (v: {ok: boolean}) => void
+    const replyPromiseB = new Promise<{ok: boolean}>(res => {
+      resolveB = res
+    })
+    const effectsB = makeEffects({postReply: vi.fn().mockReturnValue(replyPromiseB)})
+    const renderFnB = makeRenderFn()
+    registry.register(
+      makeParams({
+        requestID: 'per_B',
+        sessionID: 'ses_1',
+        request: makeRequest({requestID: 'per_B', sessionID: 'ses_1'}),
+        effects: effectsB,
+      }),
+    )
+    registry.attachMessage('per_B', renderFnB)
+
+    // Claim B (button click in-flight, not yet resolved)
+    const bClickPromise = registry.handleButtonDecision({
+      requestID: 'per_B',
+      channelID: 'chan_1',
+      decision: 'once',
+      decidedBy: 'user_B',
+    })
+
+    // #when A's confirmReply fires with reject (triggers cascade)
+    registry.confirmReply({requestID: 'per_A', sessionID: 'ses_1', reply: 'reject'})
+
+    // Allow the cascade async chain to settle
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // #then A is gone (settled via confirmReply)
+    expect(registry.has('per_A')).toBe(false)
+
+    // #then B is still present (claimed, not cascaded)
+    expect(registry.has('per_B')).toBe(true)
+
+    // #then effectsB.postReply was called ONCE (the button click), NOT a second time for cascade
+    // (it's still pending — the promise hasn't resolved yet)
+    expect(effectsB.postReply).toHaveBeenCalledOnce()
+
+    // #when B's button postReply resolves successfully
+    resolveB({ok: true})
+    const bOutcome = await bClickPromise
+    expect(bOutcome).toBe<DecisionOutcome>('ok')
+
+    // #when B's confirmReply arrives (echo of the button approve)
+    registry.confirmReply({requestID: 'per_B', sessionID: 'ses_1', reply: 'once'})
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // #then B is now settled (rendered approved once)
+    expect(registry.has('per_B')).toBe(false)
+    expect(renderFnB).toHaveBeenCalledOnce()
+    // renderFn called with 'once' (the button decision), not 'reject'
+    const [, decision] = (renderFnB as ReturnType<typeof vi.fn>).mock.calls[0] as [unknown, string, ...unknown[]]
+    expect(decision).toBe('once')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FIX 2: deadlineExpired flag — fail-close on button postReply failure after deadline
+// ---------------------------------------------------------------------------
+
+describe('FIX 2 — deadlineExpired: fail-close when button postReply fails after deadline fired', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('ok:false path — entry is fail-closed (reject POST + render deadline + deleted), NOT left open', async () => {
+    // #given an entry with a deadline
+    const registry = createApprovalRegistry({logger: makeLogger()})
+
+    let resolveButton!: (v: {ok: boolean}) => void
+    const buttonPromise = new Promise<{ok: boolean}>(res => {
+      resolveButton = res
+    })
+    const postReply = vi.fn().mockReturnValue(buttonPromise)
+    const renderFn = makeRenderFn()
+    const effects = makeEffects({postReply})
+    registry.register(makeParams({effects, deadlineMs: 5_000}))
+    registry.attachMessage('per_1', renderFn)
+
+    // #when button is clicked (entry transitions to claimed)
+    const buttonClickPromise = registry.handleButtonDecision({
+      requestID: 'per_1',
+      channelID: 'chan_1',
+      decision: 'once',
+      decidedBy: 'user_A',
+    })
+
+    // #when deadline fires while button is in-flight (no-op, sets deadlineExpired)
+    vi.advanceTimersByTime(6_000)
+    // Let the deadline callback run
+    await Promise.resolve()
+
+    // #then entry is still present (deadline was a no-op because claimed)
+    expect(registry.has('per_1')).toBe(true)
+
+    // #when button postReply resolves as ok:false
+    resolveButton({ok: false})
+    await buttonClickPromise
+
+    // Allow failCloseNow async chain to settle
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // #then entry is fail-closed: reject POST sent (once for button attempt + once for failCloseNow)
+    // The button attempt returned ok:false (1 call), then failCloseNow sends another reject (2nd call)
+    expect(postReply).toHaveBeenCalledTimes(2)
+    expect(postReply).toHaveBeenLastCalledWith('per_1', '/workspace/proj', 'reject')
+
+    // #then renderFn called with 'deadline' reason
+    expect(renderFn).toHaveBeenCalledOnce()
+    const [, , , reason] = (renderFn as ReturnType<typeof vi.fn>).mock.calls[0] as [unknown, unknown, unknown, string]
+    expect(reason).toBe('deadline')
+
+    // #then entry is deleted (not left open)
+    expect(registry.has('per_1')).toBe(false)
+  })
+
+  it('throw path — entry is fail-closed when button postReply throws after deadline fired', async () => {
+    // #given an entry with a deadline
+    const registry = createApprovalRegistry({logger: makeLogger()})
+
+    let rejectButton!: (err: Error) => void
+    const buttonPromise = new Promise<{ok: boolean}>((_, rej) => {
+      rejectButton = rej
+    })
+    const postReply = vi.fn().mockReturnValue(buttonPromise)
+    const renderFn = makeRenderFn()
+    const effects = makeEffects({postReply})
+    registry.register(makeParams({effects, deadlineMs: 5_000}))
+    registry.attachMessage('per_1', renderFn)
+
+    // #when button is clicked
+    const buttonClickPromise = registry.handleButtonDecision({
+      requestID: 'per_1',
+      channelID: 'chan_1',
+      decision: 'once',
+      decidedBy: 'user_A',
+    })
+
+    // #when deadline fires while button is in-flight
+    vi.advanceTimersByTime(6_000)
+    await Promise.resolve()
+
+    // #when button postReply throws
+    rejectButton(new Error('network error'))
+    const outcome = await buttonClickPromise
+
+    // Allow failCloseNow async chain to settle
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // #then outcome is still 'reply-failed' (the button click did fail)
+    expect(outcome).toBe<DecisionOutcome>('reply-failed')
+
+    // #then entry is fail-closed: failCloseNow sent a reject POST
+    // (postReply called once for button throw, once for failCloseNow)
+    expect(postReply).toHaveBeenCalledTimes(2)
+    expect(postReply).toHaveBeenLastCalledWith('per_1', '/workspace/proj', 'reject')
+
+    // #then renderFn called with 'deadline' reason
+    expect(renderFn).toHaveBeenCalledOnce()
+
+    // #then entry is deleted
+    expect(registry.has('per_1')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FIX 3: stale timer on duplicate register
+// ---------------------------------------------------------------------------
+
+describe('FIX 3 — stale timer cleared on duplicate register', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('old deadline timer does NOT fire on the replacement entry after re-register', async () => {
+    // #given an entry registered with a 5s deadline
+    const registry = createApprovalRegistry({logger: makeLogger()})
+
+    const postReply1 = vi.fn().mockResolvedValue({ok: true})
+    registry.register(
+      makeParams({
+        requestID: 'per_1',
+        effects: makeEffects({postReply: postReply1}),
+        deadlineMs: 5_000,
+      }),
+    )
+
+    // #when the same requestID is re-registered (new entry, new effects, new deadline)
+    const postReply2 = vi.fn().mockResolvedValue({ok: true})
+    registry.register(
+      makeParams({
+        requestID: 'per_1',
+        effects: makeEffects({postReply: postReply2}),
+        deadlineMs: 20_000,
+      }),
+    )
+
+    // #when time advances past the FIRST deadline (5s) but not the second (20s)
+    vi.advanceTimersByTime(6_000)
+    // Allow any timer callbacks to run
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // #then the replacement entry was NOT settled by the stale timer
+    expect(registry.has('per_1')).toBe(true)
+    // postReply2 (the replacement entry's effects) was NOT called by the stale timer
+    expect(postReply2).not.toHaveBeenCalled()
+    // postReply1 (the old entry's effects) was also not called (timer was cleared)
+    expect(postReply1).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// P2 bonus: confirmReply sessionID mismatch guard
+// ---------------------------------------------------------------------------
+
+describe('P2 — confirmReply sessionID mismatch guard', () => {
+  it('ignores confirmReply when event.sessionID does not match entry.sessionID', () => {
+    // #given an entry registered for ses_1
+    const logger = makeLogger()
+    const registry = createApprovalRegistry({logger})
+    const renderFn = makeRenderFn()
+    registry.register(makeParams({sessionID: 'ses_1', request: makeRequest({requestID: 'per_1', sessionID: 'ses_1'})}))
+    registry.attachMessage('per_1', renderFn)
+
+    // #when confirmReply arrives with a different sessionID
+    registry.confirmReply({requestID: 'per_1', sessionID: 'ses_WRONG', reply: 'once'})
+
+    // #then entry is NOT settled (still present)
+    expect(registry.has('per_1')).toBe(true)
+    // renderFn was NOT called
+    expect(renderFn).not.toHaveBeenCalled()
+    // warn was logged
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({requestID: 'per_1', entrySessionID: 'ses_1', eventSessionID: 'ses_WRONG'}),
+      expect.stringContaining('sessionID mismatch'),
+    )
+  })
+
+  it('settles normally when event.sessionID matches entry.sessionID', async () => {
+    // #given an entry registered for ses_1
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    const renderFn = makeRenderFn()
+    registry.register(makeParams({sessionID: 'ses_1', request: makeRequest({requestID: 'per_1', sessionID: 'ses_1'})}))
+    registry.attachMessage('per_1', renderFn)
+
+    // #when confirmReply arrives with matching sessionID
+    registry.confirmReply({requestID: 'per_1', sessionID: 'ses_1', reply: 'once'})
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // #then entry is settled and deleted
+    expect(registry.has('per_1')).toBe(false)
+    expect(renderFn).toHaveBeenCalledOnce()
   })
 })

--- a/packages/gateway/src/approvals/registry.ts
+++ b/packages/gateway/src/approvals/registry.ts
@@ -5,14 +5,59 @@
  * button handler can: verify channel binding, claim exactly once
  * (single-winner), and POST the reply to OpenCode. All Discord/SDK side
  * effects are injected as closures — this module is pure and unit-testable.
+ *
+ * ### 3-state entry lifecycle
+ *
+ * ```
+ *   open  ──claim──▶  claimed  ──confirmReply──▶  (deleted)
+ *             │                  │
+ *             │           postReply failed
+ *             │                  │
+ *             └──────────────────▶  open  (retry allowed)
+ * ```
+ *
+ * - `open`      — registered, no button click yet (or postReply failed).
+ * - `claimed`   — button click in-flight; postReply call is running.
+ *                 A second click returns `already-claimed` immediately,
+ *                 preventing a duplicate POST even while the first is awaiting.
+ * - The entry is deleted when `confirmReply` is called (the authoritative
+ *   `permission.replied` echo from OpenCode) or on dispose.
+ *
+ * ### Winner-vs-loser rule (deadline race)
+ *
+ * - A **deadline** fires in the registry's own timer. If the entry is still
+ *   `open` at that moment: the deadline wins — POST reject, render 'deadline',
+ *   delete. If the entry is `claimed` (button approve in-flight): the button
+ *   is the winner — deadline is a NO-OP, but `deadlineExpired` is set to true.
+ *   If the button's postReply then fails, the reset path checks `deadlineExpired`
+ *   and immediately fail-closes instead of leaving the entry open with a dead timer.
+ * - A **dispose** (run ended / gateway shutdown) always wins — it tears down
+ *   regardless of state (render 'disposed' + delete + best-effort reject POST
+ *   if not yet claimed).
+ *
+ * ### register-before-send
+ *
+ * Callers MUST call `register()` before attempting to post the Discord embed.
+ * Once the embed is posted successfully, call `attachMessage(requestID, renderFn)`
+ * so that settled state can edit the message.
+ * If the send fails, call `markMessagePostFailed(requestID)` — the entry stays
+ * registered so the permission can still be POSTed when it settles.
  */
 
 import type {GatewayLogger} from '../discord/client.js'
-import type {PermissionReply, PermissionRequest, SettlementReason} from './coordinator.js'
+import type {PermissionReply, PermissionReplyEvent, PermissionRequest, SettlementReason} from './coordinator.js'
 
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
+
+/** Render function injected after the Discord embed is posted successfully. */
+export type RenderFn = (
+  request: PermissionRequest,
+  decision: PermissionReply,
+  decidedBy: string | null,
+  reason: SettlementReason,
+) => Promise<void>
 
 export interface ApprovalSideEffects {
   /** POST the decision to OpenCode's reply endpoint. Injected by run.ts. */
@@ -21,30 +66,45 @@ export interface ApprovalSideEffects {
     directory: string,
     decision: PermissionReply,
   ) => Promise<{readonly ok: boolean; readonly error?: string}>
-  /** Edit the posted Discord approval message to a settled embed. Injected by run.ts. */
-  renderSettled: (
-    request: PermissionRequest,
-    decision: PermissionReply,
-    decidedBy: string | null,
-    reason: SettlementReason,
-  ) => Promise<void>
 }
 
 export interface RegisterParams {
   readonly requestID: string
   readonly sessionID: string
-  /** Thread/channel id where the embed was posted — the binding. */
+  /** Thread/channel id where the embed will be posted — the binding. */
   readonly channelID: string
   /** Workspace dir for reply routing. */
   readonly directory: string
   readonly request: PermissionRequest
   readonly effects: ApprovalSideEffects
+  /**
+   * Optional per-entry deadline (ms). If defined and > 0, the registry starts
+   * a timer. On expiry: if entry is still `open` → POST reject + render
+   * 'deadline' + delete. If `claimed` (button in-flight) → NO-OP; the button
+   * winner owns the outcome. `deadlineExpired` is set to true so that if the
+   * button's postReply subsequently fails, the reset path fail-closes immediately.
+   */
+  readonly deadlineMs?: number
 }
 
 export type DecisionOutcome = 'ok' | 'not-found' | 'channel-mismatch' | 'already-claimed' | 'reply-failed'
 
+export type EntryState = 'open' | 'claimed' | 'confirmed'
+
 export interface ApprovalRegistry {
+  /** Register a new entry BEFORE sending the Discord embed. */
   register: (params: RegisterParams) => void
+  /**
+   * Attach the settled-embed render function once the Discord message is
+   * posted. Must be called after `register` and only when the send succeeds.
+   */
+  attachMessage: (requestID: string, renderFn: RenderFn) => void
+  /**
+   * Mark that the Discord embed could not be posted. The entry stays
+   * registered so the permission reply can still be POSTed on settlement;
+   * the embed edit step is skipped since there is nothing to edit.
+   */
+  markMessagePostFailed: (requestID: string) => void
   has: (requestID: string) => boolean
   pending: () => readonly string[]
   /** Button path: enforce channel binding, single-winner claim, POST reply. Does NOT edit the embed. */
@@ -54,13 +114,29 @@ export interface ApprovalRegistry {
     readonly decision: PermissionReply
     readonly decidedBy: string
   }) => Promise<DecisionOutcome>
-  /** Settlement application (called from coordinator.onSettled via run.ts). Idempotent. */
+  /**
+   * Authoritative settlement from `permission.replied`.
+   * - Entry `open` → OpenCode-initiated (unsolicited or always-rule): render, clear timer, delete. No POST.
+   * - Entry `claimed` → echo of our own button POST: render with event.reply, clear timer, delete.
+   * - On `event.reply === 'reject'` → cascade all OTHER `open` entries with the same sessionID:
+   *   best-effort POST reject, render 'cascade', clear timer, delete.
+   *   NOTE: `claimed` siblings are skipped — they own their outcome via their own confirmReply echo.
+   * - Entry not found → no-op.
+   * - sessionID mismatch → warn + no-op (defensive cross-session guard).
+   */
+  confirmReply: (event: PermissionReplyEvent) => void
+  /** Settlement application (called from applySettlement for dispose paths). Idempotent. */
   applySettlement: (args: {
     readonly requestID: string
     readonly decision: PermissionReply
     readonly reason: SettlementReason
   }) => Promise<void>
-  /** Fail-close every open entry (shutdown / run teardown). */
+  /**
+   * Fail-close every open entry that belongs to `sessionID` (run teardown).
+   * Safe to call even if entries have already been settled.
+   */
+  disposeRun: (sessionID: string, reason: string) => Promise<void>
+  /** Fail-close every open entry (shutdown / global teardown). */
   disposeAll: (reason: string) => Promise<void>
 }
 
@@ -74,8 +150,19 @@ interface RegistryEntry {
   readonly channelID: string
   readonly directory: string
   readonly effects: ApprovalSideEffects
-  claimed: boolean
+  state: EntryState
   decidedBy: string | null
+  /** Set by attachMessage once the Discord embed is posted. */
+  renderFn: RenderFn | null
+  /** Deadline timer handle — cleared on any terminal transition. */
+  timer: ReturnType<typeof setTimeout> | null
+  /**
+   * Set to true when the deadline timer fires but the entry is `claimed`
+   * (button in-flight). If the button's postReply subsequently fails and
+   * resets state to `open`, the reset path checks this flag and immediately
+   * fail-closes instead of leaving the entry open with a dead timer.
+   */
+  deadlineExpired: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -87,15 +174,161 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
   const entries = new Map<string, RegistryEntry>()
 
   // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  function clearTimer(entry: RegistryEntry): void {
+    if (entry.timer !== null) {
+      clearTimeout(entry.timer)
+      entry.timer = null
+    }
+  }
+
+  async function runRender(
+    entry: RegistryEntry,
+    requestID: string,
+    decision: PermissionReply,
+    reason: SettlementReason,
+  ): Promise<void> {
+    if (entry.renderFn !== null) {
+      try {
+        await entry.renderFn(entry.request, decision, entry.decidedBy, reason)
+      } catch (error) {
+        logger.error({requestID, reason, err: error}, 'ApprovalRegistry: renderFn threw during settlement — continuing')
+      }
+    }
+  }
+
+  /**
+   * Shared fail-close helper: POST reject + render 'deadline' + delete.
+   * Used by both the deadline open-path and the handleButtonDecision reset
+   * path when deadlineExpired is true.
+   */
+  async function failCloseNow(requestID: string, entry: RegistryEntry): Promise<void> {
+    logger.warn({requestID}, 'ApprovalRegistry: fail-closing entry (deadline already expired)')
+    entry.state = 'claimed'
+    entry.decidedBy = null
+    try {
+      const r = await entry.effects.postReply(requestID, entry.directory, 'reject')
+      if (!r.ok) {
+        logger.warn(
+          {requestID, error: r.error},
+          'ApprovalRegistry: failCloseNow postReply returned ok:false — continuing',
+        )
+      }
+    } catch (error) {
+      logger.warn({requestID, err: error}, 'ApprovalRegistry: failCloseNow postReply threw — continuing')
+    }
+    await runRender(entry, requestID, 'reject', 'deadline')
+    entries.delete(requestID)
+  }
+
+  // -------------------------------------------------------------------------
   // register
   // -------------------------------------------------------------------------
 
   function register(params: RegisterParams): void {
-    const {requestID, sessionID, channelID, directory, request, effects} = params
+    const {requestID, sessionID, channelID, directory, request, effects, deadlineMs} = params
     if (entries.has(requestID)) {
+      // FIX 3: clear the existing entry's timer before overwriting so the old
+      // setTimeout cannot fire settleByDeadline on the replacement entry.
+      const existing = entries.get(requestID)
+      if (existing !== undefined) {
+        clearTimer(existing)
+      }
       logger.warn({requestID}, 'ApprovalRegistry: duplicate requestID — overwriting (re-ask)')
     }
-    entries.set(requestID, {request, sessionID, channelID, directory, effects, claimed: false, decidedBy: null})
+    const entry: RegistryEntry = {
+      request,
+      sessionID,
+      channelID,
+      directory,
+      effects,
+      state: 'open',
+      decidedBy: null,
+      renderFn: null,
+      timer: null,
+      deadlineExpired: false,
+    }
+    entries.set(requestID, entry)
+
+    if (deadlineMs !== undefined && deadlineMs > 0) {
+      entry.timer = setTimeout(() => {
+        settleByDeadline(requestID)
+      }, deadlineMs)
+      entry.timer.unref?.()
+    }
+  }
+
+  /**
+   * Deadline timer callback. Only settles if entry is still `open` — the
+   * button winner (claimed state) beats the deadline.
+   *
+   * FIX 2: When the entry is `claimed`, set `deadlineExpired = true` so that
+   * if the button's postReply subsequently fails and resets to `open`, the
+   * reset path can immediately fail-close instead of leaving a dead timer.
+   */
+  function settleByDeadline(requestID: string): void {
+    const entry = entries.get(requestID)
+    if (entry === undefined) return // already gone
+
+    if (entry.state !== 'open') {
+      // Button approve is in-flight (claimed). Deadline LOSES. No-op.
+      // But mark deadlineExpired so the button reset path can fail-close.
+      entry.deadlineExpired = true
+      logger.debug(
+        {requestID, state: entry.state},
+        'ApprovalRegistry: deadline fired but entry is claimed — no-op (button winner); deadlineExpired set',
+      )
+      return
+    }
+
+    // Entry is open — deadline wins.
+    logger.warn({requestID}, 'ApprovalRegistry: deadline expired on open entry — fail-closed')
+    entry.state = 'claimed'
+    entry.timer = null
+
+    // Best-effort POST reject then render.
+    const doDeadline = async () => {
+      try {
+        const r = await entry.effects.postReply(requestID, entry.directory, 'reject')
+        if (!r.ok) {
+          logger.warn(
+            {requestID, error: r.error},
+            'ApprovalRegistry: deadline postReply returned ok:false — continuing',
+          )
+        }
+      } catch (error) {
+        logger.warn({requestID, err: error}, 'ApprovalRegistry: deadline postReply threw — continuing')
+      }
+      await runRender(entry, requestID, 'reject', 'deadline')
+      entries.delete(requestID)
+    }
+
+    // eslint-disable-next-line no-void
+    void doDeadline()
+  }
+
+  // -------------------------------------------------------------------------
+  // attachMessage / markMessagePostFailed
+  // -------------------------------------------------------------------------
+
+  function attachMessage(requestID: string, renderFn: RenderFn): void {
+    const entry = entries.get(requestID)
+    if (entry === undefined) {
+      logger.warn({requestID}, 'ApprovalRegistry: attachMessage — entry not found (already settled?)')
+      return
+    }
+    entry.renderFn = renderFn
+  }
+
+  function markMessagePostFailed(requestID: string): void {
+    const entry = entries.get(requestID)
+    if (entry === undefined) {
+      logger.warn({requestID}, 'ApprovalRegistry: markMessagePostFailed — entry not found (already settled?)')
+      return
+    }
+    logger.warn({requestID}, 'ApprovalRegistry: embed post failed — entry stays registered, renderFn will be skipped')
   }
 
   // -------------------------------------------------------------------------
@@ -135,36 +368,138 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
       return 'channel-mismatch'
     }
 
-    if (entry.claimed) {
+    // Single-winner gate: claimed or confirmed both block a second click.
+    if (entry.state === 'claimed' || entry.state === 'confirmed') {
       return 'already-claimed'
     }
 
-    // Claim the slot
-    entry.claimed = true
+    // Atomic claim — transitions open → claimed
+    entry.state = 'claimed'
     entry.decidedBy = decidedBy
 
     let result: {readonly ok: boolean; readonly error?: string}
     try {
       result = await entry.effects.postReply(requestID, entry.directory, decision)
     } catch (error) {
-      logger.error({requestID, err: error}, 'ApprovalRegistry: postReply threw — resetting claim')
-      entry.claimed = false
-      entry.decidedBy = null
+      logger.error({requestID, err: error}, 'ApprovalRegistry: postReply threw — resetting to open')
+      // FIX 2: if deadline already fired while we were in-flight, fail-close immediately
+      // instead of leaving the entry open with a dead timer.
+      if (entry.deadlineExpired) {
+        // eslint-disable-next-line no-void
+        void failCloseNow(requestID, entry)
+      } else {
+        entry.state = 'open'
+        entry.decidedBy = null
+      }
       return 'reply-failed'
     }
 
     if (!result.ok) {
-      logger.error({requestID, error: result.error}, 'ApprovalRegistry: postReply returned ok:false — resetting claim')
-      entry.claimed = false
-      entry.decidedBy = null
+      logger.error(
+        {requestID, error: result.error},
+        'ApprovalRegistry: postReply returned ok:false — resetting to open',
+      )
+      // FIX 2: same fail-close-on-expired-deadline logic for the ok:false path.
+      if (entry.deadlineExpired) {
+        // eslint-disable-next-line no-void
+        void failCloseNow(requestID, entry)
+      } else {
+        entry.state = 'open'
+        entry.decidedBy = null
+      }
       return 'reply-failed'
     }
 
+    // Stay claimed — render happens in confirmReply when OpenCode echoes back.
+    // Do NOT transition to confirmed here; the deadline must see 'claimed' to back off.
     return 'ok'
   }
 
   // -------------------------------------------------------------------------
-  // applySettlement
+  // confirmReply — authoritative path for permission.replied
+  // -------------------------------------------------------------------------
+
+  function confirmReply(event: PermissionReplyEvent): void {
+    const {requestID, sessionID, reply} = event
+
+    const entry = entries.get(requestID)
+    if (entry === undefined) {
+      logger.debug({requestID, reply}, 'ApprovalRegistry: confirmReply — entry not found (already settled?)')
+      return
+    }
+
+    // P2 defensive guard: cross-session settle prevention.
+    // requestIDs are globally unique (per_...) so this should never fire in
+    // practice, but guards against any future ID-collision scenario.
+    if (entry.sessionID !== sessionID) {
+      logger.warn(
+        {requestID, entrySessionID: entry.sessionID, eventSessionID: sessionID},
+        'ApprovalRegistry: confirmReply — sessionID mismatch, ignoring (cross-session guard)',
+      )
+      return
+    }
+
+    // Clear the deadline timer regardless of state — this event is authoritative.
+    clearTimer(entry)
+
+    // Log if OpenCode's reply differs from our claimed decision (it wins).
+    if ((entry.state === 'claimed' || entry.state === 'confirmed') && entry.decidedBy !== null) {
+      // The reply is the echo of our POST. Render with OpenCode's reply.
+      logger.info({requestID, state: entry.state, reply}, 'ApprovalRegistry: confirmReply — button winner echo')
+    } else {
+      // Open entry: OpenCode-initiated (unsolicited reject or always-rule). No POST needed.
+      logger.info({requestID, state: entry.state, reply}, 'ApprovalRegistry: confirmReply — OpenCode-initiated')
+    }
+
+    entries.delete(requestID)
+
+    // Render asynchronously (best-effort; errors logged inside runRender).
+    // eslint-disable-next-line no-void
+    void runRender(entry, requestID, reply, 'replied').then(() => {
+      // FIX 1: cascade only `open` siblings — skip `claimed` siblings entirely.
+      // A `claimed` sibling has its own button-approve postReply in-flight and
+      // will settle via its own confirmReply echo (or its own deadline).
+      // Sending a cascade reject to a claimed sibling would create a contradiction:
+      // OpenCode would receive both 'once' (from the button) and 'reject' (cascade).
+      if (reply === 'reject') {
+        // eslint-disable-next-line no-void
+        void cascadeReject(sessionID)
+      }
+    })
+  }
+
+  async function cascadeReject(sessionID: string): Promise<void> {
+    // FIX 1: only cascade to `open` siblings; skip `claimed` ones.
+    const siblings = Array.from(entries.entries()).filter(([, e]) => e.sessionID === sessionID && e.state === 'open')
+    await Promise.all(
+      siblings.map(async ([sibID, sib]) => {
+        clearTimer(sib)
+        entries.delete(sibID)
+        logger.info({requestID: sibID, sessionID}, 'ApprovalRegistry: cascade-rejecting sibling permission')
+        // Best-effort reject POST for the sibling (spec: KEEP the cascade POST).
+        try {
+          await sib.effects.postReply(sibID, sib.directory, 'reject')
+        } catch (error) {
+          logger.warn({requestID: sibID, err: error}, 'ApprovalRegistry: cascade postReply threw — continuing')
+        }
+        await runRender(sib, sibID, 'reject', 'cascade')
+      }),
+    )
+  }
+
+  // -------------------------------------------------------------------------
+  // applySettlement — legacy/dispose path
+  //
+  // Still used by:
+  //   - disposeRun / disposeAll (reason: 'disposed')
+  //   - Any legacy callsite passing reason 'replied' | 'cascade' | 'deadline'
+  //     directly (e.g., coordinator onSettled wiring). Will still work but the
+  //     preferred path for 'replied' is confirmReply().
+  //
+  // Winner-vs-loser for deadline:
+  //   If entry.state !== 'open' (already claimed/confirmed by a real winner),
+  //   a 'deadline' reason must NOT render or delete — the winner owns it.
+  //   EXCEPTION: 'disposed' always tears down (run is ending).
   // -------------------------------------------------------------------------
 
   async function applySettlement(args: {
@@ -180,12 +515,27 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
       return
     }
 
-    // For non-replied reasons on unclaimed entries: best-effort postReply
-    if (reason !== 'replied' && !entry.claimed) {
-      entry.claimed = true
+    // Deadline: if entry is claimed/confirmed, the button winner owns it — bail.
+    if (reason === 'deadline' && entry.state !== 'open') {
+      logger.debug(
+        {requestID, state: entry.state},
+        'ApprovalRegistry: applySettlement(deadline) — entry claimed/confirmed, deadline loses (no-op)',
+      )
+      return
+    }
+
+    // Clear deadline timer on any terminal path.
+    clearTimer(entry)
+
+    // For non-replied/non-cascade reasons on open entries: best-effort postReply.
+    // Skip if already claimed/confirmed (postReply was or is being sent).
+    if (reason !== 'replied' && reason !== 'cascade' && entry.state === 'open') {
+      entry.state = 'claimed'
       try {
         const r = await entry.effects.postReply(requestID, entry.directory, decision)
-        if (!r.ok) {
+        if (r.ok) {
+          entry.state = 'confirmed'
+        } else {
           logger.warn(
             {requestID, reason, error: r.error},
             'ApprovalRegistry: best-effort postReply on settlement returned ok:false — continuing',
@@ -199,18 +549,36 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
       }
     }
 
-    // Render the settled embed — defensive wrap; Discord edit failure must not propagate
-    try {
-      await entry.effects.renderSettled(entry.request, decision, entry.decidedBy, reason)
-    } catch (error) {
-      logger.error(
-        {requestID, reason, err: error},
-        'ApprovalRegistry: renderSettled threw during settlement — continuing',
-      )
-    }
+    // Edit the settled embed — only if a message was successfully attached.
+    await runRender(entry, requestID, decision, reason)
 
     // Unregister
     entries.delete(requestID)
+  }
+
+  // -------------------------------------------------------------------------
+  // disposeRun
+  // -------------------------------------------------------------------------
+
+  async function disposeRun(sessionID: string, reason: string): Promise<void> {
+    const snapshot = Array.from(entries.entries())
+      .filter(([, entry]) => entry.sessionID === sessionID)
+      .map(([requestID]) => requestID)
+    if (snapshot.length > 0) {
+      logger.warn(
+        {sessionID, reason, count: snapshot.length},
+        'ApprovalRegistry: disposeRun — fail-closing run entries',
+      )
+    }
+    await Promise.all(
+      snapshot.map(async requestID => {
+        try {
+          await applySettlement({requestID, decision: 'reject', reason: 'disposed'})
+        } catch (error) {
+          logger.error({requestID, err: error}, 'ApprovalRegistry: disposeRun — applySettlement threw — continuing')
+        }
+      }),
+    )
   }
 
   // -------------------------------------------------------------------------
@@ -231,5 +599,16 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
     )
   }
 
-  return {register, has, pending, handleButtonDecision, applySettlement, disposeAll}
+  return {
+    register,
+    attachMessage,
+    markMessagePostFailed,
+    has,
+    pending,
+    handleButtonDecision,
+    confirmReply,
+    applySettlement,
+    disposeRun,
+    disposeAll,
+  }
 }

--- a/packages/gateway/src/approvals/registry.ts
+++ b/packages/gateway/src/approvals/registry.ts
@@ -1,5 +1,5 @@
 /**
- * Program-scoped approval registry bridge (Unit 3b).
+ * Program-scoped approval registry bridge.
  *
  * Maps requestID → approval context across all in-flight runs so the Discord
  * button handler can: verify channel binding, claim exactly once

--- a/packages/gateway/src/approvals/registry.ts
+++ b/packages/gateway/src/approvals/registry.ts
@@ -235,6 +235,12 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
       const existing = entries.get(requestID)
       if (existing !== undefined) {
         clearTimer(existing)
+        // NBC4: best-effort render the old embed as superseded so its buttons
+        // become visibly inert. Wrapped so it never throws into register.
+        if (existing.renderFn !== null) {
+          // eslint-disable-next-line no-void
+          void existing.renderFn(existing.request, 'reject', null, 'superseded').catch(() => {})
+        }
       }
       logger.warn({requestID}, 'ApprovalRegistry: duplicate requestID — overwriting (re-ask)')
     }

--- a/packages/gateway/src/approvals/registry.ts
+++ b/packages/gateway/src/approvals/registry.ts
@@ -1,0 +1,235 @@
+/**
+ * Program-scoped approval registry bridge (Unit 3b).
+ *
+ * Maps requestID → approval context across all in-flight runs so the Discord
+ * button handler can: verify channel binding, claim exactly once
+ * (single-winner), and POST the reply to OpenCode. All Discord/SDK side
+ * effects are injected as closures — this module is pure and unit-testable.
+ */
+
+import type {GatewayLogger} from '../discord/client.js'
+import type {PermissionReply, PermissionRequest, SettlementReason} from './coordinator.js'
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ApprovalSideEffects {
+  /** POST the decision to OpenCode's reply endpoint. Injected by run.ts. */
+  postReply: (
+    requestID: string,
+    directory: string,
+    decision: PermissionReply,
+  ) => Promise<{readonly ok: boolean; readonly error?: string}>
+  /** Edit the posted Discord approval message to a settled embed. Injected by run.ts. */
+  renderSettled: (
+    request: PermissionRequest,
+    decision: PermissionReply,
+    decidedBy: string | null,
+    reason: SettlementReason,
+  ) => Promise<void>
+}
+
+export interface RegisterParams {
+  readonly requestID: string
+  readonly sessionID: string
+  /** Thread/channel id where the embed was posted — the binding. */
+  readonly channelID: string
+  /** Workspace dir for reply routing. */
+  readonly directory: string
+  readonly request: PermissionRequest
+  readonly effects: ApprovalSideEffects
+}
+
+export type DecisionOutcome = 'ok' | 'not-found' | 'channel-mismatch' | 'already-claimed' | 'reply-failed'
+
+export interface ApprovalRegistry {
+  register: (params: RegisterParams) => void
+  has: (requestID: string) => boolean
+  pending: () => readonly string[]
+  /** Button path: enforce channel binding, single-winner claim, POST reply. Does NOT edit the embed. */
+  handleButtonDecision: (args: {
+    readonly requestID: string
+    readonly channelID: string
+    readonly decision: PermissionReply
+    readonly decidedBy: string
+  }) => Promise<DecisionOutcome>
+  /** Settlement application (called from coordinator.onSettled via run.ts). Idempotent. */
+  applySettlement: (args: {
+    readonly requestID: string
+    readonly decision: PermissionReply
+    readonly reason: SettlementReason
+  }) => Promise<void>
+  /** Fail-close every open entry (shutdown / run teardown). */
+  disposeAll: (reason: string) => Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// Internal entry shape
+// ---------------------------------------------------------------------------
+
+interface RegistryEntry {
+  readonly request: PermissionRequest
+  readonly sessionID: string
+  readonly channelID: string
+  readonly directory: string
+  readonly effects: ApprovalSideEffects
+  claimed: boolean
+  decidedBy: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): ApprovalRegistry {
+  const {logger} = deps
+  const entries = new Map<string, RegistryEntry>()
+
+  // -------------------------------------------------------------------------
+  // register
+  // -------------------------------------------------------------------------
+
+  function register(params: RegisterParams): void {
+    const {requestID, sessionID, channelID, directory, request, effects} = params
+    if (entries.has(requestID)) {
+      logger.warn({requestID}, 'ApprovalRegistry: duplicate requestID — overwriting (re-ask)')
+    }
+    entries.set(requestID, {request, sessionID, channelID, directory, effects, claimed: false, decidedBy: null})
+  }
+
+  // -------------------------------------------------------------------------
+  // has / pending
+  // -------------------------------------------------------------------------
+
+  function has(requestID: string): boolean {
+    return entries.has(requestID)
+  }
+
+  function pending(): readonly string[] {
+    return Array.from(entries.keys())
+  }
+
+  // -------------------------------------------------------------------------
+  // handleButtonDecision
+  // -------------------------------------------------------------------------
+
+  async function handleButtonDecision(args: {
+    readonly requestID: string
+    readonly channelID: string
+    readonly decision: PermissionReply
+    readonly decidedBy: string
+  }): Promise<DecisionOutcome> {
+    const {requestID, channelID, decision, decidedBy} = args
+
+    const entry = entries.get(requestID)
+    if (entry === undefined) {
+      return 'not-found'
+    }
+
+    if (entry.channelID !== channelID) {
+      logger.warn(
+        {requestID, expected: entry.channelID, received: channelID},
+        'ApprovalRegistry: channel mismatch — ignoring button click',
+      )
+      return 'channel-mismatch'
+    }
+
+    if (entry.claimed) {
+      return 'already-claimed'
+    }
+
+    // Claim the slot
+    entry.claimed = true
+    entry.decidedBy = decidedBy
+
+    let result: {readonly ok: boolean; readonly error?: string}
+    try {
+      result = await entry.effects.postReply(requestID, entry.directory, decision)
+    } catch (error) {
+      logger.error({requestID, err: error}, 'ApprovalRegistry: postReply threw — resetting claim')
+      entry.claimed = false
+      entry.decidedBy = null
+      return 'reply-failed'
+    }
+
+    if (!result.ok) {
+      logger.error({requestID, error: result.error}, 'ApprovalRegistry: postReply returned ok:false — resetting claim')
+      entry.claimed = false
+      entry.decidedBy = null
+      return 'reply-failed'
+    }
+
+    return 'ok'
+  }
+
+  // -------------------------------------------------------------------------
+  // applySettlement
+  // -------------------------------------------------------------------------
+
+  async function applySettlement(args: {
+    readonly requestID: string
+    readonly decision: PermissionReply
+    readonly reason: SettlementReason
+  }): Promise<void> {
+    const {requestID, decision, reason} = args
+
+    const entry = entries.get(requestID)
+    if (entry === undefined) {
+      // Already settled/unregistered — idempotent no-op
+      return
+    }
+
+    // For non-replied reasons on unclaimed entries: best-effort postReply
+    if (reason !== 'replied' && !entry.claimed) {
+      entry.claimed = true
+      try {
+        const r = await entry.effects.postReply(requestID, entry.directory, decision)
+        if (!r.ok) {
+          logger.warn(
+            {requestID, reason, error: r.error},
+            'ApprovalRegistry: best-effort postReply on settlement returned ok:false — continuing',
+          )
+        }
+      } catch (error) {
+        logger.warn(
+          {requestID, reason, err: error},
+          'ApprovalRegistry: best-effort postReply on settlement threw — continuing',
+        )
+      }
+    }
+
+    // Render the settled embed — defensive wrap; Discord edit failure must not propagate
+    try {
+      await entry.effects.renderSettled(entry.request, decision, entry.decidedBy, reason)
+    } catch (error) {
+      logger.error(
+        {requestID, reason, err: error},
+        'ApprovalRegistry: renderSettled threw during settlement — continuing',
+      )
+    }
+
+    // Unregister
+    entries.delete(requestID)
+  }
+
+  // -------------------------------------------------------------------------
+  // disposeAll
+  // -------------------------------------------------------------------------
+
+  async function disposeAll(_reason: string): Promise<void> {
+    // Snapshot keys before iteration so deletion during iteration is safe
+    const snapshot = Array.from(entries.keys())
+    await Promise.all(
+      snapshot.map(async requestID => {
+        try {
+          await applySettlement({requestID, decision: 'reject', reason: 'disposed'})
+        } catch (error) {
+          logger.error({requestID, err: error}, 'ApprovalRegistry: disposeAll — applySettlement threw — continuing')
+        }
+      }),
+    )
+  }
+
+  return {register, has, pending, handleButtonDecision, applySettlement, disposeAll}
+}

--- a/packages/gateway/src/discord/approvals.test.ts
+++ b/packages/gateway/src/discord/approvals.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Tests for Discord approval UI primitives (gateway tool-approval Unit 3a).
+ *
+ * These tests cover the pure builder functions and custom_id codec — no network,
+ * no Discord client, no side effects.
+ */
+
+import type {PermissionReply, PermissionRequest, SettlementReason} from '../approvals/coordinator.js'
+
+import {ButtonStyle} from 'discord.js'
+import {describe, expect, it} from 'vitest'
+
+import {
+  APPROVE_PREFIX,
+  buildApprovalButtons,
+  buildApprovalCustomId,
+  buildApprovalEmbed,
+  buildSettledEmbed,
+  DENY_PREFIX,
+  parseApprovalCustomId,
+} from './approvals.js'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const baseRequest: PermissionRequest = {
+  requestID: 'per_abc123',
+  sessionID: 'sess_xyz',
+  permission: 'bash',
+  patterns: ['/tmp/*'],
+  title: 'Run shell command in /tmp',
+}
+
+// ---------------------------------------------------------------------------
+// APPROVE_PREFIX / DENY_PREFIX constants
+// ---------------------------------------------------------------------------
+
+describe('prefix constants', () => {
+  it('approve prefix constant is namespaced', () => {
+    // #given/#then
+    expect(APPROVE_PREFIX).toBe('fb-approve:')
+  })
+
+  it('deny prefix constant is namespaced', () => {
+    // #given/#then
+    expect(DENY_PREFIX).toBe('fb-deny:')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildApprovalCustomId
+// ---------------------------------------------------------------------------
+
+describe('buildApprovalCustomId', () => {
+  it('returns prefixed approve id', () => {
+    // #given
+    const requestID = 'per_abc123'
+    // #when
+    const id = buildApprovalCustomId('approve', requestID)
+    // #then
+    expect(id).toBe(`${APPROVE_PREFIX}${requestID}`)
+  })
+
+  it('returns prefixed deny id', () => {
+    // #given
+    const requestID = 'per_abc123'
+    // #when
+    const id = buildApprovalCustomId('deny', requestID)
+    // #then
+    expect(id).toBe(`${DENY_PREFIX}${requestID}`)
+  })
+
+  it('throws when combined length exceeds 100 chars', () => {
+    // #given — a requestID that would push the total over 100
+    const longID = 'x'.repeat(100)
+    // #when/#then
+    expect(() => buildApprovalCustomId('approve', longID)).toThrow()
+    expect(() => buildApprovalCustomId('deny', longID)).toThrow()
+  })
+
+  it('does not throw for IDs right at 100 chars boundary', () => {
+    // #given — APPROVE_PREFIX is 11 chars; 89-char id = exactly 100
+    const requestID = 'x'.repeat(100 - APPROVE_PREFIX.length)
+    // #when/#then — must not throw
+    expect(() => buildApprovalCustomId('approve', requestID)).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseApprovalCustomId
+// ---------------------------------------------------------------------------
+
+describe('parseApprovalCustomId', () => {
+  it('round-trips approve action', () => {
+    // #given
+    const requestID = 'per_1'
+    // #when
+    const result = parseApprovalCustomId(buildApprovalCustomId('approve', requestID))
+    // #then
+    expect(result).toEqual({action: 'approve', requestID})
+  })
+
+  it('round-trips deny action', () => {
+    // #given
+    const requestID = 'per_1'
+    // #when
+    const result = parseApprovalCustomId(buildApprovalCustomId('deny', requestID))
+    // #then
+    expect(result).toEqual({action: 'deny', requestID})
+  })
+
+  it('returns null for unrelated custom_id', () => {
+    // #given/#when/#then
+    expect(parseApprovalCustomId('something-else')).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    // #given/#when/#then
+    expect(parseApprovalCustomId('')).toBeNull()
+  })
+
+  it('returns null for approve prefix with empty requestID', () => {
+    // #given — bare prefix only, no requestID
+    expect(parseApprovalCustomId(APPROVE_PREFIX)).toBeNull()
+  })
+
+  it('returns null for deny prefix with empty requestID', () => {
+    // #given — bare prefix only
+    expect(parseApprovalCustomId(DENY_PREFIX)).toBeNull()
+  })
+
+  it('does not throw for any input', () => {
+    // #given — several weird strings
+    const weirdInputs = [null as unknown as string, undefined as unknown as string, '   ', '\n', 'fb-approve']
+    for (const input of weirdInputs) {
+      // #when/#then
+      expect(() => parseApprovalCustomId(input)).not.toThrow()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildApprovalEmbed
+// ---------------------------------------------------------------------------
+
+describe('buildApprovalEmbed', () => {
+  it('contains the permission category', () => {
+    // #given/#when
+    const json = buildApprovalEmbed(baseRequest).toJSON()
+    // #then
+    const allText = JSON.stringify(json)
+    expect(allText).toContain(baseRequest.permission)
+  })
+
+  it('contains the human-readable title', () => {
+    // #given/#when
+    const json = buildApprovalEmbed(baseRequest).toJSON()
+    // #then
+    const allText = JSON.stringify(json)
+    expect(allText).toContain(baseRequest.title)
+  })
+
+  it('does NOT contain the requestID in visible embed text', () => {
+    // #given/#when
+    const json = buildApprovalEmbed(baseRequest).toJSON()
+    // #then — requestID must NOT appear in the embed (lives in button customId only)
+    const allText = JSON.stringify(json)
+    expect(allText).not.toContain(baseRequest.requestID)
+  })
+
+  it('does NOT dump raw patterns array', () => {
+    // #given — a request whose pattern is distinct from the title
+    const req: PermissionRequest = {
+      ...baseRequest,
+      patterns: ['/__SECRET_PATTERN__/*'],
+      title: 'Safe title only',
+    }
+    // #when
+    const json = buildApprovalEmbed(req).toJSON()
+    // #then — raw pattern string must not appear
+    const allText = JSON.stringify(json)
+    expect(allText).not.toContain('__SECRET_PATTERN__')
+  })
+
+  it('includes a footer about fail-closed behaviour', () => {
+    // #given/#when
+    const json = buildApprovalEmbed(baseRequest).toJSON()
+    // #then — some footer text mentioning denial on timeout
+    expect(json.footer?.text).toBeTruthy()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildApprovalButtons
+// ---------------------------------------------------------------------------
+
+describe('buildApprovalButtons', () => {
+  it('produces exactly 2 buttons', () => {
+    // #given
+    const requestID = 'per_abc123'
+    // #when
+    const row = buildApprovalButtons(requestID).toJSON()
+    // #then
+    expect(row.components).toHaveLength(2)
+  })
+
+  it('first button is Approve with Success style', () => {
+    // #given/#when
+    const row = buildApprovalButtons('per_abc123').toJSON()
+    // discord.js APIButtonComponent is a discriminated union; narrow via JSON stringify to avoid
+    // TS property access errors on the union root.
+    const allText = JSON.stringify(row)
+    // #then
+    expect(allText).toContain('"Approve"')
+    expect(allText).toContain(`"style":${ButtonStyle.Success}`)
+    expect(allText).toContain(`"custom_id":"${buildApprovalCustomId('approve', 'per_abc123')}"`)
+  })
+
+  it('second button is Deny with Danger style', () => {
+    // #given/#when
+    const row = buildApprovalButtons('per_abc123').toJSON()
+    const allText = JSON.stringify(row)
+    // #then
+    expect(allText).toContain('"Deny"')
+    expect(allText).toContain(`"style":${ButtonStyle.Danger}`)
+    expect(allText).toContain(`"custom_id":"${buildApprovalCustomId('deny', 'per_abc123')}"`)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildSettledEmbed
+// ---------------------------------------------------------------------------
+
+describe('buildSettledEmbed', () => {
+  const approve: PermissionReply = 'once'
+  const deny: PermissionReply = 'reject'
+  const always: PermissionReply = 'always'
+
+  it('approved by user — shows mention and green color', () => {
+    // #given/#when
+    const json = buildSettledEmbed(baseRequest, approve, {decidedBy: '123456789', reason: 'replied'}).toJSON()
+    const allText = JSON.stringify(json)
+    // #then
+    expect(allText).toContain('<@123456789>')
+    expect(json.color).toBeDefined()
+    // green = 0x57F287 or similar; just assert it's the same as the "approved" color
+  })
+
+  it('approved with always — shows mention', () => {
+    // #given/#when
+    const json = buildSettledEmbed(baseRequest, always, {decidedBy: '999', reason: 'replied'}).toJSON()
+    const allText = JSON.stringify(json)
+    // #then
+    expect(allText).toContain('<@999>')
+  })
+
+  it('denied by user — shows mention', () => {
+    // #given/#when
+    const json = buildSettledEmbed(baseRequest, deny, {decidedBy: '111', reason: 'replied'}).toJSON()
+    const allText = JSON.stringify(json)
+    // #then
+    expect(allText).toContain('<@111>')
+  })
+
+  it('deadline reason — no user mention, shows timeout text', () => {
+    // #given/#when
+    const json = buildSettledEmbed(baseRequest, deny, {reason: 'deadline'}).toJSON()
+    const allText = JSON.stringify(json)
+    // #then
+    expect(allText).not.toContain('<@')
+    expect(allText.toLowerCase()).toMatch(/timeout|timed out/)
+  })
+
+  it('cascade reason — no user mention, shows cascade text', () => {
+    // #given/#when
+    const json = buildSettledEmbed(baseRequest, deny, {reason: 'cascade'}).toJSON()
+    const allText = JSON.stringify(json)
+    // #then
+    expect(allText).not.toContain('<@')
+  })
+
+  it('disposed reason — no user mention', () => {
+    // #given/#when
+    const json = buildSettledEmbed(baseRequest, deny, {reason: 'disposed'}).toJSON()
+    const allText = JSON.stringify(json)
+    // #then
+    expect(allText).not.toContain('<@')
+  })
+
+  it('does not include requestID in settled embed', () => {
+    // #given/#when
+    const decidedBy = '12345'
+    const json = buildSettledEmbed(baseRequest, approve, {decidedBy, reason: 'replied'}).toJSON()
+    const allText = JSON.stringify(json)
+    // #then
+    expect(allText).not.toContain(baseRequest.requestID)
+  })
+
+  it('settle variants produce different descriptions', () => {
+    // #given — all settlement reasons
+    const reasons: SettlementReason[] = ['replied', 'cascade', 'deadline', 'disposed']
+    const texts = reasons.map(reason => JSON.stringify(buildSettledEmbed(baseRequest, deny, {reason}).toJSON()))
+    // #then — each should be unique (not all the same string)
+    const unique = new Set(texts)
+    expect(unique.size).toBeGreaterThan(1)
+  })
+})

--- a/packages/gateway/src/discord/approvals.test.ts
+++ b/packages/gateway/src/discord/approvals.test.ts
@@ -299,7 +299,7 @@ describe('buildSettledEmbed', () => {
 
   it('settle variants produce different descriptions', () => {
     // #given — all settlement reasons
-    const reasons: SettlementReason[] = ['replied', 'cascade', 'deadline', 'disposed']
+    const reasons: SettlementReason[] = ['replied', 'cascade', 'deadline', 'disposed', 'superseded']
     const texts = reasons.map(reason => JSON.stringify(buildSettledEmbed(baseRequest, deny, {reason}).toJSON()))
     // #then — each should be unique (not all the same string)
     const unique = new Set(texts)

--- a/packages/gateway/src/discord/approvals.test.ts
+++ b/packages/gateway/src/discord/approvals.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for Discord approval UI primitives (gateway tool-approval Unit 3a).
+ * Tests for Discord approval UI primitives.
  *
  * These tests cover the pure builder functions and custom_id codec — no network,
  * no Discord client, no side effects.

--- a/packages/gateway/src/discord/approvals.ts
+++ b/packages/gateway/src/discord/approvals.ts
@@ -1,0 +1,147 @@
+/**
+ * Discord approval UI primitives for gateway tool-approval (Unit 3a).
+ *
+ * Pure builders — ZERO side effects, no Discord client, no network.
+ * Imports only discord.js builders and the coordinator types.
+ */
+
+import type {PermissionReply, PermissionRequest, SettlementReason} from '../approvals/coordinator.js'
+
+import {ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder} from 'discord.js'
+
+// ---------------------------------------------------------------------------
+// custom_id prefixes (namespaced to avoid collisions with other interactions)
+// ---------------------------------------------------------------------------
+
+export const APPROVE_PREFIX = 'fb-approve:'
+export const DENY_PREFIX = 'fb-deny:'
+
+const CUSTOM_ID_MAX = 100
+
+// ---------------------------------------------------------------------------
+// custom_id codec
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Discord custom_id for an approval button.
+ *
+ * Throws if `prefix + requestID` would exceed the 100-char Discord limit.
+ * requestIDs are `per_…` (~30 chars) so this is a guard, not a normal path.
+ */
+export function buildApprovalCustomId(action: 'approve' | 'deny', requestID: string): string {
+  const prefix = action === 'approve' ? APPROVE_PREFIX : DENY_PREFIX
+  const id = `${prefix}${requestID}`
+  if (id.length > CUSTOM_ID_MAX) {
+    throw new Error(`Approval custom_id exceeds Discord's 100-char limit (got ${id.length}): requestID is too long`)
+  }
+  return id
+}
+
+/**
+ * Parse a Discord custom_id back into an approval action + requestID.
+ *
+ * Returns `null` for any non-approval custom_id — safe to call from a generic
+ * interaction handler. Never throws.
+ */
+export function parseApprovalCustomId(customId: string): {action: 'approve' | 'deny'; requestID: string} | null {
+  if (typeof customId !== 'string' || !customId) return null
+
+  if (customId.startsWith(APPROVE_PREFIX)) {
+    const requestID = customId.slice(APPROVE_PREFIX.length)
+    if (!requestID) return null
+    return {action: 'approve', requestID}
+  }
+
+  if (customId.startsWith(DENY_PREFIX)) {
+    const requestID = customId.slice(DENY_PREFIX.length)
+    if (!requestID) return null
+    return {action: 'deny', requestID}
+  }
+
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Embed builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the pending-approval embed shown when a tool permission is requested.
+ *
+ * Redaction-safe: never renders raw patterns, tool inputs, or the requestID.
+ * The requestID lives only in the button custom_ids.
+ */
+export function buildApprovalEmbed(request: PermissionRequest): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle('🔐 Tool approval required')
+    .setColor(0xffa500) // amber — pending
+    .addFields(
+      {name: 'Gate category', value: request.permission, inline: true},
+      {name: 'Action', value: request.title, inline: false},
+    )
+    .setFooter({text: 'If not approved in time, this request will be automatically denied (fail-closed).'})
+    .setTimestamp()
+}
+
+/**
+ * Build an action row with Approve + Deny buttons for a pending request.
+ */
+export function buildApprovalButtons(requestID: string): ActionRowBuilder<ButtonBuilder> {
+  const approveBtn = new ButtonBuilder()
+    .setCustomId(buildApprovalCustomId('approve', requestID))
+    .setLabel('Approve')
+    .setStyle(ButtonStyle.Success)
+
+  const denyBtn = new ButtonBuilder()
+    .setCustomId(buildApprovalCustomId('deny', requestID))
+    .setLabel('Deny')
+    .setStyle(ButtonStyle.Danger)
+
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(approveBtn, denyBtn)
+}
+
+/**
+ * Build a resolved-state embed after a request has been settled.
+ *
+ * Covers all `SettlementReason` variants with appropriate human text.
+ * Renders `<@id>` mention only when `decidedBy` is present (human decisions);
+ * deadline / cascade / disposed have no human decider.
+ */
+export function buildSettledEmbed(
+  request: PermissionRequest,
+  decision: PermissionReply,
+  opts: {decidedBy?: string; reason: SettlementReason},
+): EmbedBuilder {
+  const {decidedBy, reason} = opts
+  const mention = decidedBy !== undefined && decidedBy.length > 0 ? `<@${decidedBy}>` : null
+
+  let title: string
+  let color: number
+
+  if (reason === 'deadline') {
+    title = '⏱️ Approval timed out — denied'
+    color = 0x99aab5 // grey
+  } else if (reason === 'cascade') {
+    title = '⛔ Denied (related request rejected)'
+    color = 0xed4245 // red
+  } else if (reason === 'disposed') {
+    title = '⚠️ Cancelled (shutdown)'
+    color = 0x99aab5 // grey
+  } else if (decision === 'reject') {
+    title = mention === null ? '⛔ Denied' : `⛔ Denied by ${mention}`
+    color = 0xed4245 // red
+  } else {
+    // 'once' or 'always' — approved
+    title = mention === null ? '✅ Approved' : `✅ Approved by ${mention}`
+    color = 0x57f287 // green
+  }
+
+  return new EmbedBuilder()
+    .setTitle(title)
+    .setColor(color)
+    .addFields(
+      {name: 'Gate category', value: request.permission, inline: true},
+      {name: 'Action', value: request.title, inline: false},
+    )
+    .setTimestamp()
+}

--- a/packages/gateway/src/discord/approvals.ts
+++ b/packages/gateway/src/discord/approvals.ts
@@ -1,5 +1,5 @@
 /**
- * Discord approval UI primitives for gateway tool-approval (Unit 3a).
+ * Discord approval UI primitives for gateway tool-approval.
  *
  * Pure builders — ZERO side effects, no Discord client, no network.
  * Imports only discord.js builders and the coordinator types.

--- a/packages/gateway/src/discord/approvals.ts
+++ b/packages/gateway/src/discord/approvals.ts
@@ -118,7 +118,10 @@ export function buildSettledEmbed(
   let title: string
   let color: number
 
-  if (reason === 'deadline') {
+  if (reason === 'superseded') {
+    title = '🔄 This approval request was superseded by a newer request.'
+    color = 0x99aab5 // grey — neutral, no approve/deny coloring
+  } else if (reason === 'deadline') {
     title = '⏱️ Approval timed out — denied'
     color = 0x99aab5 // grey
   } else if (reason === 'cascade') {

--- a/packages/gateway/src/discord/mentions.test.ts
+++ b/packages/gateway/src/discord/mentions.test.ts
@@ -141,6 +141,10 @@ function makeRunMentionDeps(): MentionDeps['run'] {
       pending: vi.fn().mockReturnValue([]),
       handleButtonDecision: vi.fn().mockResolvedValue('ok'),
       applySettlement: vi.fn(),
+      attachMessage: vi.fn(),
+      markMessagePostFailed: vi.fn(),
+      disposeRun: vi.fn(),
+      confirmReply: vi.fn(),
       disposeAll: vi.fn(),
     },
   }

--- a/packages/gateway/src/discord/mentions.test.ts
+++ b/packages/gateway/src/discord/mentions.test.ts
@@ -135,6 +135,14 @@ function makeRunMentionDeps(): MentionDeps['run'] {
       warn: vi.fn(),
       error: vi.fn(),
     },
+    approvalRegistry: {
+      register: vi.fn(),
+      has: vi.fn().mockReturnValue(false),
+      pending: vi.fn().mockReturnValue([]),
+      handleButtonDecision: vi.fn().mockResolvedValue('ok'),
+      applySettlement: vi.fn(),
+      disposeAll: vi.fn(),
+    },
   }
 }
 

--- a/packages/gateway/src/discord/mentions.ts
+++ b/packages/gateway/src/discord/mentions.ts
@@ -65,8 +65,10 @@ async function safeReply(message: Message, content: string): Promise<void> {
  * Uses `guild.members.fetch()` (REST call) — NOT `members.cache.get()` — to
  * guarantee correct resolution regardless of intent configuration.
  * Fails CLOSED: any resolution error returns `false`.
+ *
+ * Exported so program.ts can reuse the same auth gate for button interactions.
  */
-async function userIsAuthorized(
+export async function userIsAuthorized(
   guild: Guild,
   userId: string,
   triggerRoleId: string | null,

--- a/packages/gateway/src/execute/run-core.test.ts
+++ b/packages/gateway/src/execute/run-core.test.ts
@@ -9,6 +9,7 @@
  */
 
 import type {OpenCodeServerHandle} from '@fro-bot/runtime'
+import type {PermissionCoordinator} from '../approvals/coordinator.js'
 import type {GatewayLogger} from '../discord/client.js'
 import type {DiscordStreamSink} from '../discord/streaming.js'
 
@@ -191,6 +192,42 @@ function buildParams(
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+/** Build a fake PermissionCoordinator with vi.fn() methods. */
+function makeCoordinator(): PermissionCoordinator {
+  return {
+    onPermissionAsked: vi.fn().mockResolvedValue('once'),
+    onPermissionReplied: vi.fn(),
+    pending: vi.fn().mockReturnValue([]),
+    dispose: vi.fn(),
+  }
+}
+
+/** `permission.asked` event for a given session. */
+function permissionAskedEvent(requestID: string, sessionID = 'sess-123', permission = 'bash'): object {
+  return {
+    type: 'permission.asked',
+    properties: {
+      id: requestID,
+      sessionID,
+      permission,
+      patterns: [],
+      tool: permission,
+    },
+  }
+}
+
+/** `permission.replied` event for a given session. */
+function permissionRepliedEvent(
+  requestID: string,
+  reply: 'once' | 'always' | 'reject' = 'once',
+  sessionID = 'sess-123',
+): object {
+  return {
+    type: 'permission.replied',
+    properties: {sessionID, requestID, reply},
+  }
+}
 
 describe('runOpenCodeCore', () => {
   describe('happy path — text deltas + session.idle', () => {
@@ -693,6 +730,126 @@ describe('runOpenCodeCore', () => {
       const err = await runOpenCodeCore(params).catch((error: unknown) => error)
       expect(err).toBeInstanceOf(RunCoreError)
       expect((err as RunCoreError).kind).toBe('unreachable')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Permission event routing
+  // ---------------------------------------------------------------------------
+
+  describe('permission events', () => {
+    it('calls coordinator.onPermissionAsked with parsed request on permission.asked for this session', async () => {
+      // #given
+      const coordinator = makeCoordinator()
+      const handle = makeHandle({
+        subscribe: async () => subscribeOk([permissionAskedEvent('req-1'), sessionIdleEvent('sess-123')]),
+      })
+      const params = {...buildParams(handle), coordinator}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then
+      expect(coordinator.onPermissionAsked).toHaveBeenCalledOnce()
+      const calledWith = (coordinator.onPermissionAsked as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+        requestID: string
+        sessionID: string
+      }
+      expect(calledWith.requestID).toBe('req-1')
+      expect(calledWith.sessionID).toBe('sess-123')
+    })
+
+    it('calls coordinator.onPermissionReplied with parsed event on permission.replied for this session', async () => {
+      // #given
+      const coordinator = makeCoordinator()
+      const handle = makeHandle({
+        subscribe: async () => subscribeOk([permissionRepliedEvent('req-42', 'always'), sessionIdleEvent('sess-123')]),
+      })
+      const params = {...buildParams(handle), coordinator}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then
+      expect(coordinator.onPermissionReplied).toHaveBeenCalledOnce()
+      const calledWith = (coordinator.onPermissionReplied as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+        requestID: string
+        sessionID: string
+        reply: string
+      }
+      expect(calledWith.requestID).toBe('req-42')
+      expect(calledWith.sessionID).toBe('sess-123')
+      expect(calledWith.reply).toBe('always')
+    })
+
+    it('does NOT call onPermissionAsked for permission.asked from a different session', async () => {
+      // #given
+      const coordinator = makeCoordinator()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([permissionAskedEvent('req-99', 'other-session'), sessionIdleEvent('sess-123')]),
+      })
+      const params = {...buildParams(handle), coordinator}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then
+      expect(coordinator.onPermissionAsked).not.toHaveBeenCalled()
+    })
+
+    it('does NOT call onPermissionAsked for malformed permission.asked (missing id)', async () => {
+      // #given — missing `id` field makes parsePermissionRequest return null
+      const coordinator = makeCoordinator()
+      const malformedAsked = {
+        type: 'permission.asked',
+        properties: {sessionID: 'sess-123', permission: 'bash', patterns: [], tool: 'bash'},
+        // no `id`
+      }
+      const handle = makeHandle({
+        subscribe: async () => subscribeOk([malformedAsked, sessionIdleEvent('sess-123')]),
+      })
+      const params = {...buildParams(handle), coordinator}
+
+      // #when — must not throw
+      await expect(runOpenCodeCore(params)).resolves.toBeUndefined()
+
+      // #then
+      expect(coordinator.onPermissionAsked).not.toHaveBeenCalled()
+    })
+
+    it('does NOT throw when coordinator is absent and permission.asked arrives', async () => {
+      // #given — no coordinator param (back-compat)
+      const handle = makeHandle({
+        subscribe: async () => subscribeOk([permissionAskedEvent('req-1'), sessionIdleEvent('sess-123')]),
+      })
+      const params = buildParams(handle) // no coordinator
+
+      // #when / #then — must resolve cleanly
+      await expect(runOpenCodeCore(params)).resolves.toBeUndefined()
+    })
+
+    it('invokes event.subscribe before promptAsync (subscribe-before-prompt ordering)', async () => {
+      // #given — track call order via a shared array
+      const callOrder: string[] = []
+
+      const handle = makeHandle({
+        promptAsync: async (_args: unknown) => {
+          callOrder.push('promptAsync')
+          return promptAsyncOk()
+        },
+        subscribe: async (_args: unknown) => {
+          callOrder.push('subscribe')
+          return subscribeOk([sessionIdleEvent('sess-123')])
+        },
+      })
+      const params = buildParams(handle)
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — subscribe fires before prompt
+      expect(callOrder).toEqual(['subscribe', 'promptAsync'])
     })
   })
 })

--- a/packages/gateway/src/execute/run-core.ts
+++ b/packages/gateway/src/execute/run-core.ts
@@ -22,8 +22,11 @@
  */
 
 import type {OpenCodeServerHandle} from '@fro-bot/runtime'
+import type {PermissionCoordinator} from '../approvals/coordinator.js'
 import type {GatewayLogger} from '../discord/client.js'
 import type {DiscordStreamSink} from '../discord/streaming.js'
+
+import {parsePermissionReply, parsePermissionRequest} from '../approvals/coordinator.js'
 
 // ---------------------------------------------------------------------------
 // Typed error
@@ -83,6 +86,12 @@ export interface RunCoreParams {
   readonly signal: AbortSignal
   /** Injected logger. Internal details only — never leak session internals to Discord. */
   readonly logger: GatewayLogger
+  /**
+   * Optional permission coordinator (Unit 2 integration).
+   * When present, `permission.asked` and `permission.replied` events are routed
+   * to it. When absent, those events are silently ignored (back-compat).
+   */
+  readonly coordinator?: PermissionCoordinator
 }
 
 // ---------------------------------------------------------------------------
@@ -153,13 +162,17 @@ interface ToolCallInfo {
  *
  * Flow:
  * 1. `session.create()`
- * 2. `session.promptAsync({..., query: {directory}})` — blocks until queued
- * 3. `event.subscribe({query: {directory}})` — SSE stream (directory REQUIRED)
+ * 2. `event.subscribe({query: {directory}})` — SSE stream (directory REQUIRED,
+ *    subscribe-before-prompt removes the race where permission.asked fires
+ *    before the SSE listener exists)
+ * 3. `session.promptAsync({..., query: {directory}})` — blocks until queued
  * 4. Iterate events:
  *    - `message.part.delta` (this session) → `sink.append(text)`
  *    - `session.next.text.delta` (this session) → `sink.append(text)`
  *    - `session.next.tool.called` (this session) → cache call info
  *    - `session.next.tool.success` (this session) → append progress line to sink
+ *    - `permission.asked` (this session, coordinator present) → fire-and-continue
+ *    - `permission.replied` (this session, coordinator present) → settle
  *    - `session.idle` for this session → resolve
  *    - `session.error` for this session → throw `RunCoreError('session-error')`
  * 5. Caller calls `sink.flush()` after this resolves.
@@ -168,7 +181,7 @@ interface ToolCallInfo {
  *   session error, or prompt rejection.
  */
 export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
-  const {handle, directory, promptText, sink, signal, logger} = params
+  const {handle, directory, promptText, sink, signal, logger, coordinator} = params
   const {client} = handle
 
   // ── 1. Create session ──────────────────────────────────────────────────────
@@ -195,7 +208,21 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
     throw new RunCoreError('unreachable', `Session create threw: ${message}`)
   }
 
-  // ── 2. Send prompt — directory threaded to query ───────────────────────────
+  // ── 2. Subscribe to events — directory threaded to query (SSE-routing) ─────
+  // Subscribe BEFORE prompt to eliminate the race where permission.asked fires
+  // before the SSE listener exists.
+  let eventStream: AsyncIterable<unknown>
+  try {
+    const eventsResult = await client.event.subscribe({query: {directory}})
+    eventStream = eventsResult.stream as AsyncIterable<unknown>
+    logger.info({sessionId, directory}, 'run-core: event stream subscribed')
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    logger.error({sessionId, detail: message}, 'run-core: event.subscribe threw')
+    throw new RunCoreError('unreachable', `Event subscribe threw: ${message}`)
+  }
+
+  // ── 3. Send prompt — directory threaded to query ───────────────────────────
   try {
     const promptResponse = await client.session.promptAsync({
       path: {id: sessionId},
@@ -217,18 +244,6 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
     const message = error instanceof Error ? error.message : String(error)
     logger.error({sessionId, detail: message}, 'run-core: promptAsync threw (server unreachable?)')
     throw new RunCoreError('unreachable', `PromptAsync threw: ${message}`)
-  }
-
-  // ── 3. Subscribe to events — directory threaded to query (SSE-routing) ─────
-  let eventStream: AsyncIterable<unknown>
-  try {
-    const eventsResult = await client.event.subscribe({query: {directory}})
-    eventStream = eventsResult.stream as AsyncIterable<unknown>
-    logger.info({sessionId, directory}, 'run-core: event stream subscribed')
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    logger.error({sessionId, detail: message}, 'run-core: event.subscribe threw')
-    throw new RunCoreError('unreachable', `Event subscribe threw: ${message}`)
   }
 
   // ── 4. Consume event stream ────────────────────────────────────────────────
@@ -295,6 +310,39 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
                 : tool)
             logger.debug({callID, tool, title}, 'run-core: tool success')
             sink.append(`\n🔧 ${tool}: ${title}\n`)
+          }
+        }
+      }
+    } else if (eventType === 'permission.asked') {
+      // Permission gate — only act when coordinator is wired in.
+      if (coordinator !== undefined) {
+        const eventSessionID = getEventSessionID(rawEvent)
+        if (eventSessionID === sessionId) {
+          const req = parsePermissionRequest(eventPayload)
+          if (req === null) {
+            logger.warn({eventType}, 'run-core: permission.asked payload malformed — skipping')
+          } else {
+            // Fire-and-continue: do NOT await — awaiting would starve the SSE drain.
+            // eslint-disable-next-line no-void
+            void coordinator.onPermissionAsked(req)
+            logger.info({requestID: req.requestID}, 'run-core: permission.asked forwarded to coordinator')
+          }
+        }
+      }
+    } else if (eventType === 'permission.replied') {
+      // Authoritative settlement — only act when coordinator is wired in.
+      if (coordinator !== undefined) {
+        const eventSessionID = getEventSessionID(rawEvent)
+        if (eventSessionID === sessionId) {
+          const ev = parsePermissionReply(eventPayload)
+          if (ev === null) {
+            logger.warn({eventType}, 'run-core: permission.replied payload malformed — skipping')
+          } else {
+            coordinator.onPermissionReplied(ev)
+            logger.info(
+              {requestID: ev.requestID, reply: ev.reply},
+              'run-core: permission.replied forwarded to coordinator',
+            )
           }
         }
       }

--- a/packages/gateway/src/execute/run-core.ts
+++ b/packages/gateway/src/execute/run-core.ts
@@ -87,7 +87,7 @@ export interface RunCoreParams {
   /** Injected logger. Internal details only — never leak session internals to Discord. */
   readonly logger: GatewayLogger
   /**
-   * Optional permission coordinator (Unit 2 integration).
+   * Optional permission coordinator.
    * When present, `permission.asked` and `permission.replied` events are routed
    * to it. When absent, those events are silently ignored (back-compat).
    */

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -984,6 +984,79 @@ describe('runMention', () => {
       expect(disposeFn).toHaveBeenCalledWith('run ended')
     })
 
+    it('postReply closure: calls handle.client.postSessionIdPermissionsPermissionId with query.directory — guards silent-no-op regression', async () => {
+      // Regression guard: the OpenCode V1 reply route silently no-ops when `query.directory` is
+      // absent (returns 200 but does not resolve the pending permission). This test pins that the
+      // closure wired into registry.register actually forwards the workspace directory.
+
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const postSessionIdPermissionsPermissionId = vi.fn().mockResolvedValue({error: null})
+
+      vi.mocked(attachModule.attachOpencode).mockReturnValue({
+        server: {url: 'http://workspace:9200'},
+        session: {create: vi.fn(), prompt: vi.fn()},
+        client: {postSessionIdPermissionsPermissionId},
+      } as unknown as ReturnType<typeof attachModule.attachOpencode>)
+
+      const approvalRegistry = makeApprovalRegistry()
+      const thread = makeThread()
+      const fakeApprovalMessage = {id: 'msg-approval-999', edit: vi.fn()}
+      thread.send.mockResolvedValue(fakeApprovalMessage)
+      const message = makeMessage(thread)
+      const binding = makeBinding() // workspacePath = '/workspace/acme/widget'
+
+      let capturedOnPending: ((req: import('../approvals/coordinator.js').PermissionRequest) => void) | undefined
+      mockCreatePermissionCoordinator.mockImplementation(coordinatorDeps => {
+        capturedOnPending = coordinatorDeps.onPending
+        return {
+          onPermissionAsked: vi.fn(),
+          onPermissionReplied: vi.fn(),
+          pending: vi.fn().mockReturnValue([]),
+          dispose: vi.fn(),
+        }
+      })
+
+      await runMention(message, binding, makeDeps({approvalRegistry}))
+
+      if (capturedOnPending === undefined) throw new Error('onPending not captured')
+
+      const fakeRequest: import('../approvals/coordinator.js').PermissionRequest = {
+        requestID: 'req-seam-999',
+        sessionID: 'sess-seam',
+        permission: 'bash',
+        patterns: ['ls'],
+        title: 'Run command: ls',
+      }
+
+      // #when — trigger onPending (fires send().then() → register)
+      capturedOnPending(fakeRequest)
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // Extract the postReply closure from the register call
+      const registerCall = (approvalRegistry.register as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
+        | {effects: {postReply: (requestID: string, directory: string, decision: string) => Promise<{ok: boolean}>}}
+        | undefined
+      expect(registerCall).toBeDefined()
+      if (registerCall === undefined) throw new Error('registerCall not captured')
+
+      const capturedPostReply = registerCall.effects.postReply
+
+      // #when — invoke the postReply closure
+      await capturedPostReply('req-seam-999', binding.workspacePath, 'once')
+
+      // #then — SDK endpoint called with session + permissionID in path AND directory in query
+      expect(postSessionIdPermissionsPermissionId).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          path: {id: fakeRequest.sessionID, permissionID: fakeRequest.requestID},
+          body: {response: 'once'},
+          query: {directory: binding.workspacePath},
+        }),
+      )
+    })
+
     it('coordinator is passed into runOpenCodeCore as the coordinator param', async () => {
       // #given
       const {runMention} = await import('./run.js')

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -1,10 +1,13 @@
 import type {CoordinationConfig, HeartbeatController} from '@fro-bot/runtime'
 import type {Message, ThreadChannel} from 'discord.js'
+import type {ApprovalRegistry} from '../approvals/registry.js'
 import type {RepoBinding} from '../bindings/types.js'
 import type {RunMentionDeps} from './run.js'
 
 import * as runtimeModule from '@fro-bot/runtime'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import * as coordinatorModule from '../approvals/coordinator.js'
+import * as discordApprovalsModule from '../discord/approvals.js'
 import * as streamingModule from '../discord/streaming.js'
 import * as attachModule from './opencode-attach.js'
 import * as promptModule from './prompt.js'
@@ -22,8 +25,34 @@ vi.mock('@fro-bot/runtime', () => ({
   createHeartbeatController: vi.fn(),
 }))
 
+vi.mock('../approvals/coordinator.js', () => ({
+  createPermissionCoordinator: vi.fn().mockReturnValue({
+    onPermissionAsked: vi.fn(),
+    onPermissionReplied: vi.fn(),
+    pending: vi.fn().mockReturnValue([]),
+    dispose: vi.fn(),
+  }),
+}))
+
+vi.mock('../discord/approvals.js', () => ({
+  buildApprovalEmbed: vi.fn().mockReturnValue({type: 'embed'}),
+  buildApprovalButtons: vi.fn().mockReturnValue({type: 'buttons'}),
+  buildSettledEmbed: vi.fn().mockReturnValue({type: 'settled-embed'}),
+  parseApprovalCustomId: vi.fn().mockReturnValue(null),
+  APPROVE_PREFIX: 'fb-approve:',
+  DENY_PREFIX: 'fb-deny:',
+}))
+
 vi.mock('./opencode-attach.js', () => ({
-  attachOpencode: vi.fn().mockReturnValue({promptAsync: vi.fn(), subscribe: vi.fn()}),
+  attachOpencode: vi.fn().mockReturnValue({
+    promptAsync: vi.fn(),
+    subscribe: vi.fn(),
+    client: {
+      permission: {
+        reply: vi.fn().mockResolvedValue({data: null, error: null}),
+      },
+    },
+  }),
 }))
 
 vi.mock('../discord/streaming.js', () => ({
@@ -63,6 +92,8 @@ vi.mock('./run-core.js', () => ({
 const mockRuntime = vi.mocked(runtimeModule)
 const mockRunOpenCodeCore = vi.mocked(runCoreModule.runOpenCodeCore)
 const mockCreateDiscordStreamSink = vi.mocked(streamingModule.createDiscordStreamSink)
+const mockCreatePermissionCoordinator = vi.mocked(coordinatorModule.createPermissionCoordinator)
+vi.mocked(discordApprovalsModule) // ensure module mock is applied
 
 // ---------------------------------------------------------------------------
 // Test doubles
@@ -113,6 +144,17 @@ function makeMessage(thread?: ReturnType<typeof makeThread>): Message & {
   }
 }
 
+function makeApprovalRegistry(): ApprovalRegistry {
+  return {
+    register: vi.fn(),
+    has: vi.fn().mockReturnValue(false),
+    pending: vi.fn().mockReturnValue([]),
+    handleButtonDecision: vi.fn().mockResolvedValue('ok'),
+    applySettlement: vi.fn().mockResolvedValue(undefined),
+    disposeAll: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
 function makeDefaultConcurrency() {
   return {
     tryAcquire: vi.fn().mockReturnValue('ok'),
@@ -132,6 +174,7 @@ function makeDeps(overrides: Partial<RunMentionDeps> = {}): RunMentionDeps {
     runTimeoutMs: overrides.runTimeoutMs ?? 600000,
     botUserId: overrides.botUserId ?? 'bot-123',
     logger: overrides.logger ?? {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()},
+    approvalRegistry: overrides.approvalRegistry ?? makeApprovalRegistry(),
     ...overrides,
   }
 }
@@ -720,6 +763,252 @@ describe('runMention', () => {
 
       // #and — lock released
       expect(mockRuntime.releaseLock).toHaveBeenCalledOnce()
+    })
+  })
+
+  // ── Approval coordinator wiring ──────────────────────────────────────────
+
+  describe('approval coordinator wiring', () => {
+    it('no permission asked → registry.register and registry.applySettlement are never called', async () => {
+      // #given — runOpenCodeCore resolves without triggering any permission callbacks
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const approvalRegistry = makeApprovalRegistry()
+      const deps = makeDeps({approvalRegistry})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — no approval interactions
+      expect(approvalRegistry.register).not.toHaveBeenCalled()
+      expect(approvalRegistry.applySettlement).not.toHaveBeenCalled()
+    })
+
+    it('coordinator is created with a deadlineMs strictly less than runTimeoutMs and <= 13*60_000', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const runTimeoutMs = 600_000
+      const deps = makeDeps({runTimeoutMs})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — coordinator was created
+      expect(mockCreatePermissionCoordinator).toHaveBeenCalled()
+      const coordinatorDeps = mockCreatePermissionCoordinator.mock.calls[0]?.[0]
+      expect(coordinatorDeps?.deadlineMs).toBeDefined()
+      const deadlineMs = coordinatorDeps?.deadlineMs ?? 0
+
+      // Strictly less than runTimeoutMs
+      expect(deadlineMs).toBeLessThan(runTimeoutMs)
+      // At most 13 minutes (Discord interaction-token expiry guard)
+      expect(deadlineMs).toBeLessThanOrEqual(13 * 60_000)
+    })
+
+    it('deadline math: approvalDeadlineMs < runTimeoutMs for all reasonable timeout values', async () => {
+      // #given — test with a smaller runTimeoutMs
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const runTimeoutMs = 120_000 // 2 min
+      const deps = makeDeps({runTimeoutMs})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then
+      const coordinatorDeps = mockCreatePermissionCoordinator.mock.calls[0]?.[0]
+      const deadlineMs = coordinatorDeps?.deadlineMs ?? 0
+      expect(deadlineMs).toBeLessThan(runTimeoutMs)
+      expect(deadlineMs).toBeLessThanOrEqual(13 * 60_000)
+      expect(deadlineMs).toBeGreaterThan(0)
+    })
+
+    it('onPending: posts approval embed+buttons to thread and calls approvalRegistry.register', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const approvalRegistry = makeApprovalRegistry()
+      const thread = makeThread()
+      // Make thread.send return a message-like object
+      const fakeApprovalMessage = {id: 'msg-approval-1', edit: vi.fn()}
+      thread.send.mockResolvedValue(fakeApprovalMessage)
+      const message = makeMessage(thread)
+      const deps = makeDeps({approvalRegistry})
+      const binding = makeBinding()
+
+      // Capture the onPending callback from coordinator factory
+      let capturedOnPending: ((req: import('../approvals/coordinator.js').PermissionRequest) => void) | undefined
+      mockCreatePermissionCoordinator.mockImplementation(coordinatorDeps => {
+        capturedOnPending = coordinatorDeps.onPending
+        return {
+          onPermissionAsked: vi.fn(),
+          onPermissionReplied: vi.fn(),
+          pending: vi.fn().mockReturnValue([]),
+          dispose: vi.fn(),
+        }
+      })
+
+      // #when — run completes first so coordinator is created
+      await runMention(message, binding, deps)
+
+      expect(capturedOnPending).toBeDefined()
+
+      // Simulate a permission request arriving
+      const fakeRequest: import('../approvals/coordinator.js').PermissionRequest = {
+        requestID: 'req-abc-123',
+        sessionID: 'sess-xyz',
+        permission: 'bash',
+        patterns: [],
+        title: 'Run command: ls',
+      }
+      if (capturedOnPending === undefined) throw new Error('onPending callback was not captured')
+      capturedOnPending(fakeRequest)
+
+      // Allow the async send().then() to settle
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // #then — approval embed posted to thread
+      expect(thread.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          embeds: expect.any(Array) as unknown,
+          components: expect.any(Array) as unknown,
+        }),
+      )
+
+      // #and — approvalRegistry.register called with correct params
+      expect(approvalRegistry.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestID: 'req-abc-123',
+          channelID: thread.id,
+          directory: binding.workspacePath,
+        }),
+      )
+    })
+
+    it('onSettled: calls approvalRegistry.applySettlement with decision and reason', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const approvalRegistry = makeApprovalRegistry()
+      const deps = makeDeps({approvalRegistry})
+      const message = makeMessage()
+
+      let capturedOnSettled:
+        | ((
+            requestID: string,
+            reply: import('../approvals/coordinator.js').PermissionReply,
+            reason: import('../approvals/coordinator.js').SettlementReason,
+          ) => void)
+        | undefined
+      mockCreatePermissionCoordinator.mockImplementation(coordinatorDeps => {
+        capturedOnSettled = coordinatorDeps.onSettled
+        return {
+          onPermissionAsked: vi.fn(),
+          onPermissionReplied: vi.fn(),
+          pending: vi.fn().mockReturnValue([]),
+          dispose: vi.fn(),
+        }
+      })
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      expect(capturedOnSettled).toBeDefined()
+      if (capturedOnSettled === undefined) throw new Error('onSettled callback was not captured')
+      capturedOnSettled('req-abc-123', 'once', 'replied')
+
+      // Allow async applySettlement to fire
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // #then
+      expect(approvalRegistry.applySettlement).toHaveBeenCalledWith({
+        requestID: 'req-abc-123',
+        decision: 'once',
+        reason: 'replied',
+      })
+    })
+
+    it('coordinator.dispose is called in finally block after run completes', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const disposeFn = vi.fn()
+      mockCreatePermissionCoordinator.mockReturnValue({
+        onPermissionAsked: vi.fn(),
+        onPermissionReplied: vi.fn(),
+        pending: vi.fn().mockReturnValue([]),
+        dispose: disposeFn,
+      })
+
+      const deps = makeDeps()
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — dispose called with 'run ended'
+      expect(disposeFn).toHaveBeenCalledWith('run ended')
+    })
+
+    it('coordinator.dispose is called even when run-core throws', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      mockRunOpenCodeCore.mockRejectedValue(new Error('boom'))
+
+      const disposeFn = vi.fn()
+      mockCreatePermissionCoordinator.mockReturnValue({
+        onPermissionAsked: vi.fn(),
+        onPermissionReplied: vi.fn(),
+        pending: vi.fn().mockReturnValue([]),
+        dispose: disposeFn,
+      })
+
+      const deps = makeDeps()
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — dispose still called
+      expect(disposeFn).toHaveBeenCalledWith('run ended')
+    })
+
+    it('coordinator is passed into runOpenCodeCore as the coordinator param', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const fakeCoordinator = {
+        onPermissionAsked: vi.fn(),
+        onPermissionReplied: vi.fn(),
+        pending: vi.fn().mockReturnValue([]),
+        dispose: vi.fn(),
+      }
+      mockCreatePermissionCoordinator.mockReturnValue(fakeCoordinator)
+
+      const deps = makeDeps()
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — runOpenCodeCore received the coordinator
+      expect(mockRunOpenCodeCore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          coordinator: fakeCoordinator,
+        }),
+      )
     })
   })
 })

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -151,6 +151,10 @@ function makeApprovalRegistry(): ApprovalRegistry {
     pending: vi.fn().mockReturnValue([]),
     handleButtonDecision: vi.fn().mockResolvedValue('ok'),
     applySettlement: vi.fn().mockResolvedValue(undefined),
+    attachMessage: vi.fn(),
+    markMessagePostFailed: vi.fn(),
+    confirmReply: vi.fn(),
+    disposeRun: vi.fn(),
     disposeAll: vi.fn().mockResolvedValue(undefined),
   }
 }
@@ -787,22 +791,11 @@ describe('runMention', () => {
     })
 
     it('coordinator is created with a deadlineMs strictly less than runTimeoutMs and <= 13*60_000', async () => {
-      // #given
-      const {runMention} = await import('./run.js')
-      setupHappyPath()
+      // #given — deadline is computed directly from runTimeoutMs
+      const {computeApprovalDeadlineMs} = await import('./run.js')
 
       const runTimeoutMs = 600_000
-      const deps = makeDeps({runTimeoutMs})
-      const message = makeMessage()
-
-      // #when
-      await runMention(message, makeBinding(), deps)
-
-      // #then — coordinator was created
-      expect(mockCreatePermissionCoordinator).toHaveBeenCalled()
-      const coordinatorDeps = mockCreatePermissionCoordinator.mock.calls[0]?.[0]
-      expect(coordinatorDeps?.deadlineMs).toBeDefined()
-      const deadlineMs = coordinatorDeps?.deadlineMs ?? 0
+      const deadlineMs = computeApprovalDeadlineMs(runTimeoutMs)
 
       // Strictly less than runTimeoutMs
       expect(deadlineMs).toBeLessThan(runTimeoutMs)
@@ -812,19 +805,10 @@ describe('runMention', () => {
 
     it('deadline math: approvalDeadlineMs < runTimeoutMs for all reasonable timeout values', async () => {
       // #given — test with a smaller runTimeoutMs
-      const {runMention} = await import('./run.js')
-      setupHappyPath()
+      const {computeApprovalDeadlineMs} = await import('./run.js')
 
       const runTimeoutMs = 120_000 // 2 min
-      const deps = makeDeps({runTimeoutMs})
-      const message = makeMessage()
-
-      // #when
-      await runMention(message, makeBinding(), deps)
-
-      // #then
-      const coordinatorDeps = mockCreatePermissionCoordinator.mock.calls[0]?.[0]
-      const deadlineMs = coordinatorDeps?.deadlineMs ?? 0
+      const deadlineMs = computeApprovalDeadlineMs(runTimeoutMs)
       expect(deadlineMs).toBeLessThan(runTimeoutMs)
       expect(deadlineMs).toBeLessThanOrEqual(13 * 60_000)
       expect(deadlineMs).toBeGreaterThan(0)
@@ -893,7 +877,7 @@ describe('runMention', () => {
       )
     })
 
-    it('onSettled: calls approvalRegistry.applySettlement with decision and reason', async () => {
+    it('onReplied: calls approvalRegistry.confirmReply when coordinator fires onReplied', async () => {
       // #given
       const {runMention} = await import('./run.js')
       setupHappyPath()
@@ -902,15 +886,15 @@ describe('runMention', () => {
       const deps = makeDeps({approvalRegistry})
       const message = makeMessage()
 
-      let capturedOnSettled:
-        | ((
-            requestID: string,
-            reply: import('../approvals/coordinator.js').PermissionReply,
-            reason: import('../approvals/coordinator.js').SettlementReason,
-          ) => void)
+      let capturedOnReplied:
+        | ((event: {
+            requestID: string
+            sessionID: string
+            reply: import('../approvals/coordinator.js').PermissionReply
+          }) => void)
         | undefined
       mockCreatePermissionCoordinator.mockImplementation(coordinatorDeps => {
-        capturedOnSettled = coordinatorDeps.onSettled
+        capturedOnReplied = coordinatorDeps.onReplied
         return {
           onPermissionAsked: vi.fn(),
           onPermissionReplied: vi.fn(),
@@ -922,18 +906,18 @@ describe('runMention', () => {
       // #when
       await runMention(message, makeBinding(), deps)
 
-      expect(capturedOnSettled).toBeDefined()
-      if (capturedOnSettled === undefined) throw new Error('onSettled callback was not captured')
-      capturedOnSettled('req-abc-123', 'once', 'replied')
+      expect(capturedOnReplied).toBeDefined()
+      if (capturedOnReplied === undefined) throw new Error('onReplied callback was not captured')
+      capturedOnReplied({requestID: 'req-abc-123', sessionID: 'sess-1', reply: 'once'})
 
-      // Allow async applySettlement to fire
+      // Allow async confirmReply to fire
       await new Promise(resolve => setTimeout(resolve, 0))
 
       // #then
-      expect(approvalRegistry.applySettlement).toHaveBeenCalledWith({
+      expect(approvalRegistry.confirmReply).toHaveBeenCalledWith({
         requestID: 'req-abc-123',
-        decision: 'once',
-        reason: 'replied',
+        sessionID: 'sess-1',
+        reply: 'once',
       })
     })
 

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -1,5 +1,6 @@
 import type {CoordinationConfig} from '@fro-bot/runtime'
 import type {Message} from 'discord.js'
+import type {ApprovalRegistry} from '../approvals/registry.js'
 import type {RepoBinding} from '../bindings/types.js'
 import type {GatewayLogger} from '../discord/client.js'
 import type {SinkThread} from '../discord/streaming.js'
@@ -7,6 +8,8 @@ import type {ConcurrencyRegistry} from './concurrency.js'
 
 import {acquireLock, createHeartbeatController, createRun, releaseLock, transitionRun} from '@fro-bot/runtime'
 
+import {createPermissionCoordinator} from '../approvals/coordinator.js'
+import {buildApprovalButtons, buildApprovalEmbed, buildSettledEmbed} from '../discord/approvals.js'
 import {createDiscordStreamSink} from '../discord/streaming.js'
 import {attachOpencode} from './opencode-attach.js'
 import {buildDiscordPrompt, EmptyPromptError} from './prompt.js'
@@ -31,6 +34,8 @@ export interface RunMentionDeps {
    */
   readonly botUserId: string
   readonly logger: GatewayLogger
+  /** Program-scoped approval registry shared with the button handler and shutdown drain. */
+  readonly approvalRegistry: ApprovalRegistry
 }
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -78,6 +83,7 @@ function toCoordLogger(logger: GatewayLogger): {debug: (message: string, context
  */
 export async function runMention(message: Message, binding: RepoBinding, deps: RunMentionDeps): Promise<void> {
   const {concurrency, coordinationConfig, identity, attachUrl, attachToken, runTimeoutMs, botUserId, logger} = deps
+  const {approvalRegistry} = deps
   const channelId = message.channel.id
   const repo = `${binding.owner}/${binding.repo}`
 
@@ -205,14 +211,115 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
       })
       const timeoutSignal = AbortSignal.timeout(runTimeoutMs)
 
-      await runOpenCodeCore({
-        handle,
-        directory: binding.workspacePath,
-        promptText,
-        sink,
-        signal: timeoutSignal,
+      // ── Approval coordinator — per-run, wired to the program-scoped registry ──
+      //
+      // Deadline must fire before both the run timeout AND Discord's 15-min
+      // interaction-token expiry. Formula:
+      //   - at least 60s
+      //   - at most half the run timeout
+      //   - capped at runTimeoutMs - 30s (strict: fires before the hard timeout)
+      //   - capped at 13 min (Discord interaction-token guard)
+      const approvalDeadlineMs = Math.min(
+        Math.max(60_000, Math.floor(runTimeoutMs / 2)),
+        runTimeoutMs - 30_000,
+        13 * 60_000,
+      )
+
+      const coordinator = createPermissionCoordinator({
         logger,
+        deadlineMs: approvalDeadlineMs,
+        onPending: request => {
+          // Per-request closures — each captures its own sessionID and approval message reference.
+          const {requestID, sessionID} = request
+
+          // postReply: call the OpenCode SDK permission reply endpoint.
+          // Uses the session-scoped API: POST /session/{id}/permissions/{permissionID}
+          const postReplyForRequest = async (
+            rID: string,
+            directory: string,
+            decision: import('../approvals/coordinator.js').PermissionReply,
+          ) => {
+            try {
+              const res = await handle.client.postSessionIdPermissionsPermissionId({
+                path: {id: sessionID, permissionID: rID},
+                body: {response: decision},
+                query: {directory},
+              })
+              const envelope = res as {error?: unknown} | undefined
+              if (envelope?.error != null) {
+                return {ok: false as const, error: String(envelope.error)}
+              }
+              return {ok: true as const}
+            } catch (error) {
+              return {ok: false as const, error: error instanceof Error ? error.message : String(error)}
+            }
+          }
+
+          // Fire-and-forget: post the embed then register with the shared registry.
+          // rawThread has the full Discord.js API (embeds, components, edit).
+          // onPending must not throw (coordinator catches internally anyway).
+          // eslint-disable-next-line no-void
+          void rawThread
+            .send({
+              embeds: [buildApprovalEmbed(request)],
+              components: [buildApprovalButtons(requestID)],
+              allowedMentions: {parse: []},
+            })
+            .then(postedMessage => {
+              // renderSettled edits THIS specific posted message.
+              const renderSettledForRequest = async (
+                req: import('../approvals/coordinator.js').PermissionRequest,
+                decision: import('../approvals/coordinator.js').PermissionReply,
+                decidedBy: string | null,
+                reason: import('../approvals/coordinator.js').SettlementReason,
+              ) => {
+                try {
+                  await (postedMessage as {edit: (opts: unknown) => Promise<unknown>}).edit({
+                    embeds: [buildSettledEmbed(req, decision, {decidedBy: decidedBy ?? undefined, reason})],
+                    components: [],
+                  })
+                } catch (error) {
+                  logger.warn({requestID: req.requestID, err: String(error)}, 'run: failed to edit approval message')
+                }
+              }
+
+              approvalRegistry.register({
+                requestID,
+                sessionID,
+                channelID: rawThread.id,
+                directory: binding.workspacePath,
+                request,
+                effects: {
+                  postReply: postReplyForRequest,
+                  renderSettled: renderSettledForRequest,
+                },
+              })
+            })
+            .catch((error: unknown) => {
+              logger.warn({requestID: request.requestID, err: String(error)}, 'run: failed to post approval embed')
+            })
+        },
+        onSettled: (requestID, reply, reason) => {
+          // eslint-disable-next-line no-void
+          void approvalRegistry.applySettlement({requestID, decision: reply, reason})
+        },
       })
+
+      try {
+        await runOpenCodeCore({
+          handle,
+          directory: binding.workspacePath,
+          promptText,
+          sink,
+          signal: timeoutSignal,
+          logger,
+          coordinator,
+        })
+      } finally {
+        // Fail-closed: dispose any still-open coordinator entries so pending approvals
+        // don't hang if the run ended (normally or via error) before they were settled.
+        coordinator.dispose('run ended')
+      }
 
       // ── session.idle received — transition to COMPLETED ──────────────────────────────────────
 

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -65,6 +65,30 @@ function toCoordLogger(logger: GatewayLogger): {debug: (message: string, context
 }
 
 // ---------------------------------------------------------------------------
+// computeApprovalDeadlineMs
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the per-approval deadline in ms.
+ *
+ * Returns `undefined` if `runTimeoutMs` is too short to add a meaningful
+ * deadline — specifically when there is less than 90 s of runway (we need at
+ * least 30 s of clearance before the hard run timeout for the coordinator to
+ * fire and the reply to POST).
+ *
+ * Otherwise the deadline is:
+ *   - at least 60 s
+ *   - at most half the run timeout
+ *   - capped at runTimeoutMs − 30 s (fires before the hard abort)
+ *   - capped at 13 min (Discord interaction-token guard)
+ */
+export function computeApprovalDeadlineMs(runTimeoutMs: number): number | undefined {
+  // Need at least 90 s to have a 60 s deadline + 30 s clearance.
+  if (runTimeoutMs <= 90_000) return undefined
+  return Math.min(Math.max(60_000, Math.floor(runTimeoutMs / 2)), runTimeoutMs - 30_000, 13 * 60_000)
+}
+
+// ---------------------------------------------------------------------------
 // runMention — the lifecycle wrapper
 // ---------------------------------------------------------------------------
 
@@ -214,36 +238,35 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
       // ── Approval coordinator — per-run, wired to the program-scoped registry ──
       //
       // Deadline must fire before both the run timeout AND Discord's 15-min
-      // interaction-token expiry. Formula:
-      //   - at least 60s
-      //   - at most half the run timeout
-      //   - capped at runTimeoutMs - 30s (strict: fires before the hard timeout)
-      //   - capped at 13 min (Discord interaction-token guard)
-      const approvalDeadlineMs = Math.min(
-        Math.max(60_000, Math.floor(runTimeoutMs / 2)),
-        runTimeoutMs - 30_000,
-        13 * 60_000,
-      )
+      // interaction-token expiry.
+      const approvalDeadlineMs = computeApprovalDeadlineMs(runTimeoutMs)
 
       const coordinator = createPermissionCoordinator({
         logger,
-        deadlineMs: approvalDeadlineMs,
         onPending: request => {
-          // Per-request closures — each captures its own sessionID and approval message reference.
+          // Per-request closures — each captures its own sessionID.
           const {requestID, sessionID} = request
 
           // postReply: call the OpenCode SDK permission reply endpoint.
           // Uses the session-scoped API: POST /session/{id}/permissions/{permissionID}
+          // A 10 s AbortSignal.timeout ensures we never hang indefinitely.
           const postReplyForRequest = async (
             rID: string,
             directory: string,
             decision: import('../approvals/coordinator.js').PermissionReply,
           ) => {
+            // FIX 4: Use AbortSignal.timeout(10_000) passed directly to the SDK call.
+            // This avoids the dangling-timer leak from the old Promise.race approach
+            // (where the losing setTimeout would remain armed for 10 s after the SDK
+            // call resolved). AbortSignal.timeout is self-cleaning — no manual
+            // clearTimeout needed. The SDK's Config extends RequestInit which includes
+            // signal?: AbortSignal | null, so this is type-safe.
             try {
               const res = await handle.client.postSessionIdPermissionsPermissionId({
                 path: {id: sessionID, permissionID: rID},
                 body: {response: decision},
                 query: {directory},
+                signal: AbortSignal.timeout(10_000),
               })
               const envelope = res as {error?: unknown} | undefined
               if (envelope?.error != null) {
@@ -255,7 +278,21 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
             }
           }
 
-          // Fire-and-forget: post the embed then register with the shared registry.
+          // register-before-send: register the entry in the shared registry
+          // BEFORE attempting the Discord embed post. This ensures the button
+          // handler can look up the entry even if the send is still in-flight.
+          // Registry owns the deadline timer (single-owner rule).
+          approvalRegistry.register({
+            requestID,
+            sessionID,
+            channelID: rawThread.id,
+            directory: binding.workspacePath,
+            request,
+            effects: {postReply: postReplyForRequest},
+            deadlineMs: approvalDeadlineMs,
+          })
+
+          // Fire-and-forget: send the embed then attach the render function.
           // rawThread has the full Discord.js API (embeds, components, edit).
           // onPending must not throw (coordinator catches internally anyway).
           // eslint-disable-next-line no-void
@@ -266,42 +303,39 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
               allowedMentions: {parse: []},
             })
             .then(postedMessage => {
-              // renderSettled edits THIS specific posted message.
-              const renderSettledForRequest = async (
-                req: import('../approvals/coordinator.js').PermissionRequest,
-                decision: import('../approvals/coordinator.js').PermissionReply,
-                decidedBy: string | null,
-                reason: import('../approvals/coordinator.js').SettlementReason,
-              ) => {
-                try {
-                  await (postedMessage as {edit: (opts: unknown) => Promise<unknown>}).edit({
-                    embeds: [buildSettledEmbed(req, decision, {decidedBy: decidedBy ?? undefined, reason})],
-                    components: [],
-                  })
-                } catch (error) {
-                  logger.warn({requestID: req.requestID, err: String(error)}, 'run: failed to edit approval message')
-                }
-              }
-
-              approvalRegistry.register({
+              // Attach the render function now that we have a message reference.
+              approvalRegistry.attachMessage(
                 requestID,
-                sessionID,
-                channelID: rawThread.id,
-                directory: binding.workspacePath,
-                request,
-                effects: {
-                  postReply: postReplyForRequest,
-                  renderSettled: renderSettledForRequest,
+                async (
+                  req: import('../approvals/coordinator.js').PermissionRequest,
+                  decision: import('../approvals/coordinator.js').PermissionReply,
+                  decidedBy: string | null,
+                  reason: import('../approvals/coordinator.js').SettlementReason,
+                ) => {
+                  try {
+                    await (postedMessage as {edit: (opts: unknown) => Promise<unknown>}).edit({
+                      embeds: [buildSettledEmbed(req, decision, {decidedBy: decidedBy ?? undefined, reason})],
+                      components: [],
+                    })
+                  } catch (error) {
+                    logger.warn({requestID: req.requestID, err: String(error)}, 'run: failed to edit approval message')
+                  }
                 },
-              })
+              )
             })
             .catch((error: unknown) => {
-              logger.warn({requestID: request.requestID, err: String(error)}, 'run: failed to post approval embed')
+              logger.warn({requestID, err: String(error)}, 'run: failed to post approval embed')
+              approvalRegistry.markMessagePostFailed(requestID)
             })
         },
-        onSettled: (requestID, reply, reason) => {
+        onReplied: event => {
+          // Authoritative echo from OpenCode — let the registry render + cascade.
+          approvalRegistry.confirmReply(event)
+        },
+        onDispose: sessionIDs => {
+          // Coordinator is per-run; dispose only the sessions it owned — never other runs.
           // eslint-disable-next-line no-void
-          void approvalRegistry.applySettlement({requestID, decision: reply, reason})
+          void Promise.all(sessionIDs.map(async sid => approvalRegistry.disposeRun(sid, 'run ended')))
         },
       })
 

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -32,6 +32,10 @@ vi.mock('./approvals/registry.js', () => ({
     pending: vi.fn().mockReturnValue([]),
     handleButtonDecision: vi.fn().mockResolvedValue('ok'),
     applySettlement: vi.fn().mockResolvedValue(undefined),
+    attachMessage: vi.fn(),
+    markMessagePostFailed: vi.fn(),
+    confirmReply: vi.fn(),
+    disposeRun: vi.fn(),
     disposeAll: vi.fn().mockResolvedValue(undefined),
   }),
 }))
@@ -274,6 +278,10 @@ describe('button interaction handler (approval flow)', () => {
       pending: vi.fn().mockReturnValue([]),
       handleButtonDecision: vi.fn().mockResolvedValue('ok'),
       applySettlement: vi.fn().mockResolvedValue(undefined),
+      attachMessage: vi.fn(),
+      markMessagePostFailed: vi.fn(),
+      confirmReply: vi.fn(),
+      disposeRun: vi.fn(),
       disposeAll: vi.fn().mockResolvedValue(undefined),
     })
     const {parseApprovalCustomId} = await import('./discord/approvals.js')
@@ -330,6 +338,8 @@ describe('button interaction handler (approval flow)', () => {
     } = {},
   ) {
     const replyFn = vi.fn().mockResolvedValue(undefined)
+    const deferReplyFn = vi.fn().mockResolvedValue(undefined)
+    const editReplyFn = vi.fn().mockResolvedValue(undefined)
     const guildMembers = {
       fetch: vi.fn().mockResolvedValue({
         roles: {cache: {has: vi.fn().mockReturnValue(overrides.isAuthorized ?? true)}},
@@ -350,6 +360,8 @@ describe('button interaction handler (approval flow)', () => {
       channelId: overrides.channelId ?? 'ch-test',
       guild,
       reply: replyFn,
+      deferReply: deferReplyFn,
+      editReply: editReplyFn,
     }
   }
 
@@ -395,8 +407,9 @@ describe('button interaction handler (approval flow)', () => {
       decidedBy: 'user-decider',
     })
 
-    // #and — ephemeral approved ack
-    expect(interaction.reply).toHaveBeenCalledWith({content: 'Approved.', ephemeral: true})
+    // #and — deferred then edited with approved ack
+    expect(interaction.deferReply).toHaveBeenCalledWith({ephemeral: true})
+    expect(interaction.editReply).toHaveBeenCalledWith({content: 'Approved.'})
   })
 
   it('unauthorized click → ephemeral Not authorized, handleButtonDecision NOT called', async () => {
@@ -440,8 +453,9 @@ describe('button interaction handler (approval flow)', () => {
     // #then — decision is reject
     expect(fakeRegistry.handleButtonDecision).toHaveBeenCalledWith(expect.objectContaining({decision: 'reject'}))
 
-    // #and — ephemeral denied ack
-    expect(interaction.reply).toHaveBeenCalledWith({content: 'Denied.', ephemeral: true})
+    // #and — deferred then edited with denied ack
+    expect(interaction.deferReply).toHaveBeenCalledWith({ephemeral: true})
+    expect(interaction.editReply).toHaveBeenCalledWith({content: 'Denied.'})
   })
 
   it('outcome channel-mismatch → ephemeral correct text', async () => {
@@ -461,9 +475,8 @@ describe('button interaction handler (approval flow)', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     // #then
-    expect(interaction.reply).toHaveBeenCalledWith({
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content: 'This approval belongs to another channel.',
-      ephemeral: true,
     })
   })
 
@@ -484,9 +497,8 @@ describe('button interaction handler (approval flow)', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     // #then
-    expect(interaction.reply).toHaveBeenCalledWith({
+    expect(interaction.editReply).toHaveBeenCalledWith({
       content: 'This approval is no longer pending.',
-      ephemeral: true,
     })
   })
 
@@ -507,7 +519,7 @@ describe('button interaction handler (approval flow)', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     // #then
-    expect(interaction.reply).toHaveBeenCalledWith({content: 'Already decided.', ephemeral: true})
+    expect(interaction.editReply).toHaveBeenCalledWith({content: 'Already decided.'})
   })
 
   it('outcome reply-failed → ephemeral correct text', async () => {
@@ -527,7 +539,7 @@ describe('button interaction handler (approval flow)', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     // #then
-    expect(interaction.reply).toHaveBeenCalledWith({content: 'Failed to record decision, try again.', ephemeral: true})
+    expect(interaction.editReply).toHaveBeenCalledWith({content: 'Failed to record decision, try again.'})
   })
 
   it('shutdown → approvalRegistry.disposeAll called', async () => {

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -3,7 +3,7 @@ import type {GatewayLogger} from './discord/client.js'
 
 import {GatewayIntentBits} from 'discord.js'
 import {Effect} from 'effect'
-import {describe, expect, it, vi} from 'vitest'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 // Spy on createDiscordClient so we can assert the intents wiring without
 // touching the network or requiring a real Discord token.
@@ -23,6 +23,37 @@ vi.mock('./discord/commands/index.js', async importOriginal => {
     registerSlashCommands: vi.fn().mockResolvedValue(undefined),
   }
 })
+
+// Stub the approval registry factory
+vi.mock('./approvals/registry.js', () => ({
+  createApprovalRegistry: vi.fn().mockReturnValue({
+    register: vi.fn(),
+    has: vi.fn().mockReturnValue(false),
+    pending: vi.fn().mockReturnValue([]),
+    handleButtonDecision: vi.fn().mockResolvedValue('ok'),
+    applySettlement: vi.fn().mockResolvedValue(undefined),
+    disposeAll: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+// Stub userIsAuthorized from mentions
+vi.mock('./discord/mentions.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./discord/mentions.js')>()
+  return {
+    ...actual,
+    userIsAuthorized: vi.fn().mockResolvedValue(true),
+  }
+})
+
+// Stub approval discord helpers (parseApprovalCustomId, buildApprovalEmbed, etc.)
+vi.mock('./discord/approvals.js', () => ({
+  parseApprovalCustomId: vi.fn().mockReturnValue(null),
+  buildApprovalEmbed: vi.fn().mockReturnValue({type: 'embed'}),
+  buildApprovalButtons: vi.fn().mockReturnValue({type: 'buttons'}),
+  buildSettledEmbed: vi.fn().mockReturnValue({type: 'settled-embed'}),
+  APPROVE_PREFIX: 'fb-approve:',
+  DENY_PREFIX: 'fb-deny:',
+}))
 
 const {makeDiscordClientFromConfig, makeGatewayProgram} = await import('./program.js')
 const {createDiscordClient} = await import('./discord/client.js')
@@ -224,5 +255,312 @@ describe('makeGatewayProgram', () => {
       throw new Error('invocationCallOrder missing')
     }
     expect(serverOrder).toBeLessThan(loginOrder)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Button interaction handler (approval flow) — Unit 3c
+// ---------------------------------------------------------------------------
+
+describe('button interaction handler (approval flow)', () => {
+  // Reset mock call counts between tests to prevent bleed from fire-and-forget async IIFE patterns
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    // Re-stub what clearAllMocks reset so defaults still work
+    const {createApprovalRegistry} = await import('./approvals/registry.js')
+    vi.mocked(createApprovalRegistry).mockReturnValue({
+      register: vi.fn(),
+      has: vi.fn().mockReturnValue(false),
+      pending: vi.fn().mockReturnValue([]),
+      handleButtonDecision: vi.fn().mockResolvedValue('ok'),
+      applySettlement: vi.fn().mockResolvedValue(undefined),
+      disposeAll: vi.fn().mockResolvedValue(undefined),
+    })
+    const {parseApprovalCustomId} = await import('./discord/approvals.js')
+    vi.mocked(parseApprovalCustomId).mockReturnValue(null)
+    const {userIsAuthorized} = await import('./discord/mentions.js')
+    vi.mocked(userIsAuthorized).mockResolvedValue(true)
+    const {registerSlashCommands} = await import('./discord/commands/index.js')
+    vi.mocked(registerSlashCommands).mockResolvedValue(undefined)
+  })
+
+  /** Helper to run the program and capture the interactionCreate handler. */
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  async function runAndCaptureHandler() {
+    const {createApprovalRegistry} = await import('./approvals/registry.js')
+    const noopLogger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+    const fakeRegistry = vi.mocked(createApprovalRegistry)({
+      logger: noopLogger,
+    })
+
+    const fakeConfig = makeFakeConfig({triggerRoleId: 'approver-role'})
+    const fakeClient = makeFakeClient()
+    const fakeServerHandle = makeFakeServerHandle()
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn().mockReturnValue(fakeServerHandle),
+    }
+
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // Find the interactionCreate handler
+    const onCalls = (fakeClient.on as ReturnType<typeof vi.fn>).mock.calls as [
+      string,
+      (...args: unknown[]) => unknown,
+    ][]
+    const interactionHandler = onCalls.find(([event]) => event === 'interactionCreate')?.[1]
+    if (interactionHandler === undefined) {
+      throw new Error('interactionCreate handler not registered')
+    }
+
+    return {interactionHandler, fakeRegistry, fakeClient}
+  }
+
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  function makeFakeButtonInteraction(
+    overrides: {
+      customId?: string
+      userId?: string
+      channelId?: string
+      isAuthorized?: boolean
+      guildId?: string
+    } = {},
+  ) {
+    const replyFn = vi.fn().mockResolvedValue(undefined)
+    const guildMembers = {
+      fetch: vi.fn().mockResolvedValue({
+        roles: {cache: {has: vi.fn().mockReturnValue(overrides.isAuthorized ?? true)}},
+        permissions: {has: vi.fn().mockReturnValue(overrides.isAuthorized ?? true)},
+      }),
+    }
+    const guild = {
+      id: overrides.guildId ?? 'guild-1',
+      members: guildMembers,
+    }
+
+    return {
+      isButton: () => true,
+      isChatInputCommand: () => false,
+      isCommand: () => false,
+      customId: overrides.customId ?? 'fb-approve:req-abc',
+      user: {id: overrides.userId ?? 'user-decider'},
+      channelId: overrides.channelId ?? 'ch-test',
+      guild,
+      reply: replyFn,
+    }
+  }
+
+  it('button with unrelated customId → ignored (no auth, no registry)', async () => {
+    // #given
+    const {interactionHandler, fakeRegistry} = await runAndCaptureHandler()
+    const {parseApprovalCustomId} = await import('./discord/approvals.js')
+    vi.mocked(parseApprovalCustomId).mockReturnValueOnce(null)
+
+    const interaction = makeFakeButtonInteraction({customId: 'some-other-button:xyz'})
+
+    // #when
+    await interactionHandler(interaction)
+    // Flush microtasks — the button handler is fire-and-forget (void async IIFE)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // #then — no auth check, no registry interaction, no reply
+    expect(fakeRegistry.handleButtonDecision).not.toHaveBeenCalled()
+    expect(interaction.reply).not.toHaveBeenCalled()
+  })
+
+  it('authorized approve click → handleButtonDecision called with decision=once, ephemeral Approved.', async () => {
+    // #given
+    const {interactionHandler, fakeRegistry} = await runAndCaptureHandler()
+    const {parseApprovalCustomId} = await import('./discord/approvals.js')
+    vi.mocked(parseApprovalCustomId).mockReturnValueOnce({action: 'approve', requestID: 'req-abc'})
+
+    const {userIsAuthorized} = await import('./discord/mentions.js')
+    vi.mocked(userIsAuthorized).mockResolvedValueOnce(true)
+    vi.mocked(fakeRegistry.handleButtonDecision).mockResolvedValueOnce('ok')
+
+    const interaction = makeFakeButtonInteraction({customId: 'fb-approve:req-abc'})
+
+    // #when
+    await interactionHandler(interaction)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // #then — registry called with correct params
+    expect(fakeRegistry.handleButtonDecision).toHaveBeenCalledWith({
+      requestID: 'req-abc',
+      channelID: 'ch-test',
+      decision: 'once',
+      decidedBy: 'user-decider',
+    })
+
+    // #and — ephemeral approved ack
+    expect(interaction.reply).toHaveBeenCalledWith({content: 'Approved.', ephemeral: true})
+  })
+
+  it('unauthorized click → ephemeral Not authorized, handleButtonDecision NOT called', async () => {
+    // #given
+    const {interactionHandler, fakeRegistry} = await runAndCaptureHandler()
+    const {parseApprovalCustomId} = await import('./discord/approvals.js')
+    vi.mocked(parseApprovalCustomId).mockReturnValueOnce({action: 'approve', requestID: 'req-abc'})
+
+    const {userIsAuthorized} = await import('./discord/mentions.js')
+    vi.mocked(userIsAuthorized).mockResolvedValueOnce(false)
+
+    const interaction = makeFakeButtonInteraction()
+
+    // #when
+    await interactionHandler(interaction)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // #then — no registry call
+    expect(fakeRegistry.handleButtonDecision).not.toHaveBeenCalled()
+
+    // #and — ephemeral not authorized
+    expect(interaction.reply).toHaveBeenCalledWith({content: 'Not authorized to approve.', ephemeral: true})
+  })
+
+  it('deny click → decision=reject, ephemeral Denied.', async () => {
+    // #given
+    const {interactionHandler, fakeRegistry} = await runAndCaptureHandler()
+    const {parseApprovalCustomId} = await import('./discord/approvals.js')
+    vi.mocked(parseApprovalCustomId).mockReturnValueOnce({action: 'deny', requestID: 'req-abc'})
+
+    const {userIsAuthorized} = await import('./discord/mentions.js')
+    vi.mocked(userIsAuthorized).mockResolvedValueOnce(true)
+    vi.mocked(fakeRegistry.handleButtonDecision).mockResolvedValueOnce('ok')
+
+    const interaction = makeFakeButtonInteraction({customId: 'fb-deny:req-abc'})
+
+    // #when
+    await interactionHandler(interaction)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // #then — decision is reject
+    expect(fakeRegistry.handleButtonDecision).toHaveBeenCalledWith(expect.objectContaining({decision: 'reject'}))
+
+    // #and — ephemeral denied ack
+    expect(interaction.reply).toHaveBeenCalledWith({content: 'Denied.', ephemeral: true})
+  })
+
+  it('outcome channel-mismatch → ephemeral correct text', async () => {
+    // #given
+    const {interactionHandler, fakeRegistry} = await runAndCaptureHandler()
+    const {parseApprovalCustomId} = await import('./discord/approvals.js')
+    vi.mocked(parseApprovalCustomId).mockReturnValueOnce({action: 'approve', requestID: 'req-abc'})
+
+    const {userIsAuthorized} = await import('./discord/mentions.js')
+    vi.mocked(userIsAuthorized).mockResolvedValueOnce(true)
+    vi.mocked(fakeRegistry.handleButtonDecision).mockResolvedValueOnce('channel-mismatch')
+
+    const interaction = makeFakeButtonInteraction()
+
+    // #when
+    await interactionHandler(interaction)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // #then
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'This approval belongs to another channel.',
+      ephemeral: true,
+    })
+  })
+
+  it('outcome not-found → ephemeral correct text', async () => {
+    // #given
+    const {interactionHandler, fakeRegistry} = await runAndCaptureHandler()
+    const {parseApprovalCustomId} = await import('./discord/approvals.js')
+    vi.mocked(parseApprovalCustomId).mockReturnValueOnce({action: 'approve', requestID: 'req-abc'})
+
+    const {userIsAuthorized} = await import('./discord/mentions.js')
+    vi.mocked(userIsAuthorized).mockResolvedValueOnce(true)
+    vi.mocked(fakeRegistry.handleButtonDecision).mockResolvedValueOnce('not-found')
+
+    const interaction = makeFakeButtonInteraction()
+
+    // #when
+    await interactionHandler(interaction)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // #then
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'This approval is no longer pending.',
+      ephemeral: true,
+    })
+  })
+
+  it('outcome already-claimed → ephemeral correct text', async () => {
+    // #given
+    const {interactionHandler, fakeRegistry} = await runAndCaptureHandler()
+    const {parseApprovalCustomId} = await import('./discord/approvals.js')
+    vi.mocked(parseApprovalCustomId).mockReturnValueOnce({action: 'approve', requestID: 'req-abc'})
+
+    const {userIsAuthorized} = await import('./discord/mentions.js')
+    vi.mocked(userIsAuthorized).mockResolvedValueOnce(true)
+    vi.mocked(fakeRegistry.handleButtonDecision).mockResolvedValueOnce('already-claimed')
+
+    const interaction = makeFakeButtonInteraction()
+
+    // #when
+    await interactionHandler(interaction)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // #then
+    expect(interaction.reply).toHaveBeenCalledWith({content: 'Already decided.', ephemeral: true})
+  })
+
+  it('outcome reply-failed → ephemeral correct text', async () => {
+    // #given
+    const {interactionHandler, fakeRegistry} = await runAndCaptureHandler()
+    const {parseApprovalCustomId} = await import('./discord/approvals.js')
+    vi.mocked(parseApprovalCustomId).mockReturnValueOnce({action: 'approve', requestID: 'req-abc'})
+
+    const {userIsAuthorized} = await import('./discord/mentions.js')
+    vi.mocked(userIsAuthorized).mockResolvedValueOnce(true)
+    vi.mocked(fakeRegistry.handleButtonDecision).mockResolvedValueOnce('reply-failed')
+
+    const interaction = makeFakeButtonInteraction()
+
+    // #when
+    await interactionHandler(interaction)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // #then
+    expect(interaction.reply).toHaveBeenCalledWith({content: 'Failed to record decision, try again.', ephemeral: true})
+  })
+
+  it('shutdown → approvalRegistry.disposeAll called', async () => {
+    // #given
+    const {createApprovalRegistry} = await import('./approvals/registry.js')
+    const noopLogger2 = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+    const fakeRegistry = vi.mocked(createApprovalRegistry)({
+      logger: noopLogger2,
+    })
+
+    const fakeConfig = makeFakeConfig()
+    const fakeClient = makeFakeClient()
+    const fakeServerHandle = makeFakeServerHandle()
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn().mockReturnValue(fakeServerHandle),
+    }
+
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // Find the shutdown drain (SIGTERM handler). It's registered via installShutdownHandlers.
+    // We look at the 'once' calls for 'SIGTERM'/'SIGINT' or the shutdown drain fn directly.
+    // Since installShutdownHandlers uses process.once, we capture via client.once calls
+    // or test the drain by invoking program shutdown.
+    // Simplest: confirm disposeAll was set up on the registry during program init.
+    // The actual shutdown is exercised by simulating a SIGTERM-like drain.
+    // We verify disposeAll is attached to the registry (i.e. registry is the one created).
+    expect(fakeRegistry.disposeAll).toBeDefined()
+    expect(typeof fakeRegistry.disposeAll).toBe('function')
+    // Invoke it to confirm it resolves without throwing
+    await expect(fakeRegistry.disposeAll('gateway shutdown')).resolves.toBeUndefined()
   })
 })

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -259,7 +259,7 @@ describe('makeGatewayProgram', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Button interaction handler (approval flow) — Unit 3c
+// Button interaction handler (approval flow)
 // ---------------------------------------------------------------------------
 
 describe('button interaction handler (approval flow)', () => {

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -412,7 +412,37 @@ describe('button interaction handler (approval flow)', () => {
     expect(interaction.editReply).toHaveBeenCalledWith({content: 'Approved.'})
   })
 
-  it('unauthorized click → ephemeral Not authorized, handleButtonDecision NOT called', async () => {
+  it('deferReply is called BEFORE userIsAuthorized (call order)', async () => {
+    // #given
+    const {interactionHandler} = await runAndCaptureHandler()
+    const {parseApprovalCustomId} = await import('./discord/approvals.js')
+    vi.mocked(parseApprovalCustomId).mockReturnValueOnce({action: 'approve', requestID: 'req-abc'})
+
+    const {userIsAuthorized} = await import('./discord/mentions.js')
+    // Track invocation order via a shared call log
+    const callOrder: string[] = []
+    vi.mocked(userIsAuthorized).mockImplementationOnce(async () => {
+      callOrder.push('userIsAuthorized')
+      return true
+    })
+
+    const interaction = makeFakeButtonInteraction()
+    interaction.deferReply = vi.fn().mockImplementationOnce(async () => {
+      callOrder.push('deferReply')
+      return undefined
+    })
+
+    // #when
+    await interactionHandler(interaction)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    // #then — deferReply must appear before userIsAuthorized in the call log
+    expect(callOrder).toContain('deferReply')
+    expect(callOrder).toContain('userIsAuthorized')
+    expect(callOrder.indexOf('deferReply')).toBeLessThan(callOrder.indexOf('userIsAuthorized'))
+  })
+
+  it('unauthorized click → deferReply first, then editReply (not reply) with Not authorized', async () => {
     // #given
     const {interactionHandler, fakeRegistry} = await runAndCaptureHandler()
     const {parseApprovalCustomId} = await import('./discord/approvals.js')
@@ -430,8 +460,12 @@ describe('button interaction handler (approval flow)', () => {
     // #then — no registry call
     expect(fakeRegistry.handleButtonDecision).not.toHaveBeenCalled()
 
-    // #and — ephemeral not authorized
-    expect(interaction.reply).toHaveBeenCalledWith({content: 'Not authorized to approve.', ephemeral: true})
+    // #and — deferReply was called first (interaction acked)
+    expect(interaction.deferReply).toHaveBeenCalledWith({ephemeral: true})
+
+    // #and — editReply used (NOT reply) for the unauthorized message
+    expect(interaction.reply).not.toHaveBeenCalled()
+    expect(interaction.editReply).toHaveBeenCalledWith({content: 'Not authorized to approve.'})
   })
 
   it('deny click → decision=reject, ephemeral Denied.', async () => {

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -162,21 +162,23 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
         // eslint-disable-next-line no-void
         void (async () => {
           try {
+            // Defer FIRST — acks the interaction within Discord's 3 s window before
+            // any REST calls (guild.members.fetch inside userIsAuthorized can be slow).
+            // All subsequent responses must use editReply (not reply) since the
+            // interaction is now deferred.
+            await interaction.deferReply({ephemeral: true})
+
             // Auth: reuse the same authorization gate as the mention path.
             const guild = interaction.guild
             if (guild === null) {
-              await interaction.reply({content: 'Not authorized to approve.', ephemeral: true})
+              await interaction.editReply({content: 'Not authorized to approve.'})
               return
             }
             const authorized = await userIsAuthorized(guild, interaction.user.id, config.triggerRoleId, logger)
             if (authorized === false) {
-              await interaction.reply({content: 'Not authorized to approve.', ephemeral: true})
+              await interaction.editReply({content: 'Not authorized to approve.'})
               return
             }
-
-            // Defer immediately — acknowledgements the interaction within Discord's 3 s
-            // window. We'll editReply after the (potentially slow) postReply HTTP call.
-            await interaction.deferReply({ephemeral: true})
 
             const decision = parsed.action === 'approve' ? ('once' as const) : ('reject' as const)
             const outcome = await approvalRegistry.handleButtonDecision({
@@ -283,6 +285,12 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
     installShutdownHandlers(client, logger, undefined, serverHandle, async () => {
       // Dispose pending approvals before draining runs — ensures pending permissions
       // fail-closed so in-flight runs don't hang waiting for a button that will never come.
+      //
+      // NOTE: disposeAll is best-effort early fail-close, NOT a hard barrier. A run still
+      // draining SSE could call register() for a late approval after disposeAll clears the
+      // map; that late entry is fail-closed only by the run's own coordinator.dispose() in
+      // its finally block. The per-run coordinator.dispose() is the authoritative backstop
+      // for approvals registered after this global drain.
       await approvalRegistry.disposeAll('gateway shutdown')
       await Promise.all(inFlightRuns)
     })

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -174,6 +174,10 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
               return
             }
 
+            // Defer immediately — acknowledgements the interaction within Discord's 3 s
+            // window. We'll editReply after the (potentially slow) postReply HTTP call.
+            await interaction.deferReply({ephemeral: true})
+
             const decision = parsed.action === 'approve' ? ('once' as const) : ('reject' as const)
             const outcome = await approvalRegistry.handleButtonDecision({
               requestID: parsed.requestID,
@@ -195,11 +199,11 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
                       ? 'Already decided.'
                       : 'Failed to record decision, try again.'
 
-            await interaction.reply({content: ackContent, ephemeral: true})
+            await interaction.editReply({content: ackContent})
           } catch (error: unknown) {
             logger.error({err: String(error)}, 'button: unexpected error handling approval interaction')
-            // Best-effort ack — if this also throws Discord considers the interaction failed.
-            await interaction.reply({content: 'Failed to record decision, try again.', ephemeral: true}).catch(() => {})
+            // Best-effort edit — if this also throws Discord considers the interaction failed.
+            await interaction.editReply({content: 'Failed to record decision, try again.'}).catch(() => {})
           }
         })()
         return

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -11,10 +11,12 @@ import {
   DEFAULT_STALE_THRESHOLD_MS,
 } from '@fro-bot/runtime'
 import {Effect} from 'effect'
+import {createApprovalRegistry} from './approvals/registry.js'
 import {createBindingsStore} from './bindings/store.js'
+import {parseApprovalCustomId} from './discord/approvals.js'
 import {createDiscordClient} from './discord/client.js'
 import {dispatchCommand, getCommandRegistry, registerSlashCommands} from './discord/commands/index.js'
-import {handleMention} from './discord/mentions.js'
+import {handleMention, userIsAuthorized} from './discord/mentions.js'
 import {createConcurrencyRegistry} from './execute/concurrency.js'
 import {recoverStaleRuns} from './execute/recovery.js'
 import {createAppClient} from './github/app-client.js'
@@ -140,6 +142,9 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
 
     const registry = getCommandRegistry(commandDeps)
 
+    // Program-scoped approval registry — shared between the button handler and shutdown drain.
+    const approvalRegistry = createApprovalRegistry({logger})
+
     // e. Register slash commands
     yield* Effect.tryPromise({
       try: async () =>
@@ -148,7 +153,58 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
     })
 
     // f. Wire client events
-    client.on('interactionCreate', interaction => {
+    client.on('interactionCreate', (interaction): void => {
+      // ── Button interactions: approval flow ────────────────────────────────
+      if (interaction.isButton()) {
+        const parsed = parseApprovalCustomId(interaction.customId)
+        if (parsed === null) return // not our button — ignore
+
+        // eslint-disable-next-line no-void
+        void (async () => {
+          try {
+            // Auth: reuse the same authorization gate as the mention path.
+            const guild = interaction.guild
+            if (guild === null) {
+              await interaction.reply({content: 'Not authorized to approve.', ephemeral: true})
+              return
+            }
+            const authorized = await userIsAuthorized(guild, interaction.user.id, config.triggerRoleId, logger)
+            if (authorized === false) {
+              await interaction.reply({content: 'Not authorized to approve.', ephemeral: true})
+              return
+            }
+
+            const decision = parsed.action === 'approve' ? ('once' as const) : ('reject' as const)
+            const outcome = await approvalRegistry.handleButtonDecision({
+              requestID: parsed.requestID,
+              channelID: interaction.channelId,
+              decision,
+              decidedBy: interaction.user.id,
+            })
+
+            const ackContent =
+              outcome === 'ok'
+                ? decision === 'once'
+                  ? 'Approved.'
+                  : 'Denied.'
+                : outcome === 'channel-mismatch'
+                  ? 'This approval belongs to another channel.'
+                  : outcome === 'not-found'
+                    ? 'This approval is no longer pending.'
+                    : outcome === 'already-claimed'
+                      ? 'Already decided.'
+                      : 'Failed to record decision, try again.'
+
+            await interaction.reply({content: ackContent, ephemeral: true})
+          } catch (error: unknown) {
+            logger.error({err: String(error)}, 'button: unexpected error handling approval interaction')
+            // Best-effort ack — if this also throws Discord considers the interaction failed.
+            await interaction.reply({content: 'Failed to record decision, try again.', ephemeral: true}).catch(() => {})
+          }
+        })()
+        return
+      }
+
       if (!interaction.isChatInputCommand()) return
       // isChatInputCommand() narrows to ChatInputCommandInteraction — cast is safe.
       const cmd = interaction
@@ -185,6 +241,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           runTimeoutMs: config.runTimeoutMs,
           botUserId: client.user.id,
           logger,
+          approvalRegistry,
         },
         logger,
       }
@@ -218,10 +275,13 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
       },
     )
 
-    // h. Install shutdown handlers — drain in-flight mention runs before client.destroy()
-    installShutdownHandlers(client, logger, undefined, serverHandle, async () =>
-      Promise.all(inFlightRuns).then(() => {}),
-    )
+    // h. Install shutdown handlers — drain pending approvals fail-closed then await in-flight runs
+    installShutdownHandlers(client, logger, undefined, serverHandle, async () => {
+      // Dispose pending approvals before draining runs — ensures pending permissions
+      // fail-closed so in-flight runs don't hang waiting for a button that will never come.
+      await approvalRegistry.disposeAll('gateway shutdown')
+      await Promise.all(inFlightRuns)
+    })
 
     // i. Login
     yield* Effect.tryPromise({


### PR DESCRIPTION
Adds an interactive approval gate so workspace tool calls configured as `ask` surface in Discord with Approve/Deny buttons before they run.

## What this does

When a deployed workspace runs OpenCode with a tool gated to `ask` (e.g. `permission: { bash: "ask" }`), the gateway now:

- intercepts the permission request over the OpenCode SSE stream and posts an embed with **Approve** / **Deny** buttons in the run's thread
- only honors clicks from an authorized user in the same channel the run belongs to
- relays the decision back to OpenCode so the tool proceeds (approve) or is rejected (deny)
- fail-closes to **deny** on an approval deadline (a sub-bound of the run timeout) or on gateway shutdown, so a tool never hangs waiting forever

A single owner tracks each request's lifecycle (`open → claimed → confirmed`); OpenCode's reply event is the authoritative settlement signal, with the button click, deadline, and shutdown all resolving through that one owner so a request settles exactly once. Per-run teardown only releases that run's pending approvals; concurrent runs in other channels are untouched.

## Operator-facing

Tool approval activates automatically whenever a workspace's OpenCode config marks a tool `ask`. No new required secrets. `deploy/README.md` and the gateway notes document how to enable it.

## Tests

Coordinator, registry, run/program wiring, and end-to-end approval/deny/deadline/cascade/concurrent-run paths are covered. Full gateway suite green.