### PR TITLE
fix(harness): add repository field to per-platform package.json

### DIFF
--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -428,6 +428,10 @@ jobs:
             "version": "${BASE_VERSION}",
             "description": "Native binary for @fro.bot/harness on ${PLATFORM}/${ARCH}",
             "license": "MIT",
+            "repository": {
+              "type": "git",
+              "url": "git+https://github.com/fro-bot/agent.git"
+            },
             "os": ["${PLATFORM}"],
             "cpu": ["${ARCH}"],
             "files": ["bin"],


### PR DESCRIPTION
The first real harness publish failed: npm rejected the per-platform packages with `E422 Unprocessable Entity` during provenance verification, because npm requires `package.json` `repository.url` to match the GitHub repository from the OIDC/provenance bundle, and the generated per-platform `package.json` omitted the `repository` field entirely.

The merge, ref push, and all four platform builds succeeded — only the npm publish step failed, and nothing was partially published. Adding the `repository` field (matching the main package) lets trusted publishing complete.