### PR TITLE
feat(harness): rebase to OpenCode 1.16.0 and fix release provenance

### DIFF
--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -460,14 +460,18 @@ jobs:
 
           # Write the provenance manifest into the main package for runtime use.
           # Values are passed via environment variables (not interpolated into the script body).
+          # integrationRefs is read from harness.config.json so the manifest is complete
+          # and isValidProvenance() accepts it (requires Array.isArray(v.integrationRefs)).
+          # INTEGRATION_COMMIT is the same SHA the build job resolved and verified — no
+          # split-brain between the binary's baked commit and the published manifest.
           node -e "
             const fs = require('fs');
             const baseVersion = process.env.BASE_VERSION;
             const integrationCommit = process.env.INTEGRATION_COMMIT;
             const buildSha = process.env.GITHUB_SHA || 'unknown';
-            let existing = {};
-            try { existing = JSON.parse(fs.readFileSync('packages/harness/provenance.json', 'utf8')); } catch {}
-            const manifest = { ...existing, baseVersion, integrationCommit, buildSha };
+            const config = JSON.parse(fs.readFileSync('packages/harness/harness.config.json', 'utf8'));
+            const integrationRefs = config.integrationRefs.map(ref => ({ ref, resolvedSha: integrationCommit }));
+            const manifest = { baseVersion, integrationRefs, integrationCommit, buildSha };
             fs.writeFileSync('packages/harness/provenance.json', JSON.stringify(manifest, null, 2) + '\n');
             console.log('provenance.json updated:', manifest);
           "

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -470,7 +470,11 @@ jobs:
             const integrationCommit = process.env.INTEGRATION_COMMIT;
             const buildSha = process.env.GITHUB_SHA || 'unknown';
             const config = JSON.parse(fs.readFileSync('packages/harness/harness.config.json', 'utf8'));
-            const integrationRefs = config.integrationRefs.map(ref => ({ ref, resolvedSha: integrationCommit }));
+            if (config.integrationRefs !== undefined && !Array.isArray(config.integrationRefs)) {
+              console.error('harness.config.json integrationRefs must be an array (got ' + typeof config.integrationRefs + ')');
+              process.exit(1);
+            }
+            const integrationRefs = (config.integrationRefs ?? []).map(ref => ({ ref, resolvedSha: integrationCommit }));
             const manifest = { baseVersion, integrationRefs, integrationCommit, buildSha };
             fs.writeFileSync('packages/harness/provenance.json', JSON.stringify(manifest, null, 2) + '\n');
             console.log('provenance.json updated:', manifest);

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -92,9 +92,11 @@ jobs:
           WORK_DIR="${RUNNER_TEMP}/harness-integrate-work"
 
           # Parse each integration ref into label and merge ref (mirrors parseSource).
-          BRANCHES=""
-          MERGES=""
-          SOURCES=""
+          # When INTEGRATION_REFS is empty, the loop body never executes and the
+          # sentinel values below are used — the prompt reads "no patches to merge".
+          BRANCHES="(none)"
+          MERGES="(none — build the release tag as-is)"
+          SOURCES="(none)"
           while IFS= read -r REF; do
             [ -z "${REF}" ] && continue
             if echo "${REF}" | grep -qE 'github\.com/([^/]+)/([^/]+)/pull/([0-9]+)'; then
@@ -115,9 +117,16 @@ jobs:
               LABEL="${REF}"
               MERGE_REF="refs/remotes/watch/local/${REF}"
             fi
-            BRANCHES="${BRANCHES:+${BRANCHES}, }${LABEL}"
-            MERGES="${MERGES:+${MERGES}, then }${MERGE_REF}"
-            SOURCES="${SOURCES:+${SOURCES}\n- }${LABEL} -> ${MERGE_REF}"
+            # First real ref: overwrite the sentinels.
+            if [ "${BRANCHES}" = "(none)" ]; then
+              BRANCHES="${LABEL}"
+              MERGES="${MERGE_REF}"
+              SOURCES="${LABEL} -> ${MERGE_REF}"
+            else
+              BRANCHES="${BRANCHES}, ${LABEL}"
+              MERGES="${MERGES}, then ${MERGE_REF}"
+              SOURCES="${SOURCES}\n- ${LABEL} -> ${MERGE_REF}"
+            fi
           done <<< "${INTEGRATION_REFS}"
 
           # --- Render the prompt template ---

--- a/packages/harness/harness.config.json
+++ b/packages/harness/harness.config.json
@@ -1,8 +1,8 @@
 {
   "release_repo": "anomalyco/opencode",
   "source_repo": "https://github.com/anomalyco/opencode.git",
-  "base_version": "1.15.13",
-  "integrationRefs": ["https://github.com/anomalyco/opencode/pull/30182"],
+  "base_version": "1.16.0",
+  "integrationRefs": [],
   "agent": "build",
   "model": "anthropic/claude-sonnet-4-6",
   "opencode_bin": "opencode"

--- a/packages/harness/prompt.txt
+++ b/packages/harness/prompt.txt
@@ -1,6 +1,6 @@
 You are working in a disposable automation clone at {{repo}}.
 
-Goal: integrate upstream release {{tag}} with the selected branches/PRs {{branches}}, then push the integrated branch to a throwaway ref in the harness repo so the build matrix can fetch it.
+Goal: integrate upstream release {{tag}} with the selected branches/PRs ({{branches}}), then push the integrated branch to a throwaway ref in the harness repo so the build matrix can fetch it. If the merge set is "(none — build the release tag as-is)", there are no patches to carry — skip merging and build the stock release tag directly.
 
 Release automation override:
 - This is a non-interactive release-integration job, not a normal issue/PR response run.
@@ -19,7 +19,7 @@ Requirements:
 - DO NOT USE BASH with background: true. This will cause this non-interactive tool to exit before the job is done. If bash gets auto-promoted to background, poll bash_status even when the tool says otherwise. This is IMPORTANT because you are running in non-interactive mode — if you end your response, you will not get the notification.
 - Base the integration branch on the release tag {{tag}}, not on dev HEAD.
 - Name the branch {{branch}}.
-- Merge these refs in order: {{merges}}.
+- If there are refs to merge ({{merges}}), merge them into {{branch}} in order; if the merge set is "(none — build the release tag as-is)", skip merging — the branch is the release tag as-is.
 - If there are merge conflicts, resolve them completely.
 - Build the host CLI.
 - The CLI must be compiled with stable release identity: OPENCODE_CHANNEL={{channel}} and OPENCODE_VERSION={{version}}.
@@ -31,7 +31,7 @@ Requirements:
 Exact tasks:
 1. Verify the repo is usable and fetch anything you need.
 2. Create or reset {{branch}} to refs/tags/{{tag}}.
-3. Merge {{merges}} into {{branch}}.
+3. If there are refs to merge ({{merges}}), merge them into {{branch}} in order. If the merge set is "(none — build the release tag as-is)", skip this step — the branch is already the release tag.
 4. Build the host CLI in `packages/opencode` with `OPENCODE_CHANNEL={{channel}} OPENCODE_VERSION={{version}} bun run build -- --single`.
 5. Ensure the built CLI binary exists at the expected path under `packages/opencode/dist/`.
 6. Run the built CLI with `--version` and verify the output is exactly `{{version}}`.
@@ -68,7 +68,6 @@ Context:
 - Upstream repo: {{release_repo}}
 - Base branch: dev
 - Release URL: {{release_url}}
-- Integration refs:
-- {{sources}}
+- Integration refs: {{sources}}
 
 If anything fails, fix it and continue until the branch is integrated, the configured build succeeds, and the ref is pushed.

--- a/packages/harness/src/cli.test.ts
+++ b/packages/harness/src/cli.test.ts
@@ -12,7 +12,7 @@ describe('getProvenance', () => {
     const p = getProvenance()
 
     // #then
-    expect(p.baseVersion).toBe('1.15.13')
+    expect(p.baseVersion).toBe('1.16.0')
     expect(Array.isArray(p.integrationRefs)).toBe(true)
     expect(p.integrationCommit).toBeNull()
     expect(p.buildSha).toBe('dev')

--- a/packages/harness/src/provenance.test.ts
+++ b/packages/harness/src/provenance.test.ts
@@ -1,0 +1,153 @@
+import {describe, expect, it} from 'vitest'
+import {isValidProvenance} from './provenance.js'
+
+/**
+ * Regression tests for the isValidProvenance writer↔validator contract.
+ *
+ * The published-provenance bug: the workflow writer produced a manifest with
+ * `integrationRefs: []` (empty carry set) but an earlier version of the manifest
+ * was missing the `integrationRefs` key entirely. isValidProvenance requires
+ * Array.isArray(v.integrationRefs), so a missing key caused it to return false,
+ * triggering the dev/scaffold fallback at runtime.
+ *
+ * These tests pin the exact shapes the workflow writer produces and the exact
+ * shapes that must be rejected, so any future regression is caught immediately.
+ */
+
+describe('isValidProvenance', () => {
+  // ── ACCEPT cases ──────────────────────────────────────────────────────────
+
+  it('accepts the empty-carry published shape (1.16.0 with no integration refs)', () => {
+    // #given — the exact shape the workflow writer produces for an empty carry set
+    const manifest = {
+      baseVersion: '1.16.0',
+      integrationRefs: [],
+      integrationCommit: 'abc1234def5678abc1234def5678abc1234def56',
+      buildSha: 'def5678abc1234def5678abc1234def5678abc12',
+    }
+
+    // #when
+    const result = isValidProvenance(manifest)
+
+    // #then — must be accepted; this is the regression guard for the empty-carry case
+    expect(result).toBe(true)
+  })
+
+  it('accepts a non-empty-carry shape with populated integrationRefs', () => {
+    // #given — a manifest with one integration ref (the normal carry case)
+    const manifest = {
+      baseVersion: '1.16.0',
+      integrationRefs: [
+        {
+          ref: 'pull/30182/head',
+          resolvedSha: 'abc1234def5678abc1234def5678abc1234def56',
+        },
+      ],
+      integrationCommit: 'abc1234def5678abc1234def5678abc1234def56',
+      buildSha: 'def5678abc1234def5678abc1234def5678abc12',
+    }
+
+    // #when
+    const result = isValidProvenance(manifest)
+
+    // #then
+    expect(result).toBe(true)
+  })
+
+  it('accepts a manifest with integrationCommit: null (dev scaffold shape)', () => {
+    // #given — integrationCommit is nullable per the Provenance interface
+    const manifest = {
+      baseVersion: '1.16.0',
+      integrationRefs: [],
+      integrationCommit: null,
+      buildSha: 'dev',
+    }
+
+    // #when
+    const result = isValidProvenance(manifest)
+
+    // #then
+    expect(result).toBe(true)
+  })
+
+  // ── REJECT cases ──────────────────────────────────────────────────────────
+
+  it('rejects a manifest MISSING integrationRefs (the published-provenance-fallback regression)', () => {
+    // #given — the EXACT shape that triggered the published-provenance bug:
+    // the manifest was written without the integrationRefs key, causing
+    // isValidProvenance to return false and getProvenance to fall back to
+    // the dev scaffold at runtime even in production.
+    // REGRESSION GUARD: this must stay false forever.
+    const manifestMissingIntegrationRefs = {
+      baseVersion: '1.16.0',
+      integrationCommit: 'abc',
+      buildSha: 'def',
+      // integrationRefs intentionally absent
+    }
+
+    // #when
+    const result = isValidProvenance(manifestMissingIntegrationRefs)
+
+    // #then — must be rejected; missing integrationRefs is invalid
+    expect(result).toBe(false)
+  })
+
+  it('rejects integrationRefs that is a string (not an array)', () => {
+    // #given — malformed config where integrationRefs is a string
+    const manifest = {
+      baseVersion: '1.16.0',
+      integrationRefs: 'pull/30182/head',
+      integrationCommit: 'abc1234',
+      buildSha: 'def5678',
+    }
+
+    // #when
+    const result = isValidProvenance(manifest)
+
+    // #then
+    expect(result).toBe(false)
+  })
+
+  it('rejects integrationRefs that is a plain object (not an array)', () => {
+    // #given — malformed config where integrationRefs is an object
+    const manifest = {
+      baseVersion: '1.16.0',
+      integrationRefs: {ref: 'pull/30182/head'},
+      integrationCommit: 'abc1234',
+      buildSha: 'def5678',
+    }
+
+    // #when
+    const result = isValidProvenance(manifest)
+
+    // #then
+    expect(result).toBe(false)
+  })
+
+  it('rejects a manifest with an empty baseVersion', () => {
+    // #given
+    const manifest = {
+      baseVersion: '',
+      integrationRefs: [],
+      integrationCommit: null,
+      buildSha: 'dev',
+    }
+
+    // #when
+    const result = isValidProvenance(manifest)
+
+    // #then
+    expect(result).toBe(false)
+  })
+
+  it('rejects null', () => {
+    // #given / #when / #then
+    expect(isValidProvenance(null)).toBe(false)
+  })
+
+  it('rejects a non-object primitive', () => {
+    // #given / #when / #then
+    expect(isValidProvenance('not-an-object')).toBe(false)
+    expect(isValidProvenance(42)).toBe(false)
+  })
+})

--- a/packages/harness/src/provenance.ts
+++ b/packages/harness/src/provenance.ts
@@ -90,7 +90,7 @@ export function getProvenance(): Provenance {
       // Malformed config — fall through to hardcoded placeholder.
       throw new Error('Invalid harness.config.json shape')
     }
-    const baseVersion = parsed.base_version ?? '1.15.13'
+    const baseVersion = parsed.base_version ?? '1.16.0'
     const integrationRefs: IntegrationRefRecord[] = (parsed.integrationRefs ?? []).map(ref => ({
       ref,
       resolvedSha: 'dev',
@@ -106,7 +106,7 @@ export function getProvenance(): Provenance {
   }
 
   return {
-    baseVersion: '1.15.13',
+    baseVersion: '1.16.0',
     integrationRefs: [],
     integrationCommit: null,
     buildSha: 'dev',


### PR DESCRIPTION
Moves the `@fro.bot/harness` base to OpenCode 1.16.0 and corrects the provenance recorded in published packages.

## OpenCode 1.16.0 base

The carry set is now empty: the signed-thinking patch previously carried was reverted upstream and is not present in 1.16.0, so the harness tracks the stock release directly. The integration step builds the release tag as-is when there are no refs to merge.

## Provenance fix

Published packages recorded incomplete provenance: the manifest omitted the `integrationRefs` field, so the runtime provenance check rejected it and `harness info` fell back to placeholder/dev values. The release workflow now writes a complete manifest (including `integrationRefs`) sourced from the same resolved integration commit the binaries are built from, so build and provenance never diverge. The writer fails closed on a malformed config.

Adds regression tests pinning the provenance writer↔validator contract, including the exact missing-`integrationRefs` shape that triggered the fallback, and the empty-carry shape.

## Verification

- harness package tests pass (provenance contract + empty-carry render covered)
- empty-carry render path confirmed to skip merging and build the release tag
- type-check, lint clean; build/publish smoke gated by CI