### PR TITLE
fix(gateway): make tool approvals fail closed

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -296,14 +296,16 @@ WORKSPACE_EGRESS_HOSTS=cliproxy.fro.bot
 
 Leave both variables unset for a clone-only deployment: the workspace boots and serves `/clone`, but the mention loop has no model until they are configured.
 
-## Enabling tool approval prompts
+## Tool approval prompts
 
-By default, all OpenCode tools run automatically and no approval prompts appear in Discord. To require a Discord Approve / Deny button-click before a specific tool executes, configure that tool's `permission` mode to `ask` in the workspace OpenCode config.
+The gateway runs in **`approval-required` mode by default**: when OpenCode requests permission to use a tool, the gateway posts an Approve / Deny embed in the run thread and the run pauses until a Discord button-click is received or the approval deadline fires. This is the only supported mode — there is no global auto-approve path.
 
-The workspace OpenCode config is supplied via `WORKSPACE_OPENCODE_CONFIG` (in `deploy/.env`) as a JSON object shallow-merged over the base config. Add a `permission` block to that JSON:
+> **Warning:** Do not add global `allow` rules for high-risk tools (`bash`, `edit`, `task`, `external_directory`) to the workspace OpenCode config. Doing so bypasses the gateway approval boundary and allows those tools to run without any Discord prompt, regardless of the gateway's approval mode.
+
+The workspace OpenCode config is supplied via `WORKSPACE_OPENCODE_CONFIG` (in `deploy/.env`) as a JSON object shallow-merged over the base config. You can configure per-tool permission defaults there:
 
 ```env
-# deploy/.env — enable approval prompts for the Bash tool
+# deploy/.env — set bash to always ask (already the gateway default for all tools)
 WORKSPACE_OPENCODE_CONFIG={"provider":{...},"permission":{"bash":{"default":"ask"}}}
 ```
 
@@ -311,8 +313,8 @@ WORKSPACE_OPENCODE_CONFIG={"provider":{...},"permission":{"bash":{"default":"ask
 
 | Mode | Behaviour |
 | --- | --- |
-| `allow` (default) | Tool runs immediately; no Discord prompt. |
-| `ask` | Gateway posts an Approve / Deny embed in the run thread; run pauses until a decision is received or the deadline fires. |
+| `ask` (gateway default) | Gateway posts an Approve / Deny embed in the run thread; run pauses until a decision is received or the deadline fires. |
+| `allow` | Tool runs immediately; no Discord prompt. Use only for low-risk, non-mutating tools. |
 | `deny` | Tool is always blocked; no prompt. |
 
 Set `"default":"ask"` inside the tool's permission block to ask for every invocation. More granular patterns (e.g. per-command) follow the OpenCode `permission` config schema.

--- a/deploy/scripts/merge-config.mjs
+++ b/deploy/scripts/merge-config.mjs
@@ -1,7 +1,8 @@
 // merge-config.mjs — OpenCode config merger for the workspace executor.
 // Pure ESM, no build step. Used by workspace-entrypoint.sh.
 
-import { fileURLToPath } from "node:url"
+import {fileURLToPath} from 'node:url'
+import process from 'node:process'
 
 /**
  * Merge an overlay and optional model into a base OpenCode config object.
@@ -9,94 +10,98 @@ import { fileURLToPath } from "node:url"
  * @param {object} baseObj - Parsed base config object.
  * @param {string} overlayRaw - Raw WORKSPACE_OPENCODE_CONFIG env string (may be empty).
  * @param {string} modelRaw - Raw WORKSPACE_OPENCODE_MODEL env string (may be empty).
- * @returns {{ ok: true, config: object } | { ok: false, error: string }}
+ * @returns {{ ok: true, config: object } | { ok: false, error: string }} Merge result.
  */
 export function mergeConfig(baseObj, overlayRaw, modelRaw) {
-  const model = (modelRaw || "").trim()
+  const model = (modelRaw ?? '').trim()
 
   // Model validation — mirrors src/harness/config/inputs.ts parseModelInput semantics.
-  let normalizedModel = ""
-  if (model !== "") {
-    const slashIdx = model.indexOf("/")
+  let normalizedModel = ''
+  if (model !== '') {
+    const slashIdx = model.indexOf('/')
     if (slashIdx === -1) {
       return {
         ok: false,
-        error: "WORKSPACE_OPENCODE_MODEL must be in provider/model form (e.g. anthropic/claude-sonnet-4-6)",
+        error: 'WORKSPACE_OPENCODE_MODEL must be in provider/model form (e.g. anthropic/claude-sonnet-4-6)',
       }
     }
-    const providerID = model.substring(0, slashIdx).trim()
-    const modelID = model.substring(slashIdx + 1).trim()
-    if (providerID === "" || modelID === "") {
+    const providerID = model.slice(0, slashIdx).trim()
+    const modelID = model.slice(slashIdx + 1).trim()
+    if (providerID === '' || modelID === '') {
       return {
         ok: false,
-        error: "WORKSPACE_OPENCODE_MODEL must be in provider/model form (e.g. anthropic/claude-sonnet-4-6)",
+        error: 'WORKSPACE_OPENCODE_MODEL must be in provider/model form (e.g. anthropic/claude-sonnet-4-6)',
       }
     }
-    if (/[\u0000-\u001f]/.test(providerID) || /[\u0000-\u001f]/.test(modelID)) {
-      return { ok: false, error: "WORKSPACE_OPENCODE_MODEL must not contain control characters" }
+    if (/\p{Cc}/u.test(providerID) || /\p{Cc}/u.test(modelID)) {
+      return {ok: false, error: 'WORKSPACE_OPENCODE_MODEL must not contain control characters'}
     }
-    normalizedModel = providerID + "/" + modelID
+    normalizedModel = `${providerID}/${modelID}`
   }
 
   let overlay = {}
-  if ((overlayRaw || "").trim() !== "") {
+  if ((overlayRaw ?? '').trim() !== '') {
     try {
       overlay = JSON.parse(overlayRaw)
     } catch {
-      return { ok: false, error: "WORKSPACE_OPENCODE_CONFIG is not valid JSON" }
+      return {ok: false, error: 'WORKSPACE_OPENCODE_CONFIG is not valid JSON'}
     }
-    if (typeof overlay !== "object" || overlay === null || Array.isArray(overlay)) {
-      return { ok: false, error: "WORKSPACE_OPENCODE_CONFIG must be a JSON object" }
+    if (typeof overlay !== 'object' || overlay === null || Array.isArray(overlay)) {
+      return {ok: false, error: 'WORKSPACE_OPENCODE_CONFIG must be a JSON object'}
     }
   }
 
-  const merged = { ...baseObj, ...overlay }
+  const merged = {...baseObj, ...overlay}
 
   // Preserve baked Systematic plugin: union, dedup, strings only.
   const basePlugins = Array.isArray(baseObj.plugin) ? baseObj.plugin : []
-  const overlayPlugins = Array.isArray(overlay.plugin) ? overlay.plugin.filter((p) => typeof p === "string") : []
+  const overlayPlugins = Array.isArray(overlay.plugin) ? overlay.plugin.filter(p => typeof p === 'string') : []
   merged.plugin = Array.from(new Set([...basePlugins, ...overlayPlugins]))
 
   // Never allow autoupdate; version is pinned.
   merged.autoupdate = false
 
   // Model wins if non-empty.
-  if (normalizedModel !== "") merged.model = normalizedModel
+  if (normalizedModel !== '') merged.model = normalizedModel
 
-  return { ok: true, config: merged }
+  return {ok: true, config: merged}
 }
 
 // CLI main guard: node merge-config.mjs <config-file-path>
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-  const fs = await import("node:fs")
+  const fs = await import('node:fs')
 
   const cfgPath = process.argv[2]
   let base
   try {
-    base = JSON.parse(fs.readFileSync(cfgPath, "utf8"))
-  } catch (e) {
-    process.stderr.write(`cannot read base opencode config: ${e.message}\n`)
+    base = JSON.parse(fs.readFileSync(cfgPath, 'utf8'))
+  } catch (error) {
+    process.stderr.write(`cannot read base opencode config: ${error.message}\n`)
     process.exit(2)
   }
 
-  const overlayRaw = process.env.WORKSPACE_OPENCODE_CONFIG || ""
-  const modelRaw = process.env.WORKSPACE_OPENCODE_MODEL || ""
+  const overlayRaw = process.env.WORKSPACE_OPENCODE_CONFIG ?? ''
+  const modelRaw = process.env.WORKSPACE_OPENCODE_MODEL ?? ''
 
   const result = mergeConfig(base, overlayRaw, modelRaw)
   if (result.ok === false) {
-    process.stderr.write(result.error + "\n")
+    process.stderr.write(`${result.error}\n`)
     process.exit(2)
   }
 
-  const output = JSON.stringify(result.config, null, 2) + "\n"
+  const output = `${JSON.stringify(result.config, null, 2)}\n`
   const tmpPath = `${cfgPath}.tmp-${process.pid}`
   try {
-    fs.writeFileSync(tmpPath, output, { encoding: "utf8", flag: "wx" })
+    fs.writeFileSync(tmpPath, output, {encoding: 'utf8', flag: 'wx'})
     fs.renameSync(tmpPath, cfgPath)
-  } catch (e) {
-    process.stderr.write(`cannot write opencode config: ${e.message}\n`)
+  } catch (error) {
+    process.stderr.write(`cannot write opencode config: ${error.message}\n`)
     // Clean up temp file if it exists
-    try { fs.unlinkSync(tmpPath) } catch { /* ignore */ }
+    try {
+      fs.unlinkSync(tmpPath)
+    } catch {
+      /* ignore */
+    }
     process.exit(2)
   }
 

--- a/deploy/scripts/merge-config.test.mjs
+++ b/deploy/scripts/merge-config.test.mjs
@@ -1,146 +1,339 @@
-import { test } from "node:test"
-import assert from "node:assert/strict"
-import { mergeConfig } from "./merge-config.mjs"
+import assert from 'node:assert/strict'
+import {test} from 'node:test'
+
+import {mergeConfig} from './merge-config.mjs'
 
 const BASE = {
-  $schema: "https://opencode.ai/config.json",
+  $schema: 'https://opencode.ai/config.json',
   autoupdate: false,
-  plugin: ["@fro.bot/systematic@2.24.0"],
+  plugin: ['@fro.bot/systematic@2.24.0'],
 }
 
-test("provider overlay applied (baseURL preserved)", () => {
+test('provider overlay applied (baseURL preserved)', () => {
   const overlay = JSON.stringify({
-    provider: { anthropic: { options: { baseURL: "https://cliproxy.fro.bot/v1" } } },
+    provider: {anthropic: {options: {baseURL: 'https://cliproxy.fro.bot/v1'}}},
   })
-  const result = mergeConfig(BASE, overlay, "")
+  const result = mergeConfig(BASE, overlay, '')
   assert.ok(result.ok, result.error)
-  assert.deepEqual(result.config.provider, { anthropic: { options: { baseURL: "https://cliproxy.fro.bot/v1" } } })
+  assert.deepEqual(result.config.provider, {anthropic: {options: {baseURL: 'https://cliproxy.fro.bot/v1'}}})
 })
 
-test("plugin preserved when overlay sets plugin:[]", () => {
-  const overlay = JSON.stringify({ plugin: [] })
-  const result = mergeConfig(BASE, overlay, "")
+test('plugin preserved when overlay sets plugin:[]', () => {
+  const overlay = JSON.stringify({plugin: []})
+  const result = mergeConfig(BASE, overlay, '')
   assert.ok(result.ok, result.error)
-  assert.ok(result.config.plugin.includes("@fro.bot/systematic@2.24.0"), "systematic plugin missing")
+  assert.ok(result.config.plugin.includes('@fro.bot/systematic@2.24.0'), 'systematic plugin missing')
 })
 
-test("autoupdate forced false when overlay sets autoupdate:true", () => {
-  const overlay = JSON.stringify({ autoupdate: true })
-  const result = mergeConfig(BASE, overlay, "")
+test('autoupdate forced false when overlay sets autoupdate:true', () => {
+  const overlay = JSON.stringify({autoupdate: true})
+  const result = mergeConfig(BASE, overlay, '')
   assert.ok(result.ok, result.error)
   assert.equal(result.config.autoupdate, false)
 })
 
-test("non-string plugin entries in overlay are filtered", () => {
-  const overlay = JSON.stringify({ plugin: [42, null, "extra-plugin"] })
-  const result = mergeConfig(BASE, overlay, "")
+test('non-string plugin entries in overlay are filtered', () => {
+  const overlay = JSON.stringify({plugin: [42, null, 'extra-plugin']})
+  const result = mergeConfig(BASE, overlay, '')
   assert.ok(result.ok, result.error)
-  assert.ok(!result.config.plugin.includes(42), "numeric plugin entry leaked through")
-  assert.ok(result.config.plugin.includes("extra-plugin"), "string plugin entry missing")
-  assert.ok(result.config.plugin.includes("@fro.bot/systematic@2.24.0"), "systematic plugin missing")
+  assert.equal(result.config.plugin.includes(42), false, 'numeric plugin entry leaked through')
+  assert.ok(result.config.plugin.includes('extra-plugin'), 'string plugin entry missing')
+  assert.ok(result.config.plugin.includes('@fro.bot/systematic@2.24.0'), 'systematic plugin missing')
 })
 
-test("model set when valid provider/model form", () => {
-  const result = mergeConfig(BASE, "", "anthropic/claude-sonnet-4-6")
+test('model set when valid provider/model form', () => {
+  const result = mergeConfig(BASE, '', 'anthropic/claude-sonnet-4-6')
   assert.ok(result.ok, result.error)
-  assert.equal(result.config.model, "anthropic/claude-sonnet-4-6")
+  assert.equal(result.config.model, 'anthropic/claude-sonnet-4-6')
 })
 
-test("model rejected when no slash (just model name)", () => {
-  const result = mergeConfig(BASE, "", "claude-sonnet")
+test('model rejected when no slash (just model name)', () => {
+  const result = mergeConfig(BASE, '', 'claude-sonnet')
   assert.equal(result.ok, false)
-  assert.ok(result.error.includes("provider/model form"), `got: ${result.error}`)
+  assert.ok(result.error.includes('provider/model form'), `got: ${result.error}`)
 })
 
-test("model rejected when leading slash only (/x)", () => {
-  const result = mergeConfig(BASE, "", "/x")
+test('model rejected when leading slash only (/x)', () => {
+  const result = mergeConfig(BASE, '', '/x')
   assert.equal(result.ok, false)
-  assert.ok(result.error.includes("provider/model form"), `got: ${result.error}`)
+  assert.ok(result.error.includes('provider/model form'), `got: ${result.error}`)
 })
 
-test("model rejected when trailing slash only (x/)", () => {
-  const result = mergeConfig(BASE, "", "x/")
+test('model rejected when trailing slash only (x/)', () => {
+  const result = mergeConfig(BASE, '', 'x/')
   assert.equal(result.ok, false)
-  assert.ok(result.error.includes("provider/model form"), `got: ${result.error}`)
+  assert.ok(result.error.includes('provider/model form'), `got: ${result.error}`)
 })
 
-test("overlay not-JSON rejected", () => {
-  const result = mergeConfig(BASE, "{not valid json", "")
+test('overlay not-JSON rejected', () => {
+  const result = mergeConfig(BASE, '{not valid json', '')
   assert.equal(result.ok, false)
-  assert.ok(result.error.includes("not valid JSON"), `got: ${result.error}`)
+  assert.ok(result.error.includes('not valid JSON'), `got: ${result.error}`)
 })
 
-test("overlay array rejected", () => {
-  const result = mergeConfig(BASE, "[]", "")
+test('overlay array rejected', () => {
+  const result = mergeConfig(BASE, '[]', '')
   assert.equal(result.ok, false)
-  assert.ok(result.error.includes("must be a JSON object"), `got: ${result.error}`)
+  assert.ok(result.error.includes('must be a JSON object'), `got: ${result.error}`)
 })
 
-test("both empty → base unchanged except autoupdate:false", () => {
-  const base = { ...BASE, autoupdate: true }
-  const result = mergeConfig(base, "", "")
+test('both empty → base unchanged except autoupdate:false', () => {
+  const base = {...BASE, autoupdate: true}
+  const result = mergeConfig(base, '', '')
   assert.ok(result.ok, result.error)
   assert.equal(result.config.autoupdate, false)
   assert.deepEqual(result.config.plugin, BASE.plugin)
-  assert.ok(!("model" in result.config), "model should not be present")
+  assert.equal('model' in result.config, false, 'model should not be present')
 })
 
-test("overlay whitespace-only treated as empty (no parse error)", () => {
-  const result = mergeConfig(BASE, "   \n  ", "")
+test('overlay whitespace-only treated as empty (no parse error)', () => {
+  const result = mergeConfig(BASE, '   \n  ', '')
   assert.ok(result.ok, result.error)
   // No overlay keys besides what base has
-  assert.ok(!("provider" in result.config), "provider should not be injected from whitespace overlay")
+  assert.equal('provider' in result.config, false, 'provider should not be injected from whitespace overlay')
 })
 
-test("plugin dedup: overlay adds duplicate systematic — deduped", () => {
-  const overlay = JSON.stringify({ plugin: ["@fro.bot/systematic@2.24.0", "other-plugin"] })
-  const result = mergeConfig(BASE, overlay, "")
+test('plugin dedup: overlay adds duplicate systematic — deduped', () => {
+  const overlay = JSON.stringify({plugin: ['@fro.bot/systematic@2.24.0', 'other-plugin']})
+  const result = mergeConfig(BASE, overlay, '')
   assert.ok(result.ok, result.error)
-  const count = result.config.plugin.filter((p) => p === "@fro.bot/systematic@2.24.0").length
-  assert.equal(count, 1, "systematic plugin should appear exactly once")
-  assert.ok(result.config.plugin.includes("other-plugin"))
+  const count = result.config.plugin.filter(p => p === '@fro.bot/systematic@2.24.0').length
+  assert.equal(count, 1, 'systematic plugin should appear exactly once')
+  assert.ok(result.config.plugin.includes('other-plugin'))
 })
 
-test("model with spaces around slash normalized (anthropic / claude → anthropic/claude)", () => {
-  const result = mergeConfig(BASE, "", "anthropic / claude")
+test('model with spaces around slash normalized (anthropic / claude → anthropic/claude)', () => {
+  const result = mergeConfig(BASE, '', 'anthropic / claude')
   assert.ok(result.ok, result.error)
-  assert.equal(result.config.model, "anthropic/claude")
+  assert.equal(result.config.model, 'anthropic/claude')
 })
 
-test("multi-slash model accepted (openai/gpt-4/turbo → provider=openai, model=gpt-4/turbo)", () => {
-  const result = mergeConfig(BASE, "", "openai/gpt-4/turbo")
+test('multi-slash model accepted (openai/gpt-4/turbo → provider=openai, model=gpt-4/turbo)', () => {
+  const result = mergeConfig(BASE, '', 'openai/gpt-4/turbo')
   assert.ok(result.ok, result.error)
-  assert.equal(result.config.model, "openai/gpt-4/turbo")
+  assert.equal(result.config.model, 'openai/gpt-4/turbo')
 })
 
-test("model rejected when no slash (claudewithnoslash)", () => {
-  const result = mergeConfig(BASE, "", "claudewithnoslash")
+test('model rejected when no slash (claudewithnoslash)', () => {
+  const result = mergeConfig(BASE, '', 'claudewithnoslash')
   assert.equal(result.ok, false)
-  assert.ok(result.error.includes("provider/model form"), `got: ${result.error}`)
+  assert.ok(result.error.includes('provider/model form'), `got: ${result.error}`)
 })
 
-test("model rejected when leading slash only (/x) — providerID empty", () => {
-  const result = mergeConfig(BASE, "", "/x")
+test('model rejected when leading slash only (/x) — providerID empty', () => {
+  const result = mergeConfig(BASE, '', '/x')
   assert.equal(result.ok, false)
-  assert.ok(result.error.includes("provider/model form"), `got: ${result.error}`)
+  assert.ok(result.error.includes('provider/model form'), `got: ${result.error}`)
 })
 
-test("model rejected when trailing slash only (x/) — modelID empty", () => {
-  const result = mergeConfig(BASE, "", "x/")
+test('model rejected when trailing slash only (x/) — modelID empty', () => {
+  const result = mergeConfig(BASE, '', 'x/')
   assert.equal(result.ok, false)
-  assert.ok(result.error.includes("provider/model form"), `got: ${result.error}`)
+  assert.ok(result.error.includes('provider/model form'), `got: ${result.error}`)
 })
 
-test("model rejected when modelID contains control character", () => {
-  const result = mergeConfig(BASE, "", "anthropic/claude\u0001")
+test('model rejected when modelID contains control character', () => {
+  const result = mergeConfig(BASE, '', 'anthropic/claude\u0001')
   assert.equal(result.ok, false)
-  assert.ok(result.error.includes("control characters"), `got: ${result.error}`)
+  assert.ok(result.error.includes('control characters'), `got: ${result.error}`)
 })
 
-test("non-array plugin overlay (string) cannot replace plugin array", () => {
-  const overlay = JSON.stringify({ plugin: "evil-plugin" })
-  const result = mergeConfig(BASE, overlay, "")
+test('non-array plugin overlay (string) cannot replace plugin array', () => {
+  const overlay = JSON.stringify({plugin: 'evil-plugin'})
+  const result = mergeConfig(BASE, overlay, '')
   assert.equal(result.ok, true)
-  assert.ok(Array.isArray(result.config.plugin), "plugin must remain an array")
-  assert.deepEqual(result.config.plugin, ["@fro.bot/systematic@2.24.0"])
+  assert.ok(Array.isArray(result.config.plugin), 'plugin must remain an array')
+  assert.deepEqual(result.config.plugin, ['@fro.bot/systematic@2.24.0'])
+})
+
+// ─── Unit 5: Unsafe-fix regression guards ────────────────────────────────────
+// These tests prevent the rejected global-pregrant approach from returning.
+// The rejected approach would have injected global permission grants for
+// high-risk tools (bash, edit, external_directory, etc.) into the merged
+// OpenCode config, bypassing the Gateway's explicit approval-mode boundary.
+//
+// Each test is written to FAIL against an implementation that synthesizes
+// permission grants and PASS against the current clean merge-only behavior.
+
+const HIGH_RISK_KEYS = ['bash', 'edit', 'external_directory', 'task', 'write']
+
+test("merge does not synthesize any 'permissions' key when overlay is empty", () => {
+  const result = mergeConfig(BASE, '', '')
+  assert.ok(result.ok, result.error)
+  assert.equal('permissions' in result.config, false, 'permissions must not be injected when overlay is empty')
+})
+
+test("merge does not synthesize any 'permissions' key when overlay is whitespace", () => {
+  const result = mergeConfig(BASE, '   \n  ', '')
+  assert.ok(result.ok, result.error)
+  assert.equal('permissions' in result.config, false, 'permissions must not be injected from whitespace overlay')
+})
+
+test("merge does not synthesize any 'permissions' key when overlay has unrelated keys", () => {
+  const overlay = JSON.stringify({provider: {anthropic: {options: {baseURL: 'https://example.com'}}}})
+  const result = mergeConfig(BASE, overlay, '')
+  assert.ok(result.ok, result.error)
+  assert.equal('permissions' in result.config, false, 'permissions must not be injected alongside provider overlay')
+})
+
+test("merge does not synthesize any 'permissions' key when model is set", () => {
+  const result = mergeConfig(BASE, '', 'anthropic/claude-sonnet-4-6')
+  assert.ok(result.ok, result.error)
+  assert.equal('permissions' in result.config, false, 'permissions must not be injected when model is set')
+})
+
+test('merge does not auto-approve bash in any synthesized permission block', () => {
+  // Simulate what the rejected unsafe implementation would have done: inject
+  // a permissions block that globally allows bash. The current implementation
+  // must not produce this output regardless of inputs.
+  const result = mergeConfig(BASE, '', '')
+  assert.ok(result.ok, result.error)
+  const cfg = result.config
+  if (!('permissions' in cfg)) return // clean — no permissions block at all
+  // If permissions somehow exists, it must not contain a bash allow.
+  const perms = cfg.permissions
+  if (!Array.isArray(perms)) return
+  const bashAllow = perms.find(
+    r => typeof r === 'object' && r !== null && r.permission === 'bash' && r.action === 'allow',
+  )
+  assert.equal(bashAllow, undefined, 'merge must not synthesize a global bash allow rule')
+})
+
+test('merge does not auto-approve edit in any synthesized permission block', () => {
+  const result = mergeConfig(BASE, '', '')
+  assert.ok(result.ok, result.error)
+  const cfg = result.config
+  if (!('permissions' in cfg)) return
+  const perms = cfg.permissions
+  if (!Array.isArray(perms)) return
+  const editAllow = perms.find(
+    r => typeof r === 'object' && r !== null && r.permission === 'edit' && r.action === 'allow',
+  )
+  assert.equal(editAllow, undefined, 'merge must not synthesize a global edit allow rule')
+})
+
+test('merge does not auto-approve external_directory in any synthesized permission block', () => {
+  const result = mergeConfig(BASE, '', '')
+  assert.ok(result.ok, result.error)
+  const cfg = result.config
+  if (!('permissions' in cfg)) return
+  const perms = cfg.permissions
+  if (!Array.isArray(perms)) return
+  const extDirAllow = perms.find(
+    r => typeof r === 'object' && r !== null && r.permission === 'external_directory' && r.action === 'allow',
+  )
+  assert.equal(extDirAllow, undefined, 'merge must not synthesize a global external_directory allow rule')
+})
+
+test('merge does not inject wildcard allow rule for any high-risk permission', () => {
+  // The rejected approach might have used a wildcard pattern ("*") with action "allow".
+  // Verify no such rule appears in the output for any high-risk key.
+  const result = mergeConfig(BASE, '', '')
+  assert.ok(result.ok, result.error)
+  const cfg = result.config
+  if (!('permissions' in cfg)) return
+  const perms = cfg.permissions
+  if (!Array.isArray(perms)) return
+  for (const key of HIGH_RISK_KEYS) {
+    const wildcardAllow = perms.find(
+      r =>
+        typeof r === 'object' &&
+        r !== null &&
+        r.permission === key &&
+        r.action === 'allow' &&
+        (r.pattern === '*' || r.pattern === '**'),
+    )
+    assert.equal(wildcardAllow, undefined, `merge must not synthesize a wildcard allow rule for '${key}'`)
+  }
+})
+
+test('explicit operator permissions in base are preserved unchanged by merge', () => {
+  // Operators may supply their own permission config. Merge must pass it through
+  // without rewriting it into hidden auto-approval.
+  const baseWithPerms = {
+    ...BASE,
+    permissions: [{permission: 'read', pattern: '/workspace/**', action: 'allow'}],
+  }
+  const result = mergeConfig(baseWithPerms, '', '')
+  assert.ok(result.ok, result.error)
+  assert.deepEqual(
+    result.config.permissions,
+    [{permission: 'read', pattern: '/workspace/**', action: 'allow'}],
+    'operator-supplied base permissions must be preserved exactly',
+  )
+})
+
+test('explicit operator permissions in overlay are preserved unchanged by merge', () => {
+  // An operator may supply permissions via overlay. Merge must pass them through
+  // without injecting additional auto-approval rules.
+  const overlay = JSON.stringify({
+    permissions: [{permission: 'glob', pattern: '/workspace/**', action: 'allow'}],
+  })
+  const result = mergeConfig(BASE, overlay, '')
+  assert.ok(result.ok, result.error)
+  assert.deepEqual(
+    result.config.permissions,
+    [{permission: 'glob', pattern: '/workspace/**', action: 'allow'}],
+    'operator-supplied overlay permissions must be preserved exactly',
+  )
+})
+
+test('overlay permissions do not get merged with synthesized high-risk grants', () => {
+  // If an operator supplies a restrictive permission list, merge must not append
+  // any synthesized high-risk allows to it.
+  const overlay = JSON.stringify({
+    permissions: [{permission: 'read', pattern: '/workspace/**', action: 'allow'}],
+  })
+  const result = mergeConfig(BASE, overlay, '')
+  assert.ok(result.ok, result.error)
+  const perms = result.config.permissions
+  assert.ok(Array.isArray(perms), 'permissions should be an array when operator supplies one')
+  for (const key of HIGH_RISK_KEYS) {
+    const highRiskAllow = perms.find(
+      r => typeof r === 'object' && r !== null && r.permission === key && r.action === 'allow',
+    )
+    assert.equal(highRiskAllow, undefined, `merge must not append a synthesized '${key}' allow to operator permissions`)
+  }
+})
+
+test('model/plugin/autoupdate behavior unchanged when permissions are present in base', () => {
+  // Regression guard: adding permissions to base must not break existing merge behavior.
+  const baseWithPerms = {
+    ...BASE,
+    autoupdate: true,
+    permissions: [{permission: 'read', pattern: '**', action: 'allow'}],
+  }
+  const overlay = JSON.stringify({plugin: ['extra-plugin']})
+  const result = mergeConfig(baseWithPerms, overlay, 'anthropic/claude-sonnet-4-6')
+  assert.ok(result.ok, result.error)
+  assert.equal(result.config.autoupdate, false, 'autoupdate must remain forced false')
+  assert.ok(result.config.plugin.includes('@fro.bot/systematic@2.24.0'), 'systematic plugin must be preserved')
+  assert.ok(result.config.plugin.includes('extra-plugin'), 'overlay plugin must be included')
+  assert.equal(result.config.model, 'anthropic/claude-sonnet-4-6', 'model must be set')
+  assert.deepEqual(
+    result.config.permissions,
+    [{permission: 'read', pattern: '**', action: 'allow'}],
+    'base permissions must be preserved',
+  )
+})
+
+test('merge output contains no unexpected top-level keys beyond known safe set', () => {
+  // Guard against future code accidentally adding new top-level keys that could
+  // carry hidden policy (e.g., 'approvals', 'policy', 'grants', 'allow').
+  const result = mergeConfig(BASE, '', '')
+  assert.ok(result.ok, result.error)
+  const KNOWN_SAFE_KEYS = new Set([
+    '$schema',
+    'autoupdate',
+    'plugin',
+    'model',
+    'provider',
+    'permissions',
+    'theme',
+    'keybinds',
+    'mcp',
+  ])
+  const outputKeys = Object.keys(result.config)
+  const unexpectedKeys = outputKeys.filter(k => !KNOWN_SAFE_KEYS.has(k) && !Object.keys(BASE).includes(k))
+  assert.deepEqual(unexpectedKeys, [], `merge introduced unexpected top-level keys: ${unexpectedKeys.join(', ')}`)
 })

--- a/docs/plans/2026-06-05-003-fix-gateway-approval-mode-787-plan.md
+++ b/docs/plans/2026-06-05-003-fix-gateway-approval-mode-787-plan.md
@@ -1,0 +1,324 @@
+---
+title: "fix: Gateway approval waits for unattended tool permissions"
+type: fix
+status: active
+date: 2026-06-05
+deepened: 2026-06-05
+---
+
+# fix: Gateway approval waits for unattended tool permissions
+
+## Overview
+
+Fix issue #787 by making the existing Gateway approval-required path fail closed and user-visible. The root cause is not a
+missing coordinator: mention runs already wire the approval coordinator. The failure is that an unattended tool-using run
+can wait on Discord approval until timeout and then flush `_(no output)_`, hiding that it was blocked on approval.
+
+The safe scope is approval-required only. The earlier `autonomous-low-risk` direction is explicitly deferred because
+OpenCode persisted `always` approvals can override session-scoped denies before the Gateway ever sees `permission.asked`.
+
+## Problem Frame
+
+Gateway mention runs can require tools. When OpenCode emits `permission.asked`, Gateway routes that event to Discord
+approval UI and OpenCode blocks until the permission is answered. If nobody responds, the run waits until the approval
+deadline or run timeout. Because no tool output has been produced yet, the final thread flush may render `_(no output)_`,
+which hides the actual state: the run was waiting on tool approval.
+
+The rejected unsafe approaches are global OpenCode permission pre-grants and session-scoped autonomous denies. Global
+pre-grants bypass the S5 approval boundary across channels and can expose workspace secrets to auto-approved commands.
+Session-scoped denies are also insufficient today because OpenCode evaluates persisted project approvals after session
+rules with last-match-wins semantics, so an old `always` allow can still bypass the Gateway.
+
+## Requirements Trace
+
+- R1. Preserve approval-required behavior as the only supported Gateway approval mode.
+- R2. Reject unsupported `GATEWAY_APPROVAL_MODE` values, including `autonomous-low-risk`, with a clear fail-closed error.
+- R3. Require a permission coordinator before `runOpenCodeCore()` can create a session or prompt OpenCode.
+- R4. Never globally or session-locally auto-approve `bash`, `edit`, `task`, or `external_directory`.
+- R5. Show visible Discord status when a run is waiting for tool approval and when approval times out or is denied.
+- R6. Base approval deadlines and the hard abort signal on the same remaining run budget.
+- R7. Preserve the final `_(no output)_` fallback only for genuinely completed runs with no visible output/status.
+- R8. Add regression guards that workspace OpenCode config merging does not synthesize high-risk permission grants.
+
+## Scope Boundaries
+
+- Do not enable autonomous mode in this PR.
+- Do not mutate global/generated OpenCode config for approval policy.
+- Do not change Discord approval button authorization semantics.
+- Do not remove the existing S5 approval coordinator or registry lifecycle.
+- Do not change action/runtime harness behavior; this is Gateway-scoped.
+
+### Deferred to Separate Tasks
+
+- Autonomous low-risk mode: requires upstream or architectural support to ignore/clear persisted project approvals for a
+  Gateway-owned session before it can be safe.
+- Broader workspace policy hardening: continue under existing workspace and egress-hardening issues.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/gateway/src/execute/run.ts` creates a per-run permission coordinator and passes it into `runOpenCodeCore()`.
+- `packages/gateway/src/execute/run-core.ts` creates the OpenCode session, subscribes before prompting, and forwards
+  `permission.asked` / `permission.replied` events.
+- `packages/gateway/src/approvals/coordinator.ts` and `packages/gateway/src/approvals/registry.ts` own the approval
+  lifecycle, deadline settlement, and authoritative `permission.replied` confirmation.
+- `packages/gateway/src/config.ts` is the Gateway environment parsing surface for approval mode validation.
+- `packages/gateway/src/discord/streaming.ts` owns Discord run-thread buffering and final empty-output flushing.
+- `deploy/scripts/merge-config.mjs` merges OpenCode config overlays, model, plugin, and autoupdate; it must not grow
+  approval pre-grants.
+
+### Institutional Learnings
+
+- S5 tool approval is single-owner and fail-closed: registry state is keyed by request ID, `permission.replied` is the
+  authoritative settlement signal, and pending approval state is intentionally in-memory.
+- OpenCode permission replies require the workspace `directory` query to affect the blocked session.
+- Global config changes can leak privilege across repos, channels, and runs.
+
+### External References
+
+- OpenCode cloned source confirms `session.create` accepts `body.permission`, but permission evaluation also applies
+  persisted project approvals after session rules.
+- OpenCode permission rules use `{ permission, pattern, action }`; evaluation is last-match-wins and defaults to `ask` when
+  no rule matches.
+
+## Key Technical Decisions
+
+- **Approval-required only:** Keep the existing S5 approval coordinator as the sole supported Gateway tool-permission path.
+  Reject `autonomous-low-risk` until OpenCode can isolate Gateway sessions from persisted project approvals.
+- **Coordinator required:** `runOpenCodeCore()` must fail before session creation if no coordinator is supplied. A missing
+  coordinator is a safety-boundary violation, not a back-compat mode.
+- **Visible approval state:** Waiting for approval is user-visible run state. The run thread should show waiting and timeout
+  statuses so a blocked approval cannot collapse into a mysterious empty-output fallback.
+- **Same budget origin:** Compute both the hard abort signal and approval deadline from the same remaining run budget.
+- **No approval policy in config merge:** `deploy/scripts/merge-config.mjs` must preserve operator-supplied config but never
+  synthesize hidden high-risk permission grants.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Is the coordinator missing? No. The current mention path creates the coordinator and passes it to `runOpenCodeCore()`.
+- Is session-scoped autonomous mode safe? No. Persisted OpenCode project approvals can override session denies.
+- Should autonomous mode be inferred from `coordinator === undefined`? No. Missing coordinator fails closed.
+
+### Deferred to Implementation
+
+- Exact Discord copy for waiting/timed-out status: keep terse, user-facing, and mention-safe while preserving the invariant
+  that blocked approval is visible.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TD
+  Mention[Mention run] --> Config[Gateway config]
+  Config -->|approval-required| Coordinator[Create approval coordinator]
+  Config -->|unsupported mode| StartupFail[Fail config load]
+  Coordinator --> Core[runOpenCodeCore requires coordinator]
+  Core --> PermissionAsked[permission.asked]
+  PermissionAsked --> DiscordApproval[Post waiting status + approval embed]
+  DiscordApproval -->|button reply| PermissionReplied[OpenCode permission.replied]
+  DiscordApproval -->|deadline| Denied[Reject + visible timeout status]
+  PermissionReplied --> Idle[session.idle]
+  Denied --> Idle
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Approval-mode config guard**
+
+**Goal:** Keep approval-required as the only supported mode and reject unsafe modes at startup.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/gateway/src/config.ts`
+- Test: `packages/gateway/src/config.test.ts`
+
+**Approach:**
+- Parse `GATEWAY_APPROVAL_MODE` with default `approval-required`.
+- Accept only `approval-required`.
+- Reject `autonomous-low-risk` with a clear message explaining it is deferred because persisted OpenCode approvals can
+  override session-scoped denies.
+- Extend the config test environment cleanup/setup scaffold so the env var cannot leak between tests.
+
+**Execution note:** Implement test-first because this is security-sensitive config behavior.
+
+**Patterns to follow:**
+- Strict parsing for `LOG_LEVEL`, `DISCORD_PRIVILEGED_INTENTS`, and numeric Gateway settings in
+  `packages/gateway/src/config.ts`.
+
+**Test scenarios:**
+- Happy path: unset `GATEWAY_APPROVAL_MODE` loads `approval-required`.
+- Happy path: `GATEWAY_APPROVAL_MODE=approval-required` loads `approval-required`.
+- Error path: `GATEWAY_APPROVAL_MODE=autonomous-low-risk` rejects with a deferral/safety message.
+- Error path: unknown approval mode rejects config loading with a clear error.
+- Edge case: empty/whitespace value follows existing optional-secret semantics and uses the default.
+
+**Verification:**
+- Gateway config exposes only the supported mode, with unsafe/invalid values rejected before runtime.
+
+- [x] **Unit 2: Coordinator-required core boundary**
+
+**Goal:** Ensure OpenCode is never prompted from the Gateway without approval coordination.
+
+**Requirements:** R1, R3, R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/gateway/src/program.ts`
+- Test: `packages/gateway/src/program.test.ts`
+- Modify: `packages/gateway/src/execute/run.ts`
+- Modify: `packages/gateway/src/execute/run-core.ts`
+- Test: `packages/gateway/src/execute/run-core.test.ts`
+- Test: `packages/gateway/src/execute/run.test.ts`
+
+**Approach:**
+- Thread `approval-required` explicitly from config through program/run wiring.
+- Require `coordinator` in `runOpenCodeCore()` before session creation and prompt dispatch.
+- Keep session creation free of `body.permission` approval overrides.
+
+**Execution note:** Start with boundary tests that fail before `session.create`.
+
+**Patterns to follow:**
+- Existing session creation and permission routing tests in `packages/gateway/src/execute/run-core.test.ts`.
+- Existing run wrapper tests in `packages/gateway/src/execute/run.test.ts`.
+
+**Test scenarios:**
+- Error path: missing coordinator fails before `session.create`.
+- Error path: missing coordinator fails before `promptAsync`.
+- Happy path: approval-required with coordinator forwards valid permission asks/replies.
+- Integration: parsed Gateway mode propagates through program wiring into mention execution.
+- Regression: no `body.permission` is injected into `session.create`.
+
+**Verification:**
+- No Gateway path can silently run OpenCode without approval coordination.
+
+- [x] **Unit 3: Approval wait and timeout UX**
+
+**Goal:** Make approval waits and deadline denials visible in the Discord run thread.
+
+**Requirements:** R5, R6, R7
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `packages/gateway/src/execute/run.ts`
+- Modify: `packages/gateway/src/discord/streaming.ts`
+- Modify: `packages/gateway/src/approvals/registry.ts`
+- Test: `packages/gateway/src/execute/run.test.ts`
+- Test: `packages/gateway/src/discord/streaming.test.ts`
+- Test: `packages/gateway/src/approvals/approval-flow.integration.test.ts`
+- Test: `packages/gateway/src/approvals/registry.test.ts`
+
+**Approach:**
+- Compute hard abort and approval deadline from the same remaining budget.
+- Post a waiting-for-approval status when a permission ask enters the approval flow.
+- Mark the stream sink as having visible output when waiting status or the approval embed is visible.
+- Render a timed-out/denied status when deadline settlement rejects the permission.
+- Preserve final `_(no output)_` only when no visible status or assistant/tool output was produced.
+
+**Execution note:** Add regression coverage for the issue symptom before changing status rendering.
+
+**Patterns to follow:**
+- Discord sink tests for empty output, long output, and `allowedMentions` in `packages/gateway/src/discord/streaming.test.ts`.
+- Approval registry deadline tests in `packages/gateway/src/approvals/registry.test.ts`.
+
+**Test scenarios:**
+- Happy path: permission ask posts visible waiting status and approval UI without mentions.
+- Error path: failed waiting-status send is caught/logged and does not create an unhandled rejection.
+- Error path: deadline settlement renders timed-out/denied status.
+- Edge case: successful approval embed suppresses misleading final no-output fallback even if waiting-status send failed.
+- Edge case: genuinely completed empty run still flushes the existing no-output fallback.
+- Integration: deadline uses remaining budget and is omitted when not enough run budget remains.
+
+**Verification:**
+- A user reading the Discord thread can distinguish “waiting on approval” from “completed with no output.”
+
+- [x] **Unit 4: Unsafe-fix regression guards**
+
+**Goal:** Prevent the rejected global-pregrant approach from returning.
+
+**Requirements:** R4, R8
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Test: `deploy/scripts/merge-config.test.mjs`
+
+**Approach:**
+- Extend existing plain Node ESM `node:test` coverage to prove overlay/model/plugin handling does not inject global
+  permission grants.
+- Cover high-risk keys such as `bash`, `edit`, and `external_directory` explicitly.
+
+**Patterns to follow:**
+- Existing `node:test` + `node:assert/strict` style in `deploy/scripts/merge-config.test.mjs`.
+
+**Test scenarios:**
+- Happy path: merge preserves existing permission fields only when explicitly supplied by the operator.
+- Error path: merge does not synthesize global `bash`, `edit`, or `external_directory` allows.
+- Edge case: model/plugin overlay behavior remains unchanged.
+
+**Verification:**
+- Workspace config merging cannot introduce approval policy behind the Gateway’s approval-required path.
+
+## Test Map / Sequencing
+
+- Start with `packages/gateway/src/config.test.ts` to pin env parsing and cleanup behavior.
+- Then cover config propagation through `packages/gateway/src/program.test.ts` and `packages/gateway/src/execute/run.test.ts`.
+- Then tighten `packages/gateway/src/execute/run-core.test.ts` around coordinator-required behavior.
+- Then cover approval lifecycle UX with `packages/gateway/src/approvals/approval-flow.integration.test.ts` and focused
+  registry tests where deadline settlement behavior changes.
+- Keep `packages/gateway/src/discord/streaming.test.ts` focused on stream-sink invariants: empty-output fallback,
+  mention-safety, and “visible approval status prevents misleading no-output fallback.”
+- Finish with `deploy/scripts/merge-config.test.mjs` to guard against the rejected global-pregrant regression.
+
+## System-Wide Impact
+
+- **Interaction graph:** Gateway config flows into mention execution, OpenCode session creation, permission event handling,
+  Discord approval UI, and final stream flush.
+- **Error propagation:** Invalid configuration fails at startup; missing coordinator fails before OpenCode session creation;
+  stream/runtime failures remain surfaced through existing run error handling.
+- **State lifecycle risks:** Approval registry entries remain per run and request ID. Deadline timers must be disposed when a
+  run ends so stale approvals do not outlive their session.
+- **API surface parity:** `GATEWAY_APPROVAL_MODE` remains an operator environment variable, but only `approval-required` is
+  supported in this PR.
+- **Integration coverage:** Tests must cover both execution wrapper and core session creation because the safety property
+  depends on mode/coordinator propagation across that boundary.
+- **Unchanged invariants:** `permission.replied` remains authoritative for approval-required settlements; approval buttons
+  still require existing Discord authorization; OpenCode config merge remains unrelated to approval policy; no path writes
+  persistent OpenCode approval rules.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Accidental global tool approval | Keep policy out of `deploy/scripts/merge-config.mjs`; add regression coverage. |
+| Existing OpenCode `always` approvals bypass Gateway approval | Do not enable autonomous mode; document that global high-risk pre-grants are unsafe for Gateway approval semantics. |
+| Approval timeout races hard run timeout | Compute deadline from remaining run budget and preserve minimum clearance. |
+| Misleading no-output fallback | Mark visible approval statuses/embeds so final flush skips `_(no output)_`. |
+| Mode plumbing drift | Pass mode explicitly through typed config/execution params and test the wrapper-to-core boundary. |
+
+## Documentation / Operational Notes
+
+- Document that Gateway defaults to approval-required behavior.
+- Warn operators not to use global high-risk OpenCode permission pre-grants to work around approval waits.
+- Document that `autonomous-low-risk` is deferred until OpenCode can isolate Gateway sessions from persisted approvals.
+
+## Sources & References
+
+- Issue: https://github.com/fro-bot/agent/issues/787
+- Related execution code: `packages/gateway/src/execute/run.ts`
+- Related core code: `packages/gateway/src/execute/run-core.ts`
+- Approval coordinator: `packages/gateway/src/approvals/coordinator.ts`
+- Approval registry: `packages/gateway/src/approvals/registry.ts`
+- Discord stream sink: `packages/gateway/src/discord/streaming.ts`
+- Gateway config: `packages/gateway/src/config.ts`
+- Workspace config merger: `deploy/scripts/merge-config.mjs`
+- OpenCode permission service: `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/permission/index.ts`
+- OpenCode permission evaluation: `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/src/permission/evaluate.ts`

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -33,6 +33,18 @@ export default defineConfig(
     },
   },
   {
+    name: 'deploy/scripts plain-Node-ESM overrides',
+    files: ['deploy/scripts/**/*.mjs'],
+    rules: {
+      // deploy/scripts uses node --test runner, not vitest
+      'vitest/no-import-node-test': 'off',
+      // plain Node ESM scripts use process directly without importing it
+      'node/prefer-global/process': 'off',
+      // import ordering is not enforced in plain-Node-ESM scripts
+      'perfectionist/sort-imports': 'off',
+    },
+  },
+  {
     name: 'vitest overrides',
     files: ['**/*.test.ts', '**/*.spec.ts'],
     rules: {

--- a/packages/gateway/src/approvals/approval-flow.integration.test.ts
+++ b/packages/gateway/src/approvals/approval-flow.integration.test.ts
@@ -608,6 +608,77 @@ describe('approval flow — cross-seam integration', () => {
     expect(registry.has(req.requestID)).toBe(false)
   })
 
+  // ── Unit 4: onDeadlineSettled callback ──────────────────────────────────
+
+  it('unit 4: onDeadlineSettled callback is invoked when deadline fires on open entry', async () => {
+    // #given — registry with a short deadline and an onDeadlineSettled callback
+    const logger = makeLogger()
+    const registry = createApprovalRegistry({logger})
+    const {effects, renderFn} = makeFakeEffects().makeEffectsFor('req-ds-1')
+
+    const deadlineSettledCalls: string[] = []
+    const onDeadlineSettled = vi.fn(async () => {
+      deadlineSettledCalls.push('req-ds-1')
+    })
+
+    registry.register({
+      requestID: 'req-ds-1',
+      sessionID: SESSION_A,
+      channelID: 'ch-test',
+      directory: DIRECTORY,
+      request: makeRequest('req-ds-1'),
+      effects,
+      deadlineMs: 100,
+      onDeadlineSettled,
+    })
+    registry.attachMessage('req-ds-1', renderFn)
+
+    // #when — advance past deadline
+    await vi.advanceTimersByTimeAsync(500)
+    await vi.runAllTimersAsync()
+
+    // #then — onDeadlineSettled was called
+    expect(onDeadlineSettled).toHaveBeenCalledOnce()
+    expect(deadlineSettledCalls).toContain('req-ds-1')
+    // Entry is gone
+    expect(registry.has('req-ds-1')).toBe(false)
+  })
+
+  it('unit 4: onDeadlineSettled is NOT called when button wins before deadline', async () => {
+    // #given — deadline wired but button wins first
+    const logger = makeLogger()
+    const registry = createApprovalRegistry({logger})
+    const {effects, renderFn} = makeFakeEffects().makeEffectsFor('req-ds-2')
+
+    const onDeadlineSettled = vi.fn()
+
+    registry.register({
+      requestID: 'req-ds-2',
+      sessionID: SESSION_A,
+      channelID: 'ch-test',
+      directory: DIRECTORY,
+      request: makeRequest('req-ds-2'),
+      effects,
+      deadlineMs: 500,
+      onDeadlineSettled,
+    })
+    registry.attachMessage('req-ds-2', renderFn)
+
+    // #when — button wins before deadline
+    await registry.handleButtonDecision({
+      requestID: 'req-ds-2',
+      channelID: 'ch-test',
+      decision: 'once',
+      decidedBy: 'user-approved',
+    })
+    registry.confirmReply({requestID: 'req-ds-2', sessionID: SESSION_A, reply: 'once'})
+    await vi.runAllTimersAsync()
+
+    // #then — onDeadlineSettled NOT called (button won)
+    expect(onDeadlineSettled).not.toHaveBeenCalled()
+    expect(registry.has('req-ds-2')).toBe(false)
+  })
+
   // 9. register-before-send: entry is immediately available in registry
   //    even before the embed "send" completes (async attach)
   // ─────────────────────────────────────────────────────────────────────────

--- a/packages/gateway/src/approvals/registry.ts
+++ b/packages/gateway/src/approvals/registry.ts
@@ -85,6 +85,15 @@ export interface RegisterParams {
    * button's postReply subsequently fails, the reset path fail-closes immediately.
    */
   readonly deadlineMs?: number
+  /**
+   * Optional callback invoked when the deadline fires on an `open` entry (i.e.
+   * the deadline wins — no button click arrived in time). Called after the
+   * reject POST and render have been dispatched. Use this to post a visible
+   * "approval timed out" status to the run thread.
+   *
+   * NOT called when the button wins before the deadline, or on dispose.
+   */
+  readonly onDeadlineSettled?: () => void | Promise<void>
 }
 
 export type DecisionOutcome = 'ok' | 'not-found' | 'channel-mismatch' | 'already-claimed' | 'reply-failed'
@@ -163,6 +172,11 @@ interface RegistryEntry {
    * fail-closes instead of leaving the entry open with a dead timer.
    */
   deadlineExpired: boolean
+  /**
+   * Optional callback invoked when the deadline fires on an `open` entry.
+   * Stored from RegisterParams.onDeadlineSettled.
+   */
+  readonly onDeadlineSettled: (() => void | Promise<void>) | undefined
 }
 
 // ---------------------------------------------------------------------------
@@ -228,7 +242,7 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
   // -------------------------------------------------------------------------
 
   function register(params: RegisterParams): void {
-    const {requestID, sessionID, channelID, directory, request, effects, deadlineMs} = params
+    const {requestID, sessionID, channelID, directory, request, effects, deadlineMs, onDeadlineSettled} = params
     if (entries.has(requestID)) {
       // FIX 3: clear the existing entry's timer before overwriting so the old
       // setTimeout cannot fire settleByDeadline on the replacement entry.
@@ -255,6 +269,7 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
       renderFn: null,
       timer: null,
       deadlineExpired: false,
+      onDeadlineSettled,
     }
     entries.set(requestID, entry)
 
@@ -294,6 +309,9 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
     entry.state = 'claimed'
     entry.timer = null
 
+    // Capture the callback before the entry is deleted.
+    const {onDeadlineSettled} = entry
+
     // Best-effort POST reject then render.
     const doDeadline = async () => {
       try {
@@ -309,6 +327,15 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
       }
       await runRender(entry, requestID, 'reject', 'deadline')
       entries.delete(requestID)
+
+      // Notify the run thread that approval timed out (best-effort).
+      if (onDeadlineSettled !== undefined) {
+        try {
+          await onDeadlineSettled()
+        } catch (error) {
+          logger.warn({requestID, err: error}, 'ApprovalRegistry: onDeadlineSettled threw — continuing')
+        }
+      }
     }
 
     // eslint-disable-next-line no-void

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -64,6 +64,8 @@ beforeEach(() => {
     'WORKSPACE_OPENCODE_TOKEN_FILE',
     'GATEWAY_TRIGGER_ROLE_ID',
     'GATEWAY_MAX_CONCURRENT_RUNS',
+    'GATEWAY_APPROVAL_MODE',
+    'GATEWAY_APPROVAL_MODE_FILE',
   ]) {
     delete process.env[key]
   }
@@ -1271,5 +1273,130 @@ describe('loadGatewayConfig — webhook secret, presence channel, http port', ()
     // #then trailing newline trimmed; announce object built with both values
     expect(config.announce?.webhookSecret).toBe('file-webhook-secret')
     expect(config.announce?.presenceChannelId).toBe('test-presence-channel-id')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GATEWAY_APPROVAL_MODE
+// ---------------------------------------------------------------------------
+
+describe('loadGatewayConfig — GATEWAY_APPROVAL_MODE', () => {
+  it('happy path: unset GATEWAY_APPROVAL_MODE → approvalMode defaults to "approval-required"', () => {
+    // #given — GATEWAY_APPROVAL_MODE not set
+    setRequiredEnv()
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.approvalMode).toBe('approval-required')
+  })
+
+  it('happy path: GATEWAY_APPROVAL_MODE=approval-required → approvalMode is "approval-required"', () => {
+    // #given
+    setRequiredEnv()
+    process.env.GATEWAY_APPROVAL_MODE = 'approval-required'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.approvalMode).toBe('approval-required')
+  })
+
+  it('error path: GATEWAY_APPROVAL_MODE=autonomous-low-risk → explicitly rejected with deferred error', () => {
+    // #given — autonomous-low-risk is deferred (unsafe due to OpenCode last-match-wins evaluation)
+    setRequiredEnv()
+    process.env.GATEWAY_APPROVAL_MODE = 'autonomous-low-risk'
+
+    // #when / #then — must throw with a clear explanation, not silently fall back
+    expect(() => loadGatewayConfig()).toThrow('GATEWAY_APPROVAL_MODE value "autonomous-low-risk" is not supported')
+  })
+
+  it('error path: unknown GATEWAY_APPROVAL_MODE value → throws with clear config error', () => {
+    // #given
+    setRequiredEnv()
+    process.env.GATEWAY_APPROVAL_MODE = 'auto-approve-everything'
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(
+      'Invalid GATEWAY_APPROVAL_MODE value: "auto-approve-everything" (valid values: approval-required)',
+    )
+  })
+
+  it('edge case: empty GATEWAY_APPROVAL_MODE → treated as unset, defaults to "approval-required"', () => {
+    // #given — empty string is treated as absent by readOptionalSecret
+    setRequiredEnv()
+    process.env.GATEWAY_APPROVAL_MODE = ''
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.approvalMode).toBe('approval-required')
+  })
+
+  it('edge case: whitespace-only GATEWAY_APPROVAL_MODE → treated as unset, defaults to "approval-required"', () => {
+    // #given — whitespace-only is treated as absent by readOptionalSecret
+    setRequiredEnv()
+    process.env.GATEWAY_APPROVAL_MODE = '   '
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.approvalMode).toBe('approval-required')
+  })
+
+  it('edge case: GATEWAY_APPROVAL_MODE_FILE with approval-required value → reads from file', () => {
+    // #given — value provided via _FILE (the compose bind-mount pattern)
+    setRequiredEnv()
+    const modeFile = join(tmpDir, 'approval-mode.txt')
+    writeFileSync(modeFile, 'approval-required\n', {mode: 0o600})
+    process.env.GATEWAY_APPROVAL_MODE_FILE = modeFile
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then — trailing newline stripped; value parsed correctly
+    expect(config.approvalMode).toBe('approval-required')
+  })
+
+  it('edge case: GATEWAY_APPROVAL_MODE_FILE with autonomous-low-risk → explicitly rejected', () => {
+    // #given — deferred mode via file
+    setRequiredEnv()
+    const modeFile = join(tmpDir, 'approval-mode-deferred.txt')
+    writeFileSync(modeFile, 'autonomous-low-risk\n', {mode: 0o600})
+    process.env.GATEWAY_APPROVAL_MODE_FILE = modeFile
+
+    // #when / #then — must throw with deferred error
+    expect(() => loadGatewayConfig()).toThrow('GATEWAY_APPROVAL_MODE value "autonomous-low-risk" is not supported')
+  })
+
+  it('edge case: GATEWAY_APPROVAL_MODE_FILE with empty file → defaults to "approval-required"', () => {
+    // #given — empty file is treated as absent by readOptionalSecret
+    setRequiredEnv()
+    const modeFile = join(tmpDir, 'approval-mode-empty.txt')
+    writeFileSync(modeFile, '', {mode: 0o600})
+    process.env.GATEWAY_APPROVAL_MODE_FILE = modeFile
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.approvalMode).toBe('approval-required')
+  })
+
+  it('error path: GATEWAY_APPROVAL_MODE_FILE with unknown value → throws with clear config error', () => {
+    // #given
+    setRequiredEnv()
+    const modeFile = join(tmpDir, 'approval-mode-bad.txt')
+    writeFileSync(modeFile, 'full-auto\n', {mode: 0o600})
+    process.env.GATEWAY_APPROVAL_MODE_FILE = modeFile
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(
+      'Invalid GATEWAY_APPROVAL_MODE value: "full-auto" (valid values: approval-required)',
+    )
   })
 })

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -10,6 +10,14 @@ const DEFAULT_GATEWAY_IDENTITY = 'discord-gateway'
 const DEFAULT_LOG_LEVEL = 'info' as const
 const VALID_LOG_LEVELS = ['debug', 'info', 'warn', 'error'] as const
 
+const DEFAULT_APPROVAL_MODE = 'approval-required' as const
+// autonomous-low-risk is deferred: OpenCode evaluates session rules before persisted project
+// 'approved' rules, and last-match-wins means persisted 'always' approvals can override session
+// denies. No permission.asked fires in that case, so gateway autonomous reject cannot save it.
+// Keep the env var so operators get a clear error instead of silent fallback if they set it.
+const VALID_APPROVAL_MODES = ['approval-required'] as const
+const DEFERRED_APPROVAL_MODES = ['autonomous-low-risk'] as const
+
 const ALLOWED_PRIVILEGED_INTENTS = {
   MessageContent: GatewayIntentBits.MessageContent,
   GuildMembers: GatewayIntentBits.GuildMembers,
@@ -40,6 +48,14 @@ export interface GatewayConfig {
   readonly maxConcurrentRuns: number
   /** Maximum wall-clock milliseconds a single run may take before being aborted. */
   readonly runTimeoutMs: number
+  /**
+   * Approval mode for tool permission requests during mention runs.
+   * - `approval-required` (default): routes permission asks to Discord approval UI.
+   *
+   * Note: `autonomous-low-risk` is deferred and explicitly rejected at startup. See config.ts for
+   * the rationale (OpenCode last-match-wins evaluation makes session-scoped denies unsafe).
+   */
+  readonly approvalMode: 'approval-required'
   /**
    * Announce/presence endpoint configuration. Present only when both
    * `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_CHANNEL_ID` are set.
@@ -265,6 +281,19 @@ export function loadGatewayConfig(): GatewayConfig {
   }
   const logLevel = rawLogLevel as GatewayConfig['logLevel']
 
+  const rawApprovalMode = readOptionalSecret('GATEWAY_APPROVAL_MODE') ?? DEFAULT_APPROVAL_MODE
+  if ((DEFERRED_APPROVAL_MODES as readonly string[]).includes(rawApprovalMode)) {
+    throw new Error(
+      `GATEWAY_APPROVAL_MODE value "${rawApprovalMode}" is not supported: autonomous-low-risk is deferred because OpenCode evaluates session rules before persisted project 'approved' rules, and last-match-wins means persisted 'always' approvals can override session denies. Use "approval-required" (the default).`,
+    )
+  }
+  if (!(VALID_APPROVAL_MODES as readonly string[]).includes(rawApprovalMode)) {
+    throw new Error(
+      `Invalid GATEWAY_APPROVAL_MODE value: "${rawApprovalMode}" (valid values: ${VALID_APPROVAL_MODES.join(', ')})`,
+    )
+  }
+  const approvalMode = rawApprovalMode as GatewayConfig['approvalMode']
+
   const rawIntents = readOptionalSecret('DISCORD_PRIVILEGED_INTENTS')
   const privilegedIntents: GatewayIntentBits[] = []
   if (rawIntents !== null) {
@@ -408,6 +437,7 @@ export function loadGatewayConfig(): GatewayConfig {
     identity,
     logLevel,
     privilegedIntents,
+    approvalMode,
     githubAppId,
     githubAppPrivateKey,
     gatewayGitHubAppInstallUrl,

--- a/packages/gateway/src/discord/mentions.test.ts
+++ b/packages/gateway/src/discord/mentions.test.ts
@@ -150,6 +150,7 @@ function makeRunMentionDeps(): MentionDeps['run'] {
       confirmReply: vi.fn(),
       disposeAll: vi.fn(),
     },
+    approvalMode: 'approval-required' as const,
   }
 }
 

--- a/packages/gateway/src/discord/streaming.test.ts
+++ b/packages/gateway/src/discord/streaming.test.ts
@@ -278,4 +278,67 @@ describe('createDiscordStreamSink', () => {
       expect(thread._send).not.toHaveBeenCalled()
     })
   })
+
+  // ── Unit 4: markVisibleOutputSent — approval status prevents _(no output)_ ──
+
+  describe('markVisibleOutputSent()', () => {
+    it('flush returns {kind:"skipped-visible"} instead of posting _(no output)_ when visible output was already sent', async () => {
+      // #given — nothing appended to buffer, but visible output was already posted (e.g. approval status)
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      sink.markVisibleOutputSent()
+
+      // #when
+      const result = await sink.flush()
+
+      // #then — no send, kind is skipped-visible (not empty)
+      expect(result.kind).toBe('skipped-visible')
+      expect(thread._send).not.toHaveBeenCalled()
+    })
+
+    it('flush sends buffered text normally even after markVisibleOutputSent (text takes precedence)', async () => {
+      // #given — text was appended AND visible output was marked
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      sink.append('agent output here')
+      sink.markVisibleOutputSent()
+
+      // #when
+      const result = await sink.flush()
+
+      // #then — text is sent normally (not suppressed)
+      expect(result.kind).toBe('sent')
+      expect(thread._send).toHaveBeenCalledOnce()
+      const call = firstCallArg<{content: string}>(thread._send)
+      expect(call.content).toBe('agent output here')
+    })
+
+    it('flush sends _(no output)_ when buffer is empty and markVisibleOutputSent was NOT called', async () => {
+      // #given — nothing appended, no visible output marked
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+
+      // #when
+      const result = await sink.flush()
+
+      // #then — existing _(no output)_ behavior preserved
+      expect(result.kind).toBe('empty')
+      expect(thread._send).toHaveBeenCalledOnce()
+    })
+
+    it('markVisibleOutputSent is idempotent — calling twice still suppresses _(no output)_', async () => {
+      // #given
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      sink.markVisibleOutputSent()
+      sink.markVisibleOutputSent()
+
+      // #when
+      const result = await sink.flush()
+
+      // #then
+      expect(result.kind).toBe('skipped-visible')
+      expect(thread._send).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/gateway/src/discord/streaming.ts
+++ b/packages/gateway/src/discord/streaming.ts
@@ -53,6 +53,7 @@ export type FlushResult =
   | {readonly kind: 'sent'; readonly charCount: number}
   | {readonly kind: 'attachment'; readonly charCount: number}
   | {readonly kind: 'empty'}
+  | {readonly kind: 'skipped-visible'}
   | {readonly kind: 'error'; readonly message: string}
 
 /** Dependencies injected into the sink factory. */
@@ -100,12 +101,21 @@ export interface DiscordStreamSink {
    * Flush the current buffer to the Discord thread.
    * - Short text (≤2000 chars): single message send.
    * - Long text (>2000 chars): summary line + `.md` attachment.
-   * - Empty/whitespace: "no output" message.
+   * - Empty/whitespace AND no visible output already sent: "no output" message.
+   * - Empty/whitespace AND visible output already sent (e.g. approval status): `{kind:'skipped-visible'}`, no send.
    * - On `thread.send` rejection: returns `{kind:'error'}` (does not throw).
    */
   readonly flush: () => Promise<FlushResult>
   /** Read the current buffered text without flushing. */
   readonly buffered: () => string
+  /**
+   * Mark that visible output has already been sent to the thread outside the
+   * buffer (e.g. an approval waiting status). When set, `flush()` will NOT
+   * post `_(no output)_` for an empty buffer — it returns `{kind:'skipped-visible'}`.
+   *
+   * Has no effect when the buffer contains non-whitespace text (text always flushes normally).
+   */
+  readonly markVisibleOutputSent: () => void
 }
 
 /**
@@ -117,6 +127,7 @@ export interface DiscordStreamSink {
 export function createDiscordStreamSink(thread: SinkThread, deps: StreamSinkDeps = {}): DiscordStreamSink {
   const {logger} = deps
   let buffer = ''
+  let visibleOutputSent = false
 
   const append = (text: string): void => {
     buffer += text
@@ -124,11 +135,20 @@ export function createDiscordStreamSink(thread: SinkThread, deps: StreamSinkDeps
 
   const buffered = (): string => buffer
 
+  const markVisibleOutputSent = (): void => {
+    visibleOutputSent = true
+  }
+
   const flush = async (): Promise<FlushResult> => {
     const text = buffer
 
-    // Empty / whitespace → post a clear "no output" message
+    // Empty / whitespace — check if visible output was already sent outside the buffer
     if (text.trim().length === 0) {
+      // Visible output already sent (e.g. approval waiting status) → skip _(no output)_
+      if (visibleOutputSent) {
+        return {kind: 'skipped-visible'}
+      }
+      // Genuinely empty run → post the "no output" fallback
       try {
         await safeSend(thread, {content: EMPTY_OUTPUT_MESSAGE})
         return {kind: 'empty'}
@@ -163,5 +183,5 @@ export function createDiscordStreamSink(thread: SinkThread, deps: StreamSinkDeps
     }
   }
 
-  return {append, flush, buffered}
+  return {append, flush, buffered, markVisibleOutputSent}
 }

--- a/packages/gateway/src/execute/run-core.test.ts
+++ b/packages/gateway/src/execute/run-core.test.ts
@@ -33,6 +33,7 @@ function makeSink(): DiscordStreamSink & {readonly _appended: string[]} {
     },
     flush: vi.fn().mockResolvedValue({kind: 'sent', charCount: buffer.length}),
     buffered: () => buffer,
+    markVisibleOutputSent: vi.fn(),
   }
 }
 
@@ -166,17 +167,24 @@ function sessionErrorEvent(sessionID: string, error = 'LLM error'): object {
 /**
  * Build a minimal `OpenCodeServerHandle` test double.
  * All SDK methods are vi.fn() by default; callers override what they need.
+ *
+ * `postPermissionReply` overrides `postSessionIdPermissionsPermissionId` — the
+ * endpoint run-core calls to reject a permission ask in autonomous-low-risk mode.
+ * Defaults to a resolved `{error: null}` response so tests that don't care about
+ * it don't need to set it up.
  */
 function makeHandle(
   overrides: {
     readonly sessionCreate?: () => Promise<unknown>
     readonly promptAsync?: (args: unknown) => Promise<unknown>
     readonly subscribe?: (args: unknown) => Promise<unknown>
+    readonly postPermissionReply?: (args: unknown) => Promise<unknown>
   } = {},
 ): OpenCodeServerHandle {
   const sessionCreate = overrides.sessionCreate ?? (async () => sessionCreateOk())
   const promptAsync = overrides.promptAsync ?? (async () => promptAsyncOk())
   const subscribe = overrides.subscribe ?? (async () => subscribeOk([sessionIdleEvent('sess-123')]))
+  const postPermissionReply = overrides.postPermissionReply ?? (async () => ({error: null}))
 
   const client = {
     session: {
@@ -186,6 +194,7 @@ function makeHandle(
     event: {
       subscribe: vi.fn().mockImplementation(subscribe),
     },
+    postSessionIdPermissionsPermissionId: vi.fn().mockImplementation(postPermissionReply),
   }
 
   return {
@@ -206,7 +215,7 @@ const BASE_PARAMS = {
 
 function buildParams(
   handle: OpenCodeServerHandle,
-  overrides: Partial<typeof BASE_PARAMS> = {},
+  overrides: Partial<typeof BASE_PARAMS & {approvalMode: 'approval-required'}> = {},
 ): Parameters<typeof runOpenCodeCore>[0] {
   return {
     handle,
@@ -215,6 +224,7 @@ function buildParams(
     sink: makeSink(),
     signal: new AbortController().signal,
     logger: makeLogger(),
+    ...(overrides.approvalMode === undefined ? {} : {approvalMode: overrides.approvalMode}),
   }
 }
 
@@ -261,9 +271,9 @@ function permissionRepliedEvent(
 describe('runOpenCodeCore', () => {
   describe('happy path — text deltas + session.idle', () => {
     it('resolves without throwing when session.idle is received', async () => {
-      // #given
+      // #given — coordinator required (approval-required is the only supported mode)
       const handle = makeHandle()
-      const params = buildParams(handle)
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
 
       // #when / #then
       await expect(runOpenCodeCore(params)).resolves.toBeUndefined()
@@ -276,7 +286,7 @@ describe('runOpenCodeCore', () => {
         subscribe: async () =>
           subscribeOk([partDeltaObjectEvent('Hello'), partDeltaObjectEvent(' world'), sessionIdleEvent('sess-123')]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -293,7 +303,7 @@ describe('runOpenCodeCore', () => {
         subscribe: async () =>
           subscribeOk([partDeltaStringEvent('Hi'), partDeltaStringEvent(' there'), sessionIdleEvent('sess-123')]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -313,7 +323,7 @@ describe('runOpenCodeCore', () => {
             sessionIdleEvent('sess-123'),
           ]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -328,7 +338,7 @@ describe('runOpenCodeCore', () => {
       const handle = makeHandle({
         subscribe: async () => subscribeOk([nextTextDeltaObjectEvent('Gamma'), sessionIdleEvent('sess-123')]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -344,7 +354,7 @@ describe('runOpenCodeCore', () => {
         subscribe: async () =>
           subscribeOk([partDeltaObjectEvent('ignored', 'other-session'), sessionIdleEvent('sess-123')]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -360,7 +370,7 @@ describe('runOpenCodeCore', () => {
         subscribe: async () =>
           subscribeOk([nextTextDeltaStringEvent('ignored', 'other-session'), sessionIdleEvent('sess-123')]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -378,7 +388,7 @@ describe('runOpenCodeCore', () => {
         sessionIdleEvent('sess-123'),
       ]
       const handle = makeHandle({subscribe: async () => subscribeOk(events)})
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       const p = runOpenCodeCore(params).then(() => {
@@ -403,7 +413,7 @@ describe('runOpenCodeCore', () => {
             sessionIdleEvent('sess-123'),
           ]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -425,7 +435,7 @@ describe('runOpenCodeCore', () => {
             sessionIdleEvent('sess-123'),
           ]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -445,7 +455,7 @@ describe('runOpenCodeCore', () => {
             sessionIdleEvent('sess-123'),
           ]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -467,7 +477,7 @@ describe('runOpenCodeCore', () => {
             sessionIdleEvent('sess-123'),
           ]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -487,7 +497,7 @@ describe('runOpenCodeCore', () => {
             sessionIdleEvent('sess-123'),
           ]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -507,7 +517,7 @@ describe('runOpenCodeCore', () => {
             sessionIdleEvent('sess-123'),
           ]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -528,7 +538,7 @@ describe('runOpenCodeCore', () => {
             sessionIdleEvent('sess-123'),
           ]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -549,7 +559,7 @@ describe('runOpenCodeCore', () => {
             sessionIdleEvent('sess-123'),
           ]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -568,7 +578,7 @@ describe('runOpenCodeCore', () => {
             sessionIdleEvent('sess-123'),
           ]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -587,7 +597,7 @@ describe('runOpenCodeCore', () => {
             sessionIdleEvent('sess-123'),
           ]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -602,7 +612,7 @@ describe('runOpenCodeCore', () => {
       const handle = makeHandle({
         subscribe: async () => subscribeOk([partUpdatedTextEvent('some text content'), sessionIdleEvent('sess-123')]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -626,7 +636,7 @@ describe('runOpenCodeCore', () => {
             sessionIdleEvent('sess-123'),
           ]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -645,7 +655,7 @@ describe('runOpenCodeCore', () => {
             sessionIdleEvent('sess-123'),
           ]),
       })
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -659,7 +669,7 @@ describe('runOpenCodeCore', () => {
     it('threads directory to promptAsync query', async () => {
       // #given
       const handle = makeHandle()
-      const params = buildParams(handle, {directory: '/repos/myrepo'})
+      const params = {...buildParams(handle, {directory: '/repos/myrepo'}), coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -673,7 +683,7 @@ describe('runOpenCodeCore', () => {
     it('threads directory to event.subscribe query', async () => {
       // #given
       const handle = makeHandle()
-      const params = buildParams(handle, {directory: '/repos/myrepo'})
+      const params = {...buildParams(handle, {directory: '/repos/myrepo'}), coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -687,7 +697,7 @@ describe('runOpenCodeCore', () => {
     it('threads directory to session.create query', async () => {
       // #given
       const handle = makeHandle()
-      const params = buildParams(handle, {directory: '/repos/myrepo'})
+      const params = {...buildParams(handle, {directory: '/repos/myrepo'}), coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -701,13 +711,77 @@ describe('runOpenCodeCore', () => {
     })
   })
 
+  describe('abort signal threading — SDK calls receive the timeout signal', () => {
+    it('passes the AbortSignal to session.create', async () => {
+      // #given — use a real AbortController so we can inspect the signal identity
+      const controller = new AbortController()
+      const handle = makeHandle()
+      const params = {...buildParams(handle), signal: controller.signal, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — session.create must have received the same signal object
+      const {session} = handle.client as unknown as {session: {create: ReturnType<typeof vi.fn>}}
+      const callArgs = (session.create.mock.calls[0] as [{signal?: AbortSignal}])[0]
+      expect(callArgs.signal).toBe(controller.signal)
+    })
+
+    it('passes the AbortSignal to event.subscribe', async () => {
+      // #given
+      const controller = new AbortController()
+      const handle = makeHandle()
+      const params = {...buildParams(handle), signal: controller.signal, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — event.subscribe must have received the same signal object
+      const {event} = handle.client as unknown as {event: {subscribe: ReturnType<typeof vi.fn>}}
+      const callArgs = (event.subscribe.mock.calls[0] as [{signal?: AbortSignal}])[0]
+      expect(callArgs.signal).toBe(controller.signal)
+    })
+
+    it('passes the AbortSignal to session.promptAsync', async () => {
+      // #given
+      const controller = new AbortController()
+      const handle = makeHandle()
+      const params = {...buildParams(handle), signal: controller.signal, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — promptAsync must have received the same signal object
+      const {session} = handle.client as unknown as {session: {promptAsync: ReturnType<typeof vi.fn>}}
+      const callArgs = (session.promptAsync.mock.calls[0] as [{signal?: AbortSignal}])[0]
+      expect(callArgs.signal).toBe(controller.signal)
+    })
+
+    it('does NOT call session.create when signal is already aborted (signal not passed to a dead call)', async () => {
+      // #given — pre-aborted signal; session.create must be skipped entirely
+      const controller = new AbortController()
+      controller.abort()
+      const handle = makeHandle()
+      const params = {...buildParams(handle), signal: controller.signal, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params).catch(() => {
+        /* expected timeout error */
+      })
+
+      // #then — session.create was never called, so signal was never passed to it
+      const {session} = handle.client as unknown as {session: {create: ReturnType<typeof vi.fn>}}
+      expect(session.create).not.toHaveBeenCalled()
+    })
+  })
+
   describe('error path — server unreachable', () => {
     it('throws RunCoreError with kind "unreachable" when session.create throws', async () => {
       // #given
       const handle = makeHandle({
         sessionCreate: async () => Promise.reject(new TypeError('fetch failed')),
       })
-      const params = buildParams(handle)
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
 
       // #when / #then
       await expect(runOpenCodeCore(params)).rejects.toThrow(RunCoreError)
@@ -719,7 +793,7 @@ describe('runOpenCodeCore', () => {
       const handle = makeHandle({
         sessionCreate: async () => Promise.resolve({data: null, error: {message: 'ECONNREFUSED'}}),
       })
-      const params = buildParams(handle)
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
 
       // #when / #then
       await expect(runOpenCodeCore(params)).rejects.toMatchObject({kind: 'unreachable'})
@@ -730,7 +804,7 @@ describe('runOpenCodeCore', () => {
       const handle = makeHandle({
         promptAsync: async () => Promise.reject(new TypeError('fetch failed')),
       })
-      const params = buildParams(handle)
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
 
       // #when / #then
       await expect(runOpenCodeCore(params)).rejects.toMatchObject({kind: 'unreachable'})
@@ -743,7 +817,7 @@ describe('runOpenCodeCore', () => {
       const handle = makeHandle({
         sessionCreate: async () => Promise.resolve({data: null, error: {status: 401, message: '401 Unauthorized'}}),
       })
-      const params = buildParams(handle)
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
 
       // #when / #then
       await expect(runOpenCodeCore(params)).rejects.toMatchObject({kind: 'auth'})
@@ -754,7 +828,7 @@ describe('runOpenCodeCore', () => {
       const handle = makeHandle({
         promptAsync: async () => Promise.resolve({data: null, error: {status: 401, message: '401 Unauthorized'}}),
       })
-      const params = buildParams(handle)
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
 
       // #when / #then
       await expect(runOpenCodeCore(params)).rejects.toMatchObject({kind: 'auth'})
@@ -765,7 +839,7 @@ describe('runOpenCodeCore', () => {
       const handle = makeHandle({
         sessionCreate: async () => Promise.resolve({data: null, error: {status: 403, message: 'Forbidden'}}),
       })
-      const params = buildParams(handle)
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
 
       // #when / #then
       await expect(runOpenCodeCore(params)).rejects.toMatchObject({kind: 'auth'})
@@ -778,7 +852,7 @@ describe('runOpenCodeCore', () => {
       const handle = makeHandle({
         subscribe: async () => subscribeOk([sessionErrorEvent('sess-123', 'LLM quota exceeded')]),
       })
-      const params = buildParams(handle)
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
 
       // #when / #then
       await expect(runOpenCodeCore(params)).rejects.toMatchObject({kind: 'session-error'})
@@ -789,7 +863,7 @@ describe('runOpenCodeCore', () => {
       const handle = makeHandle({
         subscribe: async () => subscribeOk([sessionErrorEvent('sess-123')]),
       })
-      const params = buildParams(handle)
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
 
       // #when / #then
       await expect(runOpenCodeCore(params)).rejects.toBeInstanceOf(RunCoreError)
@@ -803,7 +877,7 @@ describe('runOpenCodeCore', () => {
         subscribe: async () => subscribeOk([partDeltaObjectEvent('Done!'), sessionIdleEvent('sess-123')]),
       })
       const sink = makeSink()
-      const params = {...buildParams(handle), sink}
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
@@ -823,13 +897,102 @@ describe('runOpenCodeCore', () => {
       const handle = makeHandle({
         subscribe: async () => subscribeOk([partDeltaObjectEvent('should not appear'), sessionIdleEvent('sess-123')]),
       })
-      const params = {...buildParams(handle), sink, signal: controller.signal}
+      const params = {...buildParams(handle), sink, signal: controller.signal, coordinator: makeCoordinator()}
 
       // #when — aborted signal → timeout kind thrown before any events processed
       await expect(runOpenCodeCore(params)).rejects.toThrow(RunCoreError)
 
       // #then — no content was appended
       expect(sink._appended).toHaveLength(0)
+    })
+
+    it('throws RunCoreError(timeout) before session.create when signal is already aborted', async () => {
+      // #given — signal pre-aborted; session.create must NOT be called
+      const controller = new AbortController()
+      controller.abort()
+
+      const handle = makeHandle()
+      const params = {...buildParams(handle), signal: controller.signal, coordinator: makeCoordinator()}
+
+      // #when / #then
+      const err = await runOpenCodeCore(params).catch((error: unknown) => error)
+      expect(err).toBeInstanceOf(RunCoreError)
+      expect((err as RunCoreError).kind).toBe('timeout')
+
+      // session.create must NOT have been called
+      const {session} = handle.client as unknown as {session: {create: ReturnType<typeof vi.fn>}}
+      expect(session.create).not.toHaveBeenCalled()
+    })
+
+    it('throws RunCoreError(timeout) when signal aborts after session.create but before subscribe', async () => {
+      // #given — signal aborts synchronously after session.create resolves
+      const controller = new AbortController()
+      const handle = makeHandle({
+        sessionCreate: async () => {
+          // Abort the signal as part of session creation completing
+          controller.abort()
+          return sessionCreateOk()
+        },
+      })
+      const params = {...buildParams(handle), signal: controller.signal, coordinator: makeCoordinator()}
+
+      // #when / #then
+      const err = await runOpenCodeCore(params).catch((error: unknown) => error)
+      expect(err).toBeInstanceOf(RunCoreError)
+      expect((err as RunCoreError).kind).toBe('timeout')
+
+      // event.subscribe must NOT have been called
+      const {event} = handle.client as unknown as {event: {subscribe: ReturnType<typeof vi.fn>}}
+      expect(event.subscribe).not.toHaveBeenCalled()
+    })
+
+    it('throws RunCoreError(timeout) when signal aborts after subscribe but before promptAsync', async () => {
+      // #given — signal aborts synchronously after subscribe resolves
+      const controller = new AbortController()
+      const handle = makeHandle({
+        subscribe: async () => {
+          controller.abort()
+          return subscribeOk([sessionIdleEvent('sess-123')])
+        },
+      })
+      const params = {...buildParams(handle), signal: controller.signal, coordinator: makeCoordinator()}
+
+      // #when / #then
+      const err = await runOpenCodeCore(params).catch((error: unknown) => error)
+      expect(err).toBeInstanceOf(RunCoreError)
+      expect((err as RunCoreError).kind).toBe('timeout')
+
+      // promptAsync must NOT have been called
+      const {session} = handle.client as unknown as {session: {promptAsync: ReturnType<typeof vi.fn>}}
+      expect(session.promptAsync).not.toHaveBeenCalled()
+    })
+
+    it('throws RunCoreError(timeout) when signal aborts after promptAsync but before first event', async () => {
+      // #given — signal aborts synchronously after promptAsync resolves; stream is silent
+      const controller = new AbortController()
+      const handle = makeHandle({
+        promptAsync: async () => {
+          controller.abort()
+          return promptAsyncOk()
+        },
+        // Silent stream — never yields an event
+        subscribe: async () => {
+          return Promise.resolve({
+            stream: (async function* () {
+              // Yield nothing — simulates a silent/hanging stream
+              await new Promise<void>(() => {
+                /* never resolves */
+              })
+            })(),
+          })
+        },
+      })
+      const params = {...buildParams(handle), signal: controller.signal, coordinator: makeCoordinator()}
+
+      // #when / #then — must not hang; abortable stream exits promptly
+      const err = await runOpenCodeCore(params).catch((error: unknown) => error)
+      expect(err).toBeInstanceOf(RunCoreError)
+      expect((err as RunCoreError).kind).toBe('timeout')
     })
   })
 
@@ -842,7 +1005,7 @@ describe('runOpenCodeCore', () => {
           error: {status: 401, message: 'Unauthorized'},
         }),
       })
-      const params = buildParams(handle)
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
 
       // #when / #then — RunCoreError with kind 'auth'
       const err = await runOpenCodeCore(params).catch((error: unknown) => error)
@@ -858,7 +1021,7 @@ describe('runOpenCodeCore', () => {
           error: {status: 403, message: 'Forbidden'},
         }),
       })
-      const params = buildParams(handle)
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
 
       // #when / #then
       const err = await runOpenCodeCore(params).catch((error: unknown) => error)
@@ -874,7 +1037,7 @@ describe('runOpenCodeCore', () => {
           error: {status: 500, message: 'Internal error: connection pool 401-queue exhausted'},
         }),
       })
-      const params = buildParams(handle)
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
 
       // #when / #then — should be 'unreachable', NOT 'auth'
       const err = await runOpenCodeCore(params).catch((error: unknown) => error)
@@ -891,7 +1054,7 @@ describe('runOpenCodeCore', () => {
           error: {message: 'The token is unauthorized for this operation', status: 500},
         }),
       })
-      const params = buildParams(handle)
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
 
       // #when / #then
       const err = await runOpenCodeCore(params).catch((error: unknown) => error)
@@ -907,12 +1070,33 @@ describe('runOpenCodeCore', () => {
           error: {message: 'ECONNREFUSED'},
         }),
       })
-      const params = buildParams(handle)
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
 
       // #when / #then — falls through to 'unreachable'
       const err = await runOpenCodeCore(params).catch((error: unknown) => error)
       expect(err).toBeInstanceOf(RunCoreError)
       expect((err as RunCoreError).kind).toBe('unreachable')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Session creation — no body.permission injection (autonomous-low-risk deferred)
+  // ---------------------------------------------------------------------------
+
+  describe('session creation', () => {
+    it('session.create is called WITHOUT a body.permission field (approval-required mode)', async () => {
+      // #given — approval-required mode (the only supported mode)
+      const handle = makeHandle()
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — session.create must NOT receive a body with permission rules
+      const {session} = handle.client as unknown as {session: {create: ReturnType<typeof vi.fn>}}
+      const callArgs = (session.create.mock.calls[0] as [{query?: unknown; body?: unknown}])[0]
+      // body should be absent (no session permission override in approval-required mode)
+      expect(callArgs.body).toBeUndefined()
     })
   })
 
@@ -1001,17 +1185,6 @@ describe('runOpenCodeCore', () => {
       expect(coordinator.onPermissionAsked).not.toHaveBeenCalled()
     })
 
-    it('does NOT throw when coordinator is absent and permission.asked arrives', async () => {
-      // #given — no coordinator param (back-compat)
-      const handle = makeHandle({
-        subscribe: async () => subscribeOk([permissionAskedEvent('req-1'), sessionIdleEvent('sess-123')]),
-      })
-      const params = buildParams(handle) // no coordinator
-
-      // #when / #then — must resolve cleanly
-      await expect(runOpenCodeCore(params)).resolves.toBeUndefined()
-    })
-
     it('invokes event.subscribe before promptAsync (subscribe-before-prompt ordering)', async () => {
       // #given — track call order via a shared array
       const callOrder: string[] = []
@@ -1026,13 +1199,68 @@ describe('runOpenCodeCore', () => {
           return subscribeOk([sessionIdleEvent('sess-123')])
         },
       })
-      const params = buildParams(handle)
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
 
       // #when
       await runOpenCodeCore(params)
 
       // #then — subscribe fires before prompt
       expect(callOrder).toEqual(['subscribe', 'promptAsync'])
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Coordinator required — fail-closed before session creation
+  // ---------------------------------------------------------------------------
+
+  describe('coordinator required — fail-closed before session creation', () => {
+    it('throws RunCoreError with kind "missing-coordinator" when no coordinator is provided', async () => {
+      // #given — no coordinator (coordinator is required unconditionally)
+      const handle = makeHandle()
+      const params = buildParams(handle) // no coordinator
+
+      // #when / #then — must fail closed before session.create
+      await expect(runOpenCodeCore(params)).rejects.toMatchObject({kind: 'missing-coordinator'})
+    })
+
+    it('throws RunCoreError(missing-coordinator) BEFORE session.create is called', async () => {
+      // #given — no coordinator
+      const handle = makeHandle()
+      const params = buildParams(handle)
+
+      // #when
+      await runOpenCodeCore(params).catch(() => {
+        /* expected */
+      })
+
+      // #then — session.create must NOT have been called
+      const {session} = handle.client as unknown as {session: {create: ReturnType<typeof vi.fn>}}
+      expect(session.create).not.toHaveBeenCalled()
+    })
+
+    it('throws RunCoreError(missing-coordinator) BEFORE promptAsync is called', async () => {
+      // #given — no coordinator
+      const handle = makeHandle()
+      const params = buildParams(handle)
+
+      // #when
+      await runOpenCodeCore(params).catch(() => {
+        /* expected */
+      })
+
+      // #then — promptAsync must NOT have been called
+      const {session} = handle.client as unknown as {session: {promptAsync: ReturnType<typeof vi.fn>}}
+      expect(session.promptAsync).not.toHaveBeenCalled()
+    })
+
+    it('coordinator present proceeds normally', async () => {
+      // #given — coordinator present
+      const coordinator = makeCoordinator()
+      const handle = makeHandle()
+      const params = {...buildParams(handle), coordinator}
+
+      // #when / #then — must resolve cleanly
+      await expect(runOpenCodeCore(params)).resolves.toBeUndefined()
     })
   })
 })

--- a/packages/gateway/src/execute/run-core.ts
+++ b/packages/gateway/src/execute/run-core.ts
@@ -40,6 +40,7 @@ export type RunCoreErrorKind =
   | 'prompt-error' // `promptAsync` returned an error
   | 'timeout' // run exceeded the configured wall-clock timeout
   | 'stream-ended' // event stream closed before session.idle was received
+  | 'missing-coordinator' // approval-required mode but no coordinator provided (fail-closed)
 
 /**
  * Error thrown by `runOpenCodeCore` on any failure path.
@@ -87,9 +88,14 @@ export interface RunCoreParams {
   /** Injected logger. Internal details only — never leak session internals to Discord. */
   readonly logger: GatewayLogger
   /**
-   * Optional permission coordinator.
-   * When present, `permission.asked` and `permission.replied` events are routed
-   * to it. When absent, those events are silently ignored (back-compat).
+   * Gateway approval mode. Currently only `approval-required` is supported.
+   * `autonomous-low-risk` is deferred (unsafe due to OpenCode last-match-wins evaluation).
+   * When present, must be `approval-required`; when absent, defaults to `approval-required`.
+   */
+  readonly approvalMode?: 'approval-required'
+  /**
+   * Permission coordinator. Required when `approvalMode` is `approval-required` (the only
+   * supported mode). Fail-closed: if absent, `runOpenCodeCore` throws before session creation.
    */
   readonly coordinator?: PermissionCoordinator
 }
@@ -156,38 +162,39 @@ interface ToolCallInfo {
 // Core
 // ---------------------------------------------------------------------------
 
-/**
- * Execute a single OpenCode prompt against a remote server and pipe text
- * events to the provided `DiscordStreamSink`.
- *
- * Flow:
- * 1. `session.create()`
- * 2. `event.subscribe({query: {directory}})` — SSE stream (directory REQUIRED,
- *    subscribe-before-prompt removes the race where permission.asked fires
- *    before the SSE listener exists)
- * 3. `session.promptAsync({..., query: {directory}})` — blocks until queued
- * 4. Iterate events:
- *    - `message.part.delta` (this session) → `sink.append(text)`
- *    - `session.next.text.delta` (this session) → `sink.append(text)`
- *    - `session.next.tool.called` (this session) → cache call info
- *    - `session.next.tool.success` (this session) → append progress line to sink
- *    - `permission.asked` (this session, coordinator present) → fire-and-continue
- *    - `permission.replied` (this session, coordinator present) → settle
- *    - `session.idle` for this session → resolve
- *    - `session.error` for this session → throw `RunCoreError('session-error')`
- * 5. Caller calls `sink.flush()` after this resolves.
- *
- * @throws {RunCoreError} on unreachable server, 401 auth rejection,
- *   session error, or prompt rejection.
- */
 export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
-  const {handle, directory, promptText, sink, signal, logger, coordinator} = params
+  const {handle, directory, promptText, sink, signal, logger, coordinator, approvalMode} = params
   const {client} = handle
+
+  // ── 0. Mode/coordinator pre-flight ────────────────────────────────────────
+  // Coordinator is required unconditionally: approval-required is the only supported mode
+  // and it requires a coordinator before any session or prompt operations.
+  // Fail closed here so no session is created without approval wiring.
+  if (coordinator === undefined) {
+    logger.error({approvalMode}, 'run-core: coordinator required — failing closed before session creation')
+    throw new RunCoreError(
+      'missing-coordinator',
+      'approval-required mode requires a PermissionCoordinator — none was provided',
+    )
+  }
+
+  // ── 0b. Pre-flight abort check ─────────────────────────────────────────────
+  // Check before any external call so an already-expired signal (e.g. AbortSignal.timeout
+  // that fired during setup) is caught immediately rather than after a blocking SDK call.
+  if (signal.aborted) {
+    logger.warn({}, 'run-core: signal already aborted before session creation')
+    throw new RunCoreError('timeout', 'Run timed out: signal was already aborted before session creation')
+  }
 
   // ── 1. Create session ──────────────────────────────────────────────────────
   let sessionId: string
   try {
-    const sessionResponse = await client.session.create({query: {directory}})
+    // approval-required mode (the only supported mode): no session permission override.
+    // Discord approval UI handles permission asks via the coordinator.
+    const sessionResponse = await client.session.create({
+      query: {directory},
+      signal,
+    })
     if (sessionResponse.error != null) {
       const errMsg = String(sessionResponse.error)
       if (isAuthError(sessionResponse)) {
@@ -208,12 +215,18 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
     throw new RunCoreError('unreachable', `Session create threw: ${message}`)
   }
 
+  // ── 1b. Post-create abort check ────────────────────────────────────────────
+  if (signal.aborted) {
+    logger.warn({sessionId}, 'run-core: signal aborted after session creation')
+    throw new RunCoreError('timeout', 'Run timed out: signal aborted after session creation')
+  }
+
   // ── 2. Subscribe to events — directory threaded to query (SSE-routing) ─────
   // Subscribe BEFORE prompt to eliminate the race where permission.asked fires
   // before the SSE listener exists.
   let eventStream: AsyncIterable<unknown>
   try {
-    const eventsResult = await client.event.subscribe({query: {directory}})
+    const eventsResult = await client.event.subscribe({query: {directory}, signal})
     eventStream = eventsResult.stream as AsyncIterable<unknown>
     logger.info({sessionId, directory}, 'run-core: event stream subscribed')
   } catch (error) {
@@ -222,12 +235,19 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
     throw new RunCoreError('unreachable', `Event subscribe threw: ${message}`)
   }
 
+  // ── 2b. Post-subscribe abort check ────────────────────────────────────────
+  if (signal.aborted) {
+    logger.warn({sessionId}, 'run-core: signal aborted after event subscribe')
+    throw new RunCoreError('timeout', 'Run timed out: signal aborted after event subscribe')
+  }
+
   // ── 3. Send prompt — directory threaded to query ───────────────────────────
   try {
     const promptResponse = await client.session.promptAsync({
       path: {id: sessionId},
       body: {parts: [{type: 'text', text: promptText}]},
       query: {directory},
+      signal,
     })
     if (promptResponse.error != null) {
       const errMsg = String(promptResponse.error)
@@ -246,11 +266,25 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
     throw new RunCoreError('unreachable', `PromptAsync threw: ${message}`)
   }
 
+  // ── 3b. Post-prompt abort check ────────────────────────────────────────────
+  if (signal.aborted) {
+    logger.warn({sessionId}, 'run-core: signal aborted after prompt send')
+    throw new RunCoreError('timeout', 'Run timed out: signal aborted after prompt send')
+  }
+
   // ── 4. Consume event stream ────────────────────────────────────────────────
   // V2 sync tool lifecycle: correlate called→success by callID.
   const pendingToolCalls = new Map<string, ToolCallInfo>()
 
-  for await (const rawEvent of eventStream) {
+  // Wrap the raw event stream in an abort-aware iterator so we do not block
+  // indefinitely waiting for the next event when the signal fires mid-stream.
+  // The inner generator races each `next()` call against the abort signal so
+  // the loop exits promptly even when the SSE server is silent.
+  const abortableStream = makeAbortableStream(eventStream, signal)
+
+  for await (const rawEvent of abortableStream) {
+    // Check abort at the top of each iteration so we exit as soon as the signal
+    // fires, even if the stream itself keeps yielding events.
     if (signal.aborted) break
 
     const eventType = getEventKind(rawEvent)
@@ -341,36 +375,34 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
         }
       }
     } else if (eventType === 'permission.asked') {
-      // Permission gate — only act when coordinator is wired in.
-      if (coordinator !== undefined) {
-        const eventSessionID = getEventSessionID(rawEvent)
-        if (eventSessionID === sessionId) {
-          const req = parsePermissionRequest(eventPayload)
-          if (req === null) {
-            logger.warn({eventType}, 'run-core: permission.asked payload malformed — skipping')
-          } else {
-            // Fire-and-continue: do NOT await — awaiting would starve the SSE drain.
-            // eslint-disable-next-line no-void
-            void coordinator.onPermissionAsked(req)
-            logger.info({requestID: req.requestID}, 'run-core: permission.asked forwarded to coordinator')
-          }
+      const eventSessionID = getEventSessionID(rawEvent)
+      if (eventSessionID === sessionId) {
+        // approval-required mode: route to coordinator.
+        // Coordinator is guaranteed non-null here (pre-flight check above).
+        const req = parsePermissionRequest(eventPayload)
+        if (req === null) {
+          logger.warn({eventType}, 'run-core: permission.asked payload malformed — skipping')
+        } else {
+          // Fire-and-continue: do NOT await — awaiting would starve the SSE drain.
+          // eslint-disable-next-line no-void
+          void coordinator.onPermissionAsked(req)
+          logger.info({requestID: req.requestID}, 'run-core: permission.asked forwarded to coordinator')
         }
       }
     } else if (eventType === 'permission.replied') {
-      // Authoritative settlement — only act when coordinator is wired in.
-      if (coordinator !== undefined) {
-        const eventSessionID = getEventSessionID(rawEvent)
-        if (eventSessionID === sessionId) {
-          const ev = parsePermissionReply(eventPayload)
-          if (ev === null) {
-            logger.warn({eventType}, 'run-core: permission.replied payload malformed — skipping')
-          } else {
-            coordinator.onPermissionReplied(ev)
-            logger.info(
-              {requestID: ev.requestID, reply: ev.reply},
-              'run-core: permission.replied forwarded to coordinator',
-            )
-          }
+      // Authoritative settlement — route to coordinator.
+      // Coordinator is guaranteed non-null here (pre-flight check above).
+      const eventSessionID = getEventSessionID(rawEvent)
+      if (eventSessionID === sessionId) {
+        const ev = parsePermissionReply(eventPayload)
+        if (ev === null) {
+          logger.warn({eventType}, 'run-core: permission.replied payload malformed — skipping')
+        } else {
+          coordinator.onPermissionReplied(ev)
+          logger.info(
+            {requestID: ev.requestID, reply: ev.reply},
+            'run-core: permission.replied forwarded to coordinator',
+          )
         }
       }
     } else if (eventType === 'session.idle') {
@@ -390,7 +422,7 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
   }
 
   // Stream exhausted. Distinguish timeout (signal aborted) from premature close.
-  if (signal.aborted === true) {
+  if (signal.aborted) {
     logger.warn({sessionId}, 'run-core: stream ended due to timeout signal')
     throw new RunCoreError('timeout', 'Run timed out: event stream aborted by timeout signal')
   }
@@ -404,6 +436,63 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Wrap an async iterable so that each `next()` call races against the abort
+ * signal. When the signal fires while the stream is blocked waiting for the
+ * next event, the generator terminates immediately rather than hanging until
+ * the server sends another event.
+ *
+ * This is the key fix for the "silent stream" reliability issue: without this
+ * wrapper the `for await` loop only checks `signal.aborted` AFTER an event
+ * arrives, meaning a timed-out run can block indefinitely on a quiet stream.
+ */
+async function* makeAbortableStream(stream: AsyncIterable<unknown>, signal: AbortSignal): AsyncGenerator<unknown> {
+  const iterator = stream[Symbol.asyncIterator]()
+
+  try {
+    while (true) {
+      // Race the next event against the abort signal.
+      const nextPromise = iterator.next()
+
+      // Build an abort promise that resolves (not rejects) so Promise.race
+      // returns cleanly rather than throwing an AbortError.
+      const abortPromise = new Promise<{done: true; value: undefined}>(resolve => {
+        if (signal.aborted === true) {
+          resolve({done: true, value: undefined})
+          return
+        }
+        const onAbort = () => {
+          resolve({done: true, value: undefined})
+        }
+        signal.addEventListener('abort', onAbort, {once: true})
+        // Clean up the listener when the next event arrives first (resolve or reject).
+        // Using .then(cleanup, cleanup) instead of .finally() to avoid creating an
+        // additional microtask chain and to handle both resolve and reject paths
+        // without swallowing the rejection (nextPromise rejection propagates normally
+        // through Promise.race — we only need the side-effect of removing the listener).
+        // eslint-disable-next-line no-void
+        void nextPromise.then(
+          () => {
+            signal.removeEventListener('abort', onAbort)
+          },
+          () => {
+            signal.removeEventListener('abort', onAbort)
+          },
+        )
+      })
+
+      const result = await Promise.race([nextPromise, abortPromise])
+
+      if (result.done === true) return
+
+      yield result.value
+    }
+  } finally {
+    // Best-effort: return the underlying iterator if it supports it.
+    await iterator.return?.()
+  }
+}
 
 /** Detect a proxy/server 401 response in an SDK response envelope. */
 function isAuthError(response: {readonly error?: unknown}): boolean {

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -60,6 +60,7 @@ vi.mock('../discord/streaming.js', () => ({
     append: vi.fn(),
     flush: vi.fn().mockResolvedValue({kind: 'sent', charCount: 10}),
     buffered: vi.fn().mockReturnValue(''),
+    markVisibleOutputSent: vi.fn(),
   }),
 }))
 
@@ -179,6 +180,7 @@ function makeDeps(overrides: Partial<RunMentionDeps> = {}): RunMentionDeps {
     botUserId: overrides.botUserId ?? 'bot-123',
     logger: overrides.logger ?? {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()},
     approvalRegistry: overrides.approvalRegistry ?? makeApprovalRegistry(),
+    approvalMode: overrides.approvalMode ?? 'approval-required',
     ...overrides,
   }
 }
@@ -211,6 +213,7 @@ function setupHappyPath(heartbeatOverrides?: {start?: ReturnType<typeof vi.fn>; 
     append: vi.fn(),
     flush: vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 10}),
     buffered: vi.fn().mockReturnValue(''),
+    markVisibleOutputSent: vi.fn(),
   })
   mockRunOpenCodeCore.mockResolvedValue(undefined)
   vi.mocked(attachModule.attachOpencode).mockReturnValue({
@@ -390,6 +393,7 @@ describe('runMention', () => {
         append: vi.fn(),
         flush: flushMock,
         buffered: vi.fn().mockReturnValue(''),
+        markVisibleOutputSent: vi.fn(),
       })
 
       const deps = makeDeps()
@@ -556,6 +560,7 @@ describe('runMention', () => {
         append: vi.fn(),
         flush: flushMock,
         buffered: vi.fn().mockReturnValue('partial output'),
+        markVisibleOutputSent: vi.fn(),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
 
@@ -583,6 +588,7 @@ describe('runMention', () => {
         append: vi.fn(),
         flush: flushMock,
         buffered: vi.fn().mockReturnValue('partial'),
+        markVisibleOutputSent: vi.fn(),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('stream-ended', 'stream closed'))
 
@@ -607,6 +613,7 @@ describe('runMention', () => {
         append: vi.fn(),
         flush: flushMock,
         buffered: vi.fn().mockReturnValue('partial'),
+        markVisibleOutputSent: vi.fn(),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('session-error', 'LLM quota exceeded'))
 
@@ -631,6 +638,7 @@ describe('runMention', () => {
         append: vi.fn(),
         flush: flushMock,
         buffered: vi.fn().mockReturnValue(''),
+        markVisibleOutputSent: vi.fn(),
       })
       setupHappyPath()
       // Make EXECUTING transition fail — error caught before sink is created
@@ -767,6 +775,27 @@ describe('runMention', () => {
 
       // #and — lock released
       expect(mockRuntime.releaseLock).toHaveBeenCalledOnce()
+    })
+  })
+
+  // ── Approval mode propagation (Unit 2) ──────────────────────────────────
+
+  describe('approval mode propagation', () => {
+    it('approval-required: runOpenCodeCore is called with approvalMode === "approval-required"', async () => {
+      // #given — default approval-required mode
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const deps = makeDeps({approvalMode: 'approval-required'})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — runOpenCodeCore called with approvalMode exactly 'approval-required'
+      expect(mockRunOpenCodeCore).toHaveBeenCalledOnce()
+      const coreParams = mockRunOpenCodeCore.mock.calls[0]?.[0] as {approvalMode?: string}
+      expect(coreParams.approvalMode).toBe('approval-required')
     })
   })
 
@@ -1066,6 +1095,323 @@ describe('runMention', () => {
           coordinator: fakeCoordinator,
         }),
       )
+    })
+  })
+
+  // ── Unit 4: Approval wait and timeout UX ────────────────────────────────
+
+  describe('approval wait and timeout UX (Unit 4)', () => {
+    it('computeApprovalDeadlineMs: uses remainingBudgetMs (not raw runTimeoutMs) — shorter budget yields shorter deadline', async () => {
+      // #given — the function should accept remainingBudgetMs
+      const {computeApprovalDeadlineMs} = await import('./run.js')
+
+      const fullBudget = 600_000
+      const halfBudget = 300_000
+
+      const deadlineFull = computeApprovalDeadlineMs(fullBudget)
+      const deadlineHalf = computeApprovalDeadlineMs(halfBudget)
+
+      // Both should be defined and less than their respective budgets
+      expect(deadlineFull).toBeDefined()
+      expect(deadlineHalf).toBeDefined()
+      // Shorter remaining budget → shorter or equal deadline
+      // Use nullish coalescing to avoid conditional expect
+      expect(deadlineHalf ?? 0).toBeLessThanOrEqual(deadlineFull ?? Infinity)
+    })
+
+    it('computeApprovalDeadlineMs: returns undefined when remaining budget is too short (< 90s)', async () => {
+      // #given — very short remaining budget
+      const {computeApprovalDeadlineMs} = await import('./run.js')
+
+      // #then — undefined when budget is too short
+      expect(computeApprovalDeadlineMs(80_000)).toBeUndefined()
+      expect(computeApprovalDeadlineMs(90_000)).toBeUndefined()
+      expect(computeApprovalDeadlineMs(91_000)).toBeDefined()
+    })
+
+    it('onPending: posts visible waiting-for-approval status to thread with allowedMentions:{parse:[]}', async () => {
+      // Regression guard: a run blocked on approval must not end with only _(no output)_
+      // because the user needs to see the run is waiting.
+
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const thread = makeThread()
+      const fakeApprovalMessage = {id: 'msg-approval-1', edit: vi.fn()}
+      thread.send.mockResolvedValue(fakeApprovalMessage)
+      const message = makeMessage(thread)
+      const deps = makeDeps()
+
+      let capturedOnPending: ((req: import('../approvals/coordinator.js').PermissionRequest) => void) | undefined
+      mockCreatePermissionCoordinator.mockImplementation(coordinatorDeps => {
+        capturedOnPending = coordinatorDeps.onPending
+        return {
+          onPermissionAsked: vi.fn(),
+          onPermissionReplied: vi.fn(),
+          pending: vi.fn().mockReturnValue([]),
+          dispose: vi.fn(),
+        }
+      })
+
+      // #when — run completes, then simulate permission ask
+      await runMention(message, makeBinding(), deps)
+
+      expect(capturedOnPending).toBeDefined()
+      if (capturedOnPending === undefined) throw new Error('onPending not captured')
+
+      const fakeRequest: import('../approvals/coordinator.js').PermissionRequest = {
+        requestID: 'req-wait-1',
+        sessionID: 'sess-wait',
+        permission: 'bash',
+        patterns: ['ls'],
+        title: 'Run command: ls',
+      }
+      capturedOnPending(fakeRequest)
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // #then — a waiting-for-approval status message was sent to the thread
+      // (separate from the approval embed — this is a plain text status)
+      const allSends = thread.send.mock.calls.map(
+        c => c[0] as {content?: string; allowedMentions?: unknown; embeds?: unknown},
+      )
+      const statusSend = allSends.find(
+        s => typeof s.content === 'string' && s.content.length > 0 && s.embeds === undefined,
+      )
+      expect(statusSend).toBeDefined()
+      expect(statusSend?.allowedMentions).toEqual({parse: []})
+      // Content must contain the approval-waiting wording
+      expect(statusSend?.content).toContain('Waiting for tool approval')
+    })
+
+    it('onPending: sink.markVisibleOutputSent() is called so flush cannot add _(no output)_ after approval status', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const markVisibleOutputSentFn = vi.fn()
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 10}),
+        buffered: vi.fn().mockReturnValue(''),
+        markVisibleOutputSent: markVisibleOutputSentFn,
+      })
+
+      const thread = makeThread()
+      const fakeApprovalMessage = {id: 'msg-approval-2', edit: vi.fn()}
+      thread.send.mockResolvedValue(fakeApprovalMessage)
+      const message = makeMessage(thread)
+      const deps = makeDeps()
+
+      let capturedOnPending: ((req: import('../approvals/coordinator.js').PermissionRequest) => void) | undefined
+      mockCreatePermissionCoordinator.mockImplementation(coordinatorDeps => {
+        capturedOnPending = coordinatorDeps.onPending
+        return {
+          onPermissionAsked: vi.fn(),
+          onPermissionReplied: vi.fn(),
+          pending: vi.fn().mockReturnValue([]),
+          dispose: vi.fn(),
+        }
+      })
+
+      await runMention(message, makeBinding(), deps)
+
+      expect(capturedOnPending).toBeDefined()
+      if (capturedOnPending === undefined) throw new Error('onPending not captured')
+
+      capturedOnPending({
+        requestID: 'req-mark-1',
+        sessionID: 'sess-mark',
+        permission: 'bash',
+        patterns: [],
+        title: 'Run command',
+      })
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // #then — markVisibleOutputSent was called on the sink
+      expect(markVisibleOutputSentFn).toHaveBeenCalled()
+    })
+
+    it('deadline settlement: posts visible timed-out/denied status to thread with allowedMentions:{parse:[]}', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const thread = makeThread()
+      const fakeApprovalMessage = {id: 'msg-approval-3', edit: vi.fn()}
+      thread.send.mockResolvedValue(fakeApprovalMessage)
+      const message = makeMessage(thread)
+      const approvalRegistry = makeApprovalRegistry()
+      const deps = makeDeps({approvalRegistry})
+
+      let capturedOnPending: ((req: import('../approvals/coordinator.js').PermissionRequest) => void) | undefined
+      mockCreatePermissionCoordinator.mockImplementation(coordinatorDeps => {
+        capturedOnPending = coordinatorDeps.onPending
+        return {
+          onPermissionAsked: vi.fn(),
+          onPermissionReplied: vi.fn(),
+          pending: vi.fn().mockReturnValue([]),
+          dispose: vi.fn(),
+        }
+      })
+
+      await runMention(message, makeBinding(), deps)
+
+      expect(capturedOnPending).toBeDefined()
+      if (capturedOnPending === undefined) throw new Error('onPending not captured')
+
+      capturedOnPending({
+        requestID: 'req-deadline-1',
+        sessionID: 'sess-deadline',
+        permission: 'bash',
+        patterns: [],
+        title: 'Run command',
+      })
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // Extract the onDeadlineSettled callback from the register call
+      const registerCall = (approvalRegistry.register as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
+        | {onDeadlineSettled?: () => void | Promise<void>}
+        | undefined
+      expect(registerCall).toBeDefined()
+      expect(registerCall?.onDeadlineSettled).toBeDefined()
+
+      // #when — simulate deadline firing
+      if (registerCall?.onDeadlineSettled !== undefined) {
+        await registerCall.onDeadlineSettled()
+      }
+
+      // #then — a timed-out/denied status was sent to the thread
+      const allSends = thread.send.mock.calls.map(
+        c => c[0] as {content?: string; allowedMentions?: unknown; embeds?: unknown},
+      )
+      // There should be at least one plain-text status (waiting + timeout)
+      const plainTextSends = allSends.filter(
+        s => typeof s.content === 'string' && s.content.length > 0 && s.embeds === undefined,
+      )
+      expect(plainTextSends.length).toBeGreaterThanOrEqual(2) // waiting + timeout
+      // All plain-text sends must have allowedMentions:{parse:[]}
+      for (const s of plainTextSends) {
+        expect(s.allowedMentions).toEqual({parse: []})
+      }
+      // The timeout message must contain approval timeout / could-not-continue semantics
+      const timeoutSend = plainTextSends.find(
+        s =>
+          typeof s.content === 'string' &&
+          (s.content.includes('timed out') || s.content.includes('could not continue')),
+      )
+      expect(timeoutSend).toBeDefined()
+      expect(timeoutSend?.content).toMatch(/timed out|could not continue/i)
+    })
+
+    it('approval deadline uses remaining budget (elapsed time subtracted from runTimeoutMs)', async () => {
+      // #given — simulate elapsed setup time so remainingBudgetMs differs from runTimeoutMs.
+      // The registered deadlineMs must equal computeApprovalDeadlineMs(runTimeoutMs - elapsedMs).
+      const {runMention, computeApprovalDeadlineMs} = await import('./run.js')
+      setupHappyPath()
+
+      const SIMULATED_ELAPSED_MS = 5_000 // 5 s of simulated setup time
+      const runTimeoutMs = 600_000
+      let callCount = 0
+      const originalDateNow = Date.now.bind(Date)
+      const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => {
+        // First call: runStartMs capture at run entry → return base time
+        // Subsequent calls: simulate elapsed setup time
+        callCount++
+        return callCount === 1 ? originalDateNow() : originalDateNow() + SIMULATED_ELAPSED_MS
+      })
+
+      const thread = makeThread()
+      const fakeApprovalMessage = {id: 'msg-approval-4', edit: vi.fn()}
+      thread.send.mockResolvedValue(fakeApprovalMessage)
+      const message = makeMessage(thread)
+      const approvalRegistry = makeApprovalRegistry()
+      const deps = makeDeps({approvalRegistry, runTimeoutMs})
+
+      let capturedOnPending: ((req: import('../approvals/coordinator.js').PermissionRequest) => void) | undefined
+      mockCreatePermissionCoordinator.mockImplementation(coordinatorDeps => {
+        capturedOnPending = coordinatorDeps.onPending
+        return {
+          onPermissionAsked: vi.fn(),
+          onPermissionReplied: vi.fn(),
+          pending: vi.fn().mockReturnValue([]),
+          dispose: vi.fn(),
+        }
+      })
+
+      await runMention(message, makeBinding(), deps)
+      dateNowSpy.mockRestore()
+
+      expect(capturedOnPending).toBeDefined()
+      if (capturedOnPending === undefined) throw new Error('onPending not captured')
+
+      capturedOnPending({
+        requestID: 'req-budget-1',
+        sessionID: 'sess-budget',
+        permission: 'bash',
+        patterns: [],
+        title: 'Run command',
+      })
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // Extract the deadlineMs from the register call
+      const registerCall = (approvalRegistry.register as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
+        | {deadlineMs?: number}
+        | undefined
+      expect(registerCall).toBeDefined()
+
+      // The deadline must equal computeApprovalDeadlineMs(runTimeoutMs - elapsedMs).
+      // With SIMULATED_ELAPSED_MS = 5_000, remainingBudgetMs = 595_000.
+      const expectedDeadlineMs = computeApprovalDeadlineMs(runTimeoutMs - SIMULATED_ELAPSED_MS)
+      expect(registerCall?.deadlineMs).toBe(expectedDeadlineMs)
+      // Sanity: must be strictly less than runTimeoutMs
+      expect(registerCall?.deadlineMs ?? runTimeoutMs).toBeLessThan(runTimeoutMs)
+      expect(registerCall?.deadlineMs ?? 0).toBeLessThanOrEqual(13 * 60_000)
+    })
+
+    it('hard abort signal and approval deadline both use remaining budget from the same origin — not raw runTimeoutMs', async () => {
+      // Regression guard: AbortSignal.timeout() passed to runOpenCodeCore must use
+      // remainingBudgetMs (runTimeoutMs − elapsed), not the raw configured runTimeoutMs.
+      // We simulate elapsed setup time by controlling Date.now() so the two values differ.
+
+      // #given — spy on AbortSignal.timeout to capture the argument it receives
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const SIMULATED_ELAPSED_MS = 5_000 // 5 s of simulated setup time
+      const runTimeoutMs = 600_000
+      let callCount = 0
+      const originalDateNow = Date.now.bind(Date)
+      const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => {
+        // First call: runStartMs capture at run entry → return base time
+        // Subsequent calls: simulate elapsed setup time
+        callCount++
+        return callCount === 1 ? originalDateNow() : originalDateNow() + SIMULATED_ELAPSED_MS
+      })
+
+      const abortTimeoutSpy = vi.spyOn(AbortSignal, 'timeout')
+
+      const deps = makeDeps({runTimeoutMs})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // Capture calls before restoring spies
+      const capturedCalls = abortTimeoutSpy.mock.calls.slice()
+      dateNowSpy.mockRestore()
+      abortTimeoutSpy.mockRestore()
+
+      // #then — AbortSignal.timeout was called with remainingBudgetMs, not raw runTimeoutMs
+      // Find the call that is NOT the 10_000 ms postReply guard (which is a fixed constant)
+      const runBudgetCall = capturedCalls.find(([ms]) => ms !== 10_000)
+      expect(runBudgetCall).toBeDefined()
+      const signalBudgetMs = runBudgetCall?.[0]
+      // Must be strictly less than runTimeoutMs (elapsed time was subtracted)
+      expect(signalBudgetMs).toBeLessThan(runTimeoutMs)
+      // Must be approximately runTimeoutMs − SIMULATED_ELAPSED_MS
+      expect(signalBudgetMs).toBeLessThanOrEqual(runTimeoutMs - SIMULATED_ELAPSED_MS + 100) // +100ms tolerance
+      expect(signalBudgetMs).toBeGreaterThan(0)
     })
   })
 })

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -36,6 +36,12 @@ export interface RunMentionDeps {
   readonly logger: GatewayLogger
   /** Program-scoped approval registry shared with the button handler and shutdown drain. */
   readonly approvalRegistry: ApprovalRegistry
+  /**
+   * Gateway approval mode. Propagated from `GatewayConfig.approvalMode`.
+   * Currently only `approval-required` is supported.
+   * `autonomous-low-risk` is deferred (unsafe due to OpenCode last-match-wins evaluation).
+   */
+  readonly approvalMode: 'approval-required'
 }
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -69,23 +75,27 @@ function toCoordLogger(logger: GatewayLogger): {debug: (message: string, context
 // ---------------------------------------------------------------------------
 
 /**
- * Compute the per-approval deadline in ms.
+ * Compute the per-approval deadline in ms from the **remaining** run budget.
  *
- * Returns `undefined` if `runTimeoutMs` is too short to add a meaningful
+ * Pass `remainingBudgetMs` — the time left after setup, lock, and thread
+ * creation — not the raw configured `runTimeoutMs`. This ensures the approval
+ * deadline and the hard abort are aligned to the same budget origin.
+ *
+ * Returns `undefined` if `remainingBudgetMs` is too short to add a meaningful
  * deadline — specifically when there is less than 90 s of runway (we need at
  * least 30 s of clearance before the hard run timeout for the coordinator to
  * fire and the reply to POST).
  *
  * Otherwise the deadline is:
  *   - at least 60 s
- *   - at most half the run timeout
- *   - capped at runTimeoutMs − 30 s (fires before the hard abort)
+ *   - at most half the remaining budget
+ *   - capped at remainingBudgetMs − 30 s (fires before the hard abort)
  *   - capped at 13 min (Discord interaction-token guard)
  */
-export function computeApprovalDeadlineMs(runTimeoutMs: number): number | undefined {
+export function computeApprovalDeadlineMs(remainingBudgetMs: number): number | undefined {
   // Need at least 90 s to have a 60 s deadline + 30 s clearance.
-  if (runTimeoutMs <= 90_000) return undefined
-  return Math.min(Math.max(60_000, Math.floor(runTimeoutMs / 2)), runTimeoutMs - 30_000, 13 * 60_000)
+  if (remainingBudgetMs <= 90_000) return undefined
+  return Math.min(Math.max(60_000, Math.floor(remainingBudgetMs / 2)), remainingBudgetMs - 30_000, 13 * 60_000)
 }
 
 // ---------------------------------------------------------------------------
@@ -107,9 +117,14 @@ export function computeApprovalDeadlineMs(runTimeoutMs: number): number | undefi
  */
 export async function runMention(message: Message, binding: RepoBinding, deps: RunMentionDeps): Promise<void> {
   const {concurrency, coordinationConfig, identity, attachUrl, attachToken, runTimeoutMs, botUserId, logger} = deps
-  const {approvalRegistry} = deps
+  const {approvalRegistry, approvalMode} = deps
   const channelId = message.channel.id
   const repo = `${binding.owner}/${binding.repo}`
+
+  // ── Budget origin — single source of truth for hard abort and approval deadline ──
+  // Captured once at run entry so both the AbortSignal.timeout and the approval
+  // deadline clearance are computed from the same wall-clock reference.
+  const runStartMs = Date.now()
 
   // ── Concurrency cap + per-channel in-flight guard ──────────
 
@@ -233,13 +248,18 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
         repo: binding.repo,
         botUserId,
       })
-      const timeoutSignal = AbortSignal.timeout(runTimeoutMs)
+
+      // ── Remaining budget — single origin for hard abort AND approval deadline ──
+      //
+      // Both the AbortSignal.timeout (hard abort) and the approval deadline are
+      // computed from the same wall-clock reference (runStartMs) so they are
+      // aligned: the approval deadline always fires before the hard abort.
+      const elapsedMs = Date.now() - runStartMs
+      const remainingBudgetMs = Math.max(0, runTimeoutMs - elapsedMs)
+      const timeoutSignal = AbortSignal.timeout(remainingBudgetMs)
 
       // ── Approval coordinator — per-run, wired to the program-scoped registry ──
-      //
-      // Deadline must fire before both the run timeout AND Discord's 15-min
-      // interaction-token expiry.
-      const approvalDeadlineMs = computeApprovalDeadlineMs(runTimeoutMs)
+      const approvalDeadlineMs = computeApprovalDeadlineMs(remainingBudgetMs)
 
       const coordinator = createPermissionCoordinator({
         logger,
@@ -282,6 +302,9 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
           // BEFORE attempting the Discord embed post. This ensures the button
           // handler can look up the entry even if the send is still in-flight.
           // Registry owns the deadline timer (single-owner rule).
+          //
+          // onDeadlineSettled: post a visible timed-out status to the run thread
+          // and mark the sink so flush() does not add a misleading _(no output)_.
           approvalRegistry.register({
             requestID,
             sessionID,
@@ -290,7 +313,26 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
             request,
             effects: {postReply: postReplyForRequest},
             deadlineMs: approvalDeadlineMs,
+            onDeadlineSettled: async () => {
+              // markVisibleOutputSent AFTER the send succeeds so flush() still
+              // adds _(no output)_ if the send fails (user needs the fallback).
+              await safeSend(rawThread, 'Approval timed out — the task could not continue.')
+              sink?.markVisibleOutputSent()
+            },
           })
+
+          // Post a visible waiting-for-approval status BEFORE the embed so the
+          // user sees the run is blocked even if the embed send is slow.
+          // Fire-and-forget: status is best-effort; must not block onPending.
+          // .catch() prevents an unhandled rejection if the Discord send fails.
+          // eslint-disable-next-line no-void
+          void safeSend(rawThread, 'Waiting for tool approval…')
+            .then(() => {
+              sink?.markVisibleOutputSent()
+            })
+            .catch((error: unknown) => {
+              logger.warn({requestID, err: String(error)}, 'run: failed to post waiting-for-approval status')
+            })
 
           // Fire-and-forget: send the embed then attach the render function.
           // rawThread has the full Discord.js API (embeds, components, edit).
@@ -303,6 +345,9 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
               allowedMentions: {parse: []},
             })
             .then(postedMessage => {
+              // Embed send succeeded — mark sink visible so flush() does not add
+              // a misleading _(no output)_ even if the waiting-status send failed.
+              sink?.markVisibleOutputSent()
               // Attach the render function now that we have a message reference.
               approvalRegistry.attachMessage(
                 requestID,
@@ -348,6 +393,7 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
           signal: timeoutSignal,
           logger,
           coordinator,
+          approvalMode,
         })
       } finally {
         // Fail-closed: dispose any still-open coordinator entries so pending approvals

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -43,12 +43,15 @@ vi.mock('./approvals/registry.js', () => ({
   }),
 }))
 
-// Stub userIsAuthorized from mentions
+// Stub userIsAuthorized and handleMention from mentions.
+// handleMention is stubbed so we can capture the deps it receives without
+// running the real execution path (which requires live S3/Discord/workspace).
 vi.mock('./discord/mentions.js', async importOriginal => {
   const actual = await importOriginal<typeof import('./discord/mentions.js')>()
   return {
     ...actual,
     userIsAuthorized: vi.fn().mockResolvedValue(true),
+    handleMention: vi.fn().mockReturnValue(Effect.void),
   }
 })
 
@@ -144,6 +147,7 @@ function makeFakeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     triggerRoleId: null,
     maxConcurrentRuns: 3,
     runTimeoutMs: 600_000,
+    approvalMode: 'approval-required',
     announce: {
       webhookSecret: 'test-webhook-secret',
       presenceChannelId: 'test-presence-channel-id',
@@ -168,7 +172,76 @@ function makeFakeServerHandle() {
   return {close: vi.fn()}
 }
 
+/**
+ * Build a fake Discord message that passes all messageCreate guards:
+ * - not a bot author
+ * - client.user is non-null and is mentioned
+ * - not shutting down
+ */
+function makeFakeMentionMessage(botUserId: string) {
+  return {
+    author: {id: 'user-111', bot: false},
+    content: 'do the thing',
+    channel: {id: 'ch-test', isThread: () => false},
+    guild: null,
+    mentions: {has: (id: string) => id === botUserId},
+    startThread: vi.fn().mockResolvedValue({id: 'thread-1', send: vi.fn()}),
+    reply: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+/**
+ * Run the program, capture the messageCreate handler, fire it with a fake
+ * mention message, and return the deps passed to handleMention.
+ */
+async function runAndCaptureMentionDeps(
+  approvalMode: 'approval-required',
+): Promise<import('./discord/mentions.js').MentionDeps> {
+  const {handleMention} = await import('./discord/mentions.js')
+  const handleMentionMock = vi.mocked(handleMention)
+
+  const fakeConfig = makeFakeConfig({approvalMode, announce: undefined})
+  const botUserId = 'bot-user-id'
+
+  // Build a fake client whose .user is set so the messageCreate guard passes.
+  const fakeClient = {
+    ...makeFakeClient(),
+    user: {id: botUserId},
+  }
+
+  const deps = {
+    makeClient: () => fakeClient as unknown as import('discord.js').Client,
+    setupReadinessFlag: vi.fn(),
+    login: vi.fn().mockResolvedValue(undefined),
+    startAnnounceServer: vi.fn(),
+    runProviderSelfTest: vi.fn(async () => {}),
+  }
+
+  await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+  // Find and fire the messageCreate handler
+  const onCalls = (fakeClient.on as ReturnType<typeof vi.fn>).mock.calls as [string, (msg: unknown) => void][]
+  const messageCreateHandler = onCalls.find(([event]) => event === 'messageCreate')?.[1]
+  if (messageCreateHandler === undefined) throw new Error('messageCreate handler not registered')
+
+  const fakeMessage = makeFakeMentionMessage(botUserId)
+  messageCreateHandler(fakeMessage)
+
+  // handleMention is fire-and-forget (Effect.runPromise inside the handler);
+  // wait one microtask tick for the synchronous Effect.void to settle.
+  await new Promise(resolve => setTimeout(resolve, 0))
+
+  expect(handleMentionMock).toHaveBeenCalledOnce()
+  const capturedDeps = handleMentionMock.mock.calls[0]?.[2] as import('./discord/mentions.js').MentionDeps
+  if (capturedDeps === undefined) throw new Error('handleMention was not called with deps')
+  return capturedDeps
+}
+
 describe('makeGatewayProgram', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('calls setupReadinessFlag before login', async () => {
     // #given
     const fakeConfig = makeFakeConfig()
@@ -437,6 +510,20 @@ describe('makeGatewayProgram', () => {
     } finally {
       consoleSpy.mockRestore()
     }
+  })
+
+  // ── Approval mode propagation (Unit 2) ──────────────────────────────────
+  //
+  // These tests fire the messageCreate handler with a fake mention message and
+  // assert that handleMention receives deps.run.approvalMode matching the config.
+  // handleMention is mocked above so we can capture its args without a live workspace.
+
+  it('approval-required: handleMention receives deps.run.approvalMode === "approval-required"', async () => {
+    // #given / #when
+    const capturedDeps = await runAndCaptureMentionDeps('approval-required')
+
+    // #then — approvalMode is threaded from GatewayConfig into the mention run deps
+    expect(capturedDeps.run.approvalMode).toBe('approval-required')
   })
 
   it('announce disabled: client events (messageCreate/interactionCreate) are still wired', async () => {

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -275,6 +275,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           botUserId: client.user.id,
           logger,
           approvalRegistry,
+          approvalMode: config.approvalMode,
         },
         logger,
         // Workspace readiness gate — uses the same :9100 base as the clone endpoint.


### PR DESCRIPTION
## Summary

Fixes #787 by keeping Gateway tool permissions on the existing approval-required path and making approval waits visible instead of ending with empty output.

The change also rejects the unsafe autonomous approval mode for now because persisted OpenCode approvals can override session-scoped denies before the gateway sees a permission request.

## Changes

- require the Gateway permission coordinator before OpenCode session creation
- reject unsupported `GATEWAY_APPROVAL_MODE` values, including `autonomous-low-risk`
- show Discord status when a run is waiting for tool approval and when approval times out
- bind OpenCode session creation, event subscription, prompt submission, and stream waits to the run timeout signal
- guard workspace config merging against synthesized high-risk tool pre-grants
- document the approval-required default and warn against global high-risk OpenCode pre-grants

## Verification

- `pnpm --filter @fro-bot/gateway exec vitest run src/execute/run-core.test.ts src/execute/run.test.ts src/config.test.ts src/program.test.ts src/discord/streaming.test.ts src/approvals/approval-flow.integration.test.ts src/approvals/registry.test.ts`
- `node --test deploy/scripts/merge-config.test.mjs`
- `pnpm --filter @fro-bot/gateway check-types`
- `pnpm --dir . exec eslint packages/gateway/src deploy/scripts/merge-config.mjs deploy/scripts/merge-config.test.mjs`