### PR TITLE
docs(harness): first-publish bootstrap runbook + helper

### DIFF
--- a/packages/harness/AGENTS.md
+++ b/packages/harness/AGENTS.md
@@ -53,7 +53,7 @@ Trusted publishing trusts at the **package level**, so each of the five packages
 
 ### First-publish bootstrap
 
-npm trusted publishing requires a package to **already exist** before it will accept OIDC publishes — a brand-new, never-published package cannot be trust-published from scratch. So the very first release of these five packages needs a bootstrap publish (a one-time token-authenticated `npm publish`, or npm's pre-registered pending-publisher flow for new packages), after which the trusted-publisher config above governs all subsequent releases with no token.
+npm trusted publishing requires a package to **already exist** before it will accept OIDC publishes — a brand-new, never-published package cannot be trust-published from scratch, and npm has no pending-publisher or pre-registration flow for packages that don't yet exist. So the very first release of these five packages requires a one-time token-authenticated `npm publish` to claim the names; after that, the trusted-publisher config above governs all subsequent releases with no token. See `BOOTSTRAP.md` for the full procedure.
 
 ## Carry Policy
 

--- a/packages/harness/BOOTSTRAP.md
+++ b/packages/harness/BOOTSTRAP.md
@@ -37,7 +37,11 @@ export NODE_AUTH_TOKEN=<paste-token-here>
 bash packages/harness/scripts/bootstrap-publish.sh
 ```
 
-The script creates a minimal `package.json` stub for each name, publishes `0.0.0`, and cleans up. It prints a reminder to revoke the token when done.
+The script detects `NODE_AUTH_TOKEN` and writes a temporary `.npmrc` (chmod 600) inside its own temp work directory, passing it to every `npm publish` call via `--userconfig`. This means the `NODE_AUTH_TOKEN` path works on any machine — no pre-existing `.npmrc` or `actions/setup-node` required. The temp `.npmrc` (which contains the token) is inside the work directory and is removed by the script's `EXIT` trap on both success and failure.
+
+If you prefer not to use `NODE_AUTH_TOKEN`, run `npm login` first and omit the export — the script falls back to ambient npm auth.
+
+The script creates a minimal `package.json` stub for each name, publishes `0.0.0`, and cleans up. The revoke reminder prints via the `EXIT` trap regardless of whether the script succeeds or fails mid-loop.
 
 ### 1c. Revoke the token immediately
 

--- a/packages/harness/BOOTSTRAP.md
+++ b/packages/harness/BOOTSTRAP.md
@@ -1,0 +1,115 @@
+# @fro.bot/harness — First-Publish Bootstrap Runbook
+
+This runbook covers the one-time steps required to claim the five `@fro.bot/harness*` package names on npm and wire up OIDC trusted publishing. Once this is done, every subsequent release runs tokenless via GitHub Actions — no npm token ever again. The `@fro.bot` scope already exists (it hosts `@fro.bot/systematic`), so org creation and membership are already handled.
+
+---
+
+## Prerequisites
+
+- npm account is a member of the `@fro.bot` org with publish rights.
+- npm CLI >= 11.5.0 installed locally (required for trusted publishing; also used by the bootstrap script for consistency).
+- `gh` CLI authenticated to `fro-bot/agent` (needed for Step 3).
+
+---
+
+## Step 1 — Claim the 5 package names with stubs (one-time, token)
+
+npm's trusted publishing (OIDC) requires a package to **already exist** before a trusted publisher can be attached. I publish a throwaway `0.0.0` stub for each of the five names to claim them, then immediately revoke the token. The real workflow overwrites these stubs at `1.15.13`.
+
+### 1a. Generate a granular access token
+
+1. Go to [npmjs.com → Access Tokens → Generate New Token → Granular Access Token](https://www.npmjs.com/settings/~/tokens/granular-access-tokens/new).
+2. Set:
+   - **Expiration**: 1 day (or the shortest available — this token is revoked immediately after use).
+   - **Packages and scopes**: Read and write, scoped to these five packages:
+     - `@fro.bot/harness`
+     - `@fro.bot/harness-linux-x64`
+     - `@fro.bot/harness-linux-arm64`
+     - `@fro.bot/harness-darwin-x64`
+     - `@fro.bot/harness-darwin-arm64`
+   - **Organizations**: `fro-bot` (read-only is fine here).
+3. Copy the token.
+
+### 1b. Run the bootstrap script
+
+```bash
+export NODE_AUTH_TOKEN=<paste-token-here>
+bash packages/harness/scripts/bootstrap-publish.sh
+```
+
+The script creates a minimal `package.json` stub for each name, publishes `0.0.0`, and cleans up. It prints a reminder to revoke the token when done.
+
+### 1c. Revoke the token immediately
+
+Back on npmjs.com → Access Tokens, delete the token you just used. It has served its only purpose.
+
+> **Why stubs?** The 4 platform packages (`@fro.bot/harness-linux-*`, `@fro.bot/harness-darwin-*`) are not local directories — the release workflow assembles them at publish time from native binaries built on per-platform CI runners. There is no way to build a linux/arm64 binary locally on a macOS arm64 machine. Publishing `0.0.0` stubs claims the names without needing real binaries. The real workflow publishes `1.15.13` (a higher version) and overwrites them cleanly.
+
+---
+
+## Step 2 — Configure trusted publishing on all 5 packages (one-time, UI)
+
+For **each** of the five packages, configure GitHub Actions as a trusted publisher so the release workflow can publish without a token.
+
+Go to: `https://www.npmjs.com/package/<package-name>` → **Settings** → **Trusted publishing** → **Add a publisher** → **GitHub Actions**
+
+Use these exact values for all five:
+
+| Field                | Value                  |
+| -------------------- | ---------------------- |
+| Organization or user | `fro-bot`              |
+| Repository           | `agent`                |
+| Workflow filename    | `harness-release.yaml` |
+| Environment          | _(leave blank)_        |
+
+Repeat for each package:
+
+1. `@fro.bot/harness`
+2. `@fro.bot/harness-linux-x64`
+3. `@fro.bot/harness-linux-arm64`
+4. `@fro.bot/harness-darwin-x64`
+5. `@fro.bot/harness-darwin-arm64`
+
+> **Note on environment**: The publish job in `harness-release.yaml` uses `environment: npm-publish` (a maintainer-gated GitHub environment). Leave the trusted publisher environment field blank on npm — the OIDC token is issued by GitHub regardless of which environment the job runs in; the environment gate is enforced on the GitHub side.
+
+---
+
+## Step 3 — Validate the pipeline with a dry run (no LLM merge, no token)
+
+Before doing any real release, validate that the native-build matrix, binary verification, and package assembly all work end-to-end. This dry run uses a real upstream OpenCode commit (no LLM-merge patch applied) so `build-platform.ts` can clone it directly from `anomalyco/opencode`.
+
+```bash
+gh workflow run harness-release.yaml \
+  --repo fro-bot/agent \
+  --field integration_commit=385cb694419f98103af0e8fc6187ddcbcbb6eecb \
+  --field base_version=1.15.13 \
+  --field dry_run=true
+```
+
+This triggers the full build matrix across all four platforms (linux/x64, linux/arm64, darwin/x64, darwin/arm64), runs `verify-binary.ts` on each output, assembles the per-platform packages, and then **skips the npm publish step** (`dry_run=true`). The publish job is also gated by the `npm-publish` GitHub environment (required reviewers), so even without `dry_run=true`, a human must approve before anything reaches npm.
+
+Watch the run:
+
+```bash
+gh run watch --repo fro-bot/agent
+```
+
+A green dry run means the build infrastructure is solid and the real `1.15.13` publish will work once the trusted publishers are configured.
+
+---
+
+## What's still blocked — a real patched release
+
+The dry run above uses a stock OpenCode commit with no LLM-merge patch. A real patched release (the actual point of this package) needs an **integrate→build bridge** that doesn't exist yet:
+
+- `packages/harness/scripts/build-platform.ts` clones `anomalyco/opencode` and checks out the integration commit.
+- The LLM-merge integration commit only exists locally after `harness integrate` runs — it is never pushed anywhere `build-platform.ts` can reach.
+- The fix is a `fro-bot/opencode` mirror repo wired into the workflow: the integrate runner pushes the frozen integration commit there, and `build-platform.ts` clones from `fro-bot/opencode` instead of `anomalyco/opencode`.
+
+This is separate, larger work. Until that bridge exists, the workflow can build and publish stock OpenCode at any upstream tag, but cannot publish a patched build.
+
+---
+
+## After bootstrap
+
+Every subsequent release is triggered by dispatching `harness-release.yaml` (or pushing a `harness-v*` tag) with the appropriate `integration_commit` and `base_version`. The publish job obtains an OIDC token from GitHub and publishes to npm with automatic provenance — no npm token, no secrets to rotate.

--- a/packages/harness/scripts/bootstrap-publish.sh
+++ b/packages/harness/scripts/bootstrap-publish.sh
@@ -45,17 +45,43 @@ echo "Using npm: $(npm --version) at $(command -v npm)"
 # Temp dir management — cleaned up on exit regardless of success/failure
 # ---------------------------------------------------------------------------
 WORK_DIR=""
+NPM_USERCONFIG_FLAG=()
 
 cleanup() {
   if [ -n "${WORK_DIR}" ] && [ -d "${WORK_DIR}" ]; then
+    # WORK_DIR contains the temp .npmrc (which holds the token) — remove it first.
     rm -rf "${WORK_DIR}"
   fi
+  # Always remind the operator to revoke the token, whether the script succeeded
+  # or failed mid-loop. A live write-scoped token must never be left un-revoked.
+  echo ""
+  echo "================================================================"
+  echo "IMPORTANT: REVOKE the npm token you used — go to:"
+  echo "  npmjs.com → Access Tokens → delete the token now."
+  echo "It has served its only purpose and must not remain active."
+  echo "================================================================"
 }
 
 trap cleanup EXIT
 
 WORK_DIR="$(mktemp -d)"
 echo "Working in temp dir: ${WORK_DIR}"
+
+# ---------------------------------------------------------------------------
+# Auth: write a temp .npmrc if NODE_AUTH_TOKEN is set, else use ambient auth
+# ---------------------------------------------------------------------------
+if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
+  NPMRC_FILE="${WORK_DIR}/.npmrc"
+  printf '//registry.npmjs.org/:_authToken=%s\n' "${NODE_AUTH_TOKEN}" > "${NPMRC_FILE}"
+  chmod 600 "${NPMRC_FILE}"
+  NPM_USERCONFIG_FLAG=(--userconfig "${NPMRC_FILE}")
+  echo "NODE_AUTH_TOKEN is set — wrote temp .npmrc (chmod 600) for auth."
+else
+  echo "NODE_AUTH_TOKEN is not set — using ambient npm auth (npm login)."
+  echo "If you are not logged in, npm publish will fail with ENEEDAUTH."
+  echo "Either set NODE_AUTH_TOKEN or run \`npm login\` first."
+fi
+
 echo ""
 
 # ---------------------------------------------------------------------------
@@ -80,20 +106,19 @@ for pkg in "${packages[@]}"; do
 }
 EOF
 
-  npm publish "${pkg_dir}"
+  npm publish "${NPM_USERCONFIG_FLAG[@]}" "${pkg_dir}"
   echo "Published: ${pkg}@0.0.0"
   echo ""
 done
 
 # ---------------------------------------------------------------------------
-# Done
+# Done — revoke reminder is printed by the EXIT trap (always, on success or failure)
 # ---------------------------------------------------------------------------
 echo "================================================================"
 echo "Bootstrap complete. All 5 package names are now claimed on npm."
 echo ""
 echo "NEXT STEPS:"
-echo "  1. REVOKE the npm token you used — go to npmjs.com → Access Tokens"
-echo "     and delete it now. It has served its only purpose."
+echo "  1. See the revoke reminder below (printed by the exit trap)."
 echo "  2. Configure trusted publishing for each package (see BOOTSTRAP.md Step 2)."
 echo "  3. Run the dry-run validation (see BOOTSTRAP.md Step 3)."
 echo "================================================================"

--- a/packages/harness/scripts/bootstrap-publish.sh
+++ b/packages/harness/scripts/bootstrap-publish.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# bootstrap-publish.sh — ONE-TIME manual bootstrap for @fro.bot/harness* package names.
+#
+# PURPOSE: npm trusted publishing (OIDC) requires a package to already exist before
+# a trusted publisher can be attached. This script publishes a throwaway 0.0.0 stub
+# for each of the five @fro.bot/harness* names to claim them. After this runs once,
+# revoke the token — all subsequent publishes use OIDC via harness-release.yaml.
+#
+# REQUIREMENTS:
+#   - NODE_AUTH_TOKEN must be set to a granular npm token with read+write access
+#     scoped to the five @fro.bot/harness* packages (see BOOTSTRAP.md Step 1).
+#   - Or: be logged in via `npm login` with a token that has publish rights.
+#   - npm must be installed and on PATH.
+#
+# USAGE:
+#   export NODE_AUTH_TOKEN=<your-granular-token>
+#   bash packages/harness/scripts/bootstrap-publish.sh
+#
+# After it completes: REVOKE THE TOKEN on npmjs.com immediately.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Package names to claim
+# ---------------------------------------------------------------------------
+packages=(
+  "@fro.bot/harness"
+  "@fro.bot/harness-linux-x64"
+  "@fro.bot/harness-linux-arm64"
+  "@fro.bot/harness-darwin-x64"
+  "@fro.bot/harness-darwin-arm64"
+)
+
+# ---------------------------------------------------------------------------
+# Sanity check: npm must be on PATH
+# ---------------------------------------------------------------------------
+if ! command -v npm > /dev/null 2>&1; then
+  echo "ERROR: npm not found on PATH. Install Node.js >= 24 and try again." >&2
+  exit 1
+fi
+
+echo "Using npm: $(npm --version) at $(command -v npm)"
+
+# ---------------------------------------------------------------------------
+# Temp dir management — cleaned up on exit regardless of success/failure
+# ---------------------------------------------------------------------------
+WORK_DIR=""
+
+cleanup() {
+  if [ -n "${WORK_DIR}" ] && [ -d "${WORK_DIR}" ]; then
+    rm -rf "${WORK_DIR}"
+  fi
+}
+
+trap cleanup EXIT
+
+WORK_DIR="$(mktemp -d)"
+echo "Working in temp dir: ${WORK_DIR}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Publish a 0.0.0 stub for each package name
+# ---------------------------------------------------------------------------
+for pkg in "${packages[@]}"; do
+  echo "--- Publishing stub: ${pkg}@0.0.0 ---"
+
+  pkg_dir="${WORK_DIR}/${pkg//\//__}"
+  mkdir -p "${pkg_dir}"
+
+  # Write a minimal package.json — just enough for npm publish to accept it.
+  cat > "${pkg_dir}/package.json" <<EOF
+{
+  "name": "${pkg}",
+  "version": "0.0.0",
+  "description": "Bootstrap stub — placeholder to claim the npm package name. Real releases use OIDC via harness-release.yaml.",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}
+EOF
+
+  npm publish "${pkg_dir}"
+  echo "Published: ${pkg}@0.0.0"
+  echo ""
+done
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+echo "================================================================"
+echo "Bootstrap complete. All 5 package names are now claimed on npm."
+echo ""
+echo "NEXT STEPS:"
+echo "  1. REVOKE the npm token you used — go to npmjs.com → Access Tokens"
+echo "     and delete it now. It has served its only purpose."
+echo "  2. Configure trusted publishing for each package (see BOOTSTRAP.md Step 2)."
+echo "  3. Run the dry-run validation (see BOOTSTRAP.md Step 3)."
+echo "================================================================"


### PR DESCRIPTION
`@fro.bot/harness` publishes to npm via trusted publishing (OIDC), but npm has no pending-publisher flow — a package name must already exist before a trusted publisher can be attached to it. The five `@fro.bot/harness*` packages have never been published, so the first publish needs a one-time bootstrap before the tokenless OIDC release pipeline can take over.

This adds the runbook and a helper to make that bootstrap a checklist rather than a research exercise:

- **`packages/harness/BOOTSTRAP.md`** — the operator runbook: claim the five package names with throwaway `0.0.0` stubs under a short-lived granular token, configure the trusted publisher per package (exact `fro-bot`/`agent`/`harness-release.yaml` field values), revoke the token, then validate the whole build/assemble pipeline with a `dry_run` dispatch against the real OpenCode `v1.15.13` commit — no LLM merge, no publish. It also records what's still required before the first *patched* release can run (the integrate→build bridge).
- **`packages/harness/scripts/bootstrap-publish.sh`** — the stub-publish helper: `mktemp` temp dirs with cleanup trap, ambient npm auth (no hardcoded token), a revoke reminder.

Docs + a manual helper script only — no runtime or workflow changes.