### PR TITLE
feat(harness): connect the integrate and build stages via a CI artifact handoff

### DIFF
--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -6,10 +6,6 @@ name: harness-release
 on:
   workflow_dispatch:
     inputs:
-      integration_commit:
-        description: Frozen integration commit SHA (from provenance manifest)
-        required: true
-        type: string
       base_version:
         description: Base release version (e.g. 1.15.13)
         required: true
@@ -34,13 +30,145 @@ permissions:
   contents: read
 
 # ---------------------------------------------------------------------------
-# Per-platform build matrix
-# Mirrors upstream anomalyco/opencode publish.yml native-runner matrix.
-# Windows is out of scope (linux x64/arm64 + darwin x64/arm64 only).
+# Integrate producer job — runs the LLM merge once, packages the clean merged
+# source snapshot, and emits the integration commit SHA + artifact digest.
+# Read-only: no id-token, no push, no write token.
 # ---------------------------------------------------------------------------
 jobs:
+  integrate:
+    name: integrate (LLM merge + artifact)
+    runs-on: ubuntu-24.04
+
+    # Read-only: no id-token. The LLM merge runs here and must not be able to
+    # publish or obtain OIDC tokens.
+    permissions:
+      contents: read
+
+    outputs:
+      integration_commit: ${{ steps.emit.outputs.integration_commit }}
+      artifact_digest: ${{ steps.emit.outputs.artifact_digest }}
+
+    steps:
+      - name: Checkout harness repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Bun (pinned to upstream packageManager version)
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          # Pinned to match anomalyco/opencode packageManager: bun@1.3.14
+          # Keep in step with HARNESS_BUN_VERSION in packages/harness/src/bun-version.ts
+          bun-version: 1.3.14
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup
+        with:
+          install-dependencies: 'false'
+
+      - name: Install harness dependencies
+        run: pnpm install --filter @fro.bot/harness --frozen-lockfile
+
+      - name: Build harness package (so cli.ts imports resolve)
+        run: pnpm --filter @fro.bot/harness build
+
+      - name: Provision OpenCode model auth (file-based, never logged)
+        env:
+          HARNESS_OPENCODE_AUTH_JSON: ${{ secrets.HARNESS_OPENCODE_AUTH_JSON }}
+        run: |
+          set -euo pipefail
+          AUTH_DIR="${HOME}/.local/share/opencode"
+          AUTH_FILE="${AUTH_DIR}/auth.json"
+          mkdir -p "${AUTH_DIR}"
+          # Write the secret to the auth file with 0600 perms.
+          # The secret value is never echoed — it is written via printf to avoid
+          # shell expansion and never appears in the step log.
+          (umask 077; printf '%s' "${HARNESS_OPENCODE_AUTH_JSON}" > "${AUTH_FILE}")
+          chmod 600 "${AUTH_FILE}"
+          # Sanity-check: file must be non-empty and valid JSON object.
+          if [ ! -s "${AUTH_FILE}" ]; then
+            echo "ERROR: HARNESS_OPENCODE_AUTH_JSON secret is empty or missing" >&2
+            exit 1
+          fi
+          node -e "
+            const fs = require('fs');
+            const raw = fs.readFileSync('${AUTH_FILE}', 'utf8');
+            let parsed;
+            try { parsed = JSON.parse(raw); } catch (e) {
+              process.stderr.write('ERROR: HARNESS_OPENCODE_AUTH_JSON is not valid JSON\n');
+              process.exit(1);
+            }
+            if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+              process.stderr.write('ERROR: HARNESS_OPENCODE_AUTH_JSON must be a JSON object\n');
+              process.exit(1);
+            }
+            process.stdout.write('auth: provisioned\n');
+          "
+
+      - name: Run harness integrate (LLM merge + artifact packaging)
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          WORK_DIR="${RUNNER_TEMP}/harness-integrate-work"
+          ARTIFACT_PATH="${RUNNER_TEMP}/integration-tree.tar"
+          PROMPT_PATH="packages/harness/prompt.txt"
+          mkdir -p "${WORK_DIR}"
+          bun run packages/harness/src/cli.ts integrate \
+            --work-dir "${WORK_DIR}" \
+            --prompt-path "${PROMPT_PATH}" \
+            --out "${ARTIFACT_PATH}"
+
+      - name: Emit integration_commit and artifact_digest outputs
+        id: emit
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          WORK_DIR="${RUNNER_TEMP}/harness-integrate-work"
+          ARTIFACT_PATH="${RUNNER_TEMP}/integration-tree.tar"
+
+          # Read the integration commit from provenance.json written by runIntegration.
+          INTEGRATION_COMMIT=$(node -e "
+            const fs = require('fs');
+            const raw = fs.readFileSync('${WORK_DIR}/provenance.json', 'utf8');
+            const m = JSON.parse(raw);
+            if (!m || typeof m.integrationCommit !== 'string' || m.integrationCommit.length === 0) {
+              process.stderr.write('ERROR: provenance.json missing or invalid integrationCommit\n');
+              process.exit(1);
+            }
+            process.stdout.write(m.integrationCommit);
+          ")
+
+          # Validate: must be a hex SHA (7–40 chars).
+          if ! echo "${INTEGRATION_COMMIT}" | grep -qE '^[0-9a-f]{7,40}$'; then
+            echo "ERROR: integrationCommit '${INTEGRATION_COMMIT}' does not match expected SHA format" >&2
+            exit 1
+          fi
+
+          # Compute the artifact digest (sha256).
+          ARTIFACT_DIGEST=$(sha256sum "${ARTIFACT_PATH}" | awk '{print $1}')
+
+          echo "integration_commit=${INTEGRATION_COMMIT}" >> "$GITHUB_OUTPUT"
+          echo "artifact_digest=${ARTIFACT_DIGEST}" >> "$GITHUB_OUTPUT"
+
+          echo "integration_commit: ${INTEGRATION_COMMIT}"
+          echo "artifact_digest:    ${ARTIFACT_DIGEST}"
+
+      - name: Upload integration-tree artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: integration-tree
+          path: ${{ runner.temp }}/integration-tree.tar
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Per-platform build matrix
+  # Mirrors upstream anomalyco/opencode publish.yml native-runner matrix.
+  # Windows is out of scope (linux x64/arm64 + darwin x64/arm64 only).
+  # ---------------------------------------------------------------------------
   build:
     name: build (${{ matrix.platform }}/${{ matrix.arch }})
+    needs: integrate
     strategy:
       fail-fast: true # All-or-nothing: one failure blocks the whole publish.
       matrix:
@@ -87,53 +215,41 @@ jobs:
       - name: Build harness package (for scripts/verify-binary.ts import)
         run: pnpm --filter @fro.bot/harness build
 
-      - name: Resolve integration commit and base version
-        id: params
+      - name: Download integration-tree artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: integration-tree
+          path: ${{ runner.temp }}/integration-tree-dl
+
+      - name: Verify artifact digest and extract source tree (R8)
         env:
-          INPUT_INTEGRATION_COMMIT: ${{ inputs.integration_commit }}
-          INPUT_BASE_VERSION: ${{ inputs.base_version }}
+          EXPECTED_DIGEST: ${{ needs.integrate.outputs.artifact_digest }}
+          RUNNER_TEMP: ${{ runner.temp }}
         run: |
           set -euo pipefail
+          ARTIFACT_PATH="${RUNNER_TEMP}/integration-tree-dl/integration-tree.tar"
+          EXTRACT_DIR="${RUNNER_TEMP}/integration-src"
 
-          if [ -n "${INPUT_INTEGRATION_COMMIT}" ]; then
-            INTEGRATION_COMMIT="${INPUT_INTEGRATION_COMMIT}"
-            BASE_VERSION="${INPUT_BASE_VERSION}"
-          else
-            # Tag-triggered: parse harness-v<version> tag.
-            TAG="${GITHUB_REF_NAME}"
-            BASE_VERSION="${TAG#harness-v}"
-            # Read integration commit from the provenance manifest in the repo.
-            INTEGRATION_COMMIT=$(node -e "
-              const fs = require('fs');
-              const raw = fs.readFileSync('./packages/harness/provenance.json', 'utf8');
-              const m = JSON.parse(raw);
-              if (!m || typeof m.integrationCommit !== 'string') {
-                process.stderr.write('ERROR: provenance.json missing or invalid integrationCommit\n');
-                process.exit(1);
-              }
-              process.stdout.write(m.integrationCommit);
-            ")
-          fi
-
-          # Validate base_version: must be a semver-ish string (digits and dots only, no shell metacharacters).
-          if ! echo "${BASE_VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([.-][a-zA-Z0-9._-]+)?$'; then
-            echo "ERROR: base_version '${BASE_VERSION}' does not match expected semver format" >&2
+          # Verify the downloaded artifact matches the declared digest before
+          # extracting. Fail-closed: any mismatch aborts the build (R8).
+          ACTUAL_DIGEST=$(sha256sum "${ARTIFACT_PATH}" | awk '{print $1}')
+          if [ "${ACTUAL_DIGEST}" != "${EXPECTED_DIGEST}" ]; then
+            echo "ERROR: artifact digest mismatch" >&2
+            echo "  expected: ${EXPECTED_DIGEST}" >&2
+            echo "  actual:   ${ACTUAL_DIGEST}" >&2
             exit 1
           fi
+          echo "Digest verified: ${ACTUAL_DIGEST}"
 
-          # Validate integration_commit: must be a hex SHA (7–40 chars).
-          if ! echo "${INTEGRATION_COMMIT}" | grep -qE '^[0-9a-f]{7,40}$'; then
-            echo "ERROR: integration_commit '${INTEGRATION_COMMIT}' does not match expected SHA format" >&2
-            exit 1
-          fi
-
-          echo "integration_commit=${INTEGRATION_COMMIT}" >> "$GITHUB_OUTPUT"
-          echo "base_version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+          # Extract the clean merged source tree.
+          mkdir -p "${EXTRACT_DIR}"
+          tar xf "${ARTIFACT_PATH}" -C "${EXTRACT_DIR}"
+          echo "Extracted to: ${EXTRACT_DIR}"
 
       - name: Build native binary for ${{ matrix.platform }}/${{ matrix.arch }}
         env:
-          INTEGRATION_COMMIT: ${{ steps.params.outputs.integration_commit }}
-          BASE_VERSION: ${{ steps.params.outputs.base_version }}
+          INTEGRATION_COMMIT: ${{ needs.integrate.outputs.integration_commit }}
+          BASE_VERSION: ${{ inputs.base_version }}
           RUNNER_TEMP: ${{ runner.temp }}
           MATRIX_PLATFORM: ${{ matrix.platform }}
           MATRIX_ARCH: ${{ matrix.arch }}
@@ -143,14 +259,14 @@ jobs:
             --base-version "$BASE_VERSION" \
             --platform "$MATRIX_PLATFORM" \
             --arch "$MATRIX_ARCH" \
-            --repo-url "https://github.com/anomalyco/opencode.git" \
+            --source-tree "$RUNNER_TEMP/integration-src" \
             --work-dir "$RUNNER_TEMP/harness-build-work" \
             --out-dir "$RUNNER_TEMP/harness-build-out"
 
       - name: Verify binary (${{ matrix.platform }}/${{ matrix.arch }})
         env:
-          INTEGRATION_COMMIT: ${{ steps.params.outputs.integration_commit }}
-          BASE_VERSION: ${{ steps.params.outputs.base_version }}
+          INTEGRATION_COMMIT: ${{ needs.integrate.outputs.integration_commit }}
+          BASE_VERSION: ${{ inputs.base_version }}
           RUNNER_TEMP: ${{ runner.temp }}
           MATRIX_PLATFORM: ${{ matrix.platform }}
           MATRIX_ARCH: ${{ matrix.arch }}
@@ -174,7 +290,7 @@ jobs:
   # ---------------------------------------------------------------------------
   publish:
     name: publish (all-or-nothing)
-    needs: build
+    needs: [integrate, build]
     runs-on: ubuntu-24.04
     environment: npm-publish # Maintainer-gated environment with required reviewers.
 
@@ -220,17 +336,20 @@ jobs:
       - name: Resolve params
         id: params
         env:
-          INPUT_INTEGRATION_COMMIT: ${{ inputs.integration_commit }}
+          INTEGRATE_COMMIT: ${{ needs.integrate.outputs.integration_commit }}
           INPUT_BASE_VERSION: ${{ inputs.base_version }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
 
-          if [ -n "${INPUT_INTEGRATION_COMMIT}" ]; then
-            INTEGRATION_COMMIT="${INPUT_INTEGRATION_COMMIT}"
+          if [ -n "${INTEGRATE_COMMIT}" ]; then
+            # workflow_dispatch path: integrate job produced the commit.
+            INTEGRATION_COMMIT="${INTEGRATE_COMMIT}"
             BASE_VERSION="${INPUT_BASE_VERSION}"
             DRY_RUN="${INPUT_DRY_RUN}"
           else
+            # Tag-triggered path: parse harness-v<version> tag; read commit from
+            # the provenance manifest committed in the repo.
             TAG="${GITHUB_REF_NAME}"
             BASE_VERSION="${TAG#harness-v}"
             INTEGRATION_COMMIT=$(node -e "

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -47,10 +47,34 @@ jobs:
     outputs:
       integration_commit: ${{ steps.emit.outputs.integration_commit }}
       artifact_digest: ${{ steps.emit.outputs.artifact_digest }}
+      base_version: ${{ steps.resolve-base-version.outputs.base_version }}
 
     steps:
       - name: Checkout harness repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Resolve base_version (dispatch input or tag)
+        id: resolve-base-version
+        env:
+          INPUT_BASE_VERSION: ${{ inputs.base_version }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_BASE_VERSION:-}" ]; then
+            BASE_VERSION="${INPUT_BASE_VERSION}"
+          else
+            # Tag-triggered path: parse harness-v<version> from the tag name.
+            TAG="${GITHUB_REF_NAME}"
+            BASE_VERSION="${TAG#harness-v}"
+          fi
+          # Validate: must be semver-ish (no shell metacharacters).
+          if ! echo "${BASE_VERSION}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([.-][a-zA-Z0-9._-]+)?$'; then
+            echo "ERROR: base_version '${BASE_VERSION}' does not match expected semver format" >&2
+            exit 1
+          fi
+          echo "base_version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved base_version: ${BASE_VERSION}"
 
       - name: Install Bun (pinned to upstream packageManager version)
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -144,8 +168,8 @@ jobs:
             exit 1
           fi
 
-          # Compute the artifact digest (sha256).
-          ARTIFACT_DIGEST=$(sha256sum "${ARTIFACT_PATH}" | awk '{print $1}')
+          # Compute the artifact digest (sha256) — portable across Linux and macOS.
+          ARTIFACT_DIGEST=$(shasum -a 256 "${ARTIFACT_PATH}" | awk '{print $1}')
 
           echo "integration_commit=${INTEGRATION_COMMIT}" >> "$GITHUB_OUTPUT"
           echo "artifact_digest=${ARTIFACT_DIGEST}" >> "$GITHUB_OUTPUT"
@@ -196,6 +220,8 @@ jobs:
     steps:
       - name: Checkout harness repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Bun (pinned to upstream packageManager version)
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -232,7 +258,7 @@ jobs:
 
           # Verify the downloaded artifact matches the declared digest before
           # extracting. Fail-closed: any mismatch aborts the build (R8).
-          ACTUAL_DIGEST=$(sha256sum "${ARTIFACT_PATH}" | awk '{print $1}')
+          ACTUAL_DIGEST=$(shasum -a 256 "${ARTIFACT_PATH}" | awk '{print $1}')
           if [ "${ACTUAL_DIGEST}" != "${EXPECTED_DIGEST}" ]; then
             echo "ERROR: artifact digest mismatch" >&2
             echo "  expected: ${EXPECTED_DIGEST}" >&2
@@ -249,7 +275,7 @@ jobs:
       - name: Build native binary for ${{ matrix.platform }}/${{ matrix.arch }}
         env:
           INTEGRATION_COMMIT: ${{ needs.integrate.outputs.integration_commit }}
-          BASE_VERSION: ${{ inputs.base_version }}
+          BASE_VERSION: ${{ needs.integrate.outputs.base_version }}
           RUNNER_TEMP: ${{ runner.temp }}
           MATRIX_PLATFORM: ${{ matrix.platform }}
           MATRIX_ARCH: ${{ matrix.arch }}
@@ -266,7 +292,7 @@ jobs:
       - name: Verify binary (${{ matrix.platform }}/${{ matrix.arch }})
         env:
           INTEGRATION_COMMIT: ${{ needs.integrate.outputs.integration_commit }}
-          BASE_VERSION: ${{ inputs.base_version }}
+          BASE_VERSION: ${{ needs.integrate.outputs.base_version }}
           RUNNER_TEMP: ${{ runner.temp }}
           MATRIX_PLATFORM: ${{ matrix.platform }}
           MATRIX_ARCH: ${{ matrix.arch }}
@@ -305,6 +331,8 @@ jobs:
     steps:
       - name: Checkout harness repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Bun (pinned)
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/docs/plans/2026-06-05-001-feat-harness-integrate-build-bridge-plan.md
+++ b/docs/plans/2026-06-05-001-feat-harness-integrate-build-bridge-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Harness integrate→build bridge via CI artifact handoff"
 type: feat
-status: active
+status: completed
 date: 2026-06-05
 ---
 
@@ -117,7 +117,7 @@ Fail-hard: integrate `{ok:false}` → no artifact + job fails → `build` never 
 
 ## Implementation Units
 
-- [ ] **Unit 1: `harness integrate` CLI subcommand (runnable entry point)**
+- [x] **Unit 1: `harness integrate` CLI subcommand (runnable entry point)**
 
 **Goal:** Give `runIntegration` a runnable entry point so CI (and a maintainer locally) can drive the merge.
 
@@ -148,7 +148,7 @@ Fail-hard: integrate `{ok:false}` → no artifact + job fails → `build` never 
 
 **Verification:** `harness integrate --help` documents the command; unit tests prove config assembly + exit-code mapping with stubbed adapters; no real merge runs in tests.
 
-- [ ] **Unit 2: Artifact packaging (clean merged source snapshot + provenance)**
+- [x] **Unit 2: Artifact packaging (clean merged source snapshot + provenance)**
 
 **Goal:** After a successful integrate, extract a clean merged source snapshot from the integration commit and package it with `provenance.json` into a single artifact-ready output. The artifact must not contain build products or `.git`.
 
@@ -176,7 +176,7 @@ Fail-hard: integrate `{ok:false}` → no artifact + job fails → `build` never 
 
 **Verification:** packaging only fires on success; artifact contents verified in tests; `.git` and build products excluded; partial/failed packaging leaves no usable artifact.
 
-- [ ] **Unit 3: `build-platform.ts` artifact-extract source path**
+- [x] **Unit 3: `build-platform.ts` artifact-extract source path**
 
 **Goal:** Let the build matrix build from an extracted merged source tree instead of cloning upstream.
 
@@ -204,7 +204,7 @@ Fail-hard: integrate `{ok:false}` → no artifact + job fails → `build` never 
 
 **Verification:** both source modes covered by tests; absent `--source-tree` is byte-identical to current behavior; version correctness without `.git` verified.
 
-- [ ] **Unit 4: `harness-release.yaml` integrate producer job + matrix consumption**
+- [x] **Unit 4: `harness-release.yaml` integrate producer job + matrix consumption**
 
 **Goal:** Add the producer `integrate` job and rewire the matrix to consume its artifact + SHA.
 
@@ -230,7 +230,7 @@ Fail-hard: integrate `{ok:false}` → no artifact + job fails → `build` never 
 
 **Verification:** `actionlint` clean; a `dry_run` dispatch carrying a real integration ref completes integrate→build→assemble green across all four platforms with the artifact handoff; digest check fires before any build.
 
-- [ ] **Unit 5: Docs + runbook update**
+- [x] **Unit 5: Docs + runbook update**
 
 **Goal:** Document the bridge and the new OpenCode-auth secret for operators.
 

--- a/docs/plans/2026-06-05-001-feat-harness-integrate-build-bridge-plan.md
+++ b/docs/plans/2026-06-05-001-feat-harness-integrate-build-bridge-plan.md
@@ -1,0 +1,289 @@
+---
+title: "feat: Harness integrate→build bridge via CI artifact handoff"
+type: feat
+status: active
+date: 2026-06-05
+---
+
+# feat: Harness integrate→build bridge via CI artifact handoff
+
+## Overview
+
+`@fro.bot/harness` ships a native binary (`harness`) that is OpenCode pinned to a stable version plus a small set of LLM-merged upstream patches. Two halves of that pipeline exist but are not connected:
+
+- `packages/harness/src/integrate.ts` (`runIntegration`) clones OpenCode at the base-version tag, fetches the configured patch refs, runs an `opencode run` LLM merge to reason them onto the stable tag, builds, verifies, captures the frozen integration commit SHA, and writes `provenance.json` to its work dir. It has **no runnable entry point** and **never persists the merged tree anywhere** beyond its disposable work dir.
+- `packages/harness/scripts/build-platform.ts` (per-platform native build, run by the `build` matrix in `.github/workflows/harness-release.yaml`) clones `anomalyco/opencode` at an `--integration-commit` and compiles. The LLM-merged commit does not exist on upstream, so the build matrix cannot find it.
+
+This plan connects them with a **CI artifact handoff (Option B)**: a new producer `integrate` job runs the LLM merge once, packages a **clean merged source snapshot** (extracted from the integration commit via `git archive` or equivalent clean checkout) plus the provenance manifest as a workflow artifact, and the `build` matrix downloads + extracts that artifact instead of cloning upstream. Each build-matrix job runs its own clean install + build from that merged source tree (the upstream-matched root install + build sequence from PR #772 still runs per-platform). No mirror repo, no cross-repo push, no write-scoped git token — the integrate job stays read-only against upstream and produces an artifact, not a pushed commit.
+
+The integrate job's own build+verify (Steps 6–7 inside `runIntegration`) is a **pre-flight correctness gate** proving the merge compiles on one platform; its build outputs are discarded, not shipped. The artifact is the clean merged source, not the post-build working tree.
+
+## Problem Frame
+
+A real (patched) harness release is currently impossible to run end-to-end: the integrate engine produces a commit on a throwaway clone that the build matrix cannot reach. The dry-run only passed because it was fed a commit that already exists on upstream (the bare 1.15.13 tag, no patches). The first patched publish is blocked on bridging integrate → build. Option B was chosen over a mirror repo (A) and a single mega-job (C) because it is the simplest path that preserves the producer/build privilege split and needs no new repo or push credentials; the provenance manifest already records integration inputs, so losing durable git history of integrations is acceptable.
+
+## Requirements Trace
+
+- R1. A runnable entry point exists for `runIntegration` (a `harness integrate` CLI subcommand), wired through `cli.ts`, with config sourced from flags/env/`harness.config.json`.
+- R2. The integrate job packages a **clean merged source snapshot** (extracted from the integration commit, e.g. via `git archive <integration_commit>`) plus `provenance.json` into a single uploadable artifact. The artifact excludes `.git` and any build products from the integrate runner's pre-flight build.
+- R3. `build-platform.ts` gains an artifact-extract path that replaces `cloneAndCheckout` when an extracted merged source tree is supplied, building from the merged source at the frozen commit.
+- R4. `harness-release.yaml` gains an `integrate` producer job that runs before `build`, produces the artifact + outputs the integration commit SHA, and the `build`/`publish`/`verify` matrix consumes the artifact + SHA.
+- R5. The integrate job is read-only against upstream (no push, no write token); the LLM merge runs with OpenCode auth provisioned the same way the workspace executor / action provision it (file-based secret, never logged).
+- R6. `dry_run` continues to work end-to-end (integrate + build + assemble, skip publish), and a non-patched run (no integration refs) still produces a valid artifact.
+- R7. The fail-hard contract is preserved: any integrate failure produces no artifact and fails the job; the build matrix never runs against a partial/missing tree.
+- R8. The build matrix verifies the downloaded artifact matches the declared integration commit / digest before compiling (no silent build of a stale or wrong tree). Because the artifact is produced via `git archive <integration_commit>`, it is inherently SHA-bound; the digest check makes this explicit and fail-closed.
+- R9. Merged refs come only from the `harness.config.json` carry-policy allowlist (no arbitrary ref input at dispatch); the release is maintainer-gated manual `workflow_dispatch`; the provenance manifest records the exact upstream inputs (base tag + each ref + resolved SHA) and is included in the artifact for audit before publish.
+
+## Scope Boundaries
+
+- Not building a `fro-bot/opencode` mirror repo or any cross-repo git push (explicitly rejected in favor of B).
+- Not changing the carry policy or which patch refs are carried (config-driven; `harness.config.json` already holds the ref set).
+- Not changing trusted publishing / OIDC (already shipped and proven).
+- Not changing the native-build internals (Bun pin, root install, upstream-matched build invocation) — those landed in PR #772.
+
+### Deferred to Separate Tasks
+
+- First actual patched release carrying PR #30182 onto 1.15.13: separate operator-driven dispatch after this bridge merges.
+- Per-ref SHA resolution in the provenance manifest (currently all refs share the integration commit): future iteration, noted in `integrate.ts`.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/harness/src/cli.ts:147-167` — subcommand dispatch (`info`/`patches`/`doctor` via `if` chain, then `cmdPassthrough`). New `integrate` branch mirrors this; `cmdDoctor` (returns `number`, never throws) is the error-handling precedent. `main()` must `await` an async `cmdIntegrate`.
+- `packages/harness/src/integrate.ts:44-53` — `IntegrationConfig` fields the CLI must supply: `baseVersion`, `releaseRepo`, `integrationRefs`, `agent`, `model`, `opencodeBin`, `workDir`, `promptPath`. `:264-368` `runIntegration` returns `{ok, manifest}`, writes `provenance.json` to `workDir`, does NOT push. `:176-240` `makeRealAdapters`.
+- `packages/harness/harness.config.json:2-8` — source of `baseVersion`/`releaseRepo`/`integrationRefs`/`agent`/`model`/`opencodeBin`. `promptPath` + `workDir` are CLI/runtime-owned.
+- `packages/harness/scripts/build-platform.ts:175` `cloneAndCheckout(repoUrl, workDir, commit)` — the exact seam Option B replaces with an extract-or-reuse path; `:96-97` `--repo-url`/`--work-dir` flag defaults.
+- `.github/workflows/harness-release.yaml:41-61` build matrix, `:90-148` params→`build-platform` arg flow, `:175-188` publish job (`needs: build`, `id-token: write`), `:399-402` dry-run assemble path.
+- `apps/workspace-agent` OpenCode auth provisioning (file-based secret, 0600, never logged) — the pattern for giving the integrate job model credentials.
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/delivery-mode-contract-for-manual-triggers-2026-04-17.md` — make the workflow contract explicit and surface resolved values as job outputs rather than letting the model choose delivery shape. Applies to the integrate job emitting the integration commit SHA as a declared output.
+- `docs/solutions/best-practices/gateway-opencode-mention-loop-best-practices-2026-05-30.md` + `workspace-executor-opencode-provisioning-best-practices-2026-06-01.md` — non-interactive `opencode run`, file-based auth, never log token/body. Applies to R5.
+- `docs/solutions/build-errors/tool-binary-caching-ephemeral-runners.md` — producer-does-setup-once, consumers-reuse mindset; informs the integrate→matrix artifact handoff contract.
+
+## Key Technical Decisions
+
+- **Artifact handoff over mirror push (Option B):** producer job uploads merged source tree + `provenance.json`; build matrix downloads + extracts. Simplest correct bridge; no new repo, no push token, smaller security surface.
+- **Artifact contents = a clean merged source snapshot extracted from the integration commit (e.g. `git archive <integration_commit>`), NOT the post-build working tree.** The integrate job's own build+verify (Steps 6–7 inside `runIntegration`) is a pre-flight correctness gate on one platform; its build outputs are discarded. Packaging the post-build working tree would poison all four cross-platform builds with platform-specific native deps and `node_modules`. The clean merged source tree excludes `.git` (keeping the artifact small) and carries `provenance.json`. The integration commit SHA travels as a job output + inside the manifest, not via git history.
+- **`build-platform.ts` gains an artifact-aware path, not a removal of clone.** When the workflow supplies an extracted merged source tree, `cloneAndCheckout` is bypassed; the existing clone path stays for local/standalone runs. Selection via a new **`--source-tree <dir>` flag** — this is the resolved decision (see below).
+- **`--source-tree <dir>` is an explicit new flag, not `--work-dir` reuse.** Using a dedicated flag makes the build-from-supplied-source intent unambiguous and fail-closed when the directory is missing, and keeps the standalone clone path untouched. The `--work-dir` reuse branch in `build-platform.ts:176-181` is left unchanged.
+- **Artifact integrity: SHA-bound by construction + explicit digest check.** Because the artifact is produced via `git archive <integration_commit>`, it is inherently bound to that commit. The build matrix additionally verifies the downloaded artifact's digest against the declared digest before compiling (R8), making the check explicit and fail-closed.
+- **Supply-chain gating as hard controls (R9):** (a) merged refs come only from the `harness.config.json` carry-policy allowlist — no arbitrary ref input at dispatch; (b) the release is maintainer-gated manual `workflow_dispatch`; (c) the provenance manifest records the exact upstream inputs (base tag + each ref + resolved SHA) and is included in the artifact for audit before publish.
+- **Integrate job is read-only + auth-scoped:** `contents: read`, no `id-token`, OpenCode model auth from a secret file (mirroring workspace executor), token/body never logged.
+- **Fail-hard preserved:** integrate writes the artifact only on `{ok:true}`; `build` `needs: integrate`, so a failed merge produces no artifact and the matrix never starts.
+- **CLI config sourcing:** `integrate` reads `harness.config.json` for the ref set/agent/model/base-version, takes `--work-dir`/`--prompt-path`/`--out` as flags, and `opencodeBin` defaults to `opencode` on PATH (the harness/stock binary). No secrets in flags.
+
+## Open Questions
+
+### Resolved During Planning
+
+- How does the commit reach the build jobs? → CI artifact (B), not git push.
+- Does the artifact need `.git`? → No (verified): upstream `build.ts` reads `OPENCODE_VERSION` from env and bakes it via a compile-time define; it does NOT shell out to git. And `build-platform.ts` derives the `+harness.<short8>` version purely from the `--integration-commit` arg via `buildHarnessVersion` (`src/version.ts`), not `git rev-parse`. So a clean `git archive` source (no `.git`) builds and versions correctly.
+- Where does model auth come from in the integrate job? → File-based secret, workspace-executor pattern, never logged.
+- Should `--source-tree` be a new flag or `--work-dir` reuse? → Resolved: explicit `--source-tree <dir>` flag. Makes the build-from-supplied-source intent unambiguous and fail-closed when the dir is missing; keeps the standalone clone path untouched.
+
+### Deferred to Implementation
+
+- Exact artifact packaging mechanism (tar vs `actions/upload-artifact` directory upload) and whether `build-platform.ts` consumes an extracted dir or a tarball — decided against the real `cloneAndCheckout`/arg shape during Unit 2/3.
+- Artifact size/retention tuning — observed empirically on the first real dispatch.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+harness-release.yaml (workflow_dispatch)
+  job: integrate            [contents: read, no id-token, opencode-auth secret file]
+    harness integrate --work-dir W --prompt-path P --out ARTIFACT
+      └─ runIntegration(): clone upstream@tag → fetch refs → LLM merge → build (pre-flight gate) → verify
+                           → capture integrationCommit → write provenance.json
+                           → discard build outputs; extract clean merged source tree via git archive
+      └─ package merged source tree (no .git, no build products) + provenance.json → upload-artifact "integration-tree"
+      └─ output: integration_commit=<sha>, artifact_digest=<digest>
+        │
+        ▼ needs: integrate   (matrix consumes artifact + sha + digest)
+  job: build (matrix linux/darwin × x64/arm64)   [contents: read]
+    download-artifact "integration-tree" → verify digest → extract into source dir
+    build-platform.ts --source-tree <extracted> --integration-commit <sha> ...
+      └─ (bypasses cloneAndCheckout; runs own clean install + build from merged source tree) → per-platform binary
+        │
+        ▼ needs: build
+  job: publish    [id-token: write]   (skipped when dry_run)
+```
+
+Fail-hard: integrate `{ok:false}` → no artifact + job fails → `build` never starts.
+
+## Implementation Units
+
+- [ ] **Unit 1: `harness integrate` CLI subcommand (runnable entry point)**
+
+**Goal:** Give `runIntegration` a runnable entry point so CI (and a maintainer locally) can drive the merge.
+
+**Requirements:** R1, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/harness/src/cli.ts`
+- Create: `packages/harness/src/integrate-command.ts` (assembles `IntegrationConfig` from `harness.config.json` + flags, calls `runIntegration(config, makeRealAdapters())`, maps result→exit code)
+- Modify: `packages/harness/src/cli.test.ts`
+- Create: `packages/harness/src/integrate-command.test.ts`
+
+**Approach:**
+- Add an `integrate` branch in the `cli.ts` dispatch chain (before passthrough), mirroring the `doctor` pattern but async; `main()` awaits it.
+- `integrate-command.ts` reads `harness.config.json` (baseVersion/releaseRepo/integrationRefs/agent/model/opencodeBin), takes `--work-dir`, `--prompt-path`, `--out` flags, defaults `opencodeBin` to `opencode`. No secrets in flags.
+- Map `{ok:true}`→0, `{ok:false}`→1 with a one-line error (no token/body in output).
+- Add `integrate` to usage text and update the reserved-set assertion in `cli.test.ts`.
+
+**Patterns to follow:** `cli.ts:159-162` (`cmdDoctor` exit-code return), `integrate.ts:176` `makeRealAdapters`.
+
+**Test scenarios:**
+- Happy path: valid config + flags → `runIntegration` invoked with the assembled `IntegrationConfig`, exit 0 on `{ok:true}` (adapters stubbed).
+- Error path: `{ok:false}` from `runIntegration` → exit 1, error line printed, no stack/secret leakage.
+- Edge case: missing required flag (`--work-dir`) → usage error, exit non-zero.
+- Config sourcing: integration refs/agent/model read from `harness.config.json` (not hardcoded).
+- Reserved-set test in `cli.test.ts` updated to include `integrate`.
+
+**Verification:** `harness integrate --help` documents the command; unit tests prove config assembly + exit-code mapping with stubbed adapters; no real merge runs in tests.
+
+- [ ] **Unit 2: Artifact packaging (clean merged source snapshot + provenance)**
+
+**Goal:** After a successful integrate, extract a clean merged source snapshot from the integration commit and package it with `provenance.json` into a single artifact-ready output. The artifact must not contain build products or `.git`.
+
+**Requirements:** R2, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/harness/src/integrate-command.ts` (add `--out`-driven packaging step after `{ok:true}`)
+- Modify: `packages/harness/src/integrate-command.test.ts`
+
+**Approach:**
+- On `{ok:true}` only, extract a clean merged source tree from the integration commit (e.g. `git archive <integrationCommit>`) into a staging path, add `provenance.json`, then **atomically finalize** — write the archive to a temp path first, move/rename to the `--out` path only after the archive completes successfully. A mid-step failure must leave no usable artifact at the `--out` path.
+- On `{ok:false}`, produce nothing (fail-hard; the artifact's absence is the signal).
+- The integration commit SHA is emitted to stdout/`GITHUB_OUTPUT` in Unit 4; here just ensure the manifest (which contains it) is included.
+
+**Patterns to follow:** existing fs/spawn helpers in `integrate.ts`/`build-platform.ts`; `provenance.json` filename from `integrate.ts:90-99`.
+
+**Test scenarios:**
+- Happy path: `{ok:true}` → artifact contains merged source tree + `provenance.json`, excludes `.git`, excludes build products.
+- Error path: `{ok:false}` → no artifact written.
+- Edge case: `--out` path parent missing → created or clean error.
+- Edge case: packaging fails mid-step (e.g. archive write interrupted) → no partial artifact left at the `--out` path (atomic staging verified).
+- Integration: `provenance.json` in the artifact carries the same `integrationCommit` the command reports.
+
+**Verification:** packaging only fires on success; artifact contents verified in tests; `.git` and build products excluded; partial/failed packaging leaves no usable artifact.
+
+- [ ] **Unit 3: `build-platform.ts` artifact-extract source path**
+
+**Goal:** Let the build matrix build from an extracted merged source tree instead of cloning upstream.
+
+**Requirements:** R3, R6
+
+**Dependencies:** Unit 2 (artifact shape known)
+
+**Files:**
+- Modify: `packages/harness/scripts/build-platform.ts`
+- Modify: `packages/harness/scripts/build-platform.test.ts`
+
+**Approach:**
+- Add a source-tree mode via the new `--source-tree <dir>` flag: when supplied, skip `cloneAndCheckout` and build the supplied merged source tree at `--integration-commit`. Each build-matrix job runs its own clean install + build from the extracted merged source tree (the upstream-matched root install + build sequence from PR #772 runs per-platform as before).
+- Preserve the existing clone path for standalone/local runs (no behavior change when `--source-tree` absent).
+- Keep `--integration-commit` required (used for the `+harness.<short8>` version string via `buildHarnessVersion` in `src/version.ts`, regardless of source — version derivation is pure-from-arg, never shells to git).
+
+**Patterns to follow:** `build-platform.ts:77-107` `parseArgs`, `:175-184` `cloneAndCheckout`.
+
+**Test scenarios:**
+- Happy path: `--source-tree` supplied → `cloneAndCheckout` bypassed, build runs against the supplied dir.
+- Backward-compat: no `--source-tree` → existing clone path unchanged.
+- Edge case: `--source-tree` dir missing/empty → clean fail (no silent fallback to clone).
+- Arg parsing: `--source-tree` parsed; `--integration-commit` still required.
+- Edge case: source-tree mode with NO `.git` present still produces the correct `+harness.<short8>` version (proves version derivation is pure-from-arg via `buildHarnessVersion`, never shells to git).
+
+**Verification:** both source modes covered by tests; absent `--source-tree` is byte-identical to current behavior; version correctness without `.git` verified.
+
+- [ ] **Unit 4: `harness-release.yaml` integrate producer job + matrix consumption**
+
+**Goal:** Add the producer `integrate` job and rewire the matrix to consume its artifact + SHA.
+
+**Requirements:** R4, R5, R6, R7, R8, R9
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Modify: `.github/workflows/harness-release.yaml`
+
+**Approach:**
+- New `integrate` job (runs first, `contents: read`, no `id-token`): checkout, setup Bun/pnpm, provision OpenCode model auth from a secret file (workspace-executor pattern, never logged), run `harness integrate --work-dir … --prompt-path … --out integration-tree.tar`, `actions/upload-artifact` the tree, and emit `integration_commit` and `artifact_digest` as job outputs (read from `provenance.json` / computed from the archive).
+- `build` matrix gains `needs: integrate`, `actions/download-artifact` + **verify artifact digest** before extracting (R8), then passes `--source-tree <extracted>` and `--integration-commit ${{ needs.integrate.outputs.integration_commit }}` to `build-platform.ts` (replacing the hardcoded `--repo-url anomalyco/opencode`).
+- Merged refs come only from the `harness.config.json` carry-policy allowlist — no arbitrary ref input at dispatch (R9).
+- `verify-binary`/`publish` consume the same SHA output.
+- `dry_run` path: integrate + build + assemble run; publish still gated off.
+- Fail-hard: `build needs: integrate` so a failed merge stops the matrix.
+- Add the OpenCode-auth secret to the documented required secrets (runbook in Unit 5).
+
+**Patterns to follow:** params-step→output pattern (`harness-release.yaml:90-131`); workspace-executor auth provisioning; `actions/upload-artifact`/`download-artifact` conventions already used elsewhere in `.github/workflows/`.
+
+**Test scenarios:** Test expectation: none — workflow YAML; validated by `actionlint` + a real `dry_run` dispatch (the end-to-end proof, per the existing dry-run convention). The matrix-build behavior is covered by Unit 3 unit tests. Digest verification step confirmed present in the workflow before extract.
+
+**Verification:** `actionlint` clean; a `dry_run` dispatch carrying a real integration ref completes integrate→build→assemble green across all four platforms with the artifact handoff; digest check fires before any build.
+
+- [ ] **Unit 5: Docs + runbook update**
+
+**Goal:** Document the bridge and the new OpenCode-auth secret for operators.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 4
+
+**Files:**
+- Modify: `packages/harness/AGENTS.md`
+- Modify: `packages/harness/BOOTSTRAP.md` (it currently names a mirror repo as the intended fix — correct it to the artifact-handoff model; this correction is **required**)
+- Modify: `packages/harness/README.md` (only if it describes the release flow; conditional, not mandatory)
+
+**Approach:**
+- Replace any mirror-repo language with the artifact-handoff description.
+- Document the OpenCode-auth secret the integrate job needs and how to dispatch a real (patched) release vs a dry-run.
+- Remove plan/taxonomy language; operator-facing only.
+
+**Patterns to follow:** existing `BOOTSTRAP.md` tone; the workspace-executor secret docs.
+
+**Test scenarios:** Test expectation: none — documentation.
+
+**Verification:** docs describe the real shipped flow; no mirror-repo references remain; no plan-speak.
+
+## System-Wide Impact
+
+- **Interaction graph:** `harness-release.yaml` gains a job dependency edge (`build needs: integrate`); `build-platform.ts` gains a branch; `cli.ts` gains a subcommand. No runtime/action/gateway code touched.
+- **Error propagation:** integrate `{ok:false}` → no artifact + job failure → matrix never starts (fail-hard preserved end-to-end).
+- **State lifecycle risks:** artifact is per-run and ephemeral; no shared/persistent state introduced. Work dir is disposable. The artifact is a clean merged source snapshot — no build products, no platform-specific native deps, no `.git`.
+- **API surface parity:** `build-platform.ts` keeps the clone path for standalone runs — no regression to the local/dry-run-with-real-commit path proven in PR #772.
+- **Unchanged invariants:** native-build internals (Bun pin, root install, upstream-matched invocation), trusted publishing/OIDC, the privilege split (publish keeps `id-token`, build/integrate stay `contents: read`). The integrate job adds NO write-scoped git token.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| LLM merge non-determinism in CI produces a bad merged source tree | `runIntegration` already builds + verifies (pre-flight gate) before capturing the commit; fail-hard means a bad merge yields no artifact. Maintainer-gated manual dispatch. |
+| Artifact size (full OpenCode source tree) slows the matrix | Exclude `.git` and build products; observe size on first dispatch; tune retention. Acceptable for a manual, infrequent release workflow. |
+| OpenCode auth secret leakage in integrate job logs | File-based secret, never echoed; mirrors the proven workspace-executor pattern; token/body never logged. |
+| `--source-tree` mode silently falling back to clone hides a broken artifact | Fail-closed when `--source-tree` is supplied but missing/empty (Unit 3 test). |
+| Provenance manifest not in artifact → lost audit trail | Unit 2 test asserts `provenance.json` is included with the matching `integrationCommit`. |
+| Partial/failed packaging leaves a corrupt artifact for upload | Atomic staging: archive written to temp path, moved to `--out` only on success (Unit 2 test). |
+| Build matrix silently builds a stale or wrong merged source tree | Artifact is SHA-bound by construction (`git archive <integration_commit>`); build matrix verifies digest before compiling (R8). |
+| Arbitrary ref injection via dispatch input bypasses carry policy | Merged refs come only from `harness.config.json` allowlist; no free-form ref input at dispatch; maintainer-gated `workflow_dispatch` (R9). |
+
+## Documentation / Operational Notes
+
+- Operators dispatch `harness-release.yaml` (`workflow_dispatch`); a real patched release needs the OpenCode-auth secret configured. Dry-run still needs no publish credentials.
+- Merged refs are drawn exclusively from the `harness.config.json` carry-policy allowlist — no arbitrary ref can be injected at dispatch time. The release is maintainer-gated.
+- The provenance manifest included in the artifact records the exact upstream inputs (base tag + each ref + resolved SHA) and should be reviewed before publish.
+- This plan unblocks the deferred "first patched release carrying PR #30182" — that remains a separate operator dispatch after merge.
+
+## Sources & References
+
+- Related code: `packages/harness/src/integrate.ts`, `packages/harness/src/cli.ts`, `packages/harness/scripts/build-platform.ts`, `.github/workflows/harness-release.yaml`
+- Related: `packages/harness/BOOTSTRAP.md` (mirror language to correct), PR #772 (native-build fixes), PR #771 (bootstrap runbook)
+- Prior art: `prepare-release-pr.yaml` / `auto-release.yaml` (job-output + auth patterns, though no push needed here)

--- a/packages/harness/AGENTS.md
+++ b/packages/harness/AGENTS.md
@@ -38,9 +38,75 @@ Each per-platform package contains only that platform's native binary. The main 
 
 The per-platform packages are **not listed in the source `package.json` `optionalDependencies`** — that keeps the workspace `pnpm-lock.yaml` clean (the packages only exist on npm after a release). The release workflow **injects** `optionalDependencies` (pinned to the release version) into the published main package's `package.json` at publish time.
 
+## Integrate→Build Bridge
+
+The release workflow connects the LLM merge engine to the per-platform build matrix via a **CI artifact handoff**:
+
+### `integrate` job (producer)
+
+Runs first. Permissions: `contents: read`, no `id-token`. Steps:
+
+1. Runs `harness integrate --work-dir W --prompt-path P --out integration-tree.tar`, which calls `runIntegration()`: clones `anomalyco/opencode` at the configured base version tag, fetches the integration refs from `harness.config.json`, runs an LLM merge via `opencode run`, builds and verifies the result as a pre-flight correctness gate, then captures the frozen integration commit SHA.
+2. Extracts a **clean merged source snapshot** from the integration commit via `git archive` — no `.git`, no build products from the pre-flight build.
+3. Packages the clean source tree + `provenance.json` into the artifact and uploads it as `integration-tree`.
+4. Emits `integration_commit` (the frozen SHA) and `artifact_digest` as job outputs.
+
+The integrate job is read-only against upstream. OpenCode model credentials come from the `HARNESS_OPENCODE_AUTH_JSON` secret (see below) — written to a 0600 temp file, never logged.
+
+Fail-hard: if `runIntegration()` returns `{ok: false}`, no artifact is written and the job fails. The build matrix never starts against a missing or partial artifact.
+
+### `build` matrix (consumer)
+
+Each platform job (`needs: integrate`):
+
+1. Downloads the `integration-tree` artifact.
+2. Verifies the artifact digest against `needs.integrate.outputs.artifact_digest` before extracting — fail-closed on mismatch.
+3. Extracts the merged source tree.
+4. Runs `build-platform.ts --source-tree <extracted> --integration-commit <sha>`, which bypasses `cloneAndCheckout` and builds from the supplied merged source tree. Each platform job runs its own clean install + build from that tree.
+
+The `--source-tree` flag is explicit and fail-closed: if the directory is missing or empty, the build fails rather than silently falling back to a clone.
+
+### Supply-chain controls
+
+- Merged refs come **only** from the `harness.config.json` carry-policy allowlist — no arbitrary ref can be injected at dispatch time.
+- The release is maintainer-gated `workflow_dispatch`.
+- `provenance.json` in the artifact records the exact upstream inputs (base tag + each ref + resolved SHA) for audit before publish.
+- The artifact is SHA-bound by construction (`git archive <integration_commit>`); the explicit digest check in the build matrix makes this fail-closed.
+
+### `HARNESS_OPENCODE_AUTH_JSON` secret
+
+Required for any release that runs an LLM merge (i.e. any release with integration refs configured). Configure in repository Settings → Secrets and variables → Actions:
+
+- **Name:** `HARNESS_OPENCODE_AUTH_JSON`
+- **Value:** JSON mapping provider to auth config:
+  ```json
+  {"anthropic":{"type":"api","key":"sk-ant-..."}}
+  ```
+
+The integrate job writes this to a 0600 temp file and passes it to OpenCode as a file-based credential. The value is never echoed to logs or included in any artifact.
+
+### Dispatching a release
+
+**Dry run** (validate build infrastructure, skip publish):
+```bash
+gh workflow run harness-release.yaml \
+  --repo fro-bot/agent \
+  --field base_version=1.15.13 \
+  --field dry_run=true
+```
+
+**Real patched release** (requires `HARNESS_OPENCODE_AUTH_JSON` configured):
+```bash
+gh workflow run harness-release.yaml \
+  --repo fro-bot/agent \
+  --field base_version=1.15.13
+```
+
+The publish job is additionally gated by the `npm-publish` GitHub environment (required reviewers). Review `provenance.json` from the artifact before approving.
+
 ## Publishing
 
-The packages are published to npm via **trusted publishing (OIDC)** from the release workflow (`.github/workflows/harness-release.yaml`) — no long-lived npm token. The workflow has `id-token: write`, upgrades npm to a trusted-publishing-capable version (npm ≥ 11.5.0; Node 24 ships an older npm), and runs a bare `npm publish` (provenance is automatic under OIDC; `--provenance`/`--access` flags are not needed — access is set via each package's `publishConfig`).
+The packages are published to npm via **trusted publishing (OIDC)** from the release workflow (`.github/workflows/harness-release.yaml`) — no long-lived npm token. The workflow has `id-token: write` scoped to the `publish` job only; the `integrate` and `build` jobs run with `contents: read` and no `id-token`. The workflow upgrades npm to a trusted-publishing-capable version (npm ≥ 11.5.0; Node 24 ships an older npm), and runs a bare `npm publish` (provenance is automatic under OIDC; `--provenance`/`--access` flags are not needed — access is set via each package's `publishConfig`).
 
 ### One-time npmjs.com setup (per package)
 

--- a/packages/harness/BOOTSTRAP.md
+++ b/packages/harness/BOOTSTRAP.md
@@ -78,19 +78,18 @@ Repeat for each package:
 
 ---
 
-## Step 3 — Validate the pipeline with a dry run (no LLM merge, no token)
+## Step 3 — Validate the pipeline with a dry run (no publish credentials needed)
 
-Before doing any real release, validate that the native-build matrix, binary verification, and package assembly all work end-to-end. This dry run uses a real upstream OpenCode commit (no LLM-merge patch applied) so `build-platform.ts` can clone it directly from `anomalyco/opencode`.
+Before doing any real release, validate that the integrate job, native-build matrix, binary verification, and package assembly all work end-to-end. A dry run with no integration refs configured (stock OpenCode, no LLM-merge patch) does not require `HARNESS_OPENCODE_AUTH_JSON`.
 
 ```bash
 gh workflow run harness-release.yaml \
   --repo fro-bot/agent \
-  --field integration_commit=385cb694419f98103af0e8fc6187ddcbcbb6eecb \
   --field base_version=1.15.13 \
   --field dry_run=true
 ```
 
-This triggers the full build matrix across all four platforms (linux/x64, linux/arm64, darwin/x64, darwin/arm64), runs `verify-binary.ts` on each output, assembles the per-platform packages, and then **skips the npm publish step** (`dry_run=true`). The publish job is also gated by the `npm-publish` GitHub environment (required reviewers), so even without `dry_run=true`, a human must approve before anything reaches npm.
+This triggers the `integrate` job (which produces the merged source artifact), then the full build matrix across all four platforms (linux/x64, linux/arm64, darwin/x64, darwin/arm64), runs `verify-binary.ts` on each output, assembles the per-platform packages, and then **skips the npm publish step** (`dry_run=true`). The publish job is also gated by the `npm-publish` GitHub environment (required reviewers), so even without `dry_run=true`, a human must approve before anything reaches npm.
 
 Watch the run:
 
@@ -102,18 +101,53 @@ A green dry run means the build infrastructure is solid and the real `1.15.13` p
 
 ---
 
-## What's still blocked — a real patched release
+## Dispatching a real patched release
 
-The dry run above uses a stock OpenCode commit with no LLM-merge patch. A real patched release (the actual point of this package) needs an **integrate→build bridge** that doesn't exist yet:
+The dry run above uses a stock OpenCode commit with no LLM-merge patch. A real patched release (the actual point of this package) requires the `HARNESS_OPENCODE_AUTH_JSON` secret to be configured in the repository, because the `integrate` job runs an LLM merge via `opencode run` and needs model credentials.
 
-- `packages/harness/scripts/build-platform.ts` clones `anomalyco/opencode` and checks out the integration commit.
-- The LLM-merge integration commit only exists locally after `harness integrate` runs — it is never pushed anywhere `build-platform.ts` can reach.
-- The fix is a `fro-bot/opencode` mirror repo wired into the workflow: the integrate runner pushes the frozen integration commit there, and `build-platform.ts` clones from `fro-bot/opencode` instead of `anomalyco/opencode`.
+### Required secret: `HARNESS_OPENCODE_AUTH_JSON`
 
-This is separate, larger work. Until that bridge exists, the workflow can build and publish stock OpenCode at any upstream tag, but cannot publish a patched build.
+Add this secret to the `fro-bot/agent` repository (Settings → Secrets and variables → Actions → New repository secret):
+
+- **Name:** `HARNESS_OPENCODE_AUTH_JSON`
+- **Value:** A JSON object mapping provider name to auth config, e.g.:
+  ```json
+  {"anthropic":{"type":"api","key":"sk-ant-..."}}
+  ```
+
+The integrate job writes this to a 0600 temp file and passes it to OpenCode as a file-based credential. The secret value is never echoed to logs.
+
+### How a patched release works
+
+When `harness-release.yaml` is dispatched, the workflow runs in two stages:
+
+1. **`integrate` job** — runs `harness integrate`, which clones `anomalyco/opencode` at the configured base version tag, fetches the integration refs listed in `harness.config.json`, and runs an LLM merge to carry those refs onto the tag. On success it extracts a clean merged source snapshot (via `git archive`) — no `.git`, no build products — packages it with `provenance.json`, and uploads the result as the `integration-tree` workflow artifact. The integration commit SHA and artifact digest are emitted as job outputs.
+
+2. **`build` matrix** — each platform job downloads the `integration-tree` artifact, verifies its digest against the declared value, extracts the merged source tree, and builds the native binary from that tree using `build-platform.ts --source-tree <extracted>`. No upstream clone happens in the build matrix; all four platforms build from the same frozen merged source snapshot.
+
+The `publish` job runs after the matrix and is gated by the `npm-publish` GitHub environment (required reviewers). It obtains an OIDC token and publishes to npm with automatic provenance — no npm token.
+
+Merged refs come exclusively from the `harness.config.json` carry-policy allowlist. No arbitrary ref can be injected at dispatch time. The `provenance.json` included in the artifact records the exact upstream inputs (base tag + each ref + resolved SHA) and should be reviewed before approving the publish gate.
+
+### Dry run (no publish credentials needed)
+
+A dry run still works without `HARNESS_OPENCODE_AUTH_JSON` **only if no integration refs are configured** (i.e. a stock OpenCode build). For a patched dry run the secret is still required — the integrate job runs the LLM merge regardless of `dry_run`. The `dry_run=true` flag skips the publish step only; integrate and build always run.
+
+```bash
+gh workflow run harness-release.yaml \
+  --repo fro-bot/agent \
+  --field base_version=1.15.13 \
+  --field dry_run=true
+```
+
+Watch the run:
+
+```bash
+gh run watch --repo fro-bot/agent
+```
 
 ---
 
 ## After bootstrap
 
-Every subsequent release is triggered by dispatching `harness-release.yaml` (or pushing a `harness-v*` tag) with the appropriate `integration_commit` and `base_version`. The publish job obtains an OIDC token from GitHub and publishes to npm with automatic provenance — no npm token, no secrets to rotate.
+Every subsequent release is triggered by dispatching `harness-release.yaml` with the appropriate `base_version` (and `dry_run=true` to skip publish). The `integrate` job derives the integration commit from the LLM merge; the `build` matrix consumes the resulting artifact. The `publish` job obtains an OIDC token from GitHub and publishes to npm with automatic provenance — no npm token, no secrets to rotate beyond `HARNESS_OPENCODE_AUTH_JSON`.

--- a/packages/harness/scripts/build-platform.test.ts
+++ b/packages/harness/scripts/build-platform.test.ts
@@ -196,6 +196,28 @@ describe('parseArgs: --source-tree flag', () => {
     expect(result).toBeNull()
   })
 
+  it('fIX 4: returns null when --source-tree is present but has no value (last arg)', () => {
+    // #given — --source-tree is the last arg with no following value
+    const argv = [...BASE_ARGV, '--source-tree']
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then — must fail-closed, not fall back to clone
+    expect(result).toBeNull()
+  })
+
+  it('fIX 4: returns null when --source-tree is followed by another flag token', () => {
+    // #given — --source-tree is followed by another flag (no value)
+    const argv = [...BASE_ARGV, '--source-tree', '--out-dir', '/some/out']
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then — must fail-closed
+    expect(result).toBeNull()
+  })
+
   it('includes all other fields correctly when --source-tree is present', () => {
     // #given
     const argv = [...BASE_ARGV, '--source-tree', '/some/tree', '--out-dir', '/some/out']

--- a/packages/harness/scripts/build-platform.test.ts
+++ b/packages/harness/scripts/build-platform.test.ts
@@ -1,21 +1,32 @@
 /**
- * build-platform.test.ts — drift guard + enforceBunVersion coverage.
+ * build-platform.test.ts — drift guard + enforceBunVersion coverage + source-tree mode.
  *
  * Tests:
  *   1. Drift guard: all `bun-version: X.Y.Z` literals in harness-release.yaml
  *      must equal HARNESS_BUN_VERSION. Catches the original version-drift gap.
  *   2. enforceBunVersion: exact match → no throw/exit; mismatch → process.exit(1);
  *      bun not found → process.exit(1).
+ *   3. parseArgs: --source-tree parsed into BuildArgs; --integration-commit still required.
+ *   4. source-tree mode: --source-tree supplied (dir exists, non-empty) → cloneAndCheckout
+ *      bypassed; build runs against the supplied dir.
+ *   5. backward-compat: no --source-tree → existing clone path unchanged.
+ *   6. fail-closed: --source-tree supplied but dir missing/empty → clean error, non-zero exit,
+ *      no fallback to clone.
+ *   7. version pure-from-arg: source-tree mode with no .git present still produces the correct
+ *      <base>+harness.<short8> version (buildHarnessVersion derives from --integration-commit,
+ *      never shells to git).
  */
 
-import {execFileSync} from 'node:child_process'
-import {readFileSync} from 'node:fs'
+import type {BuildArgs} from './build-platform.js'
+import {execFileSync, spawnSync} from 'node:child_process'
+import {readdirSync, readFileSync, statSync} from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import {fileURLToPath} from 'node:url'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {HARNESS_BUN_VERSION} from '../src/bun-version.js'
-import {enforceBunVersion} from './build-platform.js'
+import {buildHarnessVersion} from '../src/version.js'
+import {cloneAndCheckout, enforceBunVersion, main, parseArgs, runUpstreamBuild} from './build-platform.js'
 
 // ---------------------------------------------------------------------------
 // Drift guard
@@ -47,7 +58,7 @@ describe('drift guard: harness-release.yaml bun-version literals', () => {
 })
 
 // ---------------------------------------------------------------------------
-// enforceBunVersion
+// Module-level mocks (hoisted by Vitest)
 // ---------------------------------------------------------------------------
 
 vi.mock('node:child_process', async importOriginal => {
@@ -55,8 +66,25 @@ vi.mock('node:child_process', async importOriginal => {
   return {
     ...actual,
     execFileSync: vi.fn(),
+    spawnSync: vi.fn(),
   }
 })
+
+vi.mock('node:fs', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    statSync: vi.fn(),
+    readdirSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    cpSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// enforceBunVersion
+// ---------------------------------------------------------------------------
 
 describe('enforceBunVersion', () => {
   const mockedExecFileSync = vi.mocked(execFileSync)
@@ -104,5 +132,486 @@ describe('enforceBunVersion', () => {
     // #when / #then — must call process.exit(1)
     expect(() => enforceBunVersion()).toThrow('process.exit called with code 1')
     expect(exitSpy.mock.calls[0]?.[0]).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseArgs — source-tree flag
+// ---------------------------------------------------------------------------
+
+describe('parseArgs: --source-tree flag', () => {
+  const BASE_ARGV = [
+    'bun',
+    'build-platform.ts',
+    '--integration-commit',
+    'abc12345def67890',
+    '--base-version',
+    '1.15.13',
+    '--platform',
+    'linux',
+    '--arch',
+    'x64',
+  ]
+
+  it('parses --source-tree into BuildArgs.sourceTree', () => {
+    // #given
+    const argv = [...BASE_ARGV, '--source-tree', '/tmp/merged-source']
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then
+    expect(result).not.toBeNull()
+    expect((result as BuildArgs).sourceTree).toBe('/tmp/merged-source')
+  })
+
+  it('sets sourceTree to null when --source-tree is absent', () => {
+    // #given — no --source-tree flag
+    const result = parseArgs(BASE_ARGV)
+
+    // #then
+    expect(result).not.toBeNull()
+    expect((result as BuildArgs).sourceTree).toBeNull()
+  })
+
+  it('still requires --integration-commit even in source-tree mode', () => {
+    // #given — --source-tree present but --integration-commit missing
+    const argv = [
+      'bun',
+      'build-platform.ts',
+      '--base-version',
+      '1.15.13',
+      '--platform',
+      'linux',
+      '--arch',
+      'x64',
+      '--source-tree',
+      '/tmp/merged-source',
+    ]
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then — must return null (missing required arg)
+    expect(result).toBeNull()
+  })
+
+  it('includes all other fields correctly when --source-tree is present', () => {
+    // #given
+    const argv = [...BASE_ARGV, '--source-tree', '/some/tree', '--out-dir', '/some/out']
+
+    // #when
+    const result = parseArgs(argv) as BuildArgs
+
+    // #then
+    expect(result.integrationCommit).toBe('abc12345def67890')
+    expect(result.baseVersion).toBe('1.15.13')
+    expect(result.platform).toBe('linux')
+    expect(result.arch).toBe('x64')
+    expect(result.sourceTree).toBe('/some/tree')
+    expect(result.outDir).toBe('/some/out')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// main() — source-tree mode integration tests
+// ---------------------------------------------------------------------------
+
+describe('main(): source-tree mode', () => {
+  const mockedExecFileSync = vi.mocked(execFileSync)
+  const mockedSpawnSync = vi.mocked(spawnSync)
+  const mockedStatSync = vi.mocked(statSync)
+  const mockedReaddirSync = vi.mocked(readdirSync)
+
+  let exitSpy: {mock: {calls: unknown[][]}}
+
+  // Minimal argv that exercises source-tree mode
+  const SOURCE_TREE_DIR = '/tmp/merged-source-tree'
+  const INTEGRATION_COMMIT = 'abc12345def67890'
+  const BASE_VERSION = '1.15.13'
+
+  const SOURCE_TREE_ARGV = [
+    'bun',
+    'build-platform.ts',
+    '--integration-commit',
+    INTEGRATION_COMMIT,
+    '--base-version',
+    BASE_VERSION,
+    '--platform',
+    'linux',
+    '--arch',
+    'x64',
+    '--source-tree',
+    SOURCE_TREE_DIR,
+    '--out-dir',
+    '/tmp/out',
+  ]
+
+  const CLONE_ARGV = [
+    'bun',
+    'build-platform.ts',
+    '--integration-commit',
+    INTEGRATION_COMMIT,
+    '--base-version',
+    BASE_VERSION,
+    '--platform',
+    'linux',
+    '--arch',
+    'x64',
+    '--out-dir',
+    '/tmp/out',
+  ]
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number | string | null | undefined) => {
+      throw new Error(`process.exit called with code ${_code}`)
+    })
+
+    // Default: bun version check passes
+    mockedExecFileSync.mockImplementation((cmd, args) => {
+      if (cmd === 'bun' && Array.isArray(args) && args[0] === '--version') {
+        return `${HARNESS_BUN_VERSION}\n`
+      }
+      // binary --version check: return the expected harness version
+      return `${buildHarnessVersion(BASE_VERSION, INTEGRATION_COMMIT)}\n`
+    })
+
+    // Default: spawnSync succeeds for all calls
+    mockedSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: '',
+      stderr: '',
+      pid: 1,
+      output: [],
+      signal: null,
+    })
+
+    // Default: statSync returns a directory stat
+    mockedStatSync.mockReturnValue({
+      isDirectory: () => true,
+      isFile: () => false,
+    } as ReturnType<typeof statSync>)
+
+    // Default: readdirSync returns non-empty listing
+    mockedReaddirSync.mockReturnValue(['package.json', 'packages'] as unknown as ReturnType<typeof readdirSync>)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  // -------------------------------------------------------------------------
+  // Happy path: source-tree mode bypasses cloneAndCheckout
+  // -------------------------------------------------------------------------
+
+  it('bypasses cloneAndCheckout when --source-tree is supplied and dir is valid', async () => {
+    // #given — source tree dir exists and is non-empty (mocked above)
+    // Override process.argv for main()
+    const origArgv = process.argv
+    process.argv = SOURCE_TREE_ARGV
+
+    try {
+      // #when — main() should complete without calling git clone
+      await main()
+    } catch (error) {
+      // process.exit throws in our spy; re-throw only if it's not a normal exit
+      if (error instanceof Error && error.message.startsWith('process.exit')) {
+        throw error
+      }
+    } finally {
+      process.argv = origArgv
+    }
+
+    // #then — git clone was NOT called (no spawnSync call with 'git' and 'clone')
+    const gitCloneCalls = mockedSpawnSync.mock.calls.filter(
+      call => call[0] === 'git' && Array.isArray(call[1]) && call[1].includes('clone'),
+    )
+    expect(gitCloneCalls).toHaveLength(0)
+
+    // statSync was called with the source tree dir (validation step)
+    const statCalls = mockedStatSync.mock.calls.filter(call => call[0] === SOURCE_TREE_DIR)
+    expect(statCalls.length).toBeGreaterThan(0)
+  })
+
+  it('runs bun install and build.ts against the source tree dir (not workDir)', async () => {
+    // #given — source tree mode
+    const origArgv = process.argv
+    process.argv = SOURCE_TREE_ARGV
+
+    try {
+      await main()
+    } catch {
+      // ignore process.exit throws from non-critical paths
+    } finally {
+      process.argv = origArgv
+    }
+
+    // #then — bun install was called with cwd = SOURCE_TREE_DIR
+    const bunInstallCalls = mockedSpawnSync.mock.calls.filter(
+      call => call[0] === 'bun' && Array.isArray(call[1]) && call[1].includes('install'),
+    )
+    expect(bunInstallCalls.length).toBeGreaterThan(0)
+    expect((bunInstallCalls[0]?.[2] as {cwd?: string} | undefined)?.cwd).toBe(SOURCE_TREE_DIR)
+
+    // bun build.ts was called with cwd = SOURCE_TREE_DIR
+    const bunBuildCalls = mockedSpawnSync.mock.calls.filter(
+      call =>
+        call[0] === 'bun' &&
+        Array.isArray(call[1]) &&
+        call[1].some((a: unknown) => typeof a === 'string' && a.includes('build.ts')),
+    )
+    expect(bunBuildCalls.length).toBeGreaterThan(0)
+    expect((bunBuildCalls[0]?.[2] as {cwd?: string} | undefined)?.cwd).toBe(SOURCE_TREE_DIR)
+  })
+
+  // -------------------------------------------------------------------------
+  // Backward-compat: no --source-tree → clone path unchanged
+  // -------------------------------------------------------------------------
+
+  it('calls cloneAndCheckout (git operations) when --source-tree is absent', async () => {
+    // #given — no --source-tree flag; git operations succeed
+    // spawnSync('test', ['-d', ...]) returns status 1 so cloneAndCheckout takes the clone branch
+    mockedSpawnSync.mockImplementation((cmd, args) => {
+      if (cmd === 'test' && Array.isArray(args) && args[0] === '-d') {
+        return {status: 1, stdout: '', stderr: '', pid: 1, output: [], signal: null}
+      }
+      return {status: 0, stdout: '', stderr: '', pid: 1, output: [], signal: null}
+    })
+
+    const origArgv = process.argv
+    process.argv = CLONE_ARGV
+
+    try {
+      await main()
+    } catch {
+      // ignore process.exit throws
+    } finally {
+      process.argv = origArgv
+    }
+
+    // #then — git clone WAS called (clone path taken because work dir did not exist)
+    const gitCloneCalls = mockedSpawnSync.mock.calls.filter(
+      call => call[0] === 'git' && Array.isArray(call[1]) && call[1].includes('clone'),
+    )
+    expect(gitCloneCalls.length).toBeGreaterThan(0)
+
+    // statSync was NOT called with a source-tree path (no source-tree validation)
+    const statCalls = mockedStatSync.mock.calls.filter(call => call[0] === SOURCE_TREE_DIR)
+    expect(statCalls).toHaveLength(0)
+  })
+
+  // -------------------------------------------------------------------------
+  // Fail-closed: missing source tree dir
+  // -------------------------------------------------------------------------
+
+  it('exits non-zero and does NOT fall back to clone when --source-tree dir is missing', async () => {
+    // #given — statSync throws ENOENT
+    mockedStatSync.mockImplementation(() => {
+      const err = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException
+      err.code = 'ENOENT'
+      throw err
+    })
+
+    const origArgv = process.argv
+    process.argv = SOURCE_TREE_ARGV
+
+    // #when / #then — must call process.exit(1)
+    await expect(async () => {
+      process.argv = SOURCE_TREE_ARGV
+      await main()
+    }).rejects.toThrow('process.exit called with code 1')
+
+    process.argv = origArgv
+
+    // git clone was NOT called (no silent fallback)
+    const gitCloneCalls = mockedSpawnSync.mock.calls.filter(
+      call => call[0] === 'git' && Array.isArray(call[1]) && call[1].includes('clone'),
+    )
+    expect(gitCloneCalls).toHaveLength(0)
+
+    // process.exit(1) was called
+    expect(exitSpy.mock.calls[0]?.[0]).toBe(1)
+  })
+
+  it('exits non-zero and does NOT fall back to clone when --source-tree dir is empty', async () => {
+    // #given — dir exists but is empty
+    mockedStatSync.mockReturnValue({
+      isDirectory: () => true,
+      isFile: () => false,
+    } as ReturnType<typeof statSync>)
+    mockedReaddirSync.mockReturnValue([])
+
+    const origArgv = process.argv
+    process.argv = SOURCE_TREE_ARGV
+
+    // #when / #then — must call process.exit(1)
+    await expect(async () => {
+      process.argv = SOURCE_TREE_ARGV
+      await main()
+    }).rejects.toThrow('process.exit called with code 1')
+
+    process.argv = origArgv
+
+    // git clone was NOT called
+    const gitCloneCalls = mockedSpawnSync.mock.calls.filter(
+      call => call[0] === 'git' && Array.isArray(call[1]) && call[1].includes('clone'),
+    )
+    expect(gitCloneCalls).toHaveLength(0)
+
+    expect(exitSpy.mock.calls[0]?.[0]).toBe(1)
+  })
+
+  it('exits non-zero when --source-tree path exists but is not a directory', async () => {
+    // #given — path is a file, not a directory
+    mockedStatSync.mockReturnValue({
+      isDirectory: () => false,
+      isFile: () => true,
+    } as ReturnType<typeof statSync>)
+
+    const origArgv = process.argv
+    process.argv = SOURCE_TREE_ARGV
+
+    await expect(async () => {
+      process.argv = SOURCE_TREE_ARGV
+      await main()
+    }).rejects.toThrow('process.exit called with code 1')
+
+    process.argv = origArgv
+    expect(exitSpy.mock.calls[0]?.[0]).toBe(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // Version pure-from-arg: no .git needed
+  // -------------------------------------------------------------------------
+
+  it('produces the correct +harness.<short8> version from --integration-commit without any git rev-parse', async () => {
+    // #given — source tree mode; no .git present (statSync/readdirSync mocked, no git calls)
+    const origArgv = process.argv
+    process.argv = SOURCE_TREE_ARGV
+
+    try {
+      await main()
+    } catch {
+      // ignore process.exit throws from non-critical paths
+    } finally {
+      process.argv = origArgv
+    }
+
+    // #then — no git rev-parse was called
+    const gitRevParseCalls = mockedSpawnSync.mock.calls.filter(
+      call => call[0] === 'git' && Array.isArray(call[1]) && call[1].includes('rev-parse'),
+    )
+    expect(gitRevParseCalls).toHaveLength(0)
+
+    // The expected version is derived purely from the --integration-commit arg
+    const expectedVersion = buildHarnessVersion(BASE_VERSION, INTEGRATION_COMMIT)
+    expect(expectedVersion).toBe(`${BASE_VERSION}+harness.${INTEGRATION_COMMIT.slice(0, 8)}`)
+
+    // bun build.ts was invoked with OPENCODE_VERSION = expectedVersion
+    const bunBuildCalls = mockedSpawnSync.mock.calls.filter(
+      call =>
+        call[0] === 'bun' &&
+        Array.isArray(call[1]) &&
+        call[1].some((a: unknown) => typeof a === 'string' && a.includes('build.ts')),
+    )
+    expect(bunBuildCalls.length).toBeGreaterThan(0)
+    const buildEnv = (bunBuildCalls[0]?.[2] as {env?: Record<string, string>} | undefined)?.env
+    expect(buildEnv?.OPENCODE_VERSION).toBe(expectedVersion)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runUpstreamBuild — version env is pure-from-arg (unit-level)
+// ---------------------------------------------------------------------------
+
+describe('runUpstreamBuild: version derivation is pure-from-arg', () => {
+  const mockedSpawnSync = vi.mocked(spawnSync)
+
+  beforeEach(() => {
+    mockedSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: '',
+      stderr: '',
+      pid: 1,
+      output: [],
+      signal: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('sets OPENCODE_VERSION to buildHarnessVersion(baseVersion, integrationCommit) — no git rev-parse', () => {
+    // #given
+    const baseVersion = '1.15.13'
+    const integrationCommit = 'deadbeef12345678'
+    const expectedVersion = buildHarnessVersion(baseVersion, integrationCommit)
+
+    // #when
+    runUpstreamBuild('/some/source-tree', baseVersion, integrationCommit)
+
+    // #then — no git rev-parse call
+    const gitRevParseCalls = mockedSpawnSync.mock.calls.filter(
+      call => call[0] === 'git' && Array.isArray(call[1]) && call[1].includes('rev-parse'),
+    )
+    expect(gitRevParseCalls).toHaveLength(0)
+
+    // OPENCODE_VERSION was set to the pure-from-arg value
+    const bunBuildCalls = mockedSpawnSync.mock.calls.filter(
+      call =>
+        call[0] === 'bun' &&
+        Array.isArray(call[1]) &&
+        call[1].some((a: unknown) => typeof a === 'string' && a.includes('build.ts')),
+    )
+    expect(bunBuildCalls.length).toBeGreaterThan(0)
+    const buildEnv = (bunBuildCalls[0]?.[2] as {env?: Record<string, string>} | undefined)?.env
+    expect(buildEnv?.OPENCODE_VERSION).toBe(expectedVersion)
+    expect(expectedVersion).toBe(`${baseVersion}+harness.${integrationCommit.slice(0, 8)}`)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// cloneAndCheckout — backward-compat: still calls git clone
+// ---------------------------------------------------------------------------
+
+describe('cloneAndCheckout: backward-compat', () => {
+  const mockedSpawnSync = vi.mocked(spawnSync)
+
+  beforeEach(() => {
+    mockedSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: '',
+      stderr: '',
+      pid: 1,
+      output: [],
+      signal: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('calls git clone when work dir does not exist', () => {
+    // #given — test -d returns non-zero (dir does not exist)
+    mockedSpawnSync.mockImplementation((cmd, args) => {
+      if (cmd === 'test' && Array.isArray(args) && args[0] === '-d') {
+        return {status: 1, stdout: '', stderr: '', pid: 1, output: [], signal: null}
+      }
+      return {status: 0, stdout: '', stderr: '', pid: 1, output: [], signal: null}
+    })
+
+    // #when
+    cloneAndCheckout('https://github.com/anomalyco/opencode.git', '/tmp/work', 'abc12345')
+
+    // #then — git clone was called
+    const gitCloneCalls = mockedSpawnSync.mock.calls.filter(
+      call => call[0] === 'git' && Array.isArray(call[1]) && call[1].includes('clone'),
+    )
+    expect(gitCloneCalls.length).toBeGreaterThan(0)
   })
 })

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -46,7 +46,7 @@
  */
 
 import {execFileSync, spawnSync} from 'node:child_process'
-import {cpSync, mkdirSync, writeFileSync} from 'node:fs'
+import {cpSync, mkdirSync, readdirSync, statSync, writeFileSync} from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import {fileURLToPath} from 'node:url'
@@ -64,7 +64,7 @@ const OPENCODE_CHANNEL = 'latest'
 // CLI argument parsing
 // ---------------------------------------------------------------------------
 
-interface BuildArgs {
+export interface BuildArgs {
   readonly integrationCommit: string
   readonly baseVersion: string
   readonly platform: string
@@ -72,9 +72,10 @@ interface BuildArgs {
   readonly repoUrl: string
   readonly workDir: string
   readonly outDir: string
+  readonly sourceTree: string | null
 }
 
-function parseArgs(argv: string[]): BuildArgs | null {
+export function parseArgs(argv: string[]): BuildArgs | null {
   const args = argv.slice(2)
 
   if (args.includes('--help') || args.includes('-h')) {
@@ -96,6 +97,7 @@ function parseArgs(argv: string[]): BuildArgs | null {
   const repoUrl = flag('--repo-url') ?? 'https://github.com/anomalyco/opencode.git'
   const workDir = flag('--work-dir') ?? path.join(process.cwd(), '.harness-build-work')
   const outDir = flag('--out-dir') ?? path.join(process.cwd(), '.harness-build-out')
+  const sourceTree = flag('--source-tree') ?? null
 
   if (integrationCommit === null || baseVersion === null || platform === null || arch === null) {
     console.error('[build-platform] Missing required arguments.')
@@ -104,7 +106,7 @@ function parseArgs(argv: string[]): BuildArgs | null {
     return null
   }
 
-  return {integrationCommit, baseVersion, platform, arch, repoUrl, workDir, outDir}
+  return {integrationCommit, baseVersion, platform, arch, repoUrl, workDir, outDir, sourceTree}
 }
 
 function printHelp(): void {
@@ -120,6 +122,7 @@ Usage:
     [--repo-url <url>]                  Upstream repo URL (default: anomalyco/opencode)
     [--work-dir <path>]                 Working directory for the clone (default: .harness-build-work)
     [--out-dir <path>]                  Output directory for the native binary (default: .harness-build-out)
+    [--source-tree <path>]              Pre-extracted merged source tree (bypasses clone; fail-closed if missing/empty)
     [--help]                            Print this help
 
 Build-environment contract:
@@ -172,7 +175,7 @@ function gitExec(args: string[], cwd?: string): void {
   }
 }
 
-function cloneAndCheckout(repoUrl: string, workDir: string, commit: string): void {
+export function cloneAndCheckout(repoUrl: string, workDir: string, commit: string): void {
   const workDirExists = spawnSync('test', ['-d', workDir]).status === 0
   if (workDirExists) {
     console.log(`[build-platform] Work dir exists, fetching and resetting to ${commit}`)
@@ -190,7 +193,7 @@ function cloneAndCheckout(repoUrl: string, workDir: string, commit: string): voi
 // Build invocation
 // ---------------------------------------------------------------------------
 
-function runUpstreamBuild(workDir: string, baseVersion: string, integrationCommit: string): void {
+export function runUpstreamBuild(workDir: string, baseVersion: string, integrationCommit: string): void {
   const opencodeVersion = buildHarnessVersion(baseVersion, integrationCommit)
   console.log(`[build-platform] Running upstream build in ${workDir}`)
   console.log(`[build-platform] Env: OPENCODE_CHANNEL=${OPENCODE_CHANNEL} OPENCODE_VERSION=${opencodeVersion}`)
@@ -325,13 +328,13 @@ function emitProvenanceManifest(
 // Main
 // ---------------------------------------------------------------------------
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const args = parseArgs(process.argv)
   if (args === null) {
     process.exit(1)
   }
 
-  const {integrationCommit, baseVersion, platform, arch, repoUrl, workDir, outDir} = args
+  const {integrationCommit, baseVersion, platform, arch, repoUrl, workDir, outDir, sourceTree} = args
 
   // Derive the harness package directory (two levels up from this script).
   const harnessPackageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
@@ -340,32 +343,75 @@ async function main(): Promise<void> {
   console.log(`  integration commit: ${integrationCommit}`)
   console.log(`  base version:       ${baseVersion}`)
   console.log(`  platform:           ${platform}/${arch}`)
-  console.log(`  repo:               ${repoUrl}`)
-  console.log(`  work dir:           ${workDir}`)
+  if (sourceTree === null) {
+    console.log(`  repo:               ${repoUrl}`)
+    console.log(`  work dir:           ${workDir}`)
+  } else {
+    console.log(`  source tree:        ${sourceTree} (artifact-extract mode; clone bypassed)`)
+  }
   console.log(`  out dir:            ${outDir}`)
 
   // 1. Enforce Bun version (build-environment contract).
   enforceBunVersion()
 
-  // 2. Clone/checkout the full upstream repo at the frozen integration commit.
-  try {
-    cloneAndCheckout(repoUrl, workDir, integrationCommit)
-  } catch (error) {
-    console.error(`[build-platform] Clone/checkout failed: ${error instanceof Error ? error.message : String(error)}`)
-    process.exit(1)
+  // 2. Resolve the source directory: either a pre-extracted merged source tree
+  //    (--source-tree mode, used by the CI artifact-handoff path) or a fresh
+  //    clone/checkout of the upstream repo (standalone/local path).
+  let buildSourceDir: string
+  if (sourceTree === null) {
+    // Standalone/local mode: clone or reuse the upstream repo at the frozen commit.
+    try {
+      cloneAndCheckout(repoUrl, workDir, integrationCommit)
+    } catch (error) {
+      console.error(`[build-platform] Clone/checkout failed: ${error instanceof Error ? error.message : String(error)}`)
+      process.exit(1)
+    }
+    buildSourceDir = workDir
+  } else {
+    // Artifact-extract mode: fail CLOSED if the supplied dir is missing or empty.
+    // Never silently fall back to cloning — a missing/empty source tree means the
+    // artifact handoff failed and we must not build from an unknown source.
+    let entries: string[]
+    try {
+      const stat = statSync(sourceTree)
+      if (!stat.isDirectory()) {
+        console.error(`[build-platform] --source-tree '${sourceTree}' exists but is not a directory.`)
+        process.exit(1)
+      }
+      entries = readdirSync(sourceTree)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        console.error(`[build-platform] --source-tree '${sourceTree}' does not exist. Refusing to fall back to clone.`)
+      } else {
+        console.error(
+          `[build-platform] --source-tree '${sourceTree}' could not be read: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        )
+      }
+      process.exit(1)
+    }
+    if (entries.length === 0) {
+      console.error(`[build-platform] --source-tree '${sourceTree}' is empty. Refusing to fall back to clone.`)
+      process.exit(1)
+    }
+    console.log(`[build-platform] Using pre-extracted source tree: ${sourceTree} (${entries.length} entries)`)
+    buildSourceDir = sourceTree
   }
 
   // 3. Run upstream's real build (embedded-app + native-dep build).
   //    OPENCODE_VERSION embeds the integration commit short SHA for binary self-reporting.
+  //    Version derivation is pure-from-arg (buildHarnessVersion uses --integration-commit
+  //    directly; no git rev-parse is invoked — works with no .git present).
   try {
-    runUpstreamBuild(workDir, baseVersion, integrationCommit)
+    runUpstreamBuild(buildSourceDir, baseVersion, integrationCommit)
   } catch (error) {
     console.error(`[build-platform] Build failed: ${error instanceof Error ? error.message : String(error)}`)
     process.exit(1)
   }
 
   // 4. Verify the built binary --version == OPENCODE_VERSION (build-environment contract).
-  const binaryPath = resolveBuiltBinaryPath(workDir, platform, arch)
+  const binaryPath = resolveBuiltBinaryPath(buildSourceDir, platform, arch)
   const expectedVersion = buildHarnessVersion(baseVersion, integrationCommit)
   try {
     verifyBuiltBinary(binaryPath, expectedVersion)

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -54,6 +54,19 @@ import {HARNESS_BUN_VERSION as REQUIRED_BUN_VERSION} from '../src/bun-version.js
 import {buildHarnessVersion} from '../src/version.js'
 
 // ---------------------------------------------------------------------------
+// Type guard utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Type-safe error code check — no `as` assertion.
+ * After `typeof e === 'object' && e !== null && 'code' in e`, TypeScript narrows
+ * `e` to `object & Record<'code', unknown>`, making `e.code` accessible.
+ */
+function hasErrorCode(e: unknown, code: string): boolean {
+  return typeof e === 'object' && e !== null && 'code' in e && e.code === code
+}
+
+// ---------------------------------------------------------------------------
 // Build-environment contract constants
 // ---------------------------------------------------------------------------
 
@@ -97,7 +110,17 @@ export function parseArgs(argv: string[]): BuildArgs | null {
   const repoUrl = flag('--repo-url') ?? 'https://github.com/anomalyco/opencode.git'
   const workDir = flag('--work-dir') ?? path.join(process.cwd(), '.harness-build-work')
   const outDir = flag('--out-dir') ?? path.join(process.cwd(), '.harness-build-out')
-  const sourceTree = flag('--source-tree') ?? null
+
+  // FIX 4: Track --source-tree PRESENCE separately from value.
+  // If --source-tree is present but has no value (or next token is another flag),
+  // fail-closed rather than silently falling back to clone.
+  const sourceTreePresent = args.includes('--source-tree')
+  const sourceTreeValue = flag('--source-tree')
+  if (sourceTreePresent && sourceTreeValue === null) {
+    console.error('[build-platform] --source-tree requires a value')
+    return null
+  }
+  const sourceTree = sourceTreeValue
 
   if (integrationCommit === null || baseVersion === null || platform === null || arch === null) {
     console.error('[build-platform] Missing required arguments.')
@@ -380,7 +403,7 @@ export async function main(): Promise<void> {
       }
       entries = readdirSync(sourceTree)
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      if (hasErrorCode(error, 'ENOENT')) {
         console.error(`[build-platform] --source-tree '${sourceTree}' does not exist. Refusing to fall back to clone.`)
       } else {
         console.error(

--- a/packages/harness/src/cli.test.ts
+++ b/packages/harness/src/cli.test.ts
@@ -180,10 +180,10 @@ describe('probeBinary', () => {
 // #region CLI subcommand disambiguation
 
 describe('subcommand disambiguation', () => {
-  it('reserved subcommands set contains exactly info, patches, doctor', () => {
-    // This test documents the contract: only these three are harness-own.
+  it('reserved subcommands set contains exactly info, patches, doctor, integrate', () => {
+    // This test documents the contract: only these four are harness-own.
     // Anything else passes through to the patched binary.
-    const reserved = ['info', 'patches', 'doctor']
+    const reserved = ['info', 'patches', 'doctor', 'integrate']
     for (const cmd of reserved) {
       // Verify they are in the set by checking the module exports don't
       // accidentally expose them as passthrough — we test the logic indirectly

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -28,7 +28,7 @@ Usage:
   harness integrate            Run the LLM merge integration pipeline
                                  --work-dir <dir>     (required) Working directory for the clone
                                  --prompt-path <path> (required) Path to the merge prompt template
-                                 --out <path>         (optional) Artifact output path (Unit 2)
+                                 --out <path>         (required) Artifact output path
   harness --version            Print harness provenance version
   harness --help               Print this help
 

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -13,6 +13,7 @@
 
 import {spawnSync} from 'node:child_process'
 import process from 'node:process'
+import {cmdIntegrate} from './integrate-command.js'
 import {formatProvenance, getProvenance} from './provenance.js'
 import {probeBinary, resolveBinary} from './resolve-binary.js'
 
@@ -24,10 +25,14 @@ Usage:
   harness info                 Print provenance (base version, integration refs, build sha)
   harness patches              List configured integration refs
   harness doctor               Check the resolved binary is present and runnable
+  harness integrate            Run the LLM merge integration pipeline
+                                 --work-dir <dir>     (required) Working directory for the clone
+                                 --prompt-path <path> (required) Path to the merge prompt template
+                                 --out <path>         (optional) Artifact output path (Unit 2)
   harness --version            Print harness provenance version
   harness --help               Print this help
 
-Reserved subcommands (info, patches, doctor) are handled by harness itself.
+Reserved subcommands (info, patches, doctor, integrate) are handled by harness itself.
 All other arguments are forwarded to the patched OpenCode binary.`)
 }
 
@@ -128,7 +133,7 @@ function cmdPassthrough(args: readonly string[]): number {
   return result.status ?? 1
 }
 
-function main(): void {
+async function main(): Promise<void> {
   const args = process.argv.slice(2)
 
   // --help: harness-own
@@ -161,10 +166,19 @@ function main(): void {
     process.exit(code)
   }
 
+  if (subcommand === 'integrate') {
+    const code = await cmdIntegrate(args.slice(1))
+    process.exit(code)
+  }
+
   // Anything not in the reserved set passes through.
   // This includes no-args (which opencode handles as its own help/default).
   const code = cmdPassthrough(args)
   process.exit(code)
 }
 
-main()
+main().catch(error => {
+  const msg = error instanceof Error ? error.message : String(error)
+  console.error(`[harness] Unexpected error: ${msg}`)
+  process.exit(1)
+})

--- a/packages/harness/src/integrate-command.test.ts
+++ b/packages/harness/src/integrate-command.test.ts
@@ -1,17 +1,25 @@
 /**
- * Tests for integrate-command.ts — config assembly, flag parsing, exit-code mapping.
+ * Tests for integrate-command.ts — config assembly, flag parsing, exit-code mapping,
+ * artifact packaging (Unit 2).
  *
  * No real merge runs here. runIntegration and makeRealAdapters are stubbed.
+ * packageArtifact is injected as a stub for command-level tests; it is tested
+ * directly for atomic-staging and provenance-inclusion contracts.
+ *
  * Tests prove: config assembly from harness.config.json + flags, exit-code mapping,
- * required-flag validation, and no secret/stack leakage on error.
+ * required-flag validation (including --out), packageArtifact invocation contract,
+ * atomic staging (throw before rename leaves outPath untouched), and no secret/stack
+ * leakage on error.
  */
 import type {IntegrationConfig, IntegrationResult} from './integrate.js'
+import {execFileSync} from 'node:child_process'
+import {existsSync} from 'node:fs'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {cmdIntegrate} from './integrate-command.js'
+import {cmdIntegrate, packageArtifact} from './integrate-command.js'
 // Import the mocked functions after vi.mock is declared.
 import {makeRealAdapters, runIntegration} from './integrate.js'
 
@@ -61,12 +69,14 @@ let tmpDir: string
 let configPath: string
 let workDir: string
 let promptPath: string
+let outPath: string
 
 beforeEach(async () => {
   tmpDir = await makeTmpDir()
   configPath = await writeHarnessConfig(tmpDir)
   workDir = path.join(tmpDir, 'work')
   promptPath = path.join(tmpDir, 'prompt.md')
+  outPath = path.join(tmpDir, 'artifact.tar')
   // Write a minimal prompt file so the command can read it.
   await fs.writeFile(promptPath, 'Merge {{branches}} onto {{tag}}.', 'utf8')
   vi.clearAllMocks()
@@ -93,11 +103,13 @@ describe('cmdIntegrate — happy path', () => {
       },
     }
     vi.mocked(runIntegration).mockResolvedValue(mockResult)
+    const stubPackage = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
 
     // #when
     const code = await cmdIntegrate(
-      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', '/tmp/out.tar'],
+      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', outPath],
       configPath,
+      stubPackage,
     )
 
     // #then
@@ -115,6 +127,27 @@ describe('cmdIntegrate — happy path', () => {
     expect(calledConfig.promptPath).toBe(promptPath)
   })
 
+  it('calls packageArtifact with workDir, integrationCommit, and outPath on {ok:true}', async () => {
+    // #given
+    const integrationCommit = 'deadbeef1234'
+    vi.mocked(runIntegration).mockResolvedValue({
+      ok: true,
+      manifest: {baseVersion: '1.15.13', integrationRefs: [], integrationCommit, buildSha: 'dev'},
+    })
+    const stubPackage = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+
+    // #when
+    const code = await cmdIntegrate(
+      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', outPath],
+      configPath,
+      stubPackage,
+    )
+
+    // #then
+    expect(code).toBe(0)
+    expect(stubPackage).toHaveBeenCalledExactlyOnceWith(workDir, integrationCommit, outPath)
+  })
+
   it('passes the real adapters from makeRealAdapters to runIntegration', async () => {
     // #given
     const fakeAdapters = {cloneRepo: vi.fn()}
@@ -123,9 +156,10 @@ describe('cmdIntegrate — happy path', () => {
       ok: true,
       manifest: {baseVersion: '1.15.13', integrationRefs: [], integrationCommit: 'abc', buildSha: 'dev'},
     })
+    const stubPackage = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
 
     // #when
-    await cmdIntegrate(['--work-dir', workDir, '--prompt-path', promptPath], configPath)
+    await cmdIntegrate(['--work-dir', workDir, '--prompt-path', promptPath, '--out', outPath], configPath, stubPackage)
 
     // #then
     expect(makeRealAdapters).toHaveBeenCalledOnce()
@@ -143,9 +177,14 @@ describe('cmdIntegrate — error path', () => {
     // #given
     vi.mocked(runIntegration).mockResolvedValue({ok: false, error: 'LLM merge failed: conflict in foo.ts'})
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const stubPackage = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
 
     // #when
-    const code = await cmdIntegrate(['--work-dir', workDir, '--prompt-path', promptPath], configPath)
+    const code = await cmdIntegrate(
+      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', outPath],
+      configPath,
+      stubPackage,
+    )
 
     // #then
     expect(code).toBe(1)
@@ -161,13 +200,38 @@ describe('cmdIntegrate — error path', () => {
     errorSpy.mockRestore()
   })
 
+  it('does NOT call packageArtifact when runIntegration returns {ok:false}', async () => {
+    // #given
+    vi.mocked(runIntegration).mockResolvedValue({ok: false, error: 'merge failed'})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const stubPackage = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+
+    // #when
+    const code = await cmdIntegrate(
+      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', outPath],
+      configPath,
+      stubPackage,
+    )
+
+    // #then
+    expect(code).toBe(1)
+    expect(stubPackage).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
+
   it('returns 1 and prints a one-line error when runIntegration throws', async () => {
     // #given
     vi.mocked(runIntegration).mockRejectedValue(new Error('Unexpected crash'))
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const stubPackage = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
 
     // #when
-    const code = await cmdIntegrate(['--work-dir', workDir, '--prompt-path', promptPath], configPath)
+    const code = await cmdIntegrate(
+      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', outPath],
+      configPath,
+      stubPackage,
+    )
 
     // #then
     expect(code).toBe(1)
@@ -177,6 +241,33 @@ describe('cmdIntegrate — error path', () => {
     expect(errorLine).toContain('Unexpected crash')
     // Must NOT leak a stack trace
     expect(errorLine).not.toMatch(/at \w+ \(/)
+
+    errorSpy.mockRestore()
+  })
+
+  it('returns 1 and leaves no artifact when packageArtifact throws', async () => {
+    // #given — integration succeeds but packaging fails
+    vi.mocked(runIntegration).mockResolvedValue({
+      ok: true,
+      manifest: {baseVersion: '1.15.13', integrationRefs: [], integrationCommit: 'abc', buildSha: 'dev'},
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const stubPackage = vi.fn<() => Promise<void>>().mockRejectedValue(new Error('git archive failed'))
+
+    // #when
+    const code = await cmdIntegrate(
+      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', outPath],
+      configPath,
+      stubPackage,
+    )
+
+    // #then
+    expect(code).toBe(1)
+    // outPath must NOT exist — packaging failure must not leave a partial artifact
+    expect(existsSync(outPath)).toBe(false)
+    expect(errorSpy).toHaveBeenCalledOnce()
+    const [errorLine] = errorSpy.mock.calls[0] as [string]
+    expect(errorLine).toContain('git archive failed')
 
     errorSpy.mockRestore()
   })
@@ -190,7 +281,7 @@ describe('cmdIntegrate — missing required flags', () => {
   it('returns non-zero when --work-dir is missing', async () => {
     // #given / #when
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    const code = await cmdIntegrate(['--prompt-path', promptPath], configPath)
+    const code = await cmdIntegrate(['--prompt-path', promptPath, '--out', outPath], configPath)
 
     // #then
     expect(code).not.toBe(0)
@@ -202,11 +293,26 @@ describe('cmdIntegrate — missing required flags', () => {
   it('returns non-zero when --prompt-path is missing', async () => {
     // #given / #when
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    const code = await cmdIntegrate(['--work-dir', workDir], configPath)
+    const code = await cmdIntegrate(['--work-dir', workDir, '--out', outPath], configPath)
 
     // #then
     expect(code).not.toBe(0)
     expect(runIntegration).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
+
+  it('returns non-zero when --out is missing', async () => {
+    // #given / #when
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const code = await cmdIntegrate(['--work-dir', workDir, '--prompt-path', promptPath], configPath)
+
+    // #then
+    expect(code).not.toBe(0)
+    expect(runIntegration).not.toHaveBeenCalled()
+    // Error message must mention --out
+    const [errorLine] = errorSpy.mock.calls[0] as [string]
+    expect(errorLine).toContain('--out')
 
     errorSpy.mockRestore()
   })
@@ -228,9 +334,14 @@ describe('cmdIntegrate — config sourcing', () => {
       ok: true,
       manifest: {baseVersion: '1.15.13', integrationRefs: [], integrationCommit: 'abc', buildSha: 'dev'},
     })
+    const stubPackage = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
 
     // #when
-    await cmdIntegrate(['--work-dir', workDir, '--prompt-path', promptPath], customConfigPath)
+    await cmdIntegrate(
+      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', outPath],
+      customConfigPath,
+      stubPackage,
+    )
 
     // #then
     const [calledConfig] = vi.mocked(runIntegration).mock.calls[0] as [IntegrationConfig, unknown]
@@ -251,9 +362,14 @@ describe('cmdIntegrate — config sourcing', () => {
       ok: true,
       manifest: {baseVersion: '1.15.13', integrationRefs: [], integrationCommit: 'abc', buildSha: 'dev'},
     })
+    const stubPackage = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
 
     // #when
-    await cmdIntegrate(['--work-dir', workDir, '--prompt-path', promptPath], customConfigPath)
+    await cmdIntegrate(
+      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', outPath],
+      customConfigPath,
+      stubPackage,
+    )
 
     // #then
     const [calledConfig] = vi.mocked(runIntegration).mock.calls[0] as [IntegrationConfig, unknown]
@@ -267,9 +383,14 @@ describe('cmdIntegrate — config sourcing', () => {
       ok: true,
       manifest: {baseVersion: '1.15.13', integrationRefs: [], integrationCommit: 'abc', buildSha: 'dev'},
     })
+    const stubPackage = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
 
     // #when
-    await cmdIntegrate(['--work-dir', workDir, '--prompt-path', promptPath], customConfigPath)
+    await cmdIntegrate(
+      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', outPath],
+      customConfigPath,
+      stubPackage,
+    )
 
     // #then
     const [calledConfig] = vi.mocked(runIntegration).mock.calls[0] as [IntegrationConfig, unknown]
@@ -278,24 +399,104 @@ describe('cmdIntegrate — config sourcing', () => {
 })
 
 // ---------------------------------------------------------------------------
-// --out flag parsing (Unit 1: parse and pass; Unit 2 will use it for packaging)
+// packageArtifact — unit tests (direct, no command layer)
 // ---------------------------------------------------------------------------
 
-describe('cmdIntegrate — --out flag', () => {
-  it('accepts --out flag without error and still returns 0 on success', async () => {
+/**
+ * Helper: set up a fake git repo in a temp dir with a commit and provenance.json.
+ * Returns {repoDir, commit, provenanceContent}.
+ */
+async function makeGitRepo(dir: string): Promise<{repoDir: string; commit: string; provenanceContent: string}> {
+  const repoDir = path.join(dir, 'repo')
+  await fs.mkdir(repoDir, {recursive: true})
+
+  // Init a minimal git repo.
+  execFileSync('git', ['init', '-b', 'main'], {cwd: repoDir, stdio: 'pipe'})
+  execFileSync('git', ['config', 'user.email', 'test@test.com'], {cwd: repoDir, stdio: 'pipe'})
+  execFileSync('git', ['config', 'user.name', 'Test'], {cwd: repoDir, stdio: 'pipe'})
+
+  // Add a tracked file.
+  await fs.writeFile(path.join(repoDir, 'README.md'), '# test\n', 'utf8')
+  execFileSync('git', ['add', 'README.md'], {cwd: repoDir, stdio: 'pipe'})
+  execFileSync('git', ['commit', '-m', 'init'], {cwd: repoDir, stdio: 'pipe'})
+
+  // Get the commit SHA.
+  const commit = execFileSync('git', ['rev-parse', 'HEAD'], {cwd: repoDir, encoding: 'utf8'}).trim()
+
+  // Write provenance.json to the repo dir (simulating what runIntegration does).
+  const provenanceContent = JSON.stringify(
+    {baseVersion: '1.15.13', integrationRefs: [], integrationCommit: commit, buildSha: 'dev'},
+    null,
+    2,
+  )
+  await fs.writeFile(path.join(repoDir, 'provenance.json'), provenanceContent, 'utf8')
+
+  return {repoDir, commit, provenanceContent}
+}
+
+describe('packageArtifact', () => {
+  it('creates a tar artifact at outPath containing provenance.json', async () => {
     // #given
-    vi.mocked(runIntegration).mockResolvedValue({
-      ok: true,
-      manifest: {baseVersion: '1.15.13', integrationRefs: [], integrationCommit: 'abc', buildSha: 'dev'},
-    })
+    const {repoDir, commit} = await makeGitRepo(tmpDir)
+    const artifactPath = path.join(tmpDir, 'out', 'artifact.tar')
 
     // #when
-    const code = await cmdIntegrate(
-      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', '/tmp/artifact.tar'],
-      configPath,
-    )
+    await packageArtifact(repoDir, commit, artifactPath)
 
-    // #then
-    expect(code).toBe(0)
+    // #then — artifact exists
+    expect(existsSync(artifactPath)).toBe(true)
+
+    // Verify provenance.json is in the tar.
+    const listOutput = execFileSync('tar', ['tf', artifactPath], {encoding: 'utf8'})
+    expect(listOutput).toContain('provenance.json')
+  })
+
+  it('archives against integrationCommit (not the dirty working tree)', async () => {
+    // #given — create a repo, get the commit, then add an untracked dirty file
+    const {repoDir, commit} = await makeGitRepo(tmpDir)
+    // Add a dirty file that is NOT committed
+    await fs.writeFile(path.join(repoDir, 'dirty.txt'), 'should not appear\n', 'utf8')
+    const artifactPath = path.join(tmpDir, 'artifact.tar')
+
+    // #when
+    await packageArtifact(repoDir, commit, artifactPath)
+
+    // #then — dirty.txt must NOT be in the archive (git archive uses the commit, not the worktree)
+    const listOutput = execFileSync('tar', ['tf', artifactPath], {encoding: 'utf8'})
+    expect(listOutput).not.toContain('dirty.txt')
+    // README.md (tracked at commit) must be present
+    expect(listOutput).toContain('README.md')
+  })
+
+  it('does NOT leave an artifact at outPath when git archive fails (atomic staging)', async () => {
+    // #given — use a non-existent commit SHA to force git archive to fail
+    const {repoDir} = await makeGitRepo(tmpDir)
+    const artifactPath = path.join(tmpDir, 'should-not-exist.tar')
+    const badCommit = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+    // #when / #then
+    await expect(packageArtifact(repoDir, badCommit, artifactPath)).rejects.toThrow()
+    // Atomic: outPath must NOT exist after the failure
+    expect(existsSync(artifactPath)).toBe(false)
+  })
+
+  it('provenance.json in the artifact carries the same integrationCommit', async () => {
+    // #given
+    const {repoDir, commit, provenanceContent} = await makeGitRepo(tmpDir)
+    const artifactPath = path.join(tmpDir, 'artifact.tar')
+
+    // #when
+    await packageArtifact(repoDir, commit, artifactPath)
+
+    // #then — extract and verify provenance.json content
+    const extractDir = path.join(tmpDir, 'extracted')
+    await fs.mkdir(extractDir, {recursive: true})
+    execFileSync('tar', ['xf', artifactPath, '-C', extractDir], {stdio: 'pipe'})
+
+    const extractedProvenance = await fs.readFile(path.join(extractDir, 'provenance.json'), 'utf8')
+    const parsed = JSON.parse(extractedProvenance) as {integrationCommit: string}
+    expect(parsed.integrationCommit).toBe(commit)
+    // Content must match what was written to workDir
+    expect(extractedProvenance.trim()).toBe(provenanceContent.trim())
   })
 })

--- a/packages/harness/src/integrate-command.test.ts
+++ b/packages/harness/src/integrate-command.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests for integrate-command.ts — config assembly, flag parsing, exit-code mapping.
+ *
+ * No real merge runs here. runIntegration and makeRealAdapters are stubbed.
+ * Tests prove: config assembly from harness.config.json + flags, exit-code mapping,
+ * required-flag validation, and no secret/stack leakage on error.
+ */
+import type {IntegrationConfig, IntegrationResult} from './integrate.js'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {cmdIntegrate} from './integrate-command.js'
+// Import the mocked functions after vi.mock is declared.
+import {makeRealAdapters, runIntegration} from './integrate.js'
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — must be hoisted before any imports of the module under test.
+// ---------------------------------------------------------------------------
+
+// We mock the integrate module so no real git/opencode runs happen.
+vi.mock('./integrate.js', () => ({
+  runIntegration: vi.fn(),
+  makeRealAdapters: vi.fn(() => ({})),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function makeTmpDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'harness-integrate-cmd-test-'))
+}
+
+/**
+ * Writes a minimal harness.config.json to the given directory.
+ * Returns the path to the written file.
+ */
+async function writeHarnessConfig(dir: string, overrides: Record<string, unknown> = {}): Promise<string> {
+  const config = {
+    release_repo: 'anomalyco/opencode',
+    source_repo: 'https://github.com/anomalyco/opencode.git',
+    base_version: '1.15.13',
+    integrationRefs: ['https://github.com/anomalyco/opencode/pull/30182'],
+    agent: 'build',
+    model: 'anthropic/claude-sonnet-4-6',
+    opencode_bin: 'opencode',
+    ...overrides,
+  }
+  const configPath = path.join(dir, 'harness.config.json')
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), 'utf8')
+  return configPath
+}
+
+// ---------------------------------------------------------------------------
+// Test setup / teardown
+// ---------------------------------------------------------------------------
+
+let tmpDir: string
+let configPath: string
+let workDir: string
+let promptPath: string
+
+beforeEach(async () => {
+  tmpDir = await makeTmpDir()
+  configPath = await writeHarnessConfig(tmpDir)
+  workDir = path.join(tmpDir, 'work')
+  promptPath = path.join(tmpDir, 'prompt.md')
+  // Write a minimal prompt file so the command can read it.
+  await fs.writeFile(promptPath, 'Merge {{branches}} onto {{tag}}.', 'utf8')
+  vi.clearAllMocks()
+})
+
+afterEach(async () => {
+  await fs.rm(tmpDir, {recursive: true, force: true})
+})
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe('cmdIntegrate — happy path', () => {
+  it('calls runIntegration with the correctly-assembled IntegrationConfig and returns 0 on {ok:true}', async () => {
+    // #given
+    const mockResult: IntegrationResult = {
+      ok: true,
+      manifest: {
+        baseVersion: '1.15.13',
+        integrationRefs: [],
+        integrationCommit: 'abc1234',
+        buildSha: 'dev',
+      },
+    }
+    vi.mocked(runIntegration).mockResolvedValue(mockResult)
+
+    // #when
+    const code = await cmdIntegrate(
+      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', '/tmp/out.tar'],
+      configPath,
+    )
+
+    // #then
+    expect(code).toBe(0)
+    expect(runIntegration).toHaveBeenCalledOnce()
+
+    const [calledConfig] = vi.mocked(runIntegration).mock.calls[0] as [IntegrationConfig, unknown]
+    expect(calledConfig.baseVersion).toBe('1.15.13')
+    expect(calledConfig.releaseRepo).toBe('anomalyco/opencode')
+    expect(calledConfig.integrationRefs).toEqual(['https://github.com/anomalyco/opencode/pull/30182'])
+    expect(calledConfig.agent).toBe('build')
+    expect(calledConfig.model).toBe('anthropic/claude-sonnet-4-6')
+    expect(calledConfig.opencodeBin).toBe('opencode')
+    expect(calledConfig.workDir).toBe(workDir)
+    expect(calledConfig.promptPath).toBe(promptPath)
+  })
+
+  it('passes the real adapters from makeRealAdapters to runIntegration', async () => {
+    // #given
+    const fakeAdapters = {cloneRepo: vi.fn()}
+    vi.mocked(makeRealAdapters).mockReturnValue(fakeAdapters as never)
+    vi.mocked(runIntegration).mockResolvedValue({
+      ok: true,
+      manifest: {baseVersion: '1.15.13', integrationRefs: [], integrationCommit: 'abc', buildSha: 'dev'},
+    })
+
+    // #when
+    await cmdIntegrate(['--work-dir', workDir, '--prompt-path', promptPath], configPath)
+
+    // #then
+    expect(makeRealAdapters).toHaveBeenCalledOnce()
+    const [, calledAdapters] = vi.mocked(runIntegration).mock.calls[0] as [IntegrationConfig, unknown]
+    expect(calledAdapters).toBe(fakeAdapters)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error path
+// ---------------------------------------------------------------------------
+
+describe('cmdIntegrate — error path', () => {
+  it('returns 1 and prints a one-line error when runIntegration returns {ok:false}', async () => {
+    // #given
+    vi.mocked(runIntegration).mockResolvedValue({ok: false, error: 'LLM merge failed: conflict in foo.ts'})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // #when
+    const code = await cmdIntegrate(['--work-dir', workDir, '--prompt-path', promptPath], configPath)
+
+    // #then
+    expect(code).toBe(1)
+    expect(errorSpy).toHaveBeenCalledOnce()
+    const [errorLine] = errorSpy.mock.calls[0] as [string]
+    // Must be a single line (no newlines in the message)
+    expect(errorLine).not.toContain('\n')
+    // Must contain the error message
+    expect(errorLine).toContain('LLM merge failed')
+    // Must NOT contain stack traces or secret-shaped content
+    expect(errorLine).not.toMatch(/at \w+ \(/)
+
+    errorSpy.mockRestore()
+  })
+
+  it('returns 1 and prints a one-line error when runIntegration throws', async () => {
+    // #given
+    vi.mocked(runIntegration).mockRejectedValue(new Error('Unexpected crash'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // #when
+    const code = await cmdIntegrate(['--work-dir', workDir, '--prompt-path', promptPath], configPath)
+
+    // #then
+    expect(code).toBe(1)
+    expect(errorSpy).toHaveBeenCalledOnce()
+    const [errorLine] = errorSpy.mock.calls[0] as [string]
+    expect(errorLine).not.toContain('\n')
+    expect(errorLine).toContain('Unexpected crash')
+    // Must NOT leak a stack trace
+    expect(errorLine).not.toMatch(/at \w+ \(/)
+
+    errorSpy.mockRestore()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Missing required flags
+// ---------------------------------------------------------------------------
+
+describe('cmdIntegrate — missing required flags', () => {
+  it('returns non-zero when --work-dir is missing', async () => {
+    // #given / #when
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const code = await cmdIntegrate(['--prompt-path', promptPath], configPath)
+
+    // #then
+    expect(code).not.toBe(0)
+    expect(runIntegration).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
+
+  it('returns non-zero when --prompt-path is missing', async () => {
+    // #given / #when
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const code = await cmdIntegrate(['--work-dir', workDir], configPath)
+
+    // #then
+    expect(code).not.toBe(0)
+    expect(runIntegration).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Config sourcing
+// ---------------------------------------------------------------------------
+
+describe('cmdIntegrate — config sourcing', () => {
+  it('reads integrationRefs, agent, and model from harness.config.json (not hardcoded)', async () => {
+    // #given — write a config with distinct values
+    const customConfigPath = await writeHarnessConfig(tmpDir, {
+      integrationRefs: ['https://github.com/anomalyco/opencode/pull/99999'],
+      agent: 'custom-agent',
+      model: 'anthropic/claude-opus-4',
+    })
+    vi.mocked(runIntegration).mockResolvedValue({
+      ok: true,
+      manifest: {baseVersion: '1.15.13', integrationRefs: [], integrationCommit: 'abc', buildSha: 'dev'},
+    })
+
+    // #when
+    await cmdIntegrate(['--work-dir', workDir, '--prompt-path', promptPath], customConfigPath)
+
+    // #then
+    const [calledConfig] = vi.mocked(runIntegration).mock.calls[0] as [IntegrationConfig, unknown]
+    expect(calledConfig.integrationRefs).toEqual(['https://github.com/anomalyco/opencode/pull/99999'])
+    expect(calledConfig.agent).toBe('custom-agent')
+    expect(calledConfig.model).toBe('anthropic/claude-opus-4')
+  })
+
+  it('defaults opencodeBin to "opencode" when opencode_bin is absent from config', async () => {
+    // #given — config without opencode_bin
+    const customConfigPath = await writeHarnessConfig(tmpDir, {opencode_bin: undefined})
+    // Remove the key entirely by rewriting
+    const raw = JSON.parse(await fs.readFile(customConfigPath, 'utf8')) as Record<string, unknown>
+    delete raw.opencode_bin
+    await fs.writeFile(customConfigPath, JSON.stringify(raw, null, 2), 'utf8')
+
+    vi.mocked(runIntegration).mockResolvedValue({
+      ok: true,
+      manifest: {baseVersion: '1.15.13', integrationRefs: [], integrationCommit: 'abc', buildSha: 'dev'},
+    })
+
+    // #when
+    await cmdIntegrate(['--work-dir', workDir, '--prompt-path', promptPath], customConfigPath)
+
+    // #then
+    const [calledConfig] = vi.mocked(runIntegration).mock.calls[0] as [IntegrationConfig, unknown]
+    expect(calledConfig.opencodeBin).toBe('opencode')
+  })
+
+  it('reads opencodeBin from config when present', async () => {
+    // #given
+    const customConfigPath = await writeHarnessConfig(tmpDir, {opencode_bin: '/usr/local/bin/opencode-custom'})
+    vi.mocked(runIntegration).mockResolvedValue({
+      ok: true,
+      manifest: {baseVersion: '1.15.13', integrationRefs: [], integrationCommit: 'abc', buildSha: 'dev'},
+    })
+
+    // #when
+    await cmdIntegrate(['--work-dir', workDir, '--prompt-path', promptPath], customConfigPath)
+
+    // #then
+    const [calledConfig] = vi.mocked(runIntegration).mock.calls[0] as [IntegrationConfig, unknown]
+    expect(calledConfig.opencodeBin).toBe('/usr/local/bin/opencode-custom')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// --out flag parsing (Unit 1: parse and pass; Unit 2 will use it for packaging)
+// ---------------------------------------------------------------------------
+
+describe('cmdIntegrate — --out flag', () => {
+  it('accepts --out flag without error and still returns 0 on success', async () => {
+    // #given
+    vi.mocked(runIntegration).mockResolvedValue({
+      ok: true,
+      manifest: {baseVersion: '1.15.13', integrationRefs: [], integrationCommit: 'abc', buildSha: 'dev'},
+    })
+
+    // #when
+    const code = await cmdIntegrate(
+      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', '/tmp/artifact.tar'],
+      configPath,
+    )
+
+    // #then
+    expect(code).toBe(0)
+  })
+})

--- a/packages/harness/src/integrate-command.test.ts
+++ b/packages/harness/src/integrate-command.test.ts
@@ -399,6 +399,114 @@ describe('cmdIntegrate — config sourcing', () => {
 })
 
 // ---------------------------------------------------------------------------
+// FIX 3: Flag parser rejects another flag token as a flag's value
+// ---------------------------------------------------------------------------
+
+describe('cmdIntegrate — FIX 3: flag value cannot be another flag', () => {
+  it('returns non-zero when --work-dir is followed by another flag', async () => {
+    // #given / #when
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const code = await cmdIntegrate(['--work-dir', '--prompt-path', promptPath, '--out', outPath], configPath)
+
+    // #then
+    expect(code).not.toBe(0)
+    expect(runIntegration).not.toHaveBeenCalled()
+    const [errorLine] = errorSpy.mock.calls[0] as [string]
+    expect(errorLine).toContain('--work-dir')
+    expect(errorLine).toContain('requires a value')
+
+    errorSpy.mockRestore()
+  })
+
+  it('returns non-zero when --prompt-path is followed by another flag', async () => {
+    // #given / #when
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const code = await cmdIntegrate(['--work-dir', workDir, '--prompt-path', '--out', outPath], configPath)
+
+    // #then
+    expect(code).not.toBe(0)
+    expect(runIntegration).not.toHaveBeenCalled()
+    const [errorLine] = errorSpy.mock.calls[0] as [string]
+    expect(errorLine).toContain('--prompt-path')
+    expect(errorLine).toContain('requires a value')
+
+    errorSpy.mockRestore()
+  })
+
+  it('returns non-zero when --out is followed by another flag', async () => {
+    // #given / #when
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const code = await cmdIntegrate(
+      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', '--dry-run'],
+      configPath,
+    )
+
+    // #then
+    expect(code).not.toBe(0)
+    expect(runIntegration).not.toHaveBeenCalled()
+    const [errorLine] = errorSpy.mock.calls[0] as [string]
+    expect(errorLine).toContain('--out')
+    expect(errorLine).toContain('requires a value')
+
+    errorSpy.mockRestore()
+  })
+
+  it('returns non-zero when --work-dir has no following value at all', async () => {
+    // #given / #when
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const code = await cmdIntegrate(['--work-dir'], configPath)
+
+    // #then
+    expect(code).not.toBe(0)
+    expect(runIntegration).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FIX 7: integrationRefs element-type validation
+// ---------------------------------------------------------------------------
+
+describe('cmdIntegrate — FIX 7: integrationRefs element validation', () => {
+  it('returns non-zero when integrationRefs contains a non-string element', async () => {
+    // #given — config with a non-string element in integrationRefs
+    const badConfigPath = await writeHarnessConfig(tmpDir, {integrationRefs: ['valid-ref', 42, null]})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // #when
+    const code = await cmdIntegrate(
+      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', outPath],
+      badConfigPath,
+    )
+
+    // #then — config rejected before runIntegration is called
+    expect(code).not.toBe(0)
+    expect(runIntegration).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
+
+  it('returns non-zero when integrationRefs contains an empty string', async () => {
+    // #given — config with an empty string element
+    const badConfigPath = await writeHarnessConfig(tmpDir, {integrationRefs: ['valid-ref', '']})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // #when
+    const code = await cmdIntegrate(
+      ['--work-dir', workDir, '--prompt-path', promptPath, '--out', outPath],
+      badConfigPath,
+    )
+
+    // #then
+    expect(code).not.toBe(0)
+    expect(runIntegration).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // packageArtifact — unit tests (direct, no command layer)
 // ---------------------------------------------------------------------------
 
@@ -423,7 +531,10 @@ async function makeGitRepo(dir: string): Promise<{repoDir: string; commit: strin
   // Get the commit SHA.
   const commit = execFileSync('git', ['rev-parse', 'HEAD'], {cwd: repoDir, encoding: 'utf8'}).trim()
 
-  // Write provenance.json to the repo dir (simulating what runIntegration does).
+  // Write provenance.json to the repo dir as an UNTRACKED file.
+  // This mirrors the real flow: runIntegration writes provenance.json after getCommitSha,
+  // so it is never committed to git. packageArtifact copies it into the artifact separately.
+  // The FIX 5 dirty-tree guard only checks TRACKED changes (not untracked '??' files).
   const provenanceContent = JSON.stringify(
     {baseVersion: '1.15.13', integrationRefs: [], integrationCommit: commit, buildSha: 'dev'},
     null,
@@ -451,21 +562,19 @@ describe('packageArtifact', () => {
     expect(listOutput).toContain('provenance.json')
   })
 
-  it('archives against integrationCommit (not the dirty working tree)', async () => {
-    // #given — create a repo, get the commit, then add an untracked dirty file
+  it('rejects a dirty working tree before git archive (FIX 5 guard)', async () => {
+    // #given — create a repo, then stage a tracked change without committing
+    // The guard only catches TRACKED uncommitted changes (not untracked '??' files).
     const {repoDir, commit} = await makeGitRepo(tmpDir)
-    // Add a dirty file that is NOT committed
-    await fs.writeFile(path.join(repoDir, 'dirty.txt'), 'should not appear\n', 'utf8')
+    // Modify a tracked file and stage it (tracked dirty change)
+    await fs.writeFile(path.join(repoDir, 'README.md'), '# modified\n', 'utf8')
+    execFileSync('git', ['add', 'README.md'], {cwd: repoDir, stdio: 'pipe'})
     const artifactPath = path.join(tmpDir, 'artifact.tar')
 
-    // #when
-    await packageArtifact(repoDir, commit, artifactPath)
-
-    // #then — dirty.txt must NOT be in the archive (git archive uses the commit, not the worktree)
-    const listOutput = execFileSync('tar', ['tf', artifactPath], {encoding: 'utf8'})
-    expect(listOutput).not.toContain('dirty.txt')
-    // README.md (tracked at commit) must be present
-    expect(listOutput).toContain('README.md')
+    // #when / #then — FIX 5: uncommitted tracked changes must be rejected
+    await expect(packageArtifact(repoDir, commit, artifactPath)).rejects.toThrow(/uncommitted/i)
+    // Artifact must NOT be created
+    expect(existsSync(artifactPath)).toBe(false)
   })
 
   it('does NOT leave an artifact at outPath when git archive fails (atomic staging)', async () => {
@@ -477,6 +586,20 @@ describe('packageArtifact', () => {
     // #when / #then
     await expect(packageArtifact(repoDir, badCommit, artifactPath)).rejects.toThrow()
     // Atomic: outPath must NOT exist after the failure
+    expect(existsSync(artifactPath)).toBe(false)
+  })
+
+  it('fIX 5: throws when working tree has uncommitted tracked changes before git archive', async () => {
+    // #given — create a repo with a commit, then stage a tracked change without committing
+    const {repoDir, commit} = await makeGitRepo(tmpDir)
+    // Modify a tracked file and stage it (tracked dirty change, not untracked)
+    await fs.writeFile(path.join(repoDir, 'README.md'), '# modified\n', 'utf8')
+    execFileSync('git', ['add', 'README.md'], {cwd: repoDir, stdio: 'pipe'})
+    const artifactPath = path.join(tmpDir, 'should-not-exist.tar')
+
+    // #when / #then — must throw because tracked changes are uncommitted
+    await expect(packageArtifact(repoDir, commit, artifactPath)).rejects.toThrow(/uncommitted/i)
+    // Artifact must NOT be created
     expect(existsSync(artifactPath)).toBe(false)
   })
 

--- a/packages/harness/src/integrate-command.ts
+++ b/packages/harness/src/integrate-command.ts
@@ -1,0 +1,149 @@
+/**
+ * integrate-command.ts — `harness integrate` subcommand implementation.
+ *
+ * Reads harness.config.json for: baseVersion, releaseRepo, integrationRefs,
+ * agent, model, opencodeBin. Parses --work-dir, --prompt-path, --out from argv.
+ * Assembles IntegrationConfig and calls runIntegration(config, makeRealAdapters()).
+ *
+ * Exit codes: 0 on {ok:true}, 1 on {ok:false} or exception.
+ * Error output: one-line message only — no stack traces, no secrets.
+ *
+ * No classes; functions only; explicit boolean checks; no as-any.
+ */
+
+import type {IntegrationConfig} from './integrate.js'
+import {readFileSync} from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {makeRealAdapters, runIntegration} from './integrate.js'
+
+// ---------------------------------------------------------------------------
+// Config file shape
+// ---------------------------------------------------------------------------
+
+interface HarnessConfig {
+  readonly release_repo: string
+  readonly base_version: string
+  readonly integrationRefs: readonly string[]
+  readonly agent: string
+  readonly model: string
+  readonly opencode_bin?: string
+}
+
+function isValidHarnessConfig(value: unknown): value is HarnessConfig {
+  if (value === null || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  if (typeof v.release_repo !== 'string' || v.release_repo.length === 0) return false
+  if (typeof v.base_version !== 'string' || v.base_version.length === 0) return false
+  if (!Array.isArray(v.integrationRefs)) return false
+  if (typeof v.agent !== 'string' || v.agent.length === 0) return false
+  if (typeof v.model !== 'string' || v.model.length === 0) return false
+  if (v.opencode_bin !== undefined && typeof v.opencode_bin !== 'string') return false
+  return true
+}
+
+// ---------------------------------------------------------------------------
+// Default config path (relative to this file's package root)
+// ---------------------------------------------------------------------------
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+export const DEFAULT_CONFIG_PATH = path.join(packageRoot, 'harness.config.json')
+
+// ---------------------------------------------------------------------------
+// Flag parsing
+// ---------------------------------------------------------------------------
+
+interface ParsedFlags {
+  readonly workDir: string | undefined
+  readonly promptPath: string | undefined
+  readonly out: string | undefined
+}
+
+function parseFlags(argv: readonly string[]): ParsedFlags {
+  let workDir: string | undefined
+  let promptPath: string | undefined
+  let out: string | undefined
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--work-dir' && i + 1 < argv.length) {
+      workDir = argv[i + 1]
+      i++
+    } else if (arg === '--prompt-path' && i + 1 < argv.length) {
+      promptPath = argv[i + 1]
+      i++
+    } else if (arg === '--out' && i + 1 < argv.length) {
+      out = argv[i + 1]
+      i++
+    }
+  }
+
+  return {workDir, promptPath, out}
+}
+
+// ---------------------------------------------------------------------------
+// Main command
+// ---------------------------------------------------------------------------
+
+/**
+ * Implements `harness integrate`.
+ *
+ * @param argv       - CLI arguments (everything after "integrate").
+ * @param configPath - Path to harness.config.json (defaults to package root; injectable for tests).
+ * @returns Exit code: 0 on success, 1 on failure.
+ */
+export async function cmdIntegrate(argv: readonly string[], configPath: string = DEFAULT_CONFIG_PATH): Promise<number> {
+  // Parse flags.
+  const flags = parseFlags(argv)
+
+  // Validate required flags.
+  if (flags.workDir === undefined) {
+    console.error('[integrate] Missing required flag: --work-dir <dir>')
+    return 1
+  }
+  if (flags.promptPath === undefined) {
+    console.error('[integrate] Missing required flag: --prompt-path <path>')
+    return 1
+  }
+
+  // Read harness.config.json.
+  let rawConfig: unknown
+  try {
+    const raw = readFileSync(configPath, 'utf8')
+    rawConfig = JSON.parse(raw)
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    console.error(`[integrate] Failed to read config: ${msg}`)
+    return 1
+  }
+
+  if (!isValidHarnessConfig(rawConfig)) {
+    console.error('[integrate] Invalid harness.config.json shape')
+    return 1
+  }
+
+  const config: IntegrationConfig = {
+    baseVersion: rawConfig.base_version,
+    releaseRepo: rawConfig.release_repo,
+    integrationRefs: rawConfig.integrationRefs,
+    agent: rawConfig.agent,
+    model: rawConfig.model,
+    opencodeBin: rawConfig.opencode_bin ?? 'opencode',
+    workDir: flags.workDir,
+    promptPath: flags.promptPath,
+  }
+
+  // Run the integration.
+  try {
+    const result = await runIntegration(config, makeRealAdapters())
+    if (result.ok === true) {
+      return 0
+    }
+    console.error(`[integrate] ${result.error}`)
+    return 1
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    console.error(`[integrate] ${msg}`)
+    return 1
+  }
+}

--- a/packages/harness/src/integrate-command.ts
+++ b/packages/harness/src/integrate-command.ts
@@ -15,7 +15,7 @@
  */
 
 import type {IntegrationConfig} from './integrate.js'
-import {execFileSync} from 'node:child_process'
+import {execFileSync, execSync} from 'node:child_process'
 import {copyFileSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync} from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -41,6 +41,7 @@ function isValidHarnessConfig(value: unknown): value is HarnessConfig {
   if (typeof v.release_repo !== 'string' || v.release_repo.length === 0) return false
   if (typeof v.base_version !== 'string' || v.base_version.length === 0) return false
   if (!Array.isArray(v.integrationRefs)) return false
+  if (!v.integrationRefs.every((el: unknown) => typeof el === 'string' && el.length > 0)) return false
   if (typeof v.agent !== 'string' || v.agent.length === 0) return false
   if (typeof v.model !== 'string' || v.model.length === 0) return false
   if (v.opencode_bin !== undefined && typeof v.opencode_bin !== 'string') return false
@@ -64,21 +65,26 @@ interface ParsedFlags {
   readonly out: string | undefined
 }
 
-function parseFlags(argv: readonly string[]): ParsedFlags {
+function parseFlags(argv: readonly string[]): ParsedFlags | null {
   let workDir: string | undefined
   let promptPath: string | undefined
   let out: string | undefined
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
-    if (arg === '--work-dir' && i + 1 < argv.length) {
-      workDir = argv[i + 1]
-      i++
-    } else if (arg === '--prompt-path' && i + 1 < argv.length) {
-      promptPath = argv[i + 1]
-      i++
-    } else if (arg === '--out' && i + 1 < argv.length) {
-      out = argv[i + 1]
+    if (arg === '--work-dir' || arg === '--prompt-path' || arg === '--out') {
+      const next = argv[i + 1]
+      if (next === undefined || next.startsWith('--')) {
+        console.error(`[integrate] ${arg} requires a value`)
+        return null
+      }
+      if (arg === '--work-dir') {
+        workDir = next
+      } else if (arg === '--prompt-path') {
+        promptPath = next
+      } else {
+        out = next
+      }
       i++
     }
   }
@@ -110,6 +116,19 @@ function parseFlags(argv: readonly string[]): ParsedFlags {
  * @param outPath           - Destination path for the final artifact tar.
  */
 export async function packageArtifact(workDir: string, integrationCommit: string, outPath: string): Promise<void> {
+  // Belt-and-suspenders guard: fail loudly if the working tree has uncommitted tracked changes.
+  // After FIX 1 commits the merge, tracked changes should always be committed.
+  // Untracked files (e.g. provenance.json written by the harness) are intentionally excluded
+  // from this check — they are copied into the artifact separately.
+  // `git status --porcelain` lines starting with '??' are untracked; we only care about the rest.
+  const statusOutput = execSync('git status --porcelain', {cwd: workDir, encoding: 'utf8'})
+  const trackedDirtyLines = statusOutput.split('\n').filter(line => line.length > 0 && !line.startsWith('??'))
+  if (trackedDirtyLines.length > 0) {
+    throw new Error(
+      `[integrate] Working tree has uncommitted tracked changes before git archive — these would be excluded from the artifact:\n${trackedDirtyLines.join('\n')}`,
+    )
+  }
+
   const tmpStaging = mkdtempSync(path.join(os.tmpdir(), 'harness-artifact-'))
   try {
     const sourceTar = path.join(tmpStaging, 'source.tar')
@@ -168,6 +187,7 @@ export async function cmdIntegrate(
 ): Promise<number> {
   // Parse flags.
   const flags = parseFlags(argv)
+  if (flags === null) return 1
 
   // Validate required flags.
   if (flags.workDir === undefined) {

--- a/packages/harness/src/integrate-command.ts
+++ b/packages/harness/src/integrate-command.ts
@@ -5,14 +5,19 @@
  * agent, model, opencodeBin. Parses --work-dir, --prompt-path, --out from argv.
  * Assembles IntegrationConfig and calls runIntegration(config, makeRealAdapters()).
  *
- * Exit codes: 0 on {ok:true}, 1 on {ok:false} or exception.
+ * On {ok:true}: packages a clean merged source snapshot (via git archive) plus
+ * provenance.json into a single artifact at --out using atomic staging.
+ *
+ * Exit codes: 0 on {ok:true} + artifact written, 1 on {ok:false} or exception.
  * Error output: one-line message only — no stack traces, no secrets.
  *
  * No classes; functions only; explicit boolean checks; no as-any.
  */
 
 import type {IntegrationConfig} from './integrate.js'
-import {readFileSync} from 'node:fs'
+import {execFileSync} from 'node:child_process'
+import {copyFileSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync} from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import {fileURLToPath} from 'node:url'
 import {makeRealAdapters, runIntegration} from './integrate.js'
@@ -82,17 +87,85 @@ function parseFlags(argv: readonly string[]): ParsedFlags {
 }
 
 // ---------------------------------------------------------------------------
+// Artifact packaging
+// ---------------------------------------------------------------------------
+
+/**
+ * Packages a clean merged source snapshot plus provenance.json into a single
+ * tar artifact at outPath using atomic staging.
+ *
+ * Steps:
+ *   1. Create a temp staging dir.
+ *   2. Run `git archive --format=tar --output=<tmp>/source.tar <integrationCommit>` in workDir.
+ *   3. Extract source.tar into <tmp>/tree, copy provenance.json into <tmp>/tree.
+ *   4. Re-tar <tmp>/tree → <tmp>/artifact.tar.
+ *   5. Ensure outPath parent dir exists, then atomically rename <tmp>/artifact.tar → outPath.
+ *   6. Clean the temp dir in a finally block.
+ *
+ * ATOMIC: the rename only happens after the artifact is fully built. Any error
+ * before the rename leaves outPath untouched.
+ *
+ * @param workDir           - The integration work directory (contains the git repo + provenance.json).
+ * @param integrationCommit - The commit SHA to archive (the frozen integration commit).
+ * @param outPath           - Destination path for the final artifact tar.
+ */
+export async function packageArtifact(workDir: string, integrationCommit: string, outPath: string): Promise<void> {
+  const tmpStaging = mkdtempSync(path.join(os.tmpdir(), 'harness-artifact-'))
+  try {
+    const sourceTar = path.join(tmpStaging, 'source.tar')
+    const treeDir = path.join(tmpStaging, 'tree')
+    const artifactTar = path.join(tmpStaging, 'artifact.tar')
+
+    // Step 2: Extract the clean merged source tree from the integration commit.
+    execFileSync('git', ['archive', '--format=tar', `--output=${sourceTar}`, integrationCommit], {
+      cwd: workDir,
+      stdio: ['ignore', 'ignore', 'pipe'],
+    })
+
+    // Step 3a: Extract source.tar into tree dir.
+    mkdirSync(treeDir, {recursive: true})
+    execFileSync('tar', ['xf', sourceTar, '-C', treeDir], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    })
+
+    // Step 3b: Copy provenance.json from workDir into the tree.
+    copyFileSync(path.join(workDir, 'provenance.json'), path.join(treeDir, 'provenance.json'))
+
+    // Step 4: Re-tar the tree (with provenance.json included) into artifact.tar.
+    execFileSync('tar', ['cf', artifactTar, '-C', treeDir, '.'], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    })
+
+    // Step 5: Ensure outPath parent exists, then atomically promote the artifact.
+    mkdirSync(path.dirname(outPath), {recursive: true})
+    renameSync(artifactTar, outPath)
+  } finally {
+    // Always clean the temp dir, even on error. Ignore cleanup failures.
+    try {
+      rmSync(tmpStaging, {recursive: true, force: true})
+    } catch {
+      // Intentionally swallowed — cleanup failure must not mask the real error.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main command
 // ---------------------------------------------------------------------------
 
 /**
  * Implements `harness integrate`.
  *
- * @param argv       - CLI arguments (everything after "integrate").
- * @param configPath - Path to harness.config.json (defaults to package root; injectable for tests).
+ * @param argv              - CLI arguments (everything after "integrate").
+ * @param configPath        - Path to harness.config.json (defaults to package root; injectable for tests).
+ * @param _packageArtifact  - Injectable override for packageArtifact (for unit tests; defaults to the real impl).
  * @returns Exit code: 0 on success, 1 on failure.
  */
-export async function cmdIntegrate(argv: readonly string[], configPath: string = DEFAULT_CONFIG_PATH): Promise<number> {
+export async function cmdIntegrate(
+  argv: readonly string[],
+  configPath: string = DEFAULT_CONFIG_PATH,
+  _packageArtifact: typeof packageArtifact = packageArtifact,
+): Promise<number> {
   // Parse flags.
   const flags = parseFlags(argv)
 
@@ -105,6 +178,13 @@ export async function cmdIntegrate(argv: readonly string[], configPath: string =
     console.error('[integrate] Missing required flag: --prompt-path <path>')
     return 1
   }
+  if (flags.out === undefined) {
+    console.error('[integrate] Missing required flag: --out <path>')
+    return 1
+  }
+
+  const workDir = flags.workDir
+  const outPath = flags.out
 
   // Read harness.config.json.
   let rawConfig: unknown
@@ -129,14 +209,15 @@ export async function cmdIntegrate(argv: readonly string[], configPath: string =
     agent: rawConfig.agent,
     model: rawConfig.model,
     opencodeBin: rawConfig.opencode_bin ?? 'opencode',
-    workDir: flags.workDir,
+    workDir,
     promptPath: flags.promptPath,
   }
 
-  // Run the integration.
+  // Run the integration and package the artifact.
   try {
     const result = await runIntegration(config, makeRealAdapters())
     if (result.ok === true) {
+      await _packageArtifact(workDir, result.manifest.integrationCommit, outPath)
       return 0
     }
     console.error(`[integrate] ${result.error}`)

--- a/packages/harness/src/integrate.test.ts
+++ b/packages/harness/src/integrate.test.ts
@@ -20,6 +20,7 @@ function makeAdapters(overrides: Partial<IntegrationAdapters> = {}): Integration
     fetchRef: async () => {},
     createBranch: async () => {},
     runMerge: async () => {},
+    commitIntegration: async () => {},
     buildCli: async () => {},
     verifyVersion: async () => {},
     getCommitSha: async () => 'abc1234deadbeef',
@@ -341,6 +342,135 @@ describe('runIntegration', () => {
       // Manifest is persisted
       const persisted = await readProvenanceManifest(dir)
       expect(persisted).toEqual(result.manifest)
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+
+  // ---------------------------------------------------------------------------
+  // FIX 1: commitIntegration called after runMerge and before getCommitSha
+  // ---------------------------------------------------------------------------
+
+  it('fIX 1: commitIntegration is called after runMerge and before getCommitSha when sources exist', async () => {
+    // #given
+    const dir = await makeTmpDir()
+    try {
+      await fs.writeFile(
+        path.join(dir, 'prompt.txt'),
+        'dummy {{tag}} {{branch}} {{merges}} {{sources}} {{repo}} {{version}} {{channel}} {{base}} {{release_repo}} {{release_url}} {{branches}}',
+      )
+      const callOrder: string[] = []
+      const adapters = makeAdapters({
+        runMerge: async () => {
+          callOrder.push('runMerge')
+        },
+        commitIntegration: async () => {
+          callOrder.push('commitIntegration')
+        },
+        getCommitSha: async () => {
+          callOrder.push('getCommitSha')
+          return 'cafebabe5678'
+        },
+      })
+
+      // #when
+      const result = await runIntegration(
+        {
+          baseVersion: '1.15.13',
+          releaseRepo: 'anomalyco/opencode',
+          integrationRefs: ['https://github.com/anomalyco/opencode/pull/30182'],
+          agent: 'build',
+          model: 'anthropic/claude-sonnet-4-6',
+          opencodeBin: 'opencode',
+          workDir: dir,
+          promptPath: path.join(dir, 'prompt.txt'),
+        },
+        adapters,
+      )
+
+      // #then
+      expect(result.ok).toBe(true)
+      // commitIntegration must come after runMerge and before getCommitSha
+      const mergeIdx = callOrder.indexOf('runMerge')
+      const commitIdx = callOrder.indexOf('commitIntegration')
+      const shaIdx = callOrder.indexOf('getCommitSha')
+      expect(mergeIdx).toBeGreaterThanOrEqual(0)
+      expect(commitIdx).toBeGreaterThan(mergeIdx)
+      expect(shaIdx).toBeGreaterThan(commitIdx)
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+
+  it('fIX 1: commitIntegration is NOT called when sources is empty', async () => {
+    // #given
+    const dir = await makeTmpDir()
+    let commitCalled = false
+    try {
+      const adapters = makeAdapters({
+        commitIntegration: async () => {
+          commitCalled = true
+        },
+      })
+
+      // #when
+      const result = await runIntegration(
+        {
+          baseVersion: '1.15.13',
+          releaseRepo: 'anomalyco/opencode',
+          integrationRefs: [],
+          agent: 'build',
+          model: 'anthropic/claude-sonnet-4-6',
+          opencodeBin: 'opencode',
+          workDir: dir,
+          promptPath: path.join(dir, 'prompt.txt'),
+        },
+        adapters,
+      )
+
+      // #then
+      expect(result.ok).toBe(true)
+      expect(commitCalled).toBe(false)
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+
+  it('fIX 1: fail-hard when commitIntegration fails', async () => {
+    // #given
+    const dir = await makeTmpDir()
+    try {
+      await fs.writeFile(
+        path.join(dir, 'prompt.txt'),
+        'dummy {{tag}} {{branch}} {{merges}} {{sources}} {{repo}} {{version}} {{channel}} {{base}} {{release_repo}} {{release_url}} {{branches}}',
+      )
+      const adapters = makeAdapters({
+        commitIntegration: async () => {
+          throw new Error('git commit failed: nothing to commit')
+        },
+      })
+
+      // #when
+      const result = await runIntegration(
+        {
+          baseVersion: '1.15.13',
+          releaseRepo: 'anomalyco/opencode',
+          integrationRefs: ['https://github.com/anomalyco/opencode/pull/30182'],
+          agent: 'build',
+          model: 'anthropic/claude-sonnet-4-6',
+          opencodeBin: 'opencode',
+          workDir: dir,
+          promptPath: path.join(dir, 'prompt.txt'),
+        },
+        adapters,
+      )
+
+      // #then
+      expect(result.ok).toBe(false)
+      const manifest = await readProvenanceManifest(dir)
+      expect(manifest).toBeNull()
+      if (result.ok) throw new Error('expected failure result')
+      expect(result.error).toMatch(/commit/i)
     } finally {
       await fs.rm(dir, {recursive: true, force: true})
     }

--- a/packages/harness/src/integrate.ts
+++ b/packages/harness/src/integrate.ts
@@ -71,6 +71,8 @@ export interface IntegrationAdapters {
   buildCli: (workDir: string, version: string, channel: string) => Promise<void>
   /** Verify the built CLI --version matches the expected version. */
   verifyVersion: (workDir: string, expectedVersion: string) => Promise<void>
+  /** Commit the integrated working tree (after LLM merge) so HEAD contains the merge. */
+  commitIntegration: (workDir: string, message: string) => Promise<void>
   /** Get the current HEAD commit SHA of the work repo. */
   getCommitSha: (workDir: string) => Promise<string>
 }
@@ -233,6 +235,35 @@ export function makeRealAdapters(): IntegrationAdapters {
       }
     },
 
+    commitIntegration: async (workDir, message) => {
+      // Stage all changes (new, modified, deleted) from the LLM merge.
+      await gitExec(
+        [
+          '-c',
+          'user.name=fro-bot harness integrate',
+          '-c',
+          'user.email=github-actions[bot]@users.noreply.github.com',
+          'add',
+          '-A',
+        ],
+        workDir,
+      )
+      // Commit with --no-verify to skip any hooks in the cloned upstream repo.
+      await gitExec(
+        [
+          '-c',
+          'user.name=fro-bot harness integrate',
+          '-c',
+          'user.email=github-actions[bot]@users.noreply.github.com',
+          'commit',
+          '--no-verify',
+          '-m',
+          message,
+        ],
+        workDir,
+      )
+    },
+
     getCommitSha: async workDir => {
       return gitExec(['rev-parse', 'HEAD'], workDir)
     },
@@ -321,6 +352,15 @@ export async function runIntegration(
       await adapters.runMerge(workDir, opencodeBin, agent, model, prompt)
     } catch (error) {
       return {ok: false, error: `LLM merge failed: ${errorMessage(error)}`}
+    }
+
+    // Step 5.5: Commit the integrated working tree so HEAD contains the merge.
+    // Without this, getCommitSha (Step 8) returns the bare tag SHA and
+    // git archive would ship the pre-merge tree.
+    try {
+      await adapters.commitIntegration(workDir, `integrate: apply LLM merge onto v${baseVersion}`)
+    } catch (error) {
+      return {ok: false, error: `Commit integration failed: ${errorMessage(error)}`}
     }
 
     // Step 6: Build the native CLI.


### PR DESCRIPTION
Connects the two halves of the `@fro.bot/harness` release pipeline so a patched build can actually run end to end.

Until now the integration engine produced a merged OpenCode commit on a throwaway clone that the per-platform build matrix could never reach — the matrix cloned upstream, where that commit does not exist. A patched release was therefore impossible to run; only a stock build (already on upstream) worked.

## What this adds

- A `harness integrate` CLI subcommand that runs the LLM merge of the configured upstream refs onto the pinned release tag, then packages a clean source snapshot.
- The release workflow now runs an `integrate` job first: it performs the merge, captures the integration commit, and uploads a clean merged-source archive (via `git archive`, plus the provenance manifest) as a workflow artifact. It emits the integration commit and an artifact digest as job outputs.
- The build matrix consumes that artifact: it verifies the digest, extracts the source, and builds each platform from it via a new `--source-tree` path instead of cloning upstream. Each platform runs its own clean install and build, so no platform-specific state from the integrate runner leaks across builds.

## Trust and safety

- The `integrate` and `build` jobs are read-only (`contents: read`, no id-token, `persist-credentials: false`); publishing privileges stay scoped to the `publish` job. The untrusted merge cannot push or publish.
- A failed merge produces no artifact, so the build matrix never runs against a partial or missing tree.
- The merge result is committed before the integration commit is captured, so the published binary actually contains the merge.
- Merged refs come only from the configured carry-policy allowlist; the release is a maintainer-gated manual dispatch, and the provenance manifest records the exact inputs for audit.

A real patched release additionally requires the `HARNESS_OPENCODE_AUTH_JSON` secret (documented in the harness bootstrap notes); a stock dry run needs no secret.