### PR TITLE
fix(ci): repair harness-release workflow startup failure

### DIFF
--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -53,7 +53,7 @@ jobs:
             runner: ubuntu-24.04-arm
           - platform: darwin
             arch: x64
-            runner: macos-13
+            runner: macos-15-intel
           - platform: darwin
             arch: arm64
             runner: macos-15
@@ -257,9 +257,11 @@ jobs:
             exit 1
           fi
 
-          echo "integration_commit=${INTEGRATION_COMMIT}" >> "$GITHUB_OUTPUT"
-          echo "base_version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "dry_run=${DRY_RUN}" >> "$GITHUB_OUTPUT"
+          {
+            echo "integration_commit=${INTEGRATION_COMMIT}"
+            echo "base_version=${BASE_VERSION}"
+            echo "dry_run=${DRY_RUN}"
+          } >> "$GITHUB_OUTPUT"
 
       # Download all four platform binaries.
       - name: Download linux/x64 binary
@@ -306,8 +308,8 @@ jobs:
               chmod +x "${BIN_DIR}/opencode"
 
               # Write the per-platform package.json (mirrors OpenCode's model).
-              # BASE_VERSION and PKG_NAME are shell variables (not ${{ }} interpolation),
-              # so they are safe from injection — validated above.
+              # BASE_VERSION and PKG_NAME are shell variables (not workflow-expression
+              # interpolation), so they are safe from injection — validated above.
               cat > "${PKG_DIR}/package.json" <<EOF
           {
             "name": "${PKG_NAME}",


### PR DESCRIPTION
The `harness-release` workflow failed to start on every push — recorded as a failed run on unrelated branches (`next`, `renovate/*`, `main`).

**Cause:** a `run:` block comment contained an empty `${{ }}` token. GitHub Actions evaluates workflow expressions inside `run:` blocks — including comment text — so the empty expression made the workflow fail to compile, which GitHub records as a failed run on every push regardless of the tag-only trigger.

**Fix:**
- Reword the comment so it no longer contains a literal expression token.
- Replace the retired `macos-13` runner label with `macos-15-intel`.
- Group the `GITHUB_OUTPUT` redirects (clears the shellcheck SC2129 warning).

`actionlint` is now clean.