### PR TITLE
fix(workspace-agent): supervise OpenCode with respawn + process-group reaping

### DIFF
--- a/apps/workspace-agent/src/main.ts
+++ b/apps/workspace-agent/src/main.ts
@@ -28,6 +28,12 @@ const WORKSPACE_REPOS_ROOT = '/workspace/repos'
 // The supervisor (runSupervisedOpencode) writes all transitions here.
 const opencodeStatus = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
 
+// AbortController for the supervised OpenCode lifecycle.
+// Aborting this stops the supervisor and reaps the child's process group.
+// Required because detached:true puts the child in its OWN process group —
+// it does NOT inherit SIGTERM from the parent on container stop.
+const opencodeController = new AbortController()
+
 const app = createApp({opencodeStatus})
 
 const server = serve({fetch: app.fetch, port: PORT, hostname: HOST}, info => {
@@ -51,6 +57,7 @@ const opencodeServerPromise = runSupervisedOpencode({
   rootDir: WORKSPACE_REPOS_ROOT,
   logger: opencodeLogger,
   statusRef: opencodeStatus,
+  signal: opencodeController.signal,
   hostname: OPENCODE_HOSTNAME,
   port: OPENCODE_PORT,
   readyTimeoutMs: opencodeReadyTimeoutMs,
@@ -96,9 +103,13 @@ function shutdown(signal: string): void {
     process.exit(1)
   }, DRAIN_MS)
 
+  // Abort the supervised OpenCode lifecycle — this stops the supervisor and
+  // reaps the child's process group via killChildGroup. The child does NOT
+  // inherit SIGTERM from the parent because detached:true puts it in its own
+  // process group; explicit abort is required to avoid orphaning it.
+  opencodeController.abort()
+
   // Close proxy, then the Hono server.
-  // Note: the OpenCode child process is managed by the supervisor (runSupervisedOpencode).
-  // On SIGTERM the container will be killed; the supervisor's child inherits the signal.
   const cleanupProxy = async (): Promise<void> => {
     if (proxy !== undefined) {
       return proxy.close().catch(() => {

--- a/apps/workspace-agent/src/main.ts
+++ b/apps/workspace-agent/src/main.ts
@@ -13,7 +13,7 @@ import {serve} from '@hono/node-server'
 import {asyncCleanupAllAskpassDirs} from './clone.js'
 import {readReadyTimeoutMs, readSecret} from './config.js'
 import {createOpencodeProxy} from './opencode-proxy.js'
-import {startOpencodeServer} from './opencode-server.js'
+import {runSupervisedOpencode} from './opencode-server.js'
 import {createApp} from './server.js'
 
 const PORT = 9100
@@ -24,8 +24,9 @@ const OPENCODE_HOSTNAME = '127.0.0.1'
 const PROXY_PORT = 9200
 const WORKSPACE_REPOS_ROOT = '/workspace/repos'
 
-// Shared mutable state for OpenCode readiness, read by /healthz
-const opencodeStatus = {status: 'starting' as 'starting' | 'ready' | 'down'}
+// Shared mutable state for OpenCode readiness, read by /healthz and /readyz.
+// The supervisor (runSupervisedOpencode) writes all transitions here.
+const opencodeStatus = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
 
 const app = createApp({opencodeStatus})
 
@@ -33,35 +34,32 @@ const server = serve({fetch: app.fetch, port: PORT, hostname: HOST}, info => {
   console.warn(`workspace-agent listening on ${info.address}:${info.port}`)
 })
 
-// Boot OpenCode server (loopback-bound) — fire-and-forget, update status ref
+// Boot OpenCode server (loopback-bound) — supervised lifecycle with bounded respawn.
 const opencodeLogger = {
   info: (msg: string, meta?: Record<string, unknown>) => console.warn(msg, meta ?? ''),
   warn: (msg: string, meta?: Record<string, unknown>) => console.warn(msg, meta ?? ''),
   error: (msg: string, meta?: Record<string, unknown>) => console.error(msg, meta ?? ''),
 }
 
-let opencodeHandle: {url: string; close: () => void} | undefined
-
 // Fail-fast: throws at startup if WORKSPACE_OPENCODE_READY_TIMEOUT_MS is set but malformed.
 const opencodeReadyTimeoutMs = readReadyTimeoutMs()
 
-const opencodeServerPromise = startOpencodeServer({
+// Fire-and-forget supervised lifecycle. The supervisor writes status transitions
+// to opencodeStatus so /readyz reflects live state. On exhaustion it lands in
+// 'degraded' (clone API still alive; /readyz returns 503).
+const opencodeServerPromise = runSupervisedOpencode({
   rootDir: WORKSPACE_REPOS_ROOT,
   logger: opencodeLogger,
+  statusRef: opencodeStatus,
   hostname: OPENCODE_HOSTNAME,
   port: OPENCODE_PORT,
   readyTimeoutMs: opencodeReadyTimeoutMs,
+}).catch((error: unknown) => {
+  // Unexpected supervisor crash (should not happen — supervisor catches internally).
+  opencodeStatus.status = 'down'
+  const message = error instanceof Error ? error.message : String(error)
+  console.error('workspace-agent: opencode supervisor crashed unexpectedly', {message})
 })
-  .then(handle => {
-    opencodeHandle = handle
-    opencodeStatus.status = 'ready'
-    console.warn('workspace-agent: opencode server ready', {url: handle.url})
-  })
-  .catch((error: unknown) => {
-    opencodeStatus.status = 'down'
-    const message = error instanceof Error ? error.message : String(error)
-    console.error('workspace-agent: opencode server failed to start', {message})
-  })
 
 // Boot bearer-token proxy — reads WORKSPACE_OPENCODE_TOKEN secret at startup
 let proxy: ReturnType<typeof createOpencodeProxy> | undefined
@@ -98,13 +96,9 @@ function shutdown(signal: string): void {
     process.exit(1)
   }, DRAIN_MS)
 
-  // Close OpenCode server and proxy, then the Hono server.
-  const cleanupOpencode = (): void => {
-    if (opencodeHandle !== undefined) {
-      opencodeHandle.close()
-    }
-  }
-
+  // Close proxy, then the Hono server.
+  // Note: the OpenCode child process is managed by the supervisor (runSupervisedOpencode).
+  // On SIGTERM the container will be killed; the supervisor's child inherits the signal.
   const cleanupProxy = async (): Promise<void> => {
     if (proxy !== undefined) {
       return proxy.close().catch(() => {
@@ -119,7 +113,6 @@ function shutdown(signal: string): void {
       // Best-effort
     })
     .finally(() => {
-      cleanupOpencode()
       cleanupProxy()
         .catch(() => {
           // Best-effort

--- a/apps/workspace-agent/src/opencode-server.test.ts
+++ b/apps/workspace-agent/src/opencode-server.test.ts
@@ -1581,3 +1581,120 @@ describe('process-group reaping (Unit 6) — supervised respawn group kill', () 
     expect(processKillSpy).toHaveBeenCalledWith(-pid, 'SIGTERM')
   })
 })
+
+// ── Memory-leak regression: abort-listener retention across stable respawns ───
+//
+// Regression test for the bug where `signal.addEventListener('abort', …)` was
+// called TWICE per while-loop iteration and never removed. With the stable-ready
+// reset feature (`attempt = 1`), a long-lived workspace that crashes occasionally
+// respawns indefinitely — causing abort listeners to accumulate without bound on
+// the single shared AbortSignal, and each captured closure retaining its dead
+// child so children are never GC'd.
+//
+// Fix: register the abort handler ONCE outside the loop (register-once pattern)
+// and remove it in a finally block when the supervisor returns.
+//
+// This test drives N stable respawns and asserts that the NET number of 'abort'
+// listeners on the signal never exceeds 1 at any point during the run.
+
+describe('runSupervisedOpencode — abort-listener retention (memory-leak regression)', () => {
+  it('abort listener count stays ≤ 1 across multiple stable respawns (register-once)', async () => {
+    // #given — tiny stableReadyResetMs so each child quickly qualifies as stable
+    const stableReadyResetMs = 20
+    const maxAttempts = 4
+    const respawnCycles = 6 // more than maxAttempts to prove budget resets
+
+    // Track net addEventListener/removeEventListener calls on the signal
+    const ac = new AbortController()
+    const signal = ac.signal
+
+    let netListeners = 0
+    let maxObservedListeners = 0
+
+    const origAdd = signal.addEventListener.bind(signal)
+    const origRemove = signal.removeEventListener.bind(signal)
+
+    vi.spyOn(signal, 'addEventListener').mockImplementation((...args: Parameters<typeof signal.addEventListener>) => {
+      if (args[0] === 'abort') {
+        netListeners++
+        if (netListeners > maxObservedListeners) {
+          maxObservedListeners = netListeners
+        }
+      }
+      return origAdd(...args)
+    })
+
+    vi.spyOn(signal, 'removeEventListener').mockImplementation(
+      (...args: Parameters<typeof signal.removeEventListener>) => {
+        if (args[0] === 'abort') {
+          netListeners--
+        }
+        return origRemove(...args)
+      },
+    )
+
+    // Build respawnCycles+1 controllable children
+    const children = Array.from({length: respawnCycles + 1}, () => makeControllableChild())
+    let childIdx = 0
+    const spawnFn: SpawnFn = () => {
+      const c = children[childIdx]
+      if (c === undefined) throw new Error('ran out of children')
+      childIdx++
+      return c.child
+    }
+
+    const statusRef = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
+
+    // #when — run the supervisor through respawnCycles stable exits
+    const supervisorPromise = runSupervisedOpencode({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      statusRef,
+      signal,
+      spawnFn,
+      pollReadyFn: alwaysReady,
+      pollIntervalMs: 0,
+      readyTimeoutMs: 5000,
+      maxAttempts,
+      initialBackoffMs: 0,
+      stableReadyResetMs,
+    })
+
+    for (let i = 0; i < respawnCycles; i++) {
+      // Wait for ready
+      await new Promise<void>(resolve => {
+        const check = (): void => {
+          if (statusRef.status === 'ready') resolve()
+          else setImmediate(check)
+        }
+        setImmediate(check)
+      })
+
+      // Wait past the stable threshold, then trigger exit to force a respawn
+      await new Promise<void>(r => setTimeout(r, stableReadyResetMs + 10))
+      children[i]?.triggerExit(0)
+    }
+
+    // Wait for the last child to become ready, then abort to stop the supervisor
+    await new Promise<void>(resolve => {
+      const check = (): void => {
+        if (statusRef.status === 'ready') resolve()
+        else setImmediate(check)
+      }
+      setImmediate(check)
+    })
+
+    ac.abort()
+    children[respawnCycles]?.triggerExit(0)
+
+    await supervisorPromise.catch(() => undefined)
+
+    // #then — the abort listener count must NEVER have exceeded 1 during the run.
+    // Before the fix: maxObservedListeners grows with each respawn (2 per iteration).
+    // After the fix: exactly 1 listener registered once, removed in finally.
+    expect(maxObservedListeners).toBeLessThanOrEqual(1)
+
+    // Net count must be 0 after the supervisor returns (finally cleanup ran).
+    expect(netListeners).toBe(0)
+  })
+})

--- a/apps/workspace-agent/src/opencode-server.test.ts
+++ b/apps/workspace-agent/src/opencode-server.test.ts
@@ -9,7 +9,7 @@ import type {SpawnFn} from './opencode-server.js'
 
 import {EventEmitter} from 'node:events'
 import {describe, expect, it, vi} from 'vitest'
-import {defaultPollReady, startOpencodeServer} from './opencode-server.js'
+import {defaultPollReady, runSupervisedOpencode, startOpencodeServer} from './opencode-server.js'
 
 // ── Test helpers ─────────────────────────────────────────────────────────────
 
@@ -382,5 +382,408 @@ describe('defaultPollReady — per-probe timeout', () => {
 
     // #then — the probe rejects with an abort error (caller abort propagates)
     await expect(probePromise).rejects.toThrow(/abort/i)
+  })
+})
+
+// ── Supervised respawn tests ──────────────────────────────────────────────────
+//
+// These tests exercise the supervised respawn loop added in Unit 5.
+// Real timers, zero/tiny delays, injected spawnFn/pollReadyFn per convention.
+
+/**
+ * Create a factory-based spawnFn that returns a different fake child on each
+ * call. Each child in `children` is used in order; the last one is reused if
+ * the list is exhausted.
+ */
+function makeMultiSpawnFn(
+  children: {readonly child: ReturnType<typeof makeFakeChild>['child']}[],
+  spawnCalls: number[] = [],
+): SpawnFn {
+  let idx = 0
+  return (_command, _args, _opts) => {
+    spawnCalls.push(idx)
+    const entry = children[Math.min(idx, children.length - 1)]
+    if (entry === undefined) {
+      throw new Error('makeMultiSpawnFn: no children provided')
+    }
+    idx++
+    return entry.child
+  }
+}
+
+/**
+ * A controllable fake child whose exit can be triggered manually.
+ * Returns `{child, killCalls, triggerExit}`.
+ */
+function makeControllableChild() {
+  const emitter = new EventEmitter()
+  let exited = false
+  const killCalls: (string | undefined)[] = []
+
+  const child = {
+    kill: (sig?: string): boolean => {
+      killCalls.push(sig)
+      if (exited === false) {
+        exited = true
+        setImmediate(() => emitter.emit('exit', 0))
+      }
+      return true
+    },
+    on: (event: string | symbol, listener: (...args: unknown[]) => void): void => {
+      emitter.on(event, listener)
+    },
+  }
+
+  const triggerExit = (code: number | null = 1): void => {
+    if (exited === false) {
+      exited = true
+      emitter.emit('exit', code)
+    }
+  }
+
+  return {child, killCalls, triggerExit}
+}
+
+describe('runSupervisedOpencode — happy path (Unit 5)', () => {
+  it('resolves with status ready when first spawn becomes ready (then exits cleanly)', async () => {
+    // #given — first child becomes ready immediately, then exits cleanly (simulates
+    // a normal lifecycle: ready → child exits → supervisor goes to degraded since
+    // maxAttempts=1 and no more attempts remain).
+    // The key assertion is that status was 'ready' at some point and the supervisor
+    // does not crash or hang.
+    const {child, triggerExit} = makeControllableChild()
+    const spawnCalls: number[] = []
+    const spawnFn = makeMultiSpawnFn([{child}], spawnCalls)
+    const statusRef = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
+
+    let wasReady = false
+
+    // #when — start supervisor; it will become ready, then we trigger exit
+    const supervisorPromise = runSupervisedOpencode({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      statusRef,
+      spawnFn,
+      pollReadyFn: alwaysReady,
+      pollIntervalMs: 0,
+      readyTimeoutMs: 5000,
+      maxAttempts: 1, // single attempt — resolves after child exits
+      initialBackoffMs: 0,
+    })
+
+    // Wait for status to become ready, then trigger a clean exit
+    await new Promise<void>(resolve => {
+      const check = (): void => {
+        if (statusRef.status === 'ready') {
+          wasReady = true
+          // Trigger clean exit so the supervisor can resolve
+          triggerExit(0)
+          resolve()
+        } else {
+          setImmediate(check)
+        }
+      }
+      setImmediate(check)
+    })
+
+    await supervisorPromise
+
+    // #then — status was ready; only one spawn; supervisor resolved cleanly
+    expect(wasReady).toBe(true)
+    expect(spawnCalls).toHaveLength(1)
+  })
+})
+
+describe('runSupervisedOpencode — transient failure recovery (Unit 5)', () => {
+  it('recovers when first spawn fails but second becomes ready', async () => {
+    // #given — first child exits immediately (failure), second becomes ready then exits
+    const failChild = makeFakeChild({exitImmediately: true, exitCode: 1})
+    const successChild = makeControllableChild()
+    const spawnCalls: number[] = []
+    const spawnFn = makeMultiSpawnFn([failChild, successChild], spawnCalls)
+    const statusRef = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
+
+    // Poll: never ready for first child (it exits), always ready for second
+    const pollReadyFn = async (_url: string): Promise<boolean> => {
+      // spawnCalls.length tracks how many spawns have happened
+      return spawnCalls.length >= 2
+    }
+
+    // #when — start supervisor; trigger exit on second child once ready
+    let wasReady = false
+    const supervisorPromise = runSupervisedOpencode({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      statusRef,
+      spawnFn,
+      pollReadyFn,
+      pollIntervalMs: 0,
+      readyTimeoutMs: 5000,
+      maxAttempts: 2, // first fails, second succeeds
+      initialBackoffMs: 0,
+    })
+
+    // Wait for ready, then trigger exit so supervisor can resolve
+    await new Promise<void>(resolve => {
+      const check = (): void => {
+        if (statusRef.status === 'ready') {
+          wasReady = true
+          successChild.triggerExit(0)
+          resolve()
+        } else {
+          setImmediate(check)
+        }
+      }
+      setImmediate(check)
+    })
+
+    await supervisorPromise
+
+    // #then — status was ready after second attempt; two spawns
+    expect(wasReady).toBe(true)
+    expect(spawnCalls).toHaveLength(2)
+  })
+
+  it('gives each respawn attempt a fresh readiness deadline', async () => {
+    // #given — first child exits immediately; second child is slow-but-ready
+    // The second attempt must NOT be killed by a carried-over deadline from attempt 1.
+    const failChild = makeFakeChild({exitImmediately: true, exitCode: 1})
+    const successChild = makeControllableChild()
+    const spawnCalls: number[] = []
+    const spawnFn = makeMultiSpawnFn([failChild, successChild], spawnCalls)
+    const statusRef = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
+
+    // Poll: returns ready only after 3 calls total (simulates slow second attempt)
+    let totalCalls = 0
+    const pollReadyFn = async (_url: string): Promise<boolean> => {
+      totalCalls++
+      // Only ready after 3 polls AND we're on the second spawn
+      return spawnCalls.length >= 2 && totalCalls >= 3
+    }
+
+    // #when — start supervisor; trigger exit on second child once ready
+    let wasReady = false
+    const supervisorPromise = runSupervisedOpencode({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      statusRef,
+      spawnFn,
+      pollReadyFn,
+      pollIntervalMs: 0,
+      readyTimeoutMs: 5000, // generous — second attempt must not be killed early
+      maxAttempts: 2,
+      initialBackoffMs: 0,
+    })
+
+    // Wait for ready, then trigger exit so supervisor can resolve
+    await new Promise<void>(resolve => {
+      const check = (): void => {
+        if (statusRef.status === 'ready') {
+          wasReady = true
+          successChild.triggerExit(0)
+          resolve()
+        } else {
+          setImmediate(check)
+        }
+      }
+      setImmediate(check)
+    })
+
+    await supervisorPromise
+
+    // #then — second attempt succeeded; deadline was reset
+    expect(wasReady).toBe(true)
+    expect(spawnCalls).toHaveLength(2)
+  })
+})
+
+describe('runSupervisedOpencode — exhaustion (Unit 5)', () => {
+  it('lands in degraded (not starting, not down) when all attempts fail', async () => {
+    // #given — all children exit immediately
+    const children = [
+      makeFakeChild({exitImmediately: true, exitCode: 1}),
+      makeFakeChild({exitImmediately: true, exitCode: 1}),
+      makeFakeChild({exitImmediately: true, exitCode: 1}),
+    ]
+    const spawnCalls: number[] = []
+    const spawnFn = makeMultiSpawnFn(children, spawnCalls)
+    const statusRef = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
+
+    // #when
+    await runSupervisedOpencode({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      statusRef,
+      spawnFn,
+      pollReadyFn: neverReady,
+      pollIntervalMs: 0,
+      readyTimeoutMs: 50,
+      maxAttempts: 3,
+      initialBackoffMs: 0,
+    })
+
+    // #then — degraded, not stuck at starting, not silently down
+    expect(statusRef.status).toBe('degraded')
+    expect(statusRef.status).not.toBe('starting')
+    expect(statusRef.status).not.toBe('down')
+  })
+
+  it('stops retrying and lands in degraded when max attempts are exhausted', async () => {
+    // #given — persistent failure; maxAttempts = 2
+    const children = [
+      makeFakeChild({exitImmediately: true, exitCode: 1}),
+      makeFakeChild({exitImmediately: true, exitCode: 1}),
+      makeFakeChild({exitImmediately: true, exitCode: 1}), // should NOT be used
+    ]
+    const spawnCalls: number[] = []
+    const spawnFn = makeMultiSpawnFn(children, spawnCalls)
+    const statusRef = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
+
+    // #when
+    await runSupervisedOpencode({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      statusRef,
+      spawnFn,
+      pollReadyFn: neverReady,
+      pollIntervalMs: 0,
+      readyTimeoutMs: 50,
+      maxAttempts: 2,
+      initialBackoffMs: 0,
+    })
+
+    // #then — spawn count bounded by maxAttempts
+    expect(spawnCalls.length).toBeLessThanOrEqual(2)
+    expect(statusRef.status).toBe('degraded')
+  })
+})
+
+describe('runSupervisedOpencode — post-ready exit latch fix (Unit 5)', () => {
+  it('flips status away from ready when child exits after becoming ready', async () => {
+    // #given — child becomes ready, then exits unexpectedly
+    const {child, triggerExit} = makeControllableChild()
+    const spawnCalls: number[] = []
+    const spawnFn = makeMultiSpawnFn([{child}], spawnCalls)
+    const statusRef = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
+
+    // Poll: ready on first call
+    let pollCount = 0
+    const pollReadyFn = async (_url: string): Promise<boolean> => {
+      pollCount++
+      return pollCount >= 1
+    }
+
+    // #when — start supervisor (will become ready), then trigger exit
+    const supervisorPromise = runSupervisedOpencode({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      statusRef,
+      spawnFn,
+      pollReadyFn,
+      pollIntervalMs: 0,
+      readyTimeoutMs: 5000,
+      maxAttempts: 1, // no respawn — go straight to terminal state
+      initialBackoffMs: 0,
+    })
+
+    // Wait for status to become ready
+    await new Promise<void>(resolve => {
+      const check = (): void => {
+        if (statusRef.status === 'ready') {
+          resolve()
+        } else {
+          setImmediate(check)
+        }
+      }
+      setImmediate(check)
+    })
+
+    // Confirm it's ready before the exit
+    expect(statusRef.status).toBe('ready')
+
+    // Trigger unexpected exit AFTER ready
+    triggerExit(1)
+
+    // Wait for supervisor to settle
+    await supervisorPromise
+
+    // #then — status must NOT be stuck at 'ready' after the child exited
+    expect(statusRef.status).not.toBe('ready')
+  })
+})
+
+describe('runSupervisedOpencode — fail-closed transition (Unit 5)', () => {
+  it('sets status to starting (not-ready) before killing the child on respawn', async () => {
+    // #given — first child times out (kill is called); we capture status at kill time.
+    // Second child becomes ready then exits so the supervisor can resolve.
+    const statusAtKill: string[] = []
+    const statusRef = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
+
+    const emitter1 = new EventEmitter()
+    let child1Exited = false
+    const child1 = {
+      kill: (_sig?: string): boolean => {
+        // Capture status at the moment kill() is called on the first child.
+        // The supervisor must have set status to 'starting' BEFORE calling kill.
+        statusAtKill.push(statusRef.status)
+        if (child1Exited === false) {
+          child1Exited = true
+          setImmediate(() => emitter1.emit('exit', 0))
+        }
+        return true
+      },
+      on: (event: string | symbol, listener: (...args: unknown[]) => void): void => {
+        emitter1.on(event, listener)
+      },
+    }
+
+    // Second child becomes ready, then we trigger exit so supervisor can resolve.
+    const child2 = makeControllableChild()
+
+    let spawnCount = 0
+    const trackingSpawnFn: SpawnFn = (_cmd, _args, _opts) => {
+      spawnCount++
+      return spawnCount === 1 ? child1 : child2.child
+    }
+
+    // Poll: never ready for first child (timeout kills it), always ready for second
+    const pollReadyFn = async (_url: string): Promise<boolean> => {
+      return spawnCount >= 2
+    }
+
+    // #when — start supervisor; first attempt times out → kill called → second becomes ready
+    let wasReady = false
+    const supervisorPromise = runSupervisedOpencode({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      statusRef,
+      spawnFn: trackingSpawnFn,
+      pollReadyFn,
+      pollIntervalMs: 0,
+      readyTimeoutMs: 10, // short timeout → first attempt times out → kill called
+      maxAttempts: 2,
+      initialBackoffMs: 0,
+    })
+
+    // Wait for ready on second attempt, then trigger exit so supervisor resolves
+    await new Promise<void>(resolve => {
+      const check = (): void => {
+        if (statusRef.status === 'ready') {
+          wasReady = true
+          child2.triggerExit(0)
+          resolve()
+        } else {
+          setImmediate(check)
+        }
+      }
+      setImmediate(check)
+    })
+
+    await supervisorPromise
+
+    // #then — at the moment kill() was called on child1, status was 'starting' (not 'ready')
+    expect(statusAtKill.length).toBeGreaterThan(0)
+    expect(statusAtKill[0]).toBe('starting')
+    expect(wasReady).toBe(true)
   })
 })

--- a/apps/workspace-agent/src/opencode-server.test.ts
+++ b/apps/workspace-agent/src/opencode-server.test.ts
@@ -8,7 +8,7 @@
 import type {SpawnFn} from './opencode-server.js'
 
 import {EventEmitter} from 'node:events'
-import {describe, expect, it, vi} from 'vitest'
+import {afterEach, describe, expect, it, vi} from 'vitest'
 import {defaultPollReady, runSupervisedOpencode, startOpencodeServer} from './opencode-server.js'
 
 // ── Test helpers ─────────────────────────────────────────────────────────────
@@ -785,5 +785,354 @@ describe('runSupervisedOpencode — fail-closed transition (Unit 5)', () => {
     expect(statusAtKill.length).toBeGreaterThan(0)
     expect(statusAtKill[0]).toBe('starting')
     expect(wasReady).toBe(true)
+  })
+})
+
+// ── Unit 6: Process-group reaping tests ──────────────────────────────────────
+//
+// These tests verify that:
+// 1. When child.pid is a number, kill uses process.kill(-pid, 'SIGTERM') (group kill).
+// 2. When child.pid is undefined, falls back to child.kill('SIGTERM').
+// 3. spawnFn is called with detached: true.
+// 4. Security invariants: loopback bind unchanged, no secret/token logging on kill path.
+// 5. Abort path uses the group-kill helper when pid is present.
+//
+// Strategy for existing kill-assertion tests:
+// - makeFakeChild() and makeControllableChild() do NOT set a pid, so they use the
+//   fallback path (child.kill('SIGTERM')). Existing assertions remain valid.
+// - New tests use makeFakeChildWithPid() which sets pid, triggering the group-kill path.
+//   Those tests spy on process.kill and assert the negative-pid call.
+
+/**
+ * Create a fake child with a numeric pid. The kill spy is a vi.fn() so we can
+ * assert it was or was not called. process.kill is spied separately per test.
+ */
+function makeFakeChildWithPid(pid: number, opts: {exitImmediately?: boolean; exitCode?: number | null} = {}) {
+  const emitter = new EventEmitter()
+  let exited = false
+
+  if (opts.exitImmediately === true) {
+    setImmediate(() => {
+      exited = true
+      emitter.emit('exit', opts.exitCode ?? 1)
+    })
+  }
+
+  const killSpy = vi.fn((_sig?: string): boolean => {
+    if (exited === false) {
+      exited = true
+      setImmediate(() => emitter.emit('exit', 0))
+    }
+    return true
+  })
+
+  const child = {
+    pid,
+    kill: killSpy,
+    on: (event: string | symbol, listener: (...args: unknown[]) => void): void => {
+      emitter.on(event, listener)
+    },
+  }
+
+  return {child, killSpy}
+}
+
+/** Build a SpawnFn that records spawn options (including detached) in spawnOpts[]. */
+function makeSpawnFnWithOpts(
+  fakeChild: ReturnType<typeof makeFakeChildWithPid>['child'],
+  spawnOpts: {
+    command: string
+    args: readonly string[]
+    options: {readonly cwd?: string; readonly env?: NodeJS.ProcessEnv; readonly detached?: boolean}
+  }[] = [],
+): SpawnFn {
+  return (command, args, opts) => {
+    spawnOpts.push({command, args, options: opts})
+    return fakeChild
+  }
+}
+
+describe('process-group reaping (Unit 6) — group kill when pid is present', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('calls process.kill(-pid, SIGTERM) on timeout when child.pid is a number', async () => {
+    // #given — child with pid 12345; server never becomes ready → timeout kill
+    const pid = 12345
+    const {child} = makeFakeChildWithPid(pid)
+    const processKillSpy = vi.spyOn(process, 'kill').mockReturnValue(true)
+
+    // #when — timeout fires
+    await expect(
+      startOpencodeServer({
+        rootDir: '/workspace/repos',
+        logger: makeLogger(),
+        spawnFn: makeSpawnFnWithOpts(child),
+        pollReadyFn: neverReady,
+        pollIntervalMs: 0,
+        readyTimeoutMs: 1, // immediate timeout
+      }),
+    ).rejects.toThrow(/did not become ready within/)
+
+    // #then — group kill via negative pid
+    expect(processKillSpy).toHaveBeenCalledWith(-pid, 'SIGTERM')
+  })
+
+  it('falls back to child.kill(SIGTERM) on timeout when child.pid is undefined', async () => {
+    // #given — child WITHOUT pid (existing makeFakeChild pattern); server never ready
+    const {child, killCalls} = makeFakeChild({})
+    const processKillSpy = vi.spyOn(process, 'kill').mockReturnValue(true)
+
+    // #when — timeout fires
+    await expect(
+      startOpencodeServer({
+        rootDir: '/workspace/repos',
+        logger: makeLogger(),
+        spawnFn: makeSpawnFn(child),
+        pollReadyFn: neverReady,
+        pollIntervalMs: 0,
+        readyTimeoutMs: 1,
+      }),
+    ).rejects.toThrow(/did not become ready within/)
+
+    // #then — fallback: child.kill called, NOT process.kill(-pid)
+    expect(killCalls).toContain('SIGTERM')
+    // process.kill should NOT have been called with a negative pid
+    const negPidCalls = processKillSpy.mock.calls.filter(([p]) => typeof p === 'number' && p < 0)
+    expect(negPidCalls).toHaveLength(0)
+  })
+
+  it('spawns with detached: true', async () => {
+    // #given — capture spawn options
+    const pid = 99999
+    const {child} = makeFakeChildWithPid(pid)
+    const spawnOpts: {
+      command: string
+      args: readonly string[]
+      options: {readonly cwd?: string; readonly env?: NodeJS.ProcessEnv; readonly detached?: boolean}
+    }[] = []
+    vi.spyOn(process, 'kill').mockReturnValue(true)
+
+    // #when — start server (will timeout, but we only care about spawn options)
+    await expect(
+      startOpencodeServer({
+        rootDir: '/workspace/repos',
+        logger: makeLogger(),
+        spawnFn: makeSpawnFnWithOpts(child, spawnOpts),
+        pollReadyFn: neverReady,
+        pollIntervalMs: 0,
+        readyTimeoutMs: 1,
+      }),
+    ).rejects.toThrow()
+
+    // #then — detached: true was passed to spawnFn
+    expect(spawnOpts).toHaveLength(1)
+    expect(spawnOpts[0]?.options).toMatchObject({detached: true})
+  })
+
+  it('bind remains 127.0.0.1 and no secret/token is logged on the kill path', async () => {
+    // #given — capture log calls; child with pid
+    const pid = 11111
+    const {child} = makeFakeChildWithPid(pid)
+    vi.spyOn(process, 'kill').mockReturnValue(true)
+
+    const loggedMeta: (Record<string, unknown> | undefined)[] = []
+    const logger = {
+      info: (_msg: string, meta?: Record<string, unknown>) => {
+        loggedMeta.push(meta)
+      },
+      warn: (_msg: string, meta?: Record<string, unknown>) => {
+        loggedMeta.push(meta)
+      },
+      error: (_msg: string, meta?: Record<string, unknown>) => {
+        loggedMeta.push(meta)
+      },
+    }
+
+    const spawnOpts: {command: string; args: readonly string[]; options: Record<string, unknown>}[] = []
+
+    // #when — timeout fires (triggers kill path)
+    await expect(
+      startOpencodeServer({
+        rootDir: '/workspace/repos',
+        logger,
+        hostname: '127.0.0.1',
+        port: 54321,
+        spawnFn: makeSpawnFnWithOpts(child, spawnOpts),
+        pollReadyFn: neverReady,
+        pollIntervalMs: 0,
+        readyTimeoutMs: 1,
+      }),
+    ).rejects.toThrow()
+
+    // #then — spawn args use loopback hostname
+    expect(spawnOpts[0]?.args).toContain('127.0.0.1')
+
+    // #then — no logged meta contains token/secret/env-like keys
+    const secretKeys = ['token', 'secret', 'password', 'credential', 'env', 'authorization']
+    for (const meta of loggedMeta) {
+      if (meta === undefined) continue
+      for (const key of Object.keys(meta)) {
+        expect(secretKeys.some(s => key.toLowerCase().includes(s))).toBe(false)
+      }
+    }
+  })
+
+  it('uses group kill on abort path when child.pid is present', async () => {
+    // #given — child with pid; abort fires while server is polling.
+    // The process.kill mock must also emit exit on the child so the polling
+    // loop terminates (otherwise the mocked kill is a no-op and the loop hangs).
+    const pid = 22222
+    const emitter = new EventEmitter()
+    let exited = false
+    const killSpy = vi.fn((_sig?: string): boolean => true)
+    const child = {
+      pid,
+      kill: killSpy,
+      on: (event: string | symbol, listener: (...args: unknown[]) => void): void => {
+        emitter.on(event, listener)
+      },
+    }
+
+    const processKillSpy = vi.spyOn(process, 'kill').mockImplementation((..._args) => {
+      // Simulate the OS killing the process group: emit exit on the child.
+      if (exited === false) {
+        exited = true
+        setImmediate(() => emitter.emit('exit', null))
+      }
+      return true
+    })
+
+    const ac = new AbortController()
+
+    const promise = startOpencodeServer({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      signal: ac.signal,
+      spawnFn: makeSpawnFnWithOpts(child),
+      pollReadyFn: neverReady,
+      pollIntervalMs: 10,
+      readyTimeoutMs: 30_000,
+    })
+
+    // #when — abort immediately
+    ac.abort()
+
+    // #then — wait for promise to settle
+    await promise.then(
+      h => h.close(),
+      () => undefined,
+    )
+
+    // group kill via negative pid should have been called
+    expect(processKillSpy).toHaveBeenCalledWith(-pid, 'SIGTERM')
+  })
+})
+
+describe('process-group reaping (Unit 6) — supervised respawn group kill', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses group kill on timeout/respawn kill when child.pid is a number', async () => {
+    // #given — first child has pid and times out; second child becomes ready then exits
+    const pid1 = 33333
+    const {child: child1} = makeFakeChildWithPid(pid1)
+    const processKillSpy = vi.spyOn(process, 'kill').mockReturnValue(true)
+
+    const child2 = makeControllableChild()
+    let spawnCount = 0
+    const trackingSpawnFn: SpawnFn = (_cmd, _args, _opts) => {
+      spawnCount++
+      return spawnCount === 1 ? child1 : child2.child
+    }
+
+    const pollReadyFn = async (_url: string): Promise<boolean> => spawnCount >= 2
+
+    const statusRef = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
+
+    // #when — start supervisor; first attempt times out → group kill → second becomes ready
+    let wasReady = false
+    const supervisorPromise = runSupervisedOpencode({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      statusRef,
+      spawnFn: trackingSpawnFn,
+      pollReadyFn,
+      pollIntervalMs: 0,
+      readyTimeoutMs: 10, // short timeout → first attempt times out
+      maxAttempts: 2,
+      initialBackoffMs: 0,
+    })
+
+    await new Promise<void>(resolve => {
+      const check = (): void => {
+        if (statusRef.status === 'ready') {
+          wasReady = true
+          child2.triggerExit(0)
+          resolve()
+        } else {
+          setImmediate(check)
+        }
+      }
+      setImmediate(check)
+    })
+
+    await supervisorPromise
+
+    // #then — group kill was used for the first child (negative pid)
+    expect(processKillSpy).toHaveBeenCalledWith(-pid1, 'SIGTERM')
+    expect(wasReady).toBe(true)
+  })
+
+  it('uses group kill on abort path in runSupervisedOpencode when child.pid is present', async () => {
+    // #given — child with pid; abort fires while supervisor is polling.
+    // The process.kill mock must also emit exit on the child so the supervisor
+    // loop terminates (otherwise the mocked kill is a no-op and the loop hangs).
+    const pid = 44444
+    const emitter = new EventEmitter()
+    let exited = false
+    const killSpy = vi.fn((_sig?: string): boolean => true)
+    const child = {
+      pid,
+      kill: killSpy,
+      on: (event: string | symbol, listener: (...args: unknown[]) => void): void => {
+        emitter.on(event, listener)
+      },
+    }
+
+    const processKillSpy = vi.spyOn(process, 'kill').mockImplementation((..._args) => {
+      // Simulate the OS killing the process group: emit exit on the child.
+      if (exited === false) {
+        exited = true
+        setImmediate(() => emitter.emit('exit', null))
+      }
+      return true
+    })
+
+    const ac = new AbortController()
+    const statusRef = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
+
+    const supervisorPromise = runSupervisedOpencode({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      statusRef,
+      signal: ac.signal,
+      spawnFn: (_cmd, _args, _opts) => child,
+      pollReadyFn: neverReady,
+      pollIntervalMs: 10,
+      readyTimeoutMs: 30_000,
+      maxAttempts: 1,
+      initialBackoffMs: 0,
+    })
+
+    // #when — abort immediately
+    ac.abort()
+
+    await supervisorPromise.catch(() => undefined)
+
+    // #then — group kill via negative pid on abort path
+    expect(processKillSpy).toHaveBeenCalledWith(-pid, 'SIGTERM')
   })
 })

--- a/apps/workspace-agent/src/opencode-server.test.ts
+++ b/apps/workspace-agent/src/opencode-server.test.ts
@@ -1030,6 +1030,451 @@ describe('process-group reaping (Unit 6) — group kill when pid is present', ()
   })
 })
 
+// ── Fix 1: pid guard — exclude pid 0 and 1 from negative-pid group kill ──────
+//
+// process.kill(-0, …) signals the supervisor's OWN process group.
+// process.kill(-1, …) broadcasts SIGTERM to every process the user can reach.
+// Both are catastrophic. The guard must be pid > 1 (not just isFinite).
+
+describe('killChildGroup — pid guard (Fix 1)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('calls process.kill(-pid, SIGTERM) for a normal pid like 12345', async () => {
+    // #given — child with pid 12345; timeout fires
+    const pid = 12345
+    const {child} = makeFakeChildWithPid(pid)
+    const processKillSpy = vi.spyOn(process, 'kill').mockReturnValue(true)
+
+    // #when — timeout fires → killChildGroup called
+    await expect(
+      startOpencodeServer({
+        rootDir: '/workspace/repos',
+        logger: makeLogger(),
+        spawnFn: makeSpawnFnWithOpts(child),
+        pollReadyFn: neverReady,
+        pollIntervalMs: 0,
+        readyTimeoutMs: 1,
+      }),
+    ).rejects.toThrow(/did not become ready within/)
+
+    // #then — group kill via negative pid
+    expect(processKillSpy).toHaveBeenCalledWith(-pid, 'SIGTERM')
+  })
+
+  it('falls back to child.kill when pid === 1 (never calls process.kill with negative arg)', async () => {
+    // #given — child with pid 1 (init process — catastrophic to group-kill)
+    const pid = 1
+    const {child, killSpy} = makeFakeChildWithPid(pid)
+    const processKillSpy = vi.spyOn(process, 'kill').mockReturnValue(true)
+
+    // #when — timeout fires → killChildGroup called
+    await expect(
+      startOpencodeServer({
+        rootDir: '/workspace/repos',
+        logger: makeLogger(),
+        spawnFn: makeSpawnFnWithOpts(child),
+        pollReadyFn: neverReady,
+        pollIntervalMs: 0,
+        readyTimeoutMs: 1,
+      }),
+    ).rejects.toThrow(/did not become ready within/)
+
+    // #then — fallback: child.kill called, NOT process.kill(-1, …)
+    expect(killSpy).toHaveBeenCalledWith('SIGTERM')
+    const negPidCalls = processKillSpy.mock.calls.filter(([p]) => typeof p === 'number' && p < 0)
+    expect(negPidCalls).toHaveLength(0)
+  })
+
+  it('falls back to child.kill when pid === 0 (never calls process.kill with negative arg)', async () => {
+    // #given — child with pid 0 (process.kill(-0) = own group — catastrophic)
+    const pid = 0
+    const {child, killSpy} = makeFakeChildWithPid(pid)
+    const processKillSpy = vi.spyOn(process, 'kill').mockReturnValue(true)
+
+    // #when — timeout fires → killChildGroup called
+    await expect(
+      startOpencodeServer({
+        rootDir: '/workspace/repos',
+        logger: makeLogger(),
+        spawnFn: makeSpawnFnWithOpts(child),
+        pollReadyFn: neverReady,
+        pollIntervalMs: 0,
+        readyTimeoutMs: 1,
+      }),
+    ).rejects.toThrow(/did not become ready within/)
+
+    // #then — fallback: child.kill called, NOT process.kill(-0, …)
+    expect(killSpy).toHaveBeenCalledWith('SIGTERM')
+    const negPidCalls = processKillSpy.mock.calls.filter(([p]) => typeof p === 'number' && p <= 0)
+    expect(negPidCalls).toHaveLength(0)
+  })
+
+  it('falls back to child.kill when pid is undefined', async () => {
+    // #given — child WITHOUT pid (existing pattern)
+    const {child, killCalls} = makeFakeChild({})
+    const processKillSpy = vi.spyOn(process, 'kill').mockReturnValue(true)
+
+    // #when — timeout fires
+    await expect(
+      startOpencodeServer({
+        rootDir: '/workspace/repos',
+        logger: makeLogger(),
+        spawnFn: makeSpawnFn(child),
+        pollReadyFn: neverReady,
+        pollIntervalMs: 0,
+        readyTimeoutMs: 1,
+      }),
+    ).rejects.toThrow(/did not become ready within/)
+
+    // #then — fallback: child.kill called, NOT process.kill with negative pid
+    expect(killCalls).toContain('SIGTERM')
+    const negPidCalls = processKillSpy.mock.calls.filter(([p]) => typeof p === 'number' && p < 0)
+    expect(negPidCalls).toHaveLength(0)
+  })
+})
+
+// ── Fix 2: stable-ready reset — respawn budget resets after stable uptime ─────
+//
+// A child that stays ready for >= stableReadyResetMs before exiting is treated
+// as a healthy run. The attempt counter + backoff reset so only RAPID crash
+// loops consume the bounded budget.
+
+describe('runSupervisedOpencode — stable-ready reset (Fix 2)', () => {
+  it('does NOT go degraded after 4+ lifetime exits when each run was stable', async () => {
+    // #given — child becomes ready, stays ready >= stableReadyResetMs (50ms), exits.
+    // With 4 exits and maxAttempts=4, WITHOUT reset it would go degraded.
+    // WITH reset, each stable run resets the budget so it keeps respawning.
+    //
+    // We run 5 stable-exit cycles and assert it never goes degraded.
+    // After the 5th stable exit we abort the supervisor to stop it cleanly.
+    const stableReadyResetMs = 50 // tiny for test speed
+    const maxAttempts = 4
+
+    // Build 6 controllable children (5 stable exits + 1 that the abort kills)
+    const children = Array.from({length: 6}, () => makeControllableChild())
+    let childIdx = 0
+    const ac = new AbortController()
+    const spawnFn: SpawnFn = () => {
+      const c = children[childIdx]
+      if (c === undefined) throw new Error('ran out of children')
+      childIdx++
+      return c.child
+    }
+
+    const statusRef = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
+
+    const supervisorPromise = runSupervisedOpencode({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      statusRef,
+      signal: ac.signal,
+      spawnFn,
+      pollReadyFn: alwaysReady,
+      pollIntervalMs: 0,
+      readyTimeoutMs: 5000,
+      maxAttempts,
+      initialBackoffMs: 0,
+      stableReadyResetMs,
+    })
+
+    // Cycle through 5 stable exits: wait for ready, wait stableReadyResetMs, exit
+    for (let i = 0; i < 5; i++) {
+      // Wait for status to become ready
+      await new Promise<void>(resolve => {
+        const check = (): void => {
+          if (statusRef.status === 'ready') {
+            resolve()
+          } else {
+            setImmediate(check)
+          }
+        }
+        setImmediate(check)
+      })
+
+      // Assert never degraded during stable cycles
+      expect(statusRef.status).toBe('ready')
+
+      // Wait for the stable period to elapse, then trigger exit
+      await new Promise<void>(r => setTimeout(r, stableReadyResetMs + 10))
+      children[i]?.triggerExit(0)
+    }
+
+    // After 5 stable exits the supervisor spawns the 6th child and waits for it
+    // to become ready. Wait for ready, then abort to stop the supervisor cleanly.
+    await new Promise<void>(resolve => {
+      const check = (): void => {
+        if (statusRef.status === 'ready') {
+          resolve()
+        } else {
+          setImmediate(check)
+        }
+      }
+      setImmediate(check)
+    })
+
+    // Abort — the supervisor's abort handler kills the 6th child's group and returns.
+    ac.abort()
+    // Also trigger exit on the 6th child so the post-ready wait resolves.
+    children[5]?.triggerExit(0)
+
+    await supervisorPromise
+
+    // #then — never went degraded despite 5+ lifetime exits (budget reset each time)
+    expect(statusRef.status).not.toBe('degraded')
+  })
+
+  it('goes degraded when child crashes RAPIDLY maxAttempts times (rapid crash-loop bounded)', async () => {
+    // #given — child crashes immediately (< stableReadyResetMs) on every spawn
+    // This must still exhaust the budget and go degraded.
+    const stableReadyResetMs = 200 // large enough that immediate crash is always "rapid"
+    const maxAttempts = 3
+
+    const children = Array.from({length: maxAttempts + 1}, () => makeFakeChild({exitImmediately: true, exitCode: 1}))
+    let childIdx = 0
+    const spawnFn: SpawnFn = () => {
+      const c = children[childIdx]
+      if (c === undefined) throw new Error('ran out of children')
+      childIdx++
+      return c.child
+    }
+
+    const statusRef = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
+
+    // #when — all children exit immediately before becoming ready
+    await runSupervisedOpencode({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      statusRef,
+      spawnFn,
+      pollReadyFn: neverReady,
+      pollIntervalMs: 0,
+      readyTimeoutMs: 50,
+      maxAttempts,
+      initialBackoffMs: 0,
+      stableReadyResetMs,
+    })
+
+    // #then — degraded (rapid crash-loop still bounded)
+    expect(statusRef.status).toBe('degraded')
+    expect(childIdx).toBeLessThanOrEqual(maxAttempts)
+  })
+})
+
+// ── Fix 3: killChildGroup does not throw ─────────────────────────────────────
+//
+// process.kill(-pid) can throw ESRCH if the child exited between the state
+// check and the OS call. The exception must not escape the supervisor path.
+
+describe('killChildGroup — does not throw on ESRCH (Fix 3)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('supervisor proceeds (no rejection) when process.kill throws ESRCH', async () => {
+    // #given — child with pid; process.kill throws ESRCH (child already gone)
+    const pid = 55555
+    const {child} = makeFakeChildWithPid(pid)
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('ESRCH: no such process'), {code: 'ESRCH'})
+    })
+
+    // #when — timeout fires → killChildGroup called → process.kill throws
+    // The supervisor must NOT reject; it should resolve (or throw only the timeout error)
+    const result = await startOpencodeServer({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      spawnFn: makeSpawnFnWithOpts(child),
+      pollReadyFn: neverReady,
+      pollIntervalMs: 0,
+      readyTimeoutMs: 1,
+    }).then(
+      () => 'resolved',
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    )
+
+    // #then — the error is the timeout error, NOT an ESRCH propagation
+    expect(result).toMatch(/did not become ready within/)
+  })
+
+  it('supervisor proceeds when child.kill throws (fallback path)', async () => {
+    // #given — child WITHOUT pid; child.kill throws
+    const emitter = new EventEmitter()
+    const child = {
+      kill: (_sig?: string): boolean => {
+        throw new Error('kill failed')
+      },
+      on: (event: string | symbol, listener: (...args: unknown[]) => void): void => {
+        emitter.on(event, listener)
+      },
+    }
+
+    // #when — timeout fires → killChildGroup → child.kill throws
+    const result = await startOpencodeServer({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      spawnFn: () => child,
+      pollReadyFn: neverReady,
+      pollIntervalMs: 0,
+      readyTimeoutMs: 1,
+    }).then(
+      () => 'resolved',
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    )
+
+    // #then — timeout error propagates, kill error is swallowed
+    expect(result).toMatch(/did not become ready within/)
+  })
+})
+
+// ── Fix 4: abort signal wires through to supervisor + stops respawn ───────────
+//
+// With detached:true the child is in its OWN process group and does NOT inherit
+// SIGTERM from the parent. The AbortController must be used to explicitly reap
+// the child group and stop the supervisor from spawning further.
+
+describe('runSupervisedOpencode — abort signal wires through (Fix 4)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('kills child group via negative pid and does NOT spawn again after abort', async () => {
+    // #given — child with pid; abort fires while supervisor is polling for ready
+    const pid = 66666
+    const emitter = new EventEmitter()
+    let exited = false
+    const killSpy = vi.fn((_sig?: string): boolean => true)
+    const child = {
+      pid,
+      kill: killSpy,
+      on: (event: string | symbol, listener: (...args: unknown[]) => void): void => {
+        emitter.on(event, listener)
+      },
+    }
+
+    let spawnCount = 0
+    const processKillSpy = vi.spyOn(process, 'kill').mockImplementation((..._args) => {
+      if (exited === false) {
+        exited = true
+        setImmediate(() => emitter.emit('exit', null))
+      }
+      return true
+    })
+
+    const ac = new AbortController()
+    const statusRef = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
+
+    const supervisorPromise = runSupervisedOpencode({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      statusRef,
+      signal: ac.signal,
+      spawnFn: (_cmd, _args, _opts) => {
+        spawnCount++
+        return child
+      },
+      pollReadyFn: neverReady,
+      pollIntervalMs: 10,
+      readyTimeoutMs: 30_000,
+      maxAttempts: 4,
+      initialBackoffMs: 0,
+    })
+
+    // #when — abort while polling
+    ac.abort()
+    await supervisorPromise.catch(() => undefined)
+
+    // #then — group kill via negative pid
+    expect(processKillSpy).toHaveBeenCalledWith(-pid, 'SIGTERM')
+    // Only one spawn — no further attempts after abort
+    expect(spawnCount).toBe(1)
+  })
+
+  it('resolves promptly when abort fires during respawn backoff (no later spawn)', async () => {
+    // #given — first child exits immediately; abort fires during backoff sleep
+    const {child: child1} = makeFakeChild({exitImmediately: true, exitCode: 1})
+    const child2 = makeControllableChild()
+    let spawnCount = 0
+
+    const ac = new AbortController()
+    const statusRef = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
+
+    const supervisorPromise = runSupervisedOpencode({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      statusRef,
+      signal: ac.signal,
+      spawnFn: (_cmd, _args, _opts) => {
+        spawnCount++
+        return spawnCount === 1 ? child1 : child2.child
+      },
+      pollReadyFn: neverReady,
+      pollIntervalMs: 0,
+      readyTimeoutMs: 50,
+      maxAttempts: 4,
+      initialBackoffMs: 500, // long enough that abort fires during backoff
+    })
+
+    // Abort after a short delay (during the backoff sleep)
+    await new Promise<void>(r => setTimeout(r, 20))
+    ac.abort()
+
+    // #then — resolves promptly (not after the full 500ms backoff)
+    const start = Date.now()
+    await supervisorPromise.catch(() => undefined)
+    const elapsed = Date.now() - start
+
+    // Should resolve well before the full backoff would have elapsed
+    expect(elapsed).toBeLessThan(400)
+    // Should NOT have spawned a second child
+    expect(spawnCount).toBe(1)
+  })
+
+  it('stops supervisor when signal.aborted is true during post-ready monitoring', async () => {
+    // #given — child becomes ready; abort fires while supervisor is in post-ready wait
+    const {child, triggerExit} = makeControllableChild()
+    let spawnCount = 0
+
+    const ac = new AbortController()
+    const statusRef = {status: 'starting' as 'starting' | 'ready' | 'down' | 'degraded'}
+
+    const supervisorPromise = runSupervisedOpencode({
+      rootDir: '/workspace/repos',
+      logger: makeLogger(),
+      statusRef,
+      signal: ac.signal,
+      spawnFn: (_cmd, _args, _opts) => {
+        spawnCount++
+        return child
+      },
+      pollReadyFn: alwaysReady,
+      pollIntervalMs: 0,
+      readyTimeoutMs: 5000,
+      maxAttempts: 4,
+      initialBackoffMs: 0,
+    })
+
+    // Wait for ready
+    await new Promise<void>(resolve => {
+      const check = (): void => {
+        if (statusRef.status === 'ready') resolve()
+        else setImmediate(check)
+      }
+      setImmediate(check)
+    })
+
+    // #when — abort while in post-ready monitoring, then trigger child exit
+    ac.abort()
+    triggerExit(0)
+
+    await supervisorPromise.catch(() => undefined)
+
+    // #then — only one spawn (no respawn after abort)
+    expect(spawnCount).toBe(1)
+  })
+})
+
 describe('process-group reaping (Unit 6) — supervised respawn group kill', () => {
   afterEach(() => {
     vi.restoreAllMocks()

--- a/apps/workspace-agent/src/opencode-server.ts
+++ b/apps/workspace-agent/src/opencode-server.ts
@@ -9,6 +9,7 @@
  * 1. Binds to 127.0.0.1 only — raw OpenCode port is never on sandbox-net.
  * 2. No token or credential is logged.
  * 3. Spawn failure is caught and reflected as 'down' status; no crash-loop.
+ * 4. Bounded respawn: max attempts + total boot budget prevent infinite retry.
  */
 
 import {spawn as nodeSpawn} from 'node:child_process'
@@ -205,4 +206,233 @@ export async function startOpencodeServer(options: StartOpencodeServerOptions): 
   // Kill unconditionally (no-op if process already exited).
   child.kill('SIGTERM')
   throw new Error(`opencode server did not become ready within ${readyTimeoutMs}ms`)
+}
+
+/** OpenCode status values (mirrors server.ts OpencodeStatus + degraded). */
+export type SupervisedOpencodeStatus = 'starting' | 'ready' | 'down' | 'degraded'
+
+/** Mutable status reference updated by the supervisor. */
+export interface SupervisedStatusRef {
+  status: SupervisedOpencodeStatus
+}
+
+export interface RunSupervisedOpencodeOptions {
+  /** Repo root directory passed to opencode serve. */
+  readonly rootDir: string
+  readonly logger: Logger
+  /** Mutable status reference — supervisor writes transitions here. */
+  readonly statusRef: SupervisedStatusRef
+  /** Optional abort signal — on abort the supervisor stops. */
+  readonly signal?: AbortSignal
+  /** Hostname to bind. Default: '127.0.0.1' (loopback only). */
+  readonly hostname?: string
+  /** Port to bind. Default: 54321 (OpenCode default). */
+  readonly port?: number
+  /**
+   * Per-attempt readiness timeout in ms. Each attempt gets a fresh deadline.
+   * Default: 60000ms.
+   */
+  readonly readyTimeoutMs?: number
+  /** Poll interval in ms. Default: 250ms. */
+  readonly pollIntervalMs?: number
+  /**
+   * Maximum number of spawn attempts (initial + respawns).
+   * Default: 4 (1 initial + 3 respawns).
+   */
+  readonly maxAttempts?: number
+  /**
+   * Initial backoff delay in ms before the first respawn.
+   * Doubles on each subsequent attempt, capped at maxBackoffMs.
+   * Default: 1000ms.
+   */
+  readonly initialBackoffMs?: number
+  /**
+   * Maximum backoff delay in ms. Default: 10000ms.
+   */
+  readonly maxBackoffMs?: number
+  /** Injected spawn function for testing. Defaults to node:child_process.spawn. */
+  readonly spawnFn?: SpawnFn
+  /** Injected readiness poll function for testing. */
+  readonly pollReadyFn?: PollReadyFn
+}
+
+/**
+ * Supervised OpenCode lifecycle with bounded respawn and state machine.
+ *
+ * State transitions:
+ *   starting → ready          (first or subsequent attempt succeeds)
+ *   starting → starting       (set BEFORE killing child on respawn — fail-closed)
+ *   ready    → starting       (post-ready exit detected; respawn if attempts remain)
+ *   ready    → degraded       (post-ready exit, no attempts remain)
+ *   starting → degraded       (all attempts exhausted without becoming ready)
+ *
+ * The supervisor writes all transitions to `statusRef.status`. The caller
+ * (main.ts) shares this ref with the Hono app so /readyz reflects live state.
+ *
+ * SECURITY INVARIANTS preserved:
+ * - Binds to 127.0.0.1 only.
+ * - No token or credential is logged.
+ * - Bounded retry: maxAttempts + per-attempt deadline prevent infinite respawn.
+ */
+export async function runSupervisedOpencode(options: RunSupervisedOpencodeOptions): Promise<void> {
+  const {
+    rootDir,
+    logger,
+    statusRef,
+    signal,
+    hostname = '127.0.0.1',
+    port = 54321,
+    readyTimeoutMs = 60_000,
+    pollIntervalMs = 250,
+    maxAttempts = 4,
+    initialBackoffMs = 1_000,
+    maxBackoffMs = 10_000,
+    spawnFn = nodeSpawn,
+    pollReadyFn = defaultPollReady,
+  } = options
+
+  const url = `http://${hostname}:${port}`
+  let backoffMs = initialBackoffMs
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    // Fail-closed: status is 'starting' (not-ready) before each spawn attempt.
+    // This ensures /readyz returns 503 during the kill→respawn transition.
+    statusRef.status = 'starting'
+
+    logger.info('opencode-server: supervisor spawning', {url, rootDir, attempt, maxAttempts})
+
+    const child = spawnFn('opencode', ['serve', '--hostname', hostname, '--port', String(port)], {
+      cwd: rootDir,
+      env: process.env,
+    })
+
+    // Per-attempt mutable state.
+    const state: {exited: boolean; exitCode: number | null; becameReady: boolean} = {
+      exited: false,
+      exitCode: null,
+      becameReady: false,
+    }
+
+    child.on('exit', (code: unknown) => {
+      state.exited = true
+      state.exitCode = typeof code === 'number' ? code : null
+      logger.info('opencode-server: process exited', {code: state.exitCode, attempt})
+
+      // POST-READY EXIT LATCH FIX: if the child exits after we marked it ready,
+      // flip status back to not-ready immediately. The outer loop will decide
+      // whether to respawn (if attempts remain) or go to degraded.
+      if (state.becameReady === true && statusRef.status === 'ready') {
+        logger.warn('opencode-server: process exited after becoming ready — flipping to starting', {
+          code: state.exitCode,
+          attempt,
+        })
+        statusRef.status = 'starting'
+      }
+    })
+
+    child.on('error', (err: unknown) => {
+      state.exited = true
+      const message = err instanceof Error ? err.message : String(err)
+      logger.error('opencode-server: spawn error', {message, attempt})
+    })
+
+    // Abort signal integration — kill child on external abort.
+    if (signal !== undefined) {
+      signal.addEventListener('abort', () => {
+        if (state.exited === false) {
+          child.kill('SIGTERM')
+        }
+      })
+    }
+
+    // Per-attempt readiness loop with a fresh deadline.
+    const deadline = Date.now() + readyTimeoutMs
+    let becameReady = false
+
+    while (Date.now() < deadline) {
+      if (state.exited === true) {
+        // Process exited before becoming ready — break to respawn logic.
+        break
+      }
+
+      const ready = await pollReadyFn(url, signal)
+      if (ready === true) {
+        becameReady = true
+        state.becameReady = true
+        statusRef.status = 'ready'
+        logger.info('opencode-server: ready', {url, attempt})
+        break
+      }
+
+      await sleep(pollIntervalMs)
+    }
+
+    if (becameReady === true) {
+      // Server is ready. Now wait for it to exit (post-ready monitoring).
+      // This is the latch fix: we don't return immediately — we stay in the
+      // loop waiting for an unexpected exit so we can flip status and respawn.
+      await new Promise<void>(resolve => {
+        if (state.exited === true) {
+          resolve()
+          return
+        }
+        child.on('exit', () => resolve())
+      })
+
+      // Child has now exited. Decide whether to respawn.
+      if (attempt < maxAttempts) {
+        // Respawn: set status to starting BEFORE killing (already exited, but
+        // the status flip is the load-bearing invariant).
+        statusRef.status = 'starting'
+        logger.warn('opencode-server: supervisor respawning after post-ready exit', {
+          attempt,
+          nextAttempt: attempt + 1,
+          maxAttempts,
+        })
+        // Apply backoff before next attempt.
+        if (backoffMs > 0) {
+          await sleep(backoffMs)
+        }
+        backoffMs = Math.min(backoffMs * 2, maxBackoffMs)
+        continue
+      }
+
+      // No attempts remain — terminal degraded state.
+      statusRef.status = 'degraded'
+      logger.error('opencode-server: supervisor exhausted attempts after post-ready exit', {
+        attempt,
+        maxAttempts,
+      })
+      return
+    }
+
+    // Did not become ready (timeout or early exit).
+    // Kill the child (fail-closed: status is already 'starting').
+    if (state.exited === false) {
+      child.kill('SIGTERM')
+    }
+
+    if (attempt < maxAttempts) {
+      logger.warn('opencode-server: supervisor attempt failed, will respawn', {
+        attempt,
+        nextAttempt: attempt + 1,
+        maxAttempts,
+        backoffMs,
+      })
+      // Apply backoff before next attempt.
+      if (backoffMs > 0) {
+        await sleep(backoffMs)
+      }
+      backoffMs = Math.min(backoffMs * 2, maxBackoffMs)
+      continue
+    }
+
+    // All attempts exhausted — terminal degraded state.
+    // Clone API (:9100) stays alive; /readyz returns 503.
+    statusRef.status = 'degraded'
+    logger.error('opencode-server: supervisor exhausted all attempts', {
+      attempt,
+      maxAttempts,
+    })
+  }
 }

--- a/apps/workspace-agent/src/opencode-server.ts
+++ b/apps/workspace-agent/src/opencode-server.ts
@@ -95,18 +95,37 @@ export interface DefaultPollReadyOptions {
 /**
  * Kill the child's entire process group when a pid is available.
  *
- * When `child.pid` is a finite number, sends SIGTERM to the whole process
+ * When `child.pid` is a safe integer > 1, sends SIGTERM to the whole process
  * group (negative pid = pgid) so no orphaned grandchildren survive a
  * timeout/respawn/shutdown. Falls back to `child.kill('SIGTERM')` when the
- * pid is not a number (e.g. test fakes that don't expose a pid).
+ * pid is not a safe integer > 1 (e.g. test fakes that don't expose a pid).
  *
- * SECURITY INVARIANT: no token, secret, or env value is logged here.
+ * SECURITY INVARIANTS:
+ * - pid must be > 1: process.kill(-0, …) signals the supervisor's OWN process
+ *   group; process.kill(-1, …) broadcasts SIGTERM to every process the user
+ *   can reach — both are catastrophic and are explicitly excluded.
+ * - No token, secret, or env value is logged here.
+ * - Errors from process.kill or child.kill are swallowed (best-effort reap)
+ *   so an ESRCH race does not escape and break respawn/degraded handling.
  */
 function killChildGroup(child: ChildHandle): void {
-  if (typeof child.pid === 'number' && Number.isFinite(child.pid)) {
-    process.kill(-child.pid, 'SIGTERM')
+  if (Number.isSafeInteger(child.pid) && (child.pid as number) > 1) {
+    try {
+      process.kill(-(child.pid as number), 'SIGTERM')
+    } catch {
+      // Best-effort: ESRCH means the child already exited — safe to ignore.
+      try {
+        child.kill('SIGTERM')
+      } catch {
+        // Swallow — child is already gone.
+      }
+    }
   } else {
-    child.kill('SIGTERM')
+    try {
+      child.kill('SIGTERM')
+    } catch {
+      // Best-effort: child already exited — safe to ignore.
+    }
   }
 }
 
@@ -281,6 +300,15 @@ export interface RunSupervisedOpencodeOptions {
    * Maximum backoff delay in ms. Default: 10000ms.
    */
   readonly maxBackoffMs?: number
+  /**
+   * Minimum uptime in ms after becoming ready before a post-ready exit is
+   * treated as a "stable run" and the attempt counter + backoff are reset.
+   * This prevents a child that crashes hours after becoming ready from
+   * consuming the bounded respawn budget — only RAPID crash loops (exit within
+   * stableReadyResetMs of becoming ready) consume the budget.
+   * Default: 60000ms.
+   */
+  readonly stableReadyResetMs?: number
   /** Injected spawn function for testing. Defaults to node:child_process.spawn. */
   readonly spawnFn?: SpawnFn
   /** Injected readiness poll function for testing. */
@@ -304,6 +332,8 @@ export interface RunSupervisedOpencodeOptions {
  * - Binds to 127.0.0.1 only.
  * - No token or credential is logged.
  * - Bounded retry: maxAttempts + per-attempt deadline prevent infinite respawn.
+ *   Rapid crash loops (exit within stableReadyResetMs of becoming ready) consume
+ *   the budget; stable runs (uptime >= stableReadyResetMs) reset it.
  */
 export async function runSupervisedOpencode(options: RunSupervisedOpencodeOptions): Promise<void> {
   const {
@@ -318,14 +348,22 @@ export async function runSupervisedOpencode(options: RunSupervisedOpencodeOption
     maxAttempts = 4,
     initialBackoffMs = 1_000,
     maxBackoffMs = 10_000,
+    stableReadyResetMs = 60_000,
     spawnFn = nodeSpawn,
     pollReadyFn = defaultPollReady,
   } = options
 
   const url = `http://${hostname}:${port}`
+  // Mutable attempt counter — can be reset after a stable run (Fix 2).
+  let attempt = 1
   let backoffMs = initialBackoffMs
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+  while (attempt <= maxAttempts) {
+    // Fix 4: stop immediately if the signal was already aborted before this spawn.
+    if (signal !== undefined && signal.aborted) {
+      return
+    }
+
     // Fail-closed: status is 'starting' (not-ready) before each spawn attempt.
     // This ensures /readyz returns 503 during the kill→respawn transition.
     statusRef.status = 'starting'
@@ -370,7 +408,9 @@ export async function runSupervisedOpencode(options: RunSupervisedOpencodeOption
       logger.error('opencode-server: spawn error', {message, attempt})
     })
 
-    // Abort signal integration — reap the whole process group on external abort.
+    // Fix 4: Abort signal integration — reap the whole process group on external abort.
+    // With detached:true the child is in its OWN process group and does NOT inherit
+    // SIGTERM from the parent. We must explicitly reap it via killChildGroup.
     if (signal !== undefined) {
       signal.addEventListener('abort', () => {
         if (state.exited === false) {
@@ -382,8 +422,17 @@ export async function runSupervisedOpencode(options: RunSupervisedOpencodeOption
     // Per-attempt readiness loop with a fresh deadline.
     const deadline = Date.now() + readyTimeoutMs
     let becameReady = false
+    let readyAt = 0
 
     while (Date.now() < deadline) {
+      // Fix 4: abort check inside the readiness poll loop.
+      if (signal !== undefined && signal.aborted) {
+        if (state.exited === false) {
+          killChildGroup(child)
+        }
+        return
+      }
+
       if (state.exited === true) {
         // Process exited before becoming ready — break to respawn logic.
         break
@@ -392,6 +441,7 @@ export async function runSupervisedOpencode(options: RunSupervisedOpencodeOption
       const ready = await pollReadyFn(url, signal)
       if (ready === true) {
         becameReady = true
+        readyAt = Date.now()
         state.becameReady = true
         statusRef.status = 'ready'
         logger.info('opencode-server: ready', {url, attempt})
@@ -410,8 +460,34 @@ export async function runSupervisedOpencode(options: RunSupervisedOpencodeOption
           resolve()
           return
         }
+        // Fix 4: also resolve immediately if the signal aborts (abort handler
+        // already called killChildGroup; we just need to unblock the wait).
+        if (signal !== undefined) {
+          signal.addEventListener('abort', () => resolve())
+        }
         child.on('exit', () => resolve())
       })
+
+      // Fix 4: if we were aborted during post-ready monitoring, stop here.
+      if (signal !== undefined && signal.aborted) {
+        return
+      }
+
+      // Fix 2: compute uptime since the child became ready.
+      const uptime = Date.now() - readyAt
+      const wasStable = uptime >= stableReadyResetMs
+
+      if (wasStable) {
+        // Stable run: reset the attempt counter and backoff so only RAPID
+        // crash loops consume the bounded budget.
+        logger.info('opencode-server: stable run detected — resetting respawn budget', {
+          uptime,
+          stableReadyResetMs,
+          attempt,
+        })
+        attempt = 1
+        backoffMs = initialBackoffMs
+      }
 
       // Child has now exited. Decide whether to respawn.
       if (attempt < maxAttempts) {
@@ -422,12 +498,19 @@ export async function runSupervisedOpencode(options: RunSupervisedOpencodeOption
           attempt,
           nextAttempt: attempt + 1,
           maxAttempts,
+          wasStable,
         })
-        // Apply backoff before next attempt.
-        if (backoffMs > 0) {
-          await sleep(backoffMs)
+        // Apply backoff before next attempt (abortable — Fix 4).
+        if (backoffMs > 0 && (signal === undefined || !signal.aborted)) {
+          await sleep(backoffMs, undefined, {signal}).catch(() => {
+            // Abort during backoff — stop immediately.
+          })
+        }
+        if (signal !== undefined && signal.aborted) {
+          return
         }
         backoffMs = Math.min(backoffMs * 2, maxBackoffMs)
+        attempt++
         continue
       }
 
@@ -453,11 +536,17 @@ export async function runSupervisedOpencode(options: RunSupervisedOpencodeOption
         maxAttempts,
         backoffMs,
       })
-      // Apply backoff before next attempt.
-      if (backoffMs > 0) {
-        await sleep(backoffMs)
+      // Apply backoff before next attempt (abortable — Fix 4).
+      if (backoffMs > 0 && (signal === undefined || !signal.aborted)) {
+        await sleep(backoffMs, undefined, {signal}).catch(() => {
+          // Abort during backoff — stop immediately.
+        })
+      }
+      if (signal !== undefined && signal.aborted) {
+        return
       }
       backoffMs = Math.min(backoffMs * 2, maxBackoffMs)
+      attempt++
       continue
     }
 
@@ -468,5 +557,6 @@ export async function runSupervisedOpencode(options: RunSupervisedOpencodeOption
       attempt,
       maxAttempts,
     })
+    return
   }
 }

--- a/apps/workspace-agent/src/opencode-server.ts
+++ b/apps/workspace-agent/src/opencode-server.ts
@@ -315,26 +315,6 @@ export interface RunSupervisedOpencodeOptions {
   readonly pollReadyFn?: PollReadyFn
 }
 
-/**
- * Supervised OpenCode lifecycle with bounded respawn and state machine.
- *
- * State transitions:
- *   starting → ready          (first or subsequent attempt succeeds)
- *   starting → starting       (set BEFORE killing child on respawn — fail-closed)
- *   ready    → starting       (post-ready exit detected; respawn if attempts remain)
- *   ready    → degraded       (post-ready exit, no attempts remain)
- *   starting → degraded       (all attempts exhausted without becoming ready)
- *
- * The supervisor writes all transitions to `statusRef.status`. The caller
- * (main.ts) shares this ref with the Hono app so /readyz reflects live state.
- *
- * SECURITY INVARIANTS preserved:
- * - Binds to 127.0.0.1 only.
- * - No token or credential is logged.
- * - Bounded retry: maxAttempts + per-attempt deadline prevent infinite respawn.
- *   Rapid crash loops (exit within stableReadyResetMs of becoming ready) consume
- *   the budget; stable runs (uptime >= stableReadyResetMs) reset it.
- */
 export async function runSupervisedOpencode(options: RunSupervisedOpencodeOptions): Promise<void> {
   const {
     rootDir,
@@ -358,147 +338,211 @@ export async function runSupervisedOpencode(options: RunSupervisedOpencodeOption
   let attempt = 1
   let backoffMs = initialBackoffMs
 
-  while (attempt <= maxAttempts) {
-    // Fix 4: stop immediately if the signal was already aborted before this spawn.
-    if (signal !== undefined && signal.aborted) {
-      return
+  // Memory-leak fix: register ONE abort handler outside the loop, referencing
+  // the current child via a mutable ref. This prevents O(N) listener accumulation
+  // on the shared AbortSignal across stable respawns (where attempt resets to 1).
+  // The handler is removed in the finally block when the supervisor returns.
+  //
+  // The same handler also resolves the post-ready wait (stored in postReadyResolve)
+  // so we never need a second listener on the signal for that purpose.
+  let currentChild: ChildHandle | null = null
+  let currentState: {exited: boolean} | null = null
+  let postReadyResolve: (() => void) | null = null
+
+  const onAbort = (): void => {
+    if (currentChild !== null && currentState !== null && currentState.exited === false) {
+      killChildGroup(currentChild)
     }
-
-    // Fail-closed: status is 'starting' (not-ready) before each spawn attempt.
-    // This ensures /readyz returns 503 during the kill→respawn transition.
-    statusRef.status = 'starting'
-
-    logger.info('opencode-server: supervisor spawning', {url, rootDir, attempt, maxAttempts})
-
-    // detached: true makes the child a process-group leader (pgid = pid) so
-    // killChildGroup can reap the whole group on timeout/abort/shutdown.
-    const child = spawnFn('opencode', ['serve', '--hostname', hostname, '--port', String(port)], {
-      cwd: rootDir,
-      env: process.env,
-      detached: true,
-    })
-
-    // Per-attempt mutable state.
-    const state: {exited: boolean; exitCode: number | null; becameReady: boolean} = {
-      exited: false,
-      exitCode: null,
-      becameReady: false,
+    // Unblock the post-ready wait if it's active.
+    if (postReadyResolve !== null) {
+      postReadyResolve()
     }
+  }
 
-    child.on('exit', (code: unknown) => {
-      state.exited = true
-      state.exitCode = typeof code === 'number' ? code : null
-      logger.info('opencode-server: process exited', {code: state.exitCode, attempt})
+  if (signal !== undefined) {
+    signal.addEventListener('abort', onAbort)
+  }
 
-      // POST-READY EXIT LATCH FIX: if the child exits after we marked it ready,
-      // flip status back to not-ready immediately. The outer loop will decide
-      // whether to respawn (if attempts remain) or go to degraded.
-      if (state.becameReady === true && statusRef.status === 'ready') {
-        logger.warn('opencode-server: process exited after becoming ready — flipping to starting', {
-          code: state.exitCode,
-          attempt,
-        })
-        statusRef.status = 'starting'
-      }
-    })
-
-    child.on('error', (err: unknown) => {
-      state.exited = true
-      const message = err instanceof Error ? err.message : String(err)
-      logger.error('opencode-server: spawn error', {message, attempt})
-    })
-
-    // Fix 4: Abort signal integration — reap the whole process group on external abort.
-    // With detached:true the child is in its OWN process group and does NOT inherit
-    // SIGTERM from the parent. We must explicitly reap it via killChildGroup.
-    if (signal !== undefined) {
-      signal.addEventListener('abort', () => {
-        if (state.exited === false) {
-          killChildGroup(child)
-        }
-      })
-    }
-
-    // Per-attempt readiness loop with a fresh deadline.
-    const deadline = Date.now() + readyTimeoutMs
-    let becameReady = false
-    let readyAt = 0
-
-    while (Date.now() < deadline) {
-      // Fix 4: abort check inside the readiness poll loop.
+  try {
+    while (attempt <= maxAttempts) {
+      // Fix 4: stop immediately if the signal was already aborted before this spawn.
       if (signal !== undefined && signal.aborted) {
-        if (state.exited === false) {
-          killChildGroup(child)
-        }
         return
       }
 
-      if (state.exited === true) {
-        // Process exited before becoming ready — break to respawn logic.
-        break
+      // Fail-closed: status is 'starting' (not-ready) before each spawn attempt.
+      // This ensures /readyz returns 503 during the kill→respawn transition.
+      statusRef.status = 'starting'
+
+      logger.info('opencode-server: supervisor spawning', {url, rootDir, attempt, maxAttempts})
+
+      // detached: true makes the child a process-group leader (pgid = pid) so
+      // killChildGroup can reap the whole group on timeout/abort/shutdown.
+      const child = spawnFn('opencode', ['serve', '--hostname', hostname, '--port', String(port)], {
+        cwd: rootDir,
+        env: process.env,
+        detached: true,
+      })
+
+      // Per-attempt mutable state.
+      const state: {exited: boolean; exitCode: number | null; becameReady: boolean} = {
+        exited: false,
+        exitCode: null,
+        becameReady: false,
       }
 
-      const ready = await pollReadyFn(url, signal)
-      if (ready === true) {
-        becameReady = true
-        readyAt = Date.now()
-        state.becameReady = true
-        statusRef.status = 'ready'
-        logger.info('opencode-server: ready', {url, attempt})
-        break
-      }
+      // Update the mutable refs so the single top-level onAbort handler targets
+      // the current child. This must happen before any await so the handler is
+      // always pointing at the live child when abort fires.
+      currentChild = child
+      currentState = state
 
-      await sleep(pollIntervalMs)
-    }
+      child.on('exit', (code: unknown) => {
+        state.exited = true
+        state.exitCode = typeof code === 'number' ? code : null
+        logger.info('opencode-server: process exited', {code: state.exitCode, attempt})
 
-    if (becameReady === true) {
-      // Server is ready. Now wait for it to exit (post-ready monitoring).
-      // This is the latch fix: we don't return immediately — we stay in the
-      // loop waiting for an unexpected exit so we can flip status and respawn.
-      await new Promise<void>(resolve => {
-        if (state.exited === true) {
-          resolve()
+        // POST-READY EXIT LATCH FIX: if the child exits after we marked it ready,
+        // flip status back to not-ready immediately. The outer loop will decide
+        // whether to respawn (if attempts remain) or go to degraded.
+        if (state.becameReady === true && statusRef.status === 'ready') {
+          logger.warn('opencode-server: process exited after becoming ready — flipping to starting', {
+            code: state.exitCode,
+            attempt,
+          })
+          statusRef.status = 'starting'
+        }
+      })
+
+      child.on('error', (err: unknown) => {
+        state.exited = true
+        const message = err instanceof Error ? err.message : String(err)
+        logger.error('opencode-server: spawn error', {message, attempt})
+      })
+
+      // Per-attempt readiness loop with a fresh deadline.
+      const deadline = Date.now() + readyTimeoutMs
+      let becameReady = false
+      let readyAt = 0
+
+      while (Date.now() < deadline) {
+        // Fix 4: abort check inside the readiness poll loop.
+        if (signal !== undefined && signal.aborted) {
+          if (state.exited === false) {
+            killChildGroup(child)
+          }
           return
         }
-        // Fix 4: also resolve immediately if the signal aborts (abort handler
-        // already called killChildGroup; we just need to unblock the wait).
-        if (signal !== undefined) {
-          signal.addEventListener('abort', () => resolve())
-        }
-        child.on('exit', () => resolve())
-      })
 
-      // Fix 4: if we were aborted during post-ready monitoring, stop here.
-      if (signal !== undefined && signal.aborted) {
+        if (state.exited === true) {
+          // Process exited before becoming ready — break to respawn logic.
+          break
+        }
+
+        const ready = await pollReadyFn(url, signal)
+        if (ready === true) {
+          becameReady = true
+          readyAt = Date.now()
+          state.becameReady = true
+          statusRef.status = 'ready'
+          logger.info('opencode-server: ready', {url, attempt})
+          break
+        }
+
+        await sleep(pollIntervalMs)
+      }
+
+      if (becameReady === true) {
+        // Server is ready. Now wait for it to exit (post-ready monitoring).
+        // This is the latch fix: we don't return immediately — we stay in the
+        // loop waiting for an unexpected exit so we can flip status and respawn.
+        //
+        // Memory-leak fix for the post-ready wait: we must NOT add another
+        // listener on the shared signal here. Instead, the top-level onAbort
+        // handler resolves the wait via the postReadyResolve ref — zero extra
+        // listeners on the signal.
+        await new Promise<void>(resolve => {
+          if (state.exited === true) {
+            resolve()
+            return
+          }
+          // Fix 4: also resolve immediately if the signal aborts (the top-level
+          // onAbort handler already called killChildGroup and will call
+          // postReadyResolve — we just need to register the resolver here).
+          postReadyResolve = resolve
+          child.on('exit', () => {
+            postReadyResolve = null
+            resolve()
+          })
+        })
+
+        // Fix 4: if we were aborted during post-ready monitoring, stop here.
+        if (signal !== undefined && signal.aborted) {
+          return
+        }
+
+        // Fix 2: compute uptime since the child became ready.
+        const uptime = Date.now() - readyAt
+        const wasStable = uptime >= stableReadyResetMs
+
+        if (wasStable) {
+          // Stable run: reset the attempt counter and backoff so only RAPID
+          // crash loops consume the bounded budget.
+          logger.info('opencode-server: stable run detected — resetting respawn budget', {
+            uptime,
+            stableReadyResetMs,
+            attempt,
+          })
+          attempt = 1
+          backoffMs = initialBackoffMs
+        }
+
+        // Child has now exited. Decide whether to respawn.
+        if (attempt < maxAttempts) {
+          // Respawn: set status to starting BEFORE killing (already exited, but
+          // the status flip is the load-bearing invariant).
+          statusRef.status = 'starting'
+          logger.warn('opencode-server: supervisor respawning after post-ready exit', {
+            attempt,
+            nextAttempt: attempt + 1,
+            maxAttempts,
+            wasStable,
+          })
+          // Apply backoff before next attempt (abortable — Fix 4).
+          if (backoffMs > 0 && (signal === undefined || !signal.aborted)) {
+            await sleep(backoffMs, undefined, {signal}).catch(() => {
+              // Abort during backoff — stop immediately.
+            })
+          }
+          if (signal !== undefined && signal.aborted) {
+            return
+          }
+          backoffMs = Math.min(backoffMs * 2, maxBackoffMs)
+          attempt++
+          continue
+        }
+
+        // No attempts remain — terminal degraded state.
+        statusRef.status = 'degraded'
+        logger.error('opencode-server: supervisor exhausted attempts after post-ready exit', {
+          attempt,
+          maxAttempts,
+        })
         return
       }
 
-      // Fix 2: compute uptime since the child became ready.
-      const uptime = Date.now() - readyAt
-      const wasStable = uptime >= stableReadyResetMs
-
-      if (wasStable) {
-        // Stable run: reset the attempt counter and backoff so only RAPID
-        // crash loops consume the bounded budget.
-        logger.info('opencode-server: stable run detected — resetting respawn budget', {
-          uptime,
-          stableReadyResetMs,
-          attempt,
-        })
-        attempt = 1
-        backoffMs = initialBackoffMs
+      // Did not become ready (timeout or early exit).
+      // Reap the whole process group (fail-closed: status is already 'starting').
+      if (state.exited === false) {
+        killChildGroup(child)
       }
 
-      // Child has now exited. Decide whether to respawn.
       if (attempt < maxAttempts) {
-        // Respawn: set status to starting BEFORE killing (already exited, but
-        // the status flip is the load-bearing invariant).
-        statusRef.status = 'starting'
-        logger.warn('opencode-server: supervisor respawning after post-ready exit', {
+        logger.warn('opencode-server: supervisor attempt failed, will respawn', {
           attempt,
           nextAttempt: attempt + 1,
           maxAttempts,
-          wasStable,
+          backoffMs,
         })
         // Apply backoff before next attempt (abortable — Fix 4).
         if (backoffMs > 0 && (signal === undefined || !signal.aborted)) {
@@ -514,49 +558,20 @@ export async function runSupervisedOpencode(options: RunSupervisedOpencodeOption
         continue
       }
 
-      // No attempts remain — terminal degraded state.
+      // All attempts exhausted — terminal degraded state.
+      // Clone API (:9100) stays alive; /readyz returns 503.
       statusRef.status = 'degraded'
-      logger.error('opencode-server: supervisor exhausted attempts after post-ready exit', {
+      logger.error('opencode-server: supervisor exhausted all attempts', {
         attempt,
         maxAttempts,
       })
       return
     }
-
-    // Did not become ready (timeout or early exit).
-    // Reap the whole process group (fail-closed: status is already 'starting').
-    if (state.exited === false) {
-      killChildGroup(child)
+  } finally {
+    // Memory-leak fix: always remove the top-level abort listener when the
+    // supervisor returns (whether normally, via abort, or via degraded state).
+    if (signal !== undefined) {
+      signal.removeEventListener('abort', onAbort)
     }
-
-    if (attempt < maxAttempts) {
-      logger.warn('opencode-server: supervisor attempt failed, will respawn', {
-        attempt,
-        nextAttempt: attempt + 1,
-        maxAttempts,
-        backoffMs,
-      })
-      // Apply backoff before next attempt (abortable — Fix 4).
-      if (backoffMs > 0 && (signal === undefined || !signal.aborted)) {
-        await sleep(backoffMs, undefined, {signal}).catch(() => {
-          // Abort during backoff — stop immediately.
-        })
-      }
-      if (signal !== undefined && signal.aborted) {
-        return
-      }
-      backoffMs = Math.min(backoffMs * 2, maxBackoffMs)
-      attempt++
-      continue
-    }
-
-    // All attempts exhausted — terminal degraded state.
-    // Clone API (:9100) stays alive; /readyz returns 503.
-    statusRef.status = 'degraded'
-    logger.error('opencode-server: supervisor exhausted all attempts', {
-      attempt,
-      maxAttempts,
-    })
-    return
   }
 }

--- a/apps/workspace-agent/src/opencode-server.ts
+++ b/apps/workspace-agent/src/opencode-server.ts
@@ -12,7 +12,7 @@
  * 4. Bounded respawn: max attempts + total boot budget prevent infinite retry.
  */
 
-import {spawn as nodeSpawn} from 'node:child_process'
+import {spawn as nodeSpawnRaw} from 'node:child_process'
 import process from 'node:process'
 import {setTimeout as sleep} from 'node:timers/promises'
 
@@ -26,14 +26,25 @@ export interface Logger {
 export interface ChildHandle {
   readonly kill: (signal?: string) => boolean
   readonly on: (event: string | symbol, listener: (...args: unknown[]) => void) => void
+  /** Process ID — present on real child_process.ChildProcess; may be undefined on test fakes. */
+  readonly pid?: number
 }
 
 /** Simplified spawn signature for dependency injection. */
 export type SpawnFn = (
   command: string,
   args: readonly string[],
-  options: {readonly cwd?: string; readonly env?: NodeJS.ProcessEnv},
+  options: {readonly cwd?: string; readonly env?: NodeJS.ProcessEnv; readonly detached?: boolean},
 ) => ChildHandle
+
+/**
+ * Thin adapter that wraps node:child_process.spawn to satisfy SpawnFn.
+ * ChildProcessWithoutNullStreams has complex overloaded `on` signatures that
+ * don't structurally match our minimal ChildHandle.on — this cast is safe
+ * because we only use the `exit`, `error`, `kill`, and `pid` surface.
+ */
+const nodeSpawn: SpawnFn = (command, args, options) =>
+  nodeSpawnRaw(command, [...args], options) as unknown as ChildHandle
 
 /** Readiness probe — return true if the server is accepting connections. */
 export type PollReadyFn = (url: string, signal?: AbortSignal) => Promise<boolean>
@@ -79,6 +90,24 @@ export interface DefaultPollReadyOptions {
    * the outer deadline loop can retry. Default: 3000ms.
    */
   readonly probeTimeoutMs?: number
+}
+
+/**
+ * Kill the child's entire process group when a pid is available.
+ *
+ * When `child.pid` is a finite number, sends SIGTERM to the whole process
+ * group (negative pid = pgid) so no orphaned grandchildren survive a
+ * timeout/respawn/shutdown. Falls back to `child.kill('SIGTERM')` when the
+ * pid is not a number (e.g. test fakes that don't expose a pid).
+ *
+ * SECURITY INVARIANT: no token, secret, or env value is logged here.
+ */
+function killChildGroup(child: ChildHandle): void {
+  if (typeof child.pid === 'number' && Number.isFinite(child.pid)) {
+    process.kill(-child.pid, 'SIGTERM')
+  } else {
+    child.kill('SIGTERM')
+  }
 }
 
 /**
@@ -148,9 +177,12 @@ export async function startOpencodeServer(options: StartOpencodeServerOptions): 
 
   logger.info('opencode-server: spawning', {url, rootDir})
 
+  // detached: true makes the child a process-group leader (pgid = pid) so
+  // killChildGroup can reap the whole group on timeout/abort/close.
   const child = spawnFn('opencode', ['serve', '--hostname', hostname, '--port', String(port)], {
     cwd: rootDir,
     env: process.env,
+    detached: true,
   })
 
   // Use an object to hold mutable state — TypeScript does not narrow mutable
@@ -169,11 +201,11 @@ export async function startOpencodeServer(options: StartOpencodeServerOptions): 
     logger.error('opencode-server: spawn error', {message})
   })
 
-  // Abort signal integration
+  // Abort signal integration — reap the whole process group on abort.
   if (signal !== undefined) {
     signal.addEventListener('abort', () => {
       if (state.exited === false) {
-        child.kill('SIGTERM')
+        killChildGroup(child)
       }
     })
   }
@@ -193,7 +225,7 @@ export async function startOpencodeServer(options: StartOpencodeServerOptions): 
         url,
         close(): void {
           if (state.exited === false) {
-            child.kill('SIGTERM')
+            killChildGroup(child)
           }
         },
       }
@@ -202,9 +234,8 @@ export async function startOpencodeServer(options: StartOpencodeServerOptions): 
     await sleep(pollIntervalMs)
   }
 
-  // Timeout reached — kill and throw.
-  // Kill unconditionally (no-op if process already exited).
-  child.kill('SIGTERM')
+  // Timeout reached — reap the whole process group and throw.
+  killChildGroup(child)
   throw new Error(`opencode server did not become ready within ${readyTimeoutMs}ms`)
 }
 
@@ -301,9 +332,12 @@ export async function runSupervisedOpencode(options: RunSupervisedOpencodeOption
 
     logger.info('opencode-server: supervisor spawning', {url, rootDir, attempt, maxAttempts})
 
+    // detached: true makes the child a process-group leader (pgid = pid) so
+    // killChildGroup can reap the whole group on timeout/abort/shutdown.
     const child = spawnFn('opencode', ['serve', '--hostname', hostname, '--port', String(port)], {
       cwd: rootDir,
       env: process.env,
+      detached: true,
     })
 
     // Per-attempt mutable state.
@@ -336,11 +370,11 @@ export async function runSupervisedOpencode(options: RunSupervisedOpencodeOption
       logger.error('opencode-server: spawn error', {message, attempt})
     })
 
-    // Abort signal integration — kill child on external abort.
+    // Abort signal integration — reap the whole process group on external abort.
     if (signal !== undefined) {
       signal.addEventListener('abort', () => {
         if (state.exited === false) {
-          child.kill('SIGTERM')
+          killChildGroup(child)
         }
       })
     }
@@ -407,9 +441,9 @@ export async function runSupervisedOpencode(options: RunSupervisedOpencodeOption
     }
 
     // Did not become ready (timeout or early exit).
-    // Kill the child (fail-closed: status is already 'starting').
+    // Reap the whole process group (fail-closed: status is already 'starting').
     if (state.exited === false) {
-      child.kill('SIGTERM')
+      killChildGroup(child)
     }
 
     if (attempt < maxAttempts) {

--- a/apps/workspace-agent/src/server.ts
+++ b/apps/workspace-agent/src/server.ts
@@ -18,8 +18,14 @@ const MAX_BODY_BYTES = 4096
 /** Simplified clone executor signature for dependency injection. */
 export type CloneExecutorFn = (request: CloneRequest, deps?: CloneHandlerDeps) => Promise<CloneHandlerResult>
 
-/** OpenCode readiness state shared between the lifecycle and the server. */
-export type OpencodeStatus = 'starting' | 'ready' | 'down'
+/**
+ * OpenCode readiness state shared between the lifecycle and the server.
+ * - starting: not yet ready (initial boot or mid-respawn transition)
+ * - ready: OpenCode HTTP server is accepting connections
+ * - down: terminal failure (unmanaged / unexpected)
+ * - degraded: retries exhausted; clone API still alive, /readyz returns 503
+ */
+export type OpencodeStatus = 'starting' | 'ready' | 'down' | 'degraded'
 
 export interface OpencodeStatusRef {
   /** Current readiness. Updated by the lifecycle holder. */

--- a/apps/workspace-agent/src/types.ts
+++ b/apps/workspace-agent/src/types.ts
@@ -58,12 +58,15 @@ export type CloneErrorCode =
 export interface HealthzResponse {
   readonly ok: true
   /** OpenCode server readiness. Present when the server lifecycle is managed. */
-  readonly opencode?: 'ready' | 'starting' | 'down'
+  readonly opencode?: 'ready' | 'starting' | 'down' | 'degraded'
 }
 
 /** GET /readyz response. */
 export interface ReadyzResponse {
   readonly ready: boolean
-  /** OpenCode server readiness. 'unknown' when no status ref is available. */
-  readonly opencode: 'ready' | 'starting' | 'down' | 'unknown'
+  /**
+   * OpenCode server readiness. 'unknown' when no status ref is available.
+   * 'degraded' = retries exhausted, clone API still alive, /readyz returns 503.
+   */
+  readonly opencode: 'ready' | 'starting' | 'down' | 'degraded' | 'unknown'
 }

--- a/docs/plans/2026-06-03-003-fix-workspace-opencode-supervisor-readiness-plan.md
+++ b/docs/plans/2026-06-03-003-fix-workspace-opencode-supervisor-readiness-plan.md
@@ -494,8 +494,8 @@ at the top of `opencode-server.ts`.
   optionally set `WORKSPACE_OPENCODE_READY_TIMEOUT_MS` if 60s is still tight). Note: PR 1 fixes supervisor startup only —
   until PR 2 ships there is no gateway liveness gate, so a genuinely-dead workspace (vs. merely slow) would still receive
   mention runs; until PR 3 ships a startup failure is still one-shot. End-to-end recovery requires all three.
-- File a tracking issue for the deferred hardening (gateway SDK call signals + proxy upstream timeout) and reference it
-  from this plan.
+- Deferred hardening (gateway SDK call signals + proxy upstream timeout + readiness depth + test gaps) is tracked in
+  issue #763.
 
 ## Sources & References
 

--- a/packages/gateway/src/workspace-api/client.test.ts
+++ b/packages/gateway/src/workspace-api/client.test.ts
@@ -85,6 +85,24 @@ describe('WorkspaceClient.readyz', () => {
       vi.unstubAllGlobals()
     })
 
+    it('returns ready:false with opencode:"degraded" when server responds 503 with degraded status', async () => {
+      // #given
+      const client = makeClient()
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({ready: false, opencode: 'degraded'}),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      const result = await client.readyz()
+
+      // #then
+      expect(result).toEqual(ok({ready: false, opencode: 'degraded'}))
+      vi.unstubAllGlobals()
+    })
+
     it('returns ready:false with opencode:"unknown" when server responds 503 with unknown status', async () => {
       // #given
       const client = makeClient()

--- a/packages/gateway/src/workspace-api/client.ts
+++ b/packages/gateway/src/workspace-api/client.ts
@@ -192,7 +192,7 @@ function isReadyzResponse(value: unknown): value is ReadyzResponse {
     return v.opencode === 'ready'
   }
   // ready === false
-  return v.opencode === 'starting' || v.opencode === 'down' || v.opencode === 'unknown'
+  return v.opencode === 'starting' || v.opencode === 'down' || v.opencode === 'degraded' || v.opencode === 'unknown'
 }
 
 function isCloneResponse(value: unknown): value is CloneSuccess | CloneFailure {

--- a/packages/gateway/src/workspace-api/types.ts
+++ b/packages/gateway/src/workspace-api/types.ts
@@ -69,7 +69,7 @@ export interface ReadyzReady {
  */
 export interface ReadyzNotReady {
   readonly ready: false
-  readonly opencode: 'starting' | 'down' | 'unknown'
+  readonly opencode: 'starting' | 'down' | 'degraded' | 'unknown'
 }
 
 /** Discriminated union of all /readyz response shapes. */


### PR DESCRIPTION
Completes the #749 supervisor hardening. The cold-boot readiness fix (#755) and the gateway liveness gate (#761) landed first; this makes the supervisor itself resilient so a transient or post-startup OpenCode failure recovers instead of permanently breaking the `@fro-bot` mention loop.

**Bounded respawn with a real state machine.** The supervisor was one-shot: status went `starting → ready` once and only `→ down` on boot failure. A single cold-boot overrun permanently disabled the mention loop. It now respawns on failure with capped exponential backoff and a fresh readiness deadline per attempt, landing in a new terminal `degraded` state (clone API still served, `/readyz` 503) only when a genuine crash loop exhausts the budget.

**Post-startup crash recovery.** If OpenCode exits *after* becoming ready, status now flips off `ready` immediately so `/readyz` returns 503 and the gateway stops routing to it — closing the "latched ready" gap. The respawn budget resets after the server stays up for a stable period, so a long-lived workspace that crashes occasionally over hours isn't permanently degraded; only rapid crash loops consume the bounded budget.

**Process-group reaping.** `opencode serve` is spawned as its own process-group leader and reaped with a group signal (`process.kill(-pid, …)`, guarded to never target pid ≤ 1, with a direct-kill fallback) so no grandchild survives a restart to confuse later probes. Because a detached child does not inherit the container's SIGTERM, shutdown now drives an abort into the supervisor to reap the group and stop respawning.

The gateway readiness types recognize `degraded` as a valid not-ready state, so the gate classifies it cleanly (still fail-closed). Loopback-only bind and no-secret-logging invariants are unchanged.

Closes #749.