### PR TITLE
feat(harness): @fro.bot/harness — patched-OpenCode build + publish pipeline

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,6 +30,16 @@
       extractVersionTemplate: '^v?(?<version>.*)$',
     },
     {
+      // Tracks the harness base release pin in packages/harness/src/base-version.ts.
+      // Capped at <=1.15.13 (same as DEFAULT_OPENCODE_VERSION) until a reviewed bump PR raises it.
+      customType: 'regex',
+      managerFilePatterns: ['/packages\\/harness\\/src\\/base-version\\.ts/'],
+      matchStrings: ["HARNESS_BASE_VERSION = '(?<currentValue>\\d+\\.\\d+\\.\\d+)'"],
+      depNameTemplate: 'anomalyco/opencode',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v?(?<version>.*)$',
+    },
+    {
       customType: 'regex',
       managerFilePatterns: ['/src\\/shared\\/constants\\.ts/'],
       matchStrings: ["DEFAULT_BUN_VERSION = '(?<currentValue>\\d+\\.\\d+\\.\\d+)'"],

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -29,7 +29,7 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write # Required for npm provenance attestation
+  id-token: write # Required for npm trusted publishing (OIDC) + automatic provenance
 
 # ---------------------------------------------------------------------------
 # Per-platform build matrix
@@ -136,11 +136,15 @@ jobs:
         with:
           bun-version: 1.3.13
 
-      - name: Setup Node.js (for npm publish with provenance)
+      - name: Setup Node.js (for npm trusted publishing via OIDC)
         uses: actions/setup-node@v4
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm to a trusted-publishing-capable version
+        # Trusted publishing (OIDC) requires npm >= 11.5.0; Node 24 ships an older npm.
+        run: npm install -g npm@latest
 
       - name: Install harness dependencies
         run: pnpm install --filter @fro.bot/harness --frozen-lockfile
@@ -247,10 +251,8 @@ jobs:
           echo "Assembly complete. Publish dir: ${PUBLISH_DIR}"
           ls -la "${PUBLISH_DIR}"
 
-      - name: Publish per-platform packages to npm (with provenance)
+      - name: Publish per-platform packages to npm (trusted publishing)
         if: steps.params.outputs.dry_run != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           BASE_VERSION="${{ steps.params.outputs.base_version }}"
@@ -260,14 +262,13 @@ jobs:
             for ARCH in x64 arm64; do
               PKG_DIR="${PUBLISH_DIR}/${PLATFORM}-${ARCH}"
               echo "Publishing @fro.bot/harness-${PLATFORM}-${ARCH}@${BASE_VERSION}..."
-              npm publish "${PKG_DIR}" --provenance --access public
+              # OIDC trusted publishing: no token, provenance is automatic.
+              npm publish "${PKG_DIR}"
             done
           done
 
-      - name: Publish main @fro.bot/harness package to npm (with provenance)
+      - name: Publish main @fro.bot/harness package to npm (trusted publishing)
         if: steps.params.outputs.dry_run != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           BASE_VERSION="${{ steps.params.outputs.base_version }}"
@@ -288,7 +289,8 @@ jobs:
             fs.writeFileSync('packages/harness/package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
           echo "Publishing @fro.bot/harness@${BASE_VERSION}..."
-          npm publish packages/harness --provenance --access public
+          # OIDC trusted publishing: no token, provenance is automatic.
+          npm publish packages/harness
 
       - name: Dry run summary
         if: steps.params.outputs.dry_run == 'true'

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -27,9 +27,11 @@ concurrency:
   group: harness-release-${{ github.ref }}
   cancel-in-progress: false
 
+# Workflow-level: read-only. The build job runs untrusted LLM-merge + upstream
+# build code and must NOT have id-token access. id-token: write is scoped to
+# the publish job only (see below).
 permissions:
   contents: read
-  id-token: write # Required for npm trusted publishing (OIDC) + automatic provenance
 
 # ---------------------------------------------------------------------------
 # Per-platform build matrix
@@ -58,6 +60,11 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
 
+    # Build job: read-only. No id-token — the untrusted LLM-merge + upstream
+    # build runs here and must not be able to publish or obtain OIDC tokens.
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout harness repo
         uses: actions/checkout@v4
@@ -76,38 +83,76 @@ jobs:
 
       - name: Resolve integration commit and base version
         id: params
+        env:
+          INPUT_INTEGRATION_COMMIT: ${{ inputs.integration_commit }}
+          INPUT_BASE_VERSION: ${{ inputs.base_version }}
         run: |
-          # Prefer workflow_dispatch inputs; fall back to tag-derived values.
-          if [ -n "${{ inputs.integration_commit }}" ]; then
-            echo "integration_commit=${{ inputs.integration_commit }}" >> "$GITHUB_OUTPUT"
-            echo "base_version=${{ inputs.base_version }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+
+          if [ -n "${INPUT_INTEGRATION_COMMIT}" ]; then
+            INTEGRATION_COMMIT="${INPUT_INTEGRATION_COMMIT}"
+            BASE_VERSION="${INPUT_BASE_VERSION}"
           else
             # Tag-triggered: parse harness-v<version> tag.
             TAG="${GITHUB_REF_NAME}"
             BASE_VERSION="${TAG#harness-v}"
             # Read integration commit from the provenance manifest in the repo.
-            INTEGRATION_COMMIT=$(node -e "const m=require('./packages/harness/provenance.json'); console.log(m.integrationCommit)")
-            echo "integration_commit=${INTEGRATION_COMMIT}" >> "$GITHUB_OUTPUT"
-            echo "base_version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+            INTEGRATION_COMMIT=$(node -e "
+              const fs = require('fs');
+              const raw = fs.readFileSync('./packages/harness/provenance.json', 'utf8');
+              const m = JSON.parse(raw);
+              if (!m || typeof m.integrationCommit !== 'string') {
+                process.stderr.write('ERROR: provenance.json missing or invalid integrationCommit\n');
+                process.exit(1);
+              }
+              process.stdout.write(m.integrationCommit);
+            ")
           fi
 
+          # Validate base_version: must be a semver-ish string (digits and dots only, no shell metacharacters).
+          if ! echo "${BASE_VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([.-][a-zA-Z0-9._-]+)?$'; then
+            echo "ERROR: base_version '${BASE_VERSION}' does not match expected semver format" >&2
+            exit 1
+          fi
+
+          # Validate integration_commit: must be a hex SHA (7–40 chars).
+          if ! echo "${INTEGRATION_COMMIT}" | grep -qE '^[0-9a-f]{7,40}$'; then
+            echo "ERROR: integration_commit '${INTEGRATION_COMMIT}' does not match expected SHA format" >&2
+            exit 1
+          fi
+
+          echo "integration_commit=${INTEGRATION_COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "base_version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Build native binary for ${{ matrix.platform }}/${{ matrix.arch }}
+        env:
+          INTEGRATION_COMMIT: ${{ steps.params.outputs.integration_commit }}
+          BASE_VERSION: ${{ steps.params.outputs.base_version }}
+          RUNNER_TEMP: ${{ runner.temp }}
+          MATRIX_PLATFORM: ${{ matrix.platform }}
+          MATRIX_ARCH: ${{ matrix.arch }}
         run: |
           bun run packages/harness/scripts/build-platform.ts \
-            --integration-commit "${{ steps.params.outputs.integration_commit }}" \
-            --base-version "${{ steps.params.outputs.base_version }}" \
-            --platform "${{ matrix.platform }}" \
-            --arch "${{ matrix.arch }}" \
+            --integration-commit "$INTEGRATION_COMMIT" \
+            --base-version "$BASE_VERSION" \
+            --platform "$MATRIX_PLATFORM" \
+            --arch "$MATRIX_ARCH" \
             --repo-url "https://github.com/anomalyco/opencode.git" \
-            --work-dir "${{ runner.temp }}/harness-build-work" \
-            --out-dir "${{ runner.temp }}/harness-build-out"
+            --work-dir "$RUNNER_TEMP/harness-build-work" \
+            --out-dir "$RUNNER_TEMP/harness-build-out"
 
       - name: Verify binary (${{ matrix.platform }}/${{ matrix.arch }})
+        env:
+          INTEGRATION_COMMIT: ${{ steps.params.outputs.integration_commit }}
+          BASE_VERSION: ${{ steps.params.outputs.base_version }}
+          RUNNER_TEMP: ${{ runner.temp }}
+          MATRIX_PLATFORM: ${{ matrix.platform }}
+          MATRIX_ARCH: ${{ matrix.arch }}
         run: |
           bun run packages/harness/scripts/verify-binary.ts \
-            --binary "${{ runner.temp }}/harness-build-out/opencode-${{ matrix.platform }}-${{ matrix.arch }}/bin/opencode" \
-            --base-version "${{ steps.params.outputs.base_version }}" \
-            --integration-commit "${{ steps.params.outputs.integration_commit }}"
+            --binary "$RUNNER_TEMP/harness-build-out/opencode-$MATRIX_PLATFORM-$MATRIX_ARCH/bin/opencode" \
+            --base-version "$BASE_VERSION" \
+            --integration-commit "$INTEGRATION_COMMIT"
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
@@ -127,6 +172,14 @@ jobs:
     runs-on: ubuntu-24.04
     environment: npm-publish # Maintainer-gated environment with required reviewers.
 
+    # id-token: write is scoped to the publish job ONLY.
+    # The build job (which runs untrusted LLM-merge + upstream build code) must
+    # NOT have id-token access. This prevents a compromised build from obtaining
+    # an OIDC token and publishing arbitrary packages.
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - name: Checkout harness repo
         uses: actions/checkout@v4
@@ -144,7 +197,8 @@ jobs:
 
       - name: Upgrade npm to a trusted-publishing-capable version
         # Trusted publishing (OIDC) requires npm >= 11.5.0; Node 24 ships an older npm.
-        run: npm install -g npm@latest
+        # Pinned to a reviewed version that supports trusted publishing.
+        run: npm install -g npm@11.5.1
 
       - name: Install harness dependencies
         run: pnpm install --filter @fro.bot/harness --frozen-lockfile
@@ -154,19 +208,48 @@ jobs:
 
       - name: Resolve params
         id: params
+        env:
+          INPUT_INTEGRATION_COMMIT: ${{ inputs.integration_commit }}
+          INPUT_BASE_VERSION: ${{ inputs.base_version }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          if [ -n "${{ inputs.integration_commit }}" ]; then
-            echo "integration_commit=${{ inputs.integration_commit }}" >> "$GITHUB_OUTPUT"
-            echo "base_version=${{ inputs.base_version }}" >> "$GITHUB_OUTPUT"
-            echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+
+          if [ -n "${INPUT_INTEGRATION_COMMIT}" ]; then
+            INTEGRATION_COMMIT="${INPUT_INTEGRATION_COMMIT}"
+            BASE_VERSION="${INPUT_BASE_VERSION}"
+            DRY_RUN="${INPUT_DRY_RUN}"
           else
             TAG="${GITHUB_REF_NAME}"
             BASE_VERSION="${TAG#harness-v}"
-            INTEGRATION_COMMIT=$(node -e "const m=require('./packages/harness/provenance.json'); console.log(m.integrationCommit)")
-            echo "integration_commit=${INTEGRATION_COMMIT}" >> "$GITHUB_OUTPUT"
-            echo "base_version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+            INTEGRATION_COMMIT=$(node -e "
+              const fs = require('fs');
+              const raw = fs.readFileSync('./packages/harness/provenance.json', 'utf8');
+              const m = JSON.parse(raw);
+              if (!m || typeof m.integrationCommit !== 'string') {
+                process.stderr.write('ERROR: provenance.json missing or invalid integrationCommit\n');
+                process.exit(1);
+              }
+              process.stdout.write(m.integrationCommit);
+            ")
+            DRY_RUN="false"
           fi
+
+          # Validate base_version: must be a semver-ish string (no shell metacharacters).
+          if ! echo "${BASE_VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([.-][a-zA-Z0-9._-]+)?$'; then
+            echo "ERROR: base_version '${BASE_VERSION}' does not match expected semver format" >&2
+            exit 1
+          fi
+
+          # Validate integration_commit: must be a hex SHA (7–40 chars).
+          if ! echo "${INTEGRATION_COMMIT}" | grep -qE '^[0-9a-f]{7,40}$'; then
+            echo "ERROR: integration_commit '${INTEGRATION_COMMIT}' does not match expected SHA format" >&2
+            exit 1
+          fi
+
+          echo "integration_commit=${INTEGRATION_COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "base_version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "dry_run=${DRY_RUN}" >> "$GITHUB_OUTPUT"
 
       # Download all four platform binaries.
       - name: Download linux/x64 binary
@@ -194,10 +277,11 @@ jobs:
           path: /tmp/harness-binaries/darwin-arm64
 
       - name: Assemble per-platform packages
+        env:
+          BASE_VERSION: ${{ steps.params.outputs.base_version }}
+          INTEGRATION_COMMIT: ${{ steps.params.outputs.integration_commit }}
         run: |
           set -euo pipefail
-          BASE_VERSION="${{ steps.params.outputs.base_version }}"
-          INTEGRATION_COMMIT="${{ steps.params.outputs.integration_commit }}"
           PUBLISH_DIR="/tmp/harness-publish"
 
           for PLATFORM in linux darwin; do
@@ -212,6 +296,8 @@ jobs:
               chmod +x "${BIN_DIR}/opencode"
 
               # Write the per-platform package.json (mirrors OpenCode's model).
+              # BASE_VERSION and PKG_NAME are shell variables (not ${{ }} interpolation),
+              # so they are safe from injection — validated above.
               cat > "${PKG_DIR}/package.json" <<EOF
           {
             "name": "${PKG_NAME}",
@@ -235,15 +321,15 @@ jobs:
           done
 
           # Write the provenance manifest into the main package for runtime use.
+          # Values are passed via environment variables (not interpolated into the script body).
           node -e "
             const fs = require('fs');
-            const existing = JSON.parse(fs.readFileSync('packages/harness/provenance.json', 'utf8'));
-            const manifest = {
-              ...existing,
-              baseVersion: '${BASE_VERSION}',
-              integrationCommit: '${INTEGRATION_COMMIT}',
-              buildSha: process.env.GITHUB_SHA || 'unknown',
-            };
+            const baseVersion = process.env.BASE_VERSION;
+            const integrationCommit = process.env.INTEGRATION_COMMIT;
+            const buildSha = process.env.GITHUB_SHA || 'unknown';
+            let existing = {};
+            try { existing = JSON.parse(fs.readFileSync('packages/harness/provenance.json', 'utf8')); } catch {}
+            const manifest = { ...existing, baseVersion, integrationCommit, buildSha };
             fs.writeFileSync('packages/harness/provenance.json', JSON.stringify(manifest, null, 2) + '\n');
             console.log('provenance.json updated:', manifest);
           "
@@ -253,9 +339,10 @@ jobs:
 
       - name: Publish per-platform packages to npm (trusted publishing)
         if: steps.params.outputs.dry_run != 'true'
+        env:
+          BASE_VERSION: ${{ steps.params.outputs.base_version }}
         run: |
           set -euo pipefail
-          BASE_VERSION="${{ steps.params.outputs.base_version }}"
           PUBLISH_DIR="/tmp/harness-publish"
 
           for PLATFORM in linux darwin; do
@@ -269,22 +356,25 @@ jobs:
 
       - name: Publish main @fro.bot/harness package to npm (trusted publishing)
         if: steps.params.outputs.dry_run != 'true'
+        env:
+          BASE_VERSION: ${{ steps.params.outputs.base_version }}
         run: |
           set -euo pipefail
-          BASE_VERSION="${{ steps.params.outputs.base_version }}"
           # Inject version + optionalDependencies before publish.
           # Source package.json intentionally omits optionalDependencies so the
           # workspace pnpm-lock.yaml stays clean (packages don't exist on npm yet).
           # We inject them here so the PUBLISHED package.json has them.
+          # BASE_VERSION is passed via env (not interpolated into the script body).
           node -e "
             const fs = require('fs');
+            const baseVersion = process.env.BASE_VERSION;
             const pkg = JSON.parse(fs.readFileSync('packages/harness/package.json', 'utf8'));
-            pkg.version = '${BASE_VERSION}';
+            pkg.version = baseVersion;
             pkg.optionalDependencies = {
-              '@fro.bot/harness-linux-x64': '${BASE_VERSION}',
-              '@fro.bot/harness-linux-arm64': '${BASE_VERSION}',
-              '@fro.bot/harness-darwin-x64': '${BASE_VERSION}',
-              '@fro.bot/harness-darwin-arm64': '${BASE_VERSION}',
+              '@fro.bot/harness-linux-x64': baseVersion,
+              '@fro.bot/harness-linux-arm64': baseVersion,
+              '@fro.bot/harness-darwin-x64': baseVersion,
+              '@fro.bot/harness-darwin-arm64': baseVersion,
             };
             fs.writeFileSync('packages/harness/package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
@@ -294,8 +384,11 @@ jobs:
 
       - name: Dry run summary
         if: steps.params.outputs.dry_run == 'true'
+        env:
+          BASE_VERSION: ${{ steps.params.outputs.base_version }}
+          INTEGRATION_COMMIT: ${{ steps.params.outputs.integration_commit }}
         run: |
           echo "DRY RUN: build + verify passed for all platforms."
-          echo "  base version:       ${{ steps.params.outputs.base_version }}"
-          echo "  integration commit: ${{ steps.params.outputs.integration_commit }}"
+          echo "  base version:       ${BASE_VERSION}"
+          echo "  integration commit: ${INTEGRATION_COMMIT}"
           echo "  No packages were published to npm."

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -75,6 +75,11 @@ jobs:
           # Pinned to match anomalyco/opencode packageManager: bun@1.3.13
           bun-version: 1.3.13
 
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup
+        with:
+          install-dependencies: 'false'
+
       - name: Install harness dependencies
         run: pnpm install --filter @fro.bot/harness --frozen-lockfile
 
@@ -188,6 +193,11 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.13
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup
+        with:
+          install-dependencies: 'false'
 
       - name: Setup Node.js (for npm trusted publishing via OIDC)
         uses: actions/setup-node@v4

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -1,0 +1,299 @@
+name: harness-release
+
+# Fenced: manual dispatch or protected release tag only.
+# Never runs on PR or push to non-release branches.
+# Maintainer-gated: no auto-publish; the workflow is triggered deliberately.
+on:
+  workflow_dispatch:
+    inputs:
+      integration_commit:
+        description: Frozen integration commit SHA (from provenance manifest)
+        required: true
+        type: string
+      base_version:
+        description: Base release version (e.g. 1.15.13)
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run: build + verify but do NOT publish to npm'
+        required: false
+        type: boolean
+        default: false
+  push:
+    tags:
+      - 'harness-v*'
+
+concurrency:
+  group: harness-release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write # Required for npm provenance attestation
+
+# ---------------------------------------------------------------------------
+# Per-platform build matrix
+# Mirrors upstream anomalyco/opencode publish.yml native-runner matrix.
+# Windows is out of scope (linux x64/arm64 + darwin x64/arm64 only).
+# ---------------------------------------------------------------------------
+jobs:
+  build:
+    name: build (${{ matrix.platform }}/${{ matrix.arch }})
+    strategy:
+      fail-fast: true # All-or-nothing: one failure blocks the whole publish.
+      matrix:
+        include:
+          - platform: linux
+            arch: x64
+            runner: ubuntu-24.04
+          - platform: linux
+            arch: arm64
+            runner: ubuntu-24.04-arm
+          - platform: darwin
+            arch: x64
+            runner: macos-13
+          - platform: darwin
+            arch: arm64
+            runner: macos-15
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Checkout harness repo
+        uses: actions/checkout@v4
+
+      - name: Install Bun (pinned to upstream packageManager version)
+        uses: oven-sh/setup-bun@v2
+        with:
+          # Pinned to match anomalyco/opencode packageManager: bun@1.3.13
+          bun-version: 1.3.13
+
+      - name: Install harness dependencies
+        run: pnpm install --filter @fro.bot/harness --frozen-lockfile
+
+      - name: Build harness package (for scripts/verify-binary.ts import)
+        run: pnpm --filter @fro.bot/harness build
+
+      - name: Resolve integration commit and base version
+        id: params
+        run: |
+          # Prefer workflow_dispatch inputs; fall back to tag-derived values.
+          if [ -n "${{ inputs.integration_commit }}" ]; then
+            echo "integration_commit=${{ inputs.integration_commit }}" >> "$GITHUB_OUTPUT"
+            echo "base_version=${{ inputs.base_version }}" >> "$GITHUB_OUTPUT"
+          else
+            # Tag-triggered: parse harness-v<version> tag.
+            TAG="${GITHUB_REF_NAME}"
+            BASE_VERSION="${TAG#harness-v}"
+            # Read integration commit from the provenance manifest in the repo.
+            INTEGRATION_COMMIT=$(node -e "const m=require('./packages/harness/provenance.json'); console.log(m.integrationCommit)")
+            echo "integration_commit=${INTEGRATION_COMMIT}" >> "$GITHUB_OUTPUT"
+            echo "base_version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build native binary for ${{ matrix.platform }}/${{ matrix.arch }}
+        run: |
+          bun run packages/harness/scripts/build-platform.ts \
+            --integration-commit "${{ steps.params.outputs.integration_commit }}" \
+            --base-version "${{ steps.params.outputs.base_version }}" \
+            --platform "${{ matrix.platform }}" \
+            --arch "${{ matrix.arch }}" \
+            --repo-url "https://github.com/anomalyco/opencode.git" \
+            --work-dir "${{ runner.temp }}/harness-build-work" \
+            --out-dir "${{ runner.temp }}/harness-build-out"
+
+      - name: Verify binary (${{ matrix.platform }}/${{ matrix.arch }})
+        run: |
+          bun run packages/harness/scripts/verify-binary.ts \
+            --binary "${{ runner.temp }}/harness-build-out/opencode-${{ matrix.platform }}-${{ matrix.arch }}/bin/opencode" \
+            --base-version "${{ steps.params.outputs.base_version }}" \
+            --integration-commit "${{ steps.params.outputs.integration_commit }}"
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: harness-binary-${{ matrix.platform }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/harness-build-out/opencode-${{ matrix.platform }}-${{ matrix.arch }}/bin/opencode
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Assemble + publish — all-or-nothing across the matrix.
+  # Runs only after ALL platform builds succeed (fail-fast: true above).
+  # ---------------------------------------------------------------------------
+  publish:
+    name: publish (all-or-nothing)
+    needs: build
+    runs-on: ubuntu-24.04
+    environment: npm-publish # Maintainer-gated environment with required reviewers.
+
+    steps:
+      - name: Checkout harness repo
+        uses: actions/checkout@v4
+
+      - name: Install Bun (pinned)
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Setup Node.js (for npm publish with provenance)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install harness dependencies
+        run: pnpm install --filter @fro.bot/harness --frozen-lockfile
+
+      - name: Build harness package
+        run: pnpm --filter @fro.bot/harness build
+
+      - name: Resolve params
+        id: params
+        run: |
+          if [ -n "${{ inputs.integration_commit }}" ]; then
+            echo "integration_commit=${{ inputs.integration_commit }}" >> "$GITHUB_OUTPUT"
+            echo "base_version=${{ inputs.base_version }}" >> "$GITHUB_OUTPUT"
+            echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
+          else
+            TAG="${GITHUB_REF_NAME}"
+            BASE_VERSION="${TAG#harness-v}"
+            INTEGRATION_COMMIT=$(node -e "const m=require('./packages/harness/provenance.json'); console.log(m.integrationCommit)")
+            echo "integration_commit=${INTEGRATION_COMMIT}" >> "$GITHUB_OUTPUT"
+            echo "base_version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Download all four platform binaries.
+      - name: Download linux/x64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: harness-binary-linux-x64
+          path: /tmp/harness-binaries/linux-x64
+
+      - name: Download linux/arm64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: harness-binary-linux-arm64
+          path: /tmp/harness-binaries/linux-arm64
+
+      - name: Download darwin/x64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: harness-binary-darwin-x64
+          path: /tmp/harness-binaries/darwin-x64
+
+      - name: Download darwin/arm64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: harness-binary-darwin-arm64
+          path: /tmp/harness-binaries/darwin-arm64
+
+      - name: Assemble per-platform packages
+        run: |
+          set -euo pipefail
+          BASE_VERSION="${{ steps.params.outputs.base_version }}"
+          INTEGRATION_COMMIT="${{ steps.params.outputs.integration_commit }}"
+          PUBLISH_DIR="/tmp/harness-publish"
+
+          for PLATFORM in linux darwin; do
+            for ARCH in x64 arm64; do
+              PKG_NAME="@fro.bot/harness-${PLATFORM}-${ARCH}"
+              PKG_DIR="${PUBLISH_DIR}/${PLATFORM}-${ARCH}"
+              BIN_DIR="${PKG_DIR}/bin"
+              mkdir -p "${BIN_DIR}"
+
+              # Copy the binary.
+              cp "/tmp/harness-binaries/${PLATFORM}-${ARCH}/opencode" "${BIN_DIR}/opencode"
+              chmod +x "${BIN_DIR}/opencode"
+
+              # Write the per-platform package.json (mirrors OpenCode's model).
+              cat > "${PKG_DIR}/package.json" <<EOF
+          {
+            "name": "${PKG_NAME}",
+            "version": "${BASE_VERSION}",
+            "description": "Native binary for @fro.bot/harness on ${PLATFORM}/${ARCH}",
+            "license": "MIT",
+            "os": ["${PLATFORM}"],
+            "cpu": ["${ARCH}"],
+            "files": ["bin"],
+            "publishConfig": {
+              "access": "public"
+            }
+          }
+          EOF
+
+              # Copy LICENSE.
+              cp packages/harness/LICENSE "${PKG_DIR}/LICENSE"
+
+              echo "Assembled: ${PKG_NAME}@${BASE_VERSION}"
+            done
+          done
+
+          # Write the provenance manifest into the main package for runtime use.
+          node -e "
+            const fs = require('fs');
+            const existing = JSON.parse(fs.readFileSync('packages/harness/provenance.json', 'utf8'));
+            const manifest = {
+              ...existing,
+              baseVersion: '${BASE_VERSION}',
+              integrationCommit: '${INTEGRATION_COMMIT}',
+              buildSha: process.env.GITHUB_SHA || 'unknown',
+            };
+            fs.writeFileSync('packages/harness/provenance.json', JSON.stringify(manifest, null, 2) + '\n');
+            console.log('provenance.json updated:', manifest);
+          "
+
+          echo "Assembly complete. Publish dir: ${PUBLISH_DIR}"
+          ls -la "${PUBLISH_DIR}"
+
+      - name: Publish per-platform packages to npm (with provenance)
+        if: steps.params.outputs.dry_run != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          BASE_VERSION="${{ steps.params.outputs.base_version }}"
+          PUBLISH_DIR="/tmp/harness-publish"
+
+          for PLATFORM in linux darwin; do
+            for ARCH in x64 arm64; do
+              PKG_DIR="${PUBLISH_DIR}/${PLATFORM}-${ARCH}"
+              echo "Publishing @fro.bot/harness-${PLATFORM}-${ARCH}@${BASE_VERSION}..."
+              npm publish "${PKG_DIR}" --provenance --access public
+            done
+          done
+
+      - name: Publish main @fro.bot/harness package to npm (with provenance)
+        if: steps.params.outputs.dry_run != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          BASE_VERSION="${{ steps.params.outputs.base_version }}"
+          # Inject version + optionalDependencies before publish.
+          # Source package.json intentionally omits optionalDependencies so the
+          # workspace pnpm-lock.yaml stays clean (packages don't exist on npm yet).
+          # We inject them here so the PUBLISHED package.json has them.
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('packages/harness/package.json', 'utf8'));
+            pkg.version = '${BASE_VERSION}';
+            pkg.optionalDependencies = {
+              '@fro.bot/harness-linux-x64': '${BASE_VERSION}',
+              '@fro.bot/harness-linux-arm64': '${BASE_VERSION}',
+              '@fro.bot/harness-darwin-x64': '${BASE_VERSION}',
+              '@fro.bot/harness-darwin-arm64': '${BASE_VERSION}',
+            };
+            fs.writeFileSync('packages/harness/package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          echo "Publishing @fro.bot/harness@${BASE_VERSION}..."
+          npm publish packages/harness --provenance --access public
+
+      - name: Dry run summary
+        if: steps.params.outputs.dry_run == 'true'
+        run: |
+          echo "DRY RUN: build + verify passed for all platforms."
+          echo "  base version:       ${{ steps.params.outputs.base_version }}"
+          echo "  integration commit: ${{ steps.params.outputs.integration_commit }}"
+          echo "  No packages were published to npm."

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ eslint-typegen.d.ts
 # Workspace package build output
 packages/runtime/dist/
 packages/gateway/dist/
+packages/harness/dist/
 apps/action/dist/
 apps/workspace-agent/dist/
 

--- a/docs/plans/2026-06-03-002-feat-fro-bot-harness-plan.md
+++ b/docs/plans/2026-06-03-002-feat-fro-bot-harness-plan.md
@@ -1,0 +1,325 @@
+---
+title: "feat: @fro.bot/harness — orw-embedded patched OpenCode (LLM-merge integration, default setup)"
+type: feat
+status: active
+date: 2026-06-03
+origin: docs/brainstorms/2026-06-02-fro-bot-harness-patched-opencode-requirements.md
+---
+
+# feat: @fro.bot/harness — orw-embedded patched OpenCode
+
+## Overview
+
+`@fro.bot/harness` is a published package that embeds **orw's integration method** (`cortexkit/orw`) into this project: on each deliberately-pinned upstream OpenCode release, it bases an integration branch on the **release tag**, fetches a configured set of integration refs (stalled/closed upstream PRs, branch URLs, local branches), and runs an **LLM merge** (`opencode run`) to carry those refs onto the release tag — resolving the base drift that `git am`/cherry-pick structurally cannot — then builds the native OpenCode CLI per platform and verifies it. The produced per-platform binary is the `harness` binary (the patched OpenCode), shipped in the package dist. The action setup **replaces** its stock OpenCode download with the harness-produced binary: the harness **is** the default OpenCode for Fro Bot, not an opt-in.
+
+This corrects the prior draft on three points:
+1. **LLM merge is the mechanism, not a flaw.** The v1 carry target (#30182) is based on upstream `dev`, not the release tag — `git am` cannot bridge that base. orw uses `opencode run` to merge it onto the tag and resolve conflicts. This **supersedes brainstorm R4** ("deterministic git-native, never LLM merge"); R4 was the wrong call. Determinism is preserved differently (below).
+2. **Harness is the default**, replacing the stock `opencode` install in the action setup — not an opt-in path.
+3. **Full harness as specified** in the origin brainstorm (published package, native per-platform distribution, scheduled deliberate bumps), delivered with orw's method as the integration engine.
+
+## Problem Frame
+
+Fro Bot has no reproducible way to carry OpenCode changes that upstream won't take (closed/stalled PRs) or to ride a newer release without a from-scratch manual re-validation. The behaviors live in `dev`-based PRs that can't be `git am`-ed onto a release tag. orw already solves exactly this — clone at the release tag, LLM-merge the dev refs, build, verify — but as a personal local watcher (launchd, desktop install). The harness embeds that method as a **project-integrated, published, CI-built** OpenCode supplier that the action consumes as its default OpenCode.
+
+## How determinism works under an LLM merge
+
+The LLM merge is non-deterministic per run, so reproducibility moves one level up — exactly orw's model plus a freeze:
+
+- The LLM merge runs **once per release bump** (scheduled or manual), in CI, producing an **integration commit** on a branch based on the release tag.
+- That integration commit is **captured, reviewed by the maintainer (the bump PR), and frozen** — its SHA is pinned. Nothing rebuilds the merge on the action's hot path.
+- Per-platform **builds are pinned to the frozen integration commit** and are deterministic from there.
+- **Provenance** = upstream release tag + ordered integration refs (each pinned by upstream commit SHA: PR `refs/pull/N/head`, branch ref, or local) + the **frozen integration commit SHA** + build sha. `harness info`/`patches`/`doctor` report this.
+- The maintainer review of the bump PR **is** the quality gate on the LLM merge — never auto-merged.
+
+So the guarantee is "the **reviewed, frozen integration commit** reproducibly builds the binary," not "base+patches byte-reproduce the binary." This is honest and matches orw + the brainstorm's deliberate-pinned-bump model.
+
+## Requirements Trace
+
+Carries the origin brainstorm's full-harness requirements, with R4 corrected to LLM-merge:
+
+- R1. New published package **`@fro.bot/harness`** under `packages/harness/` (dot-scope, ESM-only/Node 24 + bun, workspace conventions). *(origin R1)*
+- R2. `harness` CLI **passes through** arbitrary OpenCode commands/args/stdio/env to the patched binary — drop-in. *(origin R2)*
+- R3. Harness commands: `harness doctor` (binary present/runnable/expected provenance), `harness patches` (integration refs + frozen integration commit), `harness info`/`--version` (base release + integration refs + integration commit + build sha). *(origin R3)*
+- **R4′ (corrected).** Integration is an **LLM merge** of configured refs onto the release tag (orw's `opencode run` method), **not** `git am`. The merge runs once per bump, is reviewed, and its result is **frozen** as a pinned integration commit. *(supersedes origin R4)*
+- R5. A failed integration (merge unresolved, build fails, or version mismatch) **fails the bump hard** and opens a maintenance issue — never a silent/partial publish. *(origin R5, R26)*
+- R6. The integration ref set carries **non-mainline value only**; refs already in the stable release tag arrive free and are not carried. A ref merged to `dev` but not yet in the stable tag (e.g. #30182 in v1) is carried until the next release includes it, then auto-drops. *(origin R6)*
+- R7. Each integration ref records provenance (upstream PR/source, pinned commit SHA, why carried, upstream-rejected → indefinite-ownership flag). *(origin R7, R22)*
+- R8/R19. Each platform's integrated OpenCode is compiled to a **native standalone binary** via upstream's **own build** (`packages/opencode/script/build.ts` — a full-repo build, not a standalone compile), **each on its own platform-native runner**; matrix mirrors OpenCode: linux x64/arm64 + darwin x64/arm64. *(origin R8, R19)*
+- R9/R18. Distribution **mirrors OpenCode's npm packaging**: a main `@fro.bot/harness` + per-platform `optionalDependencies` (`@fro.bot/harness-linux-x64`, …), `bin` shim + `postinstall` resolver; **published to public npm**, runnable via `bunx @fro.bot/harness <cmd>`. *(origin R9, R18)*
+- R10/R20–R25. Provenance + integrity: published packages carry npm provenance attestation; `postinstall` resolver verifies integrity before exec; publish authority fenced to a protected CI workflow + maintainer gate; all-or-nothing across the matrix; MIT attribution preserved. *(origin R10, R20–R25)*
+- R11/R12. The harness pins an **exact, validated** base release — initial target **1.15.13** (already validated/shipped). *(origin R11, R12)*
+- **R15′ (corrected).** The action setup **replaces** its stock OpenCode download with the harness binary — the harness **is the default** OpenCode for the action. *(corrects origin R15 — not opt-in)*
+- R13/R14. A **scheduled CI job** detects new upstream releases, runs the integration + verification, and opens a **bump PR only when green**; never auto-merged; maintainer reviews the frozen LLM-merge result. *(origin R13, R14)*
+- R16. **Gateway/workspace-image cutover follows** after the action validates the harness binary in production. *(origin R16 — fast-follow, not v1)*
+- R17. The action cutover **verifies** SDK/event-stream + tool-output compatibility against the integrated binary (reuse the proven streaming/tool-output assertion), not assume it. *(origin R17)*
+
+## Scope Boundaries
+
+- **Action is the cutover surface; gateway/workspace follows** (R16) — see Deferred.
+- **No auto-tracking of upstream dev/latest** — bumps are deliberate, maintainer-reviewed (R11/R14).
+- **The LLM merge is a build/bump-time step, never on the action's hot path** — the action consumes the published, frozen, pre-built binary.
+- **windows out of scope** (origin) — matrix is linux x64/arm64 + darwin x64/arm64.
+
+### Deferred to Separate Tasks
+
+- **Gateway + workspace-image cutover** to the harness binary (`deploy/*.Dockerfile`): the immediate fast-follow after the action validates the harness in production (R16).
+- **`harness`-driven local dev install** (orw's launchd/desktop-install ergonomics) beyond `bunx @fro.bot/harness` inspection/run: out of v1; the project-integration + action-consumption path is v1.
+
+## Context & Research
+
+### orw method (the integration engine to embed) — read in `.slim/clonedeps/repos/cortexkit__orw/`
+
+- `src/index.ts` `check()` → `prep()` → `render()` → `opencode run` → `verifyBuild()` is the core loop: detect latest release → clone `git_origin` into a disposable work repo → fetch each integration ref → render `prompt.txt` → run `opencode run --agent build --model <model> <prompt>` (the LLM merge: base branch on the release tag, merge refs in order, resolve conflicts, build the host CLI) → verify the built CLI `--version` equals the release version.
+- `parseSource()` maps each config ref to a fetch ref: **local branch** → `refs/heads/<b>`; **GitHub branch URL** (`/tree/`) → that branch; **GitHub PR URL** (`/pull/N`) → `refs/pull/N/head`. This is exactly how dev-targeted PRs (e.g. #30182 `/pull/30182`) are carried.
+- `prompt.txt` is the merge instruction: "Base the integration branch on the release tag … Merge these refs in order … resolve conflicts completely … build the host CLI with `OPENCODE_CHANNEL=… OPENCODE_VERSION=… bun run build -- --single` … verify `--version`."
+- `package.json`: orw is MIT, `bin: { orw }`, `bunx @cortexkit/orw`-runnable, config-driven (`orw.config.json`: `release_repo`, `base_branch: dev`, `branches: []`, `agent`, `model`, `opencode_bin`). The harness mirrors this config + CLI shape.
+
+### Cut-over seam (action) — verified in-repo
+
+- The SDK spawns `opencode` **by name from PATH** (`src/features/agent/execution.ts` `createOpencode`; `src/features/agent/server.ts` `ensureOpenCodeAvailable` resolves `process.env.OPENCODE_PATH ?? 'opencode'`). `src/services/setup/opencode.ts` `installOpenCode()` downloads the stock binary and `runSetup()` `core.addPath()`s it. → The cutover **replaces** what `installOpenCode()` puts on PATH with the harness-published binary. SDK/event code is untouched.
+- `src/services/setup/tools-cache.ts` caches the opencode binary under a version-keyed tools-cache; the harness binary reuses this accelerator.
+- `DEFAULT_OPENCODE_VERSION` (`packages/runtime/src/shared/constants.ts`, Renovate-tracked, `<=1.15.13` cap) pins the base release the harness integrates onto.
+
+### Upstream build reality — verified in clonedeps
+
+- `packages/opencode/script/build.ts` is **not** a standalone compile: it runs `bun run --cwd ${appDir} build` (embedded app) and `bun install @opentui/core` / `@parcel/watcher` (platform-native deps). `.github/workflows/publish.yml` builds each platform on its **own native runner** (`macos-26`/`macos-26-intel`/`ubuntu`). → The harness build must check out the **full upstream repo** at the frozen integration commit and invoke upstream's real build script per platform; it cannot "compile just opencode" in isolation. The LLM merge also needs a bootstrap `opencode` on PATH to run the merge.
+
+### Institutional Learnings
+
+- `docs/solutions/build-errors/tool-binary-caching-ephemeral-runners.md` — OpenCode binary must be cached under a dedicated tools-cache key; `latest` is a non-determinism trap → the harness binary follows the same cache discipline; bumps are pinned.
+- `docs/solutions/build-errors/gateway-docker-runtime-resolution-crash-loop-2026-05-31.md` — ship compiled artifacts, not source-resolved entries → harness CLI ships built `dist/`; the per-platform packages ship native binaries.
+- `docs/solutions/best-practices/versioned-tool-config-plugin-pattern-2026-03-29.md` — pinned-version-constant + Renovate regex idiom → the base-release pin reuses it.
+
+### External References
+
+- `cortexkit/orw` (MIT) — the integration method embedded here.
+- `anomalyco/opencode` (MIT) `packages/opencode/script/build.ts` + `.github/workflows/publish.yml` — the per-platform native build model.
+- Live PR status (verified 2026-06-03): **#30182 MERGED→`dev`** (NOT in 1.15.13 tag — v1 carry; auto-drops when next release includes it); #28582, #26036 **CLOSED** (upstream-rejected, dropped); #20084, #19961 **OPEN**, base `dev` (watch/needs-empirical-check, NOT in v1 — see Carry Policy). Latest release 1.15.13.
+
+## Key Technical Decisions
+
+- **Embed orw's LLM-merge integration as the harness engine.** It is the only mechanism that carries `dev`-based refs onto a release tag. The merge runs at bump time, is maintainer-reviewed, and is frozen. *(supersedes brainstorm R4)*
+- **Harness is the default OpenCode for the action** — `installOpenCode()` is replaced to put the harness binary on PATH; the SDK is unchanged. Not opt-in. The shipped artifact is a native binary named `harness` that IS the pinned, patched OpenCode (a drop-in) with the carried refs baked into the binary dist — the way upstream ships its per-platform binaries. Installing it as the `opencode` on PATH (or invoking `harness` directly) both work since it is OpenCode with the integration applied.
+- **LLM merge off the hot path.** The action consumes the published, frozen, pre-built binary; the merge never runs during an action invocation.
+- **Determinism via frozen integration commit + pinned builds** (see "How determinism works"). Provenance pins refs by commit SHA + the integration commit SHA + build sha.
+- **Native per-platform distribution mirroring OpenCode** — full-repo build per native runner, `optionalDependencies` packaging, npm publish with provenance attestation, MIT attribution. Publish fenced to a protected workflow + maintainer gate.
+- **Deliberate, reviewed bumps** — scheduled detection → integrate → verify → bump PR; a failed integration opens a maintenance issue, never a silent red build.
+
+## Carry Policy
+
+The pipeline is the asset; the patch list stays boring. Target **1–3 carried refs max**. Every carried ref records: reason, owner, upstream status, drop condition, verification fixture. Re-gauge every upstream release tag.
+
+**A ref qualifies to carry only if it is one of:**
+1. **Merged-to-dev correctness fix not yet in stable** — small diff, clear Fro Bot impact, auto-drops on the next release that includes it (e.g. #30182).
+2. **Open/stalled upstream fix for Fro-Bot-critical behavior** — affects event-stream correctness, retry/error classification, permission flow, session durability, or Anthropic/OpenAI request correctness; has a failing fixture or reproducible incident; explicit carry owner.
+3. **Perf/DX/agent-quality patch with evidence** — before/after numbers required (token cost, latency, failure rate, degraded output). No vibes.
+4. **Stable-lane guardrail** — must preserve 1.15.x public behavior unless Fro Bot explicitly owns the divergence. No broad refactors, provider rewrites, or speculative plugin-API changes without a concrete Fro Bot failure.
+
+**Drop a carried ref when any of:** upstream stable release includes it; it stops applying cleanly and no longer has high value; upstream rejected it and Fro Bot lacks a concrete ongoing need; it changes event/API semantics without matching Fro Bot consumer handling; no recent incident/metric/test justifies the maintenance burden.
+
+**Drift controls:** keep the carry count tiny; prefer 'merged-to-dev, not yet released' over 'closed-rejected-forever'; don't carry a ref just because it was Fro-Bot-authored — past-authored stale PRs are guilty until re-proven useful; never leap ahead of the stable lane.
+
+**Watch-list (carry candidates, not yet carried):** Anthropic request correctness (signed thinking, redacted reasoning, tool-call ordering, prompt-cache boundaries); SSE/event robustness (message.part.updated/delta, session.idle/error, permission events); permission-flow reliability (asked/replied ordering, duplicate asks, cancellation, timeout); error classification (provider/LLM-retryable vs plugin/config/session-lifecycle); session/workspace routing (query:{directory}, remote attach, project-scoped listing); token/cost regressions (summarization/compaction/context transforms — with numbers).
+
+**#20084 (plugin.error vs session.error) — NEEDS-EMPIRICAL-CHECK before carrying:** structurally still relevant (Fro Bot treats session.error as retry signal in src/features/agent/streaming.ts and the gateway throws on it in run-core.ts; 1.15.13 publishes plugin-load failures as sessionless session.error). But carrying it changes the event contract, so promote only after a fixture proves: plugin load failure is surfaced clearly; it does NOT trigger LLM retry; it does NOT falsely fail an unrelated active session; a critical Fro Bot plugin failure is NOT silently swallowed. Tracked as a future carry candidate, not v1.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Integration mechanism → **LLM merge (orw method)**, not git am (the dev→tag base drift requires it).
+- Default vs opt-in → **harness replaces the stock opencode install; it is the default**.
+- Cut-over seam → replace what `installOpenCode()` puts on PATH (SDK spawns `opencode` by name — verified).
+- Build reality → full upstream-repo build per native runner (verified in clonedeps), not a standalone compile.
+- Initial carry set → v1 carries **#30182** (preserve signed Anthropic thinking during reorder) as the sole integration ref. It is MERGED to upstream `dev` but not in the 1.15.13 release tag, so the LLM merge carries it onto the tag — which is exactly why it's the ideal proof-carry: it genuinely exercises the dev→release-tag LLM-merge mechanism, delivers real Anthropic-model correctness value (Fro Bot runs Claude), is small/correctness-only, and AUTO-DROPS when the next upstream release includes it. #20084 and #19961 are NOT in v1 (see Carry Policy). #28582/#26036 dropped.
+
+### Deferred to Implementation
+
+- **Exact model/agent for the merge** (orw uses a configurable `model`; the harness merge runs in CI non-interactively — pick a capable model + the `build` agent; budget token cost per bump).
+- **Where the frozen integration commit lives** (a `fro-bot/opencode-integration` mirror branch vs an artifact-captured patch series re-derived from the frozen commit) and how per-platform build jobs check it out.
+- **Whether the tools-cache stores the resolved native binary directly vs the installed `@fro.bot/harness` package tree** (perf detail); the resolver flow itself is specified in Unit 4.
+- **(Specified in Unit 2 — stock base binary from a dedicated bootstrap cache key.)**
+
+## Output Structure
+
+    packages/harness/
+    ├── package.json            # @fro.bot/harness, public, type:module, bin:{harness}, optionalDependencies (per-platform), postinstall resolver
+    ├── tsconfig.json · tsdown.config.ts · AGENTS.md · LICENSE (MIT + OpenCode + orw attribution)
+    ├── harness.config.json     # release_repo, base pin, integration refs (PR/branch/local), model, agent
+    ├── prompt.txt              # the LLM-merge instruction (adapted from orw)
+    ├── src/
+    │   ├── cli.ts              # bin: passthrough + doctor/patches/info
+    │   ├── integrate.ts        # orw-embedded: detect release → clone@tag → fetch refs → opencode run (LLM merge) → build → verify → freeze
+    │   ├── sources.ts          # parseSource: PR URL / branch URL / local → fetch refs (orw parseSource)
+    │   ├── provenance.ts       # base tag + refs(SHA) + integration commit + build sha
+    │   └── resolve-binary.ts   # postinstall resolver: select+verify host binary
+    ├── scripts/
+    │   ├── build-platform.mjs       # per-platform: checkout frozen integration commit → upstream build → native binary
+    │   ├── verify-binary.mjs        # spike: --version == base, tool-output streams, integration markers present
+    │   └── *.test.mjs               # node --test for integrate/sources/provenance/verify logic
+    └── patches/README.md       # integration-ref policy + provenance format
+
+## Implementation Units
+
+- [ ] **Unit 1: `packages/harness/` published scaffold + CLI (passthrough + doctor/patches/info)**
+
+**Goal:** A public `@fro.bot/harness` package that builds with the repo toolchain, exposes a `bunx`-runnable `harness` bin (passthrough + provenance/operability commands), with the `optionalDependencies` + `postinstall` resolver skeleton.
+
+**Requirements:** R1, R2, R3, R9 (packaging skeleton), R18, R24
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/harness/{package.json,tsconfig.json,tsdown.config.ts,AGENTS.md,LICENSE}`, `packages/harness/src/{cli.ts,provenance.ts,resolve-binary.ts}`, `packages/harness/src/cli.test.ts`
+- Modify: root `package.json` script matrix + `pnpm-workspace.yaml`/`workspaces` to include the package; `.github/renovate.json5` (track the base-release pin)
+
+**Approach:** Mirror `packages/runtime`/`packages/gateway` (composite tsconfig, tsdown ESM) + add `bin` (first in-repo) + `optionalDependencies` per-platform + `postinstall` resolver + `publishConfig.access: public`. CLI: passthrough execs the resolved binary (args/stdio/env, propagate exit code); `info`/`--version`/`patches`/`doctor` read provenance. LICENSE = MIT + OpenCode + orw attribution.
+
+**Patterns to follow:** `packages/runtime` shape; orw `package.json` (`bin`, `bunx`, `publishConfig`).
+
+**Test scenarios:**
+- Happy: `harness info` prints base+refs+(placeholder)commit/sha; `--version` returns a string; `patches` lists configured refs.
+- Edge: `doctor` non-zero when no binary resolvable, zero when one is present.
+- Edge: passthrough forwards args + stdio + exit code; harness commands (info/patches/doctor) disambiguated from passthrough.
+
+**Verification:** `pnpm --filter @fro.bot/harness build` emits `dist/cli.mjs`; CLI runs; tests + types + lint clean.
+
+- [ ] **Unit 2: Integration engine — orw-embedded LLM merge onto the release tag**
+
+**Goal:** Given a pinned release + configured integration refs, base a branch on the release tag, fetch the refs, run the LLM merge (`opencode run`) to integrate + resolve conflicts, build the native CLI, verify `--version`, and freeze the integration commit + provenance.
+
+**Requirements:** R4′, R5, R6, R7, R11, R12
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `packages/harness/src/{integrate.ts,sources.ts}`, `packages/harness/prompt.txt`, `packages/harness/harness.config.json`, `packages/harness/scripts/integrate.test.mjs`, `packages/harness/scripts/sources.test.mjs`
+
+**Approach:** Port orw's `check`/`prep`/`render`/`parseSource`/`verifyBuild` into `integrate.ts`/`sources.ts`, adapted for CI/non-interactive use: clone the base repo, base the integration branch on `refs/tags/v<pin>`, fetch each ref (`parseSource`: PR `refs/pull/N/head`, branch, local), render `prompt.txt`, run `opencode run --agent build --model <model> <prompt>` (needs a bootstrap `opencode` on PATH), then build + verify `--version == base`. **Freeze** the resulting integration commit SHA + write the provenance manifest (base tag, ordered refs with resolved commit SHAs, integration commit SHA). On any failure (unresolved merge / build fail / version mismatch) → exit non-zero with the failure surfaced (R5). Initial `harness.config.json` carries **#30182** as `https://github.com/anomalyco/opencode/pull/30182` (the sole v1 integration ref).
+
+**CI merge runner contract (non-interactive determinism):** The `opencode run` merge runs headless in CI, so the job must specify: (a) a **pinned bootstrap `opencode`** version (see Unit 2 bootstrap below) and a **fixed model + `build` agent** (the merge model is a `harness.config.json` field; pick a capable model — the merge reasons over conflicts); (b) a **hard timeout** on the merge job and a **poll-to-terminal-state** loop (do not let bash background-promotion end the run — mirror orw's prompt.txt guidance that warns `background:true` breaks the non-interactive tool); (c) **explicit failure criteria** that abort the bump: merge left unresolved, build fails, or built `--version` != base; (d) **log/artifact capture** of the full merge transcript so the maintainer reviews a deterministic bump PR. The merge prompt is adapted from orw's prompt.txt (base branch on the release tag, merge refs in order, resolve conflicts completely, build the host CLI, verify version) and must retain the non-interactive guardrails (no background bash; poll completion).
+
+**Bootstrap opencode (chicken-and-egg):** the merge step needs a working stock `opencode` on PATH to run `opencode run` — but the harness PRODUCES opencode. Resolve by bootstrapping the **stock upstream release binary at the pinned base** (e.g. stock `opencode@1.15.13` from a **dedicated bootstrap cache key**, separate from the integration-artifact cache). The merge job runs with that bootstrap binary only; **fail the job if the bootstrap version != the declared base pin** (prevents version skew at the exact step where determinism matters most). Bootstrapping stock to build patched is sound — there is no circularity because the bootstrap is the unpatched base, used only to drive the merge, not shipped.
+
+**Execution note:** Test-first for `sources.parseSource` (ref mapping) and the fail-hard/freeze/provenance contract (the load-bearing guarantees). The actual `opencode run` merge is exercised by the Unit 4 CI integration job, not a unit test.
+
+**Patterns to follow:** orw `src/index.ts` `parseSource` (lines ~632-680), `prep`/`render`/`check` (lines ~297-456), `prompt.txt`; `deploy/scripts/*.mjs` + `node --test` style.
+
+**Test scenarios:**
+- Happy: `parseSource` maps a PR URL → `refs/pull/N/head`, a `/tree/` URL → branch ref, a local name → `refs/heads/<b>` (mirror orw).
+- Error (R5): a stubbed merge/build failure → `integrate` exits non-zero, freezes nothing, surfaces which ref/step failed.
+- Edge: empty ref set → integration = the release tag unchanged; provenance manifest is base-only and valid.
+- Integration: the provenance manifest content matches what `harness info`/`patches` reports (single source of truth).
+
+**Verification:** running `integrate` against `v1.15.13` with the bootstrap opencode fetches the refs, the LLM merge integrates #30182 onto the tag, the built CLI reports `1.15.13`, and a frozen integration commit + manifest are produced.
+
+- [ ] **Unit 3: Native per-platform build + distribution (optionalDependencies, npm publish, provenance)**
+
+**Goal:** Build the integrated OpenCode to native binaries for the full matrix from the frozen integration commit, package as a main + per-platform `optionalDependencies` set, and publish to npm with provenance attestation + MIT attribution, fenced to a protected workflow.
+
+**Requirements:** R8, R19, R9, R10, R20, R21, R23, R24, R25
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Create: `packages/harness/scripts/build-platform.mjs`, `packages/harness/scripts/verify-binary.mjs`, `.github/workflows/harness-release.yaml` (per-platform native runners → build → verify → assemble → publish, maintainer-gated)
+- Modify: `packages/harness/package.json` (`optionalDependencies` + `postinstall` resolver finalized)
+
+**Build-environment contract:** upstream `packages/opencode/script/build.ts` is a full-repo build (embedded-app build + native `@opentui/core`/`@parcel/watcher` install), not a standalone compile. Each per-platform job must: pin the **Bun version** (match upstream's `packageManager`/declared bun), check out the **full upstream repo** at the frozen integration commit (native-dep install + embedded-app build happen under the **upstream repo root**, not the harness package), and run the build with the release-identity env orw's prompt.txt uses — `OPENCODE_CHANNEL=<stable> OPENCODE_VERSION=<base> bun run build -- --single` (or the fork's equivalent flags). Verify the built binary `--version` == base before packaging.
+
+**Approach:** Per platform on its **own native runner** (mirror upstream `publish.yml`): check out the **full upstream repo** at the frozen integration commit → run upstream's real build (`packages/opencode/script/build.ts`, the embedded-app + native-dep build) → emit the native binary → `verify-binary.mjs` (version == base, tool-output streams, integration markers present). Assemble the main package + per-platform packages; publish **all-or-nothing** with npm provenance attestation; `postinstall` resolver selects + integrity-verifies the host binary **before** exec (R20). Publish fenced to the protected workflow + maintainer gate (R21).
+
+**Patterns to follow:** upstream `.github/workflows/publish.yml` matrix; OpenCode `script/publish.ts` `optionalDependencies` model; the gateway image-smoke job shape for a build+smoke job.
+
+**Test scenarios:**
+- Happy: each platform leg builds a binary; `verify-binary.mjs` asserts version + integration marker + tool-output → zero.
+- Error: wrong version / missing marker / unverified integrity → `verify-binary`/resolver exits non-zero (the spike + resolver actually gate).
+- Edge: a missing platform leg blocks the whole publish (all-or-nothing, R25).
+- Test expectation: build/publish exercised by the CI workflow; `verify-binary.mjs` + `resolve-binary.ts` have `node --test`/unit coverage against stubs.
+
+**Verification:** `harness-release.yaml` builds the matrix from the frozen commit, verifies, and publishes a provenance-attested package set; `bunx @fro.bot/harness info` on a host resolves the right binary.
+
+- [ ] **Unit 4: Action cutover — harness binary becomes the default OpenCode**
+
+**Goal:** The action setup installs the harness-published binary as `opencode` (replacing the stock download) as the **default**, CI-proven to stream tool output end-to-end through the real harness path.
+
+**Requirements:** R15′, R17
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `src/services/setup/opencode.ts` / `src/services/setup/setup.ts` (install the harness binary as the `opencode` on PATH instead of the stock GitHub-release download), `src/services/setup/tools-cache.ts` (cache key/paths for the harness binary)
+- Modify: `.github/workflows/ci.yaml` (the agent/review path runs on the harness binary and asserts tool-output renders — the SDK-level R17 proof)
+- Test: `src/services/setup/*.test.ts` (the install path now resolves the harness binary)
+
+**Source-of-binary (the critical seam):** setup installs the published **`@fro.bot/harness`** package; its `postinstall` resolver selects the host-platform `optionalDependencies` package and exposes the native binary; setup **integrity-verifies** it and **caches it under the existing tools-cache key** (extend the key with the harness/base version + frozen integration commit), then `addPath`s it as the `opencode` on PATH. If the published package or the host-platform binary is **missing or fails integrity** (e.g. a publish is mid-flight or partial), setup **fails loud with an actionable error** — no silent stock fallback (the harness is the default; its absence is an error, not a degraded mode).
+
+**Approach:** Replace the stock `installOpenCode()` acquisition with `@fro.bot/harness` resolution (npm/bunx into the tools-cache → `addPath` the resolved binary as `opencode`). SDK/event code (`server.ts`, `execution.ts`, `streaming.ts`, `retry.ts`) is **untouched** — it spawns `opencode` by name. CI runs the real agent path on the harness binary and asserts the `| Bash` tool line + assistant text render (reuse the proven 1.15.13 tool-output assertion) — the consumer-level R17 check. Update setup/docs to reflect the harness as the OpenCode source.
+
+**Execution note:** Characterization-first — capture the current stock-install behavior, then replace it, asserting the agent path still streams tool output on the harness binary.
+
+**Patterns to follow:** `installOpenCode()` + `core.addPath()` seam; tools-cache version-keying; the lean-path tool-output CI assertion.
+
+**Test scenarios:**
+- Happy: setup resolves + installs the harness binary as `opencode`; `--version` reports the base release; `harness info` reports the integration refs.
+- Integration: the CI agent path renders tool output on the harness binary (SDK-level R17).
+- Error: harness binary unavailable → setup fails loud (no silent fallback to stock — the harness is the default, its absence is an error).
+
+**Verification:** CI shows the agent streaming tool output on the harness binary as the default; setup tests updated; `dist/` in sync if the action surface changed.
+
+- [ ] **Unit 5: Scheduled deliberate-bump pipeline + maintainer review**
+
+**Goal:** A scheduled CI job detects new upstream releases, runs the integration + verification, and opens a **bump PR only when green** (maintainer reviews the frozen LLM-merge result); a failed integration opens a maintenance issue. Never auto-merged.
+
+**Requirements:** R13, R14, R5/R26
+
+**Dependencies:** Units 2-3
+
+**Files:**
+- Create: `.github/workflows/harness-bump.yaml` (scheduled: detect latest release vs pin → run integrate → verify → on green open a bump PR updating the base pin + frozen integration commit; on failure open a maintenance issue)
+
+**Approach:** Mirror orw's `check` cadence as CI: compare latest upstream release to the pinned base; if newer, run `integrate` (LLM merge onto the new tag) + `verify-binary`; on green, open a bump PR (updates `DEFAULT_OPENCODE_VERSION`/the harness base pin + the frozen integration commit + provenance) for maintainer review; on a merge/build/spike failure, open a maintenance issue naming the conflicting ref + step (R26). Never auto-merge (R14).
+
+**Patterns to follow:** orw `check`/`latest`; the repo's existing scheduled-workflow + bump-PR patterns; the patch-conflict→maintenance-issue policy.
+
+**Test scenarios:**
+- Happy: new release + clean integration + green spike → a bump PR is opened with updated pins + provenance.
+- Error: integration fails on the new base → no bump PR; a maintenance issue is opened naming the failing ref/step.
+- Edge: no new release → no-op.
+- Test expectation: the workflow is validated by a manual dispatch run; the detect/compare logic has unit coverage.
+
+**Verification:** a manual dispatch against a newer (or forced) release runs the integration and opens either a bump PR (green) or a maintenance issue (fail), never auto-merging.
+
+## System-Wide Impact
+
+- **Interaction graph:** Unit 4 replaces the OpenCode acquisition in setup; the SDK spawn path is unchanged (binary is `opencode` on PATH). The LLM merge is build/bump-time only — never in an action run.
+- **Error propagation:** integration, build, publish, and the action install all **fail loud** — unresolved merge/build/version-mismatch blocks the bump and opens a maintenance issue; a missing harness binary fails setup (no silent stock fallback, since the harness is the default).
+- **State lifecycle:** the harness binary follows the existing tools-cache discipline; the frozen integration commit + provenance manifest are the durable pinned state.
+- **API surface parity:** the published `@fro.bot/harness` is a new external artifact; the base-release pin stays Renovate-tracked.
+- **Integration coverage:** the Unit 4 CI agent-path proof and the Unit 3 per-platform verify-binary spike are the cross-layer guarantees unit tests can't provide.
+- **Unchanged invariants:** the SDK/event/streaming code; the tools-cache accelerator pattern; `<=1.15.13` base pin until a reviewed bump. **Changed invariant (intended):** the action's OpenCode source is now the harness binary, not the stock GitHub-release download.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| LLM merge is non-deterministic / could mis-resolve a conflict | Runs once per bump, **maintainer-reviewed** as the bump PR, then **frozen**; builds pin to the frozen commit; `verify-binary` asserts version + tool-output before publish. |
+| The merge needs a bootstrap `opencode` + model tokens in CI | Pin a bootstrap opencode; budget per-bump token cost; the merge is bump-time only, not per-action. |
+| Upstream build is a full-repo build (embedded app + native deps), not a standalone compile | Build jobs check out the full upstream repo at the frozen commit and run upstream's real build per native runner (verified in clonedeps). |
+| Carrying CLOSED/stalled PRs is an indefinite re-merge tax | Governed by the Carry Policy: v1 carries only #30182 (merged-to-dev, auto-drops on the next release that includes it), keeping the indefinite-carry tax near zero for v1. Provenance flags upstream-rejected refs; the scheduled bump re-runs the LLM merge each release; a documented drop/upstream threshold per ref per the Carry Policy. |
+| Harness publish/supply-chain is a new trust surface | Fenced publish workflow + maintainer gate; npm provenance attestation; resolver integrity-verifies before exec; all-or-nothing matrix. |
+| Action depends on a published external package for its core runtime | Tools-cache accelerator + integrity pin; setup fails loud if unavailable; bumps are deliberate/reviewed. |
+
+## Documentation / Operational Notes
+
+- `packages/harness/AGENTS.md` + `patches/README.md` document the integration-ref policy, the LLM-merge + freeze model, the provenance format, and the bump cadence.
+- Strong `ce:compound` candidate post-merge: "patched-dependency via LLM-merge integration + frozen-commit determinism" — no existing docs/solutions covers it.
+- Gateway/workspace cutover (R16) is the immediate documented fast-follow once the action validates the harness in production.
+
+## Sources & References
+
+- **Origin:** [docs/brainstorms/2026-06-02-fro-bot-harness-patched-opencode-requirements.md](docs/brainstorms/2026-06-02-fro-bot-harness-patched-opencode-requirements.md) (full-harness spec; R4 corrected here to LLM-merge per orw)
+- Integration method: `cortexkit/orw` (`src/index.ts`, `prompt.txt`, `package.json`) — embedded as the harness engine
+- Build/publish model: `anomalyco/opencode` `packages/opencode/script/build.ts`, `script/publish.ts`, `.github/workflows/publish.yml`
+- Cut-over seam: `src/services/setup/opencode.ts`, `src/services/setup/setup.ts`, `src/features/agent/server.ts`, `src/services/setup/tools-cache.ts`
+- Carry candidates (verified 2026-06-03): anomalyco/opencode **#30182 = v1 carry** (MERGED→`dev`, not in 1.15.13 tag; auto-drops when next release includes it); #20084, #19961 = watch/needs-empirical-check (OPEN, dev-based; NOT in v1 — see Carry Policy); #28582, #26036 = dropped (CLOSED, upstream-rejected)

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   ],
   "scripts": {
     "bootstrap": "SKIP_INSTALL_SIMPLE_GIT_HOOKS=1 pnpm install --no-strict-peer-dependencies --prefer-offline --loglevel warn",
-    "build": "pnpm --filter @fro-bot/runtime build && pnpm --filter @fro-bot/action build",
-    "check-types": "pnpm --filter @fro-bot/runtime check-types && pnpm --filter @fro-bot/action check-types",
-    "fix": "pnpm --filter @fro-bot/runtime fix && pnpm --filter @fro-bot/action fix",
+    "build": "pnpm --filter @fro-bot/runtime build && pnpm --filter @fro-bot/action build && pnpm --filter @fro.bot/harness build",
+    "check-types": "pnpm --filter @fro-bot/runtime check-types && pnpm --filter @fro-bot/action check-types && pnpm --filter @fro.bot/harness check-types",
+    "fix": "pnpm --filter @fro-bot/runtime fix && pnpm --filter @fro-bot/action fix && pnpm --filter @fro.bot/harness fix",
     "postinstall": "simple-git-hooks",
-    "lint": "pnpm --filter @fro-bot/runtime lint && pnpm --filter @fro-bot/action lint",
-    "test": "pnpm --filter @fro-bot/runtime test && pnpm --filter @fro-bot/action test"
+    "lint": "pnpm --filter @fro-bot/runtime lint && pnpm --filter @fro-bot/action lint && pnpm --filter @fro.bot/harness lint",
+    "test": "pnpm --filter @fro-bot/runtime test && pnpm --filter @fro-bot/action test && pnpm --filter @fro.bot/harness test"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm exec lint-staged",

--- a/packages/harness/AGENTS.md
+++ b/packages/harness/AGENTS.md
@@ -25,18 +25,35 @@ Provenance = upstream release tag + ordered integration refs (each pinned by ups
 
 The LLM merge runs **once per release bump** in CI, is maintainer-reviewed as the bump PR, and is **frozen** — its SHA is pinned. Per-platform builds pin to the frozen integration commit. The action consumes the published, frozen, pre-built binary; the merge never runs during an action invocation.
 
-## Per-Platform Distribution (Unit 3 target)
+## Per-Platform Distribution
 
-The harness ships as a main `@fro.bot/harness` package + per-platform `optionalDependencies`:
+The harness ships as a main `@fro.bot/harness` package + per-platform packages:
 
 - `@fro.bot/harness-linux-x64`
 - `@fro.bot/harness-linux-arm64`
 - `@fro.bot/harness-darwin-x64`
 - `@fro.bot/harness-darwin-arm64`
 
-These packages do not exist yet (Unit 3 builds and publishes them). The `resolve-binary.ts` module will be extended in Unit 3 to select the host-platform binary from the installed optionalDependency package, verify its integrity, and return it. The current scaffold falls back to `opencode` on PATH.
+Each per-platform package contains only that platform's native binary. The main package's `bin` shim + `postinstall` resolver (`resolve-binary.ts` → `platform.ts`) select the host's binary by computed package name (`@fro.bot/harness-<os>-<arch>`) and verify it before exec; `OPENCODE_PATH` and a bare `opencode` on PATH are honored as fallbacks for local/unbuilt use.
 
-`optionalDependencies` is intentionally **empty** in the scaffold — the per-platform packages don't exist yet and adding them as real deps would break `pnpm install`. Unit 3 adds them once the packages are published.
+The per-platform packages are **not listed in the source `package.json` `optionalDependencies`** — that keeps the workspace `pnpm-lock.yaml` clean (the packages only exist on npm after a release). The release workflow **injects** `optionalDependencies` (pinned to the release version) into the published main package's `package.json` at publish time.
+
+## Publishing
+
+The packages are published to npm via **trusted publishing (OIDC)** from the release workflow (`.github/workflows/harness-release.yaml`) — no long-lived npm token. The workflow has `id-token: write`, upgrades npm to a trusted-publishing-capable version (npm ≥ 11.5.0; Node 24 ships an older npm), and runs a bare `npm publish` (provenance is automatic under OIDC; `--provenance`/`--access` flags are not needed — access is set via each package's `publishConfig`).
+
+### One-time npmjs.com setup (per package)
+
+Trusted publishing trusts at the **package level**, so each of the five packages (`@fro.bot/harness` + the four `@fro.bot/harness-<os>-<arch>` packages) needs its own trusted-publisher configured once on npmjs.com → the package's Settings → Trusted publishing → GitHub Actions:
+
+- **Organization or user:** `fro-bot`
+- **Repository:** `agent`
+- **Workflow filename:** `harness-release.yaml`
+- **Environment:** (leave blank)
+
+### First-publish bootstrap
+
+npm trusted publishing requires a package to **already exist** before it will accept OIDC publishes — a brand-new, never-published package cannot be trust-published from scratch. So the very first release of these five packages needs a bootstrap publish (a one-time token-authenticated `npm publish`, or npm's pre-registered pending-publisher flow for new packages), after which the trusted-publisher config above governs all subsequent releases with no token.
 
 ## Carry Policy
 

--- a/packages/harness/AGENTS.md
+++ b/packages/harness/AGENTS.md
@@ -1,0 +1,76 @@
+# Harness Package — Agent Notes
+
+`@fro.bot/harness` is the **default OpenCode for Fro Bot**: a published, patched OpenCode binary built via orw's LLM-merge integration method. It replaces the stock OpenCode download in the action setup.
+
+## Purpose
+
+The harness embeds [cortexkit/orw](https://github.com/cortexkit/orw)'s integration method: on each deliberately-pinned upstream OpenCode release, it bases an integration branch on the release tag, fetches a configured set of integration refs (stalled/closed upstream PRs, branch URLs), and runs an LLM merge (`opencode run`) to carry those refs onto the release tag — resolving the base drift that `git am`/cherry-pick cannot handle. The produced per-platform binary is the `harness` binary (the patched OpenCode), shipped in the package dist.
+
+## CLI Contract
+
+```
+harness <opencode-args...>   Pass through to the patched OpenCode binary (drop-in)
+harness info                 Print provenance (base version, integration refs, build sha)
+harness patches              List configured integration refs
+harness doctor               Check the resolved binary is present and runnable
+harness --version            Print harness provenance version
+harness --help               Print usage
+```
+
+**Disambiguation rule:** `info`, `patches`, `doctor` are harness-own subcommands. `--version` and `--help` are harness-own. Everything else passes through to the patched binary with inherited stdio, env, and exit code propagation.
+
+## Provenance Model
+
+Provenance = upstream release tag + ordered integration refs (each pinned by upstream commit SHA) + frozen integration commit SHA + build sha. `harness info`/`patches`/`doctor` report this.
+
+The LLM merge runs **once per release bump** in CI, is maintainer-reviewed as the bump PR, and is **frozen** — its SHA is pinned. Per-platform builds pin to the frozen integration commit. The action consumes the published, frozen, pre-built binary; the merge never runs during an action invocation.
+
+## Per-Platform Distribution (Unit 3 target)
+
+The harness ships as a main `@fro.bot/harness` package + per-platform `optionalDependencies`:
+
+- `@fro.bot/harness-linux-x64`
+- `@fro.bot/harness-linux-arm64`
+- `@fro.bot/harness-darwin-x64`
+- `@fro.bot/harness-darwin-arm64`
+
+These packages do not exist yet (Unit 3 builds and publishes them). The `resolve-binary.ts` module will be extended in Unit 3 to select the host-platform binary from the installed optionalDependency package, verify its integrity, and return it. The current scaffold falls back to `opencode` on PATH.
+
+`optionalDependencies` is intentionally **empty** in the scaffold — the per-platform packages don't exist yet and adding them as real deps would break `pnpm install`. Unit 3 adds them once the packages are published.
+
+## Carry Policy
+
+The pipeline is the asset; the patch list stays boring. Target 1–3 carried refs max. Every carried ref records: reason, owner, upstream status, drop condition. Re-gauge every upstream release tag.
+
+A ref qualifies to carry only if it is:
+1. Merged-to-dev correctness fix not yet in stable (auto-drops on the next release that includes it).
+2. Open/stalled upstream fix for Fro-Bot-critical behavior with a failing fixture or reproducible incident.
+3. Perf/DX/agent-quality patch with before/after evidence (numbers required).
+4. Stable-lane guardrail — must preserve public behavior unless Fro Bot explicitly owns the divergence.
+
+Drop a carried ref when: upstream stable release includes it; it stops applying cleanly; upstream rejected it and Fro Bot lacks a concrete ongoing need; no recent incident/metric/test justifies the maintenance burden.
+
+## Conventions
+
+- ESM-only, Node 24, `type: "module"`.
+- Functions only — no classes.
+- Explicit boolean checks — no implicit falsy (`!value`); use `=== null`, `=== undefined`, `.length === 0`.
+- `readonly` on all interface properties.
+- No `as any`, `@ts-ignore`, `@ts-expect-error`.
+- Logger injection where applicable; no `console.log` in library code (CLI entry point is the exception).
+- Vitest for tests; BDD comments (`// #given`, `// #when`, `// #then`).
+
+## Build
+
+```bash
+pnpm --filter @fro.bot/harness build       # type-check + bundle → dist/cli.mjs
+pnpm --filter @fro.bot/harness check-types # tsc --noEmit only
+pnpm --filter @fro.bot/harness test        # vitest
+pnpm --filter @fro.bot/harness lint        # eslint
+```
+
+The build produces `dist/cli.mjs` — the `harness` bin entry point.
+
+## Attribution
+
+This package embeds orw's integration method (MIT, cortexkit/orw) and redistributes a modified OpenCode build (MIT, anomalyco/opencode). See LICENSE for full attribution.

--- a/packages/harness/LICENSE
+++ b/packages/harness/LICENSE
@@ -1,0 +1,76 @@
+MIT License
+
+Copyright (c) 2026 Fro Bot <agent@fro.bot>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+This package embeds the integration method from cortexkit/orw and redistributes
+a modified build of anomalyco/opencode. Both upstream projects are MIT-licensed.
+
+---
+
+cortexkit/orw (integration method)
+MIT License
+Copyright (c) Cortexkit
+https://github.com/cortexkit/orw
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+anomalyco/opencode (modified binary distribution)
+MIT License
+Copyright (c) 2024 SST Inc.
+https://github.com/anomalyco/opencode
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/harness/harness.config.json
+++ b/packages/harness/harness.config.json
@@ -1,0 +1,9 @@
+{
+  "release_repo": "anomalyco/opencode",
+  "source_repo": "https://github.com/anomalyco/opencode.git",
+  "base_version": "1.15.13",
+  "integrationRefs": ["https://github.com/anomalyco/opencode/pull/30182"],
+  "agent": "build",
+  "model": "anthropic/claude-sonnet-4-6",
+  "opencode_bin": "opencode"
+}

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@fro.bot/harness",
+  "version": "0.0.0-development",
+  "description": "Published patched-OpenCode binary with orw-embedded LLM-merge integration — the default OpenCode for Fro Bot",
+  "keywords": [
+    "opencode",
+    "fro-bot",
+    "harness",
+    "cli"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fro-bot/agent.git"
+  },
+  "license": "MIT",
+  "author": "Fro Bot <agent@fro.bot>",
+  "type": "module",
+  "bin": {
+    "harness": "./dist/cli.mjs"
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "dist"
+  ],
+  "scripts": {
+    "build": "pnpm exec tsc -p tsconfig.json --noEmit && pnpm exec tsdown src/cli.ts --format esm --out-dir dist",
+    "check-types": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "fix": "pnpm --dir ../.. exec eslint --fix packages/harness/src",
+    "lint": "pnpm --dir ../.. exec eslint packages/harness/src",
+    "test": "pnpm exec vitest run --passWithNoTests src"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -27,8 +27,8 @@
   "scripts": {
     "build": "pnpm exec tsc -p tsconfig.json --noEmit && pnpm exec tsdown",
     "check-types": "pnpm exec tsc -p tsconfig.json --noEmit",
-    "fix": "pnpm --dir ../.. exec eslint --fix packages/harness/src",
-    "lint": "pnpm --dir ../.. exec eslint packages/harness/src",
+    "fix": "pnpm --dir ../.. exec eslint --fix packages/harness/src packages/harness/scripts",
+    "lint": "pnpm --dir ../.. exec eslint packages/harness/src packages/harness/scripts",
     "postinstall": "node dist/postinstall.mjs || true",
     "test": "pnpm exec vitest run --passWithNoTests src"
   },

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -21,13 +21,15 @@
   "files": [
     "LICENSE",
     "README.md",
-    "dist"
+    "dist",
+    "provenance.json"
   ],
   "scripts": {
-    "build": "pnpm exec tsc -p tsconfig.json --noEmit && pnpm exec tsdown src/cli.ts --format esm --out-dir dist",
+    "build": "pnpm exec tsc -p tsconfig.json --noEmit && pnpm exec tsdown",
     "check-types": "pnpm exec tsc -p tsconfig.json --noEmit",
     "fix": "pnpm --dir ../.. exec eslint --fix packages/harness/src",
     "lint": "pnpm --dir ../.. exec eslint packages/harness/src",
+    "postinstall": "node dist/postinstall.mjs || true",
     "test": "pnpm exec vitest run --passWithNoTests src"
   },
   "engines": {

--- a/packages/harness/prompt.txt
+++ b/packages/harness/prompt.txt
@@ -1,0 +1,34 @@
+You are working in a disposable automation clone at {{repo}}.
+
+Goal: integrate upstream release {{tag}} with the selected branches/PRs {{branches}} without pushing anything.
+
+Requirements:
+- Work only in this automation clone.
+- Do not open a PR.
+- Do not push.
+- Do NOT ask for final approval.
+- DO NOT USE BASH with background: true. This will cause this non-interactive tool to exit before the job is done. If bash gets auto-promoted to background, poll bash_status even when the tool says otherwise. This is IMPORTANT because you are running in non-interactive mode — if you end your response, you will not get the notification.
+- Base the integration branch on the release tag {{tag}}, not on dev HEAD.
+- Name the branch {{branch}}.
+- Merge these refs in order: {{merges}}.
+- If there are merge conflicts, resolve them completely.
+- Build the host CLI.
+- The CLI must be compiled with stable release identity: OPENCODE_CHANNEL={{channel}} and OPENCODE_VERSION={{version}}.
+
+Exact tasks:
+1. Verify the repo is usable and fetch anything you need.
+2. Create or reset {{branch}} to refs/tags/{{tag}}.
+3. Merge {{merges}} into {{branch}}.
+4. Build the host CLI in `packages/opencode` with `OPENCODE_CHANNEL={{channel}} OPENCODE_VERSION={{version}} bun run build -- --single`.
+5. Ensure the built CLI binary exists at the expected path under `packages/opencode/dist/`.
+6. Run the built CLI with `--version` and verify the output is exactly `{{version}}`.
+7. Return a concise summary with the final branch name and artifact paths.
+
+Context:
+- Upstream repo: {{release_repo}}
+- Base branch: dev
+- Release URL: {{release_url}}
+- Integration refs:
+- {{sources}}
+
+If anything fails, fix it and continue until the branch is integrated and the configured build succeeds.

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -1,0 +1,317 @@
+#!/usr/bin/env bun
+/**
+ * build-platform.ts — per-platform native build of the integrated OpenCode.
+ *
+ * Given the frozen integration commit (from Unit 2's provenance manifest) and a
+ * target platform, checks out the FULL upstream repo at that commit, runs upstream's
+ * real build (packages/opencode/script/build.ts — the embedded-app + native-dep build)
+ * with the release-identity env, and emits the native binary for that platform.
+ *
+ * Build-environment contract (from the plan):
+ *   - Bun version is pinned to match upstream's packageManager (bun@1.3.13).
+ *   - The full upstream repo is checked out at the frozen integration commit.
+ *   - Native-dep install + embedded-app build happen under the UPSTREAM repo root.
+ *   - Build runs with: OPENCODE_CHANNEL=latest OPENCODE_VERSION=<base> bun run build -- --single
+ *   - Built binary --version is verified == base before emitting.
+ *
+ * Usage:
+ *   bun run packages/harness/scripts/build-platform.ts \
+ *     --integration-commit <sha> \
+ *     --base-version <version> \
+ *     --platform <linux|darwin> \
+ *     --arch <x64|arm64> \
+ *     --repo-url <https://github.com/anomalyco/opencode.git> \
+ *     --work-dir <path> \
+ *     --out-dir <path>
+ *
+ * The script exits non-zero on any failure (version mismatch, build error, etc.).
+ * It does NOT run a real build when --help is passed.
+ */
+
+import {execFileSync, spawnSync} from 'node:child_process'
+import {cpSync, existsSync, mkdirSync} from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+// ---------------------------------------------------------------------------
+// Build-environment contract constants
+// ---------------------------------------------------------------------------
+
+/** Pinned Bun version — matches upstream anomalyco/opencode packageManager field. */
+const REQUIRED_BUN_VERSION = '1.3.13'
+
+/** The release channel used for the build identity env. */
+const OPENCODE_CHANNEL = 'latest'
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+interface BuildArgs {
+  readonly integrationCommit: string
+  readonly baseVersion: string
+  readonly platform: string
+  readonly arch: string
+  readonly repoUrl: string
+  readonly workDir: string
+  readonly outDir: string
+}
+
+function parseArgs(argv: string[]): BuildArgs | null {
+  const args = argv.slice(2)
+
+  if (args.includes('--help') || args.includes('-h')) {
+    printHelp()
+    process.exit(0)
+  }
+
+  function flag(name: string): string | null {
+    const idx = args.indexOf(name)
+    if (idx === -1) return null
+    const val = args[idx + 1]
+    return val !== undefined && !val.startsWith('--') ? val : null
+  }
+
+  const integrationCommit = flag('--integration-commit')
+  const baseVersion = flag('--base-version')
+  const platform = flag('--platform')
+  const arch = flag('--arch')
+  const repoUrl = flag('--repo-url') ?? 'https://github.com/anomalyco/opencode.git'
+  const workDir = flag('--work-dir') ?? path.join(process.cwd(), '.harness-build-work')
+  const outDir = flag('--out-dir') ?? path.join(process.cwd(), '.harness-build-out')
+
+  if (integrationCommit === null || baseVersion === null || platform === null || arch === null) {
+    console.error('[build-platform] Missing required arguments.')
+    console.error('  Required: --integration-commit, --base-version, --platform, --arch')
+    printHelp()
+    process.exit(1)
+  }
+
+  return {integrationCommit, baseVersion, platform, arch, repoUrl, workDir, outDir}
+}
+
+function printHelp(): void {
+  console.log(String.raw`
+build-platform.ts — per-platform native build of the integrated OpenCode
+
+Usage:
+  bun run packages/harness/scripts/build-platform.ts \
+    --integration-commit <sha>          Frozen integration commit SHA (from provenance manifest)
+    --base-version <version>            Base release version (e.g. 1.15.13)
+    --platform <linux|darwin>           Target OS (linux or darwin; no windows)
+    --arch <x64|arm64>                  Target CPU arch
+    [--repo-url <url>]                  Upstream repo URL (default: anomalyco/opencode)
+    [--work-dir <path>]                 Working directory for the clone (default: .harness-build-work)
+    [--out-dir <path>]                  Output directory for the native binary (default: .harness-build-out)
+    [--help]                            Print this help
+
+Build-environment contract:
+  - Bun ${REQUIRED_BUN_VERSION} required (matches upstream packageManager).
+  - Full upstream repo checked out at the frozen integration commit.
+  - Build: OPENCODE_CHANNEL=${OPENCODE_CHANNEL} OPENCODE_VERSION=<base> bun run build -- --single
+  - Built binary --version verified == base before emitting.
+  - Exits non-zero on any failure.
+`)
+}
+
+// ---------------------------------------------------------------------------
+// Bun version enforcement
+// ---------------------------------------------------------------------------
+
+function enforceBunVersion(): void {
+  let actual: string
+  try {
+    const result = execFileSync('bun', ['--version'], {encoding: 'utf8', timeout: 10_000})
+    actual = result.trim()
+  } catch {
+    console.error(`[build-platform] bun not found on PATH. Install bun@${REQUIRED_BUN_VERSION}`)
+    process.exit(1)
+  }
+
+  if (actual !== REQUIRED_BUN_VERSION) {
+    console.error(
+      `[build-platform] Bun version mismatch: got ${actual}, required ${REQUIRED_BUN_VERSION}. ` +
+        `Install the pinned version: curl -fsSL https://bun.sh/install | bash -s "bun-v${REQUIRED_BUN_VERSION}"`,
+    )
+    process.exit(1)
+  }
+
+  console.log(`[build-platform] Bun version ok: ${actual}`)
+}
+
+// ---------------------------------------------------------------------------
+// Git operations
+// ---------------------------------------------------------------------------
+
+function gitExec(args: string[], cwd?: string): void {
+  const result = spawnSync('git', args, {
+    cwd,
+    stdio: 'inherit',
+    encoding: 'utf8',
+  })
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed with exit code ${result.status ?? 'unknown'}`)
+  }
+}
+
+function cloneAndCheckout(repoUrl: string, workDir: string, commit: string): void {
+  if (existsSync(workDir)) {
+    console.log(`[build-platform] Work dir exists, fetching and resetting to ${commit}`)
+    gitExec(['fetch', 'origin'], workDir)
+    gitExec(['checkout', '--detach', commit], workDir)
+    gitExec(['clean', '-fdx'], workDir)
+  } else {
+    console.log(`[build-platform] Cloning ${repoUrl} into ${workDir}`)
+    gitExec(['clone', repoUrl, workDir])
+    gitExec(['checkout', '--detach', commit], workDir)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Build invocation
+// ---------------------------------------------------------------------------
+
+function runUpstreamBuild(workDir: string, baseVersion: string): void {
+  const opencodeDir = path.join(workDir, 'packages', 'opencode')
+  console.log(`[build-platform] Running upstream build in ${opencodeDir}`)
+  console.log(`[build-platform] Env: OPENCODE_CHANNEL=${OPENCODE_CHANNEL} OPENCODE_VERSION=${baseVersion}`)
+
+  // Install native deps first (mirrors upstream build.ts skipInstall=false path).
+  // The upstream build.ts does this internally, but we invoke it via `bun run build -- --single`
+  // which triggers the full build.ts including the bun install steps.
+  const result = spawnSync('bun', ['run', 'build', '--', '--single'], {
+    cwd: opencodeDir,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      OPENCODE_CHANNEL,
+      OPENCODE_VERSION: baseVersion,
+    },
+    timeout: 30 * 60 * 1000, // 30-minute hard timeout
+  })
+
+  if (result.status !== 0) {
+    throw new Error(`Upstream build failed with exit code ${result.status ?? 'unknown'}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Binary resolution and version verification
+// ---------------------------------------------------------------------------
+
+function resolveBuiltBinaryPath(workDir: string, platform: string, arch: string): string {
+  // Upstream build.ts emits to: packages/opencode/dist/opencode-<os>-<arch>/bin/opencode
+  const name = `opencode-${platform}-${arch}`
+  const binary = 'opencode'
+  return path.join(workDir, 'packages', 'opencode', 'dist', name, 'bin', binary)
+}
+
+function verifyBuiltBinary(binaryPath: string, expectedVersion: string): void {
+  console.log(`[build-platform] Verifying binary: ${binaryPath} --version`)
+
+  if (!existsSync(binaryPath)) {
+    throw new Error(`Built binary not found at: ${binaryPath}`)
+  }
+
+  let actual: string
+  try {
+    const output = execFileSync(binaryPath, ['--version'], {
+      encoding: 'utf8',
+      timeout: 30_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    actual = output.trim()
+  } catch (error) {
+    throw new Error(`Binary --version failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  if (actual !== expectedVersion) {
+    throw new Error(`Version mismatch: got '${actual}', expected '${expectedVersion}'`)
+  }
+
+  console.log(`[build-platform] Version ok: ${actual}`)
+}
+
+// ---------------------------------------------------------------------------
+// Output emission
+// ---------------------------------------------------------------------------
+
+function emitBinary(binaryPath: string, outDir: string, platform: string, arch: string): string {
+  mkdirSync(outDir, {recursive: true})
+  const destName = `opencode-${platform}-${arch}`
+  const destBinDir = path.join(outDir, destName, 'bin')
+  mkdirSync(destBinDir, {recursive: true})
+  const destPath = path.join(destBinDir, 'opencode')
+
+  cpSync(binaryPath, destPath)
+
+  // Ensure the binary is executable.
+  const chmodResult = spawnSync('chmod', ['+x', destPath], {stdio: 'inherit'})
+  if (chmodResult.status !== 0) {
+    throw new Error(`chmod +x failed for ${destPath}`)
+  }
+
+  console.log(`[build-platform] Binary emitted: ${destPath}`)
+  return destPath
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv)
+  if (args === null) {
+    process.exit(1)
+  }
+
+  const {integrationCommit, baseVersion, platform, arch, repoUrl, workDir, outDir} = args
+
+  console.log(`[build-platform] Starting build`)
+  console.log(`  integration commit: ${integrationCommit}`)
+  console.log(`  base version:       ${baseVersion}`)
+  console.log(`  platform:           ${platform}/${arch}`)
+  console.log(`  repo:               ${repoUrl}`)
+  console.log(`  work dir:           ${workDir}`)
+  console.log(`  out dir:            ${outDir}`)
+
+  // 1. Enforce Bun version (build-environment contract).
+  enforceBunVersion()
+
+  // 2. Clone/checkout the full upstream repo at the frozen integration commit.
+  try {
+    cloneAndCheckout(repoUrl, workDir, integrationCommit)
+  } catch (error) {
+    console.error(`[build-platform] Clone/checkout failed: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+
+  // 3. Run upstream's real build (embedded-app + native-dep build).
+  try {
+    runUpstreamBuild(workDir, baseVersion)
+  } catch (error) {
+    console.error(`[build-platform] Build failed: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+
+  // 4. Verify the built binary --version == base (build-environment contract).
+  const binaryPath = resolveBuiltBinaryPath(workDir, platform, arch)
+  try {
+    verifyBuiltBinary(binaryPath, baseVersion)
+  } catch (error) {
+    console.error(`[build-platform] Verification failed: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+
+  // 5. Emit the binary to the output directory.
+  try {
+    emitBinary(binaryPath, outDir, platform, arch)
+  } catch (error) {
+    console.error(`[build-platform] Emit failed: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+
+  console.log(`[build-platform] Done. Binary ready at: ${outDir}/opencode-${platform}-${arch}/bin/opencode`)
+}
+
+await main()

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -2,17 +2,34 @@
 /**
  * build-platform.ts — per-platform native build of the integrated OpenCode.
  *
- * Given the frozen integration commit (from Unit 2's provenance manifest) and a
+ * Given the frozen integration commit (from the provenance manifest) and a
  * target platform, checks out the FULL upstream repo at that commit, runs upstream's
  * real build (packages/opencode/script/build.ts — the embedded-app + native-dep build)
  * with the release-identity env, and emits the native binary for that platform.
  *
- * Build-environment contract (from the plan):
+ * Build-environment contract:
  *   - Bun version is pinned to match upstream's packageManager (bun@1.3.13).
  *   - The full upstream repo is checked out at the frozen integration commit.
  *   - Native-dep install + embedded-app build happen under the UPSTREAM repo root.
- *   - Build runs with: OPENCODE_CHANNEL=latest OPENCODE_VERSION=<base> bun run build -- --single
- *   - Built binary --version is verified == base before emitting.
+ *   - Build runs with:
+ *       OPENCODE_CHANNEL=latest
+ *       OPENCODE_VERSION=<baseVersion>+harness.<integrationCommit[0..7]>
+ *     The version string embeds the integration commit short SHA so the binary
+ *     self-reports it. The upstream build bakes OPENCODE_VERSION into the binary
+ *     via the `define: { OPENCODE_VERSION: ... }` field in build.ts.
+ *   - Built binary --version is verified == OPENCODE_VERSION before emitting.
+ *   - provenance.json is written to packages/harness/ for the workflow assemble step.
+ *
+ * Integration commit embedding mechanism:
+ *   OpenCode's build.ts reads OPENCODE_VERSION from the environment (via the
+ *   @opencode-ai/script package's Script.version getter) and bakes it into the
+ *   binary as a compile-time define. We set OPENCODE_VERSION to
+ *   "<baseVersion>+harness.<shortSha>" so the binary's --version output includes
+ *   the integration commit. verify-binary.ts then probes `binary info` (which calls
+ *   formatProvenance) for the structured "integration commit: <sha>" line.
+ *
+ *   NOTE: The binary's --version output will be "<baseVersion>+harness.<shortSha>"
+ *   rather than the bare "<baseVersion>". The verify step uses the full version string.
  *
  * Usage:
  *   bun run packages/harness/scripts/build-platform.ts \
@@ -29,9 +46,11 @@
  */
 
 import {execFileSync, spawnSync} from 'node:child_process'
-import {cpSync, existsSync, mkdirSync} from 'node:fs'
+import {cpSync, mkdirSync, writeFileSync} from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
+import {fileURLToPath} from 'node:url'
+import {buildHarnessVersion} from '../src/version.js'
 
 // ---------------------------------------------------------------------------
 // Build-environment contract constants
@@ -108,8 +127,9 @@ Usage:
 Build-environment contract:
   - Bun ${REQUIRED_BUN_VERSION} required (matches upstream packageManager).
   - Full upstream repo checked out at the frozen integration commit.
-  - Build: OPENCODE_CHANNEL=${OPENCODE_CHANNEL} OPENCODE_VERSION=<base> bun run build -- --single
-  - Built binary --version verified == base before emitting.
+  - Build: OPENCODE_CHANNEL=${OPENCODE_CHANNEL} OPENCODE_VERSION=<base>+harness.<shortSha> bun run build -- --single
+  - Built binary --version verified == OPENCODE_VERSION before emitting.
+  - provenance.json written to packages/harness/ for the workflow assemble step.
   - Exits non-zero on any failure.
 `)
 }
@@ -155,7 +175,8 @@ function gitExec(args: string[], cwd?: string): void {
 }
 
 function cloneAndCheckout(repoUrl: string, workDir: string, commit: string): void {
-  if (existsSync(workDir)) {
+  const workDirExists = spawnSync('test', ['-d', workDir]).status === 0
+  if (workDirExists) {
     console.log(`[build-platform] Work dir exists, fetching and resetting to ${commit}`)
     gitExec(['fetch', 'origin'], workDir)
     gitExec(['checkout', '--detach', commit], workDir)
@@ -171,10 +192,11 @@ function cloneAndCheckout(repoUrl: string, workDir: string, commit: string): voi
 // Build invocation
 // ---------------------------------------------------------------------------
 
-function runUpstreamBuild(workDir: string, baseVersion: string): void {
+function runUpstreamBuild(workDir: string, baseVersion: string, integrationCommit: string): void {
   const opencodeDir = path.join(workDir, 'packages', 'opencode')
+  const opencodeVersion = buildHarnessVersion(baseVersion, integrationCommit)
   console.log(`[build-platform] Running upstream build in ${opencodeDir}`)
-  console.log(`[build-platform] Env: OPENCODE_CHANNEL=${OPENCODE_CHANNEL} OPENCODE_VERSION=${baseVersion}`)
+  console.log(`[build-platform] Env: OPENCODE_CHANNEL=${OPENCODE_CHANNEL} OPENCODE_VERSION=${opencodeVersion}`)
 
   // Install native deps first (mirrors upstream build.ts skipInstall=false path).
   // The upstream build.ts does this internally, but we invoke it via `bun run build -- --single`
@@ -185,7 +207,7 @@ function runUpstreamBuild(workDir: string, baseVersion: string): void {
     env: {
       ...process.env,
       OPENCODE_CHANNEL,
-      OPENCODE_VERSION: baseVersion,
+      OPENCODE_VERSION: opencodeVersion,
     },
     timeout: 30 * 60 * 1000, // 30-minute hard timeout
   })
@@ -209,7 +231,8 @@ function resolveBuiltBinaryPath(workDir: string, platform: string, arch: string)
 function verifyBuiltBinary(binaryPath: string, expectedVersion: string): void {
   console.log(`[build-platform] Verifying binary: ${binaryPath} --version`)
 
-  if (!existsSync(binaryPath)) {
+  const binaryExists = spawnSync('test', ['-f', binaryPath]).status === 0
+  if (!binaryExists) {
     throw new Error(`Built binary not found at: ${binaryPath}`)
   }
 
@@ -256,6 +279,34 @@ function emitBinary(binaryPath: string, outDir: string, platform: string, arch: 
 }
 
 // ---------------------------------------------------------------------------
+// Provenance manifest emission
+// ---------------------------------------------------------------------------
+
+/**
+ * Writes provenance.json to packages/harness/ so the workflow assemble step
+ * can read it. This is the canonical provenance record for the build.
+ *
+ * The manifest records the integration commit, base version, and build SHA
+ * so the runtime getProvenance() function can serve it to `harness info`.
+ */
+function emitProvenanceManifest(
+  harnessPackageDir: string,
+  baseVersion: string,
+  integrationCommit: string,
+  buildSha: string,
+): void {
+  const manifest = {
+    baseVersion,
+    integrationRefs: [], // populated by the integration engine; preserved here as empty for build-only runs
+    integrationCommit,
+    buildSha,
+  }
+  const manifestPath = path.join(harnessPackageDir, 'provenance.json')
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
+  console.log(`[build-platform] provenance.json written: ${manifestPath}`)
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -266,6 +317,9 @@ async function main(): Promise<void> {
   }
 
   const {integrationCommit, baseVersion, platform, arch, repoUrl, workDir, outDir} = args
+
+  // Derive the harness package directory (two levels up from this script).
+  const harnessPackageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 
   console.log(`[build-platform] Starting build`)
   console.log(`  integration commit: ${integrationCommit}`)
@@ -287,17 +341,19 @@ async function main(): Promise<void> {
   }
 
   // 3. Run upstream's real build (embedded-app + native-dep build).
+  //    OPENCODE_VERSION embeds the integration commit short SHA for binary self-reporting.
   try {
-    runUpstreamBuild(workDir, baseVersion)
+    runUpstreamBuild(workDir, baseVersion, integrationCommit)
   } catch (error) {
     console.error(`[build-platform] Build failed: ${error instanceof Error ? error.message : String(error)}`)
     process.exit(1)
   }
 
-  // 4. Verify the built binary --version == base (build-environment contract).
+  // 4. Verify the built binary --version == OPENCODE_VERSION (build-environment contract).
   const binaryPath = resolveBuiltBinaryPath(workDir, platform, arch)
+  const expectedVersion = buildHarnessVersion(baseVersion, integrationCommit)
   try {
-    verifyBuiltBinary(binaryPath, baseVersion)
+    verifyBuiltBinary(binaryPath, expectedVersion)
   } catch (error) {
     console.error(`[build-platform] Verification failed: ${error instanceof Error ? error.message : String(error)}`)
     process.exit(1)
@@ -308,6 +364,15 @@ async function main(): Promise<void> {
     emitBinary(binaryPath, outDir, platform, arch)
   } catch (error) {
     console.error(`[build-platform] Emit failed: ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
+
+  // 6. Write provenance.json for the workflow assemble step.
+  const buildSha = process.env.GITHUB_SHA ?? 'dev'
+  try {
+    emitProvenanceManifest(harnessPackageDir, baseVersion, integrationCommit, buildSha)
+  } catch (error) {
+    console.error(`[build-platform] Provenance emit failed: ${error instanceof Error ? error.message : String(error)}`)
     process.exit(1)
   }
 

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -103,7 +103,7 @@ function parseArgs(argv: string[]): BuildArgs | null {
     console.error('[build-platform] Missing required arguments.')
     console.error('  Required: --integration-commit, --base-version, --platform, --arch')
     printHelp()
-    process.exit(1)
+    return null
   }
 
   return {integrationCommit, baseVersion, platform, arch, repoUrl, workDir, outDir}

--- a/packages/harness/scripts/verify-binary.ts
+++ b/packages/harness/scripts/verify-binary.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * verify-binary.ts — spike: verify the built native binary before packaging.
+ * verify-binary.ts — verify the built native binary before packaging.
  *
  * Asserts:
  *   1. --version == base version (exact match).
@@ -25,6 +25,7 @@
 import {execFileSync} from 'node:child_process'
 import process from 'node:process'
 import {runVerifications} from '../src/verify.js'
+import {buildHarnessVersion} from '../src/version.js'
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing
@@ -147,8 +148,17 @@ function main(): void {
 
   const {binaryPath, baseVersion, integrationCommit} = args
 
+  // Compute the full expected version string.
+  // When an integration commit is present, the binary self-reports the full
+  // harness version ("<baseVersion>+harness.<shortSha>") — not the bare base version.
+  // When absent (dev scaffold), the bare base version is used.
+  const expectedVersion =
+    integrationCommit !== null && integrationCommit.length > 0
+      ? buildHarnessVersion(baseVersion, integrationCommit)
+      : baseVersion
+
   console.log(`[verify-binary] Verifying binary: ${binaryPath}`)
-  console.log(`  expected version:   ${baseVersion}`)
+  console.log(`  expected version:   ${expectedVersion}`)
   console.log(`  integration commit: ${integrationCommit ?? '(none — dev scaffold)'}`)
 
   const probe = probeBinary(binaryPath)
@@ -158,7 +168,7 @@ function main(): void {
 
   const result = runVerifications({
     versionOutput: probe.versionOutput,
-    expectedVersion: baseVersion,
+    expectedVersion,
     probeOutput: probe.probeOutput,
     integrationCommit,
     exitCode: probe.exitCode,

--- a/packages/harness/scripts/verify-binary.ts
+++ b/packages/harness/scripts/verify-binary.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env bun
+/**
+ * verify-binary.ts — spike: verify the built native binary before packaging.
+ *
+ * Asserts:
+ *   1. --version == base version (exact match).
+ *   2. Integration marker (frozen integration commit SHA) present in binary output.
+ *   3. Minimal boot smoke: binary exits 0 on --version.
+ *
+ * Exits non-zero on any mismatch — this gates the publish step.
+ *
+ * The assertion LOGIC is extracted into src/verify.ts (unit-testable with stubs).
+ * This script wires the real binary exec to those assertions.
+ *
+ * Usage:
+ *   bun run packages/harness/scripts/verify-binary.ts \
+ *     --binary <path> \
+ *     --base-version <version> \
+ *     [--integration-commit <sha>]
+ *
+ * The --integration-commit is optional: when absent (dev scaffold), the marker
+ * check is skipped. When present, the marker must appear in the binary's output.
+ */
+
+import {execFileSync} from 'node:child_process'
+import process from 'node:process'
+import {runVerifications} from '../src/verify.js'
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+interface VerifyArgs {
+  readonly binaryPath: string
+  readonly baseVersion: string
+  readonly integrationCommit: string | null
+}
+
+function parseArgs(argv: string[]): VerifyArgs | null {
+  const args = argv.slice(2)
+
+  if (args.includes('--help') || args.includes('-h')) {
+    printHelp()
+    process.exit(0)
+  }
+
+  function flag(name: string): string | null {
+    const idx = args.indexOf(name)
+    if (idx === -1) return null
+    const val = args[idx + 1]
+    return val !== undefined && !val.startsWith('--') ? val : null
+  }
+
+  const binaryPath = flag('--binary')
+  const baseVersion = flag('--base-version')
+  const integrationCommit = flag('--integration-commit')
+
+  if (binaryPath === null || baseVersion === null) {
+    console.error('[verify-binary] Missing required arguments.')
+    console.error('  Required: --binary, --base-version')
+    printHelp()
+    process.exit(1)
+  }
+
+  return {binaryPath, baseVersion, integrationCommit}
+}
+
+function printHelp(): void {
+  console.log(String.raw`
+verify-binary.ts — verify the built native binary before packaging
+
+Usage:
+  bun run packages/harness/scripts/verify-binary.ts \
+    --binary <path>                     Path to the built native binary
+    --base-version <version>            Expected base version (e.g. 1.15.13)
+    [--integration-commit <sha>]        Frozen integration commit SHA to assert as marker
+    [--help]                            Print this help
+
+Assertions:
+  1. Binary exits 0 on --version.
+  2. --version output == base-version (exact match, trimmed).
+  3. Integration commit SHA present in binary output (when --integration-commit provided).
+
+Exits non-zero on any assertion failure.
+`)
+}
+
+// ---------------------------------------------------------------------------
+// Binary probe
+// ---------------------------------------------------------------------------
+
+interface ProbeResult {
+  readonly exitCode: number
+  readonly versionOutput: string
+  readonly probeOutput: string
+}
+
+function probeBinary(binaryPath: string): ProbeResult {
+  let exitCode = 0
+  let versionOutput = ''
+  let probeOutput = ''
+
+  // Probe 1: --version
+  try {
+    const out = execFileSync(binaryPath, ['--version'], {
+      encoding: 'utf8',
+      timeout: 30_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    versionOutput = out.trim()
+    probeOutput += out
+  } catch (error: unknown) {
+    // Capture the exit code from the error if available.
+    const spawnErr = error as {status?: number; message?: string}
+    exitCode = spawnErr.status ?? 1
+    console.error(`[verify-binary] --version probe failed: ${spawnErr.message ?? String(error)}`)
+  }
+
+  // Probe 2: info (for integration marker — harness-own subcommand)
+  // Only attempt if the --version probe succeeded.
+  if (exitCode === 0) {
+    try {
+      const infoOut = execFileSync(binaryPath, ['info'], {
+        encoding: 'utf8',
+        timeout: 30_000,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      probeOutput += `\n${infoOut}`
+    } catch {
+      // info subcommand may not be available on a stock opencode binary.
+      // Not a fatal error — the marker check will fail if the commit is required.
+    }
+  }
+
+  return {exitCode, versionOutput, probeOutput}
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const args = parseArgs(process.argv)
+  if (args === null) {
+    process.exit(1)
+  }
+
+  const {binaryPath, baseVersion, integrationCommit} = args
+
+  console.log(`[verify-binary] Verifying binary: ${binaryPath}`)
+  console.log(`  expected version:   ${baseVersion}`)
+  console.log(`  integration commit: ${integrationCommit ?? '(none — dev scaffold)'}`)
+
+  const probe = probeBinary(binaryPath)
+
+  console.log(`  --version output:   '${probe.versionOutput}'`)
+  console.log(`  exit code:          ${probe.exitCode}`)
+
+  const result = runVerifications({
+    versionOutput: probe.versionOutput,
+    expectedVersion: baseVersion,
+    probeOutput: probe.probeOutput,
+    integrationCommit,
+    exitCode: probe.exitCode,
+  })
+
+  if (result.ok) {
+    console.log(`[verify-binary] All assertions passed.`)
+    process.exit(0)
+  }
+
+  console.error(`[verify-binary] Verification FAILED:`)
+  for (const failure of result.failures) {
+    console.error(`  - ${failure}`)
+  }
+  process.exit(1)
+}
+
+main()

--- a/packages/harness/scripts/verify-binary.ts
+++ b/packages/harness/scripts/verify-binary.ts
@@ -3,9 +3,15 @@
  * verify-binary.ts — verify the built native binary before packaging.
  *
  * Asserts:
- *   1. --version == base version (exact match).
- *   2. Integration marker (frozen integration commit SHA) present in binary output.
- *   3. Minimal boot smoke: binary exits 0 on --version.
+ *   1. Binary exits 0 on --version.
+ *   2. --version == expected version (exact match, trimmed).
+ *      For a harness build, the expected version is "<base>+harness.<short8>" (from
+ *      buildHarnessVersion). A stock upstream binary reports bare "<base>", which
+ *      fails this check — proving the binary is a harness build for this exact
+ *      base+commit. Full provenance lives in the package's provenance.json manifest;
+ *      npm provenance attestation is the cryptographic gate.
+ *   3. Integration marker: when --integration-commit is supplied, the --version output
+ *      must contain "+harness.<short8>" (defense-in-depth on top of the exact match).
  *
  * Exits non-zero on any mismatch — this gates the publish step.
  *
@@ -19,7 +25,8 @@
  *     [--integration-commit <sha>]
  *
  * The --integration-commit is optional: when absent (dev scaffold), the marker
- * check is skipped. When present, the marker must appear in the binary's output.
+ * check is skipped. When present, the binary's --version must contain
+ * "+harness.<short8>" where short8 is the first 8 chars of the commit.
  */
 
 import {execFileSync} from 'node:child_process'
@@ -60,7 +67,7 @@ function parseArgs(argv: string[]): VerifyArgs | null {
     console.error('[verify-binary] Missing required arguments.')
     console.error('  Required: --binary, --base-version')
     printHelp()
-    process.exit(1)
+    return null
   }
 
   return {binaryPath, baseVersion, integrationCommit}
@@ -74,13 +81,18 @@ Usage:
   bun run packages/harness/scripts/verify-binary.ts \
     --binary <path>                     Path to the built native binary
     --base-version <version>            Expected base version (e.g. 1.15.13)
-    [--integration-commit <sha>]        Frozen integration commit SHA to assert as marker
+    [--integration-commit <sha>]        Frozen integration commit SHA; when supplied,
+                                        the binary's --version must contain
+                                        "+harness.<short8>" (first 8 chars of the SHA)
     [--help]                            Print this help
 
 Assertions:
   1. Binary exits 0 on --version.
-  2. --version output == base-version (exact match, trimmed).
-  3. Integration commit SHA present in binary output (when --integration-commit provided).
+  2. --version output == expected version (exact match, trimmed).
+     For a harness build: "<base>+harness.<short8>". A stock binary reports bare
+     "<base>" and fails — proving this is a harness build for the expected commit.
+  3. Integration marker "+harness.<short8>" present in --version (when --integration-commit
+     supplied). Defense-in-depth on top of the exact version match.
 
 Exits non-zero on any assertion failure.
 `)
@@ -93,15 +105,14 @@ Exits non-zero on any assertion failure.
 interface ProbeResult {
   readonly exitCode: number
   readonly versionOutput: string
-  readonly probeOutput: string
 }
 
 function probeBinary(binaryPath: string): ProbeResult {
   let exitCode = 0
   let versionOutput = ''
-  let probeOutput = ''
 
-  // Probe 1: --version
+  // Probe: --version (the binary self-reports its version, including the
+  // "+harness.<short8>" segment for harness builds).
   try {
     const out = execFileSync(binaryPath, ['--version'], {
       encoding: 'utf8',
@@ -109,7 +120,6 @@ function probeBinary(binaryPath: string): ProbeResult {
       stdio: ['ignore', 'pipe', 'pipe'],
     })
     versionOutput = out.trim()
-    probeOutput += out
   } catch (error: unknown) {
     // Capture the exit code from the error if available.
     const spawnErr = error as {status?: number; message?: string}
@@ -117,23 +127,7 @@ function probeBinary(binaryPath: string): ProbeResult {
     console.error(`[verify-binary] --version probe failed: ${spawnErr.message ?? String(error)}`)
   }
 
-  // Probe 2: info (for integration marker — harness-own subcommand)
-  // Only attempt if the --version probe succeeded.
-  if (exitCode === 0) {
-    try {
-      const infoOut = execFileSync(binaryPath, ['info'], {
-        encoding: 'utf8',
-        timeout: 30_000,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      })
-      probeOutput += `\n${infoOut}`
-    } catch {
-      // info subcommand may not be available on a stock opencode binary.
-      // Not a fatal error — the marker check will fail if the commit is required.
-    }
-  }
-
-  return {exitCode, versionOutput, probeOutput}
+  return {exitCode, versionOutput}
 }
 
 // ---------------------------------------------------------------------------
@@ -149,9 +143,8 @@ function main(): void {
   const {binaryPath, baseVersion, integrationCommit} = args
 
   // Compute the full expected version string.
-  // When an integration commit is present, the binary self-reports the full
-  // harness version ("<baseVersion>+harness.<shortSha>") — not the bare base version.
-  // When absent (dev scaffold), the bare base version is used.
+  // For a harness build, the binary self-reports "<base>+harness.<short8>".
+  // For dev scaffold (no integration commit), the bare base version is used.
   const expectedVersion =
     integrationCommit !== null && integrationCommit.length > 0
       ? buildHarnessVersion(baseVersion, integrationCommit)
@@ -169,7 +162,6 @@ function main(): void {
   const result = runVerifications({
     versionOutput: probe.versionOutput,
     expectedVersion,
-    probeOutput: probe.probeOutput,
     integrationCommit,
     exitCode: probe.exitCode,
   })

--- a/packages/harness/src/base-version.ts
+++ b/packages/harness/src/base-version.ts
@@ -1,0 +1,8 @@
+/**
+ * Pinned base release version for the harness integration.
+ *
+ * This constant is tracked by Renovate via a customManager regex.
+ * The cap stays at 1.15.13 until a reviewed bump PR raises it.
+ * Do not change this value without running the full integration pipeline.
+ */
+export const HARNESS_BASE_VERSION = '1.15.13'

--- a/packages/harness/src/cli.test.ts
+++ b/packages/harness/src/cli.test.ts
@@ -1,0 +1,153 @@
+import process from 'node:process'
+import {describe, expect, it} from 'vitest'
+import {formatProvenance, getProvenance} from './provenance.js'
+import {probeBinary, resolveBinary} from './resolve-binary.js'
+
+// #region provenance
+
+describe('getProvenance', () => {
+  it('returns a valid dev-scaffold provenance', () => {
+    // #given / #when
+    const p = getProvenance()
+
+    // #then
+    expect(p.baseVersion).toBe('1.15.13')
+    expect(p.integrationRefs).toEqual([])
+    expect(p.integrationCommit).toBeNull()
+    expect(p.buildSha).toBe('dev')
+  })
+})
+
+describe('formatProvenance', () => {
+  it('includes base version and dev-scaffold markers', () => {
+    // #given
+    const p = getProvenance()
+
+    // #when
+    const output = formatProvenance(p)
+
+    // #then
+    expect(output).toContain('1.15.13')
+    expect(output).toContain('(unbuilt/dev scaffold)')
+    expect(output).toContain('dev')
+    expect(output).toContain('(none — dev scaffold)')
+  })
+
+  it('lists integration refs when present', () => {
+    // #given
+    const p = {
+      baseVersion: '1.15.13',
+      integrationRefs: ['https://github.com/anomalyco/opencode/pull/30182'],
+      integrationCommit: 'abc1234',
+      buildSha: 'def5678',
+    }
+
+    // #when
+    const output = formatProvenance(p)
+
+    // #then
+    expect(output).toContain('pull/30182')
+    expect(output).toContain('abc1234')
+    expect(output).toContain('def5678')
+  })
+})
+
+// #endregion
+
+// #region resolve-binary
+
+describe('resolveBinary', () => {
+  it('returns opencode as the dev-scaffold fallback', () => {
+    // #given — no OPENCODE_PATH set
+    const original = process.env.OPENCODE_PATH
+    delete process.env.OPENCODE_PATH
+
+    // #when
+    const result = resolveBinary()
+
+    // #then
+    expect(result.resolved).toBe(true)
+    expect(result.path).toBe('opencode')
+    expect(result.isBuilt).toBe(false)
+
+    // cleanup
+    if (original !== undefined) {
+      process.env.OPENCODE_PATH = original
+    }
+  })
+
+  it('honours OPENCODE_PATH override', () => {
+    // #given
+    process.env.OPENCODE_PATH = '/usr/local/bin/my-opencode'
+
+    // #when
+    const result = resolveBinary()
+
+    // #then
+    expect(result.resolved).toBe(true)
+    expect(result.path).toBe('/usr/local/bin/my-opencode')
+    expect(result.isBuilt).toBe(false)
+
+    // cleanup
+    delete process.env.OPENCODE_PATH
+  })
+
+  it('ignores empty OPENCODE_PATH and falls back to opencode', () => {
+    // #given
+    process.env.OPENCODE_PATH = ''
+
+    // #when
+    const result = resolveBinary()
+
+    // #then
+    expect(result.path).toBe('opencode')
+
+    // cleanup
+    delete process.env.OPENCODE_PATH
+  })
+})
+
+describe('probeBinary', () => {
+  it('returns null for a non-existent binary', () => {
+    // #given / #when
+    const result = probeBinary('/nonexistent/path/to/binary-that-does-not-exist')
+
+    // #then
+    expect(result).toBeNull()
+  })
+
+  it('returns a string for a runnable binary', () => {
+    // #given — `node --version` is always available in the test environment
+    // #when
+    const result = probeBinary(process.execPath)
+
+    // #then — node --version returns something like "v24.x.x"
+    expect(typeof result).toBe('string')
+    expect(result).not.toBeNull()
+  })
+})
+
+// #endregion
+
+// #region CLI subcommand disambiguation
+
+describe('subcommand disambiguation', () => {
+  it('reserved subcommands set contains exactly info, patches, doctor', () => {
+    // This test documents the contract: only these three are harness-own.
+    // Anything else passes through to the patched binary.
+    const reserved = ['info', 'patches', 'doctor']
+    for (const cmd of reserved) {
+      // Verify they are in the set by checking the module exports don't
+      // accidentally expose them as passthrough — we test the logic indirectly
+      // via the provenance/resolve-binary modules which back each command.
+      expect(typeof cmd).toBe('string')
+    }
+    // Passthrough candidates must NOT be in the reserved set.
+    const passthrough = ['serve', 'run', 'chat', 'session', '--model', 'unknown-cmd']
+    for (const cmd of passthrough) {
+      expect(reserved.includes(cmd)).toBe(false)
+    }
+  })
+})
+
+// #endregion

--- a/packages/harness/src/cli.test.ts
+++ b/packages/harness/src/cli.test.ts
@@ -1,3 +1,4 @@
+import type {Provenance} from './provenance.js'
 import process from 'node:process'
 import {describe, expect, it} from 'vitest'
 import {formatProvenance, getProvenance} from './provenance.js'
@@ -6,13 +7,13 @@ import {probeBinary, resolveBinary} from './resolve-binary.js'
 // #region provenance
 
 describe('getProvenance', () => {
-  it('returns a valid dev-scaffold provenance', () => {
+  it('returns a valid provenance with base version', () => {
     // #given / #when
     const p = getProvenance()
 
     // #then
     expect(p.baseVersion).toBe('1.15.13')
-    expect(p.integrationRefs).toEqual([])
+    expect(Array.isArray(p.integrationRefs)).toBe(true)
     expect(p.integrationCommit).toBeNull()
     expect(p.buildSha).toBe('dev')
   })
@@ -20,8 +21,13 @@ describe('getProvenance', () => {
 
 describe('formatProvenance', () => {
   it('includes base version and dev-scaffold markers', () => {
-    // #given
-    const p = getProvenance()
+    // #given — use a known provenance object, not the live config-reading one
+    const p: Provenance = {
+      baseVersion: '1.15.13',
+      integrationRefs: [],
+      integrationCommit: null,
+      buildSha: 'dev',
+    }
 
     // #when
     const output = formatProvenance(p)
@@ -37,7 +43,12 @@ describe('formatProvenance', () => {
     // #given
     const p = {
       baseVersion: '1.15.13',
-      integrationRefs: ['https://github.com/anomalyco/opencode/pull/30182'],
+      integrationRefs: [
+        {
+          ref: 'https://github.com/anomalyco/opencode/pull/30182',
+          resolvedSha: 'deadbeef',
+        },
+      ],
       integrationCommit: 'abc1234',
       buildSha: 'def5678',
     }

--- a/packages/harness/src/cli.test.ts
+++ b/packages/harness/src/cli.test.ts
@@ -68,25 +68,6 @@ describe('formatProvenance', () => {
 // #region resolve-binary
 
 describe('resolveBinary', () => {
-  it('returns opencode as the dev-scaffold fallback', () => {
-    // #given — no OPENCODE_PATH set
-    const original = process.env.OPENCODE_PATH
-    delete process.env.OPENCODE_PATH
-
-    // #when
-    const result = resolveBinary()
-
-    // #then
-    expect(result.resolved).toBe(true)
-    expect(result.path).toBe('opencode')
-    expect(result.isBuilt).toBe(false)
-
-    // cleanup
-    if (original !== undefined) {
-      process.env.OPENCODE_PATH = original
-    }
-  })
-
   it('honours OPENCODE_PATH override', () => {
     // #given
     process.env.OPENCODE_PATH = '/usr/local/bin/my-opencode'
@@ -103,9 +84,10 @@ describe('resolveBinary', () => {
     delete process.env.OPENCODE_PATH
   })
 
-  it('ignores empty OPENCODE_PATH and falls back to opencode', () => {
+  it('ignores empty OPENCODE_PATH and uses escape hatch fallback when HARNESS_ALLOW_PATH_FALLBACK=1', () => {
     // #given
     process.env.OPENCODE_PATH = ''
+    process.env.HARNESS_ALLOW_PATH_FALLBACK = '1'
 
     // #when
     const result = resolveBinary()
@@ -115,6 +97,61 @@ describe('resolveBinary', () => {
 
     // cleanup
     delete process.env.OPENCODE_PATH
+    delete process.env.HARNESS_ALLOW_PATH_FALLBACK
+  })
+
+  it('falls back to opencode on PATH when HARNESS_ALLOW_PATH_FALLBACK=1 (dev escape hatch)', () => {
+    // #given — no OPENCODE_PATH, no platform binary, but dev escape hatch active
+    const original = process.env.OPENCODE_PATH
+    delete process.env.OPENCODE_PATH
+    process.env.HARNESS_ALLOW_PATH_FALLBACK = '1'
+
+    // #when
+    const result = resolveBinary()
+
+    // #then
+    expect(result.resolved).toBe(true)
+    expect(result.path).toBe('opencode')
+    expect(result.isBuilt).toBe(false)
+
+    // cleanup
+    if (original !== undefined) {
+      process.env.OPENCODE_PATH = original
+    }
+    delete process.env.HARNESS_ALLOW_PATH_FALLBACK
+  })
+
+  it('resolveBinary without escape hatch: either returns built artifact or throws actionable error', () => {
+    // #given — no OPENCODE_PATH, no escape hatch
+    // This test documents the fail-closed contract: in production (no escape hatch),
+    // resolveBinary must either find a built platform binary or throw with remediation.
+    // We verify the throw path by asserting the error message shape when it throws.
+    const originalPath = process.env.OPENCODE_PATH
+    const originalFallback = process.env.HARNESS_ALLOW_PATH_FALLBACK
+    delete process.env.OPENCODE_PATH
+    delete process.env.HARNESS_ALLOW_PATH_FALLBACK
+
+    // #when — wrap in a function so expect.toThrow can inspect it
+    const callResolveBinary = (): ReturnType<typeof resolveBinary> => resolveBinary()
+
+    // #then — must not silently return a non-built binary (the old fail-open behavior)
+    // Either it returns a built artifact (isBuilt: true) or throws with an actionable message.
+    // We assert the throw case; if a platform binary is installed, the call succeeds instead.
+    let result: ReturnType<typeof resolveBinary> | undefined
+    let threw = false
+    try {
+      result = callResolveBinary()
+    } catch {
+      threw = true
+    } finally {
+      if (originalPath !== undefined) process.env.OPENCODE_PATH = originalPath
+      if (originalFallback !== undefined) process.env.HARNESS_ALLOW_PATH_FALLBACK = originalFallback
+    }
+
+    // The invariant: if it didn't throw, it must have returned a built artifact.
+    // If it threw, the error must be an Error (not a string or undefined).
+    // We assert the non-throw case unconditionally to avoid conditional-expect.
+    expect(threw || (result !== undefined && result.isBuilt === true)).toBe(true)
   })
 })
 

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -16,8 +16,6 @@ import process from 'node:process'
 import {formatProvenance, getProvenance} from './provenance.js'
 import {probeBinary, resolveBinary} from './resolve-binary.js'
 
-const HARNESS_SUBCOMMANDS = new Set(['info', 'patches', 'doctor'])
-
 function printUsage(): void {
   console.log(`harness — patched OpenCode binary (Fro Bot integration)
 
@@ -58,7 +56,15 @@ function cmdPatches(): void {
 }
 
 function cmdDoctor(): number {
-  const binary = resolveBinary()
+  let binary
+  try {
+    binary = resolveBinary()
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    console.error(`\n[FAIL] ${msg}`)
+    return 1
+  }
+
   const p = getProvenance()
 
   console.log(`harness doctor`)
@@ -68,8 +74,12 @@ function cmdDoctor(): number {
   console.log(`  binary path:        ${binary.path}`)
   console.log(`  is built artifact:  ${binary.isBuilt}`)
 
-  if (!binary.resolved) {
-    console.error('\n[FAIL] No binary resolved. Install @fro.bot/harness or set OPENCODE_PATH.')
+  // In production (isBuilt: false with no dev escape hatch), fail with remediation.
+  if (!binary.isBuilt && process.env.HARNESS_ALLOW_PATH_FALLBACK !== '1' && process.env.OPENCODE_PATH === undefined) {
+    console.error('\n[FAIL] Binary is not a built harness artifact.')
+    console.error(
+      '       Install the platform package or set OPENCODE_PATH / HARNESS_ALLOW_PATH_FALLBACK=1 for dev use.',
+    )
     return 1
   }
 
@@ -81,15 +91,27 @@ function cmdDoctor(): number {
   }
 
   console.log(`  binary version:     ${version}`)
+
+  // Verify binary version matches provenance baseVersion when we have a built artifact.
+  if (binary.isBuilt && version !== p.baseVersion) {
+    console.error(
+      `\n[FAIL] Binary version mismatch: binary reports '${version}', provenance expects '${p.baseVersion}'.`,
+    )
+    console.error('       Reinstall @fro.bot/harness or check the platform package version.')
+    return 1
+  }
+
   console.log('\n[OK] Binary is present and runnable.')
   return 0
 }
 
 function cmdPassthrough(args: readonly string[]): number {
-  const binary = resolveBinary()
-
-  if (!binary.resolved) {
-    console.error('[harness] No binary resolved. Install @fro.bot/harness or set OPENCODE_PATH.')
+  let binary
+  try {
+    binary = resolveBinary()
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    console.error(`[harness] ${msg}`)
     return 1
   }
 
@@ -141,13 +163,6 @@ function main(): void {
 
   // Anything not in the reserved set passes through.
   // This includes no-args (which opencode handles as its own help/default).
-  if (subcommand !== undefined && HARNESS_SUBCOMMANDS.has(subcommand)) {
-    // Unreachable — all reserved subcommands handled above.
-    // Kept as a safety net to satisfy exhaustiveness.
-    console.error(`[harness] Unhandled reserved subcommand: ${subcommand}`)
-    process.exit(1)
-  }
-
   const code = cmdPassthrough(args)
   process.exit(code)
 }

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -41,12 +41,16 @@ function cmdInfo(): void {
 function cmdPatches(): void {
   const p = getProvenance()
   if (p.integrationRefs.length === 0) {
-    console.log('No integration refs configured (dev scaffold — Unit 2 wires the real manifest).')
+    console.log('No integration refs configured (dev scaffold).')
     return
   }
   console.log('Integration refs:')
-  for (const ref of p.integrationRefs) {
-    console.log(`  - ${ref}`)
+  for (const r of p.integrationRefs) {
+    const status = r.upstreamStatus === undefined ? '' : ` [${r.upstreamStatus}]`
+    console.log(`  - ${r.ref}${status}`)
+    if (r.reason !== undefined) {
+      console.log(`    reason: ${r.reason}`)
+    }
   }
   if (p.integrationCommit !== null) {
     console.log(`\nFrozen integration commit: ${p.integrationCommit}`)

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * harness CLI — patched OpenCode binary with provenance/operability commands.
+ *
+ * Subcommand disambiguation:
+ *   Reserved harness subcommands: info, patches, doctor
+ *   --version / --help: harness-own (prints provenance / usage)
+ *   Everything else: passed through to the resolved patched binary.
+ *
+ * This is the ONLY entry point for the @fro.bot/harness package.
+ * No classes; functions only; explicit boolean checks; no as-any.
+ */
+
+import {spawnSync} from 'node:child_process'
+import process from 'node:process'
+import {formatProvenance, getProvenance} from './provenance.js'
+import {probeBinary, resolveBinary} from './resolve-binary.js'
+
+const HARNESS_SUBCOMMANDS = new Set(['info', 'patches', 'doctor'])
+
+function printUsage(): void {
+  console.log(`harness — patched OpenCode binary (Fro Bot integration)
+
+Usage:
+  harness <opencode-args...>   Pass through to the patched OpenCode binary
+  harness info                 Print provenance (base version, integration refs, build sha)
+  harness patches              List configured integration refs
+  harness doctor               Check the resolved binary is present and runnable
+  harness --version            Print harness provenance version
+  harness --help               Print this help
+
+Reserved subcommands (info, patches, doctor) are handled by harness itself.
+All other arguments are forwarded to the patched OpenCode binary.`)
+}
+
+function cmdInfo(): void {
+  const p = getProvenance()
+  console.log(formatProvenance(p))
+}
+
+function cmdPatches(): void {
+  const p = getProvenance()
+  if (p.integrationRefs.length === 0) {
+    console.log('No integration refs configured (dev scaffold — Unit 2 wires the real manifest).')
+    return
+  }
+  console.log('Integration refs:')
+  for (const ref of p.integrationRefs) {
+    console.log(`  - ${ref}`)
+  }
+  if (p.integrationCommit !== null) {
+    console.log(`\nFrozen integration commit: ${p.integrationCommit}`)
+  }
+}
+
+function cmdDoctor(): number {
+  const binary = resolveBinary()
+  const p = getProvenance()
+
+  console.log(`harness doctor`)
+  console.log(`  base version:       ${p.baseVersion}`)
+  console.log(`  integration commit: ${p.integrationCommit ?? '(unbuilt/dev scaffold)'}`)
+  console.log(`  build sha:          ${p.buildSha}`)
+  console.log(`  binary path:        ${binary.path}`)
+  console.log(`  is built artifact:  ${binary.isBuilt}`)
+
+  if (!binary.resolved) {
+    console.error('\n[FAIL] No binary resolved. Install @fro.bot/harness or set OPENCODE_PATH.')
+    return 1
+  }
+
+  const version = probeBinary(binary.path)
+  if (version === null) {
+    console.error(`\n[FAIL] Binary not runnable: ${binary.path}`)
+    console.error('       Ensure opencode is on PATH or set OPENCODE_PATH.')
+    return 1
+  }
+
+  console.log(`  binary version:     ${version}`)
+  console.log('\n[OK] Binary is present and runnable.')
+  return 0
+}
+
+function cmdPassthrough(args: readonly string[]): number {
+  const binary = resolveBinary()
+
+  if (!binary.resolved) {
+    console.error('[harness] No binary resolved. Install @fro.bot/harness or set OPENCODE_PATH.')
+    return 1
+  }
+
+  const result = spawnSync(binary.path, [...args], {
+    stdio: 'inherit',
+    env: process.env,
+  })
+
+  if (result.error !== undefined) {
+    console.error(`[harness] Failed to spawn ${binary.path}: ${result.error.message}`)
+    return 1
+  }
+
+  return result.status ?? 1
+}
+
+function main(): void {
+  const args = process.argv.slice(2)
+
+  // --help: harness-own
+  if (args[0] === '--help' || args[0] === '-h') {
+    printUsage()
+    process.exit(0)
+  }
+
+  // --version: harness-own provenance version
+  if (args[0] === '--version' || args[0] === '-v') {
+    const p = getProvenance()
+    console.log(`@fro.bot/harness base:${p.baseVersion} build:${p.buildSha}`)
+    process.exit(0)
+  }
+
+  const subcommand = args[0]
+
+  if (subcommand === 'info') {
+    cmdInfo()
+    process.exit(0)
+  }
+
+  if (subcommand === 'patches') {
+    cmdPatches()
+    process.exit(0)
+  }
+
+  if (subcommand === 'doctor') {
+    const code = cmdDoctor()
+    process.exit(code)
+  }
+
+  // Anything not in the reserved set passes through.
+  // This includes no-args (which opencode handles as its own help/default).
+  if (subcommand !== undefined && HARNESS_SUBCOMMANDS.has(subcommand)) {
+    // Unreachable — all reserved subcommands handled above.
+    // Kept as a safety net to satisfy exhaustiveness.
+    console.error(`[harness] Unhandled reserved subcommand: ${subcommand}`)
+    process.exit(1)
+  }
+
+  const code = cmdPassthrough(args)
+  process.exit(code)
+}
+
+main()

--- a/packages/harness/src/integrate.test.ts
+++ b/packages/harness/src/integrate.test.ts
@@ -1,0 +1,391 @@
+import type {IntegrationAdapters, ProvenanceManifest} from './integrate.js'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {describe, expect, it} from 'vitest'
+import {readProvenanceManifest, runIntegration, writeProvenanceManifest} from './integrate.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function makeTmpDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'harness-test-'))
+}
+
+function makeAdapters(overrides: Partial<IntegrationAdapters> = {}): IntegrationAdapters {
+  return {
+    cloneRepo: async () => {},
+    fetchTags: async () => {},
+    fetchRef: async () => {},
+    createBranch: async () => {},
+    runMerge: async () => {},
+    buildCli: async () => {},
+    verifyVersion: async () => {},
+    getCommitSha: async () => 'abc1234deadbeef',
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Provenance round-trip
+// ---------------------------------------------------------------------------
+
+describe('writeProvenanceManifest / readProvenanceManifest', () => {
+  it('provenance round-trip: writeProvenanceManifest → readProvenanceManifest', async () => {
+    // #given
+    const dir = await makeTmpDir()
+    try {
+      const manifest: ProvenanceManifest = {
+        baseVersion: '1.15.13',
+        integrationRefs: [
+          {
+            ref: 'https://github.com/anomalyco/opencode/pull/30182',
+            resolvedSha: 'deadbeef1234',
+            reason: 'Signed Anthropic thinking during reorder — merged to dev, not in 1.15.13 tag',
+            upstreamStatus: 'merged-to-dev',
+          },
+        ],
+        integrationCommit: 'abc1234deadbeef',
+        buildSha: 'dev',
+      }
+
+      // #when
+      await writeProvenanceManifest(dir, manifest)
+      const read = await readProvenanceManifest(dir)
+
+      // #then
+      expect(read).toEqual(manifest)
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+
+  it('returns null when manifest does not exist', async () => {
+    // #given
+    const dir = await makeTmpDir()
+    try {
+      // #when
+      const result = await readProvenanceManifest(dir)
+
+      // #then
+      expect(result).toBeNull()
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Empty ref set → base-only provenance
+// ---------------------------------------------------------------------------
+
+describe('runIntegration', () => {
+  it('empty refs → base-only provenance, no merge called', async () => {
+    // #given
+    const dir = await makeTmpDir()
+    let mergeCalled = false
+    try {
+      const adapters = makeAdapters({
+        runMerge: async () => {
+          mergeCalled = true
+        },
+      })
+
+      // #when
+      const result = await runIntegration(
+        {
+          baseVersion: '1.15.13',
+          releaseRepo: 'anomalyco/opencode',
+          integrationRefs: [],
+          agent: 'build',
+          model: 'anthropic/claude-sonnet-4-6',
+          opencodeBin: 'opencode',
+          workDir: dir,
+          promptPath: path.join(dir, 'prompt.txt'),
+        },
+        adapters,
+      )
+
+      // #then
+      expect(result.ok).toBe(true)
+      expect(mergeCalled).toBe(false)
+      // Narrow via assertion — avoids conditional expect
+      if (!result.ok) throw new Error(`expected ok, got error: ${result.error}`)
+      expect(result.manifest.baseVersion).toBe('1.15.13')
+      expect(result.manifest.integrationRefs.length).toBe(0)
+      expect(typeof result.manifest.integrationCommit).toBe('string')
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // Fail-hard contract: merge failure
+  // ---------------------------------------------------------------------------
+
+  it('fail-hard: merge failure → non-zero result, nothing frozen', async () => {
+    // #given
+    const dir = await makeTmpDir()
+    try {
+      await fs.writeFile(
+        path.join(dir, 'prompt.txt'),
+        'dummy {{tag}} {{branch}} {{merges}} {{sources}} {{repo}} {{version}} {{channel}} {{base}} {{release_repo}} {{release_url}} {{branches}}',
+      )
+      const adapters = makeAdapters({
+        runMerge: async () => {
+          throw new Error('LLM merge left unresolved conflicts in packages/opencode/src/session/prompt.ts')
+        },
+      })
+
+      // #when
+      const result = await runIntegration(
+        {
+          baseVersion: '1.15.13',
+          releaseRepo: 'anomalyco/opencode',
+          integrationRefs: ['https://github.com/anomalyco/opencode/pull/30182'],
+          agent: 'build',
+          model: 'anthropic/claude-sonnet-4-6',
+          opencodeBin: 'opencode',
+          workDir: dir,
+          promptPath: path.join(dir, 'prompt.txt'),
+        },
+        adapters,
+      )
+
+      // #then
+      expect(result.ok).toBe(false)
+      // Nothing frozen: no manifest written
+      const manifest = await readProvenanceManifest(dir)
+      expect(manifest).toBeNull()
+      // Narrow via assertion — avoids conditional expect
+      if (result.ok) throw new Error('expected failure result')
+      expect(result.error).toMatch(/merge|unresolved/)
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // Fail-hard contract: build failure
+  // ---------------------------------------------------------------------------
+
+  it('fail-hard: build failure → non-zero result, nothing frozen', async () => {
+    // #given
+    const dir = await makeTmpDir()
+    try {
+      await fs.writeFile(
+        path.join(dir, 'prompt.txt'),
+        'dummy {{tag}} {{branch}} {{merges}} {{sources}} {{repo}} {{version}} {{channel}} {{base}} {{release_repo}} {{release_url}} {{branches}}',
+      )
+      const adapters = makeAdapters({
+        buildCli: async () => {
+          throw new Error('bun run build exited with code 1')
+        },
+      })
+
+      // #when
+      const result = await runIntegration(
+        {
+          baseVersion: '1.15.13',
+          releaseRepo: 'anomalyco/opencode',
+          integrationRefs: ['https://github.com/anomalyco/opencode/pull/30182'],
+          agent: 'build',
+          model: 'anthropic/claude-sonnet-4-6',
+          opencodeBin: 'opencode',
+          workDir: dir,
+          promptPath: path.join(dir, 'prompt.txt'),
+        },
+        adapters,
+      )
+
+      // #then
+      expect(result.ok).toBe(false)
+      const manifest = await readProvenanceManifest(dir)
+      expect(manifest).toBeNull()
+      // Narrow via assertion — avoids conditional expect
+      if (result.ok) throw new Error('expected failure result')
+      expect(result.error).toMatch(/build|bun/)
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // Fail-hard contract: version mismatch
+  // ---------------------------------------------------------------------------
+
+  it('fail-hard: version mismatch → non-zero result, nothing frozen', async () => {
+    // #given
+    const dir = await makeTmpDir()
+    try {
+      await fs.writeFile(
+        path.join(dir, 'prompt.txt'),
+        'dummy {{tag}} {{branch}} {{merges}} {{sources}} {{repo}} {{version}} {{channel}} {{base}} {{release_repo}} {{release_url}} {{branches}}',
+      )
+      const adapters = makeAdapters({
+        verifyVersion: async () => {
+          throw new Error('Built CLI reported version 1.15.12, expected 1.15.13')
+        },
+      })
+
+      // #when
+      const result = await runIntegration(
+        {
+          baseVersion: '1.15.13',
+          releaseRepo: 'anomalyco/opencode',
+          integrationRefs: ['https://github.com/anomalyco/opencode/pull/30182'],
+          agent: 'build',
+          model: 'anthropic/claude-sonnet-4-6',
+          opencodeBin: 'opencode',
+          workDir: dir,
+          promptPath: path.join(dir, 'prompt.txt'),
+        },
+        adapters,
+      )
+
+      // #then
+      expect(result.ok).toBe(false)
+      const manifest = await readProvenanceManifest(dir)
+      expect(manifest).toBeNull()
+      // Narrow via assertion — avoids conditional expect
+      if (result.ok) throw new Error('expected failure result')
+      expect(result.error).toMatch(/version|mismatch/)
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // Fail-hard contract: clone failure
+  // ---------------------------------------------------------------------------
+
+  it('fail-hard: clone failure → non-zero result, nothing frozen', async () => {
+    // #given
+    const dir = await makeTmpDir()
+    try {
+      const adapters = makeAdapters({
+        cloneRepo: async () => {
+          throw new Error('git clone failed: repository not found')
+        },
+      })
+
+      // #when
+      const result = await runIntegration(
+        {
+          baseVersion: '1.15.13',
+          releaseRepo: 'anomalyco/opencode',
+          integrationRefs: ['https://github.com/anomalyco/opencode/pull/30182'],
+          agent: 'build',
+          model: 'anthropic/claude-sonnet-4-6',
+          opencodeBin: 'opencode',
+          workDir: dir,
+          promptPath: path.join(dir, 'prompt.txt'),
+        },
+        adapters,
+      )
+
+      // #then
+      expect(result.ok).toBe(false)
+      const manifest = await readProvenanceManifest(dir)
+      expect(manifest).toBeNull()
+      // Narrow via assertion — avoids conditional expect
+      if (result.ok) throw new Error('expected failure result')
+      expect(result.error.length).toBeGreaterThan(0)
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // Happy path: successful integration with refs
+  // ---------------------------------------------------------------------------
+
+  it('happy path: successful integration writes provenance manifest', async () => {
+    // #given
+    const dir = await makeTmpDir()
+    try {
+      // Write a dummy prompt.txt so render doesn't fail
+      await fs.writeFile(
+        path.join(dir, 'prompt.txt'),
+        'dummy prompt {{tag}} {{branch}} {{merges}} {{sources}} {{repo}} {{version}} {{channel}} {{base}} {{release_repo}} {{release_url}} {{branches}}',
+      )
+      const adapters = makeAdapters({
+        getCommitSha: async () => 'cafebabe1234',
+      })
+
+      // #when
+      const result = await runIntegration(
+        {
+          baseVersion: '1.15.13',
+          releaseRepo: 'anomalyco/opencode',
+          integrationRefs: ['https://github.com/anomalyco/opencode/pull/30182'],
+          agent: 'build',
+          model: 'anthropic/claude-sonnet-4-6',
+          opencodeBin: 'opencode',
+          workDir: dir,
+          promptPath: path.join(dir, 'prompt.txt'),
+        },
+        adapters,
+      )
+
+      // #then
+      expect(result.ok).toBe(true)
+      // Narrow via assertion — avoids conditional expect
+      if (!result.ok) throw new Error(`expected ok, got error: ${result.error}`)
+      expect(result.manifest.baseVersion).toBe('1.15.13')
+      expect(result.manifest.integrationRefs.length).toBe(1)
+      const [firstRef] = result.manifest.integrationRefs
+      expect(firstRef?.ref).toBe('https://github.com/anomalyco/opencode/pull/30182')
+      expect(result.manifest.integrationCommit).toBe('cafebabe1234')
+      // Manifest is persisted
+      const persisted = await readProvenanceManifest(dir)
+      expect(persisted).toEqual(result.manifest)
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // Provenance manifest matches what getProvenance() would read (single source of truth)
+  // ---------------------------------------------------------------------------
+
+  it('provenance single source of truth: manifest content matches getProvenance shape', async () => {
+    // #given
+    const dir = await makeTmpDir()
+    try {
+      const manifest: ProvenanceManifest = {
+        baseVersion: '1.15.13',
+        integrationRefs: [
+          {
+            ref: 'https://github.com/anomalyco/opencode/pull/30182',
+            resolvedSha: 'deadbeef',
+            reason: 'test',
+            upstreamStatus: 'merged-to-dev',
+          },
+        ],
+        integrationCommit: 'abc123',
+        buildSha: 'dev',
+      }
+
+      // #when
+      await writeProvenanceManifest(dir, manifest)
+      const read = await readProvenanceManifest(dir)
+
+      // #then — shape must match the ProvenanceManifest interface fields
+      expect(read).not.toBeNull()
+      // Narrow via assertion — avoids conditional expect
+      if (read === null) throw new Error('expected non-null manifest')
+      expect('baseVersion' in read).toBe(true)
+      expect('integrationRefs' in read).toBe(true)
+      expect('integrationCommit' in read).toBe(true)
+      expect('buildSha' in read).toBe(true)
+      expect(read.baseVersion).toBe('1.15.13')
+      expect(read.integrationCommit).toBe('abc123')
+      const [firstIntegrationRef] = read.integrationRefs
+      expect(firstIntegrationRef?.ref).toBe('https://github.com/anomalyco/opencode/pull/30182')
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+})

--- a/packages/harness/src/integrate.ts
+++ b/packages/harness/src/integrate.ts
@@ -1,0 +1,349 @@
+/**
+ * Integration engine — orw-embedded LLM merge onto the release tag.
+ *
+ * Ported from cortexkit/orw src/index.ts check/prep/render/verifyBuild (MIT).
+ * Adapted for CI/non-interactive use: no launchd, no desktop, no interactive prompts.
+ *
+ * The actual opencode run LLM merge is NOT unit-tested here — it requires a live
+ * opencode binary + model + network. Unit tests cover the fail-hard/freeze/provenance
+ * contract via injected adapters (cloneRepo, fetchRef, runMerge, buildCli, verifyVersion).
+ *
+ * Fail-hard contract: any failure (merge unresolved, build fail, version mismatch)
+ * returns {ok:false, error} and writes NO provenance manifest. The manifest is the
+ * single source of truth — it is only written after all steps succeed (freeze).
+ */
+
+import type {IntegrationSource} from './sources.js'
+import {execFile} from 'node:child_process'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import {promisify} from 'node:util'
+import {resolveSources} from './sources.js'
+
+// ---------------------------------------------------------------------------
+// Provenance manifest types
+// ---------------------------------------------------------------------------
+
+export interface IntegrationRefRecord {
+  readonly ref: string
+  readonly resolvedSha: string
+  readonly reason?: string
+  readonly upstreamStatus?: string
+}
+
+export interface ProvenanceManifest {
+  readonly baseVersion: string
+  readonly integrationRefs: readonly IntegrationRefRecord[]
+  readonly integrationCommit: string
+  readonly buildSha: string
+}
+
+// ---------------------------------------------------------------------------
+// Integration config
+// ---------------------------------------------------------------------------
+
+export interface IntegrationConfig {
+  readonly baseVersion: string
+  readonly releaseRepo: string
+  readonly integrationRefs: readonly string[]
+  readonly agent: string
+  readonly model: string
+  readonly opencodeBin: string
+  readonly workDir: string
+  readonly promptPath: string
+}
+
+// ---------------------------------------------------------------------------
+// Injectable adapters (dependency injection for testability)
+// ---------------------------------------------------------------------------
+
+export interface IntegrationAdapters {
+  /** Clone the release repo into workDir. */
+  cloneRepo: (repoUrl: string, workDir: string) => Promise<void>
+  /** Fetch tags from origin. */
+  fetchTags: (workDir: string) => Promise<void>
+  /** Fetch a single integration ref into a local tracking ref. */
+  fetchRef: (workDir: string, remoteUrl: string, fetchRef: string, localRef: string) => Promise<void>
+  /** Create/reset the integration branch to the release tag. */
+  createBranch: (workDir: string, branch: string, tag: string) => Promise<void>
+  /** Run the LLM merge via opencode run. */
+  runMerge: (workDir: string, opencodeBin: string, agent: string, model: string, prompt: string) => Promise<void>
+  /** Build the native CLI in the work repo. */
+  buildCli: (workDir: string, version: string, channel: string) => Promise<void>
+  /** Verify the built CLI --version matches the expected version. */
+  verifyVersion: (workDir: string, expectedVersion: string) => Promise<void>
+  /** Get the current HEAD commit SHA of the work repo. */
+  getCommitSha: (workDir: string) => Promise<string>
+}
+
+// ---------------------------------------------------------------------------
+// Integration result
+// ---------------------------------------------------------------------------
+
+export type IntegrationResult =
+  | {readonly ok: true; readonly manifest: ProvenanceManifest}
+  | {readonly ok: false; readonly error: string}
+
+// ---------------------------------------------------------------------------
+// Provenance manifest I/O (single source of truth)
+// ---------------------------------------------------------------------------
+
+const MANIFEST_FILENAME = 'provenance.json'
+
+/**
+ * Writes the provenance manifest to the given directory.
+ * This is the freeze step — called only after all integration steps succeed.
+ */
+export async function writeProvenanceManifest(dir: string, manifest: ProvenanceManifest): Promise<void> {
+  await fs.mkdir(dir, {recursive: true})
+  await fs.writeFile(path.join(dir, MANIFEST_FILENAME), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
+}
+
+/**
+ * Reads the provenance manifest from the given directory.
+ * Returns null if the manifest does not exist.
+ */
+export async function readProvenanceManifest(dir: string): Promise<ProvenanceManifest | null> {
+  const manifestPath = path.join(dir, MANIFEST_FILENAME)
+  try {
+    const raw = await fs.readFile(manifestPath, 'utf8')
+    return JSON.parse(raw) as ProvenanceManifest
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt rendering (adapted from orw render())
+// ---------------------------------------------------------------------------
+
+function integrationBranch(version: string): string {
+  return `integrate/v${version}`
+}
+
+async function renderPrompt(
+  promptPath: string,
+  workDir: string,
+  baseVersion: string,
+  releaseRepo: string,
+  sources: IntegrationSource[],
+): Promise<string> {
+  const tag = `v${baseVersion}`
+  const branch = integrationBranch(baseVersion)
+  const channel = 'latest'
+  const tpl = await fs.readFile(promptPath, 'utf8')
+  const vars: Record<string, string> = {
+    repo: workDir,
+    tag,
+    version: baseVersion,
+    channel,
+    branches: sources.map(s => s.label).join(', '),
+    branch,
+    merges: sources.map(s => s.merge).join(', then '),
+    sources: sources.map(s => `${s.label} -> ${s.merge}`).join('\n- '),
+    release_repo: releaseRepo,
+    base: 'dev',
+    release_url: `https://github.com/${releaseRepo}/releases/tag/${tag}`,
+  }
+  return Object.entries(vars).reduce((text, [key, value]) => text.replaceAll(`{{${key}}}`, value), tpl)
+}
+
+const execFileAsync = promisify(execFile)
+
+async function gitExec(args: string[], cwd?: string): Promise<string> {
+  const {stdout} = await execFileAsync('git', args, {cwd, encoding: 'utf8'})
+  return stdout.trim()
+}
+
+export function makeRealAdapters(): IntegrationAdapters {
+  return {
+    cloneRepo: async (repoUrl, workDir) => {
+      await fs.rm(workDir, {recursive: true, force: true})
+      await fs.mkdir(path.dirname(workDir), {recursive: true})
+      await gitExec(['clone', repoUrl, workDir])
+    },
+
+    fetchTags: async workDir => {
+      await gitExec(['fetch', 'origin', '--tags'], workDir)
+    },
+
+    fetchRef: async (workDir, remoteUrl, fetchRef, localRef) => {
+      await gitExec(['fetch', remoteUrl, `${fetchRef}:${localRef}`], workDir)
+    },
+
+    createBranch: async (workDir, branch, tag) => {
+      // Reset or create the integration branch at the release tag.
+      try {
+        await gitExec(['checkout', '-B', branch, `refs/tags/${tag}`], workDir)
+      } catch {
+        await gitExec(['checkout', '-b', branch, `refs/tags/${tag}`], workDir)
+      }
+    },
+
+    runMerge: async (workDir, opencodeBin, agent, model, prompt) => {
+      // Run opencode run synchronously — do NOT use background:true.
+      // Poll to terminal state; the non-interactive tool exits when done.
+      await execFileAsync(opencodeBin, ['run', '--agent', agent, '--model', model, prompt], {
+        cwd: workDir,
+        encoding: 'utf8',
+        timeout: 30 * 60 * 1000, // 30-minute hard timeout
+      })
+    },
+
+    buildCli: async (workDir, version, channel) => {
+      await execFileAsync('bun', ['run', 'build', '--', '--single'], {
+        cwd: path.join(workDir, 'packages', 'opencode'),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          OPENCODE_CHANNEL: channel,
+          OPENCODE_VERSION: version,
+        },
+        timeout: 20 * 60 * 1000, // 20-minute hard timeout
+      })
+    },
+
+    verifyVersion: async (workDir, expectedVersion) => {
+      const cliPath = resolveCliPath(workDir)
+      const {stdout} = await execFileAsync(cliPath, ['--version'], {
+        encoding: 'utf8',
+        timeout: 30_000,
+      })
+      const actual = stdout.trim()
+      if (actual !== expectedVersion) {
+        throw new Error(`Built CLI reported version ${actual}, expected ${expectedVersion}`)
+      }
+    },
+
+    getCommitSha: async workDir => {
+      return gitExec(['rev-parse', 'HEAD'], workDir)
+    },
+  }
+}
+
+function resolveCliPath(workDir: string): string {
+  const os = process.platform === 'win32' ? 'windows' : process.platform
+  const arch = process.arch
+  const name = `opencode-${os}-${arch}`
+  const binary = process.platform === 'win32' ? 'opencode.exe' : 'opencode'
+  return path.join(workDir, 'packages', 'opencode', 'dist', name, 'bin', binary)
+}
+
+// ---------------------------------------------------------------------------
+// Core integration orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs the full integration pipeline:
+ *   clone → fetch tags → fetch refs → create branch → LLM merge → build → verify → freeze
+ *
+ * On any failure: returns {ok:false, error} and writes NO manifest (fail-hard contract).
+ * On success: writes the provenance manifest to workDir and returns {ok:true, manifest}.
+ *
+ * @param config   - Integration configuration (base version, refs, model, etc.)
+ * @param adapters - Injectable adapters for each step (real or stubbed for tests).
+ */
+export async function runIntegration(
+  config: IntegrationConfig,
+  adapters: IntegrationAdapters,
+): Promise<IntegrationResult> {
+  const {baseVersion, releaseRepo, integrationRefs, agent, model, opencodeBin, workDir, promptPath} = config
+  const tag = `v${baseVersion}`
+  const branch = integrationBranch(baseVersion)
+  const channel = 'latest'
+
+  const sources = resolveSources(integrationRefs, `https://github.com/${releaseRepo}.git`)
+
+  // Step 1: Clone the release repo.
+  try {
+    await adapters.cloneRepo(`https://github.com/${releaseRepo}.git`, workDir)
+  } catch (error) {
+    return {ok: false, error: `Clone failed: ${errorMessage(error)}`}
+  }
+
+  // Step 2: Fetch tags.
+  try {
+    await adapters.fetchTags(workDir)
+  } catch (error) {
+    return {ok: false, error: `Fetch tags failed: ${errorMessage(error)}`}
+  }
+
+  // Step 3: Fetch each integration ref.
+  for (const source of sources) {
+    try {
+      await adapters.fetchRef(workDir, source.repo, source.fetchRef, source.fetch)
+    } catch (error) {
+      return {ok: false, error: `Fetch ref ${source.label} failed: ${errorMessage(error)}`}
+    }
+  }
+
+  // Step 4: Create/reset the integration branch at the release tag.
+  try {
+    await adapters.createBranch(workDir, branch, tag)
+  } catch (error) {
+    return {ok: false, error: `Create branch ${branch} at ${tag} failed: ${errorMessage(error)}`}
+  }
+
+  // Step 5: Run the LLM merge (only when there are refs to merge).
+  if (sources.length > 0) {
+    let prompt: string
+    try {
+      prompt = await renderPrompt(promptPath, workDir, baseVersion, releaseRepo, sources)
+    } catch (error) {
+      return {ok: false, error: `Render merge prompt failed: ${errorMessage(error)}`}
+    }
+
+    try {
+      await adapters.runMerge(workDir, opencodeBin, agent, model, prompt)
+    } catch (error) {
+      return {ok: false, error: `LLM merge failed: ${errorMessage(error)}`}
+    }
+
+    // Step 6: Build the native CLI.
+    try {
+      await adapters.buildCli(workDir, baseVersion, channel)
+    } catch (error) {
+      return {ok: false, error: `Build CLI failed: ${errorMessage(error)}`}
+    }
+
+    // Step 7: Verify --version matches the base.
+    try {
+      await adapters.verifyVersion(workDir, baseVersion)
+    } catch (error) {
+      return {ok: false, error: `Version verification failed: ${errorMessage(error)}`}
+    }
+  }
+
+  // Step 8: Capture the frozen integration commit SHA.
+  let integrationCommit: string
+  try {
+    integrationCommit = await adapters.getCommitSha(workDir)
+  } catch (error) {
+    return {ok: false, error: `Get commit SHA failed: ${errorMessage(error)}`}
+  }
+
+  // Step 9: Build the provenance manifest and freeze it.
+  const manifest: ProvenanceManifest = {
+    baseVersion,
+    integrationRefs: sources.map((s, i) => ({
+      ref: integrationRefs[i] ?? s.label,
+      resolvedSha: integrationCommit, // per-ref SHA resolution is a Unit 3 enhancement
+    })),
+    integrationCommit,
+    buildSha: 'dev', // replaced by the per-platform build job in Unit 3
+  }
+
+  try {
+    await writeProvenanceManifest(workDir, manifest)
+  } catch (error) {
+    return {ok: false, error: `Write provenance manifest failed: ${errorMessage(error)}`}
+  }
+
+  return {ok: true, manifest}
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return String(err)
+}

--- a/packages/harness/src/integrate.ts
+++ b/packages/harness/src/integrate.ts
@@ -99,14 +99,33 @@ export async function writeProvenanceManifest(dir: string, manifest: ProvenanceM
 }
 
 /**
+ * Type guard: validates that an unknown value has the shape of a ProvenanceManifest.
+ * Treats malformed/partial JSON as invalid rather than silently returning partial data.
+ */
+function isValidProvenanceManifest(value: unknown): value is ProvenanceManifest {
+  if (value === null || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  if (typeof v.baseVersion !== 'string' || v.baseVersion.length === 0) return false
+  if (!Array.isArray(v.integrationRefs)) return false
+  if (typeof v.integrationCommit !== 'string' || v.integrationCommit.length === 0) return false
+  if (typeof v.buildSha !== 'string') return false
+  return true
+}
+
+/**
  * Reads the provenance manifest from the given directory.
- * Returns null if the manifest does not exist.
+ * Returns null if the manifest does not exist or has an invalid shape.
+ * Uses isValidProvenanceManifest to guard against malformed/partial manifests.
  */
 export async function readProvenanceManifest(dir: string): Promise<ProvenanceManifest | null> {
   const manifestPath = path.join(dir, MANIFEST_FILENAME)
   try {
     const raw = await fs.readFile(manifestPath, 'utf8')
-    return JSON.parse(raw) as ProvenanceManifest
+    const parsed: unknown = JSON.parse(raw)
+    if (!isValidProvenanceManifest(parsed)) {
+      return null
+    }
+    return parsed
   } catch {
     return null
   }

--- a/packages/harness/src/integrate.ts
+++ b/packages/harness/src/integrate.ts
@@ -13,6 +13,8 @@
  * single source of truth — it is only written after all steps succeed (freeze).
  */
 
+// IntegrationRefRecord is the canonical type — defined once in provenance.ts.
+import type {IntegrationRefRecord} from './provenance.js'
 import type {IntegrationSource} from './sources.js'
 import {execFile} from 'node:child_process'
 import fs from 'node:fs/promises'
@@ -21,16 +23,12 @@ import process from 'node:process'
 import {promisify} from 'node:util'
 import {resolveSources} from './sources.js'
 
+// Re-export so callers that previously imported from integrate.ts still work.
+export type {IntegrationRefRecord} from './provenance.js'
+
 // ---------------------------------------------------------------------------
 // Provenance manifest types
 // ---------------------------------------------------------------------------
-
-export interface IntegrationRefRecord {
-  readonly ref: string
-  readonly resolvedSha: string
-  readonly reason?: string
-  readonly upstreamStatus?: string
-}
 
 export interface ProvenanceManifest {
   readonly baseVersion: string
@@ -253,7 +251,13 @@ export async function runIntegration(
   const branch = integrationBranch(baseVersion)
   const channel = 'latest'
 
-  const sources = resolveSources(integrationRefs, `https://github.com/${releaseRepo}.git`)
+  // Resolve sources — wrap in try/catch so invalid refs return {ok:false} instead of throwing.
+  let sources: IntegrationSource[]
+  try {
+    sources = resolveSources(integrationRefs, `https://github.com/${releaseRepo}.git`)
+  } catch (error) {
+    return {ok: false, error: `Resolve sources failed: ${errorMessage(error)}`}
+  }
 
   // Step 1: Clone the release repo.
   try {
@@ -324,14 +328,15 @@ export async function runIntegration(
   }
 
   // Step 9: Build the provenance manifest and freeze it.
+  // Per-ref SHA resolution is tracked separately; all refs share the integration commit for now.
   const manifest: ProvenanceManifest = {
     baseVersion,
     integrationRefs: sources.map((s, i) => ({
       ref: integrationRefs[i] ?? s.label,
-      resolvedSha: integrationCommit, // per-ref SHA resolution is a Unit 3 enhancement
+      resolvedSha: integrationCommit,
     })),
     integrationCommit,
-    buildSha: 'dev', // replaced by the per-platform build job in Unit 3
+    buildSha: 'dev', // replaced by the per-platform build job at publish time
   }
 
   try {

--- a/packages/harness/src/platform.test.ts
+++ b/packages/harness/src/platform.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {binaryPathInPackage, getHostPlatformInfo, getPlatformInfo, UnsupportedPlatformError} from './platform.js'
+import {binaryPathInPackage, getHostPlatformInfo, getPlatformInfo} from './platform.js'
 
 // ---------------------------------------------------------------------------
 // getPlatformInfo — supported matrix
@@ -8,71 +8,89 @@ import {binaryPathInPackage, getHostPlatformInfo, getPlatformInfo, UnsupportedPl
 describe('getPlatformInfo', () => {
   it('linux/x64 → @fro.bot/harness-linux-x64', () => {
     // #given / #when
-    const info = getPlatformInfo('linux', 'x64')
+    const result = getPlatformInfo('linux', 'x64')
 
     // #then
-    expect(info.os).toBe('linux')
-    expect(info.arch).toBe('x64')
-    expect(info.packageName).toBe('@fro.bot/harness-linux-x64')
-    expect(info.binaryName).toBe('opencode')
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.info.os).toBe('linux')
+    expect(result.info.arch).toBe('x64')
+    expect(result.info.packageName).toBe('@fro.bot/harness-linux-x64')
+    expect(result.info.binaryName).toBe('opencode')
   })
 
   it('linux/arm64 → @fro.bot/harness-linux-arm64', () => {
     // #given / #when
-    const info = getPlatformInfo('linux', 'arm64')
+    const result = getPlatformInfo('linux', 'arm64')
 
     // #then
-    expect(info.packageName).toBe('@fro.bot/harness-linux-arm64')
-    expect(info.binaryName).toBe('opencode')
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.info.packageName).toBe('@fro.bot/harness-linux-arm64')
+    expect(result.info.binaryName).toBe('opencode')
   })
 
   it('darwin/x64 → @fro.bot/harness-darwin-x64', () => {
     // #given / #when
-    const info = getPlatformInfo('darwin', 'x64')
+    const result = getPlatformInfo('darwin', 'x64')
 
     // #then
-    expect(info.packageName).toBe('@fro.bot/harness-darwin-x64')
-    expect(info.binaryName).toBe('opencode')
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.info.packageName).toBe('@fro.bot/harness-darwin-x64')
+    expect(result.info.binaryName).toBe('opencode')
   })
 
   it('darwin/arm64 → @fro.bot/harness-darwin-arm64', () => {
     // #given / #when
-    const info = getPlatformInfo('darwin', 'arm64')
+    const result = getPlatformInfo('darwin', 'arm64')
 
     // #then
-    expect(info.packageName).toBe('@fro.bot/harness-darwin-arm64')
-    expect(info.binaryName).toBe('opencode')
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.info.packageName).toBe('@fro.bot/harness-darwin-arm64')
+    expect(result.info.binaryName).toBe('opencode')
   })
 
   // ---------------------------------------------------------------------------
-  // Unsupported platforms
+  // Unsupported platforms — return {ok: false} (no throw)
   // ---------------------------------------------------------------------------
 
-  it('win32/x64 → UnsupportedPlatformError', () => {
-    // #given / #when / #then
-    expect(() => getPlatformInfo('win32', 'x64')).toThrow(UnsupportedPlatformError)
+  it('win32/x64 → {ok: false} with error message', () => {
+    // #given / #when
+    const result = getPlatformInfo('win32', 'x64')
+
+    // #then
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected not ok')
+    expect(result.error).toContain('win32')
+    expect(result.error).toContain('x64')
   })
 
-  it('win32/arm64 → UnsupportedPlatformError', () => {
+  it('win32/arm64 → {ok: false}', () => {
     // #given / #when / #then
-    expect(() => getPlatformInfo('win32', 'arm64')).toThrow(UnsupportedPlatformError)
+    expect(getPlatformInfo('win32', 'arm64').ok).toBe(false)
   })
 
-  it('linux/ia32 → UnsupportedPlatformError', () => {
+  it('linux/ia32 → {ok: false}', () => {
     // #given / #when / #then
-    expect(() => getPlatformInfo('linux', 'ia32')).toThrow(UnsupportedPlatformError)
+    expect(getPlatformInfo('linux', 'ia32').ok).toBe(false)
   })
 
-  it('freebsd/x64 → UnsupportedPlatformError', () => {
+  it('freebsd/x64 → {ok: false}', () => {
     // #given / #when / #then
-    expect(() => getPlatformInfo('freebsd', 'x64')).toThrow(UnsupportedPlatformError)
+    expect(getPlatformInfo('freebsd', 'x64').ok).toBe(false)
   })
 
-  it('unsupportedPlatformError message includes os and arch', () => {
-    // #given / #when / #then — use toThrow with a matcher to avoid conditional expects
-    expect(() => getPlatformInfo('win32', 'x64')).toThrow('win32')
-    expect(() => getPlatformInfo('win32', 'x64')).toThrow('x64')
-    expect(() => getPlatformInfo('win32', 'x64')).toThrow(UnsupportedPlatformError)
+  it('unsupported platform error message includes os and arch', () => {
+    // #given / #when
+    const result = getPlatformInfo('win32', 'x64')
+
+    // #then
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected not ok')
+    expect(result.error).toContain('win32')
+    expect(result.error).toContain('x64')
   })
 })
 
@@ -88,13 +106,23 @@ describe('getHostPlatformInfo', () => {
   // Skip on unsupported platforms (e.g. windows dev machine) — no conditional expects.
   it.skipIf(!isHostSupported)('returns a valid PlatformInfo for the current host (linux or darwin)', () => {
     // #given / #when
-    const info = getHostPlatformInfo()
+    const result = getHostPlatformInfo()
 
     // #then
-    expect(info.os).toBe(process.platform)
-    expect(info.arch).toBe(process.arch)
-    expect(info.packageName).toMatch(/^@fro\.bot\/harness-(linux|darwin)-(x64|arm64)$/)
-    expect(info.binaryName).toBe('opencode')
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected ok')
+    expect(result.info.os).toBe(process.platform)
+    expect(result.info.arch).toBe(process.arch)
+    expect(result.info.packageName).toMatch(/^@fro\.bot\/harness-(linux|darwin)-(x64|arm64)$/)
+    expect(result.info.binaryName).toBe('opencode')
+  })
+
+  it.skipIf(isHostSupported)('returns {ok: false} on unsupported host platform', () => {
+    // #given / #when
+    const result = getHostPlatformInfo()
+
+    // #then
+    expect(result.ok).toBe(false)
   })
 })
 
@@ -105,23 +133,25 @@ describe('getHostPlatformInfo', () => {
 describe('binaryPathInPackage', () => {
   it('constructs the expected binary path', () => {
     // #given
-    const info = getPlatformInfo('linux', 'x64')
+    const result = getPlatformInfo('linux', 'x64')
+    if (!result.ok) throw new Error('expected ok')
 
     // #when
-    const result = binaryPathInPackage('/home/runner/.npm/@fro.bot/harness-linux-x64', info)
+    const binaryPath = binaryPathInPackage('/home/runner/.npm/@fro.bot/harness-linux-x64', result.info)
 
     // #then
-    expect(result).toBe('/home/runner/.npm/@fro.bot/harness-linux-x64/bin/opencode')
+    expect(binaryPath).toBe('/home/runner/.npm/@fro.bot/harness-linux-x64/bin/opencode')
   })
 
   it('darwin/arm64 binary path', () => {
     // #given
-    const info = getPlatformInfo('darwin', 'arm64')
+    const result = getPlatformInfo('darwin', 'arm64')
+    if (!result.ok) throw new Error('expected ok')
 
     // #when
-    const result = binaryPathInPackage('/usr/local/lib/node_modules/@fro.bot/harness-darwin-arm64', info)
+    const binaryPath = binaryPathInPackage('/usr/local/lib/node_modules/@fro.bot/harness-darwin-arm64', result.info)
 
     // #then
-    expect(result).toBe('/usr/local/lib/node_modules/@fro.bot/harness-darwin-arm64/bin/opencode')
+    expect(binaryPath).toBe('/usr/local/lib/node_modules/@fro.bot/harness-darwin-arm64/bin/opencode')
   })
 })

--- a/packages/harness/src/platform.test.ts
+++ b/packages/harness/src/platform.test.ts
@@ -1,0 +1,127 @@
+import {describe, expect, it} from 'vitest'
+import {binaryPathInPackage, getHostPlatformInfo, getPlatformInfo, UnsupportedPlatformError} from './platform.js'
+
+// ---------------------------------------------------------------------------
+// getPlatformInfo — supported matrix
+// ---------------------------------------------------------------------------
+
+describe('getPlatformInfo', () => {
+  it('linux/x64 → @fro.bot/harness-linux-x64', () => {
+    // #given / #when
+    const info = getPlatformInfo('linux', 'x64')
+
+    // #then
+    expect(info.os).toBe('linux')
+    expect(info.arch).toBe('x64')
+    expect(info.packageName).toBe('@fro.bot/harness-linux-x64')
+    expect(info.binaryName).toBe('opencode')
+  })
+
+  it('linux/arm64 → @fro.bot/harness-linux-arm64', () => {
+    // #given / #when
+    const info = getPlatformInfo('linux', 'arm64')
+
+    // #then
+    expect(info.packageName).toBe('@fro.bot/harness-linux-arm64')
+    expect(info.binaryName).toBe('opencode')
+  })
+
+  it('darwin/x64 → @fro.bot/harness-darwin-x64', () => {
+    // #given / #when
+    const info = getPlatformInfo('darwin', 'x64')
+
+    // #then
+    expect(info.packageName).toBe('@fro.bot/harness-darwin-x64')
+    expect(info.binaryName).toBe('opencode')
+  })
+
+  it('darwin/arm64 → @fro.bot/harness-darwin-arm64', () => {
+    // #given / #when
+    const info = getPlatformInfo('darwin', 'arm64')
+
+    // #then
+    expect(info.packageName).toBe('@fro.bot/harness-darwin-arm64')
+    expect(info.binaryName).toBe('opencode')
+  })
+
+  // ---------------------------------------------------------------------------
+  // Unsupported platforms
+  // ---------------------------------------------------------------------------
+
+  it('win32/x64 → UnsupportedPlatformError', () => {
+    // #given / #when / #then
+    expect(() => getPlatformInfo('win32', 'x64')).toThrow(UnsupportedPlatformError)
+  })
+
+  it('win32/arm64 → UnsupportedPlatformError', () => {
+    // #given / #when / #then
+    expect(() => getPlatformInfo('win32', 'arm64')).toThrow(UnsupportedPlatformError)
+  })
+
+  it('linux/ia32 → UnsupportedPlatformError', () => {
+    // #given / #when / #then
+    expect(() => getPlatformInfo('linux', 'ia32')).toThrow(UnsupportedPlatformError)
+  })
+
+  it('freebsd/x64 → UnsupportedPlatformError', () => {
+    // #given / #when / #then
+    expect(() => getPlatformInfo('freebsd', 'x64')).toThrow(UnsupportedPlatformError)
+  })
+
+  it('unsupportedPlatformError message includes os and arch', () => {
+    // #given / #when / #then — use toThrow with a matcher to avoid conditional expects
+    expect(() => getPlatformInfo('win32', 'x64')).toThrow('win32')
+    expect(() => getPlatformInfo('win32', 'x64')).toThrow('x64')
+    expect(() => getPlatformInfo('win32', 'x64')).toThrow(UnsupportedPlatformError)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getHostPlatformInfo — smoke test (host must be in the supported matrix in CI)
+// ---------------------------------------------------------------------------
+
+const isHostSupported =
+  (process.platform === 'linux' || process.platform === 'darwin') &&
+  (process.arch === 'x64' || process.arch === 'arm64')
+
+describe('getHostPlatformInfo', () => {
+  // Skip on unsupported platforms (e.g. windows dev machine) — no conditional expects.
+  it.skipIf(!isHostSupported)('returns a valid PlatformInfo for the current host (linux or darwin)', () => {
+    // #given / #when
+    const info = getHostPlatformInfo()
+
+    // #then
+    expect(info.os).toBe(process.platform)
+    expect(info.arch).toBe(process.arch)
+    expect(info.packageName).toMatch(/^@fro\.bot\/harness-(linux|darwin)-(x64|arm64)$/)
+    expect(info.binaryName).toBe('opencode')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// binaryPathInPackage
+// ---------------------------------------------------------------------------
+
+describe('binaryPathInPackage', () => {
+  it('constructs the expected binary path', () => {
+    // #given
+    const info = getPlatformInfo('linux', 'x64')
+
+    // #when
+    const result = binaryPathInPackage('/home/runner/.npm/@fro.bot/harness-linux-x64', info)
+
+    // #then
+    expect(result).toBe('/home/runner/.npm/@fro.bot/harness-linux-x64/bin/opencode')
+  })
+
+  it('darwin/arm64 binary path', () => {
+    // #given
+    const info = getPlatformInfo('darwin', 'arm64')
+
+    // #when
+    const result = binaryPathInPackage('/usr/local/lib/node_modules/@fro.bot/harness-darwin-arm64', info)
+
+    // #then
+    expect(result).toBe('/usr/local/lib/node_modules/@fro.bot/harness-darwin-arm64/bin/opencode')
+  })
+})

--- a/packages/harness/src/platform.ts
+++ b/packages/harness/src/platform.ts
@@ -26,46 +26,59 @@ export interface PlatformInfo {
   readonly binaryName: string
 }
 
-/** Thrown when the host platform is not in the supported matrix. */
-export class UnsupportedPlatformError extends Error {
-  constructor(os: string, arch: string) {
-    super(`Unsupported platform: ${os}/${arch}. @fro.bot/harness supports linux/darwin × x64/arm64 only (no windows).`)
-    this.name = 'UnsupportedPlatformError'
-  }
-}
+/**
+ * Discriminated result for platform detection.
+ *
+ * ok: true  → platform is supported; info contains the resolved PlatformInfo.
+ * ok: false → platform is not in the supported matrix; error contains a human-readable message.
+ */
+export type PlatformResult =
+  | {readonly ok: true; readonly info: PlatformInfo}
+  | {readonly ok: false; readonly error: string}
 
 /**
- * Returns the platform info for the given os/arch pair.
+ * Returns the platform result for the given os/arch pair.
+ *
+ * Returns {ok: false} when the platform is not in the supported matrix
+ * (linux/darwin × x64/arm64 only; no windows).
  *
  * @param os   - Node.js process.platform value (e.g. 'linux', 'darwin', 'win32').
  * @param arch - Node.js process.arch value (e.g. 'x64', 'arm64').
- * @throws {UnsupportedPlatformError} when the platform is not in the supported matrix.
  */
-export function getPlatformInfo(os: string, arch: string): PlatformInfo {
+export function getPlatformInfo(os: string, arch: string): PlatformResult {
   if (os !== 'linux' && os !== 'darwin') {
-    throw new UnsupportedPlatformError(os, arch)
+    return {
+      ok: false,
+      error: `Unsupported platform: ${os}/${arch}. @fro.bot/harness supports linux/darwin × x64/arm64 only (no windows).`,
+    }
   }
   if (arch !== 'x64' && arch !== 'arm64') {
-    throw new UnsupportedPlatformError(os, arch)
+    return {
+      ok: false,
+      error: `Unsupported platform: ${os}/${arch}. @fro.bot/harness supports linux/darwin × x64/arm64 only (no windows).`,
+    }
   }
 
   const supportedOs: SupportedOs = os
   const supportedArch: SupportedArch = arch
 
   return {
-    os: supportedOs,
-    arch: supportedArch,
-    packageName: `@fro.bot/harness-${supportedOs}-${supportedArch}`,
-    binaryName: 'opencode',
+    ok: true,
+    info: {
+      os: supportedOs,
+      arch: supportedArch,
+      packageName: `@fro.bot/harness-${supportedOs}-${supportedArch}`,
+      binaryName: 'opencode',
+    },
   }
 }
 
 /**
- * Returns the platform info for the current host process.
+ * Returns the platform result for the current host process.
  *
- * @throws {UnsupportedPlatformError} when the host platform is not in the supported matrix.
+ * Returns {ok: false} when the host platform is not in the supported matrix.
  */
-export function getHostPlatformInfo(): PlatformInfo {
+export function getHostPlatformInfo(): PlatformResult {
   return getPlatformInfo(process.platform, process.arch)
 }
 
@@ -79,7 +92,5 @@ export function getHostPlatformInfo(): PlatformInfo {
  * @param info        - Platform info (from getPlatformInfo or getHostPlatformInfo).
  */
 export function binaryPathInPackage(packageRoot: string, info: PlatformInfo): string {
-  // Use path.join via dynamic import to avoid circular deps — inline the join.
-  // Node path.join is synchronous and safe here.
   return `${packageRoot}/bin/${info.binaryName}`
 }

--- a/packages/harness/src/platform.ts
+++ b/packages/harness/src/platform.ts
@@ -1,0 +1,85 @@
+/**
+ * Host platform/arch detection → optionalDependencies package name.
+ *
+ * Maps the current Node.js process.platform + process.arch to the
+ * @fro.bot/harness-<os>-<arch> package name that ships the native binary.
+ *
+ * Mirrors OpenCode's per-platform packaging model (anomalyco/opencode script/publish.ts).
+ * Windows is out of scope (matrix: linux x64/arm64 + darwin x64/arm64 only).
+ */
+
+import process from 'node:process'
+
+/** Supported OS identifiers (Node.js process.platform values we handle). */
+export type SupportedOs = 'linux' | 'darwin'
+
+/** Supported CPU arch identifiers (Node.js process.arch values we handle). */
+export type SupportedArch = 'x64' | 'arm64'
+
+/** A resolved platform identity. */
+export interface PlatformInfo {
+  readonly os: SupportedOs
+  readonly arch: SupportedArch
+  /** The @fro.bot/harness-<os>-<arch> package name for this platform. */
+  readonly packageName: string
+  /** The binary filename inside the package (always 'opencode' on supported platforms). */
+  readonly binaryName: string
+}
+
+/** Thrown when the host platform is not in the supported matrix. */
+export class UnsupportedPlatformError extends Error {
+  constructor(os: string, arch: string) {
+    super(`Unsupported platform: ${os}/${arch}. @fro.bot/harness supports linux/darwin × x64/arm64 only (no windows).`)
+    this.name = 'UnsupportedPlatformError'
+  }
+}
+
+/**
+ * Returns the platform info for the given os/arch pair.
+ *
+ * @param os   - Node.js process.platform value (e.g. 'linux', 'darwin', 'win32').
+ * @param arch - Node.js process.arch value (e.g. 'x64', 'arm64').
+ * @throws {UnsupportedPlatformError} when the platform is not in the supported matrix.
+ */
+export function getPlatformInfo(os: string, arch: string): PlatformInfo {
+  if (os !== 'linux' && os !== 'darwin') {
+    throw new UnsupportedPlatformError(os, arch)
+  }
+  if (arch !== 'x64' && arch !== 'arm64') {
+    throw new UnsupportedPlatformError(os, arch)
+  }
+
+  const supportedOs: SupportedOs = os
+  const supportedArch: SupportedArch = arch
+
+  return {
+    os: supportedOs,
+    arch: supportedArch,
+    packageName: `@fro.bot/harness-${supportedOs}-${supportedArch}`,
+    binaryName: 'opencode',
+  }
+}
+
+/**
+ * Returns the platform info for the current host process.
+ *
+ * @throws {UnsupportedPlatformError} when the host platform is not in the supported matrix.
+ */
+export function getHostPlatformInfo(): PlatformInfo {
+  return getPlatformInfo(process.platform, process.arch)
+}
+
+/**
+ * Returns the expected binary path inside an installed optionalDependencies package.
+ *
+ * The per-platform packages ship the native binary at:
+ *   <packageRoot>/bin/<binaryName>
+ *
+ * @param packageRoot - Absolute path to the installed platform package root.
+ * @param info        - Platform info (from getPlatformInfo or getHostPlatformInfo).
+ */
+export function binaryPathInPackage(packageRoot: string, info: PlatformInfo): string {
+  // Use path.join via dynamic import to avoid circular deps — inline the join.
+  // Node path.join is synchronous and safe here.
+  return `${packageRoot}/bin/${info.binaryName}`
+}

--- a/packages/harness/src/postinstall.ts
+++ b/packages/harness/src/postinstall.ts
@@ -3,7 +3,8 @@
  *
  * Runs after `npm install @fro.bot/harness` to:
  *   1. Detect the host platform.
- *   2. Locate the per-platform binary from the installed optionalDependencies package.
+ *   2. Locate the per-platform binary from the installed optionalDependencies package
+ *      via Node module resolution (handles pnpm/npm hoisting correctly).
  *   3. Verify the binary is executable (basic probe — npm provenance attestation
  *      is the cryptographic integrity gate; this is a belt-and-suspenders exec check).
  *   4. Print a clear status message.
@@ -12,19 +13,15 @@
  * The `|| true` in package.json scripts.postinstall ensures install never fails here.
  *
  * A missing binary is NOT a fatal install error — the harness falls back to the
- * dev scaffold (opencode on PATH). The action setup (Unit 4) fails loud if the
- * binary is absent in CI, where it is required.
+ * dev scaffold (opencode on PATH). The action setup fails loud if the binary is
+ * absent in CI, where it is required.
  */
 
 import {execFileSync} from 'node:child_process'
-import {existsSync} from 'node:fs'
+import {createRequire} from 'node:module'
 import path from 'node:path'
 import process from 'node:process'
-import {fileURLToPath} from 'node:url'
-import {binaryPathInPackage, getHostPlatformInfo, UnsupportedPlatformError} from './platform.js'
-
-// Resolve the package root (postinstall runs from the package root).
-const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+import {binaryPathInPackage, getHostPlatformInfo} from './platform.js'
 
 function log(msg: string): void {
   process.stderr.write(`[harness postinstall] ${msg}\n`)
@@ -32,30 +29,31 @@ function log(msg: string): void {
 
 function main(): void {
   // 1. Detect host platform.
-  let info
-  try {
-    info = getHostPlatformInfo()
-  } catch (error) {
-    if (error instanceof UnsupportedPlatformError) {
-      log(`Platform not supported: ${error.message}`)
-      log('No platform binary available. Using opencode on PATH as fallback.')
-      process.exit(0)
-    }
-    throw error
+  const platformResult = getHostPlatformInfo()
+  if (!platformResult.ok) {
+    log(`Platform not supported: ${platformResult.error}`)
+    log('No platform binary available. Using opencode on PATH as fallback.')
+    process.exit(0)
   }
 
+  const info = platformResult.info
   log(`Host platform: ${info.os}/${info.arch} → ${info.packageName}`)
 
-  // 2. Locate the platform binary.
-  const platformPkgRoot = path.join(packageRoot, 'node_modules', info.packageName)
-  const binaryPath = binaryPathInPackage(platformPkgRoot, info)
-
-  if (!existsSync(binaryPath)) {
-    log(`Platform binary not found at: ${binaryPath}`)
-    log(`The ${info.packageName} optional dependency may not be installed.`)
+  // 2. Locate the platform binary via Node module resolution.
+  //    createRequire resolves from this file's location, correctly handling
+  //    pnpm/npm hoisting (the platform package may not be in a local node_modules).
+  const require = createRequire(import.meta.url)
+  let platformPkgRoot: string
+  try {
+    const pkgJsonPath = require.resolve(`${info.packageName}/package.json`)
+    platformPkgRoot = path.dirname(pkgJsonPath)
+  } catch {
+    log(`Platform package ${info.packageName} not found (optional dependency not installed).`)
     log('Using opencode on PATH as fallback.')
     process.exit(0)
   }
+
+  const binaryPath = binaryPathInPackage(platformPkgRoot, info)
 
   // 3. Verify the binary is executable.
   try {

--- a/packages/harness/src/postinstall.ts
+++ b/packages/harness/src/postinstall.ts
@@ -1,0 +1,75 @@
+/**
+ * postinstall.ts — integrity-verifying binary resolver run at install time.
+ *
+ * Runs after `npm install @fro.bot/harness` to:
+ *   1. Detect the host platform.
+ *   2. Locate the per-platform binary from the installed optionalDependencies package.
+ *   3. Verify the binary is executable (basic probe — npm provenance attestation
+ *      is the cryptographic integrity gate; this is a belt-and-suspenders exec check).
+ *   4. Print a clear status message.
+ *
+ * Exits 0 on success or when no platform binary is available (optional dep not installed).
+ * The `|| true` in package.json scripts.postinstall ensures install never fails here.
+ *
+ * A missing binary is NOT a fatal install error — the harness falls back to the
+ * dev scaffold (opencode on PATH). The action setup (Unit 4) fails loud if the
+ * binary is absent in CI, where it is required.
+ */
+
+import {execFileSync} from 'node:child_process'
+import {existsSync} from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import {fileURLToPath} from 'node:url'
+import {binaryPathInPackage, getHostPlatformInfo, UnsupportedPlatformError} from './platform.js'
+
+// Resolve the package root (postinstall runs from the package root).
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+function log(msg: string): void {
+  process.stderr.write(`[harness postinstall] ${msg}\n`)
+}
+
+function main(): void {
+  // 1. Detect host platform.
+  let info
+  try {
+    info = getHostPlatformInfo()
+  } catch (error) {
+    if (error instanceof UnsupportedPlatformError) {
+      log(`Platform not supported: ${error.message}`)
+      log('No platform binary available. Using opencode on PATH as fallback.')
+      process.exit(0)
+    }
+    throw error
+  }
+
+  log(`Host platform: ${info.os}/${info.arch} → ${info.packageName}`)
+
+  // 2. Locate the platform binary.
+  const platformPkgRoot = path.join(packageRoot, 'node_modules', info.packageName)
+  const binaryPath = binaryPathInPackage(platformPkgRoot, info)
+
+  if (!existsSync(binaryPath)) {
+    log(`Platform binary not found at: ${binaryPath}`)
+    log(`The ${info.packageName} optional dependency may not be installed.`)
+    log('Using opencode on PATH as fallback.')
+    process.exit(0)
+  }
+
+  // 3. Verify the binary is executable.
+  try {
+    const version = execFileSync(binaryPath, ['--version'], {
+      encoding: 'utf8',
+      timeout: 10_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim()
+    log(`Binary verified: ${binaryPath} (version: ${version})`)
+    log('Platform binary ready.')
+  } catch {
+    log(`Binary found but not executable: ${binaryPath}`)
+    log('Using opencode on PATH as fallback.')
+  }
+}
+
+main()

--- a/packages/harness/src/provenance.ts
+++ b/packages/harness/src/provenance.ts
@@ -31,6 +31,31 @@ export interface Provenance {
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 
 /**
+ * Type guard: validates that an unknown value has the shape of a Provenance manifest.
+ * Treats malformed JSON as an explicit error rather than silently returning partial data.
+ */
+function isValidProvenance(value: unknown): value is Provenance {
+  if (value === null || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  if (typeof v.baseVersion !== 'string' || v.baseVersion.length === 0) return false
+  if (!Array.isArray(v.integrationRefs)) return false
+  if (v.integrationCommit !== null && typeof v.integrationCommit !== 'string') return false
+  if (typeof v.buildSha !== 'string') return false
+  return true
+}
+
+/**
+ * Type guard: validates that an unknown value has the shape of a harness.config.json.
+ */
+function isValidHarnessConfig(value: unknown): value is {base_version?: string; integrationRefs?: string[]} {
+  if (value === null || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  if (v.base_version !== undefined && typeof v.base_version !== 'string') return false
+  if (v.integrationRefs !== undefined && !Array.isArray(v.integrationRefs)) return false
+  return true
+}
+
+/**
  * Returns the provenance for the current harness binary.
  *
  * Resolution order:
@@ -38,18 +63,20 @@ const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '
  *   2. harness.config.json (dev scaffold — shows configured refs without a frozen commit).
  *   3. Hardcoded dev placeholder (no config file present).
  *
- * Unit 3 generates a provenance.json at build time that this function reads,
- * making the manifest available at runtime without filesystem reads in production.
+ * The integration engine writes provenance.json at build time; this function reads
+ * it at runtime, making the manifest available without additional filesystem reads
+ * in production.
  */
 export function getProvenance(): Provenance {
   // 1. Try bundled provenance.json (written by the integration engine).
   try {
     const manifestPath = path.join(packageRoot, 'provenance.json')
     const raw = readFileSync(manifestPath, 'utf8')
-    const manifest = JSON.parse(raw) as Provenance
-    if (manifest !== null && typeof manifest === 'object' && typeof manifest.baseVersion === 'string') {
-      return manifest
+    const parsed: unknown = JSON.parse(raw)
+    if (isValidProvenance(parsed)) {
+      return parsed
     }
+    // Malformed manifest — fall through to dev scaffold.
   } catch {
     // No bundled manifest — fall through.
   }
@@ -58,12 +85,13 @@ export function getProvenance(): Provenance {
   try {
     const configPath = path.join(packageRoot, 'harness.config.json')
     const raw = readFileSync(configPath, 'utf8')
-    const cfg = JSON.parse(raw) as {
-      base_version?: string
-      integrationRefs?: string[]
+    const parsed: unknown = JSON.parse(raw)
+    if (!isValidHarnessConfig(parsed)) {
+      // Malformed config — fall through to hardcoded placeholder.
+      throw new Error('Invalid harness.config.json shape')
     }
-    const baseVersion = cfg.base_version ?? '1.15.13'
-    const integrationRefs: IntegrationRefRecord[] = (cfg.integrationRefs ?? []).map(ref => ({
+    const baseVersion = parsed.base_version ?? '1.15.13'
+    const integrationRefs: IntegrationRefRecord[] = (parsed.integrationRefs ?? []).map(ref => ({
       ref,
       resolvedSha: 'dev',
     }))

--- a/packages/harness/src/provenance.ts
+++ b/packages/harness/src/provenance.ts
@@ -1,25 +1,82 @@
 /**
- * Provenance shape for the harness binary.
+ * Provenance manifest for the harness binary.
  *
- * baseVersion    — the upstream OpenCode release tag this binary is based on.
- * integrationRefs — ordered list of integration refs carried onto the base tag
- *                   (PR URLs, branch URLs, or local branch names).
- * integrationCommit — the frozen integration commit SHA produced by the LLM merge,
- *                     or null when running from a dev/unbuilt scaffold.
- * buildSha       — the git SHA of the harness build, or 'dev' in the scaffold.
+ * The manifest is the single source of truth written by the integration engine
+ * and read by the CLI commands (info, patches, doctor).
+ *
+ * baseVersion       — the upstream OpenCode release tag this binary is based on.
+ * integrationRefs   — ordered list of integration refs carried onto the base tag,
+ *                     each with the resolved commit SHA and optional metadata.
+ * integrationCommit — the frozen integration commit SHA produced by the LLM merge.
+ * buildSha          — the git SHA of the harness build, or 'dev' in the scaffold.
  */
+import {readFileSync} from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+export interface IntegrationRefRecord {
+  readonly ref: string
+  readonly resolvedSha: string
+  readonly reason?: string
+  readonly upstreamStatus?: string
+}
+
 export interface Provenance {
   readonly baseVersion: string
-  readonly integrationRefs: readonly string[]
+  readonly integrationRefs: readonly IntegrationRefRecord[]
   readonly integrationCommit: string | null
   readonly buildSha: string
 }
 
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
 /**
- * Returns the placeholder dev provenance used before Unit 2/3 wire the real manifest.
- * Unit 2 replaces this with a manifest read from a generated provenance.json at build time.
+ * Returns the provenance for the current harness binary.
+ *
+ * Resolution order:
+ *   1. Bundled provenance.json (written by the integration engine at build time).
+ *   2. harness.config.json (dev scaffold — shows configured refs without a frozen commit).
+ *   3. Hardcoded dev placeholder (no config file present).
+ *
+ * Unit 3 generates a provenance.json at build time that this function reads,
+ * making the manifest available at runtime without filesystem reads in production.
  */
 export function getProvenance(): Provenance {
+  // 1. Try bundled provenance.json (written by the integration engine).
+  try {
+    const manifestPath = path.join(packageRoot, 'provenance.json')
+    const raw = readFileSync(manifestPath, 'utf8')
+    const manifest = JSON.parse(raw) as Provenance
+    if (manifest !== null && typeof manifest === 'object' && typeof manifest.baseVersion === 'string') {
+      return manifest
+    }
+  } catch {
+    // No bundled manifest — fall through.
+  }
+
+  // 2. Fall back to harness.config.json for the dev scaffold.
+  try {
+    const configPath = path.join(packageRoot, 'harness.config.json')
+    const raw = readFileSync(configPath, 'utf8')
+    const cfg = JSON.parse(raw) as {
+      base_version?: string
+      integrationRefs?: string[]
+    }
+    const baseVersion = cfg.base_version ?? '1.15.13'
+    const integrationRefs: IntegrationRefRecord[] = (cfg.integrationRefs ?? []).map(ref => ({
+      ref,
+      resolvedSha: 'dev',
+    }))
+    return {
+      baseVersion,
+      integrationRefs,
+      integrationCommit: null,
+      buildSha: 'dev',
+    }
+  } catch {
+    // No config file — return hardcoded placeholder.
+  }
+
   return {
     baseVersion: '1.15.13',
     integrationRefs: [],
@@ -40,8 +97,12 @@ export function formatProvenance(p: Provenance): string {
   ]
   if (p.integrationRefs.length > 0) {
     lines.push(`  integration refs:`)
-    for (const ref of p.integrationRefs) {
-      lines.push(`    - ${ref}`)
+    for (const r of p.integrationRefs) {
+      const meta = r.upstreamStatus === undefined ? '' : ` [${r.upstreamStatus}]`
+      lines.push(`    - ${r.ref}${meta}`)
+      if (r.reason !== undefined) {
+        lines.push(`      reason: ${r.reason}`)
+      }
     }
   } else {
     lines.push(`  integration refs:   (none — dev scaffold)`)

--- a/packages/harness/src/provenance.ts
+++ b/packages/harness/src/provenance.ts
@@ -1,0 +1,50 @@
+/**
+ * Provenance shape for the harness binary.
+ *
+ * baseVersion    — the upstream OpenCode release tag this binary is based on.
+ * integrationRefs — ordered list of integration refs carried onto the base tag
+ *                   (PR URLs, branch URLs, or local branch names).
+ * integrationCommit — the frozen integration commit SHA produced by the LLM merge,
+ *                     or null when running from a dev/unbuilt scaffold.
+ * buildSha       — the git SHA of the harness build, or 'dev' in the scaffold.
+ */
+export interface Provenance {
+  readonly baseVersion: string
+  readonly integrationRefs: readonly string[]
+  readonly integrationCommit: string | null
+  readonly buildSha: string
+}
+
+/**
+ * Returns the placeholder dev provenance used before Unit 2/3 wire the real manifest.
+ * Unit 2 replaces this with a manifest read from a generated provenance.json at build time.
+ */
+export function getProvenance(): Provenance {
+  return {
+    baseVersion: '1.15.13',
+    integrationRefs: [],
+    integrationCommit: null,
+    buildSha: 'dev',
+  }
+}
+
+/**
+ * Formats provenance as a human-readable string for `harness info`.
+ */
+export function formatProvenance(p: Provenance): string {
+  const lines: string[] = [
+    `harness (patched OpenCode)`,
+    `  base:               ${p.baseVersion}`,
+    `  integration commit: ${p.integrationCommit ?? '(unbuilt/dev scaffold)'}`,
+    `  build sha:          ${p.buildSha}`,
+  ]
+  if (p.integrationRefs.length > 0) {
+    lines.push(`  integration refs:`)
+    for (const ref of p.integrationRefs) {
+      lines.push(`    - ${ref}`)
+    }
+  } else {
+    lines.push(`  integration refs:   (none — dev scaffold)`)
+  }
+  return lines.join('\n')
+}

--- a/packages/harness/src/provenance.ts
+++ b/packages/harness/src/provenance.ts
@@ -34,7 +34,7 @@ const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '
  * Type guard: validates that an unknown value has the shape of a Provenance manifest.
  * Treats malformed JSON as an explicit error rather than silently returning partial data.
  */
-function isValidProvenance(value: unknown): value is Provenance {
+export function isValidProvenance(value: unknown): value is Provenance {
   if (value === null || typeof value !== 'object') return false
   const v = value as Record<string, unknown>
   if (typeof v.baseVersion !== 'string' || v.baseVersion.length === 0) return false

--- a/packages/harness/src/resolve-binary.ts
+++ b/packages/harness/src/resolve-binary.ts
@@ -1,12 +1,16 @@
 /**
  * Resolves the patched OpenCode binary for the current host.
  *
- * Resolution order:
- *   0. OPENCODE_PATH env override (explicit override, always honoured).
+ * Resolution order (precedence, highest to lowest):
+ *   0. OPENCODE_PATH env override — always honoured; marks isBuilt: false.
  *   1. Host-platform optionalDependencies binary (the real harness-built artifact).
- *      Looks up the @fro.bot/harness-<os>-<arch> package installed alongside this
- *      package and integrity-verifies the binary before returning it.
- *   2. Dev/PATH fallback: `opencode` on PATH (dev scaffold, isBuilt: false).
+ *      Resolved via Node module resolution (createRequire) so pnpm/npm hoisting
+ *      is handled correctly — the platform package may be hoisted outside the
+ *      local node_modules tree.
+ *   2. PATH fallback (`opencode` on PATH) — ONLY when an explicit dev escape hatch
+ *      is active: HARNESS_ALLOW_PATH_FALLBACK=1 or OPENCODE_PATH is set.
+ *      In published/production use (no escape hatch), a missing platform binary
+ *      is a hard error with an actionable message.
  *
  * The integrity check in step 1 is a basic executable-probe (--version succeeds).
  * A full cryptographic integrity check (npm provenance) is enforced by the
@@ -15,10 +19,9 @@
  */
 
 import {execFileSync} from 'node:child_process'
-import {existsSync} from 'node:fs'
+import {createRequire} from 'node:module'
 import path from 'node:path'
 import process from 'node:process'
-import {fileURLToPath} from 'node:url'
 import {binaryPathInPackage, getHostPlatformInfo} from './platform.js'
 
 /**
@@ -35,42 +38,39 @@ export interface ResolvedBinary {
   readonly isBuilt: boolean
 }
 
-// The harness package root is two levels up from this compiled file (dist/resolve-binary.js → ../..)
-// At runtime (compiled), __dirname is packages/harness/dist.
-// At test time (ts-node/vitest), __dirname is packages/harness/src.
-// We resolve the package root by walking up to find package.json.
-function findPackageRoot(): string {
-  const here = path.dirname(fileURLToPath(import.meta.url))
-  // Walk up until we find a directory containing package.json for @fro.bot/harness.
-  // In practice: dist/ → packages/harness/ (one level up) or src/ → packages/harness/ (one level up).
-  const candidate = path.resolve(here, '..')
-  return candidate
-}
-
 /**
  * Attempts to resolve the host-platform binary from the installed
  * @fro.bot/harness-<os>-<arch> optionalDependencies package.
  *
+ * Uses Node module resolution (createRequire) to locate the package, which
+ * correctly handles pnpm/npm hoisting — the platform package may be installed
+ * outside the local node_modules tree.
+ *
  * Returns the binary path if found and executable, or null otherwise.
  */
 function resolveOptionalDepBinary(): string | null {
-  let info
+  const platformResult = getHostPlatformInfo()
+  if (!platformResult.ok) {
+    // Unsupported platform — no platform binary available.
+    return null
+  }
+
+  const info = platformResult.info
+
+  // Resolve the platform package via Node module resolution.
+  // This handles pnpm/npm hoisting correctly — the package may not be in
+  // a local node_modules directory.
+  const require = createRequire(import.meta.url)
+  let platformPkgRoot: string
   try {
-    info = getHostPlatformInfo()
+    const pkgJsonPath = require.resolve(`${info.packageName}/package.json`)
+    platformPkgRoot = path.dirname(pkgJsonPath)
   } catch {
-    // Unsupported platform or other error — fall through to dev scaffold.
+    // Platform package not installed (optional dependency absent).
     return null
   }
 
-  // The per-platform package is installed as a sibling of @fro.bot/harness in node_modules.
-  // Path: <packageRoot>/node_modules/@fro.bot/harness-<os>-<arch>/bin/opencode
-  const packageRoot = findPackageRoot()
-  const platformPkgRoot = path.join(packageRoot, 'node_modules', info.packageName)
   const binaryPath = binaryPathInPackage(platformPkgRoot, info)
-
-  if (!existsSync(binaryPath)) {
-    return null
-  }
 
   // Basic executable probe — confirm the binary runs before returning it.
   try {
@@ -86,12 +86,32 @@ function resolveOptionalDepBinary(): string | null {
 }
 
 /**
+ * Returns true when an explicit dev escape hatch is active.
+ *
+ * The escape hatch allows PATH fallback in local/dev/unbuilt environments.
+ * It is NEVER active in published/production use (no env set by default).
+ *
+ * Escape hatches:
+ *   - HARNESS_ALLOW_PATH_FALLBACK=1  — explicit opt-in for dev/CI without platform binary.
+ *   - OPENCODE_PATH set              — explicit override already provided; PATH fallback is moot.
+ */
+function isDevEscapeHatchActive(): boolean {
+  return (
+    process.env.HARNESS_ALLOW_PATH_FALLBACK === '1' ||
+    (process.env.OPENCODE_PATH !== undefined && process.env.OPENCODE_PATH.length > 0)
+  )
+}
+
+/**
  * Resolves the patched OpenCode binary for the current host.
  *
  * Resolution order:
  *   0. OPENCODE_PATH env override.
  *   1. Host-platform optionalDependencies binary (isBuilt: true).
- *   2. Dev/PATH fallback: `opencode` on PATH (isBuilt: false).
+ *   2. PATH fallback — ONLY when HARNESS_ALLOW_PATH_FALLBACK=1 (dev escape hatch).
+ *      In production (no escape hatch), missing platform binary → throws with remediation.
+ *
+ * @throws {Error} when no platform binary is found and no dev escape hatch is active.
  */
 export function resolveBinary(): ResolvedBinary {
   // 0. Explicit override — always wins.
@@ -106,8 +126,23 @@ export function resolveBinary(): ResolvedBinary {
     return {resolved: true, path: optionalBinary, isBuilt: true}
   }
 
-  // 2. Dev scaffold: fall back to `opencode` on PATH.
-  return {resolved: true, path: 'opencode', isBuilt: false}
+  // 2. No platform binary found.
+  //    In dev/unbuilt environments with an explicit escape hatch, fall back to PATH.
+  //    In production (no escape hatch), fail closed with an actionable error.
+  if (isDevEscapeHatchActive()) {
+    return {resolved: true, path: 'opencode', isBuilt: false}
+  }
+
+  // Determine which platform package was expected for the error message.
+  const platformResult = getHostPlatformInfo()
+  const expectedPkg = platformResult.ok ? platformResult.info.packageName : '@fro.bot/harness-<os>-<arch>'
+
+  throw new Error(
+    `[harness] Platform binary not found. Expected package: ${expectedPkg}\n` +
+      `  Remediation: ensure ${expectedPkg} is installed as an optionalDependency,\n` +
+      `  or set OPENCODE_PATH to an explicit binary path,\n` +
+      `  or set HARNESS_ALLOW_PATH_FALLBACK=1 to use opencode on PATH (dev only).`,
+  )
 }
 
 /**

--- a/packages/harness/src/resolve-binary.ts
+++ b/packages/harness/src/resolve-binary.ts
@@ -1,12 +1,32 @@
+/**
+ * Resolves the patched OpenCode binary for the current host.
+ *
+ * Resolution order:
+ *   0. OPENCODE_PATH env override (explicit override, always honoured).
+ *   1. Host-platform optionalDependencies binary (the real harness-built artifact).
+ *      Looks up the @fro.bot/harness-<os>-<arch> package installed alongside this
+ *      package and integrity-verifies the binary before returning it.
+ *   2. Dev/PATH fallback: `opencode` on PATH (dev scaffold, isBuilt: false).
+ *
+ * The integrity check in step 1 is a basic executable-probe (--version succeeds).
+ * A full cryptographic integrity check (npm provenance) is enforced by the
+ * postinstall resolver at install time; this runtime check is a belt-and-suspenders
+ * guard against a corrupted or missing binary.
+ */
+
 import {execFileSync} from 'node:child_process'
+import {existsSync} from 'node:fs'
+import path from 'node:path'
 import process from 'node:process'
+import {fileURLToPath} from 'node:url'
+import {binaryPathInPackage, getHostPlatformInfo} from './platform.js'
 
 /**
  * Result of binary resolution.
  *
  * resolved  — true when a usable binary was found.
  * path      — the resolved binary path or command name.
- * isBuilt   — true when the binary is a real harness-built artifact (Unit 3).
+ * isBuilt   — true when the binary is a real harness-built artifact.
  *             false in the dev scaffold (falls back to opencode on PATH).
  */
 export interface ResolvedBinary {
@@ -15,26 +35,78 @@ export interface ResolvedBinary {
   readonly isBuilt: boolean
 }
 
+// The harness package root is two levels up from this compiled file (dist/resolve-binary.js → ../..)
+// At runtime (compiled), __dirname is packages/harness/dist.
+// At test time (ts-node/vitest), __dirname is packages/harness/src.
+// We resolve the package root by walking up to find package.json.
+function findPackageRoot(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  // Walk up until we find a directory containing package.json for @fro.bot/harness.
+  // In practice: dist/ → packages/harness/ (one level up) or src/ → packages/harness/ (one level up).
+  const candidate = path.resolve(here, '..')
+  return candidate
+}
+
+/**
+ * Attempts to resolve the host-platform binary from the installed
+ * @fro.bot/harness-<os>-<arch> optionalDependencies package.
+ *
+ * Returns the binary path if found and executable, or null otherwise.
+ */
+function resolveOptionalDepBinary(): string | null {
+  let info
+  try {
+    info = getHostPlatformInfo()
+  } catch {
+    // Unsupported platform or other error — fall through to dev scaffold.
+    return null
+  }
+
+  // The per-platform package is installed as a sibling of @fro.bot/harness in node_modules.
+  // Path: <packageRoot>/node_modules/@fro.bot/harness-<os>-<arch>/bin/opencode
+  const packageRoot = findPackageRoot()
+  const platformPkgRoot = path.join(packageRoot, 'node_modules', info.packageName)
+  const binaryPath = binaryPathInPackage(platformPkgRoot, info)
+
+  if (!existsSync(binaryPath)) {
+    return null
+  }
+
+  // Basic executable probe — confirm the binary runs before returning it.
+  try {
+    execFileSync(binaryPath, ['--version'], {
+      encoding: 'utf8',
+      timeout: 10_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    return binaryPath
+  } catch {
+    return null
+  }
+}
+
 /**
  * Resolves the patched OpenCode binary for the current host.
  *
- * Resolution order (Unit 3 will prepend the optionalDependencies host-binary step):
- *   1. OPENCODE_PATH env override (explicit override, always honoured).
- *   2. Dev/scaffold fallback: `opencode` on PATH.
- *
- * Unit 3 wires step 0: select the host-platform binary from the installed
- * @fro.bot/harness-<platform>-<arch> optionalDependency package, verify its
- * integrity, and return it as isBuilt:true.
+ * Resolution order:
+ *   0. OPENCODE_PATH env override.
+ *   1. Host-platform optionalDependencies binary (isBuilt: true).
+ *   2. Dev/PATH fallback: `opencode` on PATH (isBuilt: false).
  */
 export function resolveBinary(): ResolvedBinary {
-  // Explicit override — always wins.
+  // 0. Explicit override — always wins.
   const override = process.env.OPENCODE_PATH
   if (override !== undefined && override.length > 0) {
     return {resolved: true, path: override, isBuilt: false}
   }
 
-  // Dev scaffold: fall back to `opencode` on PATH.
-  // Unit 3 inserts the optionalDependencies host-binary resolution here.
+  // 1. Host-platform optionalDependencies binary.
+  const optionalBinary = resolveOptionalDepBinary()
+  if (optionalBinary !== null) {
+    return {resolved: true, path: optionalBinary, isBuilt: true}
+  }
+
+  // 2. Dev scaffold: fall back to `opencode` on PATH.
   return {resolved: true, path: 'opencode', isBuilt: false}
 }
 

--- a/packages/harness/src/resolve-binary.ts
+++ b/packages/harness/src/resolve-binary.ts
@@ -1,0 +1,56 @@
+import {execFileSync} from 'node:child_process'
+import process from 'node:process'
+
+/**
+ * Result of binary resolution.
+ *
+ * resolved  — true when a usable binary was found.
+ * path      — the resolved binary path or command name.
+ * isBuilt   — true when the binary is a real harness-built artifact (Unit 3).
+ *             false in the dev scaffold (falls back to opencode on PATH).
+ */
+export interface ResolvedBinary {
+  readonly resolved: boolean
+  readonly path: string
+  readonly isBuilt: boolean
+}
+
+/**
+ * Resolves the patched OpenCode binary for the current host.
+ *
+ * Resolution order (Unit 3 will prepend the optionalDependencies host-binary step):
+ *   1. OPENCODE_PATH env override (explicit override, always honoured).
+ *   2. Dev/scaffold fallback: `opencode` on PATH.
+ *
+ * Unit 3 wires step 0: select the host-platform binary from the installed
+ * @fro.bot/harness-<platform>-<arch> optionalDependency package, verify its
+ * integrity, and return it as isBuilt:true.
+ */
+export function resolveBinary(): ResolvedBinary {
+  // Explicit override — always wins.
+  const override = process.env.OPENCODE_PATH
+  if (override !== undefined && override.length > 0) {
+    return {resolved: true, path: override, isBuilt: false}
+  }
+
+  // Dev scaffold: fall back to `opencode` on PATH.
+  // Unit 3 inserts the optionalDependencies host-binary resolution here.
+  return {resolved: true, path: 'opencode', isBuilt: false}
+}
+
+/**
+ * Checks whether the resolved binary is present and runnable by invoking it
+ * with `--version`. Returns the version string on success, or null on failure.
+ */
+export function probeBinary(binaryPath: string): string | null {
+  try {
+    const output = execFileSync(binaryPath, ['--version'], {
+      encoding: 'utf8',
+      timeout: 10_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    return output.trim()
+  } catch {
+    return null
+  }
+}

--- a/packages/harness/src/sources.test.ts
+++ b/packages/harness/src/sources.test.ts
@@ -1,0 +1,150 @@
+import {describe, expect, it} from 'vitest'
+import {parseSource, resolveSources} from './sources.js'
+
+const SOURCE_REPO = 'https://github.com/anomalyco/opencode.git'
+
+// ---------------------------------------------------------------------------
+// parseSource — PR URL
+// ---------------------------------------------------------------------------
+
+describe('parseSource', () => {
+  it('pull request URL maps to refs/pull/N/head', () => {
+    // #given / #when
+    const src = parseSource('https://github.com/anomalyco/opencode/pull/30182', SOURCE_REPO)
+
+    // #then
+    expect(src.fetchRef).toBe('refs/pull/30182/head')
+    expect(src.repo).toBe('https://github.com/anomalyco/opencode.git')
+    expect(src.label).toBe('anomalyco/opencode#30182')
+    // merge ref is the remote-tracking ref
+    expect(src.merge).toContain('pr-30182')
+  })
+
+  it('pull request URL with trailing slash still maps correctly', () => {
+    // #given / #when
+    const src = parseSource('https://github.com/anomalyco/opencode/pull/30182/', SOURCE_REPO)
+
+    // #then
+    expect(src.fetchRef).toBe('refs/pull/30182/head')
+  })
+
+  it('pull request URL with non-numeric PR number throws', () => {
+    // #given / #when / #then
+    expect(() => parseSource('https://github.com/anomalyco/opencode/pull/abc', SOURCE_REPO)).toThrow(
+      /Unsupported GitHub pull request URL/,
+    )
+  })
+
+  // ---------------------------------------------------------------------------
+  // parseSource — /tree/ branch URL
+  // ---------------------------------------------------------------------------
+
+  it('/tree/ branch URL maps to refs/heads/<branch>', () => {
+    // #given / #when
+    const src = parseSource('https://github.com/anomalyco/opencode/tree/dev', SOURCE_REPO)
+
+    // #then
+    expect(src.fetchRef).toBe('refs/heads/dev')
+    expect(src.repo).toBe('https://github.com/anomalyco/opencode.git')
+    expect(src.label).toBe('anomalyco/opencode:dev')
+  })
+
+  it('/tree/ URL with nested branch name', () => {
+    // #given / #when
+    const src = parseSource('https://github.com/anomalyco/opencode/tree/feat/my-feature', SOURCE_REPO)
+
+    // #then
+    expect(src.fetchRef).toBe('refs/heads/feat/my-feature')
+    expect(src.label).toBe('anomalyco/opencode:feat/my-feature')
+  })
+
+  // ---------------------------------------------------------------------------
+  // parseSource — local branch name
+  // ---------------------------------------------------------------------------
+
+  it('local branch name maps to refs/heads/<b>', () => {
+    // #given / #when
+    const src = parseSource('my-local-branch', SOURCE_REPO)
+
+    // #then
+    expect(src.fetchRef).toBe('refs/heads/my-local-branch')
+    expect(src.repo).toBe(SOURCE_REPO)
+    expect(src.label).toBe('my-local-branch')
+    expect(src.merge).toBe('refs/remotes/watch/local/my-local-branch')
+  })
+
+  it('local branch name with slash maps to refs/heads/<b>', () => {
+    // #given / #when
+    const src = parseSource('feat/something', SOURCE_REPO)
+
+    // #then
+    expect(src.fetchRef).toBe('refs/heads/feat/something')
+    expect(src.merge).toBe('refs/remotes/watch/local/feat/something')
+  })
+
+  // ---------------------------------------------------------------------------
+  // parseSource — unsupported GitHub URL forms
+  // ---------------------------------------------------------------------------
+
+  it('bare GitHub repo URL (no path segment) throws', () => {
+    // #given / #when / #then
+    expect(() => parseSource('https://github.com/anomalyco/opencode', SOURCE_REPO)).toThrow(
+      /Unsupported GitHub integration source URL/,
+    )
+  })
+
+  it('github URL with unknown path segment throws', () => {
+    // #given / #when / #then
+    expect(() => parseSource('https://github.com/anomalyco/opencode/issues/123', SOURCE_REPO)).toThrow(
+      /Unsupported GitHub integration source URL/,
+    )
+  })
+
+  it('github URL missing owner/repo throws', () => {
+    // #given / #when / #then
+    expect(() => parseSource('https://github.com/anomalyco', SOURCE_REPO)).toThrow(/Unsupported GitHub source URL/)
+  })
+
+  it('empty string throws', () => {
+    // #given / #when / #then
+    expect(() => parseSource('', SOURCE_REPO)).toThrow(/Empty integration source/)
+  })
+
+  it('whitespace-only string throws', () => {
+    // #given / #when / #then
+    expect(() => parseSource('   ', SOURCE_REPO)).toThrow(/Empty integration source/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveSources
+// ---------------------------------------------------------------------------
+
+describe('resolveSources', () => {
+  it('maps array of mixed inputs', () => {
+    // #given / #when
+    const sources = resolveSources(
+      [
+        'https://github.com/anomalyco/opencode/pull/30182',
+        'https://github.com/anomalyco/opencode/tree/dev',
+        'local-branch',
+      ],
+      SOURCE_REPO,
+    )
+
+    // #then
+    expect(sources.length).toBe(3)
+    const [first, second, third] = sources
+    expect(first?.fetchRef).toBe('refs/pull/30182/head')
+    expect(second?.fetchRef).toBe('refs/heads/dev')
+    expect(third?.fetchRef).toBe('refs/heads/local-branch')
+  })
+
+  it('empty array returns empty array', () => {
+    // #given / #when
+    const sources = resolveSources([], SOURCE_REPO)
+
+    // #then
+    expect(sources.length).toBe(0)
+  })
+})

--- a/packages/harness/src/sources.ts
+++ b/packages/harness/src/sources.ts
@@ -33,7 +33,7 @@ export interface IntegrationSource {
  */
 export function parseSource(input: string, sourceRepo: string): IntegrationSource {
   const value = input.trim()
-  if (!value) throw new Error('Empty integration source in config branches')
+  if (value.length === 0) throw new Error('Empty integration source in config branches')
 
   if (!value.startsWith('https://github.com/')) {
     // Local branch name — fetch from the source repo.

--- a/packages/harness/src/sources.ts
+++ b/packages/harness/src/sources.ts
@@ -1,0 +1,99 @@
+/**
+ * Integration source resolution — maps each configured ref to git fetch refs.
+ *
+ * Ported from cortexkit/orw src/index.ts parseSource (MIT).
+ * Adapted for CI/non-interactive use: no launchd, no desktop, no interactive prompts.
+ *
+ * Supported input forms:
+ *   - Local branch name (no https:// prefix) → refs/heads/<b>
+ *   - GitHub branch URL (https://github.com/owner/repo/tree/<branch>) → refs/heads/<branch>
+ *   - GitHub PR URL (https://github.com/owner/repo/pull/N) → refs/pull/N/head
+ *
+ * Throws on empty input or unsupported URL forms.
+ */
+
+export interface IntegrationSource {
+  /** Human-readable label for log output and the merge prompt. */
+  readonly label: string
+  /** Git remote URL for the source repository. */
+  readonly repo: string
+  /** The ref to fetch from the remote (e.g. refs/pull/N/head, refs/heads/<b>). */
+  readonly fetchRef: string
+  /** The local remote-tracking ref to store the fetched ref under. */
+  readonly fetch: string
+  /** The ref to merge (same as fetch; kept separate for prompt rendering). */
+  readonly merge: string
+}
+
+/**
+ * Maps a single integration source input to a typed IntegrationSource.
+ *
+ * @param input      - A PR URL, branch URL, or local branch name from config.
+ * @param sourceRepo - The default source repo URL (used for local branch names).
+ */
+export function parseSource(input: string, sourceRepo: string): IntegrationSource {
+  const value = input.trim()
+  if (!value) throw new Error('Empty integration source in config branches')
+
+  if (!value.startsWith('https://github.com/')) {
+    // Local branch name — fetch from the source repo.
+    return {
+      label: value,
+      repo: sourceRepo,
+      fetchRef: `refs/heads/${value}`,
+      fetch: `refs/remotes/watch/local/${value}`,
+      merge: `refs/remotes/watch/local/${value}`,
+    }
+  }
+
+  const url = new URL(value)
+  const parts = url.pathname.split('/').filter(Boolean)
+  const owner = parts[0]
+  const repo = parts[1]
+  if (owner === undefined || repo === undefined) throw new Error(`Unsupported GitHub source URL: ${value}`)
+
+  if (parts.length >= 4 && parts[2] === 'tree') {
+    const branch = decodeURIComponent(parts.slice(3).join('/'))
+    const slug = watchSlug(owner, repo)
+    const ref = `refs/remotes/watch/${slug}/${branch}`
+    return {
+      label: `${owner}/${repo}:${branch}`,
+      repo: `https://github.com/${owner}/${repo}.git`,
+      fetchRef: `refs/heads/${branch}`,
+      fetch: ref,
+      merge: ref,
+    }
+  }
+
+  if (parts.length >= 4 && parts[2] === 'pull') {
+    const number = parts[3] ?? ''
+    if (!/^\d+$/.test(number)) {
+      throw new Error(`Unsupported GitHub pull request URL: ${value}`)
+    }
+    const slug = watchSlug(owner, repo)
+    const ref = `refs/remotes/watch/${slug}/pr-${number}`
+    return {
+      label: `${owner}/${repo}#${number}`,
+      repo: `https://github.com/${owner}/${repo}.git`,
+      fetchRef: `refs/pull/${number}/head`,
+      fetch: ref,
+      merge: ref,
+    }
+  }
+
+  throw new Error(`Unsupported GitHub integration source URL: ${value}`)
+}
+
+/**
+ * Maps an array of integration source inputs to typed IntegrationSources.
+ *
+ * @param refs       - Array of PR URLs, branch URLs, or local branch names.
+ * @param sourceRepo - The default source repo URL (used for local branch names).
+ */
+export function resolveSources(refs: readonly string[], sourceRepo: string): IntegrationSource[] {
+  return refs.map(input => parseSource(input, sourceRepo))
+}
+
+function watchSlug(owner: string, repo: string): string {
+  return `${owner}-${repo}`.replaceAll(/[^\w.-]/g, '-')
+}

--- a/packages/harness/src/verify.test.ts
+++ b/packages/harness/src/verify.test.ts
@@ -75,8 +75,8 @@ describe('assertIntegrationMarker', () => {
     expect(result.ok).toBe(true)
   })
 
-  it('marker present in probe output → ok', () => {
-    // #given
+  it('marker present on structured line → ok', () => {
+    // #given — output matches the "  integration commit: <sha>" format from formatProvenance
     const commit = 'cafebabe1234abcd'
     const probeOutput = `harness (patched OpenCode)\n  integration commit: ${commit}\n  build sha: abc`
 
@@ -102,10 +102,25 @@ describe('assertIntegrationMarker', () => {
     expect(result.message).toContain(commit)
   })
 
-  it('marker is a substring of probe output → ok', () => {
-    // #given — partial SHA match (first 8 chars) is sufficient for the probe
-    const commit = 'cafebabe'
-    const probeOutput = 'integration commit: cafebabe1234abcd'
+  it('marker only in unstructured position (not on dedicated line) → not ok', () => {
+    // #given — SHA appears in an error message, not in the structured "integration commit:" line.
+    // This is the wrong-binary-right-version case: a binary that prints the version but
+    // does NOT have the structured marker in the expected position.
+    const commit = 'cafebabe1234abcd'
+    const probeOutput = `1.15.13\nError: unknown commit cafebabe1234abcd referenced\n`
+
+    // #when
+    const result = assertIntegrationMarker(probeOutput, commit)
+
+    // #then — must fail: SHA in unstructured position is not sufficient
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('missing')
+  })
+
+  it('marker with leading/trailing whitespace on the structured line → ok', () => {
+    // #given — some whitespace variation is tolerated
+    const commit = 'cafebabe1234abcd'
+    const probeOutput = `harness (patched OpenCode)\n  integration commit:   ${commit}  \n  build sha: abc`
 
     // #when
     const result = assertIntegrationMarker(probeOutput, commit)
@@ -155,11 +170,11 @@ describe('assertExitZero', () => {
 
 describe('runVerifications', () => {
   it('all passing → ok with no failures', () => {
-    // #given / #when
+    // #given / #when — structured marker line as emitted by formatProvenance
     const result = runVerifications({
       versionOutput: '1.15.13',
       expectedVersion: '1.15.13',
-      probeOutput: 'integration commit: cafebabe1234',
+      probeOutput: 'harness (patched OpenCode)\n  integration commit: cafebabe1234\n  build sha: abc',
       integrationCommit: 'cafebabe1234',
       exitCode: 0,
     })
@@ -174,7 +189,7 @@ describe('runVerifications', () => {
     const result = runVerifications({
       versionOutput: '1.15.12',
       expectedVersion: '1.15.13',
-      probeOutput: 'integration commit: cafebabe1234',
+      probeOutput: 'harness (patched OpenCode)\n  integration commit: cafebabe1234\n  build sha: abc',
       integrationCommit: 'cafebabe1234',
       exitCode: 0,
     })
@@ -189,7 +204,7 @@ describe('runVerifications', () => {
     const result = runVerifications({
       versionOutput: '1.15.13',
       expectedVersion: '1.15.13',
-      probeOutput: 'integration commit: deadbeef',
+      probeOutput: 'harness (patched OpenCode)\n  integration commit: deadbeef\n  build sha: abc',
       integrationCommit: 'cafebabe1234',
       exitCode: 0,
     })
@@ -243,5 +258,21 @@ describe('runVerifications', () => {
     // #then
     expect(result.ok).toBe(true)
     expect(result.failures.length).toBe(0)
+  })
+
+  it('wrong-binary-right-version: version matches but structured marker absent → not ok', () => {
+    // #given — a stock opencode binary that prints the right version but has no harness provenance
+    const result = runVerifications({
+      versionOutput: '1.15.13',
+      expectedVersion: '1.15.13',
+      probeOutput: '1.15.13\n', // no "integration commit:" line
+      integrationCommit: 'cafebabe1234',
+      exitCode: 0,
+    })
+
+    // #then — version passes but marker check fails
+    expect(result.ok).toBe(false)
+    expect(result.failures.some(f => f.includes('missing'))).toBe(true)
+    expect(result.failures.some(f => f.includes('mismatch'))).toBe(false)
   })
 })

--- a/packages/harness/src/verify.test.ts
+++ b/packages/harness/src/verify.test.ts
@@ -1,0 +1,247 @@
+import {describe, expect, it} from 'vitest'
+import {assertExitZero, assertIntegrationMarker, assertVersionMatch, runVerifications} from './verify.js'
+
+// ---------------------------------------------------------------------------
+// assertVersionMatch
+// ---------------------------------------------------------------------------
+
+describe('assertVersionMatch', () => {
+  it('exact match → ok', () => {
+    // #given / #when
+    const result = assertVersionMatch('1.15.13', '1.15.13')
+
+    // #then
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain('1.15.13')
+  })
+
+  it('trims whitespace before comparing', () => {
+    // #given / #when
+    const result = assertVersionMatch('  1.15.13\n', '1.15.13')
+
+    // #then
+    expect(result.ok).toBe(true)
+  })
+
+  it('wrong version → not ok with mismatch message', () => {
+    // #given / #when
+    const result = assertVersionMatch('1.15.12', '1.15.13')
+
+    // #then
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('mismatch')
+    expect(result.message).toContain('1.15.12')
+    expect(result.message).toContain('1.15.13')
+  })
+
+  it('empty version string → not ok', () => {
+    // #given / #when
+    const result = assertVersionMatch('', '1.15.13')
+
+    // #then
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('mismatch')
+  })
+
+  it('version with extra text → not ok (exact match required)', () => {
+    // #given / #when — binary outputs "opencode 1.15.13" instead of just "1.15.13"
+    const result = assertVersionMatch('opencode 1.15.13', '1.15.13')
+
+    // #then
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('mismatch')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// assertIntegrationMarker
+// ---------------------------------------------------------------------------
+
+describe('assertIntegrationMarker', () => {
+  it('null integrationCommit → ok (dev scaffold, no marker required)', () => {
+    // #given / #when
+    const result = assertIntegrationMarker('some binary output', null)
+
+    // #then
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain('not required')
+  })
+
+  it('empty integrationCommit → ok (dev scaffold)', () => {
+    // #given / #when
+    const result = assertIntegrationMarker('some binary output', '')
+
+    // #then
+    expect(result.ok).toBe(true)
+  })
+
+  it('marker present in probe output → ok', () => {
+    // #given
+    const commit = 'cafebabe1234abcd'
+    const probeOutput = `harness (patched OpenCode)\n  integration commit: ${commit}\n  build sha: abc`
+
+    // #when
+    const result = assertIntegrationMarker(probeOutput, commit)
+
+    // #then
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain(commit)
+  })
+
+  it('marker absent from probe output → not ok', () => {
+    // #given
+    const commit = 'cafebabe1234abcd'
+    const probeOutput = 'harness (patched OpenCode)\n  integration commit: deadbeef\n'
+
+    // #when
+    const result = assertIntegrationMarker(probeOutput, commit)
+
+    // #then
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('missing')
+    expect(result.message).toContain(commit)
+  })
+
+  it('marker is a substring of probe output → ok', () => {
+    // #given — partial SHA match (first 8 chars) is sufficient for the probe
+    const commit = 'cafebabe'
+    const probeOutput = 'integration commit: cafebabe1234abcd'
+
+    // #when
+    const result = assertIntegrationMarker(probeOutput, commit)
+
+    // #then
+    expect(result.ok).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// assertExitZero
+// ---------------------------------------------------------------------------
+
+describe('assertExitZero', () => {
+  it('exit code 0 → ok', () => {
+    // #given / #when
+    const result = assertExitZero(0, '--version')
+
+    // #then
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain('--version')
+    expect(result.message).toContain('exit 0')
+  })
+
+  it('exit code 1 → not ok', () => {
+    // #given / #when
+    const result = assertExitZero(1, '--version')
+
+    // #then
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('1')
+  })
+
+  it('exit code 127 (not found) → not ok', () => {
+    // #given / #when
+    const result = assertExitZero(127, '--version')
+
+    // #then
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('127')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runVerifications — combined
+// ---------------------------------------------------------------------------
+
+describe('runVerifications', () => {
+  it('all passing → ok with no failures', () => {
+    // #given / #when
+    const result = runVerifications({
+      versionOutput: '1.15.13',
+      expectedVersion: '1.15.13',
+      probeOutput: 'integration commit: cafebabe1234',
+      integrationCommit: 'cafebabe1234',
+      exitCode: 0,
+    })
+
+    // #then
+    expect(result.ok).toBe(true)
+    expect(result.failures.length).toBe(0)
+  })
+
+  it('wrong version → not ok, failures list contains version mismatch', () => {
+    // #given / #when
+    const result = runVerifications({
+      versionOutput: '1.15.12',
+      expectedVersion: '1.15.13',
+      probeOutput: 'integration commit: cafebabe1234',
+      integrationCommit: 'cafebabe1234',
+      exitCode: 0,
+    })
+
+    // #then
+    expect(result.ok).toBe(false)
+    expect(result.failures.some(f => f.includes('mismatch'))).toBe(true)
+  })
+
+  it('missing integration marker → not ok, failures list contains marker missing', () => {
+    // #given / #when
+    const result = runVerifications({
+      versionOutput: '1.15.13',
+      expectedVersion: '1.15.13',
+      probeOutput: 'integration commit: deadbeef',
+      integrationCommit: 'cafebabe1234',
+      exitCode: 0,
+    })
+
+    // #then
+    expect(result.ok).toBe(false)
+    expect(result.failures.some(f => f.includes('missing'))).toBe(true)
+  })
+
+  it('non-zero exit code → not ok, failures list contains exit code', () => {
+    // #given / #when
+    const result = runVerifications({
+      versionOutput: '',
+      expectedVersion: '1.15.13',
+      probeOutput: '',
+      integrationCommit: null,
+      exitCode: 1,
+    })
+
+    // #then
+    expect(result.ok).toBe(false)
+    expect(result.failures.some(f => f.includes('non-zero'))).toBe(true)
+  })
+
+  it('multiple failures → all reported', () => {
+    // #given / #when
+    const result = runVerifications({
+      versionOutput: '1.15.12',
+      expectedVersion: '1.15.13',
+      probeOutput: 'no marker here',
+      integrationCommit: 'cafebabe1234',
+      exitCode: 1,
+    })
+
+    // #then
+    expect(result.ok).toBe(false)
+    // All three assertions failed
+    expect(result.failures.length).toBe(3)
+  })
+
+  it('dev scaffold (null integrationCommit) → ok when version + exit match', () => {
+    // #given / #when
+    const result = runVerifications({
+      versionOutput: '1.15.13',
+      expectedVersion: '1.15.13',
+      probeOutput: 'some output without a commit sha',
+      integrationCommit: null,
+      exitCode: 0,
+    })
+
+    // #then
+    expect(result.ok).toBe(true)
+    expect(result.failures.length).toBe(0)
+  })
+})

--- a/packages/harness/src/verify.test.ts
+++ b/packages/harness/src/verify.test.ts
@@ -51,6 +51,14 @@ describe('assertVersionMatch', () => {
     expect(result.ok).toBe(false)
     expect(result.message).toContain('mismatch')
   })
+
+  it('harness version string exact match → ok', () => {
+    // #given / #when — harness build self-reports "<base>+harness.<short8>"
+    const result = assertVersionMatch('1.15.13+harness.cafebabe', '1.15.13+harness.cafebabe')
+
+    // #then
+    expect(result.ok).toBe(true)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -60,7 +68,7 @@ describe('assertVersionMatch', () => {
 describe('assertIntegrationMarker', () => {
   it('null integrationCommit → ok (dev scaffold, no marker required)', () => {
     // #given / #when
-    const result = assertIntegrationMarker('some binary output', null)
+    const result = assertIntegrationMarker('1.15.13', null)
 
     // #then
     expect(result.ok).toBe(true)
@@ -69,64 +77,65 @@ describe('assertIntegrationMarker', () => {
 
   it('empty integrationCommit → ok (dev scaffold)', () => {
     // #given / #when
-    const result = assertIntegrationMarker('some binary output', '')
+    const result = assertIntegrationMarker('1.15.13', '')
 
     // #then
     expect(result.ok).toBe(true)
   })
 
-  it('marker present on structured line → ok', () => {
-    // #given — output matches the "  integration commit: <sha>" format from formatProvenance
+  it('correct harness build: +harness.<short8> present in --version → ok', () => {
+    // #given — harness build self-reports "<base>+harness.<short8>" via --version
     const commit = 'cafebabe1234abcd'
-    const probeOutput = `harness (patched OpenCode)\n  integration commit: ${commit}\n  build sha: abc`
+    const versionOutput = `1.15.13+harness.${commit.slice(0, 8)}`
 
     // #when
-    const result = assertIntegrationMarker(probeOutput, commit)
+    const result = assertIntegrationMarker(versionOutput, commit)
 
     // #then
     expect(result.ok).toBe(true)
-    expect(result.message).toContain(commit)
+    expect(result.message).toContain(`+harness.${commit.slice(0, 8)}`)
   })
 
-  it('marker absent from probe output → not ok', () => {
-    // #given
+  it('stock binary: bare base version, no +harness. segment → not ok', () => {
+    // #given — a stock upstream binary reports bare "<base>", no harness marker
     const commit = 'cafebabe1234abcd'
-    const probeOutput = 'harness (patched OpenCode)\n  integration commit: deadbeef\n'
+    const versionOutput = '1.15.13'
 
     // #when
-    const result = assertIntegrationMarker(probeOutput, commit)
+    const result = assertIntegrationMarker(versionOutput, commit)
 
     // #then
     expect(result.ok).toBe(false)
     expect(result.message).toContain('missing')
-    expect(result.message).toContain(commit)
+    expect(result.message).toContain(`+harness.${commit.slice(0, 8)}`)
   })
 
-  it('marker only in unstructured position (not on dedicated line) → not ok', () => {
-    // #given — SHA appears in an error message, not in the structured "integration commit:" line.
-    // This is the wrong-binary-right-version case: a binary that prints the version but
-    // does NOT have the structured marker in the expected position.
-    const commit = 'cafebabe1234abcd'
-    const probeOutput = `1.15.13\nError: unknown commit cafebabe1234abcd referenced\n`
+  it('harness build with DIFFERENT commit short8 → not ok', () => {
+    // #given — a harness build of a different commit; short8 does not match
+    const expectedCommit = 'cafebabe1234abcd'
+    const otherCommit = 'deadbeef99887766'
+    const versionOutput = `1.15.13+harness.${otherCommit.slice(0, 8)}`
 
     // #when
-    const result = assertIntegrationMarker(probeOutput, commit)
-
-    // #then — must fail: SHA in unstructured position is not sufficient
-    expect(result.ok).toBe(false)
-    expect(result.message).toContain('missing')
-  })
-
-  it('marker with leading/trailing whitespace on the structured line → ok', () => {
-    // #given — some whitespace variation is tolerated
-    const commit = 'cafebabe1234abcd'
-    const probeOutput = `harness (patched OpenCode)\n  integration commit:   ${commit}  \n  build sha: abc`
-
-    // #when
-    const result = assertIntegrationMarker(probeOutput, commit)
+    const result = assertIntegrationMarker(versionOutput, expectedCommit)
 
     // #then
-    expect(result.ok).toBe(true)
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('missing')
+    expect(result.message).toContain(`+harness.${expectedCommit.slice(0, 8)}`)
+  })
+
+  it('marker only as substring in unrelated text (not the +harness. format) → not ok', () => {
+    // #given — SHA appears in output but not as "+harness.<short8>"
+    const commit = 'cafebabe1234abcd'
+    const versionOutput = `1.15.13\nError: unknown commit cafebabe1234abcd referenced\n`
+
+    // #when
+    const result = assertIntegrationMarker(versionOutput, commit)
+
+    // #then — must fail: SHA in unstructured position is not the harness marker
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('missing')
   })
 })
 
@@ -169,13 +178,13 @@ describe('assertExitZero', () => {
 // ---------------------------------------------------------------------------
 
 describe('runVerifications', () => {
-  it('all passing → ok with no failures', () => {
-    // #given / #when — structured marker line as emitted by formatProvenance
+  it('correct harness build: all passing → ok with no failures', () => {
+    // #given / #when — harness build self-reports "<base>+harness.<short8>"
+    const commit = 'cafebabe1234abcd'
     const result = runVerifications({
-      versionOutput: '1.15.13',
-      expectedVersion: '1.15.13',
-      probeOutput: 'harness (patched OpenCode)\n  integration commit: cafebabe1234\n  build sha: abc',
-      integrationCommit: 'cafebabe1234',
+      versionOutput: `1.15.13+harness.${commit.slice(0, 8)}`,
+      expectedVersion: `1.15.13+harness.${commit.slice(0, 8)}`,
+      integrationCommit: commit,
       exitCode: 0,
     })
 
@@ -186,11 +195,11 @@ describe('runVerifications', () => {
 
   it('wrong version → not ok, failures list contains version mismatch', () => {
     // #given / #when
+    const commit = 'cafebabe1234abcd'
     const result = runVerifications({
       versionOutput: '1.15.12',
-      expectedVersion: '1.15.13',
-      probeOutput: 'harness (patched OpenCode)\n  integration commit: cafebabe1234\n  build sha: abc',
-      integrationCommit: 'cafebabe1234',
+      expectedVersion: `1.15.13+harness.${commit.slice(0, 8)}`,
+      integrationCommit: commit,
       exitCode: 0,
     })
 
@@ -199,19 +208,51 @@ describe('runVerifications', () => {
     expect(result.failures.some(f => f.includes('mismatch'))).toBe(true)
   })
 
-  it('missing integration marker → not ok, failures list contains marker missing', () => {
-    // #given / #when
+  it('stock binary (bare base version) with integration commit required → not ok', () => {
+    // #given — a stock upstream binary reports bare "<base>"; expected is "<base>+harness.<short8>"
+    const commit = 'cafebabe1234abcd'
+    const result = runVerifications({
+      versionOutput: '1.15.13',
+      expectedVersion: `1.15.13+harness.${commit.slice(0, 8)}`,
+      integrationCommit: commit,
+      exitCode: 0,
+    })
+
+    // #then — version mismatch AND marker missing both fail
+    expect(result.ok).toBe(false)
+    expect(result.failures.some(f => f.includes('mismatch'))).toBe(true)
+    expect(result.failures.some(f => f.includes('missing'))).toBe(true)
+  })
+
+  it('harness build with wrong commit short8 → not ok (marker fails)', () => {
+    // #given — binary has +harness.<other8>, not the expected commit's short8
+    const expectedCommit = 'cafebabe1234abcd'
+    const otherCommit = 'deadbeef99887766'
+    const result = runVerifications({
+      versionOutput: `1.15.13+harness.${otherCommit.slice(0, 8)}`,
+      expectedVersion: `1.15.13+harness.${expectedCommit.slice(0, 8)}`,
+      integrationCommit: expectedCommit,
+      exitCode: 0,
+    })
+
+    // #then — version mismatch AND marker missing both fail
+    expect(result.ok).toBe(false)
+    expect(result.failures.some(f => f.includes('mismatch'))).toBe(true)
+    expect(result.failures.some(f => f.includes('missing'))).toBe(true)
+  })
+
+  it('dev scaffold (null integrationCommit) → ok when version + exit match', () => {
+    // #given / #when — dev scaffold: no integration commit, bare base version
     const result = runVerifications({
       versionOutput: '1.15.13',
       expectedVersion: '1.15.13',
-      probeOutput: 'harness (patched OpenCode)\n  integration commit: deadbeef\n  build sha: abc',
-      integrationCommit: 'cafebabe1234',
+      integrationCommit: null,
       exitCode: 0,
     })
 
     // #then
-    expect(result.ok).toBe(false)
-    expect(result.failures.some(f => f.includes('missing'))).toBe(true)
+    expect(result.ok).toBe(true)
+    expect(result.failures.length).toBe(0)
   })
 
   it('non-zero exit code → not ok, failures list contains exit code', () => {
@@ -219,7 +260,6 @@ describe('runVerifications', () => {
     const result = runVerifications({
       versionOutput: '',
       expectedVersion: '1.15.13',
-      probeOutput: '',
       integrationCommit: null,
       exitCode: 1,
     })
@@ -231,11 +271,11 @@ describe('runVerifications', () => {
 
   it('multiple failures → all reported', () => {
     // #given / #when
+    const commit = 'cafebabe1234abcd'
     const result = runVerifications({
       versionOutput: '1.15.12',
-      expectedVersion: '1.15.13',
-      probeOutput: 'no marker here',
-      integrationCommit: 'cafebabe1234',
+      expectedVersion: `1.15.13+harness.${commit.slice(0, 8)}`,
+      integrationCommit: commit,
       exitCode: 1,
     })
 
@@ -243,36 +283,5 @@ describe('runVerifications', () => {
     expect(result.ok).toBe(false)
     // All three assertions failed
     expect(result.failures.length).toBe(3)
-  })
-
-  it('dev scaffold (null integrationCommit) → ok when version + exit match', () => {
-    // #given / #when
-    const result = runVerifications({
-      versionOutput: '1.15.13',
-      expectedVersion: '1.15.13',
-      probeOutput: 'some output without a commit sha',
-      integrationCommit: null,
-      exitCode: 0,
-    })
-
-    // #then
-    expect(result.ok).toBe(true)
-    expect(result.failures.length).toBe(0)
-  })
-
-  it('wrong-binary-right-version: version matches but structured marker absent → not ok', () => {
-    // #given — a stock opencode binary that prints the right version but has no harness provenance
-    const result = runVerifications({
-      versionOutput: '1.15.13',
-      expectedVersion: '1.15.13',
-      probeOutput: '1.15.13\n', // no "integration commit:" line
-      integrationCommit: 'cafebabe1234',
-      exitCode: 0,
-    })
-
-    // #then — version passes but marker check fails
-    expect(result.ok).toBe(false)
-    expect(result.failures.some(f => f.includes('missing'))).toBe(true)
-    expect(result.failures.some(f => f.includes('mismatch'))).toBe(false)
   })
 })

--- a/packages/harness/src/verify.ts
+++ b/packages/harness/src/verify.ts
@@ -5,13 +5,17 @@
  * The actual exec calls live in scripts/verify-binary.ts.
  *
  * Verification contract:
- *   1. --version output == expectedVersion (exact match, trimmed).
- *   2. Integration marker present in a STRUCTURED position in the probe output.
- *      The marker must appear on a dedicated line matching:
- *        "  integration commit: <sha>"
- *      This prevents a binary that merely mentions the SHA in unrelated output
- *      from passing the check.
- *   3. Binary is executable (exit code 0 on --version).
+ *   1. Binary is executable (exit code 0 on --version).
+ *   2. --version output == expectedVersion (exact match, trimmed).
+ *      For a harness build, expectedVersion is "<base>+harness.<short8>" (from
+ *      buildHarnessVersion). A stock upstream binary reports bare "<base>", which
+ *      fails this check — proving the binary is a harness build for this exact
+ *      base+commit. Full provenance (full SHA, refs) lives in the package's
+ *      provenance.json manifest; npm provenance attestation is the cryptographic gate.
+ *   3. Integration marker: when an integrationCommit is supplied, the --version output
+ *      must contain "+harness.<short8>" where short8 is the first 8 chars of the commit.
+ *      This is defense-in-depth on top of the exact version match — it explicitly
+ *      confirms the harness segment encodes the expected integration commit.
  */
 
 /** Result of a single verification assertion. */
@@ -21,10 +25,14 @@ export interface VerifyResult {
 }
 
 /**
- * Asserts that the binary's reported version matches the expected base version.
+ * Asserts that the binary's reported version matches the expected version string.
+ *
+ * For a harness build with an integration commit, expectedVersion is
+ * "<base>+harness.<short8>" (as produced by buildHarnessVersion). A stock upstream
+ * binary reports bare "<base>", which fails this check.
  *
  * @param actualVersion   - The trimmed stdout from `binary --version`.
- * @param expectedVersion - The base release version (e.g. '1.15.13').
+ * @param expectedVersion - The full expected version string (e.g. '1.15.13+harness.cafebabe').
  */
 export function assertVersionMatch(actualVersion: string, expectedVersion: string): VerifyResult {
   const trimmed = actualVersion.trim()
@@ -38,48 +46,38 @@ export function assertVersionMatch(actualVersion: string, expectedVersion: strin
 }
 
 /**
- * Asserts that the integration commit marker is present in a STRUCTURED position
- * in the binary's probe output.
+ * Asserts that the binary's --version output contains the "+harness.<short8>" marker,
+ * where short8 is the first 8 characters of the integration commit.
  *
- * The integration marker is the frozen integration commit SHA embedded in the
- * binary's provenance. We probe it via `binary info` which outputs the harness
- * provenance in a structured format. The marker must appear on a dedicated line:
+ * This is defense-in-depth on top of assertVersionMatch: it explicitly confirms the
+ * harness segment encodes the expected integration commit, catching any case where
+ * the version string has the right format but the wrong commit embedded.
  *
- *   "  integration commit: <sha>"
+ * A stock upstream binary reports bare "<base>" with no "+harness." segment — it fails.
+ * A harness build of a DIFFERENT commit reports "+harness.<other8>" — it also fails.
  *
- * This structured check prevents a binary that merely mentions the SHA in
- * unrelated output (e.g. error messages, help text) from passing the check.
+ * An empty or null integrationCommit is treated as "no marker required" (dev scaffold).
  *
- * An empty integrationCommit is treated as "no marker required" (dev scaffold).
- *
- * @param probeOutput       - Combined output from the binary probe (--version + info).
- * @param integrationCommit - The frozen integration commit SHA to look for, or null/empty.
+ * @param versionOutput     - The trimmed stdout from `binary --version`.
+ * @param integrationCommit - The frozen integration commit SHA to derive short8 from, or null/empty.
  */
-export function assertIntegrationMarker(probeOutput: string, integrationCommit: string | null): VerifyResult {
+export function assertIntegrationMarker(versionOutput: string, integrationCommit: string | null): VerifyResult {
   if (integrationCommit === null || integrationCommit.length === 0) {
     // Dev scaffold — no marker required.
     return {ok: true, message: 'integration marker: not required (dev scaffold)'}
   }
 
-  // The marker must appear on a dedicated structured line in the probe output.
-  // Format: "  integration commit: <sha>" (as emitted by `harness info` / formatProvenance).
-  // This prevents substring matches in unrelated output from passing.
-  const structuredMarkerPattern = new RegExp(
-    String.raw`^\s*integration commit:\s+${escapeRegex(integrationCommit)}\s*$`,
-    'm',
-  )
-  if (structuredMarkerPattern.test(probeOutput)) {
-    return {ok: true, message: `integration marker present: ${integrationCommit}`}
+  const short8 = integrationCommit.slice(0, 8)
+  const marker = `+harness.${short8}`
+
+  if (versionOutput.includes(marker)) {
+    return {ok: true, message: `integration marker present: ${marker}`}
   }
 
   return {
     ok: false,
-    message: `integration marker missing: '${integrationCommit}' not found in structured position in binary output`,
+    message: `integration marker missing: '${marker}' not found in --version output '${versionOutput}'`,
   }
-}
-
-function escapeRegex(s: string): string {
-  return s.replaceAll(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`)
 }
 
 /**
@@ -101,26 +99,28 @@ export function assertExitZero(exitCode: number, probe: string): VerifyResult {
 /**
  * Runs all verification assertions and returns a combined result.
  *
+ * The binary self-reports its version via --version. For a harness build, this is
+ * "<base>+harness.<short8>". A stock upstream binary reports bare "<base>", which
+ * fails the version match. Full provenance lives in the package's provenance.json.
+ *
  * @param params - Verification inputs.
  * @param params.versionOutput      - Trimmed stdout from `binary --version`.
- * @param params.expectedVersion    - The base release version to assert.
- * @param params.probeOutput        - Combined probe output for marker check.
+ * @param params.expectedVersion    - The full expected version string to assert.
  * @param params.integrationCommit  - Frozen integration commit SHA, or null.
  * @param params.exitCode           - Exit code from the --version probe.
  */
 export function runVerifications(params: {
   readonly versionOutput: string
   readonly expectedVersion: string
-  readonly probeOutput: string
   readonly integrationCommit: string | null
   readonly exitCode: number
 }): {readonly ok: boolean; readonly failures: readonly string[]} {
-  const {versionOutput, expectedVersion, probeOutput, integrationCommit, exitCode} = params
+  const {versionOutput, expectedVersion, integrationCommit, exitCode} = params
 
   const results: VerifyResult[] = [
     assertExitZero(exitCode, '--version'),
     assertVersionMatch(versionOutput, expectedVersion),
-    assertIntegrationMarker(probeOutput, integrationCommit),
+    assertIntegrationMarker(versionOutput, integrationCommit),
   ]
 
   const failures = results.filter(r => !r.ok).map(r => r.message)

--- a/packages/harness/src/verify.ts
+++ b/packages/harness/src/verify.ts
@@ -1,0 +1,111 @@
+/**
+ * Binary verification logic — unit-testable assertions extracted from verify-binary.ts.
+ *
+ * These pure functions are tested in verify.test.ts against fake binary stubs.
+ * The actual exec calls live in scripts/verify-binary.ts.
+ *
+ * Verification contract:
+ *   1. --version output == expectedVersion (exact match, trimmed).
+ *   2. Integration marker(s) present in --version or a dedicated probe output.
+ *   3. Binary is executable (exit code 0 on --version).
+ */
+
+/** Result of a single verification assertion. */
+export interface VerifyResult {
+  readonly ok: boolean
+  readonly message: string
+}
+
+/**
+ * Asserts that the binary's reported version matches the expected base version.
+ *
+ * @param actualVersion   - The trimmed stdout from `binary --version`.
+ * @param expectedVersion - The base release version (e.g. '1.15.13').
+ */
+export function assertVersionMatch(actualVersion: string, expectedVersion: string): VerifyResult {
+  const trimmed = actualVersion.trim()
+  if (trimmed === expectedVersion) {
+    return {ok: true, message: `version ok: ${trimmed}`}
+  }
+  return {
+    ok: false,
+    message: `version mismatch: got '${trimmed}', expected '${expectedVersion}'`,
+  }
+}
+
+/**
+ * Asserts that the integration commit marker is present in the binary's output.
+ *
+ * The integration marker is the frozen integration commit SHA embedded in the
+ * binary's provenance. We probe it via `binary info` or a dedicated env var.
+ *
+ * For the spike, we accept the marker in any of:
+ *   - The --version output (if the binary embeds it there).
+ *   - The probeOutput string (from `binary info` or similar).
+ *
+ * An empty integrationCommit is treated as "no marker required" (dev scaffold).
+ *
+ * @param probeOutput       - Combined output from the binary probe (--version + info).
+ * @param integrationCommit - The frozen integration commit SHA to look for, or null/empty.
+ */
+export function assertIntegrationMarker(probeOutput: string, integrationCommit: string | null): VerifyResult {
+  if (integrationCommit === null || integrationCommit.length === 0) {
+    // Dev scaffold — no marker required.
+    return {ok: true, message: 'integration marker: not required (dev scaffold)'}
+  }
+
+  // The marker must appear somewhere in the probe output.
+  if (probeOutput.includes(integrationCommit)) {
+    return {ok: true, message: `integration marker present: ${integrationCommit}`}
+  }
+
+  return {
+    ok: false,
+    message: `integration marker missing: '${integrationCommit}' not found in binary output`,
+  }
+}
+
+/**
+ * Asserts that the binary exited with code 0 on a probe invocation.
+ *
+ * @param exitCode - The exit code from the binary probe.
+ * @param probe    - The probe command used (for error messages).
+ */
+export function assertExitZero(exitCode: number, probe: string): VerifyResult {
+  if (exitCode === 0) {
+    return {ok: true, message: `${probe}: exit 0`}
+  }
+  return {
+    ok: false,
+    message: `${probe}: non-zero exit code ${exitCode}`,
+  }
+}
+
+/**
+ * Runs all verification assertions and returns a combined result.
+ *
+ * @param params - Verification inputs.
+ * @param params.versionOutput      - Trimmed stdout from `binary --version`.
+ * @param params.expectedVersion    - The base release version to assert.
+ * @param params.probeOutput        - Combined probe output for marker check.
+ * @param params.integrationCommit  - Frozen integration commit SHA, or null.
+ * @param params.exitCode           - Exit code from the --version probe.
+ */
+export function runVerifications(params: {
+  readonly versionOutput: string
+  readonly expectedVersion: string
+  readonly probeOutput: string
+  readonly integrationCommit: string | null
+  readonly exitCode: number
+}): {readonly ok: boolean; readonly failures: readonly string[]} {
+  const {versionOutput, expectedVersion, probeOutput, integrationCommit, exitCode} = params
+
+  const results: VerifyResult[] = [
+    assertExitZero(exitCode, '--version'),
+    assertVersionMatch(versionOutput, expectedVersion),
+    assertIntegrationMarker(probeOutput, integrationCommit),
+  ]
+
+  const failures = results.filter(r => !r.ok).map(r => r.message)
+  return {ok: failures.length === 0, failures}
+}

--- a/packages/harness/src/verify.ts
+++ b/packages/harness/src/verify.ts
@@ -6,7 +6,11 @@
  *
  * Verification contract:
  *   1. --version output == expectedVersion (exact match, trimmed).
- *   2. Integration marker(s) present in --version or a dedicated probe output.
+ *   2. Integration marker present in a STRUCTURED position in the probe output.
+ *      The marker must appear on a dedicated line matching:
+ *        "  integration commit: <sha>"
+ *      This prevents a binary that merely mentions the SHA in unrelated output
+ *      from passing the check.
  *   3. Binary is executable (exit code 0 on --version).
  */
 
@@ -34,14 +38,17 @@ export function assertVersionMatch(actualVersion: string, expectedVersion: strin
 }
 
 /**
- * Asserts that the integration commit marker is present in the binary's output.
+ * Asserts that the integration commit marker is present in a STRUCTURED position
+ * in the binary's probe output.
  *
  * The integration marker is the frozen integration commit SHA embedded in the
- * binary's provenance. We probe it via `binary info` or a dedicated env var.
+ * binary's provenance. We probe it via `binary info` which outputs the harness
+ * provenance in a structured format. The marker must appear on a dedicated line:
  *
- * For the spike, we accept the marker in any of:
- *   - The --version output (if the binary embeds it there).
- *   - The probeOutput string (from `binary info` or similar).
+ *   "  integration commit: <sha>"
+ *
+ * This structured check prevents a binary that merely mentions the SHA in
+ * unrelated output (e.g. error messages, help text) from passing the check.
  *
  * An empty integrationCommit is treated as "no marker required" (dev scaffold).
  *
@@ -54,15 +61,25 @@ export function assertIntegrationMarker(probeOutput: string, integrationCommit: 
     return {ok: true, message: 'integration marker: not required (dev scaffold)'}
   }
 
-  // The marker must appear somewhere in the probe output.
-  if (probeOutput.includes(integrationCommit)) {
+  // The marker must appear on a dedicated structured line in the probe output.
+  // Format: "  integration commit: <sha>" (as emitted by `harness info` / formatProvenance).
+  // This prevents substring matches in unrelated output from passing.
+  const structuredMarkerPattern = new RegExp(
+    String.raw`^\s*integration commit:\s+${escapeRegex(integrationCommit)}\s*$`,
+    'm',
+  )
+  if (structuredMarkerPattern.test(probeOutput)) {
     return {ok: true, message: `integration marker present: ${integrationCommit}`}
   }
 
   return {
     ok: false,
-    message: `integration marker missing: '${integrationCommit}' not found in binary output`,
+    message: `integration marker missing: '${integrationCommit}' not found in structured position in binary output`,
   }
+}
+
+function escapeRegex(s: string): string {
+  return s.replaceAll(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`)
 }
 
 /**

--- a/packages/harness/src/version.test.ts
+++ b/packages/harness/src/version.test.ts
@@ -1,0 +1,39 @@
+import {describe, expect, it} from 'vitest'
+import {buildHarnessVersion} from './version.js'
+
+// ---------------------------------------------------------------------------
+// buildHarnessVersion
+// ---------------------------------------------------------------------------
+
+describe('buildHarnessVersion', () => {
+  it('normal base + commit → <baseVersion>+harness.<shortSha>', () => {
+    // #given / #when
+    const result = buildHarnessVersion('1.15.13', 'cafebabe12345678')
+
+    // #then
+    expect(result).toBe('1.15.13+harness.cafebabe')
+  })
+
+  it('short sha is exactly the first 8 chars of a 40-char sha', () => {
+    // #given
+    const fullSha = 'abcdef1234567890abcdef1234567890abcdef12'
+
+    // #when
+    const result = buildHarnessVersion('1.15.13', fullSha)
+
+    // #then
+    expect(result).toBe('1.15.13+harness.abcdef12')
+    expect(result.split('+harness.')[1]).toBe(fullSha.slice(0, 8))
+  })
+
+  it('commit shorter than 8 chars → uses the full (short) commit as-is', () => {
+    // #given — a commit shorter than 8 chars (e.g. a dev stub)
+    const shortCommit = 'abc'
+
+    // #when
+    const result = buildHarnessVersion('1.15.13', shortCommit)
+
+    // #then — slice(0, 8) on a 3-char string returns the full string
+    expect(result).toBe('1.15.13+harness.abc')
+  })
+})

--- a/packages/harness/src/version.ts
+++ b/packages/harness/src/version.ts
@@ -1,0 +1,9 @@
+/**
+ * Builds the version string a harness-built OpenCode binary self-reports.
+ * The integration commit is embedded so the binary's --version proves which
+ * frozen integration produced it: "<baseVersion>+harness.<shortSha>".
+ */
+export function buildHarnessVersion(baseVersion: string, integrationCommit: string): string {
+  const shortSha = integrationCommit.slice(0, 8)
+  return `${baseVersion}+harness.${shortSha}`
+}

--- a/packages/harness/tsconfig.json
+++ b/packages/harness/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsconfig.tsbuildinfo",
+    "rootDir": "../../",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/harness/tsconfig.json
+++ b/packages/harness/tsconfig.json
@@ -8,6 +8,6 @@
     "declarationMap": true,
     "outDir": "./dist"
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "scripts/**/*.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/harness/tsdown.config.ts
+++ b/packages/harness/tsdown.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/cli.ts'],
+  format: 'esm',
+  outDir: 'dist',
+})

--- a/packages/harness/tsdown.config.ts
+++ b/packages/harness/tsdown.config.ts
@@ -1,7 +1,7 @@
 import {defineConfig} from 'tsdown'
 
 export default defineConfig({
-  entry: ['src/cli.ts'],
+  entry: ['src/cli.ts', 'src/postinstall.ts'],
   format: 'esm',
   outDir: 'dist',
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,8 @@ importers:
         specifier: 4.12.23
         version: 4.12.23
 
+  packages/harness: {}
+
   packages/runtime:
     dependencies:
       '@bfra.me/es':


### PR DESCRIPTION
Adds `@fro.bot/harness`: a published package that ships a patched build of upstream OpenCode behind a forwarding CLI, distributed as native per-platform binaries. It gives Fro Bot durable, reproducible control over a small set of non-mainline OpenCode changes while tracking a deliberately-pinned recent release.

## What's here

**The package** (`packages/harness/`)
- A `harness` CLI that passes any command through to the resolved OpenCode binary (stdio + exit code preserved), plus `info` / `patches` / `doctor` for provenance and diagnostics. `bunx @fro.bot/harness`-runnable.
- The integration engine: on a pinned OpenCode release, it bases a branch on the release tag, fetches the configured integration refs (PR/branch URLs), and uses an LLM merge to carry them onto the tag and resolve conflicts — the only mechanism that bridges a dev-targeted change onto a release tag. The merge runs once per bump, is reviewed, and is frozen as a pinned integration commit; builds pin to that commit.
- Native per-platform builds (linux + darwin, x64 + arm64) on their own runners, distributed as a main package plus per-platform `optionalDependencies` with a host-resolving `postinstall`.

**Publishing** — npm trusted publishing (OIDC): no long-lived token, automatic provenance, with OIDC scoped to a maintainer-gated publish job. The build job that runs the merge is read-only.

**Initial carry set** — one ref: anomalyco/opencode#30182 (preserve signed Anthropic thinking during reorder). It's merged upstream to `dev` but not in the pinned release, so the merge carries it onto the tag; it drops automatically once a release includes it. A carry policy in the package AGENTS.md keeps the set small.

## Scope

This is the package + pipeline only. The action does **not** consume the harness binary yet — wiring the harness in as the default OpenCode is a deliberate follow-up after the package is published, so the action is never pointed at an unpublished package. The release workflow is dispatch/tag-gated and does not run on PRs.

## Notes for review

- `harness-release.yaml` won't run here (gated); it builds, verifies, and publishes only on deliberate dispatch.
- First publish requires a one-time per-package trusted-publisher setup on npmjs.com (documented in `packages/harness/AGENTS.md`), since trusted publishing needs a package to exist before it accepts OIDC publishes.