### PR TITLE
fix(deploy): restore workspace egress + add configurable proxy allowlist

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -346,6 +346,10 @@ jobs:
         uses: ./.github/actions/setup
       - name: Run deploy/scripts unit tests
         run: node --test deploy/scripts/*.test.mjs
+      - name: Run mitmproxy allowlist tests
+        run: python3 deploy/mitmproxy/test_allowlist.py
+      - name: Check compose network topology invariants
+        run: bash deploy/validate-stack.sh --topology-only
       - name: Build workspace Docker image
         run: |
           for attempt in 1 2 3; do

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -350,6 +350,8 @@ jobs:
         run: python3 deploy/mitmproxy/test_allowlist.py
       - name: Check compose network topology invariants
         run: bash deploy/validate-stack.sh --topology-only
+      - name: Topology guard negative test
+        run: bash deploy/validate-stack.test.sh
       - name: Build workspace Docker image
         run: |
           for attempt in 1 2 3; do

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -7,3 +7,11 @@
 # omitted for Discord-plumbing testing.
 # Example: my-bucket.s3.amazonaws.com,my-account.r2.cloudflarestorage.com
 OBJECT_STORE_HOSTS=
+
+# Optional — additional exact egress hosts the workspace may reach through
+# the proxy. Use as an escape hatch for explicitly-justified hosts only
+# (e.g. a self-hosted OpenCode proxy). Comma-separated exact hostnames;
+# wildcards, IPs, and ports are rejected. If unset or empty, no extra hosts
+# are added (fail-closed default). A malformed value prevents proxy startup.
+# Example: cliproxy.fro.bot
+WORKSPACE_EGRESS_HOSTS=

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -419,4 +419,4 @@ workspace → sandbox-net (internal:true) → mitmproxy → egress-net → inter
 - `sandbox-net` is `internal: true` — no container on this network has a host gateway or direct internet access.
 - The workspace is attached to `sandbox-net` only. It has zero direct egress.
 - mitmproxy is dual-homed: it receives workspace traffic on `sandbox-net` and dials allowlisted upstream hosts via `egress-net` (a dedicated non-internal network). Only mitmproxy joins `egress-net`.
-- The gateway is dual-homed on `gateway-net` (external) and `sandbox-net`; its Discord/S3 traffic does not route through mitmproxy.
+- The gateway is dual-homed on `gateway-net` (external) and `sandbox-net`. Its own egress also routes through mitmproxy (`HTTPS_PROXY=http://mitmproxy:8080`), which is why Discord and the GitHub/object-store hosts it needs are in the static allowlist. The topology guard intentionally does not constrain the gateway's networks — only the workspace is held to sandbox-net-only.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -287,7 +287,11 @@ WORKSPACE_OPENCODE_CONFIG={"provider":{"anthropic":{"options":{"baseURL":"https:
 echo -n '{"anthropic":{"type":"api","key":"<cliproxy-token>"},"openai":{"type":"api","key":"<cliproxy-token>"}}' > deploy/secrets/workspace-opencode-auth
 ```
 
-Add the proxy host to the egress allowlist (`OBJECT_STORE_HOSTS` is S3-only; provider hosts are covered by the static allowlist — add your cliproxyapi host there if it is not already permitted).
+Add the proxy host to the egress allowlist using `WORKSPACE_EGRESS_HOSTS` (see [Egress Allowlist](#egress-allowlist)):
+
+```env
+WORKSPACE_EGRESS_HOSTS=cliproxy.fro.bot
+```
 
 Leave both variables unset for a clone-only deployment: the workspace boots and serves `/clone`, but the mention loop has no model until they are configured.
 
@@ -376,3 +380,43 @@ OBJECT_STORE_HOSTS=my-bucket.s3.amazonaws.com,my-account.r2.cloudflarestorage.co
 If `OBJECT_STORE_HOSTS` is unset or empty, all S3/R2 traffic is blocked (fail-closed default). This prevents workspace processes from exfiltrating data to attacker-controlled buckets in those clouds.
 
 Set the variable in your `.env` file or `compose.override.yaml` (see `compose.override.example.yaml` for an example).
+
+### Additional workspace egress hosts
+
+`WORKSPACE_EGRESS_HOSTS` is an escape hatch for workspace egress hosts that are not covered by the static allowlist and are not object-store buckets. Use it for explicitly-justified hosts only — for example, a self-hosted OpenCode proxy:
+
+```
+WORKSPACE_EGRESS_HOSTS=cliproxy.fro.bot
+```
+
+Multiple hosts are comma-separated:
+
+```
+WORKSPACE_EGRESS_HOSTS=cliproxy.fro.bot,proxy2.example.com
+```
+
+**Validation rules** (same as `OBJECT_STORE_HOSTS`):
+
+- Wildcards (`*.example.com`) are rejected.
+- IP literals that are private, loopback, link-local, or otherwise reserved (`10.x`, `127.x`, `169.254.x`, `::1`, etc.) are rejected at import time.
+- Hosts with a port suffix (`host:443`) are rejected.
+- Invalid hostnames (leading/trailing/consecutive dots) are rejected.
+- At connect time, operator-supplied hosts are also resolved via DNS and rejected with 403 if any resolved address is private, loopback, link-local, or reserved (DNS-rebinding defense). Resolution failure is treated as a block (fail-closed).
+- A malformed value prevents proxy startup entirely (fail-closed).
+
+If `WORKSPACE_EGRESS_HOSTS` is unset or empty, no extra hosts are added (fail-closed default).
+
+**Do not use `WORKSPACE_EGRESS_HOSTS` as a general allowlist.** It is intended for a small number of explicitly-justified hosts (e.g. a self-hosted model proxy). Accumulating unrelated hosts here defeats the purpose of the allowlist. If a host is needed by all deployments, it belongs in the static `ALLOWLIST` in `deploy/mitmproxy/allowlist.py`.
+
+### Egress topology
+
+The containment model is:
+
+```
+workspace → sandbox-net (internal:true) → mitmproxy → egress-net → internet
+```
+
+- `sandbox-net` is `internal: true` — no container on this network has a host gateway or direct internet access.
+- The workspace is attached to `sandbox-net` only. It has zero direct egress.
+- mitmproxy is dual-homed: it receives workspace traffic on `sandbox-net` and dials allowlisted upstream hosts via `egress-net` (a dedicated non-internal network). Only mitmproxy joins `egress-net`.
+- The gateway is dual-homed on `gateway-net` (external) and `sandbox-net`; its Discord/S3 traffic does not route through mitmproxy.

--- a/deploy/compose.override.example.yaml
+++ b/deploy/compose.override.example.yaml
@@ -29,6 +29,12 @@ services:
     #   Set it in your .env file or shell environment instead.
     #   Example: "my-bucket.s3.amazonaws.com,my-account.r2.cloudflarestorage.com"
     #   If unset or empty, all S3/R2 traffic is blocked (fail-closed default).
+    #
+    #   WORKSPACE_EGRESS_HOSTS is likewise omitted here; it falls through to
+    #   compose.yaml's interpolation: WORKSPACE_EGRESS_HOSTS: ${WORKSPACE_EGRESS_HOSTS:-}
+    #   Set it in your .env file for additional exact egress hosts (e.g. a
+    #   self-hosted OpenCode proxy). Example: "cliproxy.fro.bot"
+    #   If unset or empty, no extra hosts are added (fail-closed default).
 
   gateway:
     # Override the mitmproxy-certs volume path for dev if you want a local dir

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -276,6 +276,14 @@ services:
       # to the exact bucket host(s) your deployment uses. If unset or empty,
       # all S3/R2 traffic is blocked (fail-closed default).
       OBJECT_STORE_HOSTS: ${OBJECT_STORE_HOSTS:-}
+      # Comma-separated list of additional exact egress hosts to allow through
+      # the proxy (e.g. a self-hosted OpenCode proxy: "cliproxy.fro.bot").
+      # Use this as an escape hatch for explicitly-justified workspace egress
+      # hosts only — not as a general allowlist. If unset or empty, no extra
+      # hosts are added (fail-closed default). Hosts are validated at import
+      # time (wildcard/private-IP/port reject) and at connect time (DNS-rebinding
+      # resolved-IP check). A malformed value prevents proxy startup.
+      WORKSPACE_EGRESS_HOSTS: ${WORKSPACE_EGRESS_HOSTS:-}
     volumes:
       - ./mitmproxy/allowlist.py:/scripts/allowlist.py:ro
       # Named volume: mitmproxy writes CA here; gateway/workspace read it for trust

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -281,7 +281,8 @@ services:
       # Named volume: mitmproxy writes CA here; gateway/workspace read it for trust
       - mitmproxy-certs:/home/mitmproxy/.mitmproxy
     networks:
-      - sandbox-net
+      - sandbox-net # receives workspace traffic (internal)
+      - egress-net # upstream leg: mitmproxy dials allowlisted hosts here
     restart: unless-stopped
     logging:
       driver: json-file
@@ -304,10 +305,16 @@ volumes:
   mitmproxy-certs:
 
 networks:
-  # External-facing network for gateway ↔ Discord
+  # External-facing network for gateway ↔ Discord/S3
   gateway-net:
     driver: bridge
-  # Internal sandbox network: workspace + mitmproxy; gateway bridges both
+  # Isolated sandbox: workspace + mitmproxy receive side only.
+  # internal:true — no host gateway, no direct internet egress for any
+  # container attached here. Workspace stays on this network exclusively.
   sandbox-net:
     driver: bridge
     internal: true
+  # mitmproxy's upstream leg only. No other service joins this network.
+  # Containment invariant: workspace → sandbox-net → mitmproxy → egress-net → internet.
+  egress-net:
+    driver: bridge

--- a/deploy/mitmproxy/allowlist.py
+++ b/deploy/mitmproxy/allowlist.py
@@ -21,10 +21,23 @@ OBJECT_STORE_HOSTS
     bucket host(s) your deployment uses.
 
     If unset or empty, all S3/R2 traffic is blocked (fail-closed default).
+
+WORKSPACE_EGRESS_HOSTS
+    Comma-separated list of additional hosts to allow for workspace egress.
+    Use this for self-hosted model proxies or other explicitly-justified egress
+    hosts that the workspace must reach (e.g. a self-hosted OpenCode proxy).
+    Example: "cliproxy.fro.bot"
+
+    Applies the same validation as OBJECT_STORE_HOSTS: wildcards, private/
+    loopback/link-local/reserved IPs, and port suffixes are all rejected.
+
+    If unset or empty, no additional workspace-egress hosts are allowed
+    (fail-closed default).
 """
 
 import ipaddress
 import os
+import socket
 import sys
 from mitmproxy import http
 
@@ -34,8 +47,9 @@ from mitmproxy import http
 #
 # Wildcard entries (*.foo.com) are permitted in this static list because they
 # go through code review. The same wildcards are REJECTED when supplied via
-# OBJECT_STORE_HOSTS env var to prevent operators (or attackers with deploy-
-# config access) from silently re-introducing over-broad allowlist holes.
+# OBJECT_STORE_HOSTS or WORKSPACE_EGRESS_HOSTS env vars to prevent operators
+# (or attackers with deploy-config access) from silently re-introducing
+# over-broad allowlist holes.
 # ---------------------------------------------------------------------------
 ALLOWLIST: list[str] = [
     # GitHub
@@ -64,45 +78,27 @@ ALLOWLIST: list[str] = [
 # ---------------------------------------------------------------------------
 
 
-def _validate_ip_literal_or_none(entry: str) -> str | None:
-    """If *entry* parses as an IP literal, validate it.
+def _ip_is_disallowed(ip_str: str) -> bool:
+    """Return True if *ip_str* is a reserved/private/loopback/link-local IP.
 
-    Returns None if the entry is not an IP (caller should fall through to the
-    hostname validator). Raises ValueError if the entry is an IP in a
-    reserved/private/loopback/link-local range.
+    Covers all ranges that must not be reachable from the workspace:
+      - RFC 1918 private (10/8, 172.16/12, 192.168/16)
+      - loopback (127/8, ::1/128)
+      - link-local (169.254/16, fe80::/10)
+      - shared address space / CGNAT (100.64/10, RFC 6598)
+      - documentation ranges (192.0.2/24, 198.51.100/24, 203.0.113/24, 2001:db8::/32)
+      - benchmarking (198.18/15)
+      - multicast, unspecified (0.0.0.0, ::), site-local, unique local IPv6 (fc00::/7)
 
-    Public IPs are accepted to support self-hosted MinIO deployments that use
-    a public IP. Reserved ranges are rejected to prevent egress to internal
-    services (e.g. cloud metadata at 169.254.169.254, loopback at 127.0.0.1,
-    private networks at 10.x/172.16-31.x/192.168.x). Implements todo 017
-    Option 2: reject private/loopback/link-local/reserved, allow public IPs.
+    Returns False for globally-routable public IPs (accepted for self-hosted
+    MinIO deployments and similar use cases).
     """
     try:
-        ip = ipaddress.ip_address(entry)
+        ip = ipaddress.ip_address(ip_str)
     except ValueError:
-        return None  # not an IP — let the hostname validator handle it
-
-    # Reject any address that is not globally routable. ip.is_global is True only
-    # for truly globally-routable unicast addresses; it excludes:
-    #   - RFC 1918 private (10/8, 172.16/12, 192.168/16)
-    #   - loopback (127/8, ::1/128)
-    #   - link-local (169.254/16, fe80::/10)
-    #   - shared address space / CGNAT (100.64/10, RFC 6598)
-    #   - documentation ranges (192.0.2/24, 198.51.100/24, 203.0.113/24, 2001:db8::/32)
-    #   - benchmarking (198.18/15)
-    #   - multicast, unspecified (0.0.0.0, ::), site-local, unique local IPv6 (fc00::/7)
-    if not ip.is_global:
-        raise ValueError(
-            f"OBJECT_STORE_HOSTS entry '{entry}' is not a globally-routable public IP.\n"
-            "Rejected: private (10.x/172.16-31.x/192.168.x), loopback (127.0.0.1, ::1),\n"
-            "link-local (169.254/16, fe80::/10), shared address space / CGNAT (100.64/10),\n"
-            "documentation (192.0.2.x, 198.51.100.x, 203.0.113.x, 2001:db8::/32),\n"
-            "multicast, and reserved ranges are blocked to prevent egress to internal\n"
-            "or unroutable destinations. Use a public IP, or set up a hostname mapping\n"
-            "for internal endpoints."
-        )
-
-    return entry  # public IP — accept
+        # Not a parseable IP address — not our concern here.
+        return False
+    return not ip.is_global
 
 
 def _is_valid_hostname(hostname: str) -> bool:
@@ -132,7 +128,7 @@ def _is_valid_hostname(hostname: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Merge OBJECT_STORE_HOSTS env var into the allowlist at module import time.
+# Shared parse/validate pipeline for operator-supplied egress host env vars.
 #
 # Validation order per entry (after strip):
 #   1. empty-skip        — blank entries are silently ignored
@@ -149,55 +145,104 @@ def _is_valid_hostname(hostname: str) -> bool:
 #   5. hostname-validate — must pass RFC 1123 check (after lowercasing)
 #   6. lowercase-normalize — stored in lowercase for consistent matching
 # ---------------------------------------------------------------------------
-_object_store_hosts_raw = os.environ.get("OBJECT_STORE_HOSTS", "")
-_object_store_hosts: list[str] = []
-for _entry in _object_store_hosts_raw.split(","):
-    _h = _entry.strip()
-    if not _h:
-        # 1. empty-skip
-        continue
-    if _h.startswith("*."):
-        # 2. wildcard-reject
-        raise ValueError(
-            f"OBJECT_STORE_HOSTS contains a wildcard entry '{_h}'. "
-            "Wildcards are not allowed in object-store hosts to prevent "
-            "re-introducing the over-broad-allowlist security gap. "
-            "Set exact bucket hostnames (e.g. 'my-bucket.s3.amazonaws.com')."
-        )
-    # 3. ip-literal-validate — fires before port-reject so bare IPv6 literals
-    # (which contain colons) are handled correctly. Returns the entry if it is
-    # a valid public IP, raises on reserved ranges, returns None if not an IP.
-    _maybe_ip = _validate_ip_literal_or_none(_h)
-    if _maybe_ip is not None:
-        _object_store_hosts.append(_maybe_ip)
-        continue
-    if ":" in _h:
-        # 4. port-reject — entry was not a bare IP but still contains ":".
-        # Could be hostname:port or bracket-form IPv6+port ([::1]:9000).
-        if _h.count(":") > 1 or _h.startswith("["):
-            raise ValueError(
-                f"OBJECT_STORE_HOSTS entry '{_h}' looks like an IPv6 address with a port "
-                "or bracket notation. Bare IPv6 addresses are validated above; "
-                "IPv6+port is not supported. Use a bare IPv6 address or a hostname."
-            )
-        raise ValueError(
-            f"OBJECT_STORE_HOSTS entry '{_h}' contains a port. mitmproxy may "
-            "or may not include the port in flow.request.host depending on "
-            "version and proxy mode. Set bare hostnames only "
-            "(e.g. 'localhost' or 'minio')."
-        )
-    _h_lower = _h.lower()
-    if not _is_valid_hostname(_h_lower):
-        # 5. hostname-validate
-        raise ValueError(
-            f"OBJECT_STORE_HOSTS entry '{_h}' is not a valid hostname. "
-            "Use RFC 1123 hostnames composed of labels separated by dots "
-            "(e.g. 'my-bucket.s3.amazonaws.com')."
-        )
-    # 6. lowercase-normalize
-    _object_store_hosts.append(_h_lower)
 
+
+def _parse_egress_hosts(env_var_name: str, raw_value: str) -> list[str]:
+    """Parse and validate a comma-separated list of egress hostnames from an env var.
+
+    *env_var_name* is used in error messages so operators know which variable
+    to fix. *raw_value* is the raw string from the environment (may be empty).
+
+    Returns the validated, lowercased host list. Raises ValueError on the first
+    invalid entry, naming the env var and the offending value.
+    """
+    result: list[str] = []
+    for _entry in raw_value.split(","):
+        _h = _entry.strip()
+        if not _h:
+            # 1. empty-skip
+            continue
+        if _h.startswith("*."):
+            # 2. wildcard-reject
+            raise ValueError(
+                f"{env_var_name} contains a wildcard entry '{_h}'. "
+                "Wildcards are not allowed in object-store hosts to prevent "
+                "re-introducing the over-broad-allowlist security gap. "
+                "Set exact bucket hostnames (e.g. 'my-bucket.s3.amazonaws.com')."
+            )
+        # 3. ip-literal-validate — fires before port-reject so bare IPv6 literals
+        # (which contain colons) are handled correctly. Returns the entry if it is
+        # a valid public IP, raises on reserved ranges, returns None if not an IP.
+        try:
+            ipaddress.ip_address(_h)
+            # Parsed as IP — check if it's disallowed.
+            if _ip_is_disallowed(_h):
+                raise ValueError(
+                    f"{env_var_name} entry '{_h}' is not a globally-routable public IP.\n"
+                    "Rejected: private (10.x/172.16-31.x/192.168.x), loopback (127.0.0.1, ::1),\n"
+                    "link-local (169.254/16, fe80::/10), shared address space / CGNAT (100.64/10),\n"
+                    "documentation (192.0.2.x, 198.51.100.x, 203.0.113.x, 2001:db8::/32),\n"
+                    "multicast, and reserved ranges are blocked to prevent egress to internal\n"
+                    "or unroutable destinations. Use a public IP, or set up a hostname mapping\n"
+                    "for internal endpoints."
+                )
+            result.append(_h)
+            continue
+        except ValueError as exc:
+            # Re-raise if it's our own validation error (not the ip_address parse failure).
+            if env_var_name in str(exc):
+                raise
+            # Otherwise it wasn't a valid IP — fall through to port/hostname checks.
+        if ":" in _h:
+            # 4. port-reject — entry was not a bare IP but still contains ":".
+            # Could be hostname:port or bracket-form IPv6+port ([::1]:9000).
+            if _h.count(":") > 1 or _h.startswith("["):
+                raise ValueError(
+                    f"{env_var_name} entry '{_h}' looks like an IPv6 address with a port "
+                    "or bracket notation. Bare IPv6 addresses are validated above; "
+                    "IPv6+port is not supported. Use a bare IPv6 address or a hostname."
+                )
+            raise ValueError(
+                f"{env_var_name} entry '{_h}' contains a port. mitmproxy may "
+                "or may not include the port in flow.request.host depending on "
+                "version and proxy mode. Set bare hostnames only "
+                "(e.g. 'localhost' or 'minio')."
+            )
+        _h_lower = _h.lower()
+        if not _is_valid_hostname(_h_lower):
+            # 5. hostname-validate
+            raise ValueError(
+                f"{env_var_name} entry '{_h}' is not a valid hostname. "
+                "Use RFC 1123 hostnames composed of labels separated by dots "
+                "(e.g. 'my-bucket.s3.amazonaws.com')."
+            )
+        # 6. lowercase-normalize
+        result.append(_h_lower)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Merge OBJECT_STORE_HOSTS env var into the allowlist at module import time.
+# ---------------------------------------------------------------------------
+_object_store_hosts = _parse_egress_hosts(
+    "OBJECT_STORE_HOSTS", os.environ.get("OBJECT_STORE_HOSTS", "")
+)
 ALLOWLIST = ALLOWLIST + _object_store_hosts
+
+# ---------------------------------------------------------------------------
+# Merge WORKSPACE_EGRESS_HOSTS env var into the allowlist at module import time.
+# ---------------------------------------------------------------------------
+_workspace_egress_hosts = _parse_egress_hosts(
+    "WORKSPACE_EGRESS_HOSTS", os.environ.get("WORKSPACE_EGRESS_HOSTS", "")
+)
+ALLOWLIST = ALLOWLIST + _workspace_egress_hosts
+
+# ---------------------------------------------------------------------------
+# Track the set of operator-supplied hosts for resolved-IP validation at
+# enforcement time. Only hosts from env vars (not the static list) are
+# subject to DNS-rebinding checks — vendor hosts go through code review.
+# ---------------------------------------------------------------------------
+_operator_supplied_hosts: set[str] = {h.lower() for h in _object_store_hosts + _workspace_egress_hosts}
 
 
 def _is_allowed(host: str) -> bool:
@@ -221,6 +266,27 @@ def _is_allowed(host: str) -> bool:
     return False
 
 
+def _resolve_has_disallowed_ip(host: str) -> bool:
+    """Resolve *host* and return True if ANY resolved address is disallowed.
+
+    Fails closed: if resolution raises, returns True (block the request).
+
+    Note: this check runs at the addon hook layer. mitmproxy performs its own
+    independent resolution for the upstream dial (TOCTOU gap). This is
+    defense-in-depth against operator misconfiguration and naive DNS rebinding,
+    not a hermetic guarantee.
+    """
+    try:
+        results = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return True  # fail closed — resolution failure blocks the request
+    for _family, _type, _proto, _canonname, sockaddr in results:
+        ip_str = sockaddr[0]
+        if _ip_is_disallowed(ip_str):
+            return True
+    return False
+
+
 class AllowlistAddon:
     def _enforce(self, flow: http.HTTPFlow, kind: str) -> None:
         """Apply the allowlist to *flow*. *kind* is 'connect' or 'request' for logging."""
@@ -241,12 +307,31 @@ class AllowlistAddon:
                 f"Blocked by fro-bot egress allowlist: {host}",
                 {"Content-Type": "text/plain"},
             )
-        else:
-            print(
-                f"[allowlist] ALLOWED {kind} host={host}",
-                file=sys.stderr,
-                flush=True,
-            )
+            return
+
+        # For operator-supplied hosts, validate the resolved IP at enforcement
+        # time to defend against DNS rebinding. Vendor static-list hosts are
+        # not resolved-checked (they go through code review).
+        if host.lower() in _operator_supplied_hosts:
+            if _resolve_has_disallowed_ip(host):
+                print(
+                    f"[allowlist] BLOCKED {kind} host={host} reason=resolves-to-disallowed-ip "
+                    f"client={flow.client_conn.peername}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                flow.response = http.Response.make(
+                    403,
+                    f"Blocked by fro-bot egress allowlist: {host} resolves to a disallowed IP",
+                    {"Content-Type": "text/plain"},
+                )
+                return
+
+        print(
+            f"[allowlist] ALLOWED {kind} host={host}",
+            file=sys.stderr,
+            flush=True,
+        )
 
     def http_connect(self, flow: http.HTTPFlow) -> None:
         """Enforce allowlist for HTTPS CONNECT tunnels."""
@@ -261,7 +346,6 @@ class AllowlistAddon:
         entirely by using http:// URLs.
         """
         self._enforce(flow, "request")
-
 
 
 addons = [AllowlistAddon()]

--- a/deploy/mitmproxy/allowlist.py
+++ b/deploy/mitmproxy/allowlist.py
@@ -166,9 +166,8 @@ def _parse_egress_hosts(env_var_name: str, raw_value: str) -> list[str]:
             # 2. wildcard-reject
             raise ValueError(
                 f"{env_var_name} contains a wildcard entry '{_h}'. "
-                "Wildcards are not allowed in object-store hosts to prevent "
-                "re-introducing the over-broad-allowlist security gap. "
-                "Set exact bucket hostnames (e.g. 'my-bucket.s3.amazonaws.com')."
+                "Wildcards are not allowed (they re-introduce the over-broad-allowlist security gap). "
+                "Set exact hostnames (e.g. 'my-bucket.s3.amazonaws.com' or 'cliproxy.example.com')."
             )
         # 3. ip-literal-validate — fires before port-reject so bare IPv6 literals
         # (which contain colons) are handled correctly. Returns the entry if it is
@@ -269,7 +268,8 @@ def _is_allowed(host: str) -> bool:
 def _resolve_has_disallowed_ip(host: str) -> bool:
     """Resolve *host* and return True if ANY resolved address is disallowed.
 
-    Fails closed: if resolution raises, returns True (block the request).
+    Fails closed: if resolution raises (DNS error, timeout, or encoding
+    failure), returns True (block the request).
 
     Note: this check runs at the addon hook layer. mitmproxy performs its own
     independent resolution for the upstream dial (TOCTOU gap). This is
@@ -278,7 +278,7 @@ def _resolve_has_disallowed_ip(host: str) -> bool:
     """
     try:
         results = socket.getaddrinfo(host, None)
-    except socket.gaierror:
+    except (OSError, UnicodeError):
         return True  # fail closed — resolution failure blocks the request
     for _family, _type, _proto, _canonname, sockaddr in results:
         ip_str = sockaddr[0]

--- a/deploy/mitmproxy/test_allowlist.py
+++ b/deploy/mitmproxy/test_allowlist.py
@@ -841,6 +841,24 @@ def test_dns_rebinding_any_private_record_blocks():
     assert call_args[0][0] == 403
 
 
+def test_dns_rebinding_all_public_records_allowed():
+    """Multiple A-records where ALL are public → operator-supplied host is allowed through."""
+    import unittest.mock as mock
+
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    mod.socket = mock.MagicMock()
+    # Both records are public — no private address in the set
+    mod.socket.getaddrinfo.return_value = [
+        (None, None, None, None, ("8.8.8.8", 0)),
+        (None, None, None, None, ("1.1.1.1", 0)),
+    ]
+    addon = mod.AllowlistAddon()
+    flow = _make_flow_with_response("cliproxy.fro.bot")
+    addon.http_connect(flow)
+    # Should NOT be blocked — response stays None
+    assert flow.response is None
+
+
 def test_dns_rebinding_vendor_host_not_resolved():
     """Vendor static-ALLOWLIST host (github.com) is NOT resolved-checked."""
     import unittest.mock as mock

--- a/deploy/mitmproxy/test_allowlist.py
+++ b/deploy/mitmproxy/test_allowlist.py
@@ -572,6 +572,345 @@ def test_object_store_hosts_rejects_documentation_ipv6():
 
 
 # ===========================================================================
+# WORKSPACE_EGRESS_HOSTS env-var merging (Unit 2)
+# ===========================================================================
+
+
+def test_workspace_egress_hosts_included_when_set():
+    """WORKSPACE_EGRESS_HOSTS=cliproxy.fro.bot → host in ALLOWLIST."""
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    assert "cliproxy.fro.bot" in mod.ALLOWLIST
+
+
+def test_workspace_egress_hosts_is_allowed():
+    """A host from WORKSPACE_EGRESS_HOSTS must pass _is_allowed."""
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    assert mod._is_allowed("cliproxy.fro.bot") is True
+
+
+def test_workspace_egress_hosts_comma_separated():
+    """Comma-separated WORKSPACE_EGRESS_HOSTS adds all entries."""
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot,proxy2.example.com"})
+    assert "cliproxy.fro.bot" in mod.ALLOWLIST
+    assert "proxy2.example.com" in mod.ALLOWLIST
+    assert mod._is_allowed("cliproxy.fro.bot") is True
+    assert mod._is_allowed("proxy2.example.com") is True
+
+
+def test_workspace_egress_hosts_unset_no_change():
+    """Unset WORKSPACE_EGRESS_HOSTS → no change to ALLOWLIST, no error."""
+    mod_without = _load_allowlist()
+    mod_with_empty = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": ""})
+    # Neither should raise; static list length should be the same
+    assert len(mod_without.ALLOWLIST) == len(mod_with_empty.ALLOWLIST)
+
+
+def test_workspace_egress_hosts_case_normalized():
+    """CliProxy.FRO.bot must be lowercased and matched case-insensitively."""
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "CliProxy.FRO.bot"})
+    assert "cliproxy.fro.bot" in mod.ALLOWLIST
+    assert mod._is_allowed("cliproxy.fro.bot") is True
+    assert mod._is_allowed("CliProxy.FRO.bot") is True  # _is_allowed lowercases
+
+
+def test_workspace_egress_hosts_rejects_wildcard():
+    """WORKSPACE_EGRESS_HOSTS='*.fro.bot' must raise ValueError naming the var."""
+    try:
+        _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "*.fro.bot"})
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        msg = str(e)
+        assert "WORKSPACE_EGRESS_HOSTS" in msg, f"Expected var name in error: {e}"
+        assert "*.fro.bot" in msg, f"Expected wildcard entry in error: {e}"
+
+
+def test_workspace_egress_hosts_rejects_private_ip_10():
+    """WORKSPACE_EGRESS_HOSTS='10.0.0.5' must raise ValueError."""
+    try:
+        _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "10.0.0.5"})
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        msg = str(e).lower()
+        assert "reserved" in msg or "private" in msg, f"Expected 'reserved' or 'private' in error: {e}"
+
+
+def test_workspace_egress_hosts_rejects_loopback_ip():
+    """WORKSPACE_EGRESS_HOSTS='127.0.0.1' must raise ValueError."""
+    try:
+        _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "127.0.0.1"})
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        msg = str(e).lower()
+        assert "reserved" in msg or "loopback" in msg, f"Expected 'reserved' or 'loopback' in error: {e}"
+
+
+def test_workspace_egress_hosts_rejects_link_local_ip():
+    """WORKSPACE_EGRESS_HOSTS='169.254.169.254' must raise ValueError."""
+    try:
+        _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "169.254.169.254"})
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        msg = str(e).lower()
+        assert "reserved" in msg or "link-local" in msg, f"Expected 'reserved' or 'link-local' in error: {e}"
+
+
+def test_workspace_egress_hosts_rejects_port():
+    """WORKSPACE_EGRESS_HOSTS='cliproxy.fro.bot:443' must raise ValueError."""
+    try:
+        _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot:443"})
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        assert "port" in str(e).lower(), f"Expected 'port' in error: {e}"
+
+
+def test_workspace_egress_hosts_rejects_invalid_hostname():
+    """WORKSPACE_EGRESS_HOSTS with leading/trailing/consecutive dots must raise ValueError."""
+    for bad in [".cliproxy.fro.bot", "cliproxy.fro.bot.", "cliproxy..fro.bot"]:
+        try:
+            _load_allowlist({"WORKSPACE_EGRESS_HOSTS": bad})
+            assert False, f"Expected ValueError for '{bad}'"
+        except ValueError as e:
+            assert bad in str(e) or "hostname" in str(e).lower(), (
+                f"Expected entry name or 'hostname' in error for '{bad}': {e}"
+            )
+
+
+def test_workspace_egress_hosts_and_object_store_hosts_both_present():
+    """Both OBJECT_STORE_HOSTS and WORKSPACE_EGRESS_HOSTS set → both in ALLOWLIST."""
+    mod = _load_allowlist({
+        "OBJECT_STORE_HOSTS": "my-bucket.s3.amazonaws.com",
+        "WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot",
+    })
+    assert "my-bucket.s3.amazonaws.com" in mod.ALLOWLIST
+    assert "cliproxy.fro.bot" in mod.ALLOWLIST
+    assert mod._is_allowed("my-bucket.s3.amazonaws.com") is True
+    assert mod._is_allowed("cliproxy.fro.bot") is True
+
+
+def test_workspace_egress_hosts_only_does_not_affect_object_store():
+    """Setting only WORKSPACE_EGRESS_HOSTS does not add object-store hosts."""
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    assert "my-bucket.s3.amazonaws.com" not in mod.ALLOWLIST
+    assert mod._is_allowed("attacker-bucket.s3.amazonaws.com") is False
+
+
+def test_object_store_hosts_only_does_not_affect_workspace_egress():
+    """Setting only OBJECT_STORE_HOSTS does not add workspace-egress hosts."""
+    mod = _load_allowlist({"OBJECT_STORE_HOSTS": "my-bucket.s3.amazonaws.com"})
+    assert "cliproxy.fro.bot" not in mod.ALLOWLIST
+    assert mod._is_allowed("cliproxy.fro.bot") is False
+
+
+# ===========================================================================
+# DNS-rebinding defense — resolved-IP validation at enforcement time (Unit 3)
+# ===========================================================================
+
+
+def _load_allowlist_with_socket_mock(extra_env, getaddrinfo_side_effect):
+    """Load allowlist with env overrides and a mocked socket.getaddrinfo.
+
+    Returns (mod, socket_mock) so tests can inspect call counts.
+    """
+    import unittest.mock as mock
+
+    mod = _load_allowlist(extra_env)
+    socket_mock = mock.MagicMock()
+    socket_mock.getaddrinfo.side_effect = getaddrinfo_side_effect
+    mod.socket = socket_mock
+    return mod, socket_mock
+
+
+def _make_flow_with_response(host: str, peername: str = "10.0.0.1:12345"):
+    """Build a mock flow that properly tracks response assignment."""
+    flow = MagicMock()
+    flow.request.host = host
+    flow.client_conn.peername = peername
+    # Track response assignment via a real attribute
+    flow.response = None
+    return flow
+
+
+def test_dns_rebinding_operator_host_public_ip_allowed():
+    """Operator-supplied host resolving to a public IP is allowed through."""
+    import unittest.mock as mock
+
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    # getaddrinfo returns a public IP (8.8.8.8)
+    mod.socket = mock.MagicMock()
+    mod.socket.getaddrinfo.return_value = [
+        (None, None, None, None, ("8.8.8.8", 0))
+    ]
+    addon = mod.AllowlistAddon()
+    flow = _make_flow_with_response("cliproxy.fro.bot")
+    addon.http_connect(flow)
+    # Should NOT be blocked — response stays None
+    assert flow.response is None
+
+
+def test_dns_rebinding_operator_host_loopback_blocked():
+    """Operator-supplied host resolving to 127.0.0.1 is rejected with 403."""
+    import unittest.mock as mock
+
+    _reset_response_mock()
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    mod.socket = mock.MagicMock()
+    mod.socket.getaddrinfo.return_value = [
+        (None, None, None, None, ("127.0.0.1", 0))
+    ]
+    addon = mod.AllowlistAddon()
+    flow = _make_flow_with_response("cliproxy.fro.bot")
+    addon.http_connect(flow)
+    assert flow.response is not None
+    mitmproxy_http_mock.Response.make.assert_called_once()
+    call_args = mitmproxy_http_mock.Response.make.call_args
+    assert call_args[0][0] == 403
+
+
+def test_dns_rebinding_operator_host_private_10_blocked():
+    """Operator-supplied host resolving to 10.0.0.5 is rejected with 403."""
+    import unittest.mock as mock
+
+    _reset_response_mock()
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    mod.socket = mock.MagicMock()
+    mod.socket.getaddrinfo.return_value = [
+        (None, None, None, None, ("10.0.0.5", 0))
+    ]
+    addon = mod.AllowlistAddon()
+    flow = _make_flow_with_response("cliproxy.fro.bot")
+    addon.http_connect(flow)
+    assert flow.response is not None
+    call_args = mitmproxy_http_mock.Response.make.call_args
+    assert call_args[0][0] == 403
+
+
+def test_dns_rebinding_operator_host_link_local_blocked():
+    """Operator-supplied host resolving to 169.254.169.254 is rejected with 403."""
+    import unittest.mock as mock
+
+    _reset_response_mock()
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    mod.socket = mock.MagicMock()
+    mod.socket.getaddrinfo.return_value = [
+        (None, None, None, None, ("169.254.169.254", 0))
+    ]
+    addon = mod.AllowlistAddon()
+    flow = _make_flow_with_response("cliproxy.fro.bot")
+    addon.http_connect(flow)
+    assert flow.response is not None
+    call_args = mitmproxy_http_mock.Response.make.call_args
+    assert call_args[0][0] == 403
+
+
+def test_dns_rebinding_operator_host_ipv6_loopback_blocked():
+    """Operator-supplied host resolving to ::1 is rejected with 403."""
+    import unittest.mock as mock
+
+    _reset_response_mock()
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    mod.socket = mock.MagicMock()
+    mod.socket.getaddrinfo.return_value = [
+        (None, None, None, None, ("::1", 0))
+    ]
+    addon = mod.AllowlistAddon()
+    flow = _make_flow_with_response("cliproxy.fro.bot")
+    addon.http_connect(flow)
+    assert flow.response is not None
+    call_args = mitmproxy_http_mock.Response.make.call_args
+    assert call_args[0][0] == 403
+
+
+def test_dns_rebinding_any_private_record_blocks():
+    """Multiple A-records where ANY is private → rejected."""
+    import unittest.mock as mock
+
+    _reset_response_mock()
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    mod.socket = mock.MagicMock()
+    # First record is public, second is private
+    mod.socket.getaddrinfo.return_value = [
+        (None, None, None, None, ("8.8.8.8", 0)),
+        (None, None, None, None, ("10.0.0.5", 0)),
+    ]
+    addon = mod.AllowlistAddon()
+    flow = _make_flow_with_response("cliproxy.fro.bot")
+    addon.http_connect(flow)
+    assert flow.response is not None
+    call_args = mitmproxy_http_mock.Response.make.call_args
+    assert call_args[0][0] == 403
+
+
+def test_dns_rebinding_vendor_host_not_resolved():
+    """Vendor static-ALLOWLIST host (github.com) is NOT resolved-checked."""
+    import unittest.mock as mock
+
+    _reset_response_mock()
+    mod = _load_allowlist()
+    socket_mock = mock.MagicMock()
+    mod.socket = socket_mock
+    addon = mod.AllowlistAddon()
+    flow = _make_flow_with_response("github.com")
+    addon.http_connect(flow)
+    # github.com is in the static list, not operator-supplied → no getaddrinfo call
+    socket_mock.getaddrinfo.assert_not_called()
+    assert flow.response is None
+
+
+def test_dns_rebinding_resolution_failure_blocks():
+    """Resolution failure for an operator-supplied host → fail closed (403)."""
+    import unittest.mock as mock
+    import socket as real_socket
+
+    _reset_response_mock()
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    mod.socket = mock.MagicMock()
+    mod.socket.gaierror = real_socket.gaierror
+    mod.socket.getaddrinfo.side_effect = real_socket.gaierror("resolution failed")
+    addon = mod.AllowlistAddon()
+    flow = _make_flow_with_response("cliproxy.fro.bot")
+    addon.http_connect(flow)
+    assert flow.response is not None
+    call_args = mitmproxy_http_mock.Response.make.call_args
+    assert call_args[0][0] == 403
+
+
+def test_dns_rebinding_object_store_host_also_checked():
+    """Operator-supplied OBJECT_STORE_HOSTS host resolving to private IP is blocked."""
+    import unittest.mock as mock
+
+    _reset_response_mock()
+    mod = _load_allowlist({"OBJECT_STORE_HOSTS": "my-bucket.s3.amazonaws.com"})
+    mod.socket = mock.MagicMock()
+    mod.socket.getaddrinfo.return_value = [
+        (None, None, None, None, ("10.0.0.5", 0))
+    ]
+    addon = mod.AllowlistAddon()
+    flow = _make_flow_with_response("my-bucket.s3.amazonaws.com")
+    addon.http_connect(flow)
+    assert flow.response is not None
+    call_args = mitmproxy_http_mock.Response.make.call_args
+    assert call_args[0][0] == 403
+
+
+def test_dns_rebinding_request_hook_also_enforced():
+    """DNS-rebinding check applies to the request hook (plain HTTP), not just http_connect."""
+    import unittest.mock as mock
+
+    _reset_response_mock()
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    mod.socket = mock.MagicMock()
+    mod.socket.getaddrinfo.return_value = [
+        (None, None, None, None, ("127.0.0.1", 0))
+    ]
+    addon = mod.AllowlistAddon()
+    flow = _make_flow_with_response("cliproxy.fro.bot")
+    addon.request(flow)
+    assert flow.response is not None
+    call_args = mitmproxy_http_mock.Response.make.call_args
+    assert call_args[0][0] == 403
+
+
+# ===========================================================================
 # Standalone runner (no pytest required)
 # ===========================================================================
 

--- a/deploy/mitmproxy/test_allowlist.py
+++ b/deploy/mitmproxy/test_allowlist.py
@@ -38,10 +38,11 @@ def _load_allowlist(extra_env: dict | None = None):
     """
     env_backup = os.environ.copy()
     try:
+        # Always clear both managed env vars first for hermetic isolation.
+        os.environ.pop("OBJECT_STORE_HOSTS", None)
+        os.environ.pop("WORKSPACE_EGRESS_HOSTS", None)
         if extra_env:
             os.environ.update(extra_env)
-        else:
-            os.environ.pop("OBJECT_STORE_HOSTS", None)
 
         # Remove cached module so import runs fresh.
         sys.modules.pop("allowlist", None)
@@ -301,7 +302,7 @@ def test_object_store_hosts_rejects_wildcard_apex():
         assert False, "Expected ValueError"
     except ValueError as e:
         msg = str(e)
-        assert "Set exact bucket hostnames" in msg, f"Expected 'Set exact bucket hostnames' in error: {e}"
+        assert "Wildcards are not allowed" in msg, f"Expected 'Wildcards are not allowed' in error: {e}"
         assert "*.s3.amazonaws.com" in msg, f"Expected wildcard entry name in error: {e}"
 
 
@@ -312,7 +313,7 @@ def test_object_store_hosts_rejects_wildcard_subdomain():
         assert False, "Expected ValueError"
     except ValueError as e:
         msg = str(e)
-        assert "Set exact bucket hostnames" in msg, f"Expected 'Set exact bucket hostnames' in error: {e}"
+        assert "Wildcards are not allowed" in msg, f"Expected 'Wildcards are not allowed' in error: {e}"
         assert "*.example.com" in msg, f"Expected wildcard entry name in error: {e}"
 
 
@@ -572,7 +573,7 @@ def test_object_store_hosts_rejects_documentation_ipv6():
 
 
 # ===========================================================================
-# WORKSPACE_EGRESS_HOSTS env-var merging (Unit 2)
+# WORKSPACE_EGRESS_HOSTS env-var merging
 # ===========================================================================
 
 
@@ -702,7 +703,7 @@ def test_object_store_hosts_only_does_not_affect_workspace_egress():
 
 
 # ===========================================================================
-# DNS-rebinding defense — resolved-IP validation at enforcement time (Unit 3)
+# DNS-rebinding defense — resolved-IP validation at enforcement time
 # ===========================================================================
 
 
@@ -866,6 +867,39 @@ def test_dns_rebinding_resolution_failure_blocks():
     mod.socket = mock.MagicMock()
     mod.socket.gaierror = real_socket.gaierror
     mod.socket.getaddrinfo.side_effect = real_socket.gaierror("resolution failed")
+    addon = mod.AllowlistAddon()
+    flow = _make_flow_with_response("cliproxy.fro.bot")
+    addon.http_connect(flow)
+    assert flow.response is not None
+    call_args = mitmproxy_http_mock.Response.make.call_args
+    assert call_args[0][0] == 403
+
+
+def test_dns_rebinding_timeout_blocks():
+    """socket.timeout during resolution for an operator-supplied host → fail closed (403)."""
+    import unittest.mock as mock
+    import socket as real_socket
+
+    _reset_response_mock()
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    mod.socket = mock.MagicMock()
+    mod.socket.getaddrinfo.side_effect = real_socket.timeout("timed out")
+    addon = mod.AllowlistAddon()
+    flow = _make_flow_with_response("cliproxy.fro.bot")
+    addon.http_connect(flow)
+    assert flow.response is not None
+    call_args = mitmproxy_http_mock.Response.make.call_args
+    assert call_args[0][0] == 403
+
+
+def test_dns_rebinding_oserror_blocks():
+    """Generic OSError during resolution for an operator-supplied host → fail closed (403)."""
+    import unittest.mock as mock
+
+    _reset_response_mock()
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    mod.socket = mock.MagicMock()
+    mod.socket.getaddrinfo.side_effect = OSError("network unreachable")
     addon = mod.AllowlistAddon()
     flow = _make_flow_with_response("cliproxy.fro.bot")
     addon.http_connect(flow)

--- a/deploy/validate-stack.sh
+++ b/deploy/validate-stack.sh
@@ -11,7 +11,7 @@
 #   bash deploy/validate-stack.sh --topology-only
 set -euo pipefail
 
-COMPOSE_FILE="deploy/compose.yaml"
+COMPOSE_FILE="${COMPOSE_FILE:-deploy/compose.yaml}"
 
 # ---------------------------------------------------------------------------
 # check_compose_topology — static network-topology invariant assertion.
@@ -37,14 +37,17 @@ COMPOSE_FILE="deploy/compose.yaml"
 check_compose_topology() {
   echo "==> Checking compose network topology invariants..."
 
-  python3 - <<'PYEOF'
+  COMPOSE_FILE="${COMPOSE_FILE}" python3 - <<'PYEOF'
 import json
+import os
 import subprocess
 import sys
 
+compose_file = os.environ.get("COMPOSE_FILE", "deploy/compose.yaml")
+
 try:
     result = subprocess.run(
-        ["docker", "compose", "-f", "deploy/compose.yaml", "config", "--format", "json"],
+        ["docker", "compose", "-f", compose_file, "config", "--format", "json"],
         capture_output=True,
         text=True,
         check=True,
@@ -52,16 +55,21 @@ try:
     cfg = json.loads(result.stdout)
 except subprocess.CalledProcessError as e:
     # Fall back to YAML parse if --format json is not supported by this
-    # docker compose version.
+    # docker compose version, or if docker compose is unavailable.
     try:
         import yaml
-        result2 = subprocess.run(
-            ["docker", "compose", "-f", "deploy/compose.yaml", "config"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        cfg = yaml.safe_load(result2.stdout)
+        try:
+            result2 = subprocess.run(
+                ["docker", "compose", "-f", compose_file, "config"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            cfg = yaml.safe_load(result2.stdout)
+        except Exception:
+            # docker compose unavailable — parse the raw YAML file directly.
+            with open(compose_file) as fh:
+                cfg = yaml.safe_load(fh)
     except Exception as e2:
         print(f"ERROR: could not parse compose config: {e2}", file=sys.stderr)
         sys.exit(1)

--- a/deploy/validate-stack.sh
+++ b/deploy/validate-stack.sh
@@ -6,13 +6,194 @@
 #
 # Usage (from repo root):
 #   bash deploy/validate-stack.sh
+#
+# To run only the static network-topology check (no running stack required):
+#   bash deploy/validate-stack.sh --topology-only
 set -euo pipefail
 
 COMPOSE_FILE="deploy/compose.yaml"
 
+# ---------------------------------------------------------------------------
+# check_compose_topology — static network-topology invariant assertion.
+#
+# Parses `docker compose config` output (no running containers needed) and
+# enforces the containment model:
+#
+#   workspace → sandbox-net (internal:true) → mitmproxy → egress-net → internet
+#
+# Invariants checked:
+#   1. sandbox-net is internal:true — no direct internet gateway for any
+#      container on this network.
+#   2. workspace is attached to sandbox-net ONLY — it has zero direct egress.
+#   3. mitmproxy is attached to sandbox-net AND at least one non-internal
+#      network (its upstream leg to the internet).
+#   4. workspace is attached to NO non-internal network — it cannot reach the
+#      internet directly, even if a new network is added to the compose file.
+#   5. egress-net has EXACTLY ONE attached service (mitmproxy) — no other
+#      service may join the internet-capable network.
+#
+# Exit non-zero with a descriptive message if any invariant fails.
+# ---------------------------------------------------------------------------
+check_compose_topology() {
+  echo "==> Checking compose network topology invariants..."
+
+  python3 - <<'PYEOF'
+import json
+import subprocess
+import sys
+
+try:
+    result = subprocess.run(
+        ["docker", "compose", "-f", "deploy/compose.yaml", "config", "--format", "json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    cfg = json.loads(result.stdout)
+except subprocess.CalledProcessError as e:
+    # Fall back to YAML parse if --format json is not supported by this
+    # docker compose version.
+    try:
+        import yaml
+        result2 = subprocess.run(
+            ["docker", "compose", "-f", "deploy/compose.yaml", "config"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        cfg = yaml.safe_load(result2.stdout)
+    except Exception as e2:
+        print(f"ERROR: could not parse compose config: {e2}", file=sys.stderr)
+        sys.exit(1)
+except json.JSONDecodeError as e:
+    print(f"ERROR: compose config JSON parse failed: {e}", file=sys.stderr)
+    sys.exit(1)
+
+networks = cfg.get("networks", {})
+services = cfg.get("services", {})
+
+failures = []
+
+# ------------------------------------------------------------------
+# Invariant 1: sandbox-net must be internal:true
+# ------------------------------------------------------------------
+sandbox = networks.get("sandbox-net", {})
+if not sandbox.get("internal", False):
+    failures.append(
+        "FAIL: sandbox-net is not internal:true — containers on this network "
+        "have a host gateway and can reach the internet directly."
+    )
+
+# ------------------------------------------------------------------
+# Helper: collect the set of non-internal network names.
+# A network is non-internal when internal is absent or false.
+# ------------------------------------------------------------------
+non_internal_nets = {
+    name for name, spec in networks.items()
+    if not (spec or {}).get("internal", False)
+}
+
+# ------------------------------------------------------------------
+# Helper: get the network names a service is attached to.
+# docker compose config normalises service.networks to a dict keyed
+# by network name; the value may be None or a config dict.
+# ------------------------------------------------------------------
+def service_networks(svc_name):
+    svc = services.get(svc_name, {})
+    nets = svc.get("networks", {})
+    if isinstance(nets, list):
+        return set(nets)
+    return set(nets.keys())
+
+workspace_nets = service_networks("workspace")
+mitmproxy_nets = service_networks("mitmproxy")
+
+# ------------------------------------------------------------------
+# Invariant 2: workspace is attached to sandbox-net only
+# ------------------------------------------------------------------
+if workspace_nets != {"sandbox-net"}:
+    failures.append(
+        f"FAIL: workspace is attached to networks {sorted(workspace_nets)!r} "
+        f"but must be attached to exactly ['sandbox-net']."
+    )
+
+# ------------------------------------------------------------------
+# Invariant 3: mitmproxy is attached to sandbox-net AND at least one
+# non-internal network (its upstream leg).
+# ------------------------------------------------------------------
+if "sandbox-net" not in mitmproxy_nets:
+    failures.append(
+        "FAIL: mitmproxy is not attached to sandbox-net — it cannot receive "
+        "workspace traffic."
+    )
+mitmproxy_egress_nets = mitmproxy_nets & non_internal_nets
+if not mitmproxy_egress_nets:
+    failures.append(
+        f"FAIL: mitmproxy is attached only to internal networks {sorted(mitmproxy_nets)!r}. "
+        "It needs at least one non-internal network as its upstream leg so it "
+        "can reach the internet on behalf of the workspace."
+    )
+
+# ------------------------------------------------------------------
+# Invariant 4: workspace is attached to NO non-internal network
+# ------------------------------------------------------------------
+workspace_egress_nets = workspace_nets & non_internal_nets
+if workspace_egress_nets:
+    failures.append(
+        f"FAIL: workspace is attached to non-internal network(s) "
+        f"{sorted(workspace_egress_nets)!r} — it has direct internet egress, "
+        "violating the containment model."
+    )
+
+# ------------------------------------------------------------------
+# Invariant 5: each non-internal network that mitmproxy uses must have
+# EXACTLY ONE attached service (mitmproxy itself).
+# ------------------------------------------------------------------
+for egress_net in mitmproxy_egress_nets:
+    attached = [
+        svc for svc, spec in services.items()
+        if egress_net in service_networks(svc)
+    ]
+    if attached != ["mitmproxy"] and set(attached) != {"mitmproxy"}:
+        others = [s for s in attached if s != "mitmproxy"]
+        failures.append(
+            f"FAIL: non-internal network '{egress_net}' has unexpected service(s) "
+            f"attached: {others!r}. Only mitmproxy may join the internet-capable "
+            "network — adding other services breaks the containment boundary."
+        )
+
+# ------------------------------------------------------------------
+# Report
+# ------------------------------------------------------------------
+if failures:
+    for msg in failures:
+        print(msg, file=sys.stderr)
+    sys.exit(1)
+
+print("    sandbox-net: internal=true  ✓")
+print(f"    workspace networks: {sorted(workspace_nets)!r}  ✓")
+print(f"    mitmproxy networks: {sorted(mitmproxy_nets)!r}  ✓")
+print(f"    mitmproxy egress leg(s): {sorted(mitmproxy_egress_nets)!r}  ✓")
+print("    workspace has no direct egress  ✓")
+print("    egress network(s) have exactly one attached service (mitmproxy)  ✓")
+PYEOF
+
+  echo "    Topology invariants: OK"
+}
+
 echo "==> Validating compose config..."
 docker compose -f "${COMPOSE_FILE}" config > /dev/null
 echo "    OK"
+
+# Run the topology check unconditionally — it is cheap (no running stack needed).
+check_compose_topology
+
+# If --topology-only was passed, stop here.
+if [[ "${1:-}" == "--topology-only" ]]; then
+  echo ""
+  echo "==> Topology-only check complete."
+  exit 0
+fi
 
 echo "==> Service status:"
 docker compose -f "${COMPOSE_FILE}" ps

--- a/deploy/validate-stack.test.sh
+++ b/deploy/validate-stack.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# validate-stack.test.sh — Topology-guard negative + positive tests.
+#
+# Tests that validate-stack.sh --topology-only:
+#   (a) EXITS NON-ZERO when workspace is attached to a non-internal network
+#       (the regression the guard exists to catch).
+#   (b) EXITS ZERO for the real compose.yaml (positive control).
+#
+# Run from repo root:
+#   bash deploy/validate-stack.test.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Crafted insecure compose: workspace is attached to egress-net (non-internal)
+# — a direct violation of Invariant 4.
+# ---------------------------------------------------------------------------
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_TEST}"' EXIT
+
+INSECURE_COMPOSE="${TMPDIR_TEST}/compose.yaml"
+cat > "${INSECURE_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+      - egress-net
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+YAML
+
+# ---------------------------------------------------------------------------
+# TEST 1 — Negative: insecure compose must be rejected (exit non-zero).
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 1: topology guard rejects workspace-on-non-internal-net ---"
+
+NEGATIVE_OUTPUT=""
+NEGATIVE_EXIT=0
+NEGATIVE_OUTPUT="$(COMPOSE_FILE="${INSECURE_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || NEGATIVE_EXIT=$?
+
+if [[ "${NEGATIVE_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${NEGATIVE_EXIT}) for insecure compose"
+else
+  fail "validate-stack.sh exited ZERO for insecure compose — guard did NOT fire"
+fi
+
+# Confirm the failure message mentions the workspace/egress violation.
+if echo "${NEGATIVE_OUTPUT}" | grep -qi "workspace"; then
+  pass "failure message mentions 'workspace'"
+else
+  fail "failure message does not mention 'workspace' — output: ${NEGATIVE_OUTPUT}"
+fi
+
+if echo "${NEGATIVE_OUTPUT}" | grep -qi "egress\|non-internal\|direct internet"; then
+  pass "failure message mentions egress/non-internal violation"
+else
+  fail "failure message does not mention egress violation — output: ${NEGATIVE_OUTPUT}"
+fi
+
+echo ""
+echo "  Negative-test output (stderr+stdout combined):"
+echo "${NEGATIVE_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 2 — Positive: real compose.yaml must pass (exit zero).
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 2: topology guard accepts the real compose.yaml ---"
+
+POSITIVE_OUTPUT=""
+POSITIVE_EXIT=0
+POSITIVE_OUTPUT="$(COMPOSE_FILE=deploy/compose.yaml bash deploy/validate-stack.sh --topology-only 2>&1)" || POSITIVE_EXIT=$?
+
+if [[ "${POSITIVE_EXIT}" -eq 0 ]]; then
+  pass "validate-stack.sh exited zero for real compose.yaml"
+else
+  fail "validate-stack.sh exited non-zero (${POSITIVE_EXIT}) for real compose.yaml — output: ${POSITIVE_OUTPUT}"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "========================================"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo "========================================"
+
+if [[ "${FAIL}" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/docs/plans/2026-06-03-001-fix-workspace-egress-topology-plan.md
+++ b/docs/plans/2026-06-03-001-fix-workspace-egress-topology-plan.md
@@ -1,0 +1,300 @@
+---
+title: "fix: Workspace egress topology + configurable OpenCode proxy allowlist"
+type: fix
+status: active
+date: 2026-06-03
+---
+
+# fix: Workspace egress topology + configurable OpenCode proxy allowlist
+
+## Overview
+
+The deployed gateway stack (`deploy/compose.yaml`) sandboxes a `workspace` executor container that runs OpenCode and performs `git clone`. All workspace egress is forced through an mitmproxy proxy with a hostname allowlist. On v0.51.0+ the proxy itself has **no route to the internet** — it is attached only to an `internal: true` network — so every workspace outbound request fails with `502 CONNECT tunnel failed`. `/fro-bot add-project` cloning and the `@fro-bot` mention loop are both non-functional on the shipped compose.
+
+This plan fixes two coupled defects in a single PR:
+1. **Egress topology** — give mitmproxy an internet-capable upstream leg via a dedicated `egress-net`, while keeping the workspace itself with zero direct egress.
+2. **Configurable proxy allowlist** — add a `WORKSPACE_EGRESS_HOSTS` env var so deployments that route OpenCode through a self-hosted proxy (e.g. cliproxyapi at `cliproxy.fro.bot`) can allowlist that host, reusing the exact validation pipeline that `OBJECT_STORE_HOSTS` already uses.
+
+It also closes a regression-coverage gap: `deploy/mitmproxy/test_allowlist.py` and `deploy/validate-stack.sh` exist but neither runs in CI, which is why a compose-wiring break shipped undetected.
+
+## Problem Frame
+
+Source: GitHub issue #741 (source-verified against current `main`).
+
+- `mitmproxy.networks` = `[sandbox-net]` only (`deploy/compose.yaml:283-284`).
+- `sandbox-net` is `internal: true` (`deploy/compose.yaml:311-313`) — no host/internet gateway, embedded DNS `127.0.0.11` cannot forward external queries.
+- mitmproxy is the **only** egress path for the workspace (`HTTPS_PROXY=http://mitmproxy:8080`, `deploy/compose.yaml:196-197`), so it can neither resolve nor dial `github.com` / `api.anthropic.com` / object storage → `502 CONNECT tunnel failed`.
+- The `gateway` service is unaffected because it is dual-homed on `gateway-net` (`internal: false`) and `sandbox-net` (`deploy/compose.yaml:177-179`); its Discord/S3 traffic does not route through mitmproxy. This is why the bug stayed latent until the v0.51.0 workspace began making real outbound requests.
+
+Secondary defect (masked by the first): once egress works, the mention loop routes OpenCode through a proxy host supplied via `WORKSPACE_OPENCODE_CONFIG`. The static allowlist in `deploy/mitmproxy/allowlist.py` covers GitHub/npm/Discord and the three first-party model APIs, but not a self-hosted proxy host, and the only env-extensible hook (`OBJECT_STORE_HOSTS`) is scoped to object storage and rejects non-object-store use by documentation. `deploy/README.md:290` currently documents the workaround as "add your cliproxyapi host there if it is not already permitted" — i.e. there is no first-class mechanism.
+
+## Requirements Trace
+
+- R1. The workspace can reach allowlisted external hosts (clone from GitHub, model round-trips) through mitmproxy on the shipped compose, with no manual override required.
+- R2. The containment model is preserved: `sandbox-net` stays `internal: true`; the workspace has zero direct egress; all workspace traffic still flows through mitmproxy's allowlist.
+- R3. A deployment can allowlist a self-hosted OpenCode proxy host (e.g. `cliproxy.fro.bot`) via a first-class env var, without repurposing `OBJECT_STORE_HOSTS`.
+- R4. The new env var enforces the same security validation as `OBJECT_STORE_HOSTS` (wildcard-reject, private/loopback/link-local/reserved-IP-reject, port-reject, RFC 1123 hostname-validate, lowercase-normalize), via a single shared validation implementation (no duplicated machinery).
+- R5. A CI regression guard catches this class of defect: (a) a static compose-topology invariant assertion, and (b) the existing `test_allowlist.py` runs in CI.
+- R6. Operator-facing docs (`deploy/README.md`, `deploy/.env.example`, compose comments) document the new env var and the corrected topology.
+- R7. Operator-supplied allowlist hosts (`OBJECT_STORE_HOSTS`, `WORKSPACE_EGRESS_HOSTS`) are validated at enforcement time against DNS rebinding: a host that resolves to a private/loopback/link-local/reserved IP is rejected (403), not just literal-IP entries at import time.
+
+## Scope Boundaries
+
+- Not changing the workspace's own network attachment — it stays `sandbox-net`-only.
+- Not removing or weakening `OBJECT_STORE_HOSTS` — it keeps its exact current contract and semantics.
+- Not adding per-client allowlist policy or separate proxy instances for gateway vs workspace (future hardening, noted below).
+- Not changing the static `ALLOWLIST` contents (GitHub/npm/Discord/model APIs stay as-is).
+
+### Deferred to Separate Tasks
+
+- **Per-client / per-instance allowlist** (workspace should not need Discord hosts): the shared static allowlist is broader than the workspace strictly needs; tightening to per-client policy or separate proxy instances is future work.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `deploy/compose.yaml` — service/network topology. Networks declared at the bottom (`gateway-net` external-capable, `sandbox-net` `internal: true`). mitmproxy env interpolation pattern to mirror: `OBJECT_STORE_HOSTS: ${OBJECT_STORE_HOSTS:-}` (`deploy/compose.yaml:278`).
+- `deploy/mitmproxy/allowlist.py` — static `ALLOWLIST` + the `OBJECT_STORE_HOSTS` merge pipeline (lines ~135-200): empty-skip → wildcard-reject → `_validate_ip_literal_or_none` (private/loopback/link-local/reserved reject) → port-reject → `_is_valid_hostname` (RFC 1123) → lowercase → append. This is the canonical validation to factor into a shared helper.
+- `deploy/mitmproxy/test_allowlist.py` — 22KB pytest suite with a `_load_allowlist(extra_env=...)` re-import harness (mocks mitmproxy, re-imports the module with env overrides). Existing `OBJECT_STORE_HOSTS` cases (e.g. `test_object_store_hosts_included_when_set`) are the exact pattern to mirror for `WORKSPACE_EGRESS_HOSTS`.
+- `deploy/validate-stack.sh` — existing compose smoke script (validates `compose config`, service status, gateway exit code). The home for the new topology assertion.
+- `deploy/scripts/*.test.mjs` + the `workspace-smoke` CI job (`.github/workflows/ci.yaml:336`) — precedent for running deploy-level tests in CI (`node --test deploy/scripts/*.test.mjs`).
+- `deploy/.env.example` (`OBJECT_STORE_HOSTS=` at line 9), `deploy/README.md` Egress Allowlist section (lines ~355-376), `deploy/compose.override.example.yaml` — operator-facing surfaces to update.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/workspace-executor-opencode-provisioning-best-practices-2026-06-01.md` — operator-supplied config must overlay without breaking baked security invariants; preserve workspace/sandbox isolation, only the proxy gets upstream access.
+- `docs/solutions/best-practices/signed-webhook-ingress-hardening-2026-05-29.md` — treat operator-supplied input as hostile; validate cheapest/most-deterministic constraints first, fail closed. Applies to `WORKSPACE_EGRESS_HOSTS` parsing.
+- `docs/solutions/build-errors/gateway-docker-runtime-resolution-crash-loop-2026-05-31.md` — image/deploy-only issues slip past local tests; add boot-time/deploy smoke coverage and verify the deployed container graph, not just code paths. Directly motivates R5.
+
+### External References
+
+- Oracle strategy consult (this session): dedicated `egress-net` over dual-homing onto `gateway-net` (cleaner audit boundary, avoids future footgun if `gateway-net` gains stateful services); keep `OBJECT_STORE_HOSTS` + add `WORKSPACE_EGRESS_HOSTS` with one shared validator; static compose-invariant guard + targeted mitmproxy-only live smoke (don't boot the whole stack).
+
+### Egress Dependency Coverage
+
+The fix is complete only if every host the workspace + mention loop actually needs is reachable post-fix. Verified coverage against the static `ALLOWLIST` in `deploy/mitmproxy/allowlist.py`:
+
+| Egress dependency | Host(s) | Covered by |
+|---|---|---|
+| Git clone (add-project) | `github.com`, `api.github.com`, `*.githubusercontent.com` | static ALLOWLIST |
+| OpenCode plugin install (Systematic, runtime npm) | `registry.npmjs.org` | static ALLOWLIST |
+| Discord (gateway path; not workspace-required) | `discord.com`, `*.discord.gg` | static ALLOWLIST |
+| First-party model APIs | `api.anthropic.com`, `api.openai.com`, `generativelanguage.googleapis.com` | static ALLOWLIST |
+| Object storage (S3-backed state) | deployment-specific bucket host | `OBJECT_STORE_HOSTS` env |
+| Self-hosted OpenCode proxy (e.g. cliproxyapi) | e.g. `cliproxy.fro.bot` | `WORKSPACE_EGRESS_HOSTS` env (this plan) |
+
+Implementer must confirm no additional host is reached at runtime before calling the fix complete; if a deployment uses a model provider not in the static list, it goes in `WORKSPACE_EGRESS_HOSTS`.
+
+## Key Technical Decisions
+
+- **Dedicated `egress-net` (not dual-home onto `gateway-net`):** mitmproxy is the component deliberately exposed to untrusted workspace traffic. Giving it adjacency to the gateway's Discord/S3 control-plane network is avoidable. A dedicated `internal: false` `egress-net` keeps the containment story auditable: `workspace → sandbox-net → mitmproxy → egress-net → internet`. Cost is one network declaration.
+- **`WORKSPACE_EGRESS_HOSTS` as a new env var, shared validator:** keep `OBJECT_STORE_HOSTS` (shipped, documented, narrow storage semantics) and add `WORKSPACE_EGRESS_HOSTS` (model/proxy egress semantics) as two semantically-distinct config surfaces backed by **one** validation/parse function. This satisfies "collapse complexity at the right layer" (one implementation) without a breaking rename of `OBJECT_STORE_HOSTS` or a broad `ADDITIONAL_ALLOWLIST_HOSTS` that invites allowlist rot.
+- **Regression guard split:** a near-zero-cost static compose-invariant assertion (mandatory) plus wiring the existing `test_allowlist.py` into CI. A full-stack live smoke is heavier; the static invariant catches the exact topology regression class. (A targeted mitmproxy-only live smoke is recorded as an optional enhancement, not required for this fix. Tracked as a follow-up in issue #745.)
+
+## Open Questions
+
+### Resolved During Planning
+
+- Dual-home vs dedicated network → dedicated `egress-net` (decision above).
+- New env var vs generalize/rename → new `WORKSPACE_EGRESS_HOSTS` + shared validator (decision above).
+- Name → `WORKSPACE_EGRESS_HOSTS` (matches containment framing: additional exact hosts the workspace may reach through mitmproxy; broader than "OpenCode proxy" so a deployment can add any required egress host under the same validation). The variable is documented as an escape hatch for explicitly-justified workspace egress hosts (e.g. a self-hosted model proxy), NOT a general-purpose allowlist — Unit 5 docs must state this to avoid the allowlist-rot the broad-rename alternative was rejected for. Validation (wildcard/private-IP/port reject) provides the technical floor; the doc framing provides the operational discipline.
+
+### Deferred to Implementation
+
+- Exact shared-helper function name and signature in `allowlist.py` (refactor detail, settled when the code is touched).
+- Whether the static compose-invariant assertion lives in `deploy/validate-stack.sh` (bash + `docker compose config` + yaml parse) or a small `node --test` alongside `deploy/scripts/` — settled by which is cleaner to wire into the `workspace-smoke` job. Both are acceptable; pick the lower-friction one at implementation.
+
+## Implementation Units
+
+- [ ] **Unit 1: Egress topology — dedicated `egress-net` for mitmproxy's upstream leg**
+
+**Goal:** mitmproxy can resolve and reach the internet while the workspace retains zero direct egress and `sandbox-net` stays `internal: true`.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `deploy/compose.yaml`
+
+**Approach:**
+- Declare a new top-level network `egress-net` with `internal: false`.
+- Add `egress-net` to the `mitmproxy` service `networks` list (so it becomes `[sandbox-net, egress-net]`).
+- Leave `workspace.networks` as `[sandbox-net]` and `gateway.networks` as `[gateway-net, sandbox-net]` unchanged.
+- Update the inline network comments to state the containment invariant: workspace has no direct egress; only mitmproxy's upstream leg reaches the internet via `egress-net`; `sandbox-net` remains `internal: true`.
+- Routing note: Docker does not assign a default gateway to `internal: true` networks, so once mitmproxy is dual-homed on `sandbox-net` (internal) + `egress-net` (internal:false), the `egress-net` gateway becomes the container's default route for outbound traffic. This is the same pattern the `gateway` service already uses successfully (dual-homed on `gateway-net` external + `sandbox-net` internal, reaching Discord/S3) — see `deploy/compose.yaml:177-179`.
+
+**Patterns to follow:**
+- Existing `gateway-net` / `sandbox-net` declarations and the gateway's dual-homing as the structural precedent.
+- The `gateway` service's existing dual-homing (external `gateway-net` + internal `sandbox-net`) is the proven precedent that an internal+external dual-homed container routes outbound via the external leg.
+
+**Test scenarios:**
+- Integration (covered by Unit 4 static guard): rendered `docker compose config` shows `sandbox-net.internal == true`, `workspace.networks == [sandbox-net]`, `mitmproxy.networks` includes both `sandbox-net` and a network with `internal: false`, and `workspace` is attached to no `internal: false` network.
+- Verification (manual / live, not CI): `docker compose up -d`, then inside the mitmproxy container `getent hosts github.com` resolves and `curl -sI https://github.com` returns 200.
+
+**Verification:**
+- `docker compose -f deploy/compose.yaml config` is valid and shows the new network on mitmproxy only.
+- Containment invariants above hold.
+
+- [ ] **Unit 2: `WORKSPACE_EGRESS_HOSTS` env var + shared validation helper in `allowlist.py`**
+
+**Goal:** A deployment can allowlist additional exact egress hosts (e.g. a self-hosted OpenCode proxy) via `WORKSPACE_EGRESS_HOSTS`, with identical security validation to `OBJECT_STORE_HOSTS`, implemented once.
+
+**Requirements:** R3, R4
+
+**Dependencies:** None (independent of Unit 1; both land in the same PR)
+
+**Files:**
+- Modify: `deploy/mitmproxy/allowlist.py`
+- Test: `deploy/mitmproxy/test_allowlist.py`
+
+**Approach:**
+- Extract the existing `OBJECT_STORE_HOSTS` parse/validate pipeline (empty-skip → wildcard-reject → IP-literal private/loopback/link-local/reserved reject → port-reject → RFC 1123 validate → lowercase) into a single shared helper that takes the env-var name (for error-message context) and its raw value, and returns the validated host list (raising `ValueError` with an env-var-specific message on bad input).
+- Route both `OBJECT_STORE_HOSTS` and the new `WORKSPACE_EGRESS_HOSTS` through that helper at module import, appending both results to `ALLOWLIST`.
+- Preserve `OBJECT_STORE_HOSTS`'s existing error-message wording/semantics (no behavior change for existing deployments).
+
+**Execution note:** Test-first — add the `WORKSPACE_EGRESS_HOSTS` cases mirroring the existing `OBJECT_STORE_HOSTS` tests, watch them fail, then refactor to the shared helper and confirm both sets stay green.
+
+**Patterns to follow:**
+- `OBJECT_STORE_HOSTS` merge block in `allowlist.py` and its tests in `test_allowlist.py` (`_load_allowlist(extra_env=...)` re-import harness; `test_object_store_hosts_included_when_set` and the reject cases).
+
+**Test scenarios:**
+- Happy path: `WORKSPACE_EGRESS_HOSTS=cliproxy.fro.bot` → `cliproxy.fro.bot` is in `ALLOWLIST` and `_is_allowed("cliproxy.fro.bot")` is True; a comma-separated list adds all entries.
+- Happy path: unset/empty `WORKSPACE_EGRESS_HOSTS` → no change to `ALLOWLIST` (no error).
+- Edge case: case normalization — `WORKSPACE_EGRESS_HOSTS=CliProxy.FRO.bot` is matched case-insensitively (lowercased on merge).
+- Error path: wildcard entry (`*.fro.bot`) → `ValueError` naming `WORKSPACE_EGRESS_HOSTS`.
+- Error path: private/loopback/link-local/reserved IP literal (`10.0.0.5`, `127.0.0.1`, `169.254.169.254`) → `ValueError`.
+- Error path: host with a port (`cliproxy.fro.bot:443`, bracket IPv6+port) → `ValueError`.
+- Error path: invalid hostname (leading/trailing/consecutive dots) → rejected.
+- Integration: both `OBJECT_STORE_HOSTS` and `WORKSPACE_EGRESS_HOSTS` set together → both host sets present in `ALLOWLIST`; setting only one does not affect the other.
+- Regression: all existing `OBJECT_STORE_HOSTS` tests still pass unchanged after the shared-helper refactor.
+
+**Verification:**
+- `pytest deploy/mitmproxy/test_allowlist.py` (or `python3 deploy/mitmproxy/test_allowlist.py`) is green, including the new and existing cases.
+
+- [ ] **Unit 3: DNS-rebinding defense — resolved-IP validation at enforcement time**
+
+**Goal:** An operator-supplied allowlist host that resolves to a private/loopback/link-local/reserved IP is rejected at connect time, closing the DNS-rebinding gap for `OBJECT_STORE_HOSTS` and `WORKSPACE_EGRESS_HOSTS`.
+
+**Requirements:** R7
+
+**Dependencies:** Unit 2 (the env-var-supplied host set + the shared validation helper)
+
+**Files:**
+- Modify: `deploy/mitmproxy/allowlist.py`
+- Test: `deploy/mitmproxy/test_allowlist.py`
+
+**Approach:**
+- Extract the range-checking core of `_validate_ip_literal_or_none` into a shared `_ip_is_disallowed(ip_str) -> bool` helper so literal-IP import validation and resolved-IP enforcement share one range definition.
+- Track the set of operator-supplied hosts (from `OBJECT_STORE_HOSTS` + `WORKSPACE_EGRESS_HOSTS`) at module import.
+- In `AllowlistAddon._enforce` (or a helper it calls), after a host passes `_is_allowed`, if the host is in the operator-supplied set, resolve it via `socket.getaddrinfo` and return 403 if ANY resolved address is disallowed. Vendor static-ALLOWLIST hosts (github/npm/discord/model-APIs) are not resolved-checked.
+- Fail closed on resolution: if resolution fails for an operator-supplied host, block (the addon already short-circuits via `flow.response`).
+
+**Execution note:** Test-first — add resolved-IP rejection cases (mock `socket.getaddrinfo`) before the enforcement code.
+
+**Patterns to follow:**
+- `_validate_ip_literal_or_none` range logic in `allowlist.py` (reuse via the extracted helper); `AllowlistAddon._enforce` / `http_connect` / `request` hooks; the `_load_allowlist(extra_env=...)` test harness.
+
+**Test scenarios:**
+- Happy path: an operator-supplied host resolving to a public IP is allowed through.
+- Error path: an operator-supplied host (in `WORKSPACE_EGRESS_HOSTS`) resolving to 127.0.0.1 / 10.0.0.5 / 169.254.169.254 / ::1 is rejected with 403 (mock `getaddrinfo`).
+- Error path: an operator-supplied host with MULTIPLE A-records where ANY is private → rejected.
+- Edge case: a vendor static-ALLOWLIST host (e.g. github.com) is NOT resolved-checked (no getaddrinfo gate) — only operator-supplied hosts are.
+- Error path: resolution failure for an operator-supplied host → fail closed (403/block).
+- Regression: existing literal-IP import-time rejection tests still pass after the `_ip_is_disallowed` extraction.
+
+**Verification:**
+- `python3 deploy/mitmproxy/test_allowlist.py` green including the new resolved-IP cases; the shared range helper backs both literal and resolved checks.
+
+- [ ] **Unit 4: CI regression guard — compose-topology invariant + run allowlist tests**
+
+**Goal:** This defect class fails CI: a static assertion on the compose network topology, and the existing `test_allowlist.py` runs on deploy-touching changes.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 1 (asserts the corrected topology), Unit 2 + Unit 3 (the allowlist tests to run, including the DNS-rebinding cases)
+
+**Files:**
+- Modify: `deploy/validate-stack.sh` (add a static topology-invariant assertion using `docker compose config` output) — or add a small `node --test` / shell check; settle at implementation.
+- Modify: `.github/workflows/ci.yaml` (run the allowlist pytest and the static topology assertion in the `workspace-smoke` job, which already does `node --test deploy/scripts/*.test.mjs`)
+
+**Approach:**
+- Add a static assertion (no running containers needed) that parses `docker compose -f deploy/compose.yaml config` and verifies: `sandbox-net.internal == true`; `workspace` attaches only to `sandbox-net`; `mitmproxy` attaches to `sandbox-net` plus at least one `internal: false` network; `workspace` is on no `internal: false` network; `egress-net` has exactly one attached service (`mitmproxy`) — no other service may join the internet-capable network.
+- Wire the allowlist tests into the `workspace-smoke` job using the no-dependency runner: `python3 deploy/mitmproxy/test_allowlist.py` (the test file mocks the `mitmproxy` package via `sys.modules` injection and runs on any standard Python 3.11+, which ubuntu-latest provides — no pytest install needed). Use this exact command rather than `pytest` to avoid a dependency-install step.
+- Keep the guard cheap: no full `docker compose up` of the stack.
+
+**Execution note:** Verify the new CI steps would have failed against the pre-fix topology (sanity-check the assertion catches the original bug).
+
+**Patterns to follow:**
+- The `workspace-smoke` job's existing `node --test deploy/scripts/*.test.mjs` step and the paths-filter gating for deploy changes.
+
+**Test scenarios:**
+- Integration: the static assertion passes on the corrected `deploy/compose.yaml` (post-Unit-1) and would fail on the pre-fix topology (mitmproxy on `sandbox-net` only). Prove both directions.
+- Integration: `test_allowlist.py` runs and passes in the `workspace-smoke` job.
+- Integration: the static assertion fails if any service other than `mitmproxy` is attached to `egress-net` (proves the single-member containment invariant).
+- Test expectation: the workflow-yaml and script wiring itself is validated by the job running green in CI on the PR.
+
+**Verification:**
+- The `workspace-smoke` (or appropriate deploy) CI job runs the allowlist tests and the topology assertion and is green on the PR; both gates are present in `.github/workflows/ci.yaml`.
+
+- [ ] **Unit 5: Operator-facing docs — env var, topology, provider-proxy example**
+
+**Goal:** Deployers can discover and correctly use `WORKSPACE_EGRESS_HOSTS`, and the corrected egress topology is reflected in docs.
+
+**Requirements:** R6
+
+**Dependencies:** Units 1-3 (documents their behavior)
+
+**Files:**
+- Modify: `deploy/.env.example` (add `WORKSPACE_EGRESS_HOSTS=` with a short comment)
+- Modify: `deploy/README.md` (Egress Allowlist section: document `WORKSPACE_EGRESS_HOSTS` alongside `OBJECT_STORE_HOSTS` with the same validation rules; update the cliproxyapi provider-config note at ~line 290 to point at `WORKSPACE_EGRESS_HOSTS` instead of "add your cliproxyapi host to the static allowlist"; note the corrected topology if operator-visible)
+- Modify: `deploy/compose.yaml` (env interpolation entry `WORKSPACE_EGRESS_HOSTS: ${WORKSPACE_EGRESS_HOSTS:-}` on the mitmproxy service, mirroring `OBJECT_STORE_HOSTS`) — and `deploy/compose.override.example.yaml` comment if it documents allowlist envs
+- Optionally Modify: `docs/solutions/` is **not** updated here (compounding is a separate post-merge step)
+
+**Approach:**
+- Mirror the existing `OBJECT_STORE_HOSTS` documentation structure exactly: purpose, format (comma-separated exact hostnames), validation/rejection rules, fail-closed-when-unset behavior.
+- Make the cliproxyapi example concrete: `WORKSPACE_EGRESS_HOSTS=cliproxy.fro.bot`.
+- The `WORKSPACE_EGRESS_HOSTS: ${WORKSPACE_EGRESS_HOSTS:-}` compose entry is the runtime wiring that makes the env var reach the mitmproxy addon — without it, Unit 2's code never sees the value. (This is functional, not just docs — but it's a one-line mirror of the `OBJECT_STORE_HOSTS` interpolation, grouped here with the operator-facing surface.)
+- Frame `WORKSPACE_EGRESS_HOSTS` in docs as an escape hatch for explicitly-justified egress hosts only (not a general allowlist), so operators don't accumulate unrelated hosts over time.
+
+**Patterns to follow:**
+- `deploy/README.md` Egress Allowlist section (lines ~355-376), `deploy/.env.example:9`, and the `OBJECT_STORE_HOSTS: ${OBJECT_STORE_HOSTS:-}` compose interpolation (`deploy/compose.yaml:278`).
+
+**Test scenarios:**
+- Test expectation: none — documentation and a compose env-interpolation passthrough. The passthrough is exercised end-to-end by Unit 2's tests (the var must be present for the addon to read it) and by the live verification in Unit 1.
+
+**Verification:**
+- `docker compose -f deploy/compose.yaml config` still valid with the new interpolation entry.
+- README and `.env.example` describe `WORKSPACE_EGRESS_HOSTS` with the same rigor as `OBJECT_STORE_HOSTS`; the cliproxyapi note points at the new var.
+
+## System-Wide Impact
+
+- **Interaction graph:** Network change affects only mitmproxy's reachability; no application-code paths change. The allowlist change affects the mitmproxy addon's import-time `ALLOWLIST` construction.
+- **Error propagation:** Bad `WORKSPACE_EGRESS_HOSTS` input fails closed at mitmproxy import (raises `ValueError`, addon fails to load) — same fail-closed posture as `OBJECT_STORE_HOSTS`. Document that a malformed value prevents proxy startup (intentional).
+- **State lifecycle risks:** None — no persistent state touched.
+- **API surface parity:** `OBJECT_STORE_HOSTS` and `WORKSPACE_EGRESS_HOSTS` now share one validator; any future change to validation rules must apply to both via the shared helper.
+- **Integration coverage:** The compose-topology invariant (Unit 4) is the cross-cutting guard that unit tests alone cannot prove.
+- **Resolution-time cost:** operator-supplied allowlist hosts incur a `socket.getaddrinfo` lookup at enforcement; vendor static-ALLOWLIST hosts are unaffected (not resolved-checked).
+- **Unchanged invariants:** `sandbox-net` stays `internal: true`; `workspace` stays `sandbox-net`-only with zero direct egress; the static `ALLOWLIST` contents are unchanged; `OBJECT_STORE_HOSTS` contract and error messages are unchanged. The new work only adds an upstream leg to mitmproxy and a second validated env-var source. mitmproxy remains a regular-mode CONNECT proxy enforcing the hostname allowlist (it does not act as a general forward/transparent router); dual-homing it onto `egress-net` only gives its allowlisted upstream dials a route, it does not turn it into a bridge between sandbox-net and egress-net.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `egress-net` inadvertently lets the workspace reach the internet directly | Workspace stays `sandbox-net`-only; only mitmproxy joins `egress-net`. Unit 4 static guard asserts the workspace is on no `internal: false` network. |
+| Shared-helper refactor breaks existing `OBJECT_STORE_HOSTS` behavior | Test-first: keep all existing `OBJECT_STORE_HOSTS` tests; they must stay green unchanged (Unit 2 regression scenario). |
+| Allowlisted hostname resolves to a private IP (DNS rebinding) | Addressed in Unit 3: resolved-IP validation rejects operator-supplied hosts resolving to private/loopback/link-local/reserved IPs. Residual TOCTOU (mitmproxy re-resolves for the actual dial) documented as accepted — addon-layer pinning is not available; this is defense-in-depth, not hermetic. |
+| Shared allowlist is broader than the workspace needs (e.g. Discord hosts) | Noted as deferred future hardening (per-client policy / separate proxy instances); not a regression introduced here. |
+| CI lacks Python/pytest in the smoke job | Use the test file's no-dependency `__main__` runner (`python3 deploy/mitmproxy/test_allowlist.py`) or add a minimal pytest install; ubuntu-latest ships Python. |
+
+## Documentation / Operational Notes
+
+- After merge, this is a strong candidate for a `ce:compound` best-practices entry (egress topology + dual-network proxy containment + shared validated allowlist env vars), since `learnings-researcher` found no existing doc covering mitmproxy allowlisting or the `internal:true`/`internal:false` proxy topology.
+- Operators on v0.51.0/v0.52.0 must redeploy with the new compose to get egress working; the `WORKSPACE_EGRESS_HOSTS` var is required only for deployments using a self-hosted OpenCode proxy.
+- DNS-rebinding defense (Unit 3) validates resolved IPs at the addon hook, but mitmproxy performs its own resolution for the upstream dial (TOCTOU). This raises the bar against operator-misconfiguration and naive rebinding but is not a hermetic guarantee; full IP-pinning would require deeper mitmproxy integration (future hardening).
+
+## Sources & References
+
+- **Origin:** GitHub issue #741 + Fro Bot triage comment + Oracle strategy consult (this session)
+- Related code: `deploy/compose.yaml`, `deploy/mitmproxy/allowlist.py`, `deploy/mitmproxy/test_allowlist.py`, `deploy/validate-stack.sh`, `.github/workflows/ci.yaml` (`workspace-smoke` job)
+- Related learnings: `docs/solutions/best-practices/workspace-executor-opencode-provisioning-best-practices-2026-06-01.md`, `docs/solutions/best-practices/signed-webhook-ingress-hardening-2026-05-29.md`, `docs/solutions/build-errors/gateway-docker-runtime-resolution-crash-loop-2026-05-31.md`


### PR DESCRIPTION
Fixes #741.

The deployed gateway sandboxes a workspace executor whose only egress path is the mitmproxy allowlist proxy. On v0.51.0+ that proxy was attached solely to the `internal: true` sandbox network, so it had no route to the internet — every workspace outbound request failed with `502 CONNECT tunnel failed`, breaking both `/fro-bot add-project` cloning and the `@fro-bot` mention loop.

## Topology

Add a dedicated `egress-net` (internal: false) and dual-home mitmproxy on `sandbox-net` + `egress-net`. The workspace stays `sandbox-net`-only with zero direct egress, and `sandbox-net` stays internal — only mitmproxy gains an upstream leg. Containment holds: workspace → sandbox-net → mitmproxy → egress-net → internet.

## Configurable egress host

Add a `WORKSPACE_EGRESS_HOSTS` env var so a deployment can allowlist exact hosts the workspace must reach — e.g. a self-hosted model proxy (cliproxyapi). It reuses the existing `OBJECT_STORE_HOSTS` validation pipeline through one shared validator (wildcard, private-IP, port, and RFC 1123 checks); `OBJECT_STORE_HOSTS` behavior is unchanged. It is an escape hatch for explicitly-justified hosts, not a general allowlist.

## DNS-rebinding defense

Operator-supplied allowlist hosts are now validated at connect time: the proxy resolves the host and returns 403 if any resolved address is private, loopback, link-local, or reserved — closing the gap where only literal-IP entries were checked. The resolver guard fails closed on any resolution error (DNS failure, timeout, or encoding error). Vendor static-list hosts are not resolved-checked (they go through code review). This is defense-in-depth with a documented TOCTOU limitation, since mitmproxy re-resolves for its own upstream dial.

## Regression guard

A static compose-topology invariant check (`deploy/validate-stack.sh --topology-only`, config-only — no running stack) asserts the containment invariants, and it plus the mitmproxy allowlist tests now run in the workspace-smoke CI job — the gap that let this break ship undetected.

Docs for `WORKSPACE_EGRESS_HOSTS` and the corrected topology are in the deploy README, `.env.example`, and compose override example. Further egress hardening (TOCTOU closure, resolver timeout, topology-guard bypass forms) is tracked in #746; a live egress smoke in #745.