### PR TITLE
fix(harness): use the existing AUTH_JSON secret for the integrate job

### DIFF
--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Provision OpenCode model auth (file-based, never logged)
         env:
-          HARNESS_OPENCODE_AUTH_JSON: ${{ secrets.HARNESS_OPENCODE_AUTH_JSON }}
+          HARNESS_OPENCODE_AUTH_JSON: ${{ secrets.AUTH_JSON }}
         run: |
           set -euo pipefail
           AUTH_DIR="${HOME}/.local/share/opencode"

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -109,7 +109,7 @@ jobs:
           chmod 600 "${AUTH_FILE}"
           # Sanity-check: file must be non-empty and valid JSON object.
           if [ ! -s "${AUTH_FILE}" ]; then
-            echo "ERROR: HARNESS_OPENCODE_AUTH_JSON secret is empty or missing" >&2
+            echo "ERROR: AUTH_JSON secret is empty or missing" >&2
             exit 1
           fi
           node -e "
@@ -117,11 +117,11 @@ jobs:
             const raw = fs.readFileSync('${AUTH_FILE}', 'utf8');
             let parsed;
             try { parsed = JSON.parse(raw); } catch (e) {
-              process.stderr.write('ERROR: HARNESS_OPENCODE_AUTH_JSON is not valid JSON\n');
+              process.stderr.write('ERROR: AUTH_JSON secret is not valid JSON\n');
               process.exit(1);
             }
             if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-              process.stderr.write('ERROR: HARNESS_OPENCODE_AUTH_JSON must be a JSON object\n');
+              process.stderr.write('ERROR: AUTH_JSON secret must be a JSON object\n');
               process.exit(1);
             }
             process.stdout.write('auth: provisioned\n');

--- a/packages/harness/AGENTS.md
+++ b/packages/harness/AGENTS.md
@@ -73,17 +73,17 @@ The `--source-tree` flag is explicit and fail-closed: if the directory is missin
 - `provenance.json` in the artifact records the exact upstream inputs (base tag + each ref + resolved SHA) for audit before publish.
 - The artifact is SHA-bound by construction (`git archive <integration_commit>`); the explicit digest check in the build matrix makes this fail-closed.
 
-### `HARNESS_OPENCODE_AUTH_JSON` secret
+### `AUTH_JSON` secret
 
-Required for any release that runs an LLM merge (i.e. any release with integration refs configured). Configure in repository Settings → Secrets and variables → Actions:
+Required for any release that runs an LLM merge (i.e. any release with integration refs configured). The integrate job reuses the repository's existing `AUTH_JSON` secret (the same model credential the action uses), so no separate secret is needed:
 
-- **Name:** `HARNESS_OPENCODE_AUTH_JSON`
+- **Name:** `AUTH_JSON`
 - **Value:** JSON mapping provider to auth config:
   ```json
   {"anthropic":{"type":"api","key":"sk-ant-..."}}
   ```
 
-The integrate job writes this to a 0600 temp file and passes it to OpenCode as a file-based credential. The value is never echoed to logs or included in any artifact.
+The integrate job maps it to an internal env var, writes it to a 0600 temp file, and passes it to OpenCode as a file-based credential. The value is never echoed to logs or included in any artifact.
 
 ### Dispatching a release
 

--- a/packages/harness/BOOTSTRAP.md
+++ b/packages/harness/BOOTSTRAP.md
@@ -103,19 +103,17 @@ A green dry run means the build infrastructure is solid and the real `1.15.13` p
 
 ## Dispatching a real patched release
 
-The dry run above uses a stock OpenCode commit with no LLM-merge patch. A real patched release (the actual point of this package) requires the `HARNESS_OPENCODE_AUTH_JSON` secret to be configured in the repository, because the `integrate` job runs an LLM merge via `opencode run` and needs model credentials.
+The dry run above uses a stock OpenCode commit with no LLM-merge patch. A real patched release (the actual point of this package) requires the `AUTH_JSON` secret to be configured in the repository, because the `integrate` job runs an LLM merge via `opencode run` and needs model credentials.
 
-### Required secret: `HARNESS_OPENCODE_AUTH_JSON`
+### Required secret: `AUTH_JSON`
 
-Add this secret to the `fro-bot/agent` repository (Settings → Secrets and variables → Actions → New repository secret):
+The `integrate` job reuses the repository's existing `AUTH_JSON` secret — the same model credential the action uses — so no separate secret needs to be created. Its value is a JSON object mapping provider name to auth config, e.g.:
 
-- **Name:** `HARNESS_OPENCODE_AUTH_JSON`
-- **Value:** A JSON object mapping provider name to auth config, e.g.:
-  ```json
-  {"anthropic":{"type":"api","key":"sk-ant-..."}}
-  ```
+```json
+{"anthropic":{"type":"api","key":"sk-ant-..."}}
+```
 
-The integrate job writes this to a 0600 temp file and passes it to OpenCode as a file-based credential. The secret value is never echoed to logs.
+The integrate job maps `AUTH_JSON` to an internal env var, writes it to a 0600 temp file, and passes it to OpenCode as a file-based credential. The secret value is never echoed to logs.
 
 ### How a patched release works
 
@@ -150,4 +148,4 @@ gh run watch --repo fro-bot/agent
 
 ## After bootstrap
 
-Every subsequent release is triggered by dispatching `harness-release.yaml` with the appropriate `base_version` (and `dry_run=true` to skip publish). The `integrate` job derives the integration commit from the LLM merge; the `build` matrix consumes the resulting artifact. The `publish` job obtains an OIDC token from GitHub and publishes to npm with automatic provenance — no npm token, no secrets to rotate beyond `HARNESS_OPENCODE_AUTH_JSON`.
+Every subsequent release is triggered by dispatching `harness-release.yaml` with the appropriate `base_version` (and `dry_run=true` to skip publish). The `integrate` job derives the integration commit from the LLM merge; the `build` matrix consumes the resulting artifact. The `publish` job obtains an OIDC token from GitHub and publishes to npm with automatic provenance — no npm token, no secrets to rotate beyond `AUTH_JSON`.


### PR DESCRIPTION
The harness release workflow's `integrate` job needs an OpenCode model credential to run the LLM merge. Point it at the repository's existing `AUTH_JSON` secret — the same credential the action already uses — rather than requiring a separate secret. This keeps a single source of truth for the cliproxy credential.

The value is still mapped to an internal env var, written to a `0600` auth file, and never logged. The bootstrap and package docs are updated to name `AUTH_JSON`.