### PR TITLE
fix(harness): align native build with upstream OpenCode invocation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -49,11 +49,23 @@
     },
     {
       // Tracks the harness native-build Bun pin in packages/harness/src/bun-version.ts.
-      // Must match anomalyco/opencode's packageManager field at the harness base version
-      // and the bun-version input in harness-release.yaml.
+      // Must match anomalyco/opencode's packageManager field at the harness base version.
+      // The workflow's setup-bun input is tracked separately by the manager below.
       customType: 'regex',
       managerFilePatterns: ['/packages\\/harness\\/src\\/bun-version\\.ts/'],
       matchStrings: ["HARNESS_BUN_VERSION = '(?<currentValue>\\d+\\.\\d+\\.\\d+)'"],
+      depNameTemplate: 'oven-sh/bun',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^bun-v(?<version>.*)$',
+    },
+    {
+      // Tracks the bun-version input in .github/workflows/harness-release.yaml.
+      // Keeps the workflow's setup-bun pin in lockstep with HARNESS_BUN_VERSION
+      // in packages/harness/src/bun-version.ts. Matches both occurrences (build
+      // job and publish job) — Renovate applies matchStrings globally per file.
+      customType: 'regex',
+      managerFilePatterns: ['/\\.github\\/workflows\\/harness-release\\.yaml/'],
+      matchStrings: ['bun-version: (?<currentValue>\\d+\\.\\d+\\.\\d+)'],
       depNameTemplate: 'oven-sh/bun',
       datasourceTemplate: 'github-releases',
       extractVersionTemplate: '^bun-v(?<version>.*)$',
@@ -126,6 +138,14 @@
       // changes in patch releases). Raise it after validating a newer release.
       matchPackageNames: ['@opencode-ai/sdk', 'anomalyco/opencode'],
       allowedVersions: '<=1.15.13',
+    },
+    {
+      // Cap Bun at 1.3.14. The build gate requires an exact match with upstream
+      // anomalyco/opencode's packageManager field at the harness base version.
+      // Bun must not outrun the validated release; raise after verifying a newer
+      // upstream packageManager declaration and updating HARNESS_BUN_VERSION.
+      matchPackageNames: ['oven-sh/bun'],
+      allowedVersions: '<=1.3.14',
     },
     {
       matchUpdateTypes: ['lockFileMaintenance'],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,6 +48,17 @@
       extractVersionTemplate: '^bun-v(?<version>.*)$',
     },
     {
+      // Tracks the harness native-build Bun pin in packages/harness/src/bun-version.ts.
+      // Must match anomalyco/opencode's packageManager field at the harness base version
+      // and the bun-version input in harness-release.yaml.
+      customType: 'regex',
+      managerFilePatterns: ['/packages\\/harness\\/src\\/bun-version\\.ts/'],
+      matchStrings: ["HARNESS_BUN_VERSION = '(?<currentValue>\\d+\\.\\d+\\.\\d+)'"],
+      depNameTemplate: 'oven-sh/bun',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^bun-v(?<version>.*)$',
+    },
+    {
       customType: 'regex',
       managerFilePatterns: ['/src\\/shared\\/constants\\.ts/'],
       matchStrings: ["DEFAULT_SYSTEMATIC_VERSION = '(?<currentValue>\\d+\\.\\d+\\.\\d+)'"],

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -72,7 +72,8 @@ jobs:
       - name: Install Bun (pinned to upstream packageManager version)
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          # Pinned to match anomalyco/opencode packageManager: bun@1.3.13
+          # Pinned to match anomalyco/opencode packageManager: bun@1.3.14
+          # Keep in step with HARNESS_BUN_VERSION in packages/harness/src/bun-version.ts
           bun-version: 1.3.14
 
       - name: Setup Node.js and pnpm

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -30,7 +30,7 @@
     "fix": "pnpm --dir ../.. exec eslint --fix packages/harness/src packages/harness/scripts",
     "lint": "pnpm --dir ../.. exec eslint packages/harness/src packages/harness/scripts",
     "postinstall": "node dist/postinstall.mjs || true",
-    "test": "pnpm exec vitest run --passWithNoTests src"
+    "test": "pnpm exec vitest run --passWithNoTests src scripts"
   },
   "engines": {
     "node": ">=24"

--- a/packages/harness/scripts/build-platform.test.ts
+++ b/packages/harness/scripts/build-platform.test.ts
@@ -1,0 +1,108 @@
+/**
+ * build-platform.test.ts — drift guard + enforceBunVersion coverage.
+ *
+ * Tests:
+ *   1. Drift guard: all `bun-version: X.Y.Z` literals in harness-release.yaml
+ *      must equal HARNESS_BUN_VERSION. Catches the original version-drift gap.
+ *   2. enforceBunVersion: exact match → no throw/exit; mismatch → process.exit(1);
+ *      bun not found → process.exit(1).
+ */
+
+import {execFileSync} from 'node:child_process'
+import {readFileSync} from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import {fileURLToPath} from 'node:url'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {HARNESS_BUN_VERSION} from '../src/bun-version.js'
+import {enforceBunVersion} from './build-platform.js'
+
+// ---------------------------------------------------------------------------
+// Drift guard
+// ---------------------------------------------------------------------------
+
+describe('drift guard: harness-release.yaml bun-version literals', () => {
+  it('all bun-version occurrences in harness-release.yaml equal HARNESS_BUN_VERSION', () => {
+    // #given — resolve the workflow file relative to this test file (scripts/ → repo root)
+    const thisDir = path.dirname(fileURLToPath(import.meta.url))
+    const repoRoot = path.resolve(thisDir, '..', '..', '..')
+    const workflowPath = path.join(repoRoot, '.github', 'workflows', 'harness-release.yaml')
+
+    // #when
+    const content = readFileSync(workflowPath, 'utf8')
+    const matches = [...content.matchAll(/bun-version:\s*(\d+\.\d+\.\d+)/g)]
+
+    // #then — there must be at least one occurrence (sanity check)
+    expect(matches.length).toBeGreaterThan(0)
+
+    // Every occurrence must equal the pinned constant
+    for (const match of matches) {
+      const workflowVersion = match[1]
+      expect(
+        workflowVersion,
+        `bun-version literal '${workflowVersion}' in harness-release.yaml does not match HARNESS_BUN_VERSION '${HARNESS_BUN_VERSION}'`,
+      ).toBe(HARNESS_BUN_VERSION)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// enforceBunVersion
+// ---------------------------------------------------------------------------
+
+vi.mock('node:child_process', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  return {
+    ...actual,
+    execFileSync: vi.fn(),
+  }
+})
+
+describe('enforceBunVersion', () => {
+  const mockedExecFileSync = vi.mocked(execFileSync)
+  // Capture the spy so we can assert on it without triggering the unbound-method lint rule.
+  // Typed as a minimal structural interface so we can inspect mock.calls without
+  // triggering the unbound-method rule that fires on `expect(process.exit).*`.
+  let exitSpy: {mock: {calls: unknown[][]}}
+
+  beforeEach(() => {
+    // Spy on process.exit and prevent it from actually terminating the test runner.
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number | string | null | undefined) => {
+      throw new Error(`process.exit called with code ${_code}`)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('does not exit when bun version matches exactly', () => {
+    // #given — bun reports the exact pinned version
+    mockedExecFileSync.mockReturnValue(`${HARNESS_BUN_VERSION}\n`)
+
+    // #when / #then — must not throw or call process.exit
+    expect(() => enforceBunVersion()).not.toThrow()
+    expect(exitSpy.mock.calls).toHaveLength(0)
+  })
+
+  it('calls process.exit(1) when bun version mismatches', () => {
+    // #given — bun reports a different version
+    mockedExecFileSync.mockReturnValue('9.9.9\n')
+
+    // #when / #then — must call process.exit(1) (which our spy turns into a throw)
+    expect(() => enforceBunVersion()).toThrow('process.exit called with code 1')
+    expect(exitSpy.mock.calls[0]?.[0]).toBe(1)
+  })
+
+  it('calls process.exit(1) when bun is not found on PATH', () => {
+    // #given — execFileSync throws (bun not found)
+    mockedExecFileSync.mockImplementation(() => {
+      throw new Error('spawn bun ENOENT')
+    })
+
+    // #when / #then — must call process.exit(1)
+    expect(() => enforceBunVersion()).toThrow('process.exit called with code 1')
+    expect(exitSpy.mock.calls[0]?.[0]).toBe(1)
+  })
+})

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -191,18 +191,18 @@ function cloneAndCheckout(repoUrl: string, workDir: string, commit: string): voi
 // ---------------------------------------------------------------------------
 
 function runUpstreamBuild(workDir: string, baseVersion: string, integrationCommit: string): void {
-  const opencodeDir = path.join(workDir, 'packages', 'opencode')
   const opencodeVersion = buildHarnessVersion(baseVersion, integrationCommit)
-  console.log(`[build-platform] Running upstream build in ${opencodeDir}`)
+  console.log(`[build-platform] Running upstream build in ${workDir}`)
   console.log(`[build-platform] Env: OPENCODE_CHANNEL=${OPENCODE_CHANNEL} OPENCODE_VERSION=${opencodeVersion}`)
 
   // Root workspace install — mirrors upstream's setup-bun action which runs `bun install`
-  // at the repo root (with --linker hoisted on Linux) before invoking build.ts.
+  // at the repo root before invoking build.ts. Hoisted linker is used ONLY on Windows
+  // (matching upstream's setup-bun action); Linux/macOS use a plain install.
   // This wires workspace symlinks (e.g. @opencode-ai/script) into node_modules so
   // packages/opencode/script/build.ts can resolve them at module load time.
   // The --single build below compiles just this platform's binary.
   console.log(`[build-platform] Installing workspace dependencies (bun install) in ${workDir}`)
-  const installArgs = process.platform === 'linux' ? ['install', '--linker', 'hoisted'] : ['install']
+  const installArgs = process.platform === 'win32' ? ['install', '--linker', 'hoisted'] : ['install']
   const installResult = spawnSync('bun', installArgs, {
     cwd: workDir,
     stdio: 'inherit',
@@ -214,8 +214,8 @@ function runUpstreamBuild(workDir: string, baseVersion: string, integrationCommi
     throw new Error(`Workspace install failed with exit code ${installResult.status ?? 'unknown'}`)
   }
 
-  const result = spawnSync('bun', ['run', 'build', '--', '--single'], {
-    cwd: opencodeDir,
+  const result = spawnSync('bun', ['./packages/opencode/script/build.ts', '--single'], {
+    cwd: workDir, // NOTE: workDir (repo root) — build.ts does its own process.chdir to packages/opencode
     stdio: 'inherit',
     env: {
       ...process.env,

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -136,7 +136,7 @@ Build-environment contract:
 // Bun version enforcement
 // ---------------------------------------------------------------------------
 
-function enforceBunVersion(): void {
+export function enforceBunVersion(): void {
   let actual: string
   try {
     const result = execFileSync('bun', ['--version'], {encoding: 'utf8', timeout: 10_000})
@@ -202,6 +202,8 @@ function runUpstreamBuild(workDir: string, baseVersion: string, integrationCommi
   // packages/opencode/script/build.ts can resolve them at module load time.
   // The --single build below compiles just this platform's binary.
   console.log(`[build-platform] Installing workspace dependencies (bun install) in ${workDir}`)
+  // The win32 branch is intentionally inert for this repo's linux/darwin-only matrix;
+  // it exists to faithfully mirror upstream's setup-bun action behavior on Windows.
   const installArgs = process.platform === 'win32' ? ['install', '--linker', 'hoisted'] : ['install']
   const installResult = spawnSync('bun', installArgs, {
     cwd: workDir,
@@ -392,4 +394,7 @@ async function main(): Promise<void> {
   console.log(`[build-platform] Done. Binary ready at: ${outDir}/opencode-${platform}-${arch}/bin/opencode`)
 }
 
-await main()
+// Only run when executed directly (not when imported by tests or other modules).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main()
+}

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -196,9 +196,24 @@ function runUpstreamBuild(workDir: string, baseVersion: string, integrationCommi
   console.log(`[build-platform] Running upstream build in ${opencodeDir}`)
   console.log(`[build-platform] Env: OPENCODE_CHANNEL=${OPENCODE_CHANNEL} OPENCODE_VERSION=${opencodeVersion}`)
 
-  // Install native deps first (mirrors upstream build.ts skipInstall=false path).
-  // The upstream build.ts does this internally, but we invoke it via `bun run build -- --single`
-  // which triggers the full build.ts including the bun install steps.
+  // Root workspace install — mirrors upstream's setup-bun action which runs `bun install`
+  // at the repo root (with --linker hoisted on Linux) before invoking build.ts.
+  // This wires workspace symlinks (e.g. @opencode-ai/script) into node_modules so
+  // packages/opencode/script/build.ts can resolve them at module load time.
+  // The --single build below compiles just this platform's binary.
+  console.log(`[build-platform] Installing workspace dependencies (bun install) in ${workDir}`)
+  const installArgs = process.platform === 'linux' ? ['install', '--linker', 'hoisted'] : ['install']
+  const installResult = spawnSync('bun', installArgs, {
+    cwd: workDir,
+    stdio: 'inherit',
+    env: {...process.env},
+    timeout: 20 * 60 * 1000, // 20-minute hard timeout
+  })
+
+  if (installResult.status !== 0) {
+    throw new Error(`Workspace install failed with exit code ${installResult.status ?? 'unknown'}`)
+  }
+
   const result = spawnSync('bun', ['run', 'build', '--', '--single'], {
     cwd: opencodeDir,
     stdio: 'inherit',

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -8,7 +8,7 @@
  * with the release-identity env, and emits the native binary for that platform.
  *
  * Build-environment contract:
- *   - Bun version is pinned to match upstream's packageManager (bun@1.3.13).
+ *   - Bun version is pinned to match upstream's packageManager (see HARNESS_BUN_VERSION).
  *   - The full upstream repo is checked out at the frozen integration commit.
  *   - Native-dep install + embedded-app build happen under the UPSTREAM repo root.
  *   - Build runs with:
@@ -50,14 +50,12 @@ import {cpSync, mkdirSync, writeFileSync} from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import {fileURLToPath} from 'node:url'
+import {HARNESS_BUN_VERSION as REQUIRED_BUN_VERSION} from '../src/bun-version.js'
 import {buildHarnessVersion} from '../src/version.js'
 
 // ---------------------------------------------------------------------------
 // Build-environment contract constants
 // ---------------------------------------------------------------------------
-
-/** Pinned Bun version — matches upstream anomalyco/opencode packageManager field. */
-const REQUIRED_BUN_VERSION = '1.3.13'
 
 /** The release channel used for the build identity env. */
 const OPENCODE_CHANNEL = 'latest'

--- a/packages/harness/src/bun-version.ts
+++ b/packages/harness/src/bun-version.ts
@@ -1,0 +1,12 @@
+/**
+ * Pinned Bun version required by the harness native build.
+ *
+ * This must match anomalyco/opencode's `packageManager` declaration at the
+ * harness base version (see HARNESS_BASE_VERSION in base-version.ts). It is
+ * kept in step with the `bun-version` input in harness-release.yaml and is
+ * tracked by Renovate via a customManager regex against oven-sh/bun releases.
+ *
+ * Do not change this value without also updating the workflow's bun-version
+ * and verifying it matches upstream's packageManager field.
+ */
+export const HARNESS_BUN_VERSION = '1.3.14'


### PR DESCRIPTION
The harness release build (`harness-release.yaml`) failed to produce native OpenCode binaries. Three issues, each surfaced and fixed via an end-to-end dry-run against all four target platforms.

## Changes

- **Track the required Bun version.** `build-platform.ts` hard-pinned a Bun version that drifted out of sync with the version the workflow installed, so the build's exact-match gate rejected the runner's Bun. The pin now lives in a single tracked constant (`HARNESS_BUN_VERSION`) with a Renovate custom manager, so it moves in lockstep with upstream's `packageManager` on future bumps.

- **Install workspace dependencies before building.** The build imports `@opencode-ai/script`, a workspace package that only resolves after a root install. Added the root `bun install` before invoking the build, mirroring upstream's setup.

- **Match upstream's build invocation exactly.** The root install used a hoisted linker on Linux, but upstream uses the hoisted linker only on Windows; Linux and macOS use a plain install. The hoisted layout on Linux broke resolution of the platform-native optional packages that the build installs internally. Removed the divergence and invoke the build script directly from the repo root, matching upstream.

## Verification

A `dry_run` dispatch built real binaries on all four platforms (`linux/x64`, `linux/arm64`, `darwin/x64`, `darwin/arm64`) and completed the assemble/verify job — all green. No publish occurred.