### PR TITLE
feat(gateway): render tool progress on the OpenCode 1.15.13 contract

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -107,18 +107,6 @@
       allowedVersions: '<=1.15.13',
     },
     {
-      // Hold the workspace executor image's baked OpenCode at 1.14.41 until the
-      // gateway mention-loop tool-progress renderer (run-core.ts) migrates from
-      // session.next.tool.* to the 1.15.13 message.part.updated contract. The
-      // global cap above would otherwise let Renovate bump this ARG to 1.15.13
-      // and silently break gateway tool-progress rendering. Remove this rule as
-      // part of the gateway 1.15.13 cutover. Placed after the cap so it wins for
-      // this file.
-      matchPackageNames: ['anomalyco/opencode'],
-      matchFileNames: ['deploy/workspace.Dockerfile'],
-      allowedVersions: '<=1.14.41',
-    },
-    {
       matchUpdateTypes: ['lockFileMaintenance'],
       semanticCommitType: 'build',
     },

--- a/deploy/workspace.Dockerfile
+++ b/deploy/workspace.Dockerfile
@@ -36,7 +36,7 @@ FROM node:24.16.0-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb
 WORKDIR /app
 
 # Pinned tool versions (track the runtime constants noted in the header).
-ARG OPENCODE_VERSION=1.14.41
+ARG OPENCODE_VERSION=1.15.13
 ARG SYSTEMATIC_VERSION=2.24.0
 
 # System packages:

--- a/packages/gateway/src/execute/run-core.test.ts
+++ b/packages/gateway/src/execute/run-core.test.ts
@@ -124,6 +124,35 @@ function toolSuccessEvent(callID: string, structured: object | null = null, sess
   }
 }
 
+/**
+ * `message.part.updated` with partType:'tool' — OpenCode 1.15.13 contract.
+ * The session ID is embedded in the part (mirrors streaming.ts:242 guard).
+ */
+function partUpdatedToolEvent(tool: string, status: string, state: object, sessionID = 'sess-123'): object {
+  return {
+    type: 'message.part.updated',
+    properties: {
+      sessionID,
+      part: {type: 'tool', tool, sessionID, state: {status, ...state}},
+    },
+  }
+}
+
+/**
+ * `message.part.updated` with partType:'text' — must NOT produce a 🔧 line.
+ * Text streaming is handled by `message.part.delta`; this guard test ensures
+ * the new branch never double-renders text parts.
+ */
+function partUpdatedTextEvent(text: string, sessionID = 'sess-123'): object {
+  return {
+    type: 'message.part.updated',
+    properties: {
+      sessionID,
+      part: {type: 'text', text, sessionID},
+    },
+  }
+}
+
 /** `session.idle` event for a given session. */
 function sessionIdleEvent(sessionID: string): object {
   return {type: 'session.idle', properties: {sessionID}}
@@ -484,6 +513,144 @@ describe('runOpenCodeCore', () => {
       await runOpenCodeCore(params)
 
       // #then — no progress line appended
+      expect(sink._appended).toHaveLength(0)
+    })
+  })
+
+  describe('tool call progress (message.part.updated — OpenCode 1.15.13 contract)', () => {
+    it('appends a progress line for a bash tool using state.title', async () => {
+      // #given
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partUpdatedToolEvent('bash', 'completed', {title: 'echo hi', input: {command: 'echo hi'}, output: ''}),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then
+      const combined = sink.buffered()
+      expect(combined).toContain('bash')
+      expect(combined).toContain('echo hi')
+    })
+
+    it('falls back to input.command when state.title is absent', async () => {
+      // #given
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partUpdatedToolEvent('bash', 'completed', {input: {command: 'pnpm test'}, output: ''}),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then
+      expect(sink.buffered()).toContain('pnpm test')
+    })
+
+    it('falls back to input.cmd when command is absent', async () => {
+      // #given
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partUpdatedToolEvent('bash', 'completed', {input: {cmd: 'ls -la'}, output: ''}),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then
+      expect(sink.buffered()).toContain('ls -la')
+    })
+
+    it('uses tool name as title for non-bash tools when state.title is absent', async () => {
+      // #given
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partUpdatedToolEvent('read_file', 'completed', {input: {path: '/foo/bar.ts'}, output: ''}),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then
+      expect(sink.buffered()).toContain('read_file')
+    })
+
+    it('does NOT emit a tool line for partType text (no double-render)', async () => {
+      // #given — message.part.updated with type:'text' must not produce a 🔧 line
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () => subscribeOk([partUpdatedTextEvent('some text content'), sessionIdleEvent('sess-123')]),
+      })
+      const params = {...buildParams(handle), sink}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — no 🔧 progress line; text part is handled by message.part.delta, not here
+      expect(sink._appended).toHaveLength(0)
+    })
+
+    it('ignores tool events from other sessions', async () => {
+      // #given
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partUpdatedToolEvent(
+              'bash',
+              'completed',
+              {title: 'rm -rf /', input: {command: 'rm -rf /'}, output: ''},
+              'other-session',
+            ),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — no progress line appended
+      expect(sink._appended).toHaveLength(0)
+    })
+
+    it('ignores tool parts that are not yet completed (pending/running)', async () => {
+      // #given
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partUpdatedToolEvent('bash', 'running', {input: {command: 'sleep 1'}, output: ''}),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — no progress line for non-completed state
       expect(sink._appended).toHaveLength(0)
     })
   })

--- a/packages/gateway/src/execute/run-core.ts
+++ b/packages/gateway/src/execute/run-core.ts
@@ -278,6 +278,33 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
         const deltaText = typeof deltaRaw === 'string' ? deltaRaw : (getStringProperty(deltaRaw, 'text') ?? null)
         if (deltaText != null) sink.append(deltaText)
       }
+    } else if (eventType === 'message.part.updated') {
+      // OpenCode 1.15.13 contract: tool lifecycle arrives via message.part.updated
+      // (partType:'tool', state.status:'completed'). session.next.tool.called/success
+      // no longer fire on 1.15.13 — this branch handles the new contract.
+      const part = getObjectProperty(eventPayload, 'part')
+      const eventSessionID = getSessionID(eventPayload) ?? getSessionID(part)
+      if (eventSessionID === sessionId) {
+        const partType = getStringProperty(part, 'type')
+        if (partType === 'tool') {
+          // ONLY handle tool parts — text parts are streamed via message.part.delta.
+          const toolState = getObjectProperty(part, 'state')
+          if (getStringProperty(toolState, 'status') === 'completed') {
+            const tool = getStringProperty(part, 'tool') ?? ''
+            // Title resolution: state.title → input.title → bash command/cmd → tool name.
+            const stateTitle = getStringProperty(toolState, 'title')
+            const stateInput = getObjectProperty(toolState, 'input')
+            const title =
+              stateTitle ??
+              getStringProperty(stateInput, 'title') ??
+              (tool.toLowerCase() === 'bash'
+                ? String(getObjectProperty(stateInput, 'command') ?? getObjectProperty(stateInput, 'cmd') ?? tool)
+                : tool)
+            logger.debug({tool, title}, 'run-core: tool completed (message.part.updated)')
+            sink.append(`\n🔧 ${tool}: ${title}\n`)
+          }
+        }
+      }
     } else if (eventType === 'session.next.tool.called') {
       // V2 sync tool lifecycle: cache call info for correlation with success event.
       const eventSessionID = getEventSessionID(rawEvent)


### PR DESCRIPTION
Brings the gateway mention-loop's Discord tool-progress rendering onto the OpenCode 1.15.13 event contract, and moves the workspace executor image off its temporary 1.14.41 hold.

The mention-loop renderer in `run-core.ts` surfaced tool-progress lines only from `session.next.tool.called`/`session.next.tool.success`. Those events no longer fire on OpenCode 1.15.13 — the tool lifecycle now arrives via `message.part.updated` (partType `tool`, state `completed`). On 1.15.13 the deployed gateway would still stream text (via `message.part.delta`) but show no tool-progress lines.

This adds a `message.part.updated` handler that renders the same progress line, mirroring the action-tier handler. It only handles tool parts — text continues to stream via `message.part.delta`, so there's no double-render. The legacy `session.next.tool.*` handlers are retained as an inert fallback.

With the gateway on the new contract, the workspace executor image's baked OpenCode moves from 1.14.41 to 1.15.13, and the temporary Renovate rule that held it below the global cap is removed — the ARG now tracks `DEFAULT_OPENCODE_VERSION`.

- `packages/gateway/src/execute/run-core.ts` — new `message.part.updated` tool handler
- `packages/gateway/src/execute/run-core.test.ts` — 7 tests (title resolution + text/other-session/non-completed guards)
- `deploy/workspace.Dockerfile` — `ARG OPENCODE_VERSION` 1.14.41 → 1.15.13
- `.github/renovate.json5` — remove the workspace-ARG hold rule