### PR TITLE
feat(gateway): make announce/presence endpoint opt-in

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -285,6 +285,42 @@ jobs:
             exit 1
           fi
           echo "OK: gateway reached config loading (DISCORD_TOKEN check), no module-resolution crash"
+      - name: Smoke-test gateway image — announce opt-out boots past config (issue # 738)
+        run: |
+          set +e
+          output="$(timeout 60s docker run --rm \
+            -e DISCORD_TOKEN=fake-token \
+            -e DISCORD_APPLICATION_ID=000000000000000000 \
+            -e S3_BUCKET=fake-bucket \
+            -e S3_REGION=us-east-1 \
+            -e GITHUB_APP_ID=000000 \
+            -e GITHUB_APP_PRIVATE_KEY=fake-key \
+            -e WORKSPACE_OPENCODE_TOKEN=fake-ws-token \
+            fro-bot-gateway:smoke 2>&1)"
+          status=$?
+          set -e
+          echo "--- docker run output ---"
+          echo "$output"
+          echo "--- exit status: $status ---"
+          if [ "$status" -eq 124 ]; then
+            echo "REGRESSION: gateway image hung on boot (timed out)"
+            exit 1
+          fi
+          # #738: with all core secrets present but announce secrets absent, config load
+          # must NOT fail on the announce secrets — the gateway must get PAST config load.
+          if echo "$output" | grep -q "Missing required secret: GATEWAY_WEBHOOK_SECRET"; then
+            echo "REGRESSION (#738): announce secret still required at config load"
+            exit 1
+          fi
+          if echo "$output" | grep -q "Missing required secret: GATEWAY_PRESENCE_CHANNEL_ID"; then
+            echo "REGRESSION (#738): announce secret still required at config load"
+            exit 1
+          fi
+          if echo "$output" | grep -q "ERR_MODULE_NOT_FOUND"; then
+            echo "REGRESSION: module resolution failed (ERR_MODULE_NOT_FOUND)"
+            exit 1
+          fi
+          echo "OK: gateway booted past config load with announce disabled (#738 fixed)"
 
   workspace-smoke:
     if: ${{ github.event_name == 'push' || needs.setup.outputs.should-build == 'true' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -316,11 +316,22 @@ jobs:
             echo "REGRESSION (#738): announce secret still required at config load"
             exit 1
           fi
+          # Broader check: no required secret failed at all (catches any other required-secret regression)
+          if echo "$output" | grep -q "Missing required secret"; then
+            echo "FAIL: a required secret was missing — did not reach past config load"
+            exit 1
+          fi
           if echo "$output" | grep -q "ERR_MODULE_NOT_FOUND"; then
             echo "REGRESSION: module resolution failed (ERR_MODULE_NOT_FOUND)"
             exit 1
           fi
-          echo "OK: gateway booted past config load with announce disabled (#738 fixed)"
+          # Positive proof: boot reached PAST config load — the provider self-test fires against
+          # the fake S3 and main.ts logs "gateway startup failed" then exits 1.
+          if ! echo "$output" | grep -q "gateway startup failed"; then
+            echo "FAIL: boot did not reach the expected post-config failure point (gateway startup failed not found)"
+            exit 1
+          fi
+          echo "OK: gateway booted PAST config load (announce disabled, #738 fixed) and reached the runtime self-test boundary"
 
   workspace-smoke:
     if: ${{ github.event_name == 'push' || needs.setup.outputs.should-build == 'true' }}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -100,6 +100,15 @@ touch deploy/secrets/workspace-opencode-auth
 touch deploy/secrets/gateway-trigger-role-id
 # echo -n 'YOUR_ROLE_ID' > deploy/secrets/gateway-trigger-role-id
 
+# Optional — announce/presence endpoint (opt-in). The gateway exposes an
+# HMAC-verified POST /v1/announce presence webhook ONLY when BOTH of these are
+# set; set NEITHER to leave it disabled (the default). Setting exactly one
+# causes a fail-fast both-or-neither startup error. To enable, create both
+# secrets AND uncomment the matching env entries + bind-mounts in compose.yaml:
+#
+# openssl rand -hex 32 > deploy/secrets/gateway-webhook-secret
+# echo -n 'YOUR_PRESENCE_CHANNEL_ID' > deploy/secrets/gateway-presence-channel-id
+
 # GitHub App credentials (required — see "GitHub App" section below)
 echo -n 'YOUR_GITHUB_APP_ID'          > deploy/secrets/github-app-id
 cp ~/Downloads/your-app.private-key.pem deploy/secrets/github-app-private-key
@@ -296,7 +305,7 @@ WORKSPACE_OPENCODE_CONFIG={"provider":{...},"permission":{"bash":{"default":"ask
 ### Permission modes
 
 | Mode | Behaviour |
-| ---- | --------- |
+| --- | --- |
 | `allow` (default) | Tool runs immediately; no Discord prompt. |
 | `ask` | Gateway posts an Approve / Deny embed in the run thread; run pauses until a decision is received or the deadline fires. |
 | `deny` | Tool is always blocked; no prompt. |

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -37,6 +37,11 @@ services:
       WORKSPACE_OPENCODE_URL_FILE: /run/secrets/workspace_opencode_url
       # Optional — Discord role ID that gates mention authorization
       GATEWAY_TRIGGER_ROLE_ID_FILE: /run/secrets/gateway_trigger_role_id
+      # Optional — announce/presence endpoint (opt-in). BOTH must be set together
+      # to enable the HMAC-verified POST /v1/announce presence webhook, or NEITHER
+      # (the endpoint stays disabled). Uncomment both lines AND both bind-mounts below.
+      # GATEWAY_WEBHOOK_SECRET_FILE: /run/secrets/gateway_webhook_secret
+      # GATEWAY_PRESENCE_CHANNEL_ID_FILE: /run/secrets/gateway_presence_channel_id
       # Egress proxy (regular proxy mode — NOT transparent)
       HTTPS_PROXY: http://mitmproxy:8080
       HTTP_PROXY: http://mitmproxy:8080
@@ -155,6 +160,20 @@ services:
         read_only: true
         bind:
           create_host_path: false
+      # Optional — announce/presence endpoint secrets (opt-in, both-or-neither).
+      # Uncomment BOTH (and the two env entries above) to enable the announce endpoint.
+      # - type: bind
+      #   source: ./secrets/gateway-webhook-secret
+      #   target: /run/secrets/gateway_webhook_secret
+      #   read_only: true
+      #   bind:
+      #     create_host_path: false
+      # - type: bind
+      #   source: ./secrets/gateway-presence-channel-id
+      #   target: /run/secrets/gateway_presence_channel_id
+      #   read_only: true
+      #   bind:
+      #     create_host_path: false
     networks:
       - gateway-net
       - sandbox-net

--- a/docs/plans/2026-06-02-001-feat-optional-announce-endpoint-plan.md
+++ b/docs/plans/2026-06-02-001-feat-optional-announce-endpoint-plan.md
@@ -26,7 +26,7 @@ The maintainer decision (per triage) is to make the endpoint **optional** rather
 - R3. When exactly one of the two is present, the gateway fails fast at config load with a clear both-or-neither error (no half-configured announce server).
 - R4. When the announce endpoint is disabled, the gateway does not start the HTTP server and shutdown handling tolerates the absent server handle.
 - R5. `deploy/compose.yaml` and `deploy/README.md` document the two optional secrets and how to enable the announce endpoint, consistent with the existing optional-secret file pattern.
-- R6. CI proves the gateway image boots in **both** the no-announce-secrets (announce disabled) and with-announce-secrets (announce enabled, server starts) configurations, and still fails fast on a genuinely-missing core secret.
+- R6. CI proves (a) the no-secrets case still fails fast on a missing core secret, and (b) with core secrets present and announce absent, config load gets past the announce check (#738 fixed); the enabled announce path is covered by `packages/gateway/src/http/server.test.ts` integration tests.
 
 ## Scope Boundaries
 
@@ -162,24 +162,27 @@ The maintainer decision (per triage) is to make the endpoint **optional** rather
 
 **Approach:**
 - `deploy/compose.yaml`: document the two announce secrets as **opt-in** in the `gateway` service — add commented-out `GATEWAY_WEBHOOK_SECRET_FILE` / `GATEWAY_PRESENCE_CHANNEL_ID_FILE` env entries and commented-out bind-mounts mirroring the `GATEWAY_TRIGGER_ROLE_ID` pattern (`create_host_path: false`), with a comment that uncommenting both enables the announce endpoint. The default (commented) state must boot cleanly.
-- `deploy/README.md`: add an "Enabling the announce/presence endpoint (optional)" subsection — both secrets are required together if you enable it; show the `openssl rand -hex 32 > deploy/secrets/gateway-webhook-secret` and presence-channel-id creation steps and the uncomment instructions. Note the both-or-neither rule.
-- `.github/workflows/ci.yaml`: the existing `Gateway Image Smoke Test` (step "Smoke-test gateway image", ~line 268) runs `docker run` with **zero** env secrets and asserts `grep -q "Missing required secret: DISCORD_TOKEN"`. `DISCORD_TOKEN` is read first in `loadGatewayConfig`, so the gateway throws before it ever reaches the announce secrets — the existing assertion is **not** testing announce and stays **valid unchanged**. The change is **additive**: add two new smoke invocations (or steps):
-  1. **Boot-disabled case:** supply all required core secrets (every `readSecret` call in config.ts — `DISCORD_TOKEN`, `DISCORD_APPLICATION_ID`, `S3_BUCKET`, `S3_REGION`, `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `WORKSPACE_OPENCODE_TOKEN`) but **omit** `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_CHANNEL_ID` → assert the gateway reaches a healthy/running state with the announce endpoint disabled (assert the "announce disabled" boot log line). This is the #738 default-deploy proof.
-  2. **Boot-enabled case:** supply the core secrets **plus** `GATEWAY_WEBHOOK_SECRET` + `GATEWAY_PRESENCE_CHANNEL_ID` → assert the gateway boots AND the real announce server starts (assert the "announce enabled" / server-listening log line). This closes the adversarial + security gap that Unit 2 only mocks `startAnnounceServer` — the enabled path proves the real `createAnnounceServer` wiring survives the config reshape.
+- `deploy/README.md`: add an opt-in announce subsection in the "Create secrets" section — both secrets are required together if you enable it; show the `openssl rand -hex 32 > deploy/secrets/gateway-webhook-secret` and presence-channel-id creation steps and the uncomment instructions. Note the both-or-neither rule.
+- `.github/workflows/ci.yaml`: the existing `Gateway Image Smoke Test` (step "Smoke-test gateway image") runs `docker run` with **zero** env secrets and asserts `grep -q "Missing required secret: DISCORD_TOKEN"`. `DISCORD_TOKEN` is read first in `loadGatewayConfig`, so the gateway throws before it ever reaches the announce secrets — the existing assertion is **not** testing announce and stays **valid unchanged**. The change is **additive** (Option A — minimal Docker smoke):
+
+  **Implementation-time discovery:** The gateway boot order is: config-load → `runProviderSelfTest` (a real S3 conditional-write round-trip, added in PR #739) → `registerSlashCommands` → announce enabled/disabled log → login. A Docker container with core secrets but no reachable S3 dies at the self-test and never reaches the announce log. Therefore we CANNOT cheaply assert "announce boots" in the Docker smoke — the full boot-proof would need MinIO + a Discord stub, out of scope for this fix.
+
+  The enabled announce path (real `createAnnounceServer` + route + bad-signature→401 rejection) is already proven by the existing `packages/gateway/src/http/server.test.ts` vitest integration tests. The Docker smoke only needs to guard the literal #738 regression.
+
+  **Additive CI step (Option A):** Add ONE new step proving that with all core secrets present (fake values) but announce secrets absent, config load does NOT emit `"Missing required secret: GATEWAY_WEBHOOK_SECRET"` or `"Missing required secret: GATEWAY_PRESENCE_CHANNEL_ID"` — i.e. the gateway gets PAST config load. The container will subsequently die at the S3 self-test (expected), but config load itself succeeds.
 
 **Patterns to follow:**
 - `deploy/compose.yaml` `GATEWAY_TRIGGER_ROLE_ID` env + bind-mount + `create_host_path: false`.
-- `deploy/README.md` existing "When adding a new optional secret" migration section.
+- `deploy/README.md` existing optional-secret commented-bash-example style.
 - The existing `Gateway Image Smoke Test` job structure in `.github/workflows/ci.yaml`.
 
 **Test scenarios:**
 - Test expectation: none for compose/README (declarative deploy config + docs). CI smoke changes are the executable proof.
 - CI smoke — **no-secrets fail-fast (existing, unchanged):** zero env secrets → gateway throws `Missing required secret: DISCORD_TOKEN`.
-- CI smoke — **core-only boot-disabled (new):** all required core secrets supplied, announce secrets omitted → gateway reaches running/healthy state with announce endpoint disabled (assert the "announce disabled" boot log line).
-- CI smoke — **core+announce boot-enabled (new):** core secrets + `GATEWAY_WEBHOOK_SECRET` + `GATEWAY_PRESENCE_CHANNEL_ID` → gateway boots AND the real announce server starts (assert the "announce enabled" / server-listening log line).
+- CI smoke — **core-only config-load-passes (new, Option A):** all required core secrets supplied (fake values), announce secrets omitted → config load does NOT emit `Missing required secret: GATEWAY_WEBHOOK_SECRET` or `GATEWAY_PRESENCE_CHANNEL_ID`; the gateway gets past config load (the literal #738 regression guard). Container exits non-zero at the S3 self-test — that is expected and not asserted against.
 
 **Verification:**
-- `docker compose config` is valid; the documented default deploy path boots without announce secrets; the `Gateway Image Smoke Test` proves all three smoke states: no-secrets fail-fast, core-only boot-disabled, and core+announce boot-enabled.
+- `docker compose config` is valid; the documented default deploy path boots without announce secrets; the `Gateway Image Smoke Test` proves: (a) no-secrets fail-fast on a missing core secret, and (b) with core secrets present and announce absent, config load gets past the announce check (#738 fixed). The enabled announce path is covered by `packages/gateway/src/http/server.test.ts` integration tests.
 
 ## System-Wide Impact
 

--- a/docs/plans/2026-06-02-001-feat-optional-announce-endpoint-plan.md
+++ b/docs/plans/2026-06-02-001-feat-optional-announce-endpoint-plan.md
@@ -1,0 +1,214 @@
+---
+title: "feat: Make gateway announce/presence endpoint opt-in"
+type: feat
+status: active
+date: 2026-06-02
+---
+
+# feat: Make gateway announce/presence endpoint opt-in
+
+## Overview
+
+The gateway daemon hard-requires `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_CHANNEL_ID` at boot, but the shipped `deploy/compose.yaml` wires neither — so a deployer following the shipped contract gets a crash-looping gateway (`Missing required secret: GATEWAY_WEBHOOK_SECRET`). This plan makes the announce/presence HTTP endpoint **opt-in**: when both secrets are present the announce server boots as today; when both are absent the gateway boots normally with the announce endpoint disabled; when exactly one is present the gateway fails fast with a clear both-or-neither error.
+
+This resolves issue #738 by making the announce subsystem a deliberate opt-in rather than a mandatory dependency, removing the forced-secret friction for deployers who only use the Discord mention loop.
+
+## Problem Frame
+
+Issue #738 (Fro Bot triage confirmed against `v0.50.0` and current `main`): `loadGatewayConfig()` calls the throwing `readSecret('GATEWAY_WEBHOOK_SECRET')` / `readSecret('GATEWAY_PRESENCE_CHANNEL_ID')` (`packages/gateway/src/config.ts:361-362`) before the gateway can boot. The announce HTTP server is started unconditionally (`packages/gateway/src/program.ts:298`) and `AnnounceServerConfig` requires both as non-optional `string` fields. Compose provides no source for either secret, and `deploy/README.md` never creates them, so the documented deploy path crash-loops under `restart: unless-stopped`.
+
+The maintainer decision (per triage) is to make the endpoint **optional** rather than wire the secrets as required. The announce/presence endpoint is a real but non-core subsystem — the core gateway value (Discord mention → OpenCode execution) does not depend on it.
+
+## Requirements Trace
+
+- R1. `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_CHANNEL_ID` become optional; the gateway boots successfully when both are absent.
+- R2. When both secrets are present, the announce HTTP server behaves exactly as today (no security or behavioral regression to the `/v1/announce` ingress path).
+- R3. When exactly one of the two is present, the gateway fails fast at config load with a clear both-or-neither error (no half-configured announce server).
+- R4. When the announce endpoint is disabled, the gateway does not start the HTTP server and shutdown handling tolerates the absent server handle.
+- R5. `deploy/compose.yaml` and `deploy/README.md` document the two optional secrets and how to enable the announce endpoint, consistent with the existing optional-secret file pattern.
+- R6. CI proves the gateway image boots in **both** the no-announce-secrets (announce disabled) and with-announce-secrets (announce enabled, server starts) configurations, and still fails fast on a genuinely-missing core secret.
+
+## Scope Boundaries
+
+- No change to the announce ingress security model (HMAC verification, replay cache, rate limiting, body limit) when the endpoint IS enabled — opt-in must not weaken hardening.
+- No change to the Discord mention loop, tool-approval, coordination, or workspace paths.
+- No change to other required gateway secrets (`DISCORD_TOKEN`, GitHub App credentials, etc.).
+
+### Deferred to Separate Tasks
+
+- A general "every required secret in config.ts has a matching compose wiring" drift-guard: noted as a future hardening idea, not built here. This plan instead proves the specific no-secrets boot case in CI (R6).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Pair-validation precedent (mirror this exactly):** `packages/gateway/src/config.ts:288-301` — the AWS credential block reads `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` optionally and enforces "both set together, or neither" with a clear error naming which one was received, then builds an optional `credentials` object only when both are present. The announce secrets should follow the identical shape.
+- **Config type:** `GatewayConfig` interface at `packages/gateway/src/config.ts:18`, fields `webhookSecret: string` / `presenceChannelId: string` at lines 43-44, assembled at lines 387-388.
+- **Optional secret reader:** `readOptionalSecret(name): string | null` (`config.ts:196`) — same precedence as `readSecret` but returns `null` instead of throwing. Already used for `DISCORD_GUILD_ID`, `S3_ENDPOINT`, etc.
+- **Announce server startup:** `packages/gateway/src/program.ts:298-310` — `deps.startAnnounceServer({client, logger, isShuttingDown}, {webhookSecret, presenceChannelId, httpPort})` returns a `CloseableServer` handle.
+- **Shutdown already tolerates an absent handle:** `installShutdownHandlers(client, logger, drainMs?, server?: CloseableServer, awaitInFlight?)` (`packages/gateway/src/shutdown.ts:69`) — `server` is already optional, so passing `undefined` when the announce server is disabled needs no shutdown change.
+- **Injection site:** `packages/gateway/src/main.ts:29` injects the real `createAnnounceServer`.
+- **Existing optional-secret compose pattern:** `deploy/compose.yaml` `GATEWAY_TRIGGER_ROLE_ID_FILE` (line 39) + its bind-mount (lines 153-157) with `create_host_path: false`, and the `deploy/README.md` "When adding a new optional secret" migration note.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/workspace-executor-opencode-provisioning-best-practices-2026-06-01.md` — **fail-soft when absent, fail-fast when malformed**; prefer explicit startup gating over implicit half-configured behavior. Maps directly to "announce boots only when both secrets exist; one-of-two is malformed → fail fast."
+- `docs/solutions/best-practices/signed-webhook-ingress-hardening-2026-05-29.md` — treat announce ingress as hostile; do not weaken the ingress security model when making the endpoint opt-in.
+- `docs/solutions/build-errors/gateway-docker-runtime-resolution-crash-loop-2026-05-31.md` — image-only regressions need a build-and-boot CI smoke test; if the gateway can start conditionally, CI should verify the "no secrets / missing config" case too.
+
+### External References
+
+- None needed — the change follows an existing in-repo precedent (AWS credential pair-validation) and established optional-secret conventions.
+
+## Key Technical Decisions
+
+- **Model announce config as a single optional object, not two independent nullable fields.** Replace `webhookSecret: string` + `presenceChannelId: string` on `GatewayConfig` with an optional `announce?: { readonly webhookSecret: string; readonly presenceChannelId: string }`. This makes both-or-neither a **type-level invariant** (you either have the announce object with both values, or you have nothing) — "make impossible states impossible." Downstream code branches on `config.announce !== undefined` rather than null-checking two separate fields. This is the AWS-credentials shape applied to announce. **Alternative considered:** two independent nullable fields (`webhookSecret?: string` + `presenceChannelId?: string`) plus pair-validation. Rejected for consistency with the AWS-credential block in the same function (`config.ts:288-301`), which already models a both-or-neither secret pair as a single optional object — matching the immediate neighbor is the stronger maintainability signal. The internal `AnnounceServerConfig` keeps its two required `string` fields; the object is unwrapped at the `program.ts` gating boundary.
+- **Pair-validation mirrors the AWS credential block.** Read both with `readOptionalSecret`; both present → build the announce object; both absent → `undefined`; exactly one present → throw a both-or-neither error naming which was received (and which is missing).
+- **Gate startup, keep ingress hardening intact.** `program.ts` starts the announce server only when `config.announce !== undefined`; when disabled, `serverHandle` is `undefined` and is passed through to `installShutdownHandlers` (already optional). The announce server code, HMAC verification, replay cache, and rate limiting are unchanged.
+- **Compose ships the secrets commented-out / documented as opt-in.** The default shipped compose must boot without them (closing #738); enabling announce is a documented opt-in step. Use the same `_FILE` + bind-mount + `create_host_path: false` pattern as `GATEWAY_TRIGGER_ROLE_ID`.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Required vs optional?** → Optional (user decision). Announce becomes opt-in.
+- **Two nullable fields vs one optional object?** → One optional `announce` object, for the type-level both-or-neither invariant.
+- **Does shutdown need changes for the disabled case?** → No. `installShutdownHandlers`'s `server` param is already optional.
+
+### Deferred to Implementation
+
+- Exact field/helper naming inside `loadGatewayConfig` for the announce block (follow the AWS block's local-variable style).
+- Whether to keep the two secrets as separate compose bind-mounts (preferred for symmetry) vs a single `env_file` — decide when editing compose; separate bind-mounts match the existing pattern.
+
+## Implementation Units
+
+- [ ] **Unit 1: Make announce secrets optional with both-or-neither validation (`config.ts`)**
+
+**Goal:** `loadGatewayConfig()` no longer throws when both announce secrets are absent; models them as an optional `announce` object with pair-validation.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/gateway/src/config.ts`
+- Test: `packages/gateway/src/config.test.ts`
+
+**Approach:**
+- Replace `webhookSecret: string` + `presenceChannelId: string` on the `GatewayConfig` interface with `readonly announce?: { readonly webhookSecret: string; readonly presenceChannelId: string }`.
+- In `loadGatewayConfig`, replace the two `readSecret(...)` calls with `readOptionalSecret(...)`, then apply pair-validation mirroring the AWS credential block (`config.ts:288-301`): both present → set `announce`; exactly one present → throw a both-or-neither error naming the received and the missing var; both absent → leave `announce` undefined.
+- Assemble `...(announce === undefined ? {} : {announce})` into the returned config, same spread style as the AWS `credentials` field.
+
+**Patterns to follow:**
+- AWS credential pair-validation: `packages/gateway/src/config.ts:288-301` and the `...(credentials === undefined ? {} : {credentials})` assembly at line 325.
+
+**Test scenarios:**
+- Happy path: both `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_CHANNEL_ID` set → `config.announce` is `{webhookSecret, presenceChannelId}` with the expected values.
+- Happy path: neither set → `config.announce` is `undefined` and `loadGatewayConfig()` does NOT throw (this is the #738 regression case — replaces the two existing "throws Missing required secret" tests at `config.test.ts:984-999`).
+- Error path: only `GATEWAY_WEBHOOK_SECRET` set → throws a both-or-neither error naming the missing `GATEWAY_PRESENCE_CHANNEL_ID`.
+- Error path: only `GATEWAY_PRESENCE_CHANNEL_ID` set → throws a both-or-neither error naming the missing `GATEWAY_WEBHOOK_SECRET`.
+- Edge case: `_FILE` variants honored (e.g., `GATEWAY_WEBHOOK_SECRET_FILE`) for both, consistent with `readOptionalSecret` precedence.
+- Edge case: empty or whitespace-only `GATEWAY_WEBHOOK_SECRET` (or its `_FILE`) is treated as **absent** (relies on `readOptionalSecret` returning `null` for empty/whitespace) — e.g. empty webhook secret + valid presence id → both-or-neither error naming the missing webhook secret, NOT a half-enabled announce server. This locks the security property that an empty secret cannot enable an unauthenticated announce endpoint.
+
+**Verification:**
+- The two former "Missing required secret" assertions are replaced by the both-absent no-throw test plus the two one-of-two error tests; full gateway suite green.
+
+---
+
+- [ ] **Unit 2: Gate announce server startup on opt-in (`program.ts`)**
+
+**Goal:** The announce HTTP server starts only when `config.announce` is present; when absent, the gateway boots with no HTTP server and shutdown handles the undefined handle.
+
+**Requirements:** R2, R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/gateway/src/program.ts`
+- Test: `packages/gateway/src/program.test.ts`
+
+**Approach:**
+- Wrap the `deps.startAnnounceServer(...)` call (`program.ts:298-310`) in `if (config.announce !== undefined)`, building the `AnnounceServerConfig` from `config.announce.webhookSecret` / `config.announce.presenceChannelId` / `config.httpPort`. Otherwise leave `serverHandle` as `undefined`.
+- Pass the possibly-undefined `serverHandle` to `installShutdownHandlers` (already optional — no signature change).
+- Add a clear comment: announce endpoint is opt-in; disabled when announce secrets are absent.
+- Log at info level whether the announce endpoint is enabled or disabled at boot (operator observability — no secret values logged).
+- Update `program.test.ts` deps/config fixtures (lines ~147-148 set `webhookSecret`/`presenceChannelId`) to use the new `announce` config shape.
+
+**Patterns to follow:**
+- The existing self-test / readiness dep-injection boot ordering in `program.ts`; the `isShuttingDown` + `serverHandle` shutdown wiring already present.
+
+**Test scenarios:**
+- Happy path: `config.announce` present → `startAnnounceServer` called once with the announce secrets + httpPort; the returned handle is passed to `installShutdownHandlers`.
+- Happy path: `config.announce` undefined → `startAnnounceServer` is NOT called; boot completes; `installShutdownHandlers` receives `undefined` for the server handle.
+- Integration: with announce disabled, the boot Effect still wires client events and logs that the announce endpoint is disabled (assert the enable/disable log line).
+
+**Verification:**
+- Boot succeeds in both modes; the announce server is started in exactly one of them; shutdown wiring is correct for both.
+
+---
+
+- [ ] **Unit 3: Compose + docs + CI no-secrets boot smoke (`deploy/`, `ci.yaml`)**
+
+**Goal:** The shipped compose boots without announce secrets (closing #738); enabling announce is a documented opt-in; CI proves the no-secrets image boot.
+
+**Requirements:** R5, R6
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `deploy/compose.yaml`
+- Modify: `deploy/README.md`
+- Modify: `.github/workflows/ci.yaml`
+
+**Approach:**
+- `deploy/compose.yaml`: document the two announce secrets as **opt-in** in the `gateway` service — add commented-out `GATEWAY_WEBHOOK_SECRET_FILE` / `GATEWAY_PRESENCE_CHANNEL_ID_FILE` env entries and commented-out bind-mounts mirroring the `GATEWAY_TRIGGER_ROLE_ID` pattern (`create_host_path: false`), with a comment that uncommenting both enables the announce endpoint. The default (commented) state must boot cleanly.
+- `deploy/README.md`: add an "Enabling the announce/presence endpoint (optional)" subsection — both secrets are required together if you enable it; show the `openssl rand -hex 32 > deploy/secrets/gateway-webhook-secret` and presence-channel-id creation steps and the uncomment instructions. Note the both-or-neither rule.
+- `.github/workflows/ci.yaml`: the existing `Gateway Image Smoke Test` (step "Smoke-test gateway image", ~line 268) runs `docker run` with **zero** env secrets and asserts `grep -q "Missing required secret: DISCORD_TOKEN"`. `DISCORD_TOKEN` is read first in `loadGatewayConfig`, so the gateway throws before it ever reaches the announce secrets — the existing assertion is **not** testing announce and stays **valid unchanged**. The change is **additive**: add two new smoke invocations (or steps):
+  1. **Boot-disabled case:** supply all required core secrets (every `readSecret` call in config.ts — `DISCORD_TOKEN`, `DISCORD_APPLICATION_ID`, `S3_BUCKET`, `S3_REGION`, `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `WORKSPACE_OPENCODE_TOKEN`) but **omit** `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_CHANNEL_ID` → assert the gateway reaches a healthy/running state with the announce endpoint disabled (assert the "announce disabled" boot log line). This is the #738 default-deploy proof.
+  2. **Boot-enabled case:** supply the core secrets **plus** `GATEWAY_WEBHOOK_SECRET` + `GATEWAY_PRESENCE_CHANNEL_ID` → assert the gateway boots AND the real announce server starts (assert the "announce enabled" / server-listening log line). This closes the adversarial + security gap that Unit 2 only mocks `startAnnounceServer` — the enabled path proves the real `createAnnounceServer` wiring survives the config reshape.
+
+**Patterns to follow:**
+- `deploy/compose.yaml` `GATEWAY_TRIGGER_ROLE_ID` env + bind-mount + `create_host_path: false`.
+- `deploy/README.md` existing "When adding a new optional secret" migration section.
+- The existing `Gateway Image Smoke Test` job structure in `.github/workflows/ci.yaml`.
+
+**Test scenarios:**
+- Test expectation: none for compose/README (declarative deploy config + docs). CI smoke changes are the executable proof.
+- CI smoke — **no-secrets fail-fast (existing, unchanged):** zero env secrets → gateway throws `Missing required secret: DISCORD_TOKEN`.
+- CI smoke — **core-only boot-disabled (new):** all required core secrets supplied, announce secrets omitted → gateway reaches running/healthy state with announce endpoint disabled (assert the "announce disabled" boot log line).
+- CI smoke — **core+announce boot-enabled (new):** core secrets + `GATEWAY_WEBHOOK_SECRET` + `GATEWAY_PRESENCE_CHANNEL_ID` → gateway boots AND the real announce server starts (assert the "announce enabled" / server-listening log line).
+
+**Verification:**
+- `docker compose config` is valid; the documented default deploy path boots without announce secrets; the `Gateway Image Smoke Test` proves all three smoke states: no-secrets fail-fast, core-only boot-disabled, and core+announce boot-enabled.
+
+## System-Wide Impact
+
+- **Interaction graph:** Only the announce subsystem boot gate changes. The Discord mention loop, tool-approval, coordination lock/self-test, and workspace paths are untouched.
+- **Error propagation:** A one-of-two announce config is now a fail-fast config error (clear both-or-neither message) instead of either a silent half-config or an unrelated crash. A genuinely-missing core secret still fails fast.
+- **State lifecycle risks:** When announce is disabled, no HTTP server is created → no listening socket, no replay cache, no rate limiter; shutdown receives `undefined` and skips server close (already supported).
+- **API surface parity:** `GatewayConfig.webhookSecret`/`presenceChannelId` become `GatewayConfig.announce?`. Every consumer (`program.ts`, `program.test.ts`, any config fixtures) must move to the new shape — grep `webhookSecret`/`presenceChannelId` across `packages/gateway/` to confirm all references are migrated.
+- **Integration coverage:** The CI image smoke is the cross-layer proof that config gating + program gating + compose defaults compose into a booting container without announce secrets.
+- **Unchanged invariants:** When announce IS enabled, the `/v1/announce` ingress behavior (HMAC verification, replay protection, rate limiting, body limit, empty-render fallback) is byte-for-byte unchanged — this plan only gates whether the server starts, never how it behaves once started.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| A consumer of `config.webhookSecret`/`presenceChannelId` is missed during the type migration → type error or runtime undefined | Grep all `packages/gateway/` references before completing Unit 2; tsc must pass; the type change makes missed sites compile errors, not silent failures |
+| Opt-in weakens ingress security if someone enables announce with only partial config | Both-or-neither validation makes a half-enabled announce impossible; ingress hardening code is untouched |
+| CI smoke still asserts the old "missing secret" crash and fails after the fix | Unit 3 explicitly updates the smoke expectation to the no-announce-secrets success boot while keeping a real missing-core-secret fail-fast case |
+| Units 1-2 land before Unit 3's additive smoke cases, temporarily leaving the new boot paths unproven in CI | Units 1-3 land as a **single PR**. The image smoke test only asserts the `DISCORD_TOKEN` fail-fast today (it never reaches the announce check), so Units 1-2 do not red-line the existing smoke even before Unit 3's additive cases land; the vitest `config.test.ts` changes are bundled atomically within Unit 1. Co-committing keeps main green throughout. |
+| Existing `config.test.ts:984-999` required-secret tests now assert wrong behavior | Unit 1 replaces them with the both-absent no-throw + two one-of-two error tests |
+
+## Documentation / Operational Notes
+
+- `deploy/README.md` gains an opt-in announce section; the default documented deploy no longer provisions announce secrets.
+- Operators upgrading from a crash-looping `v0.50.0` deploy simply pull the new image — the gateway boots without announce secrets; no migration action required unless they want the announce endpoint.
+- **Stale partial installs:** under the old contract both announce secrets were required, so a half-configured install was already a boot failure. With both-or-neither, an operator who has exactly one announce secret lingering (env or secret file) from a partial setup still gets a fail-fast both-or-neither error. Remediation: either create the matching second secret to enable announce, or remove both to opt out. The boot error names which secret is missing.
+- A patch/minor release after merge lets infra move off the `v0.46.3` hold (issue #738's interim workaround).
+
+## Sources & References
+
+- Origin: issue #738 + Fro Bot triage comment (verified against `v0.50.0` and `main`).
+- Related code: `packages/gateway/src/config.ts:288-301` (AWS pair-validation precedent), `:361-362` (the throwing reads), `packages/gateway/src/program.ts:298-312` (announce startup + shutdown), `packages/gateway/src/shutdown.ts:69` (optional server handle).
+- Related learnings: `docs/solutions/best-practices/workspace-executor-opencode-provisioning-best-practices-2026-06-01.md`, `docs/solutions/best-practices/signed-webhook-ingress-hardening-2026-05-29.md`, `docs/solutions/build-errors/gateway-docker-runtime-resolution-crash-loop-2026-05-31.md`.

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -964,8 +964,8 @@ describe('loadGatewayConfig — webhook secret, presence channel, http port', ()
     const config = loadGatewayConfig()
 
     // #then
-    expect(config.webhookSecret).toBe('test-webhook-secret')
-    expect(config.presenceChannelId).toBe('test-presence-channel-id')
+    expect(config.announce?.webhookSecret).toBe('test-webhook-secret')
+    expect(config.announce?.presenceChannelId).toBe('test-presence-channel-id')
     expect(config.httpPort).toBe(8080)
   })
 
@@ -981,22 +981,94 @@ describe('loadGatewayConfig — webhook secret, presence channel, http port', ()
     expect(config.httpPort).toBe(3000)
   })
 
-  it('error: GATEWAY_WEBHOOK_SECRET missing → throws "Missing required secret"', () => {
-    // #given
+  it('happy path (#738 regression): neither announce secret set → config.announce is undefined, no throw', () => {
+    // #given — announce secrets absent (the default deploy path that was crash-looping)
     setRequiredEnv()
     delete process.env.GATEWAY_WEBHOOK_SECRET
+    delete process.env.GATEWAY_PRESENCE_CHANNEL_ID
 
-    // #when / #then
-    expect(() => loadGatewayConfig()).toThrow('Missing required secret: GATEWAY_WEBHOOK_SECRET')
+    // #when / #then — must NOT throw; announce is opt-in
+    let config: GatewayConfig | undefined
+    expect(() => {
+      config = loadGatewayConfig()
+    }).not.toThrow()
+    expect(config?.announce).toBeUndefined()
   })
 
-  it('error: GATEWAY_PRESENCE_CHANNEL_ID missing → throws "Missing required secret"', () => {
+  it('happy path: both GATEWAY_WEBHOOK_SECRET and GATEWAY_PRESENCE_CHANNEL_ID set → config.announce has both values', () => {
     // #given
     setRequiredEnv()
+    process.env.GATEWAY_WEBHOOK_SECRET = 'my-webhook-secret'
+    process.env.GATEWAY_PRESENCE_CHANNEL_ID = 'my-channel-id'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.announce).toEqual({webhookSecret: 'my-webhook-secret', presenceChannelId: 'my-channel-id'})
+  })
+
+  it('error: only GATEWAY_WEBHOOK_SECRET set → throws both-or-neither error naming missing GATEWAY_PRESENCE_CHANNEL_ID', () => {
+    // #given — webhook present, presence absent
+    setRequiredEnv()
+    process.env.GATEWAY_WEBHOOK_SECRET = 'my-webhook-secret'
     delete process.env.GATEWAY_PRESENCE_CHANNEL_ID
 
     // #when / #then
-    expect(() => loadGatewayConfig()).toThrow('Missing required secret: GATEWAY_PRESENCE_CHANNEL_ID')
+    expect(() => loadGatewayConfig()).toThrow('GATEWAY_PRESENCE_CHANNEL_ID')
+    expect(() => loadGatewayConfig()).toThrow('GATEWAY_WEBHOOK_SECRET')
+  })
+
+  it('error: only GATEWAY_PRESENCE_CHANNEL_ID set → throws both-or-neither error naming missing GATEWAY_WEBHOOK_SECRET', () => {
+    // #given — presence present, webhook absent
+    setRequiredEnv()
+    delete process.env.GATEWAY_WEBHOOK_SECRET
+    process.env.GATEWAY_PRESENCE_CHANNEL_ID = 'my-channel-id'
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow('GATEWAY_WEBHOOK_SECRET')
+    expect(() => loadGatewayConfig()).toThrow('GATEWAY_PRESENCE_CHANNEL_ID')
+  })
+
+  it('edge: empty GATEWAY_WEBHOOK_SECRET with valid GATEWAY_PRESENCE_CHANNEL_ID → both-or-neither error (empty = absent)', () => {
+    // #given — empty webhook secret is treated as absent by readOptionalSecret
+    setRequiredEnv()
+    process.env.GATEWAY_WEBHOOK_SECRET = ''
+    process.env.GATEWAY_PRESENCE_CHANNEL_ID = 'my-channel-id'
+
+    // #when / #then — empty secret cannot enable a half-configured announce endpoint
+    expect(() => loadGatewayConfig()).toThrow('GATEWAY_WEBHOOK_SECRET')
+    expect(() => loadGatewayConfig()).toThrow('GATEWAY_PRESENCE_CHANNEL_ID')
+  })
+
+  it('edge: whitespace-only GATEWAY_WEBHOOK_SECRET with valid GATEWAY_PRESENCE_CHANNEL_ID → both-or-neither error', () => {
+    // #given — whitespace-only is treated as absent by readOptionalSecret
+    setRequiredEnv()
+    process.env.GATEWAY_WEBHOOK_SECRET = '   '
+    process.env.GATEWAY_PRESENCE_CHANNEL_ID = 'my-channel-id'
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow('GATEWAY_WEBHOOK_SECRET')
+    expect(() => loadGatewayConfig()).toThrow('GATEWAY_PRESENCE_CHANNEL_ID')
+  })
+
+  it('edge: _FILE variants honored — both via GATEWAY_WEBHOOK_SECRET_FILE / GATEWAY_PRESENCE_CHANNEL_ID_FILE → announce object built', () => {
+    // #given — both secrets provided via _FILE (the compose bind-mount pattern)
+    setRequiredEnv()
+    delete process.env.GATEWAY_WEBHOOK_SECRET
+    delete process.env.GATEWAY_PRESENCE_CHANNEL_ID
+    const webhookFile = join(tmpDir, 'webhook-secret-file.txt')
+    const channelFile = join(tmpDir, 'presence-channel-id-file.txt')
+    writeFileSync(webhookFile, 'file-webhook-secret\n', {mode: 0o600})
+    writeFileSync(channelFile, 'file-channel-id\n', {mode: 0o600})
+    process.env.GATEWAY_WEBHOOK_SECRET_FILE = webhookFile
+    process.env.GATEWAY_PRESENCE_CHANNEL_ID_FILE = channelFile
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then — _FILE values are read and trimmed; announce object is built
+    expect(config.announce).toEqual({webhookSecret: 'file-webhook-secret', presenceChannelId: 'file-channel-id'})
   })
 
   it('edge: GATEWAY_HTTP_PORT = "0" → throws invalid port error', () => {
@@ -1163,7 +1235,7 @@ describe('loadGatewayConfig — webhook secret, presence channel, http port', ()
   })
 
   it('edge: GATEWAY_WEBHOOK_SECRET_FILE with trailing newline → trimmed and accepted', () => {
-    // #given
+    // #given — webhook via _FILE, presence via env (both present → announce object built)
     setRequiredEnv()
     delete process.env.GATEWAY_WEBHOOK_SECRET
     const secretFile = join(tmpDir, 'webhook-secret.txt')
@@ -1173,7 +1245,8 @@ describe('loadGatewayConfig — webhook secret, presence channel, http port', ()
     // #when
     const config = loadGatewayConfig()
 
-    // #then trailing newline trimmed
-    expect(config.webhookSecret).toBe('file-webhook-secret')
+    // #then trailing newline trimmed; announce object built with both values
+    expect(config.announce?.webhookSecret).toBe('file-webhook-secret')
+    expect(config.announce?.presenceChannelId).toBe('test-presence-channel-id')
   })
 })

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -966,11 +966,11 @@ describe('loadGatewayConfig — webhook secret, presence channel, http port', ()
     // #then
     expect(config.announce?.webhookSecret).toBe('test-webhook-secret')
     expect(config.announce?.presenceChannelId).toBe('test-presence-channel-id')
-    expect(config.httpPort).toBe(8080)
+    expect(config.announce?.httpPort).toBe(8080)
   })
 
   it('happy path: GATEWAY_HTTP_PORT unset → httpPort defaults to 3000', () => {
-    // #given
+    // #given — announce secrets present so httpPort is read
     setRequiredEnv()
     // GATEWAY_HTTP_PORT not set
 
@@ -978,7 +978,7 @@ describe('loadGatewayConfig — webhook secret, presence channel, http port', ()
     const config = loadGatewayConfig()
 
     // #then
-    expect(config.httpPort).toBe(3000)
+    expect(config.announce?.httpPort).toBe(3000)
   })
 
   it('happy path (#738 regression): neither announce secret set → config.announce is undefined, no throw', () => {
@@ -1004,30 +1004,34 @@ describe('loadGatewayConfig — webhook secret, presence channel, http port', ()
     // #when
     const config = loadGatewayConfig()
 
-    // #then
-    expect(config.announce).toEqual({webhookSecret: 'my-webhook-secret', presenceChannelId: 'my-channel-id'})
+    // #then — announce includes httpPort (defaults to 3000 when GATEWAY_HTTP_PORT unset)
+    expect(config.announce).toEqual({
+      webhookSecret: 'my-webhook-secret',
+      presenceChannelId: 'my-channel-id',
+      httpPort: 3000,
+    })
   })
 
-  it('error: only GATEWAY_WEBHOOK_SECRET set → throws both-or-neither error naming missing GATEWAY_PRESENCE_CHANNEL_ID', () => {
+  it('error: only GATEWAY_WEBHOOK_SECRET set → throws both-or-neither error naming received and missing vars', () => {
     // #given — webhook present, presence absent
     setRequiredEnv()
     process.env.GATEWAY_WEBHOOK_SECRET = 'my-webhook-secret'
     delete process.env.GATEWAY_PRESENCE_CHANNEL_ID
 
-    // #when / #then
-    expect(() => loadGatewayConfig()).toThrow('GATEWAY_PRESENCE_CHANNEL_ID')
-    expect(() => loadGatewayConfig()).toThrow('GATEWAY_WEBHOOK_SECRET')
+    // #when / #then — error must name the received var and the missing var directionally
+    expect(() => loadGatewayConfig()).toThrow('received: GATEWAY_WEBHOOK_SECRET')
+    expect(() => loadGatewayConfig()).toThrow('missing: GATEWAY_PRESENCE_CHANNEL_ID')
   })
 
-  it('error: only GATEWAY_PRESENCE_CHANNEL_ID set → throws both-or-neither error naming missing GATEWAY_WEBHOOK_SECRET', () => {
+  it('error: only GATEWAY_PRESENCE_CHANNEL_ID set → throws both-or-neither error naming received and missing vars', () => {
     // #given — presence present, webhook absent
     setRequiredEnv()
     delete process.env.GATEWAY_WEBHOOK_SECRET
     process.env.GATEWAY_PRESENCE_CHANNEL_ID = 'my-channel-id'
 
-    // #when / #then
-    expect(() => loadGatewayConfig()).toThrow('GATEWAY_WEBHOOK_SECRET')
-    expect(() => loadGatewayConfig()).toThrow('GATEWAY_PRESENCE_CHANNEL_ID')
+    // #when / #then — error must name the received var and the missing var directionally
+    expect(() => loadGatewayConfig()).toThrow('received: GATEWAY_PRESENCE_CHANNEL_ID')
+    expect(() => loadGatewayConfig()).toThrow('missing: GATEWAY_WEBHOOK_SECRET')
   })
 
   it('edge: empty GATEWAY_WEBHOOK_SECRET with valid GATEWAY_PRESENCE_CHANNEL_ID → both-or-neither error (empty = absent)', () => {
@@ -1067,12 +1071,16 @@ describe('loadGatewayConfig — webhook secret, presence channel, http port', ()
     // #when
     const config = loadGatewayConfig()
 
-    // #then — _FILE values are read and trimmed; announce object is built
-    expect(config.announce).toEqual({webhookSecret: 'file-webhook-secret', presenceChannelId: 'file-channel-id'})
+    // #then — _FILE values are read and trimmed; announce object is built (httpPort defaults to 3000)
+    expect(config.announce).toEqual({
+      webhookSecret: 'file-webhook-secret',
+      presenceChannelId: 'file-channel-id',
+      httpPort: 3000,
+    })
   })
 
-  it('edge: GATEWAY_HTTP_PORT = "0" → throws invalid port error', () => {
-    // #given
+  it('edge: GATEWAY_HTTP_PORT = "0" → throws invalid port error (announce secrets set)', () => {
+    // #given — announce secrets must be set so httpPort is actually read+validated
     setRequiredEnv()
     process.env.GATEWAY_HTTP_PORT = '0'
 
@@ -1080,8 +1088,8 @@ describe('loadGatewayConfig — webhook secret, presence channel, http port', ()
     expect(() => loadGatewayConfig()).toThrow('Invalid GATEWAY_HTTP_PORT value: "0"')
   })
 
-  it('edge: GATEWAY_HTTP_PORT = "70000" → throws invalid port error', () => {
-    // #given
+  it('edge: GATEWAY_HTTP_PORT = "70000" → throws invalid port error (announce secrets set)', () => {
+    // #given — announce secrets must be set so httpPort is actually read+validated
     setRequiredEnv()
     process.env.GATEWAY_HTTP_PORT = '70000'
 
@@ -1089,8 +1097,8 @@ describe('loadGatewayConfig — webhook secret, presence channel, http port', ()
     expect(() => loadGatewayConfig()).toThrow('Invalid GATEWAY_HTTP_PORT value: "70000"')
   })
 
-  it('edge: GATEWAY_HTTP_PORT = "abc" → throws invalid port error', () => {
-    // #given
+  it('edge: GATEWAY_HTTP_PORT = "abc" → throws invalid port error (announce secrets set)', () => {
+    // #given — announce secrets must be set so httpPort is actually read+validated
     setRequiredEnv()
     process.env.GATEWAY_HTTP_PORT = 'abc'
 
@@ -1099,7 +1107,7 @@ describe('loadGatewayConfig — webhook secret, presence channel, http port', ()
   })
 
   it('edge: GATEWAY_HTTP_PORT = "1" → accepted (boundary, minimum port)', () => {
-    // #given
+    // #given — announce secrets present so httpPort is read
     setRequiredEnv()
     process.env.GATEWAY_HTTP_PORT = '1'
 
@@ -1107,11 +1115,11 @@ describe('loadGatewayConfig — webhook secret, presence channel, http port', ()
     const config = loadGatewayConfig()
 
     // #then
-    expect(config.httpPort).toBe(1)
+    expect(config.announce?.httpPort).toBe(1)
   })
 
   it('edge: GATEWAY_HTTP_PORT = "65535" → accepted (boundary, maximum port)', () => {
-    // #given
+    // #given — announce secrets present so httpPort is read
     setRequiredEnv()
     process.env.GATEWAY_HTTP_PORT = '65535'
 
@@ -1119,7 +1127,22 @@ describe('loadGatewayConfig — webhook secret, presence channel, http port', ()
     const config = loadGatewayConfig()
 
     // #then
-    expect(config.httpPort).toBe(65535)
+    expect(config.announce?.httpPort).toBe(65535)
+  })
+
+  it('regression (#738-adjacent): announce secrets absent + invalid GATEWAY_HTTP_PORT → no throw, config.announce is undefined', () => {
+    // #given — no announce secrets; invalid port value that would have crashed boot before this fix
+    setRequiredEnv()
+    delete process.env.GATEWAY_WEBHOOK_SECRET
+    delete process.env.GATEWAY_PRESENCE_CHANNEL_ID
+    process.env.GATEWAY_HTTP_PORT = '999999'
+
+    // #when / #then — must NOT throw; httpPort is only read when announce is enabled
+    let config: GatewayConfig | undefined
+    expect(() => {
+      config = loadGatewayConfig()
+    }).not.toThrow()
+    expect(config?.announce).toBeUndefined()
   })
 
   // ---------------------------------------------------------------------------

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -40,8 +40,15 @@ export interface GatewayConfig {
   readonly maxConcurrentRuns: number
   /** Maximum wall-clock milliseconds a single run may take before being aborted. */
   readonly runTimeoutMs: number
-  readonly webhookSecret: string
-  readonly presenceChannelId: string
+  /**
+   * Announce/presence endpoint configuration. Present only when both
+   * `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_CHANNEL_ID` are set.
+   * When absent, the announce HTTP server is not started.
+   */
+  readonly announce?: {
+    readonly webhookSecret: string
+    readonly presenceChannelId: string
+  }
   readonly httpPort: number
 }
 
@@ -358,8 +365,27 @@ export function loadGatewayConfig(): GatewayConfig {
     throw new Error(`Invalid GATEWAY_RUN_TIMEOUT_MS value: "${rawRunTimeout}" (must be a positive integer)`)
   }
 
-  const webhookSecret = readSecret('GATEWAY_WEBHOOK_SECRET')
-  const presenceChannelId = readSecret('GATEWAY_PRESENCE_CHANNEL_ID')
+  // Announce/presence endpoint — opt-in: both secrets must be set together, or neither.
+  // Mirrors the AWS credential pair-validation block above.
+  const gatewayWebhookSecret = readOptionalSecret('GATEWAY_WEBHOOK_SECRET')
+  const gatewayPresenceChannelId = readOptionalSecret('GATEWAY_PRESENCE_CHANNEL_ID')
+
+  if (gatewayWebhookSecret !== null && gatewayPresenceChannelId === null) {
+    throw new Error(
+      'Both GATEWAY_WEBHOOK_SECRET and GATEWAY_PRESENCE_CHANNEL_ID must be set together (received: GATEWAY_WEBHOOK_SECRET, missing: GATEWAY_PRESENCE_CHANNEL_ID). Set both to enable the announce endpoint, or set neither to disable it.',
+    )
+  }
+
+  if (gatewayPresenceChannelId !== null && gatewayWebhookSecret === null) {
+    throw new Error(
+      'Both GATEWAY_WEBHOOK_SECRET and GATEWAY_PRESENCE_CHANNEL_ID must be set together (received: GATEWAY_PRESENCE_CHANNEL_ID, missing: GATEWAY_WEBHOOK_SECRET). Set both to enable the announce endpoint, or set neither to disable it.',
+    )
+  }
+
+  const announce =
+    gatewayWebhookSecret !== null && gatewayPresenceChannelId !== null
+      ? {webhookSecret: gatewayWebhookSecret, presenceChannelId: gatewayPresenceChannelId}
+      : undefined
 
   const rawHttpPort = readOptionalSecret('GATEWAY_HTTP_PORT') ?? '3000'
   const httpPort = Number.parseInt(rawHttpPort, 10)
@@ -384,8 +410,7 @@ export function loadGatewayConfig(): GatewayConfig {
     triggerRoleId,
     maxConcurrentRuns,
     runTimeoutMs,
-    webhookSecret,
-    presenceChannelId,
+    ...(announce === undefined ? {} : {announce}),
     httpPort,
   }
 }

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -48,8 +48,8 @@ export interface GatewayConfig {
   readonly announce?: {
     readonly webhookSecret: string
     readonly presenceChannelId: string
+    readonly httpPort: number
   }
-  readonly httpPort: number
 }
 
 const MAX_SECRET_BYTES = 4096
@@ -382,15 +382,22 @@ export function loadGatewayConfig(): GatewayConfig {
     )
   }
 
-  const announce =
-    gatewayWebhookSecret !== null && gatewayPresenceChannelId !== null
-      ? {webhookSecret: gatewayWebhookSecret, presenceChannelId: gatewayPresenceChannelId}
-      : undefined
+  let announce:
+    | {readonly webhookSecret: string; readonly presenceChannelId: string; readonly httpPort: number}
+    | undefined
 
-  const rawHttpPort = readOptionalSecret('GATEWAY_HTTP_PORT') ?? '3000'
-  const httpPort = Number.parseInt(rawHttpPort, 10)
-  if (Number.isFinite(httpPort) === false || Number.isInteger(httpPort) === false || httpPort < 1 || httpPort > 65535) {
-    throw new Error(`Invalid GATEWAY_HTTP_PORT value: "${rawHttpPort}" (must be an integer in the range 1–65535)`)
+  if (gatewayWebhookSecret !== null && gatewayPresenceChannelId !== null) {
+    const rawHttpPort = readOptionalSecret('GATEWAY_HTTP_PORT') ?? '3000'
+    const httpPort = Number.parseInt(rawHttpPort, 10)
+    if (
+      Number.isFinite(httpPort) === false ||
+      Number.isInteger(httpPort) === false ||
+      httpPort < 1 ||
+      httpPort > 65535
+    ) {
+      throw new Error(`Invalid GATEWAY_HTTP_PORT value: "${rawHttpPort}" (must be an integer in the range 1–65535)`)
+    }
+    announce = {webhookSecret: gatewayWebhookSecret, presenceChannelId: gatewayPresenceChannelId, httpPort}
   }
 
   return {
@@ -411,6 +418,5 @@ export function loadGatewayConfig(): GatewayConfig {
     maxConcurrentRuns,
     runTimeoutMs,
     ...(announce === undefined ? {} : {announce}),
-    httpPort,
   }
 }

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -147,8 +147,8 @@ function makeFakeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     announce: {
       webhookSecret: 'test-webhook-secret',
       presenceChannelId: 'test-presence-channel-id',
+      httpPort: 3000,
     },
-    httpPort: 3000,
     ...overrides,
   }
 }
@@ -331,7 +331,7 @@ describe('makeGatewayProgram', () => {
   it('announce enabled: startAnnounceServer called once with announce secrets + httpPort', async () => {
     // #given — config has announce present
     const fakeConfig = makeFakeConfig({
-      announce: {webhookSecret: 'test-webhook-secret', presenceChannelId: 'test-presence-channel-id'},
+      announce: {webhookSecret: 'test-webhook-secret', presenceChannelId: 'test-presence-channel-id', httpPort: 3000},
     })
     const fakeClient = makeFakeClient()
     const fakeServerHandle = makeFakeServerHandle()
@@ -364,7 +364,7 @@ describe('makeGatewayProgram', () => {
   it('announce enabled: logs "announce endpoint enabled" at boot', async () => {
     // #given — config has announce present; spy on console.log (makeLogger writes JSON there)
     const fakeConfig = makeFakeConfig({
-      announce: {webhookSecret: 'test-webhook-secret', presenceChannelId: 'test-presence-channel-id'},
+      announce: {webhookSecret: 'test-webhook-secret', presenceChannelId: 'test-presence-channel-id', httpPort: 3000},
     })
     const fakeClient = makeFakeClient()
     const fakeServerHandle = makeFakeServerHandle()

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -144,8 +144,10 @@ function makeFakeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     triggerRoleId: null,
     maxConcurrentRuns: 3,
     runTimeoutMs: 600_000,
-    webhookSecret: 'test-webhook-secret',
-    presenceChannelId: 'test-presence-channel-id',
+    announce: {
+      webhookSecret: 'test-webhook-secret',
+      presenceChannelId: 'test-presence-channel-id',
+    },
     httpPort: 3000,
     ...overrides,
   }
@@ -324,6 +326,140 @@ describe('makeGatewayProgram', () => {
 
     // #then — login was NOT called (fail before connecting to Discord)
     expect(loginSpy).not.toHaveBeenCalled()
+  })
+
+  it('announce enabled: startAnnounceServer called once with announce secrets + httpPort', async () => {
+    // #given — config has announce present
+    const fakeConfig = makeFakeConfig({
+      announce: {webhookSecret: 'test-webhook-secret', presenceChannelId: 'test-presence-channel-id'},
+    })
+    const fakeClient = makeFakeClient()
+    const fakeServerHandle = makeFakeServerHandle()
+    const startAnnounceServerSpy = vi.fn().mockReturnValue(fakeServerHandle)
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: startAnnounceServerSpy,
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    // #when
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then — factory called exactly once
+    expect(startAnnounceServerSpy).toHaveBeenCalledOnce()
+
+    // #and — serverConfig carries the announce secrets and httpPort
+    const [, serverConfig] = startAnnounceServerSpy.mock.calls[0] as [
+      import('./http/server.js').AnnounceServerDeps,
+      import('./http/server.js').AnnounceServerConfig,
+    ]
+    expect(serverConfig.webhookSecret).toBe('test-webhook-secret')
+    expect(serverConfig.presenceChannelId).toBe('test-presence-channel-id')
+    expect(serverConfig.httpPort).toBe(3000)
+  })
+
+  it('announce enabled: logs "announce endpoint enabled" at boot', async () => {
+    // #given — config has announce present; spy on console.log (makeLogger writes JSON there)
+    const fakeConfig = makeFakeConfig({
+      announce: {webhookSecret: 'test-webhook-secret', presenceChannelId: 'test-presence-channel-id'},
+    })
+    const fakeClient = makeFakeClient()
+    const fakeServerHandle = makeFakeServerHandle()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn().mockReturnValue(fakeServerHandle),
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    try {
+      // #when
+      await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+      // #then — at least one console.log call contained the enabled message
+      const loggedMessages = consoleSpy.mock.calls.map(args => String(args[0]))
+      expect(loggedMessages.some(m => m.includes('announce endpoint enabled — HTTP server started'))).toBe(true)
+    } finally {
+      consoleSpy.mockRestore()
+    }
+  })
+
+  it('announce disabled: startAnnounceServer is NOT called when config.announce is undefined', async () => {
+    // #given — config has no announce block
+    const fakeConfig = makeFakeConfig({announce: undefined})
+    const fakeClient = makeFakeClient()
+    const startAnnounceServerSpy = vi.fn()
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: startAnnounceServerSpy,
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    // #when
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then — announce server was never started
+    expect(startAnnounceServerSpy).not.toHaveBeenCalled()
+  })
+
+  it('announce disabled: boot completes successfully and logs "announce endpoint disabled"', async () => {
+    // #given — config has no announce block; spy on console.log (makeLogger writes JSON there)
+    const fakeConfig = makeFakeConfig({announce: undefined})
+    const fakeClient = makeFakeClient()
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    try {
+      // #when — must not throw
+      await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+      // #then — the disabled log line was emitted
+      const loggedMessages = consoleSpy.mock.calls.map(args => String(args[0]))
+      expect(loggedMessages.some(m => m.includes('announce endpoint disabled — no announce secrets configured'))).toBe(
+        true,
+      )
+    } finally {
+      consoleSpy.mockRestore()
+    }
+  })
+
+  it('announce disabled: client events (messageCreate/interactionCreate) are still wired', async () => {
+    // #given — config has no announce block
+    const fakeConfig = makeFakeConfig({announce: undefined})
+    const fakeClient = makeFakeClient()
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    // #when
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then — both Discord event handlers are registered regardless of announce state
+    const onCalls = (fakeClient.on as ReturnType<typeof vi.fn>).mock.calls as [string, unknown][]
+    const registeredEvents = onCalls.map(([event]) => event)
+    expect(registeredEvents).toContain('messageCreate')
+    expect(registeredEvents).toContain('interactionCreate')
   })
 })
 

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -311,7 +311,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
         {
           webhookSecret: config.announce.webhookSecret,
           presenceChannelId: config.announce.presenceChannelId,
-          httpPort: config.httpPort,
+          httpPort: config.announce.httpPort,
         },
       )
       logger.info({}, 'announce endpoint enabled — HTTP server started')

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -294,19 +294,28 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
         })
     })
 
-    // g. Start announce HTTP server (before shutdown handlers so the handle is available)
-    const serverHandle = deps.startAnnounceServer(
-      {
-        client,
-        logger,
-        isShuttingDown,
-      },
-      {
-        webhookSecret: config.webhookSecret,
-        presenceChannelId: config.presenceChannelId,
-        httpPort: config.httpPort,
-      },
-    )
+    // g. Start announce HTTP server (before shutdown handlers so the handle is available).
+    //    Announce endpoint is opt-in: only started when both GATEWAY_WEBHOOK_SECRET and
+    //    GATEWAY_PRESENCE_CHANNEL_ID are configured. When absent, serverHandle is undefined
+    //    and installShutdownHandlers skips server close (server param is already optional).
+    let serverHandle: CloseableServer | undefined
+    if (config.announce === undefined) {
+      logger.info({}, 'announce endpoint disabled — no announce secrets configured')
+    } else {
+      serverHandle = deps.startAnnounceServer(
+        {
+          client,
+          logger,
+          isShuttingDown,
+        },
+        {
+          webhookSecret: config.announce.webhookSecret,
+          presenceChannelId: config.announce.presenceChannelId,
+          httpPort: config.httpPort,
+        },
+      )
+      logger.info({}, 'announce endpoint enabled — HTTP server started')
+    }
 
     // h. Install shutdown handlers — drain pending approvals fail-closed then await in-flight runs
     installShutdownHandlers(client, logger, undefined, serverHandle, async () => {


### PR DESCRIPTION
Fixes #738.

The gateway daemon hard-required `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_CHANNEL_ID` at boot, but the shipped compose stack wired neither — so a deployer following the documented contract got a crash-looping gateway (`Missing required secret: GATEWAY_WEBHOOK_SECRET`).

## What changed

The announce/presence HTTP endpoint is now opt-in:

- **Both secrets absent** → the gateway boots normally with the announce endpoint disabled (the default deploy case). This is the fix for the crash loop.
- **Both secrets present** → the announce server starts and behaves exactly as before. The HMAC verification, replay cache, rate limiting, and body limit on `POST /v1/announce` are unchanged.
- **Exactly one present** → fail-fast at config load with a clear both-or-neither error naming the missing variable.

Modeled as an optional `announce` config object so the both-or-neither rule is a type-level invariant, mirroring the existing AWS-credential pair-validation. `GATEWAY_HTTP_PORT` is scoped to the announce config — it's only read when the endpoint is enabled. An empty or whitespace secret is treated as absent, so it can never enable an unauthenticated endpoint.

The compose stack and deploy README document the two secrets as an opt-in step. The gateway image smoke test gains a case proving the gateway boots past config load when announce secrets are absent.

Operators upgrading from a crash-looping deploy just pull the new image — no action needed unless they want the announce endpoint. An operator with exactly one leftover announce secret from the old contract gets a clear both-or-neither error pointing to the fix.