### PR TITLE
fix(harness): publish main package from its directory; skip already-live versions

### DIFF
--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -476,7 +476,12 @@ jobs:
           for PLATFORM in linux darwin; do
             for ARCH in x64 arm64; do
               PKG_DIR="${PUBLISH_DIR}/${PLATFORM}-${ARCH}"
-              echo "Publishing @fro.bot/harness-${PLATFORM}-${ARCH}@${BASE_VERSION}..."
+              PKG_NAME="@fro.bot/harness-${PLATFORM}-${ARCH}"
+              if npm view "${PKG_NAME}@${BASE_VERSION}" version >/dev/null 2>&1; then
+                echo "Already published: ${PKG_NAME}@${BASE_VERSION}; skipping"
+                continue
+              fi
+              echo "Publishing ${PKG_NAME}@${BASE_VERSION}..."
               # OIDC trusted publishing: no token, provenance is automatic.
               npm publish "${PKG_DIR}"
             done
@@ -506,9 +511,15 @@ jobs:
             };
             fs.writeFileSync('packages/harness/package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
-          echo "Publishing @fro.bot/harness@${BASE_VERSION}..."
-          # OIDC trusted publishing: no token, provenance is automatic.
-          npm publish packages/harness
+          if npm view "@fro.bot/harness@${BASE_VERSION}" version >/dev/null 2>&1; then
+            echo "Already published: @fro.bot/harness@${BASE_VERSION}; skipping"
+          else
+            echo "Publishing @fro.bot/harness@${BASE_VERSION}..."
+            # OIDC trusted publishing: no token, provenance is automatic.
+            # Use a directory-anchored publish so npm does not parse the path as a
+            # github: package spec (npm publish <path> needs ./ or cd into the dir).
+            (cd packages/harness && npm publish .)
+          fi
 
       - name: Dry run summary
         if: steps.params.outputs.dry_run == 'true'


### PR DESCRIPTION
The first real publish left the release in a partial state: the four per-platform packages published at 1.15.13, but the main `@fro.bot/harness` failed.

`npm publish packages/harness` (a bare path without `./`) is parsed by npm as a GitHub shorthand package spec, so npm tried to resolve `ssh://git@github.com/packages/harness.git` and failed with a publickey error — it never reached the local package. Running the publish from inside the package directory (`cd packages/harness && npm publish .`) makes npm treat it as a local package.

This also adds idempotent guards: each package publish is skipped if that exact `name@version` is already live on npm. npm versions are immutable, so this lets a recovery run finish a partially-published release — it skips the four platform packages already at 1.15.13 and publishes only the missing main package.