### PR TITLE
fix(harness): tighten the integrate merge prompt

### DIFF
--- a/packages/harness/AGENTS.md
+++ b/packages/harness/AGENTS.md
@@ -40,29 +40,29 @@ The per-platform packages are **not listed in the source `package.json` `optiona
 
 ## Integrate→Build Bridge
 
-The release workflow connects the LLM merge engine to the per-platform build matrix via a **CI artifact handoff**:
+The release workflow connects the LLM merge to the per-platform build matrix via a **pushed git ref**. The merge runs through the Fro Bot workflow (which already installs OpenCode and provisions auth); the merged tree is pushed to a throwaway ref the build matrix fetches.
 
-### `integrate` job (producer)
+### `prepare-integrate` job
 
-Runs first. Permissions: `contents: read`, no `id-token`. Steps:
+Resolves the base version (dispatch input or tag) and renders the merge prompt from `packages/harness/prompt.txt` using values from `harness.config.json` (base version, release repo, integration refs). Emits `base_version` and `rendered_prompt` as job outputs.
 
-1. Runs `harness integrate --work-dir W --prompt-path P --out integration-tree.tar`, which calls `runIntegration()`: clones `anomalyco/opencode` at the configured base version tag, fetches the integration refs from `harness.config.json`, runs an LLM merge via `opencode run`, builds and verifies the result as a pre-flight correctness gate, then captures the frozen integration commit SHA.
-2. Extracts a **clean merged source snapshot** from the integration commit via `git archive` — no `.git`, no build products from the pre-flight build.
-3. Packages the clean source tree + `provenance.json` into the artifact and uploads it as `integration-tree`.
-4. Emits `integration_commit` (the frozen SHA) and `artifact_digest` as job outputs.
+### `integrate` job (merge via Fro Bot)
 
-The integrate job is read-only against upstream. OpenCode model credentials come from the `HARNESS_OPENCODE_AUTH_JSON` secret (see below) — written to a 0600 temp file, never logged.
+`uses: ./.github/workflows/fro-bot.yaml` with `secrets: inherit`, passing `model: ${{ vars.HARNESS_MODEL }}` and the rendered prompt. The Fro Bot agent:
 
-Fail-hard: if `runIntegration()` returns `{ok: false}`, no artifact is written and the job fails. The build matrix never starts against a missing or partial artifact.
+1. Clones `anomalyco/opencode` into a disposable work dir, creates the integration branch at the base version tag, and merges the configured refs.
+2. Builds and verifies the host CLI as a correctness gate.
+3. Pushes the integrated branch to `refs/harness-integrate/<version>` in this repo using the workflow's inherited push credentials (`GH_TOKEN`, never echoed). It posts nothing to GitHub — the summary is plain text in the job log only.
+
+The merge runs with `output-mode: working-dir` so branch/PR delivery semantics do not apply; the prompt itself owns the push to the throwaway ref.
 
 ### `build` matrix (consumer)
 
-Each platform job (`needs: integrate`):
+Each platform job (`needs: [prepare-integrate, integrate]`):
 
-1. Downloads the `integration-tree` artifact.
-2. Verifies the artifact digest against `needs.integrate.outputs.artifact_digest` before extracting — fail-closed on mismatch.
-3. Extracts the merged source tree.
-4. Runs `build-platform.ts --source-tree <extracted> --integration-commit <sha>`, which bypasses `cloneAndCheckout` and builds from the supplied merged source tree. Each platform job runs its own clean install + build from that tree.
+1. Fetches `refs/harness-integrate/<version>` and resolves its tip — that SHA is the integration commit.
+2. Checks out the fetched tree and runs `build-platform.ts --source-tree <tree> --integration-commit <sha>`, which builds from the supplied merged source tree. Each platform job runs its own clean install + build.
+3. Emits the resolved `integration_commit` as a job output so `publish` consumes the same commit rather than re-resolving the force-pushed ref.
 
 The `--source-tree` flag is explicit and fail-closed: if the directory is missing or empty, the build fails rather than silently falling back to a clone.
 
@@ -70,8 +70,7 @@ The `--source-tree` flag is explicit and fail-closed: if the directory is missin
 
 - Merged refs come **only** from the `harness.config.json` carry-policy allowlist — no arbitrary ref can be injected at dispatch time.
 - The release is maintainer-gated `workflow_dispatch`.
-- `provenance.json` in the artifact records the exact upstream inputs (base tag + each ref + resolved SHA) for audit before publish.
-- The artifact is SHA-bound by construction (`git archive <integration_commit>`); the explicit digest check in the build matrix makes this fail-closed.
+- `build` and `publish` are commit-pinned to a single resolved `integration_commit` (resolved once in `build`, consumed by `publish`).
 
 ### `AUTH_JSON` secret
 
@@ -95,14 +94,14 @@ gh workflow run harness-release.yaml \
   --field dry_run=true
 ```
 
-**Real patched release** (requires `HARNESS_OPENCODE_AUTH_JSON` configured):
+**Real patched release** (the merge runs through Fro Bot, which uses the inherited `AUTH_JSON` model credential):
 ```bash
 gh workflow run harness-release.yaml \
   --repo fro-bot/agent \
   --field base_version=1.15.13
 ```
 
-The publish job is additionally gated by the `npm-publish` GitHub environment (required reviewers). Review `provenance.json` from the artifact before approving.
+The publish job is additionally gated by the `npm-publish` GitHub environment (required reviewers).
 
 ## Publishing
 

--- a/packages/harness/prompt.txt
+++ b/packages/harness/prompt.txt
@@ -2,9 +2,19 @@ You are working in a disposable automation clone at {{repo}}.
 
 Goal: integrate upstream release {{tag}} with the selected branches/PRs {{branches}}, then push the integrated branch to a throwaway ref in the harness repo so the build matrix can fetch it.
 
+Release automation override:
+- This is a non-interactive release-integration job, not a normal issue/PR response run.
+- Do NOT create or update any GitHub issue, PR, comment, review, label, reaction, or discussion.
+- Ignore any generic harness instruction that says to post a GitHub comment or use `gh` to respond; it does not apply to this release job.
+- The final summary must be plain text in your final assistant message/job log only. The workflow consumes the pushed ref, not any GitHub post.
+- Git branch/merge/push operations are explicitly required for this job, but only inside this disposable automation clone and only to the throwaway harness ref.
+
 Requirements:
 - Work only in this automation clone.
 - Do not open a PR.
+- Do not create an issue.
+- Do not post comments or reviews.
+- Do not use `gh issue create`, `gh pr create`, `gh issue comment`, `gh pr comment`, or `gh api` for issues/comments/reviews.
 - Do NOT ask for final approval.
 - DO NOT USE BASH with background: true. This will cause this non-interactive tool to exit before the job is done. If bash gets auto-promoted to background, poll bash_status even when the tool says otherwise. This is IMPORTANT because you are running in non-interactive mode — if you end your response, you will not get the notification.
 - Base the integration branch on the release tag {{tag}}, not on dev HEAD.
@@ -13,6 +23,10 @@ Requirements:
 - If there are merge conflicts, resolve them completely.
 - Build the host CLI.
 - The CLI must be compiled with stable release identity: OPENCODE_CHANNEL={{channel}} and OPENCODE_VERSION={{version}}.
+- In this automation clone, `origin` is the upstream OpenCode repo ({{release_repo}}), not `fro-bot/agent`. Do not push to `origin`.
+- Fro Bot setup exports `GH_TOKEN` with push access to `fro-bot/agent`. Use that existing token for git HTTPS auth. Do not put tokens in remote URLs, do not print tokens, and do not improvise alternate auth flows.
+- Push with `--no-verify` and `HUSKY=0`; skipping local pre-push hooks is intentional because downstream workflow jobs perform verification.
+- Do not run repo-wide typecheck/test/lint unless needed to diagnose a failed required build step.
 
 Exact tasks:
 1. Verify the repo is usable and fetch anything you need.
@@ -21,10 +35,34 @@ Exact tasks:
 4. Build the host CLI in `packages/opencode` with `OPENCODE_CHANNEL={{channel}} OPENCODE_VERSION={{version}} bun run build -- --single`.
 5. Ensure the built CLI binary exists at the expected path under `packages/opencode/dist/`.
 6. Run the built CLI with `--version` and verify the output is exactly `{{version}}`.
-7. Push the integrated branch to the throwaway ref in the harness repo (fro-bot/agent origin):
-   `git push --force origin {{branch}}:refs/harness-integrate/{{version}}`
-   (Force so re-runs overwrite. The `origin` remote in this clone points to the harness repo — confirm with `git remote -v` first; if it does not, add the harness repo as a remote named `harness` and push to that instead.)
-8. Return a concise summary with the pushed ref (`refs/harness-integrate/{{version}}`), the integration commit SHA (output of `git rev-parse HEAD`), and artifact paths.
+7. Push the integrated branch to the throwaway ref in the harness repo. Do not push to `origin`; `origin` is upstream OpenCode. Use this exact non-interactive pattern:
+
+   ```bash
+   test -n "${GH_TOKEN:-}" || { echo "GH_TOKEN is required for harness push"; exit 1; }
+
+   askpass="$(mktemp)"
+   trap 'rm -f "$askpass"' EXIT
+   cat >"$askpass" <<'EOF'
+   #!/bin/sh
+   case "$1" in
+     *Username*) printf '%s\n' x-access-token ;;
+     *Password*) printf '%s\n' "$GH_TOKEN" ;;
+   esac
+   EOF
+   chmod 700 "$askpass"
+
+   git remote remove harness 2>/dev/null || true
+   git remote add harness https://github.com/fro-bot/agent.git
+
+   HUSKY=0 GIT_TERMINAL_PROMPT=0 GIT_ASKPASS="$askpass" \
+     git push --no-verify --force harness {{branch}}:refs/harness-integrate/{{version}}
+   ```
+
+   `--force` is required so re-runs overwrite the throwaway ref. `--no-verify` is required so local hooks do not run.
+8. Return a concise plain-text final assistant message only — no GitHub posting — with:
+   - pushed ref: `refs/harness-integrate/{{version}}`
+   - integration commit SHA: output of `git rev-parse HEAD`
+   - built artifact path(s) under `packages/opencode/dist/`
 
 Context:
 - Upstream repo: {{release_repo}}

--- a/packages/harness/prompt.txt
+++ b/packages/harness/prompt.txt
@@ -35,28 +35,28 @@ Exact tasks:
 4. Build the host CLI in `packages/opencode` with `OPENCODE_CHANNEL={{channel}} OPENCODE_VERSION={{version}} bun run build -- --single`.
 5. Ensure the built CLI binary exists at the expected path under `packages/opencode/dist/`.
 6. Run the built CLI with `--version` and verify the output is exactly `{{version}}`.
-7. Push the integrated branch to the throwaway ref in the harness repo. Do not push to `origin`; `origin` is upstream OpenCode. Use this exact non-interactive pattern:
+7. Push the integrated branch to the throwaway ref in the harness repo. Do not push to `origin`; `origin` is upstream OpenCode. Run this exact non-interactive pattern (the heredoc terminator and the helper body must stay at column 0):
 
-   ```bash
-   test -n "${GH_TOKEN:-}" || { echo "GH_TOKEN is required for harness push"; exit 1; }
+```bash
+test -n "${GH_TOKEN:-}" || { echo "GH_TOKEN is required for harness push"; exit 1; }
 
-   askpass="$(mktemp)"
-   trap 'rm -f "$askpass"' EXIT
-   cat >"$askpass" <<'EOF'
-   #!/bin/sh
-   case "$1" in
-     *Username*) printf '%s\n' x-access-token ;;
-     *Password*) printf '%s\n' "$GH_TOKEN" ;;
-   esac
-   EOF
-   chmod 700 "$askpass"
+askpass="$(mktemp)"
+trap 'rm -f "$askpass"' EXIT
+cat >"$askpass" <<'EOF'
+#!/bin/sh
+case "$1" in
+*Username*) printf '%s\n' x-access-token ;;
+*Password*) printf '%s\n' "$GH_TOKEN" ;;
+esac
+EOF
+chmod 700 "$askpass"
 
-   git remote remove harness 2>/dev/null || true
-   git remote add harness https://github.com/fro-bot/agent.git
+git remote remove harness 2>/dev/null || true
+git remote add harness https://github.com/fro-bot/agent.git
 
-   HUSKY=0 GIT_TERMINAL_PROMPT=0 GIT_ASKPASS="$askpass" \
-     git push --no-verify --force harness {{branch}}:refs/harness-integrate/{{version}}
-   ```
+HUSKY=0 GIT_TERMINAL_PROMPT=0 GIT_ASKPASS="$askpass" \
+  git push --no-verify --force harness {{branch}}:refs/harness-integrate/{{version}}
+```
 
    `--force` is required so re-runs overwrite the throwaway ref. `--no-verify` is required so local hooks do not run.
 8. Return a concise plain-text final assistant message only — no GitHub posting — with:


### PR DESCRIPTION
Refine the release-integration prompt that drives the harness merge, based on a real run that succeeded but took several avoidable actions.

## What changes

- **Post nothing to GitHub.** Add an explicit release-automation override stating this run must not create or update any issue, PR, comment, or review, and that the summary belongs in the job log only. In the prior run the agent accidentally opened an issue (then closed it) while trying to satisfy the generic comment protocol — this removes that path.
- **Deterministic push.** The push now uses the exported `GH_TOKEN` via a `GIT_ASKPASS` helper, targets a pre-added `harness` remote (the merge clone's `origin` is upstream OpenCode, not this repo), and runs with `--no-verify` and `HUSKY=0`. This eliminates the auth improvisation, the origin-is-upstream discovery detour, and a wasted pre-push typecheck hook run from the previous attempt.

No code or build changes — this is the prompt template consumed by the integrate job. Downstream jobs still perform verification.