### PR TITLE
feat(harness): skip integration job when no patches are carried

### DIFF
--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -207,7 +207,7 @@ jobs:
     # integrate.result is 'success' for non-empty carry → build runs.
     # integrate.result is 'failure' or 'cancelled' → build is blocked.
     # !cancelled() prevents running if the workflow was manually cancelled.
-    if: ${{ !cancelled() && needs.prepare-integrate.result == 'success' && needs.integrate.result != 'failure' }}
+    if: ${{ !cancelled() && needs.prepare-integrate.result == 'success' && (needs.integrate.result == 'success' || needs.integrate.result == 'skipped') }}
     strategy:
       fail-fast: true # All-or-nothing: one failure blocks the whole publish.
       matrix:
@@ -350,7 +350,7 @@ jobs:
     # build success already implies integrate didn't fail (build wouldn't have run),
     # but the explicit check makes the gate clear and guards against future refactors.
     # !cancelled() prevents running if the workflow was manually cancelled.
-    if: ${{ !cancelled() && needs.build.result == 'success' && needs.integrate.result != 'failure' }}
+    if: ${{ !cancelled() && needs.build.result == 'success' && (needs.integrate.result == 'success' || needs.integrate.result == 'skipped') }}
     runs-on: ubuntu-24.04
     environment: npm-publish # Maintainer-gated environment with required reviewers.
 

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -50,6 +50,7 @@ jobs:
     outputs:
       base_version: ${{ steps.render.outputs.base_version }}
       rendered_prompt: ${{ steps.render.outputs.rendered_prompt }}
+      has_refs: ${{ steps.render.outputs.has_refs }}
 
     steps:
       - name: Checkout harness repo
@@ -84,6 +85,15 @@ jobs:
           RELEASE_REPO=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('${CONFIG}','utf8')).release_repo)")
           INTEGRATION_REFS=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('${CONFIG}','utf8')).integrationRefs.join('\n'))")
 
+          # --- Emit has_refs: true iff the trimmed ref list is non-empty ---
+          if [ -n "$(echo "${INTEGRATION_REFS}" | tr -d '[:space:]')" ]; then
+            HAS_REFS="true"
+          else
+            HAS_REFS="false"
+          fi
+          echo "has_refs=${HAS_REFS}" >> "$GITHUB_OUTPUT"
+          echo "has_refs: ${HAS_REFS}"
+
           # --- Compute template variables (mirrors renderPrompt in integrate.ts) ---
           TAG="v${BASE_VERSION}"
           BRANCH="integrate/v${BASE_VERSION}"
@@ -92,11 +102,10 @@ jobs:
           WORK_DIR="${RUNNER_TEMP}/harness-integrate-work"
 
           # Parse each integration ref into label and merge ref (mirrors parseSource).
-          # When INTEGRATION_REFS is empty, the loop body never executes and the
-          # sentinel values below are used — the prompt reads "no patches to merge".
-          BRANCHES="(none)"
-          MERGES="(none — build the release tag as-is)"
-          SOURCES="(none)"
+          # When INTEGRATION_REFS is empty, the loop body never executes.
+          BRANCHES=""
+          MERGES=""
+          SOURCES=""
           while IFS= read -r REF; do
             [ -z "${REF}" ] && continue
             if echo "${REF}" | grep -qE 'github\.com/([^/]+)/([^/]+)/pull/([0-9]+)'; then
@@ -117,8 +126,8 @@ jobs:
               LABEL="${REF}"
               MERGE_REF="refs/remotes/watch/local/${REF}"
             fi
-            # First real ref: overwrite the sentinels.
-            if [ "${BRANCHES}" = "(none)" ]; then
+            # First real ref: set the values; subsequent refs: append.
+            if [ -z "${BRANCHES}" ]; then
               BRANCHES="${LABEL}"
               MERGES="${MERGE_REF}"
               SOURCES="${LABEL} -> ${MERGE_REF}"
@@ -160,10 +169,12 @@ jobs:
   # Integrate job — calls fro-bot.yaml as a reusable workflow.
   # Fro Bot installs opencode, provisions auth, and runs the LLM merge.
   # vars.HARNESS_MODEL must be set to anthropic/claude-sonnet-4-6 in repo vars.
+  # Skipped when the carry set is empty (has_refs == 'false').
   # ---------------------------------------------------------------------------
   integrate:
     name: integrate (LLM merge via Fro Bot)
     needs: prepare-integrate
+    if: ${{ needs.prepare-integrate.outputs.has_refs == 'true' }}
     uses: ./.github/workflows/fro-bot.yaml
     secrets: inherit
     with:
@@ -179,6 +190,10 @@ jobs:
   build:
     name: build (${{ matrix.platform }}/${{ matrix.arch }})
     needs: [prepare-integrate, integrate]
+    # Run when prepare-integrate succeeded, regardless of whether integrate was
+    # skipped (empty carry set) or completed (non-empty carry set).
+    # !cancelled() prevents running if the workflow was manually cancelled.
+    if: ${{ !cancelled() && needs.prepare-integrate.result == 'success' }}
     strategy:
       fail-fast: true # All-or-nothing: one failure blocks the whole publish.
       matrix:
@@ -234,24 +249,43 @@ jobs:
         id: fetch-integrate
         env:
           BASE_VERSION: ${{ needs.prepare-integrate.outputs.base_version }}
+          HAS_REFS: ${{ needs.prepare-integrate.outputs.has_refs }}
           RUNNER_TEMP: ${{ runner.temp }}
         run: |
           set -euo pipefail
-          INTEGRATE_REF="refs/harness-integrate/${BASE_VERSION}"
           EXTRACT_DIR="${RUNNER_TEMP}/integration-src"
-
-          # Fetch the throwaway ref pushed by Fro Bot into fro-bot/agent.
-          git fetch origin "+${INTEGRATE_REF}:${INTEGRATE_REF}"
-
-          # Resolve the integration commit SHA from the fetched ref tip.
-          INTEGRATION_COMMIT=$(git rev-parse "${INTEGRATE_REF}")
-          echo "Integration commit: ${INTEGRATION_COMMIT}"
-          echo "integration_commit=${INTEGRATION_COMMIT}" >> "$GITHUB_OUTPUT"
-
-          # Check out the integrated source tree into a clean directory.
           mkdir -p "${EXTRACT_DIR}"
-          git --work-tree="${EXTRACT_DIR}" checkout "${INTEGRATE_REF}" -- .
-          echo "Checked out integration tree to: ${EXTRACT_DIR}"
+
+          if [ "${HAS_REFS}" = "true" ]; then
+            # Non-empty carry set: fetch the throwaway ref pushed by Fro Bot.
+            INTEGRATE_REF="refs/harness-integrate/${BASE_VERSION}"
+
+            # Fetch the throwaway ref pushed by Fro Bot into fro-bot/agent.
+            git fetch origin "+${INTEGRATE_REF}:${INTEGRATE_REF}"
+
+            # Resolve the integration commit SHA from the fetched ref tip.
+            INTEGRATION_COMMIT=$(git rev-parse "${INTEGRATE_REF}")
+            echo "Integration commit (from harness-integrate ref): ${INTEGRATION_COMMIT}"
+
+            # Check out the integrated source tree into a clean directory.
+            git --work-tree="${EXTRACT_DIR}" checkout "${INTEGRATE_REF}" -- .
+            echo "Checked out integration tree to: ${EXTRACT_DIR}"
+          else
+            # Empty carry set: clone the stock release tag directly.
+            # No agent ran; the stock tag IS the integration source.
+            CONFIG="packages/harness/harness.config.json"
+            RELEASE_REPO=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('${CONFIG}','utf8')).release_repo)")
+            TAG="v${BASE_VERSION}"
+
+            echo "Empty carry set — cloning stock tag ${TAG} from ${RELEASE_REPO}"
+            git clone --depth 1 --branch "${TAG}" "https://github.com/${RELEASE_REPO}.git" "${EXTRACT_DIR}"
+
+            # Resolve the tag commit SHA from the cloned HEAD.
+            INTEGRATION_COMMIT=$(git -C "${EXTRACT_DIR}" rev-parse HEAD)
+            echo "Integration commit (from stock tag clone): ${INTEGRATION_COMMIT}"
+          fi
+
+          echo "integration_commit=${INTEGRATION_COMMIT}" >> "$GITHUB_OUTPUT"
 
       - name: Build native binary for ${{ matrix.platform }}/${{ matrix.arch }}
         env:
@@ -298,6 +332,9 @@ jobs:
   publish:
     name: publish (all-or-nothing)
     needs: [prepare-integrate, integrate, build]
+    # Run when build succeeded, regardless of whether integrate was skipped.
+    # !cancelled() prevents running if the workflow was manually cancelled.
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
     runs-on: ubuntu-24.04
     environment: npm-publish # Maintainer-gated environment with required reviewers.
 

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -85,15 +85,6 @@ jobs:
           RELEASE_REPO=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('${CONFIG}','utf8')).release_repo)")
           INTEGRATION_REFS=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('${CONFIG}','utf8')).integrationRefs.join('\n'))")
 
-          # --- Emit has_refs: true iff the trimmed ref list is non-empty ---
-          if [ -n "$(echo "${INTEGRATION_REFS}" | tr -d '[:space:]')" ]; then
-            HAS_REFS="true"
-          else
-            HAS_REFS="false"
-          fi
-          echo "has_refs=${HAS_REFS}" >> "$GITHUB_OUTPUT"
-          echo "has_refs: ${HAS_REFS}"
-
           # --- Compute template variables (mirrors renderPrompt in integrate.ts) ---
           TAG="v${BASE_VERSION}"
           BRANCH="integrate/v${BASE_VERSION}"
@@ -101,8 +92,12 @@ jobs:
           RELEASE_URL="https://github.com/${RELEASE_REPO}/releases/tag/${TAG}"
           WORK_DIR="${RUNNER_TEMP}/harness-integrate-work"
 
-          # Parse each integration ref into label and merge ref (mirrors parseSource).
+          # Parse each integration ref into label, fetch URL, fetchRef, and local merge ref
+          # (mirrors parseSource in packages/harness/src/sources.ts).
           # When INTEGRATION_REFS is empty, the loop body never executes.
+          # HAS_REFS is derived from the parsed merge list AFTER the loop so that
+          # whitespace-only or malformed-only entries that produce no real merge ref
+          # correctly yield has_refs=false rather than a bogus prompt.
           BRANCHES=""
           MERGES=""
           SOURCES=""
@@ -114,29 +109,46 @@ jobs:
               PR_NUM=$(echo "${REF}" | sed -E 's|https://github.com/([^/]+)/([^/]+)/pull/([0-9]+).*|\3|')
               SLUG=$(echo "${OWNER}-${REPO_NAME}" | tr -cs 'a-zA-Z0-9._-' '-' | sed 's/-$//')
               LABEL="${OWNER}/${REPO_NAME}#${PR_NUM}"
-              MERGE_REF="refs/remotes/watch/${SLUG}/pr-${PR_NUM}"
+              FETCH_URL="https://github.com/${OWNER}/${REPO_NAME}.git"
+              FETCH_REF="refs/pull/${PR_NUM}/head"
+              LOCAL_REF="refs/remotes/watch/${SLUG}/pr-${PR_NUM}"
             elif echo "${REF}" | grep -qE 'github\.com/([^/]+)/([^/]+)/tree/(.+)'; then
               OWNER=$(echo "${REF}" | sed -E 's|https://github.com/([^/]+)/([^/]+)/tree/(.+)|\1|')
               REPO_NAME=$(echo "${REF}" | sed -E 's|https://github.com/([^/]+)/([^/]+)/tree/(.+)|\2|')
               BRANCH_NAME=$(echo "${REF}" | sed -E 's|https://github.com/([^/]+)/([^/]+)/tree/(.+)|\3|')
               SLUG=$(echo "${OWNER}-${REPO_NAME}" | tr -cs 'a-zA-Z0-9._-' '-' | sed 's/-$//')
               LABEL="${OWNER}/${REPO_NAME}:${BRANCH_NAME}"
-              MERGE_REF="refs/remotes/watch/${SLUG}/${BRANCH_NAME}"
+              FETCH_URL="https://github.com/${OWNER}/${REPO_NAME}.git"
+              FETCH_REF="refs/heads/${BRANCH_NAME}"
+              LOCAL_REF="refs/remotes/watch/${SLUG}/${BRANCH_NAME}"
             else
               LABEL="${REF}"
-              MERGE_REF="refs/remotes/watch/local/${REF}"
+              FETCH_URL="https://github.com/${RELEASE_REPO}.git"
+              FETCH_REF="refs/heads/${REF}"
+              LOCAL_REF="refs/remotes/watch/local/${REF}"
             fi
             # First real ref: set the values; subsequent refs: append.
             if [ -z "${BRANCHES}" ]; then
               BRANCHES="${LABEL}"
-              MERGES="${MERGE_REF}"
-              SOURCES="${LABEL} -> ${MERGE_REF}"
+              MERGES="${FETCH_URL} ${FETCH_REF}:${LOCAL_REF}"
+              SOURCES="${LABEL}: git fetch ${FETCH_URL} ${FETCH_REF}:${LOCAL_REF}, then git merge --no-ff ${LOCAL_REF}"
             else
               BRANCHES="${BRANCHES}, ${LABEL}"
-              MERGES="${MERGES}, then ${MERGE_REF}"
-              SOURCES="${SOURCES}\n- ${LABEL} -> ${MERGE_REF}"
+              MERGES="${MERGES}; ${FETCH_URL} ${FETCH_REF}:${LOCAL_REF}"
+              SOURCES="${SOURCES}\n- ${LABEL}: git fetch ${FETCH_URL} ${FETCH_REF}:${LOCAL_REF}, then git merge --no-ff ${LOCAL_REF}"
             fi
           done <<< "${INTEGRATION_REFS}"
+
+          # --- Emit has_refs: true iff at least one valid ref was parsed into the merge list ---
+          # Derived from the parsed MERGES list (not the raw string) so whitespace-only or
+          # malformed-only entries that produce no real merge ref yield has_refs=false.
+          if [ -n "${MERGES}" ]; then
+            HAS_REFS="true"
+          else
+            HAS_REFS="false"
+          fi
+          echo "has_refs=${HAS_REFS}" >> "$GITHUB_OUTPUT"
+          echo "has_refs: ${HAS_REFS}"
 
           # --- Render the prompt template ---
           PROMPT_TPL=$(cat packages/harness/prompt.txt)
@@ -190,10 +202,12 @@ jobs:
   build:
     name: build (${{ matrix.platform }}/${{ matrix.arch }})
     needs: [prepare-integrate, integrate]
-    # Run when prepare-integrate succeeded, regardless of whether integrate was
-    # skipped (empty carry set) or completed (non-empty carry set).
+    # Run when prepare-integrate succeeded AND integrate did not fail.
+    # integrate.result is 'skipped' for empty carry → build runs.
+    # integrate.result is 'success' for non-empty carry → build runs.
+    # integrate.result is 'failure' or 'cancelled' → build is blocked.
     # !cancelled() prevents running if the workflow was manually cancelled.
-    if: ${{ !cancelled() && needs.prepare-integrate.result == 'success' }}
+    if: ${{ !cancelled() && needs.prepare-integrate.result == 'success' && needs.integrate.result != 'failure' }}
     strategy:
       fail-fast: true # All-or-nothing: one failure blocks the whole publish.
       matrix:
@@ -332,9 +346,11 @@ jobs:
   publish:
     name: publish (all-or-nothing)
     needs: [prepare-integrate, integrate, build]
-    # Run when build succeeded, regardless of whether integrate was skipped.
+    # Run when build succeeded and integrate did not fail (defense-in-depth).
+    # build success already implies integrate didn't fail (build wouldn't have run),
+    # but the explicit check makes the gate clear and guards against future refactors.
     # !cancelled() prevents running if the workflow was manually cancelled.
-    if: ${{ !cancelled() && needs.build.result == 'success' }}
+    if: ${{ !cancelled() && needs.build.result == 'success' && needs.integrate.result != 'failure' }}
     runs-on: ubuntu-24.04
     environment: npm-publish # Maintainer-gated environment with required reviewers.
 

--- a/docs/plans/2026-06-05-002-feat-skip-integrate-empty-carry-plan.md
+++ b/docs/plans/2026-06-05-002-feat-skip-integrate-empty-carry-plan.md
@@ -1,0 +1,257 @@
+---
+title: "feat: Skip integrate job for empty carry set + tune merge prompt for Sonnet 4.6"
+type: feat
+status: active
+date: 2026-06-05
+---
+
+# feat: Skip integrate job for empty carry set + tune merge prompt for Sonnet 4.6
+
+## Overview
+
+The harness release pipeline runs a full Fro Bot agent (`integrate` job, ~3.5 min) on every release, even when the carry set is empty. With no patches to merge, that agent run does nothing but clone the stock release tag and push it to `refs/harness-integrate/<version>` — pure wasted CI time and a non-deterministic agent round-trip for a deterministic outcome.
+
+This change makes the `integrate` job conditional: it runs only when there are patches to merge. When the carry set is empty, the `build` job clones the stock release tag directly and resolves its commit SHA, making empty-carry builds faster and idempotent. It also applies Oracle's Sonnet 4.6 prompt tuning to the merge path (which is now the only path that runs the agent).
+
+## Problem Frame
+
+`packages/harness/harness.config.json` currently has `integrationRefs: []` (empty — PR #30182 was reverted upstream and is not in OpenCode 1.16.0). The 1.16.0 dry-run (run 27024542968) proved the current pipeline works end-to-end, but the `integrate` job consumed ~3.5 min running an agent that produced a ref tip identical to the stock 1.16.0 tag commit. Oracle's audit of three recent `integrate` runs confirmed: the empty-carry agent run is functionally correct but entirely redundant, and even the merge-path runs waste turns on "orientation" (reading build internals/action.yaml the prompt told them to ignore).
+
+Two improvements fall out:
+1. **Skip the agent entirely when the carry set is empty** — deterministic stock-tag build, no agent.
+2. **Tune the merge prompt for Sonnet 4.6** — since the empty-carry conditionals can leave the prompt (the prompt only renders for the merge path now), replace the ambiguous `(none)` conditionals with a deterministic merge-only runbook.
+
+## Requirements Trace
+
+- R1. When `harness.config.json` `integrationRefs` is empty, the `integrate` (Fro Bot agent) job does not run.
+- R2. With an empty carry set, the `build` job clones the stock release tag from `release_repo`, resolves the tag commit SHA as `integration_commit`, and builds `<base>+harness.<sha[0:8]>` — identical output to today's path, just without the agent.
+- R3. Empty-carry builds are idempotent: the same `base_version` + empty carry set yields the same `integration_commit` (the tag SHA) on every run.
+- R4. With a non-empty carry set, the pipeline behaves exactly as today (integrate runs, pushes the ref, build fetches it).
+- R5. `publish` continues to consume `needs.build.outputs.integration_commit` unchanged and provenance records the same SHA the binaries were built from (no split-brain regression in either path).
+- R6. The merge prompt is restructured per Oracle's Sonnet 4.6 guidance (deterministic runbook, explicit merge mode, exact happy-path commands, ban on source-spelunking) — and no longer needs to carry the empty-carry / `(none)` conditional wording.
+
+## Scope Boundaries
+
+- Not changing the carry policy or which refs are carried (stays in `harness.config.json`).
+- Not touching the action/runtime OpenCode pin (stays 1.15.13 separately).
+- Not changing the publish/OIDC/provenance writer logic beyond what R5 requires (the writer already sources the build's `integration_commit`).
+- Not adding per-ref resolved-SHA provenance (Fro Bot NBC on #786 — deferred to a future multi-ref carry).
+
+### Deferred to Separate Tasks
+
+- Per-ref `resolvedSha` in the provenance manifest (currently all entries share the integration commit): future task, only matters when a real multi-ref carry set exists.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `.github/workflows/harness-release.yaml`:
+  - `prepare-integrate` job (renders prompt, outputs `base_version` + `rendered_prompt`; already computes `INTEGRATION_REFS` from `harness.config.json`).
+  - `integrate` job — a `uses: ./.github/workflows/fro-bot.yaml` reusable-workflow call gated on `needs: prepare-integrate`.
+  - `build` job — matrix, `Fetch integration ref and resolve commit SHA` step fetches `refs/harness-integrate/<version>` and resolves the tip; emits `integration_commit` job output.
+  - `publish` job — consumes `needs.build.outputs.integration_commit`; writes the provenance manifest from `harness.config.json` integrationRefs + that commit.
+- `packages/harness/prompt.txt` — the merge prompt template (currently carries empty-carry `(none)` conditionals + the merge path). The `{{...}}` placeholders are substituted in `prepare-integrate`'s render step.
+- `packages/harness/harness.config.json` — `integrationRefs` source of truth.
+
+### Institutional Learnings
+
+- Version-pin integrity is a hard invariant; the build must produce `<base>+harness.<sha>` deterministically (workspace-executor provisioning learnings).
+- Pin aggressively, avoid non-deterministic `latest` (tool-binary-caching learnings) — supports the idempotent stock-tag clone.
+
+### External References
+
+- Oracle audit (this session): empty-carry agent run is redundant; merge-path prompt should be a deterministic runbook with explicit mode, exact commands, artifact discovery via `find`, and a ban on reading build/action internals unless a required command fails.
+
+## Key Technical Decisions
+
+- **`has_refs` gate in `prepare-integrate`**: the render step already parses `integrationRefs`; emit a boolean `has_refs` output. The `integrate` job gets `if: needs.prepare-integrate.outputs.has_refs == 'true'`. Rationale: single source of truth, no new parsing.
+- **`build` dual-source by `has_refs`, not by "ref exists"**: branch explicitly on `needs.prepare-integrate.outputs.has_refs`. When `'true'`, fetch the pushed ref (today's path). When `'false'`, clone `release_repo` at `refs/tags/<tag>` and `git rev-parse` the tag commit as `integration_commit`. Rationale: explicit and race-free; avoids probing for a ref that was intentionally never pushed.
+- **Skipped-job output propagation**: when `integrate` is skipped, `build`'s `needs: [prepare-integrate, integrate]` still resolves (a skipped needed job does not fail dependents as long as the dependent's own `if` allows it; `build` must use `if: always() && <prepare succeeded>` semantics OR rely on the default that skipped needs are permitted). Decision: verify the skipped-`integrate` dependency does not skip `build` — add `if: ${{ !cancelled() && needs.prepare-integrate.result == 'success' }}` to `build` so it runs whether or not `integrate` ran. This is the critical correctness seam.
+- **Idempotency**: the stock-tag clone resolves `refs/tags/<tag>` → an immutable tag commit, so `integration_commit` is stable across runs (R3). The `+harness.<sha>` marker is derived purely from that SHA.
+- **Prompt restructure**: remove empty-carry/`(none)` conditional wording from `prompt.txt`; it now only renders for the merge path. Apply Oracle's runbook structure (constants block, explicit merge mode, exact clone/fetch/branch/build/verify/push commands, `find`-based artifact discovery, ban on reading harness/build/action internals unless a required command fails). The `prepare-integrate` render only runs the prompt path when `has_refs == 'true'`, so the sentinel-init logic for empty refs can also be simplified.
+
+## Open Questions
+
+### Resolved During Planning
+
+- How does `build` know the carry set is empty? → `prepare-integrate` emits `has_refs`; `build` branches on it.
+- Does a skipped `integrate` job fail `build`? → No, as long as `build`'s `if` uses `!cancelled() && needs.prepare-integrate.result == 'success'` and does not require `integrate` success. Verified as the key seam.
+- Does the stock-tag path stay idempotent? → Yes; `refs/tags/<tag>` is immutable.
+
+### Deferred to Implementation
+
+- Exact `if:` expression form for `build` and `publish` to tolerate the skipped `integrate` job (GitHub Actions skipped-needs semantics) — verify with a dry-run on both empty and (simulated) non-empty carry sets.
+- Whether `publish`'s `needs` list + `if` also need `!cancelled()` adjustment so a skipped `integrate` doesn't skip `publish`.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification.*
+
+```
+prepare-integrate (always)
+  ├─ resolve base_version, tag
+  ├─ compute has_refs  (integrationRefs non-empty?)
+  └─ render prompt  (only meaningful when has_refs)
+        │
+        ├─ has_refs == true ──► integrate (Fro Bot agent: merge refs, push refs/harness-integrate/<v>)
+        │                              │
+        │                              ▼
+        │                       build: FETCH refs/harness-integrate/<v>, resolve tip → integration_commit
+        │
+        └─ has_refs == false ─► (integrate SKIPPED)
+                                       │
+                                       ▼
+                                build: CLONE release_repo @ refs/tags/<tag>, rev-parse tag → integration_commit
+
+build (matrix, runs in BOTH cases via if: !cancelled() && prepare succeeded)
+  └─ emits integration_commit
+        │
+        ▼
+publish (consumes needs.build.outputs.integration_commit; provenance = same SHA)
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Emit `has_refs` from `prepare-integrate`**
+
+**Goal:** Make the empty/non-empty carry decision an explicit job output.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `.github/workflows/harness-release.yaml` (prepare-integrate `outputs:` + render step)
+
+**Approach:**
+- In the render step, after computing `INTEGRATION_REFS`, set `has_refs=true|false` (true iff non-empty after trimming) to `$GITHUB_OUTPUT`.
+- Add `has_refs: ${{ steps.render.outputs.has_refs }}` to the job `outputs:`.
+- Keep `base_version` + `rendered_prompt` outputs as-is.
+
+**Test scenarios:**
+- Test expectation: none — workflow YAML, validated by actionlint + dry-run on both carry states.
+
+**Verification:**
+- actionlint clean; a dry-run logs `has_refs=false` for the current empty config.
+
+- [ ] **Unit 2: Gate the `integrate` job on `has_refs`**
+
+**Goal:** Skip the agent run when there are no patches.
+
+**Requirements:** R1, R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `.github/workflows/harness-release.yaml` (integrate job `if:`)
+
+**Approach:**
+- Add `if: ${{ needs.prepare-integrate.outputs.has_refs == 'true' }}` to the `integrate` job.
+
+**Test scenarios:**
+- Test expectation: none — validated by dry-run (empty → integrate skipped; would need a non-empty config to prove it runs, simulated/deferred).
+
+**Verification:**
+- Empty-carry dry-run shows `integrate` skipped; build still proceeds.
+
+- [ ] **Unit 3: `build` dual-source (fetch ref OR clone stock tag)**
+
+**Goal:** Make `build` produce the correct `integration_commit` in both paths and run even when `integrate` is skipped.
+
+**Requirements:** R2, R3, R4, R5
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `.github/workflows/harness-release.yaml` (build job `if:` + `Fetch integration ref and resolve commit SHA` step)
+
+**Approach:**
+- Add `if: ${{ !cancelled() && needs.prepare-integrate.result == 'success' }}` to `build` so a skipped `integrate` does not skip it. **This is the critical seam — verify carefully.**
+- In the fetch/resolve step, branch on `needs.prepare-integrate.outputs.has_refs`:
+  - `'true'`: existing behavior — `git fetch origin +refs/harness-integrate/<version>:...`, `git rev-parse` the tip, checkout into `EXTRACT_DIR`.
+  - `'false'`: `git clone --depth 1 --branch <tag> <release_repo_url> <EXTRACT_DIR>` (or fetch the tag), `git rev-parse refs/tags/<tag>` (or the cloned HEAD) → `integration_commit`. The extracted tree IS the stock tag source.
+- Keep `integration_commit` job output emission identical so `publish` is unchanged.
+
+**Test scenarios:**
+- Test expectation: none — workflow shell; validated by dry-run (empty path clones tag, builds `<base>+harness.<tagsha>`).
+
+**Verification:**
+- Empty-carry dry-run: build clones the stock tag, resolves the tag SHA, builds all 4 platforms reporting `<base>+harness.<sha>`, emits `integration_commit` = tag SHA.
+
+- [ ] **Unit 4: `publish` tolerates skipped `integrate`**
+
+**Goal:** Ensure publish runs in the empty-carry path and records the correct commit.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `.github/workflows/harness-release.yaml` (publish job `if:`/`needs:` if required)
+
+**Approach:**
+- Verify `publish`'s `needs: [prepare-integrate, integrate, build]` + any `if:` does not get skipped because `integrate` was skipped. Adjust to `if: ${{ !cancelled() && needs.build.result == 'success' }}` if needed.
+- Provenance writer already reads `harness.config.json` integrationRefs (empty → `[]`) + `needs.build.outputs.integration_commit` — no change needed, but confirm the empty path still produces a valid manifest with `integrationRefs: []` and the tag SHA.
+
+**Test scenarios:**
+- Test expectation: none — validated by dry-run (publish job runs, provenance valid).
+
+**Verification:**
+- Empty-carry dry-run: publish job runs (skip-guards/dry-run as configured), provenance manifest has `integrationRefs: []` + tag SHA.
+
+- [ ] **Unit 5: Restructure the merge prompt for Sonnet 4.6**
+
+**Goal:** Make the (now merge-only) prompt a deterministic runbook; remove empty-carry conditionals.
+
+**Requirements:** R6
+
+**Dependencies:** Unit 2 (prompt only runs for the merge path now)
+
+**Files:**
+- Modify: `packages/harness/prompt.txt`
+- Modify: `.github/workflows/harness-release.yaml` (render step — simplify sentinel-init now that empty refs never reach the prompt; keep the `bash -n` guard intact)
+- Test: `packages/harness/src/cli.test.ts` (the `bash -n` prompt-snippet guard must still pass)
+
+**Approach (Oracle's guidance):**
+- Remove `(none)` / "if there are refs to merge" conditional wording — the prompt now always has refs.
+- Add a `<constants>` block (tag, version, branch, workdir, release_repo) and a numbered `<procedure>` with exact commands for clone/fetch/branch/merge/build/verify/push.
+- Artifact discovery via `find packages/opencode/dist -path '*/bin/opencode' -type f -print -quit` instead of "expected path".
+- Explicit ban: "Do not read package.json, build scripts, action.yaml, or workflow files to understand the task. Run the exact commands below. Inspect files only to diagnose a failed required command."
+- Keep the deterministic push heredoc (already good) + the embedded `bash -n`-validated snippet.
+- Keep the no-GitHub-posting release-automation override (it eliminated the accidental-issue behavior).
+
+**Test scenarios:**
+- Happy path: the `bash -n` prompt-snippet guard test still extracts the fenced bash block and validates clean (no heredoc/indent regression).
+- Edge case: render step still produces a coherent prompt for a non-empty carry set (the merge path) — manual/dry-run verification.
+
+**Verification:**
+- `bash -n` guard test green; a (simulated/future) non-empty-carry render reads as a clean runbook; Oracle's wasted-action behaviors (orientation reads, source-spelunking) are addressed by the ban + exact commands.
+
+## System-Wide Impact
+
+- **Interaction graph:** `prepare-integrate` → (`integrate` | skip) → `build` → `publish`. The skipped-`integrate` dependency is the critical seam — `build` and `publish` must use `!cancelled()`-style `if` so a skipped job doesn't cascade a skip.
+- **Error propagation:** empty-carry path has fewer failure modes (no agent, no LLM merge). The stock-tag clone fails loudly if the tag doesn't exist.
+- **State lifecycle risks:** none new; the stock-tag clone is read-only + deterministic.
+- **API surface parity:** the `integration_commit` job output contract is unchanged in both paths, so `publish` + provenance are untouched.
+- **Unchanged invariants:** non-empty carry path behaves exactly as today (R4); provenance still records the build's commit (R5); the action/runtime OpenCode pin is untouched.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Skipped `integrate` cascades a skip to `build`/`publish` (GitHub Actions skipped-needs semantics) | Use `if: !cancelled() && needs.<prev>.result == 'success'`; verify with an empty-carry dry-run before any real publish. This is the #1 thing the dry-run must prove. |
+| Stock-tag clone resolves a different SHA than the agent path would | Empty carry = no merge, so the agent path's ref tip IS the tag commit; cloning the tag yields the same SHA. Idempotent by construction. |
+| Prompt restructure breaks the merge path (no non-empty carry to test now) | Keep the `bash -n` guard; the merge-path render is exercised only when a real ref is carried — note as the validation gap, verify on the next real carry. |
+| Empty-carry `build` clone misses git history needed by the build | The upstream build reads `OPENCODE_VERSION` from env, not git; `--depth 1` tag clone is sufficient (verified earlier this session that build.ts has no git reads). |
+
+## Documentation / Operational Notes
+
+- `packages/harness/AGENTS.md` already documents the ref-push handoff; add a note that the `integrate` job is skipped for empty carry sets and `build` clones the stock tag directly.
+- The empty-carry dry-run is the gate before the real 1.16.0 publish.
+
+## Sources & References
+
+- `.github/workflows/harness-release.yaml`, `packages/harness/prompt.txt`, `packages/harness/harness.config.json`
+- Oracle integrate-log audit (this session)
+- 1.16.0 dry-run run 27024542968 (proved current empty-carry path works end-to-end)
+- Prior plan: `docs/plans/2026-06-05-001-feat-harness-integrate-build-bridge-plan.md`

--- a/packages/harness/AGENTS.md
+++ b/packages/harness/AGENTS.md
@@ -44,11 +44,13 @@ The release workflow connects the LLM merge to the per-platform build matrix via
 
 ### `prepare-integrate` job
 
-Resolves the base version (dispatch input or tag) and renders the merge prompt from `packages/harness/prompt.txt` using values from `harness.config.json` (base version, release repo, integration refs). Emits `base_version` and `rendered_prompt` as job outputs.
+Resolves the base version (dispatch input or tag) and renders the merge prompt from `packages/harness/prompt.txt` using values from `harness.config.json` (base version, release repo, integration refs). Emits `base_version`, `rendered_prompt`, and `has_refs` as job outputs.
+
+`has_refs` is derived from the **parsed merge list** after the ref-parsing loop — not from the raw `integrationRefs` string. Whitespace-only or malformed-only entries that produce no real merge ref correctly yield `has_refs=false`.
 
 ### `integrate` job (merge via Fro Bot)
 
-`uses: ./.github/workflows/fro-bot.yaml` with `secrets: inherit`, passing `model: ${{ vars.HARNESS_MODEL }}` and the rendered prompt. The Fro Bot agent:
+Skipped when `has_refs == 'false'` (empty carry set). When it runs, `uses: ./.github/workflows/fro-bot.yaml` with `secrets: inherit`, passing `model: ${{ vars.HARNESS_MODEL }}` and the rendered prompt. The Fro Bot agent:
 
 1. Clones `anomalyco/opencode` into a disposable work dir, creates the integration branch at the base version tag, and merges the configured refs.
 2. Builds and verifies the host CLI as a correctness gate.
@@ -58,9 +60,14 @@ The merge runs with `output-mode: working-dir` so branch/PR delivery semantics d
 
 ### `build` matrix (consumer)
 
-Each platform job (`needs: [prepare-integrate, integrate]`):
+Each platform job (`needs: [prepare-integrate, integrate]`) runs when `prepare-integrate` succeeded **and** `integrate` did not fail. This means:
 
-1. Fetches `refs/harness-integrate/<version>` and resolves its tip — that SHA is the integration commit.
+- **Empty carry set** (`has_refs=false`): `integrate` is skipped → `integrate.result == 'skipped'` → build runs. The fetch-integrate step clones the stock release tag directly instead of fetching `refs/harness-integrate/<version>`.
+- **Non-empty carry set** (`has_refs=true`): `integrate` runs → if it succeeds, build runs; if it fails or is cancelled, build is blocked.
+
+Each platform job:
+
+1. Fetches `refs/harness-integrate/<version>` (non-empty carry) or clones the stock tag (empty carry) and resolves the tip SHA as the integration commit.
 2. Checks out the fetched tree and runs `build-platform.ts --source-tree <tree> --integration-commit <sha>`, which builds from the supplied merged source tree. Each platform job runs its own clean install + build.
 3. Emits the resolved `integration_commit` as a job output so `publish` consumes the same commit rather than re-resolving the force-pushed ref.
 

--- a/packages/harness/prompt.txt
+++ b/packages/harness/prompt.txt
@@ -1,6 +1,12 @@
-You are working in a disposable automation clone at {{repo}}.
+You are working in a disposable automation clone. This is a merge-integration job: you will clone the upstream release, merge the listed patches, build the CLI, and push the result to a throwaway ref.
 
-Goal: integrate upstream release {{tag}} with the selected branches/PRs ({{branches}}), then push the integrated branch to a throwaway ref in the harness repo so the build matrix can fetch it. If the merge set is "(none — build the release tag as-is)", there are no patches to carry — skip merging and build the stock release tag directly.
+<constants>
+tag={{tag}}
+version={{version}}
+branch={{branch}}
+workdir={{repo}}
+release_repo={{release_repo}}
+</constants>
 
 Release automation override:
 - This is a non-interactive release-integration job, not a normal issue/PR response run.
@@ -9,33 +15,48 @@ Release automation override:
 - The final summary must be plain text in your final assistant message/job log only. The workflow consumes the pushed ref, not any GitHub post.
 - Git branch/merge/push operations are explicitly required for this job, but only inside this disposable automation clone and only to the throwaway harness ref.
 
-Requirements:
-- Work only in this automation clone.
-- Do not open a PR.
-- Do not create an issue.
-- Do not post comments or reviews.
-- Do not use `gh issue create`, `gh pr create`, `gh issue comment`, `gh pr comment`, or `gh api` for issues/comments/reviews.
-- Do NOT ask for final approval.
-- DO NOT USE BASH with background: true. This will cause this non-interactive tool to exit before the job is done. If bash gets auto-promoted to background, poll bash_status even when the tool says otherwise. This is IMPORTANT because you are running in non-interactive mode — if you end your response, you will not get the notification.
-- Base the integration branch on the release tag {{tag}}, not on dev HEAD.
-- Name the branch {{branch}}.
-- If there are refs to merge ({{merges}}), merge them into {{branch}} in order; if the merge set is "(none — build the release tag as-is)", skip merging — the branch is the release tag as-is.
-- If there are merge conflicts, resolve them completely.
-- Build the host CLI.
-- The CLI must be compiled with stable release identity: OPENCODE_CHANNEL={{channel}} and OPENCODE_VERSION={{version}}.
-- In this automation clone, `origin` is the upstream OpenCode repo ({{release_repo}}), not `fro-bot/agent`. Do not push to `origin`.
-- Fro Bot setup exports `GH_TOKEN` with push access to `fro-bot/agent`. Use that existing token for git HTTPS auth. Do not put tokens in remote URLs, do not print tokens, and do not improvise alternate auth flows.
-- Push with `--no-verify` and `HUSKY=0`; skipping local pre-push hooks is intentional because downstream workflow jobs perform verification.
-- Do not run repo-wide typecheck/test/lint unless needed to diagnose a failed required build step.
+Do not read package.json, build scripts, action.yaml, or workflow files to understand the task. Run the exact commands below. Inspect files only to diagnose a FAILED required command.
 
-Exact tasks:
-1. Verify the repo is usable and fetch anything you need.
-2. Create or reset {{branch}} to refs/tags/{{tag}}.
-3. If there are refs to merge ({{merges}}), merge them into {{branch}} in order. If the merge set is "(none — build the release tag as-is)", skip this step — the branch is already the release tag.
-4. Build the host CLI in `packages/opencode` with `OPENCODE_CHANNEL={{channel}} OPENCODE_VERSION={{version}} bun run build -- --single`.
-5. Ensure the built CLI binary exists at the expected path under `packages/opencode/dist/`.
-6. Run the built CLI with `--version` and verify the output is exactly `{{version}}`.
-7. Push the integrated branch to the throwaway ref in the harness repo. Do not push to `origin`; `origin` is upstream OpenCode. Run this exact non-interactive pattern (the heredoc terminator and the helper body must stay at column 0):
+- DO NOT USE BASH with background: true. This will cause this non-interactive tool to exit before the job is done. If bash gets auto-promoted to background, poll bash_status even when the tool says otherwise. This is IMPORTANT because you are running in non-interactive mode — if you end your response, you will not get the notification.
+
+<procedure>
+1. Clone {{release_repo}} at {{tag}} into {{repo}} and create branch {{branch}}:
+
+```bash
+git clone --depth 1 --branch {{tag}} https://github.com/{{release_repo}}.git {{repo}}
+cd {{repo}}
+git checkout -b {{branch}} refs/tags/{{tag}}
+```
+
+2. Fetch and merge the listed refs into {{branch}} IN ORDER.
+
+   Sources: {{sources}}
+   Merge refs: {{merges}}
+
+   For each merge ref in the list above, run:
+   - `git fetch https://github.com/{{release_repo}}.git <that-merge-ref>`
+   - `git merge --no-ff FETCH_HEAD -m "Merge <label> into {{branch}}"`
+
+   If there are merge conflicts, resolve them completely before proceeding.
+
+3. Build the host CLI in `packages/opencode`:
+
+```bash
+cd {{repo}}
+OPENCODE_CHANNEL=latest OPENCODE_VERSION={{version}} bun run build -- --single
+```
+
+4. Verify the built binary exists and reports the correct version:
+
+```bash
+artifact="$(find packages/opencode/dist -path '*/bin/opencode' -type f -print -quit)"
+test -n "$artifact" || { echo "ERROR: built binary not found under packages/opencode/dist"; exit 1; }
+"$artifact" --version
+```
+
+   The `--version` output must be exactly `{{version}}`.
+
+5. Push the integrated branch to the throwaway ref in the harness repo. Do not push to `origin`; `origin` is upstream OpenCode. Run this exact non-interactive pattern (the heredoc terminator and the helper body must stay at column 0):
 
 ```bash
 test -n "${GH_TOKEN:-}" || { echo "GH_TOKEN is required for harness push"; exit 1; }
@@ -59,15 +80,35 @@ HUSKY=0 GIT_TERMINAL_PROMPT=0 GIT_ASKPASS="$askpass" \
 ```
 
    `--force` is required so re-runs overwrite the throwaway ref. `--no-verify` is required so local hooks do not run.
-8. Return a concise plain-text final assistant message only — no GitHub posting — with:
+
+6. Return a concise plain-text final assistant message only — no GitHub posting — with:
    - pushed ref: `refs/harness-integrate/{{version}}`
    - integration commit SHA: output of `git rev-parse HEAD`
    - built artifact path(s) under `packages/opencode/dist/`
+</procedure>
 
 Context:
 - Upstream repo: {{release_repo}}
 - Base branch: dev
 - Release URL: {{release_url}}
 - Integration refs: {{sources}}
+
+Requirements:
+- Work only in this automation clone.
+- Do not open a PR.
+- Do not create an issue.
+- Do not post comments or reviews.
+- Do not use `gh issue create`, `gh pr create`, `gh issue comment`, `gh pr comment`, or `gh api` for issues/comments/reviews.
+- Do NOT ask for final approval.
+- Base the integration branch on the release tag {{tag}}, not on dev HEAD.
+- Name the branch {{branch}}.
+- Merge refs {{merges}} into {{branch}} in order.
+- If there are merge conflicts, resolve them completely.
+- Build the host CLI.
+- The CLI must be compiled with stable release identity: OPENCODE_CHANNEL=latest and OPENCODE_VERSION={{version}}.
+- In this automation clone, `origin` is the upstream OpenCode repo ({{release_repo}}), not `fro-bot/agent`. Do not push to `origin`.
+- Fro Bot setup exports `GH_TOKEN` with push access to `fro-bot/agent`. Use that existing token for git HTTPS auth. Do not put tokens in remote URLs, do not print tokens, and do not improvise alternate auth flows.
+- Push with `--no-verify` and `HUSKY=0`; skipping local pre-push hooks is intentional because downstream workflow jobs perform verification.
+- Do not run repo-wide typecheck/test/lint unless needed to diagnose a failed required build step.
 
 If anything fails, fix it and continue until the branch is integrated, the configured build succeeds, and the ref is pushed.

--- a/packages/harness/prompt.txt
+++ b/packages/harness/prompt.txt
@@ -30,21 +30,20 @@ git checkout -b {{branch}} refs/tags/{{tag}}
 
 2. Fetch and merge the listed refs into {{branch}} IN ORDER.
 
-   Sources: {{sources}}
-   Merge refs: {{merges}}
+   Sources and merge instructions:
+   {{sources}}
 
-   For each merge ref in the list above, run:
-   - `git fetch https://github.com/{{release_repo}}.git <that-merge-ref>`
-   - `git merge --no-ff FETCH_HEAD -m "Merge <label> into {{branch}}"`
-
+   For each source listed above, run the fetch and merge commands exactly as shown.
+   Use the local ref name (the part after the colon in the fetch command) as the merge target.
    If there are merge conflicts, resolve them completely before proceeding.
 
-3. Build the host CLI in `packages/opencode`:
+3. Build the host CLI. Run from the repo root ({{repo}}) — build.ts does its own chdir into packages/opencode:
 
-```bash
-cd {{repo}}
-OPENCODE_CHANNEL=latest OPENCODE_VERSION={{version}} bun run build -- --single
-```
+   First install workspace dependencies:
+   bun install
+
+   Then run the upstream build script with release identity:
+   OPENCODE_CHANNEL=latest OPENCODE_VERSION={{version}} bun ./packages/opencode/script/build.ts --single
 
 4. Verify the built binary exists and reports the correct version:
 


### PR DESCRIPTION
## Summary

The harness release pipeline previously ran the full integration agent on every release, even when no patches were being carried. With an empty carry set that agent run only re-derived the stock release tag — wasted CI time for a deterministic result.

This makes the integration job conditional: it runs only when there are patches to merge. When the carry set is empty, the build job clones the stock release tag directly and resolves its commit SHA, so empty-carry builds are deterministic and skip the agent entirely.

## What changed

- `prepare-integrate` emits `has_refs`; the integration job is gated on it.
- The build job sources from the pushed integration ref when patches exist, or clones the stock release tag directly when the carry set is empty. Build and publish are gated so a failed integration run cannot proceed (a skipped run still proceeds).
- The merge runbook is restructured into a deterministic set of steps: explicit constants, exact fetch/merge commands using real source refs, the proven build invocation, and a discovery step for the built binary.

## Validation

- Harness package tests pass (including the prompt bash-syntax guard); actionlint clean.
- The empty-carry path is verified by a dry-run dispatch of the release workflow before any real publish.