### PR TITLE
feat(gateway): gate mention dispatch on workspace OpenCode readiness

### DIFF
--- a/apps/workspace-agent/src/server.test.ts
+++ b/apps/workspace-agent/src/server.test.ts
@@ -410,3 +410,88 @@ describe('POST /clone — clone-timeout returns 504 (Fix #4)', () => {
     expect(body).toEqual({ok: false, error: 'clone-timeout'})
   })
 })
+
+describe('GET /readyz', () => {
+  it('returns 200 with ready: true when opencode status is "ready"', async () => {
+    // #given
+    const opencodeStatus = {status: 'ready' as const}
+    const app = createApp({opencodeStatus})
+
+    // #when
+    const res = await app.request('/readyz')
+
+    // #then
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ready: true, opencode: 'ready'})
+  })
+
+  it('returns 503 with ready: false when opencode status is "starting"', async () => {
+    // #given
+    const opencodeStatus = {status: 'starting' as const}
+    const app = createApp({opencodeStatus})
+
+    // #when
+    const res = await app.request('/readyz')
+
+    // #then
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body).toEqual({ready: false, opencode: 'starting'})
+  })
+
+  it('returns 503 with ready: false when opencode status is "down"', async () => {
+    // #given
+    const opencodeStatus = {status: 'down' as const}
+    const app = createApp({opencodeStatus})
+
+    // #when
+    const res = await app.request('/readyz')
+
+    // #then
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body).toEqual({ready: false, opencode: 'down'})
+  })
+
+  it('returns 503 (fail-closed) when no opencode status ref is provided', async () => {
+    // #given — createApp without opencodeStatus (clone-only mode)
+    const app = createApp()
+
+    // #when
+    const res = await app.request('/readyz')
+
+    // #then — unknown liveness → not ready
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body).toEqual({ready: false, opencode: 'unknown'})
+  })
+
+  it('does not affect /healthz — always 200 regardless of opencode status', async () => {
+    // #given — test all three status values
+    const statuses = ['ready', 'starting', 'down'] as const
+    for (const status of statuses) {
+      const opencodeStatus = {status}
+      const app = createApp({opencodeStatus})
+
+      // #when
+      const res = await app.request('/healthz')
+
+      // #then — /healthz is always 200 (clone-only liveness invariant)
+      expect(res.status).toBe(200)
+    }
+  })
+
+  it('does not affect /healthz when no opencode status ref is provided', async () => {
+    // #given
+    const app = createApp()
+
+    // #when
+    const res = await app.request('/healthz')
+
+    // #then
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ok: true})
+  })
+})

--- a/apps/workspace-agent/src/server.ts
+++ b/apps/workspace-agent/src/server.ts
@@ -57,7 +57,7 @@ export function createApp(deps: ServerDeps = {}): Hono {
     }
     const isReady = opencodeStatus.status === 'ready'
     const body: ReadyzResponse = {ready: isReady, opencode: opencodeStatus.status}
-    return c.json(body, isReady ? 200 : 503)
+    return c.json(body, isReady === true ? 200 : 503)
   })
 
   // POST /clone — clone a GitHub repo into the workspace

--- a/apps/workspace-agent/src/server.ts
+++ b/apps/workspace-agent/src/server.ts
@@ -6,7 +6,7 @@
  */
 
 import type {CloneHandlerDeps, CloneHandlerResult} from './clone.js'
-import type {CloneFailure, CloneRequest, HealthzResponse} from './types.js'
+import type {CloneFailure, CloneRequest, HealthzResponse, ReadyzResponse} from './types.js'
 
 import {Hono} from 'hono'
 import {executeClone, scrubCredentials} from './clone.js'
@@ -42,11 +42,22 @@ export function createApp(deps: ServerDeps = {}): Hono {
   const {cloneExecutor = executeClone, opencodeStatus} = deps
   const app = new Hono()
 
-  // GET /healthz — liveness probe
+  // GET /healthz — liveness probe (always 200; clone-only signal)
   app.get('/healthz', c => {
     const body: HealthzResponse =
       opencodeStatus === undefined ? {ok: true} : {ok: true, opencode: opencodeStatus.status}
     return c.json(body, 200)
+  })
+
+  // GET /readyz — readiness probe (200 only when OpenCode is ready; 503 otherwise)
+  app.get('/readyz', c => {
+    if (opencodeStatus === undefined) {
+      const body: ReadyzResponse = {ready: false, opencode: 'unknown'}
+      return c.json(body, 503)
+    }
+    const isReady = opencodeStatus.status === 'ready'
+    const body: ReadyzResponse = {ready: isReady, opencode: opencodeStatus.status}
+    return c.json(body, isReady ? 200 : 503)
   })
 
   // POST /clone — clone a GitHub repo into the workspace

--- a/apps/workspace-agent/src/types.ts
+++ b/apps/workspace-agent/src/types.ts
@@ -3,7 +3,8 @@
  *
  * These types define the contract between the gateway (PR D workspace-api client)
  * and the workspace-agent server. The gateway MUST import from
- * `packages/gateway/src/workspace-api/types.ts` which mirrors these shapes exactly.
+ * `packages/gateway/src/workspace-api/types.ts`, whose types are wire-compatible with these
+ * (some intentionally narrower for stricter consumer-side checking).
  *
  * SECURITY: `repoPath` is NOT in CloneRequest. The agent derives the path internally.
  * The caller never controls where the repo is cloned.

--- a/apps/workspace-agent/src/types.ts
+++ b/apps/workspace-agent/src/types.ts
@@ -59,3 +59,10 @@ export interface HealthzResponse {
   /** OpenCode server readiness. Present when the server lifecycle is managed. */
   readonly opencode?: 'ready' | 'starting' | 'down'
 }
+
+/** GET /readyz response. */
+export interface ReadyzResponse {
+  readonly ready: boolean
+  /** OpenCode server readiness. 'unknown' when no status ref is available. */
+  readonly opencode: 'ready' | 'starting' | 'down' | 'unknown'
+}

--- a/packages/gateway/src/discord/commands/add-project.test.ts
+++ b/packages/gateway/src/discord/commands/add-project.test.ts
@@ -159,6 +159,7 @@ function makeWorkspaceClient(overrides?: {clone?: ReturnType<typeof vi.fn>}): Wo
     clone:
       overrides?.clone ??
       vi.fn().mockResolvedValue(ok({ok: true, path: '/workspace/repos/testowner/testrepo', commit: 'abc123'})),
+    readyz: vi.fn().mockResolvedValue(ok({ready: true, opencode: 'ready'})),
   } as unknown as WorkspaceClient
 }
 

--- a/packages/gateway/src/discord/commands/index.test.ts
+++ b/packages/gateway/src/discord/commands/index.test.ts
@@ -25,6 +25,7 @@ function makeMockDeps(): AddProjectDeps {
     },
     workspaceClient: {
       clone: vi.fn(),
+      readyz: vi.fn().mockResolvedValue({success: true, data: {ready: true, opencode: 'ready'}}),
     },
     installUrl: 'https://github.com/apps/fro-bot-agent/installations/new',
     logger: {

--- a/packages/gateway/src/discord/mentions.test.ts
+++ b/packages/gateway/src/discord/mentions.test.ts
@@ -1,7 +1,10 @@
+import type {Result} from '@fro-bot/runtime'
 import type {Guild, GuildMember, Message, TextChannel} from 'discord.js'
 import type {BindingsStore} from '../bindings/store.js'
+import type {ReadyzResponse, WorkspaceError} from '../workspace-api/types.js'
 import type {MentionDeps} from './mentions.js'
 
+import {err, ok} from '@fro-bot/runtime'
 import {PermissionsBitField} from 'discord.js'
 import {Effect} from 'effect'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
@@ -154,12 +157,26 @@ function makeNoopLogger(): MentionDeps['logger'] {
   return {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
 }
 
+function makeReadyzFn(
+  result: 'ready' | 'not-ready' | 'error' | 'throws',
+  opencodeStatus: 'starting' | 'down' | 'unknown' = 'starting',
+): () => Promise<Result<ReadyzResponse, WorkspaceError>> {
+  return vi.fn(async () => {
+    if (result === 'throws') throw new Error('readyz threw unexpectedly')
+    if (result === 'ready') return ok({ready: true, opencode: 'ready'} satisfies ReadyzResponse)
+    if (result === 'not-ready') return ok({ready: false, opencode: opencodeStatus} satisfies ReadyzResponse)
+    // error
+    return err({kind: 'network-error'} satisfies WorkspaceError)
+  })
+}
+
 function makeDeps(overrides: Partial<MentionDeps> = {}): MentionDeps {
   return {
     bindingsStore: overrides.bindingsStore ?? makeBindingsStore('found'),
     triggerRoleId: overrides.triggerRoleId === undefined ? null : overrides.triggerRoleId,
     run: overrides.run ?? makeRunMentionDeps(),
     logger: overrides.logger ?? makeNoopLogger(),
+    readyz: overrides.readyz ?? makeReadyzFn('ready'),
   }
 }
 
@@ -393,6 +410,118 @@ describe('handleMention', () => {
 
       // #then
       expect(runMentionMock).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── Readiness gate ──────────────────────────────────────────────────────────
+
+  describe('readiness gate (after binding lookup, before runMention)', () => {
+    it('happy path: readiness=ready → runMention IS invoked', async () => {
+      // #given
+      const {handleMention} = await import('./mentions.js')
+      const member = makeGuildMember({hasManageChannels: true})
+      const message = makeMessage({guildMember: member})
+      const deps = makeDeps({readyz: makeReadyzFn('ready')})
+
+      // #when
+      await Effect.runPromise(handleMention(message, BOT_USER_ID, deps))
+
+      // #then — workspace is ready, runMention proceeds
+      expect(runMentionMock).toHaveBeenCalledOnce()
+    })
+
+    it('readiness=not-ready → runMention NOT invoked, coarse reply sent', async () => {
+      // #given
+      const {handleMention} = await import('./mentions.js')
+      const member = makeGuildMember({hasManageChannels: true})
+      const replyFn = makeReplyFn()
+      const message = makeMessage({guildMember: member, replyFn})
+      const deps = makeDeps({readyz: makeReadyzFn('not-ready', 'starting')})
+
+      // #when
+      await Effect.runPromise(handleMention(message, BOT_USER_ID, deps))
+
+      // #then — workspace not ready: no runMention, coarse reply
+      expect(runMentionMock).not.toHaveBeenCalled()
+      expect(replyFn).toHaveBeenCalledOnce()
+      const call = replyFn.mock.calls[0]?.[0] as {content?: string; allowedMentions?: unknown} | undefined
+      expect(call?.content).toContain('not reachable')
+      expect(call?.allowedMentions).toEqual({parse: []})
+    })
+
+    it('readiness=error (transport error) → fail-closed: coarse reply, runMention NOT invoked', async () => {
+      // #given
+      const {handleMention} = await import('./mentions.js')
+      const member = makeGuildMember({hasManageChannels: true})
+      const replyFn = makeReplyFn()
+      const message = makeMessage({guildMember: member, replyFn})
+      const deps = makeDeps({readyz: makeReadyzFn('error')})
+
+      // #when
+      await Effect.runPromise(handleMention(message, BOT_USER_ID, deps))
+
+      // #then — transport error treated as not-ready (fail-closed)
+      expect(runMentionMock).not.toHaveBeenCalled()
+      expect(replyFn).toHaveBeenCalledOnce()
+      const call = replyFn.mock.calls[0]?.[0] as {content?: string; allowedMentions?: unknown} | undefined
+      expect(call?.content).toContain('not reachable')
+      expect(call?.allowedMentions).toEqual({parse: []})
+    })
+
+    it('readiness check throws/times out → fail-closed: coarse reply, runMention NOT invoked', async () => {
+      // #given
+      const {handleMention} = await import('./mentions.js')
+      const member = makeGuildMember({hasManageChannels: true})
+      const replyFn = makeReplyFn()
+      const message = makeMessage({guildMember: member, replyFn})
+      const deps = makeDeps({readyz: makeReadyzFn('throws')})
+
+      // #when
+      await Effect.runPromise(handleMention(message, BOT_USER_ID, deps))
+
+      // #then — thrown exception treated as not-ready (fail-closed)
+      expect(runMentionMock).not.toHaveBeenCalled()
+      expect(replyFn).toHaveBeenCalledOnce()
+      const call = replyFn.mock.calls[0]?.[0] as {content?: string; allowedMentions?: unknown} | undefined
+      expect(call?.content).toContain('not reachable')
+      expect(call?.allowedMentions).toEqual({parse: []})
+    })
+
+    it('ordering: missing binding short-circuits BEFORE readiness check (readyz never called)', async () => {
+      // #given — no binding for this channel
+      const {handleMention} = await import('./mentions.js')
+      const member = makeGuildMember({hasManageChannels: true})
+      const replyFn = makeReplyFn()
+      const message = makeMessage({guildMember: member, replyFn})
+      const readyzFn = makeReadyzFn('ready')
+      const deps = makeDeps({
+        bindingsStore: makeBindingsStore('not-found'),
+        readyz: readyzFn,
+      })
+
+      // #when
+      await Effect.runPromise(handleMention(message, BOT_USER_ID, deps))
+
+      // #then — binding lookup short-circuits before readiness check
+      expect(readyzFn).not.toHaveBeenCalled()
+      expect(runMentionMock).not.toHaveBeenCalled()
+    })
+
+    it('not-ready reply uses allowedMentions: {parse: []}', async () => {
+      // #given
+      const {handleMention} = await import('./mentions.js')
+      const member = makeGuildMember({hasManageChannels: true})
+      const replyFn = makeReplyFn()
+      const message = makeMessage({guildMember: member, replyFn})
+      const deps = makeDeps({readyz: makeReadyzFn('not-ready', 'down')})
+
+      // #when
+      await Effect.runPromise(handleMention(message, BOT_USER_ID, deps))
+
+      // #then — invariant: all replies use allowedMentions: {parse: []}
+      expect(replyFn).toHaveBeenCalledOnce()
+      const call = replyFn.mock.calls[0]?.[0] as {allowedMentions?: unknown} | undefined
+      expect(call?.allowedMentions).toEqual({parse: []})
     })
   })
 

--- a/packages/gateway/src/discord/mentions.ts
+++ b/packages/gateway/src/discord/mentions.ts
@@ -18,10 +18,12 @@
  * - No internal detail (error messages, IDs, paths) is ever posted to Discord.
  */
 
+import type {Result} from '@fro-bot/runtime'
 import type {Guild, Message} from 'discord.js'
 
 import type {BindingsStore} from '../bindings/store.js'
 import type {RunMentionDeps} from '../execute/run.js'
+import type {ReadyzResponse, WorkspaceError} from '../workspace-api/types.js'
 import type {GatewayLogger} from './client.js'
 import {PermissionFlagsBits} from 'discord.js'
 import {Effect} from 'effect'
@@ -45,6 +47,13 @@ export interface MentionDeps {
   /** Run-lifecycle deps forwarded verbatim to `runMention`. */
   readonly run: RunMentionDeps
   readonly logger: GatewayLogger
+  /**
+   * Workspace readiness check. Called after binding lookup, before runMention.
+   * Injected so tests can stub it without a live workspace.
+   *
+   * Fail-closed: any error result or thrown exception → treat as not-ready.
+   */
+  readonly readyz: () => Promise<Result<ReadyzResponse, WorkspaceError>>
 }
 
 // ---------------------------------------------------------------------------
@@ -106,7 +115,7 @@ export async function userIsAuthorized(
  * Internal errors are logged; coarse user-visible messages are posted to Discord.
  */
 export function handleMention(message: Message, botUserId: string, deps: MentionDeps): Effect.Effect<void, Error> {
-  const {bindingsStore, triggerRoleId, run: runDeps, logger} = deps
+  const {bindingsStore, triggerRoleId, run: runDeps, logger, readyz} = deps
 
   // ── Guard 1: Skip if already in a thread ────────────────────────────────
   if (message.channel.isThread()) {
@@ -154,7 +163,29 @@ export function handleMention(message: Message, botUserId: string, deps: Mention
       const binding = bindingResult.data
       logger.info({channelId: message.channel.id, repo: `${binding.owner}/${binding.repo}`}, 'mention: binding found')
 
-      // ── Steps 4–11: Execution lifecycle (concurrency + lock + run-state) ─
+      // ── Step 4: Workspace readiness gate ────────────────────────────────
+      // Fail-closed: any error result or thrown exception → treat as not-ready.
+      // This prevents creating a thread, acquiring a lock, or creating run-state
+      // for a workspace that is not yet serving OpenCode.
+      let workspaceReady = false
+      try {
+        const readyzResult = await readyz()
+        workspaceReady = readyzResult.success === true && readyzResult.data.ready === true
+      } catch {
+        // Thrown exception (e.g. timeout) → fail closed
+        workspaceReady = false
+      }
+
+      if (workspaceReady === false) {
+        logger.warn(
+          {channelId: message.channel.id, repo: `${binding.owner}/${binding.repo}`},
+          'mention: workspace not ready — aborting',
+        )
+        await safeReply(message, 'The workspace is not reachable right now. Please try again later.')
+        return
+      }
+
+      // ── Steps 5–11: Execution lifecycle (concurrency + lock + run-state) ─
       await runMention(message, binding, runDeps)
     },
     catch: (error: unknown) => (error instanceof Error ? error : new Error(String(error))),

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -277,6 +277,8 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           approvalRegistry,
         },
         logger,
+        // Workspace readiness gate — uses the same :9100 base as the clone endpoint.
+        readyz: async () => workspaceClient.readyz(),
       }
 
       const runPromise: Promise<void> = Effect.runPromise(handleMention(message, client.user.id, mentionDeps)).catch(

--- a/packages/gateway/src/workspace-api/client.test.ts
+++ b/packages/gateway/src/workspace-api/client.test.ts
@@ -6,6 +6,226 @@ import {describe, expect, it, vi} from 'vitest'
 import {createWorkspaceClient} from './client.js'
 
 // ---------------------------------------------------------------------------
+// readyz tests
+// ---------------------------------------------------------------------------
+
+describe('WorkspaceClient.readyz', () => {
+  describe('200 response → ready', () => {
+    it('returns ready:true when server responds 200 with {ready:true, opencode:"ready"}', async () => {
+      // #given
+      const client = makeClient()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ready: true, opencode: 'ready'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.readyz()
+
+      // #then
+      expect(result).toEqual(ok({ready: true, opencode: 'ready'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('gETs /readyz on the same base URL as /clone', async () => {
+      // #given
+      const client = makeClient()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ready: true, opencode: 'ready'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      await client.readyz()
+
+      // #then
+      expect(fetchMock).toHaveBeenCalledWith('http://workspace:9100/readyz', expect.objectContaining({method: 'GET'}))
+      vi.unstubAllGlobals()
+    })
+  })
+
+  describe('503 response → not-ready', () => {
+    it('returns ready:false with opencode status when server responds 503', async () => {
+      // #given
+      const client = makeClient()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({ready: false, opencode: 'starting'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.readyz()
+
+      // #then
+      expect(result).toEqual(ok({ready: false, opencode: 'starting'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('returns ready:false with opencode:"down" when server responds 503 with down status', async () => {
+      // #given
+      const client = makeClient()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({ready: false, opencode: 'down'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.readyz()
+
+      // #then
+      expect(result).toEqual(ok({ready: false, opencode: 'down'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('returns ready:false with opencode:"unknown" when server responds 503 with unknown status', async () => {
+      // #given
+      const client = makeClient()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({ready: false, opencode: 'unknown'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.readyz()
+
+      // #then
+      expect(result).toEqual(ok({ready: false, opencode: 'unknown'}))
+      vi.unstubAllGlobals()
+    })
+  })
+
+  describe('transport error / non-200-503 / timeout → error result', () => {
+    it('returns network-error on connection refused', async () => {
+      // #given
+      const client = makeClient()
+      const fetchMock = vi.fn().mockRejectedValue(Object.assign(new Error('ECONNREFUSED'), {name: 'TypeError'}))
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.readyz()
+
+      // #then
+      expect(result).toEqual(err({kind: 'network-error'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('returns timeout on AbortSignal.timeout expiry (TimeoutError)', async () => {
+      // #given
+      const client = makeClient()
+      const timeoutErr = Object.assign(new Error('The operation was aborted due to timeout'), {name: 'TimeoutError'})
+      const fetchMock = vi.fn().mockRejectedValue(timeoutErr)
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.readyz()
+
+      // #then
+      expect(result).toEqual(err({kind: 'timeout'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('returns timeout on AbortError', async () => {
+      // #given
+      const client = makeClient()
+      const abortErr = Object.assign(new Error('The operation was aborted'), {name: 'AbortError'})
+      const fetchMock = vi.fn().mockRejectedValue(abortErr)
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.readyz()
+
+      // #then
+      expect(result).toEqual(err({kind: 'timeout'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('returns http-error on unexpected non-200-non-503 status (e.g. 500)', async () => {
+      // #given
+      const client = makeClient()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => undefined,
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.readyz()
+
+      // #then
+      expect(result).toEqual(err({kind: 'http-error', status: 500}))
+      vi.unstubAllGlobals()
+    })
+
+    it('returns http-error on 404 (unexpected status)', async () => {
+      // #given
+      const client = makeClient()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => undefined,
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.readyz()
+
+      // #then
+      expect(result).toEqual(err({kind: 'http-error', status: 404}))
+      vi.unstubAllGlobals()
+    })
+
+    it('returns parse-error when 200 body is not valid JSON', async () => {
+      // #given
+      const client = makeClient()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError('Unexpected token')
+        },
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.readyz()
+
+      // #then
+      expect(result).toEqual(err({kind: 'parse-error'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('returns parse-error when 200 body has wrong shape', async () => {
+      // #given
+      const client = makeClient()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({unexpected: 'shape'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.readyz()
+
+      // #then
+      expect(result).toEqual(err({kind: 'parse-error'}))
+      vi.unstubAllGlobals()
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/packages/gateway/src/workspace-api/client.test.ts
+++ b/packages/gateway/src/workspace-api/client.test.ts
@@ -222,6 +222,42 @@ describe('WorkspaceClient.readyz', () => {
       expect(result).toEqual(err({kind: 'parse-error'}))
       vi.unstubAllGlobals()
     })
+
+    it('503 response with ready:true body → returns err (status/body mismatch, fail-closed)', async () => {
+      // #given — a not-ready workspace lying about its status; must be rejected fail-closed
+      const client = makeClient()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({ready: true, opencode: 'ready'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.readyz()
+
+      // #then — status↔body mismatch → parse-error (fail-closed, not treated as ready)
+      expect(result).toEqual(err({kind: 'parse-error'}))
+      vi.unstubAllGlobals()
+    })
+
+    it('200 response with ready:false body → returns err (status/body mismatch)', async () => {
+      // #given — incoherent response: HTTP 200 but body says not ready
+      const client = makeClient()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ready: false, opencode: 'down'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.readyz()
+
+      // #then — status↔body mismatch → parse-error
+      expect(result).toEqual(err({kind: 'parse-error'}))
+      vi.unstubAllGlobals()
+    })
   })
 })
 

--- a/packages/gateway/src/workspace-api/client.ts
+++ b/packages/gateway/src/workspace-api/client.ts
@@ -9,20 +9,35 @@
 
 import type {Result} from '@fro-bot/runtime'
 
-import type {CloneErrorCode, CloneFailure, CloneRequest, CloneSuccess, WorkspaceError} from './types.js'
+import type {CloneErrorCode, CloneFailure, CloneRequest, CloneSuccess, ReadyzResponse, WorkspaceError} from './types.js'
 
 import {err, ok} from '@fro-bot/runtime'
 
 export interface WorkspaceClientOptions {
   readonly baseUrl: string
   readonly timeoutMs?: number
+  /** Timeout for /readyz checks. Defaults to 5 seconds — much shorter than clone. */
+  readonly readyzTimeoutMs?: number
 }
 
 export interface WorkspaceClient {
   readonly clone: (request: CloneRequest) => Promise<Result<CloneSuccess, WorkspaceError>>
+  /**
+   * Check workspace readiness via GET /readyz.
+   *
+   * Returns:
+   * - `ok({ready: true, opencode: 'ready'})` on HTTP 200
+   * - `ok({ready: false, opencode: ...})` on HTTP 503 (workspace not ready)
+   * - `err({kind: 'http-error', status})` on unexpected HTTP status
+   * - `err({kind: 'timeout'})` on AbortSignal.timeout expiry
+   * - `err({kind: 'network-error'})` on connection failure
+   * - `err({kind: 'parse-error'})` on malformed response body
+   */
+  readonly readyz: () => Promise<Result<ReadyzResponse, WorkspaceError>>
 }
 
 const DEFAULT_TIMEOUT_MS = 300_000 // 5 minutes
+const DEFAULT_READYZ_TIMEOUT_MS = 5_000 // 5 seconds — fast gate check
 
 // Mirrors WORKSPACE_REPOS_ROOT in apps/workspace-agent/src/clone.ts (separate
 // package/container boundary, so not imported). Module-private: callers use
@@ -46,7 +61,46 @@ export function workspaceRepoPath(owner: string, repo: string): string {
  * Never logs request or response bodies.
  */
 export function createWorkspaceClient(options: WorkspaceClientOptions): WorkspaceClient {
-  const {baseUrl, timeoutMs = DEFAULT_TIMEOUT_MS} = options
+  const {baseUrl, timeoutMs = DEFAULT_TIMEOUT_MS, readyzTimeoutMs = DEFAULT_READYZ_TIMEOUT_MS} = options
+
+  async function readyz(): Promise<Result<ReadyzResponse, WorkspaceError>> {
+    let response: Response
+    try {
+      response = await fetch(`${baseUrl}/readyz`, {
+        method: 'GET',
+        signal: AbortSignal.timeout(readyzTimeoutMs),
+      })
+    } catch (fetchError) {
+      if (fetchError instanceof Error && fetchError.name === 'TimeoutError') {
+        return err({kind: 'timeout'})
+      }
+      if (fetchError instanceof Error && fetchError.name === 'AbortError') {
+        return err({kind: 'timeout'})
+      }
+      return err({kind: 'network-error'})
+    }
+
+    const httpStatus = response.status
+
+    // Only 200 (ready) and 503 (not-ready) are expected.
+    // Any other status is an unexpected error.
+    if (httpStatus !== 200 && httpStatus !== 503) {
+      return err({kind: 'http-error', status: httpStatus})
+    }
+
+    let parsed: unknown
+    try {
+      parsed = await response.json()
+    } catch {
+      return err({kind: 'parse-error'})
+    }
+
+    if (!isReadyzResponse(parsed)) {
+      return err({kind: 'parse-error'})
+    }
+
+    return ok(parsed)
+  }
 
   async function clone(request: CloneRequest): Promise<Result<CloneSuccess, WorkspaceError>> {
     const {owner, repo} = request
@@ -113,12 +167,23 @@ export function createWorkspaceClient(options: WorkspaceClientOptions): Workspac
     return ok(parsed)
   }
 
-  return {clone}
+  return {clone, readyz}
 }
 
 // ---------------------------------------------------------------------------
 // Type guards
 // ---------------------------------------------------------------------------
+
+function isReadyzResponse(value: unknown): value is ReadyzResponse {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  if (typeof v.ready !== 'boolean') return false
+  if (v.ready === true) {
+    return v.opencode === 'ready'
+  }
+  // ready === false
+  return v.opencode === 'starting' || v.opencode === 'down' || v.opencode === 'unknown'
+}
 
 function isCloneResponse(value: unknown): value is CloneSuccess | CloneFailure {
   if (typeof value !== 'object' || value === null) return false

--- a/packages/gateway/src/workspace-api/client.ts
+++ b/packages/gateway/src/workspace-api/client.ts
@@ -95,7 +95,17 @@ export function createWorkspaceClient(options: WorkspaceClientOptions): Workspac
       return err({kind: 'parse-error'})
     }
 
-    if (!isReadyzResponse(parsed)) {
+    if (isReadyzResponse(parsed) === false) {
+      return err({kind: 'parse-error'})
+    }
+
+    // Status↔body coherence check: HTTP status must agree with the body's ready field.
+    // A 503 + {ready:true} would be a fail-OPEN (not-ready workspace classified as ready).
+    // A 200 + {ready:false} is also incoherent. Both are treated as parse-error (fail-closed).
+    if (httpStatus === 200 && parsed.ready !== true) {
+      return err({kind: 'parse-error'})
+    }
+    if (httpStatus === 503 && parsed.ready !== false) {
       return err({kind: 'parse-error'})
     }
 

--- a/packages/gateway/src/workspace-api/types.ts
+++ b/packages/gateway/src/workspace-api/types.ts
@@ -53,6 +53,27 @@ export type CloneErrorCode =
   | 'overloaded'
 
 /**
+ * GET /readyz success response (HTTP 200).
+ * Mirrors `apps/workspace-agent/src/readyz.ts`.
+ */
+export interface ReadyzReady {
+  readonly ready: true
+  readonly opencode: 'ready'
+}
+
+/**
+ * GET /readyz not-ready response (HTTP 503).
+ * Mirrors `apps/workspace-agent/src/readyz.ts`.
+ */
+export interface ReadyzNotReady {
+  readonly ready: false
+  readonly opencode: 'starting' | 'down' | 'unknown'
+}
+
+/** Discriminated union of all /readyz response shapes. */
+export type ReadyzResponse = ReadyzReady | ReadyzNotReady
+
+/**
  * Client-side error discriminated union for workspace-api calls.
  * These are the errors the gateway's workspace client can return.
  */

--- a/packages/gateway/src/workspace-api/types.ts
+++ b/packages/gateway/src/workspace-api/types.ts
@@ -1,8 +1,10 @@
 /**
  * Request/response types for the workspace-agent HTTP service.
  *
- * These types MIRROR `apps/workspace-agent/src/types.ts` exactly.
- * The gateway MUST import from this file — never from the workspace-agent package directly.
+ * These types are wire-compatible with `apps/workspace-agent/src/types.ts`. Some are
+ * intentionally narrower (e.g. the `/readyz` shapes below are split into a discriminated
+ * union here for stricter consumer-side checking). The gateway MUST import from this file —
+ * never from the workspace-agent package directly.
  *
  * SECURITY: `repoPath` is NOT in CloneRequest. The agent derives the path internally.
  * The caller never controls where the repo is cloned.
@@ -54,7 +56,7 @@ export type CloneErrorCode =
 
 /**
  * GET /readyz success response (HTTP 200).
- * Mirrors `apps/workspace-agent/src/readyz.ts`.
+ * Narrows the flat `ReadyzResponse` emitted by `apps/workspace-agent/src/server.ts`.
  */
 export interface ReadyzReady {
   readonly ready: true
@@ -63,7 +65,7 @@ export interface ReadyzReady {
 
 /**
  * GET /readyz not-ready response (HTTP 503).
- * Mirrors `apps/workspace-agent/src/readyz.ts`.
+ * Narrows the flat `ReadyzResponse` emitted by `apps/workspace-agent/src/server.ts`.
  */
 export interface ReadyzNotReady {
   readonly ready: false


### PR DESCRIPTION
Before this change the gateway routed `@fro-bot` mention runs to a workspace without checking whether its OpenCode was actually serving. `/healthz` returns 200 whenever the workspace's Hono service is up, so a workspace whose OpenCode is dead or still starting looked healthy — and the gateway kept dispatching runs that were guaranteed to fail with "the workspace is not reachable".

This adds the missing liveness signal and consumes it:

- **`GET /readyz` on the workspace agent** — returns 200 only when OpenCode is `ready`, 503 for any non-ready status (checked as `!== 'ready'`, so it fails closed for future states too; the no-status case reports `unknown` → 503). `/healthz` is unchanged (always 200) so container/clone liveness does not regress.
- **A readiness gate in the gateway** — `handleMention` now checks `/readyz` after resolving the channel's repo binding and before dispatching the run. It fails closed: a not-ready workspace, a transport error, or a timeout (5s) all reply with a coarse "workspace not reachable" message and stop — without creating a Discord thread, acquiring a lock, or creating run-state. Only a confirmed-ready workspace proceeds.

The `/readyz` client also cross-checks HTTP status against the response body, so an incoherent `503 + ready:true` can't slip a not-ready workspace past the gate.

Part of #749 (the cold-boot readiness fix shipped first; supervisor respawn + process-group reaping follow before #749 is fully resolved).