### PR TITLE
fix(gateway): persist workspace repos

### DIFF
--- a/apps/workspace-agent/src/clone.test.ts
+++ b/apps/workspace-agent/src/clone.test.ts
@@ -325,8 +325,9 @@ describe('executeClone — happy path', () => {
 })
 
 describe('executeClone — idempotency (repo-exists)', () => {
-  it('returns 409 repo-exists when destination already exists', async () => {
-    // #given — realpath succeeds on first call (path exists)
+  it('returns 409 repo-exists when destination already exists and is a valid non-bare git checkout', async () => {
+    // #given — realpath succeeds on first call (path exists);
+    // rev-parse --is-inside-work-tree returns "true" and rev-parse --verify HEAD^{commit} succeeds
     vi.resetAllMocks()
     resetCloneSemaphoreForTesting()
     mockMkdir.mockResolvedValue(undefined)
@@ -336,7 +337,13 @@ describe('executeClone — idempotency (repo-exists)', () => {
     fakeMkdtempFn.mockResolvedValue(FAKE_ASKPASS_DIR)
     // First realpath call succeeds → path already exists (no ENOENT)
     mockRealpath.mockResolvedValueOnce(`${TEST_REPOS_ROOT}/fro-bot/agent`)
-    const execFileFn = vi.fn()
+    // Second realpath call (symlink defense after repo-exists check) also succeeds
+    mockRealpath.mockResolvedValueOnce(`${TEST_REPOS_ROOT}/fro-bot/agent`)
+    // Two git validation calls: --is-inside-work-tree → "true", --verify HEAD^{commit} → sha
+    const execFileFn = makeExecFile([
+      {stdout: 'true\n', stderr: ''}, // rev-parse --is-inside-work-tree
+      {stdout: 'abc123def456\n', stderr: ''}, // rev-parse --verify HEAD^{commit}
+    ])
 
     // #when
     const result = await executeClone(VALID_REQUEST, {
@@ -349,8 +356,155 @@ describe('executeClone — idempotency (repo-exists)', () => {
     // #then
     expect(result.statusCode).toBe(409)
     expect(result.response).toEqual({ok: false, error: 'repo-exists'})
-    // No git clone invoked
-    expect(execFileFn).not.toHaveBeenCalled()
+  })
+
+  it('does NOT return repo-exists when destination is a bare repo (--is-inside-work-tree returns false)', async () => {
+    // #given — realpath succeeds (path exists) but --is-inside-work-tree returns "false" (bare repo)
+    vi.resetAllMocks()
+    resetCloneSemaphoreForTesting()
+    mockMkdir.mockResolvedValue(undefined)
+    mockOpen.mockResolvedValue(makeFakeFileHandle() as unknown as import('node:fs/promises').FileHandle)
+    mockRename.mockResolvedValue(undefined)
+    mockRm.mockResolvedValue(undefined)
+    fakeMkdtempFn.mockResolvedValue(FAKE_ASKPASS_DIR)
+    // First realpath call succeeds → path exists
+    mockRealpath.mockResolvedValueOnce(`${TEST_REPOS_ROOT}/fro-bot/agent`)
+    // --is-inside-work-tree returns "false" → bare repo
+    const execFileFn = makeExecFile([{stdout: 'false\n', stderr: ''}])
+
+    // #when
+    const result = await executeClone(VALID_REQUEST, {
+      execFileFn,
+      reposRoot: TEST_REPOS_ROOT,
+      mkdtempFn: fakeMkdtempFn,
+      options: {timeoutMs: 500},
+    })
+
+    // #then — bare repo must NOT return repo-exists; fail closed
+    expect(result.response).not.toEqual({ok: false, error: 'repo-exists'})
+    expect(result.response.ok).toBe(false)
+  })
+
+  it('does NOT return repo-exists when destination exists but is empty (not a git repo)', async () => {
+    // #given — realpath succeeds (path exists) but --is-inside-work-tree fails (empty/non-git dir)
+    vi.resetAllMocks()
+    resetCloneSemaphoreForTesting()
+    mockMkdir.mockResolvedValue(undefined)
+    mockOpen.mockResolvedValue(makeFakeFileHandle() as unknown as import('node:fs/promises').FileHandle)
+    mockRename.mockResolvedValue(undefined)
+    mockRm.mockResolvedValue(undefined)
+    fakeMkdtempFn.mockResolvedValue(FAKE_ASKPASS_DIR)
+    // First realpath call succeeds → path exists
+    mockRealpath.mockResolvedValueOnce(`${TEST_REPOS_ROOT}/fro-bot/agent`)
+    // --is-inside-work-tree fails → not a git repo
+    const execFileFn = makeExecFile([{error: new Error('fatal: not a git repository')}])
+
+    // #when
+    const result = await executeClone(VALID_REQUEST, {
+      execFileFn,
+      reposRoot: TEST_REPOS_ROOT,
+      mkdtempFn: fakeMkdtempFn,
+      options: {timeoutMs: 500},
+    })
+
+    // #then — must NOT return repo-exists for a non-git directory
+    expect(result.response).not.toEqual({ok: false, error: 'repo-exists'})
+    // Should fail closed (clone-failed or similar non-success)
+    expect(result.response.ok).toBe(false)
+  })
+
+  it('does NOT return repo-exists when destination exists but HEAD^{commit} returns empty (unborn branch)', async () => {
+    // #given — realpath succeeds (path exists); --is-inside-work-tree returns "true" but
+    // --verify HEAD^{commit} returns empty string (unborn branch / corrupt checkout)
+    vi.resetAllMocks()
+    resetCloneSemaphoreForTesting()
+    mockMkdir.mockResolvedValue(undefined)
+    mockOpen.mockResolvedValue(makeFakeFileHandle() as unknown as import('node:fs/promises').FileHandle)
+    mockRename.mockResolvedValue(undefined)
+    mockRm.mockResolvedValue(undefined)
+    fakeMkdtempFn.mockResolvedValue(FAKE_ASKPASS_DIR)
+    // First realpath call succeeds → path exists
+    mockRealpath.mockResolvedValueOnce(`${TEST_REPOS_ROOT}/fro-bot/agent`)
+    // --is-inside-work-tree returns "true" but HEAD^{commit} returns empty
+    const execFileFn = makeExecFile([
+      {stdout: 'true\n', stderr: ''}, // --is-inside-work-tree
+      {stdout: '', stderr: ''}, // --verify HEAD^{commit} → empty (unborn branch)
+    ])
+
+    // #when
+    const result = await executeClone(VALID_REQUEST, {
+      execFileFn,
+      reposRoot: TEST_REPOS_ROOT,
+      mkdtempFn: fakeMkdtempFn,
+      options: {timeoutMs: 500},
+    })
+
+    // #then — must NOT return repo-exists for an unborn/corrupt checkout
+    expect(result.response).not.toEqual({ok: false, error: 'repo-exists'})
+    expect(result.response.ok).toBe(false)
+  })
+
+  it('passes an AbortSignal to the validation exec calls (timeout signal propagation)', async () => {
+    // #given — realpath succeeds (path exists); capture the signal passed to validation calls
+    vi.resetAllMocks()
+    resetCloneSemaphoreForTesting()
+    mockMkdir.mockResolvedValue(undefined)
+    mockOpen.mockResolvedValue(makeFakeFileHandle() as unknown as import('node:fs/promises').FileHandle)
+    mockRename.mockResolvedValue(undefined)
+    mockRm.mockResolvedValue(undefined)
+    fakeMkdtempFn.mockResolvedValue(FAKE_ASKPASS_DIR)
+    // First realpath call succeeds → path exists
+    mockRealpath.mockResolvedValueOnce(`${TEST_REPOS_ROOT}/fro-bot/agent`)
+
+    const capturedSignals: (AbortSignal | undefined)[] = []
+    const execFileFn = vi
+      .fn()
+      .mockImplementation(
+        async (_file: string, _args: string[], opts: {env: Record<string, string>; signal?: AbortSignal}) => {
+          capturedSignals.push(opts.signal)
+          return {stdout: 'true\n', stderr: ''}
+        },
+      ) as unknown as ExecFileFn
+
+    // #when
+    await executeClone(VALID_REQUEST, {
+      execFileFn,
+      reposRoot: TEST_REPOS_ROOT,
+      mkdtempFn: fakeMkdtempFn,
+      options: {timeoutMs: 500},
+    })
+
+    // #then — the first two calls are the validation calls; both must receive an AbortSignal
+    // (call[0] = --is-inside-work-tree, call[1] = --verify HEAD^{commit})
+    expect(capturedSignals.length).toBeGreaterThanOrEqual(2)
+    expect(capturedSignals[0]).toBeInstanceOf(AbortSignal)
+    expect(capturedSignals[1]).toBeInstanceOf(AbortSignal)
+  })
+
+  it('preserves symlink/root safety: does NOT return repo-exists when resolved path escapes repos root', async () => {
+    // #given — realpath succeeds but resolves to a path outside the repos root (symlink attack)
+    vi.resetAllMocks()
+    resetCloneSemaphoreForTesting()
+    mockMkdir.mockResolvedValue(undefined)
+    mockOpen.mockResolvedValue(makeFakeFileHandle() as unknown as import('node:fs/promises').FileHandle)
+    mockRename.mockResolvedValue(undefined)
+    mockRm.mockResolvedValue(undefined)
+    fakeMkdtempFn.mockResolvedValue(FAKE_ASKPASS_DIR)
+    // First realpath call resolves to a path OUTSIDE the repos root
+    mockRealpath.mockResolvedValueOnce('/etc/passwd')
+    const execFileFn = vi.fn()
+
+    // #when
+    const result = await executeClone(VALID_REQUEST, {
+      execFileFn,
+      reposRoot: TEST_REPOS_ROOT,
+      mkdtempFn: fakeMkdtempFn,
+      options: {timeoutMs: 500},
+    })
+
+    // #then — must NOT return repo-exists; path-escaped-workspace or similar failure
+    expect(result.response.ok).toBe(false)
+    expect(result.response).not.toEqual({ok: false, error: 'repo-exists'})
   })
 })
 
@@ -609,6 +763,173 @@ describe('executeClone — atomic clone (rename)', () => {
     const tmpRm = rmCalls.find(p => p.includes('.tmp-agent-'))
     expect(tmpRm).toBeDefined()
   })
+
+  it('rename race EEXIST + valid non-bare git checkout at dest → returns repo-exists (409)', async () => {
+    // #given — clone succeeds, rename fails with EEXIST (race), dest is a valid non-bare git checkout
+    // execFile calls: [clone, --is-inside-work-tree (race dest), --verify HEAD^{commit} (race dest)]
+    const execFileFn = makeExecFile([
+      {stdout: '', stderr: ''}, // git clone
+      {stdout: 'true\n', stderr: ''}, // --is-inside-work-tree (race dest)
+      {stdout: 'abc123def456\n', stderr: ''}, // --verify HEAD^{commit} (race dest)
+    ])
+    mockRename.mockRejectedValueOnce(new Error('EEXIST: file already exists'))
+    // realpath for the race dest resolves successfully within repos root
+    mockRealpath.mockResolvedValueOnce(`${TEST_REPOS_ROOT}/fro-bot/agent`)
+
+    // #when
+    const result = await executeClone(VALID_REQUEST, {
+      execFileFn,
+      reposRoot: TEST_REPOS_ROOT,
+      mkdtempFn: fakeMkdtempFn,
+      options: {timeoutMs: 500},
+    })
+
+    // #then — race dest is a valid non-bare git checkout → repo-exists
+    expect(result.statusCode).toBe(409)
+    expect(result.response).toEqual({ok: false, error: 'repo-exists'})
+  })
+
+  it('rename race ENOTEMPTY + valid non-bare git checkout at dest → returns repo-exists (409)', async () => {
+    // #given — clone succeeds, rename fails with ENOTEMPTY (race), dest is a valid non-bare git checkout
+    const execFileFn = makeExecFile([
+      {stdout: '', stderr: ''}, // git clone
+      {stdout: 'true\n', stderr: ''}, // --is-inside-work-tree (race dest)
+      {stdout: 'deadbeef1234\n', stderr: ''}, // --verify HEAD^{commit} (race dest)
+    ])
+    mockRename.mockRejectedValueOnce(new Error('ENOTEMPTY: directory not empty'))
+    mockRealpath.mockResolvedValueOnce(`${TEST_REPOS_ROOT}/fro-bot/agent`)
+
+    // #when
+    const result = await executeClone(VALID_REQUEST, {
+      execFileFn,
+      reposRoot: TEST_REPOS_ROOT,
+      mkdtempFn: fakeMkdtempFn,
+      options: {timeoutMs: 500},
+    })
+
+    // #then — race dest is a valid non-bare git checkout → repo-exists
+    expect(result.statusCode).toBe(409)
+    expect(result.response).toEqual({ok: false, error: 'repo-exists'})
+  })
+
+  it('rename race EEXIST + dest is a bare repo → does NOT return repo-exists, fails closed', async () => {
+    // #given — clone succeeds, rename fails with EEXIST (race), but dest is a bare repo
+    // (--is-inside-work-tree returns "false")
+    const execFileFn = makeExecFile([
+      {stdout: '', stderr: ''}, // git clone
+      {stdout: 'false\n', stderr: ''}, // --is-inside-work-tree → bare repo
+    ])
+    mockRename.mockRejectedValueOnce(new Error('EEXIST: file already exists'))
+    mockRealpath.mockResolvedValueOnce(`${TEST_REPOS_ROOT}/fro-bot/agent`)
+
+    // #when
+    const result = await executeClone(VALID_REQUEST, {
+      execFileFn,
+      reposRoot: TEST_REPOS_ROOT,
+      mkdtempFn: fakeMkdtempFn,
+      options: {timeoutMs: 500},
+    })
+
+    // #then — bare repo must NOT return repo-exists; fail closed
+    expect(result.response).not.toEqual({ok: false, error: 'repo-exists'})
+    expect(result.response.ok).toBe(false)
+    expect(result.statusCode).toBe(500)
+  })
+
+  it('rename race EEXIST + dest is empty/non-git → does NOT return repo-exists, fails closed', async () => {
+    // #given — clone succeeds, rename fails with EEXIST (race), but dest is NOT a git repo
+    // (empty directory — --is-inside-work-tree fails)
+    const execFileFn = makeExecFile([
+      {stdout: '', stderr: ''}, // git clone
+      {error: new Error('fatal: not a git repository')}, // --is-inside-work-tree fails (non-git dest)
+    ])
+    mockRename.mockRejectedValueOnce(new Error('EEXIST: file already exists'))
+    mockRealpath.mockResolvedValueOnce(`${TEST_REPOS_ROOT}/fro-bot/agent`)
+
+    // #when
+    const result = await executeClone(VALID_REQUEST, {
+      execFileFn,
+      reposRoot: TEST_REPOS_ROOT,
+      mkdtempFn: fakeMkdtempFn,
+      options: {timeoutMs: 500},
+    })
+
+    // #then — must NOT return repo-exists for a non-git directory; fail closed
+    expect(result.response).not.toEqual({ok: false, error: 'repo-exists'})
+    expect(result.response.ok).toBe(false)
+    expect(result.statusCode).toBe(500)
+  })
+
+  it('rename race EEXIST + dest HEAD^{commit} returns empty (unborn branch) → does NOT return repo-exists', async () => {
+    // #given — clone succeeds, rename fails with EEXIST (race), dest --is-inside-work-tree is "true"
+    // but --verify HEAD^{commit} returns empty (unborn branch / corrupt checkout)
+    const execFileFn = makeExecFile([
+      {stdout: '', stderr: ''}, // git clone
+      {stdout: 'true\n', stderr: ''}, // --is-inside-work-tree → true
+      {stdout: '', stderr: ''}, // --verify HEAD^{commit} → empty (unborn branch)
+    ])
+    mockRename.mockRejectedValueOnce(new Error('EEXIST: file already exists'))
+    mockRealpath.mockResolvedValueOnce(`${TEST_REPOS_ROOT}/fro-bot/agent`)
+
+    // #when
+    const result = await executeClone(VALID_REQUEST, {
+      execFileFn,
+      reposRoot: TEST_REPOS_ROOT,
+      mkdtempFn: fakeMkdtempFn,
+      options: {timeoutMs: 500},
+    })
+
+    // #then — must NOT return repo-exists for an unborn/corrupt checkout; fail closed
+    expect(result.response).not.toEqual({ok: false, error: 'repo-exists'})
+    expect(result.response.ok).toBe(false)
+    expect(result.statusCode).toBe(500)
+  })
+
+  it('rename race EEXIST + realpath of dest fails (ENOENT) → does NOT return repo-exists, fails closed', async () => {
+    // #given — clone succeeds, rename fails with EEXIST (race), but realpath of dest throws ENOENT
+    // (dest disappeared between rename failure and realpath — transient race)
+    const execFileFn = makeExecFile([
+      {stdout: '', stderr: ''}, // git clone (only call; rev-parse never reached)
+    ])
+    mockRename.mockRejectedValueOnce(new Error('EEXIST: file already exists'))
+    // realpath for the race dest throws (dest vanished)
+    mockRealpath.mockRejectedValueOnce(Object.assign(new Error('ENOENT'), {code: 'ENOENT'}))
+
+    // #when
+    const result = await executeClone(VALID_REQUEST, {
+      execFileFn,
+      reposRoot: TEST_REPOS_ROOT,
+      mkdtempFn: fakeMkdtempFn,
+      options: {timeoutMs: 500},
+    })
+
+    // #then — must NOT return repo-exists; fail closed
+    expect(result.response).not.toEqual({ok: false, error: 'repo-exists'})
+    expect(result.response.ok).toBe(false)
+    expect(result.statusCode).toBe(500)
+  })
+
+  it('rename race EEXIST + dest realpath escapes repos root → returns path-escaped-workspace', async () => {
+    // #given — clone succeeds, rename fails with EEXIST (race), dest realpath escapes workspace
+    const execFileFn = makeExecFile([
+      {stdout: '', stderr: ''}, // git clone (only call; rev-parse never reached)
+    ])
+    mockRename.mockRejectedValueOnce(new Error('EEXIST: file already exists'))
+    // realpath for the race dest resolves outside the repos root (symlink attack)
+    mockRealpath.mockResolvedValueOnce('/etc/passwd')
+
+    // #when
+    const result = await executeClone(VALID_REQUEST, {
+      execFileFn,
+      reposRoot: TEST_REPOS_ROOT,
+      mkdtempFn: fakeMkdtempFn,
+      options: {timeoutMs: 500},
+    })
+
+    // #then — path-escaped-workspace, not repo-exists
+    expect(result.response).toEqual({ok: false, error: 'path-escaped-workspace'})
+    expect(result.statusCode).toBe(500)
+  })
 })
 
 describe('executeClone — concurrency (overloaded)', () => {
@@ -810,11 +1131,11 @@ describe('clone.ts — no module-level SIGTERM/SIGINT handlers', () => {
 })
 
 describe('executeClone — rev-parse env omits GITHUB_TOKEN (Fix #2)', () => {
-  it('does not pass GITHUB_TOKEN to rev-parse execFile call', async () => {
-    // #given
+  it('does not pass GITHUB_TOKEN to the post-clone rev-parse HEAD call', async () => {
+    // #given — happy path: clone + post-clone rev-parse HEAD (no existing-path check)
     const execFileFn = makeExecFile([
       {stdout: '', stderr: ''}, // git clone
-      {stdout: 'abc123def456\n', stderr: ''}, // git rev-parse HEAD
+      {stdout: 'abc123def456\n', stderr: ''}, // git rev-parse HEAD (post-clone)
     ])
 
     // #when
@@ -825,7 +1146,7 @@ describe('executeClone — rev-parse env omits GITHUB_TOKEN (Fix #2)', () => {
       options: {timeoutMs: 500},
     })
 
-    // #then — second call is rev-parse; its env must NOT contain GITHUB_TOKEN
+    // #then — second call is the post-clone rev-parse HEAD; its env must NOT contain GITHUB_TOKEN
     const revParseCall = execFileFn.mock.calls[1] as [string, string[], {env: Record<string, string>}] | undefined
     expect(revParseCall).toBeDefined()
     expect(revParseCall![1]).toContain('rev-parse')
@@ -876,8 +1197,11 @@ describe('executeClone — per-repo lock serialization (Test B)', () => {
             cloneCallCount++
             // First clone hangs until released
             releaseFirst = () => resolve({stdout: '', stderr: ''})
+          } else if (args.includes('--is-inside-work-tree')) {
+            // Validation: non-bare worktree
+            resolve({stdout: 'true\n', stderr: ''})
           } else {
-            // rev-parse resolves immediately
+            // --verify HEAD^{commit} or final rev-parse HEAD — resolve with a sha
             resolve({stdout: 'sha123\n', stderr: ''})
           }
         }),

--- a/apps/workspace-agent/src/clone.ts
+++ b/apps/workspace-agent/src/clone.ts
@@ -256,10 +256,77 @@ async function executeCloneInner(
   try {
     // Ensure the owner dir exists.
     await mkdir(join(reposRoot, owner), {recursive: true, mode: 0o755})
-    // Idempotency: if the destination already exists, return 409.
+    // Idempotency: if the destination already exists, verify it is a usable git
+    // checkout before returning repo-exists. An empty or corrupt directory must
+    // not be treated as a successful prior clone — fail closed instead.
     try {
-      await realpath(destPath)
-      // If realpath succeeds, the path exists.
+      const existingResolved = await realpath(destPath)
+      // Symlink defense: verify the existing path is still within the repos root.
+      if (existingResolved.startsWith(`${reposRoot}/`) === false && existingResolved !== reposRoot) {
+        // Path escaped the workspace — reject without returning repo-exists.
+        return {
+          response: {ok: false, error: 'path-escaped-workspace'},
+          statusCode: 500,
+        }
+      }
+      // Verify it is a usable non-bare worktree with a resolvable HEAD commit.
+      // Two checks are required:
+      //   1. rev-parse --is-inside-work-tree must output exactly "true" — bare repos
+      //      and non-git directories both fail this check.
+      //   2. rev-parse --verify HEAD^{commit} must succeed — proves HEAD resolves to
+      //      a real commit object (not an empty/unborn branch).
+      // Use a minimal env (no GITHUB_TOKEN) for these local-only checks.
+      // Pass controller.signal so hung validation does not hold locks past timeout.
+      const localEnv: Record<string, string> = {
+        GIT_TRACE: '0',
+        GIT_TRACE_PACKET: '0',
+        GIT_TRACE_PERFORMANCE: '0',
+        GIT_CURL_VERBOSE: '0',
+        HOME: process.env.HOME ?? '/root',
+        PATH: process.env.PATH ?? '/usr/bin:/bin',
+      }
+      try {
+        const {stdout: insideWorkTree} = await execFileFn(
+          'git',
+          ['-C', existingResolved, 'rev-parse', '--is-inside-work-tree'],
+          {env: localEnv, signal: controller.signal},
+        )
+        if (insideWorkTree.trim() !== 'true') {
+          // Not inside a work tree (e.g. bare repo). Fail closed.
+          return {
+            response: {ok: false, error: 'head-resolution-failed'},
+            statusCode: 500,
+          }
+        }
+      } catch {
+        // rev-parse failed — directory exists but is not a valid git repo.
+        // Fail closed: do not return repo-exists for a non-git directory.
+        return {
+          response: {ok: false, error: 'head-resolution-failed'},
+          statusCode: 500,
+        }
+      }
+      try {
+        const {stdout: headCommit} = await execFileFn(
+          'git',
+          ['-C', existingResolved, 'rev-parse', '--verify', 'HEAD^{commit}'],
+          {env: localEnv, signal: controller.signal},
+        )
+        if (headCommit.trim().length === 0) {
+          // Empty output — unborn branch or corrupt checkout. Fail closed.
+          return {
+            response: {ok: false, error: 'head-resolution-failed'},
+            statusCode: 500,
+          }
+        }
+      } catch {
+        // HEAD^{commit} failed — unborn branch or corrupt checkout. Fail closed.
+        return {
+          response: {ok: false, error: 'head-resolution-failed'},
+          statusCode: 500,
+        }
+      }
+      // Valid non-bare worktree with resolvable HEAD confirmed — return repo-exists.
       return {
         response: {ok: false, error: 'repo-exists'},
         statusCode: 409,
@@ -373,7 +440,82 @@ async function executeCloneInner(
       const raw = error instanceof Error ? error.message : String(error)
       const scrubbed = scrubCredentials(raw)
       // Check if dest appeared concurrently (race with another request that won the lock).
+      // IMPORTANT: do NOT return repo-exists without validating the destination is a usable
+      // git checkout. An empty or corrupt directory at destPath must not be treated as a
+      // successful prior clone — fail closed instead.
       if (scrubbed.includes('ENOTEMPTY') || scrubbed.includes('EEXIST')) {
+        // Validate the race destination using the same logic as the initial existing-path check.
+        let raceResolved: string
+        try {
+          raceResolved = await realpath(destPath)
+        } catch {
+          // Cannot resolve the path — treat as a failed clone, not repo-exists.
+          return {
+            response: {ok: false, error: 'clone-failed'},
+            statusCode: 500,
+          }
+        }
+        // Symlink defense: verify the race destination is still within the repos root.
+        if (raceResolved.startsWith(`${reposRoot}/`) === false && raceResolved !== reposRoot) {
+          return {
+            response: {ok: false, error: 'path-escaped-workspace'},
+            statusCode: 500,
+          }
+        }
+        // Verify it is a usable non-bare worktree with a resolvable HEAD commit.
+        // Same two-step check as the initial existing-path validation:
+        //   1. rev-parse --is-inside-work-tree must output exactly "true".
+        //   2. rev-parse --verify HEAD^{commit} must succeed.
+        // Pass controller.signal so hung validation does not hold locks past timeout.
+        const localEnv: Record<string, string> = {
+          GIT_TRACE: '0',
+          GIT_TRACE_PACKET: '0',
+          GIT_TRACE_PERFORMANCE: '0',
+          GIT_CURL_VERBOSE: '0',
+          HOME: process.env.HOME ?? '/root',
+          PATH: process.env.PATH ?? '/usr/bin:/bin',
+        }
+        try {
+          const {stdout: insideWorkTree} = await execFileFn(
+            'git',
+            ['-C', raceResolved, 'rev-parse', '--is-inside-work-tree'],
+            {env: localEnv, signal: controller.signal},
+          )
+          if (insideWorkTree.trim() !== 'true') {
+            // Not inside a work tree (e.g. bare repo). Fail closed.
+            return {
+              response: {ok: false, error: 'clone-failed'},
+              statusCode: 500,
+            }
+          }
+        } catch {
+          // rev-parse failed — directory exists but is not a valid git repo. Fail closed.
+          return {
+            response: {ok: false, error: 'clone-failed'},
+            statusCode: 500,
+          }
+        }
+        try {
+          const {stdout: raceHeadCommit} = await execFileFn(
+            'git',
+            ['-C', raceResolved, 'rev-parse', '--verify', 'HEAD^{commit}'],
+            {env: localEnv, signal: controller.signal},
+          )
+          if (raceHeadCommit.trim().length === 0) {
+            // Empty output — unborn branch or corrupt checkout. Fail closed.
+            return {
+              response: {ok: false, error: 'clone-failed'},
+              statusCode: 500,
+            }
+          }
+        } catch {
+          // HEAD^{commit} failed — unborn branch or corrupt checkout. Fail closed.
+          return {
+            response: {ok: false, error: 'clone-failed'},
+            statusCode: 500,
+          }
+        }
+        // Valid non-bare worktree with resolvable HEAD confirmed — return repo-exists.
         return {
           response: {ok: false, error: 'repo-exists'},
           statusCode: 409,

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -183,6 +183,8 @@ The healthcheck is baked into `deploy/gateway.Dockerfile` — there is no overri
 
 The compose stack bind-mounts each secret file individually with `create_host_path: false`. A missing source file produces a clear `docker compose up` error instead of silently materializing as a directory. This is the fail-fast diagnostic — but it means **every time the compose stack adds a new optional secret, existing deployments must `touch` the new file before their next `docker compose up`**.
 
+The `workspace-repos` named volume is created automatically by Docker Compose on the first `up` after this change — no manual step is required. Existing repo checkouts in the container's ephemeral filesystem are not migrated; the workspace will re-clone them on the next mention.
+
 Run the full `touch` block from [Create secrets](#2-create-secrets) on every upgrade. It is idempotent: `touch` on an existing file is a no-op, but a missing file gets created empty. Empty files mean "secret not set", which is the same as the file being absent — the gateway treats both as opt-out.
 
 ### Current optional secrets
@@ -330,6 +332,34 @@ Each approval prompt has a deadline that is a sub-deadline of the overall run ti
 ### Restart limitation
 
 A pending approval prompt is held in memory by the per-run coordinator. If the gateway or workspace container restarts while a prompt is open, the approval is abandoned. The run surfaces as interrupted in the thread. Re-mention to retry.
+
+## Persistent Volumes
+
+The stack uses two named Docker volumes that survive container recreation and daemon upgrades:
+
+| Volume | Mounted at | Contents |
+| --- | --- | --- |
+| `workspace-repos` | `/workspace/repos` (workspace service) | Cloned repository checkouts |
+| `mitmproxy-certs` | `/home/mitmproxy/.mitmproxy` (mitmproxy) and `/run/mitmproxy-certs` (workspace, gateway) | mitmproxy CA certificate |
+
+**Safe operations** — these preserve both volumes:
+
+```bash
+# Rebuild and recreate containers without touching volumes
+docker compose -f deploy/compose.yaml up -d --build --force-recreate
+
+# Restart a single service
+docker compose -f deploy/compose.yaml restart workspace
+```
+
+**Destructive operation** — `docker compose down -v` removes all named volumes, including `workspace-repos` and `mitmproxy-certs`:
+
+```bash
+# WARNING: destroys cloned repos and mitmproxy CA state
+docker compose -f deploy/compose.yaml down -v
+```
+
+After a `down -v`, re-run `bash deploy/init-certs.sh` to regenerate the mitmproxy CA. Cloned repos are rehydrated automatically: mentioning Fro Bot in a bound channel triggers a fresh clone of the missing checkout before the agent run starts.
 
 ## Stopping the Stack
 

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -237,6 +237,12 @@ services:
       # entrypoint trusts this for git/libcurl and the opencode binary, which
       # read the system store (NODE_EXTRA_CA_CERTS does not cover them).
       - mitmproxy-certs:/run/mitmproxy-certs:ro
+      # workspace-repos: named volume for cloned repository checkouts.
+      # Survives `docker compose up --force-recreate` and daemon upgrades.
+      # WARNING: `docker compose down -v` removes this volume and destroys all
+      # cloned repos. Mentioning Fro Bot in a bound channel after a volume loss
+      # will rehydrate the checkout automatically.
+      - workspace-repos:/workspace/repos
     # Port model:
     #   9100 — Hono API (/healthz, /clone) — sandbox-net only, no host mapping
     #   9200 — OpenCode bearer-token proxy — sandbox-net only, no host mapping
@@ -311,6 +317,9 @@ services:
 volumes:
   # Shared CA cert volume: mitmproxy writes, gateway + workspace read
   mitmproxy-certs:
+  # Cloned repository checkouts — survives container recreation and daemon upgrades.
+  # Destroyed by `docker compose down -v` (same as mitmproxy-certs).
+  workspace-repos:
 
 networks:
   # External-facing network for gateway ↔ Discord/S3

--- a/deploy/validate-stack.sh
+++ b/deploy/validate-stack.sh
@@ -12,9 +12,10 @@
 set -euo pipefail
 
 COMPOSE_FILE="${COMPOSE_FILE:-deploy/compose.yaml}"
+PYTHON3_BIN="${PYTHON3_BIN:-python3}"
 
 # ---------------------------------------------------------------------------
-# check_compose_topology — static network-topology invariant assertion.
+# check_compose_topology — static network-topology and persistence invariant assertion.
 #
 # Parses `docker compose config` output (no running containers needed) and
 # enforces the containment model:
@@ -31,13 +32,15 @@ COMPOSE_FILE="${COMPOSE_FILE:-deploy/compose.yaml}"
 #      internet directly, even if a new network is added to the compose file.
 #   5. egress-net has EXACTLY ONE attached service (mitmproxy) — no other
 #      service may join the internet-capable network.
+#   6. workspace mounts the named volume 'workspace-repos' at exactly
+#      '/workspace/repos' — repo checkouts must survive container recreation.
 #
 # Exit non-zero with a descriptive message if any invariant fails.
 # ---------------------------------------------------------------------------
 check_compose_topology() {
   echo "==> Checking compose network topology invariants..."
 
-  COMPOSE_FILE="${COMPOSE_FILE}" python3 - <<'PYEOF'
+  COMPOSE_FILE="${COMPOSE_FILE}" "${PYTHON3_BIN}" - <<'PYEOF'
 import json
 import os
 import subprocess
@@ -53,9 +56,12 @@ try:
         check=True,
     )
     cfg = json.loads(result.stdout)
-except subprocess.CalledProcessError as e:
-    # Fall back to YAML parse if --format json is not supported by this
-    # docker compose version, or if docker compose is unavailable.
+except (subprocess.CalledProcessError, OSError):
+    # Fall back to YAML parse if:
+    #   - docker/compose is not installed (OSError/FileNotFoundError), or
+    #   - --format json is not supported by this docker compose version
+    #     (CalledProcessError), or
+    #   - docker compose is otherwise unavailable.
     try:
         import yaml
         try:
@@ -66,7 +72,7 @@ except subprocess.CalledProcessError as e:
                 check=True,
             )
             cfg = yaml.safe_load(result2.stdout)
-        except Exception:
+        except (subprocess.CalledProcessError, OSError):
             # docker compose unavailable — parse the raw YAML file directly.
             with open(compose_file) as fh:
                 cfg = yaml.safe_load(fh)
@@ -171,6 +177,75 @@ for egress_net in mitmproxy_egress_nets:
         )
 
 # ------------------------------------------------------------------
+# Invariant 6: workspace must mount the named volume 'workspace-repos'
+# at exactly '/workspace/repos'.
+#
+# docker compose config normalises volumes to a list of dicts with
+# 'type', 'source', and 'target' keys.  A short-form volume entry
+# (e.g. "workspace-repos:/workspace/repos") is expanded to:
+#   {"type": "volume", "source": "workspace-repos", "target": "/workspace/repos"}
+#
+# However, when falling back to raw YAML parsing (docker compose unavailable),
+# volume entries may remain as short-form strings:
+#   "workspace-repos:/workspace/repos"
+#   "workspace-repos:/workspace/repos:ro"
+# We must handle both dict entries and short-form string entries.
+# ------------------------------------------------------------------
+workspace_svc = services.get("workspace", {})
+workspace_vols = workspace_svc.get("volumes", [])
+
+REQUIRED_SOURCE = "workspace-repos"
+REQUIRED_TARGET = "/workspace/repos"
+
+def parse_volume_entry(v):
+    """Return (source, target) from a volume entry that is either a dict or a short-form string."""
+    if isinstance(v, dict):
+        return (v.get("source"), v.get("target"))
+    if isinstance(v, str):
+        # Short-form: "source:target" or "source:target:mode"
+        parts = v.split(":")
+        if len(parts) >= 2:
+            return (parts[0], parts[1])
+    return (None, None)
+
+repos_mount_found = any(
+    (
+        # Dict form: type must be "volume" (or absent in raw YAML short-form fallback)
+        (not isinstance(v, dict) or (v or {}).get("type") in ("volume", None))
+        and parse_volume_entry(v) == (REQUIRED_SOURCE, REQUIRED_TARGET)
+    )
+    for v in workspace_vols
+)
+
+if not repos_mount_found:
+    # Provide a targeted message: distinguish missing-entirely from wrong-path/wrong-name.
+    has_source = any(
+        parse_volume_entry(v)[0] == REQUIRED_SOURCE for v in workspace_vols
+    )
+    has_target = any(
+        parse_volume_entry(v)[1] == REQUIRED_TARGET for v in workspace_vols
+    )
+    if has_source and not has_target:
+        failures.append(
+            f"FAIL: workspace mounts volume '{REQUIRED_SOURCE}' but not at "
+            f"'{REQUIRED_TARGET}'. Repo checkouts will not survive container "
+            "recreation. Mount workspace-repos at /workspace/repos."
+        )
+    elif has_target and not has_source:
+        failures.append(
+            f"FAIL: workspace has a volume mounted at '{REQUIRED_TARGET}' but it "
+            f"is not the named volume '{REQUIRED_SOURCE}'. Repo checkouts will not "
+            "survive container recreation. Use the workspace-repos named volume."
+        )
+    else:
+        failures.append(
+            f"FAIL: workspace does not mount the named volume '{REQUIRED_SOURCE}' "
+            f"at '{REQUIRED_TARGET}'. Repo checkouts will not survive container "
+            "recreation. Add workspace-repos:/workspace/repos to the workspace "
+            "service volumes."
+        )
+
+# ------------------------------------------------------------------
 # Report
 # ------------------------------------------------------------------
 if failures:
@@ -184,24 +259,31 @@ print(f"    mitmproxy networks: {sorted(mitmproxy_nets)!r}  ✓")
 print(f"    mitmproxy egress leg(s): {sorted(mitmproxy_egress_nets)!r}  ✓")
 print("    workspace has no direct egress  ✓")
 print("    egress network(s) have exactly one attached service (mitmproxy)  ✓")
+print(f"    workspace mounts {REQUIRED_SOURCE!r} at {REQUIRED_TARGET!r}  ✓")
 PYEOF
 
   echo "    Topology invariants: OK"
 }
 
-echo "==> Validating compose config..."
-docker compose -f "${COMPOSE_FILE}" config > /dev/null
-echo "    OK"
-
-# Run the topology check unconditionally — it is cheap (no running stack needed).
-check_compose_topology
-
-# If --topology-only was passed, stop here.
+# If --topology-only was passed, skip the Docker config validation (which
+# requires a working Docker/compose installation) and go straight to the
+# raw-YAML topology check.  The topology check itself has a Docker-free
+# fallback path, so it works in environments without Docker.
 if [[ "${1:-}" == "--topology-only" ]]; then
+  check_compose_topology
   echo ""
   echo "==> Topology-only check complete."
   exit 0
 fi
+
+# Full validation: require Docker compose to be available and the config to
+# be syntactically valid before running the topology check.
+echo "==> Validating compose config..."
+docker compose -f "${COMPOSE_FILE}" config > /dev/null
+echo "    OK"
+
+# Run the topology check — it is cheap (no running stack needed).
+check_compose_topology
 
 echo "==> Service status:"
 docker compose -f "${COMPOSE_FILE}" ps

--- a/deploy/validate-stack.test.sh
+++ b/deploy/validate-stack.test.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
-# validate-stack.test.sh — Topology-guard negative + positive tests.
+# validate-stack.test.sh — Topology-guard and persistence-guard negative + positive tests.
 #
 # Tests that validate-stack.sh --topology-only:
 #   (a) EXITS NON-ZERO when workspace is attached to a non-internal network
-#       (the regression the guard exists to catch).
-#   (b) EXITS ZERO for the real compose.yaml (positive control).
+#       (the regression the topology guard exists to catch).
+#   (b) EXITS NON-ZERO when workspace has no workspace-repos volume mounted at
+#       /workspace/repos (the regression the persistence guard exists to catch).
+#   (c) EXITS NON-ZERO when workspace mounts the wrong volume or wrong target path.
+#   (d) EXITS ZERO for the real compose.yaml (positive control).
+#   (e) EXITS ZERO for --topology-only when Docker/compose is absent from PATH
+#       (raw YAML fallback must handle both dict and short-form volume entries).
+#   (f) EXITS NON-ZERO for long-form bind mounts at /workspace/repos.
+#   (g) EXITS NON-ZERO for --topology-only without Docker when workspace-repos
+#       mount is missing (raw YAML fallback must still catch the invariant).
 #
 # Run from repo root:
 #   bash deploy/validate-stack.test.sh
@@ -12,6 +20,8 @@ set -euo pipefail
 
 PASS=0
 FAIL=0
+BASH_BIN="$(command -v bash)"
+PYTHON3_BIN="$(command -v python3)"
 
 pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
@@ -91,6 +101,477 @@ if [[ "${POSITIVE_EXIT}" -eq 0 ]]; then
 else
   fail "validate-stack.sh exited non-zero (${POSITIVE_EXIT}) for real compose.yaml — output: ${POSITIVE_OUTPUT}"
 fi
+
+# ---------------------------------------------------------------------------
+# TEST 3 — Negative: compose with workspace-repos volume absent must be rejected.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 3: persistence guard rejects compose missing workspace-repos volume ---"
+
+NO_REPOS_COMPOSE="${TMPDIR_TEST}/compose-no-repos.yaml"
+cat > "${NO_REPOS_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - mitmproxy-certs:/run/mitmproxy-certs:ro
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  mitmproxy-certs:
+YAML
+
+NO_REPOS_OUTPUT=""
+NO_REPOS_EXIT=0
+NO_REPOS_OUTPUT="$(COMPOSE_FILE="${NO_REPOS_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || NO_REPOS_EXIT=$?
+
+if [[ "${NO_REPOS_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${NO_REPOS_EXIT}) for compose missing workspace-repos"
+else
+  fail "validate-stack.sh exited ZERO for compose missing workspace-repos — guard did NOT fire"
+fi
+
+if echo "${NO_REPOS_OUTPUT}" | grep -q "/workspace/repos"; then
+  pass "failure message mentions '/workspace/repos'"
+else
+  fail "failure message does not mention '/workspace/repos' — output: ${NO_REPOS_OUTPUT}"
+fi
+
+echo ""
+echo "  No-repos-test output (stderr+stdout combined):"
+echo "${NO_REPOS_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 4 — Negative: compose mounting wrong volume name at /workspace/repos
+#          must be rejected.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 4: persistence guard rejects compose with wrong volume name at /workspace/repos ---"
+
+WRONG_VOL_COMPOSE="${TMPDIR_TEST}/compose-wrong-vol.yaml"
+cat > "${WRONG_VOL_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - mitmproxy-certs:/run/mitmproxy-certs:ro
+      - some-other-volume:/workspace/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  mitmproxy-certs:
+  some-other-volume:
+YAML
+
+WRONG_VOL_OUTPUT=""
+WRONG_VOL_EXIT=0
+WRONG_VOL_OUTPUT="$(COMPOSE_FILE="${WRONG_VOL_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || WRONG_VOL_EXIT=$?
+
+if [[ "${WRONG_VOL_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${WRONG_VOL_EXIT}) for compose with wrong volume name"
+else
+  fail "validate-stack.sh exited ZERO for compose with wrong volume name — guard did NOT fire"
+fi
+
+if echo "${WRONG_VOL_OUTPUT}" | grep -q "workspace-repos"; then
+  pass "failure message mentions 'workspace-repos'"
+else
+  fail "failure message does not mention 'workspace-repos' — output: ${WRONG_VOL_OUTPUT}"
+fi
+
+echo ""
+echo "  Wrong-vol-test output (stderr+stdout combined):"
+echo "${WRONG_VOL_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 5 — Negative: compose mounting workspace-repos at wrong target path
+#          must be rejected.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 5: persistence guard rejects compose with workspace-repos at wrong target ---"
+
+WRONG_TARGET_COMPOSE="${TMPDIR_TEST}/compose-wrong-target.yaml"
+cat > "${WRONG_TARGET_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - mitmproxy-certs:/run/mitmproxy-certs:ro
+      - workspace-repos:/data/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  mitmproxy-certs:
+  workspace-repos:
+YAML
+
+WRONG_TARGET_OUTPUT=""
+WRONG_TARGET_EXIT=0
+WRONG_TARGET_OUTPUT="$(COMPOSE_FILE="${WRONG_TARGET_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || WRONG_TARGET_EXIT=$?
+
+if [[ "${WRONG_TARGET_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${WRONG_TARGET_EXIT}) for compose with workspace-repos at wrong target"
+else
+  fail "validate-stack.sh exited ZERO for compose with workspace-repos at wrong target — guard did NOT fire"
+fi
+
+if echo "${WRONG_TARGET_OUTPUT}" | grep -q "/workspace/repos"; then
+  pass "failure message mentions '/workspace/repos'"
+else
+  fail "failure message does not mention '/workspace/repos' — output: ${WRONG_TARGET_OUTPUT}"
+fi
+
+echo ""
+echo "  Wrong-target-test output (stderr+stdout combined):"
+echo "${WRONG_TARGET_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 6 — Positive: compose using raw short-form volume string
+#          "workspace-repos:/workspace/repos" must be accepted.
+#
+# When docker compose is unavailable (e.g. CI without Docker), the script
+# falls back to parsing the raw YAML file directly. Raw YAML may contain
+# short-form volume strings like "workspace-repos:/workspace/repos[:ro]"
+# instead of the normalized dict form. The invariant check must handle both.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 6: persistence guard accepts raw short-form volume string ---"
+
+RAW_SHORTFORM_COMPOSE="${TMPDIR_TEST}/compose-raw-shortform.yaml"
+cat > "${RAW_SHORTFORM_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+RAW_SHORTFORM_OUTPUT=""
+RAW_SHORTFORM_EXIT=0
+RAW_SHORTFORM_OUTPUT="$(COMPOSE_FILE="${RAW_SHORTFORM_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || RAW_SHORTFORM_EXIT=$?
+
+if [[ "${RAW_SHORTFORM_EXIT}" -eq 0 ]]; then
+  pass "validate-stack.sh exited zero for compose with raw short-form volume string"
+else
+  fail "validate-stack.sh exited non-zero (${RAW_SHORTFORM_EXIT}) for raw short-form volume — output: ${RAW_SHORTFORM_OUTPUT}"
+fi
+
+echo ""
+echo "  Raw-shortform-test output (stderr+stdout combined):"
+echo "${RAW_SHORTFORM_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 7 — Negative: raw short-form volume with wrong target must be rejected.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 7: persistence guard rejects raw short-form volume with wrong target ---"
+
+RAW_WRONG_TARGET_COMPOSE="${TMPDIR_TEST}/compose-raw-wrong-target.yaml"
+cat > "${RAW_WRONG_TARGET_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/data/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+RAW_WRONG_TARGET_OUTPUT=""
+RAW_WRONG_TARGET_EXIT=0
+RAW_WRONG_TARGET_OUTPUT="$(COMPOSE_FILE="${RAW_WRONG_TARGET_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || RAW_WRONG_TARGET_EXIT=$?
+
+if [[ "${RAW_WRONG_TARGET_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${RAW_WRONG_TARGET_EXIT}) for raw short-form volume with wrong target"
+else
+  fail "validate-stack.sh exited ZERO for raw short-form volume with wrong target — guard did NOT fire"
+fi
+
+echo ""
+echo "  Raw-wrong-target-test output (stderr+stdout combined):"
+echo "${RAW_WRONG_TARGET_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 8 — Negative: long-form bind mount at /workspace/repos must be rejected.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 8: persistence guard rejects long-form bind mount at /workspace/repos ---"
+
+BIND_REPOS_COMPOSE="${TMPDIR_TEST}/compose-bind-repos.yaml"
+cat > "${BIND_REPOS_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - type: bind
+        source: ./repos
+        target: /workspace/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+YAML
+
+BIND_REPOS_OUTPUT=""
+BIND_REPOS_EXIT=0
+BIND_REPOS_OUTPUT="$(COMPOSE_FILE="${BIND_REPOS_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || BIND_REPOS_EXIT=$?
+
+if [[ "${BIND_REPOS_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${BIND_REPOS_EXIT}) for bind mount at /workspace/repos"
+else
+  fail "validate-stack.sh exited ZERO for bind mount at /workspace/repos — guard DID NOT require named volume"
+fi
+
+if echo "${BIND_REPOS_OUTPUT}" | grep -qi "named volume\|workspace-repos"; then
+  pass "bind-mount failure message mentions named workspace-repos volume"
+else
+  fail "bind-mount failure message does not mention named workspace-repos volume — output: ${BIND_REPOS_OUTPUT}"
+fi
+
+echo ""
+echo "  Bind-repos-test output (stderr+stdout combined):"
+echo "${BIND_REPOS_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# Helper: build a PATH that strips Docker and docker-compose binaries so we
+# can simulate a no-Docker environment while keeping Python (and other tools)
+# available.  We filter out any PATH component that contains a 'docker'
+# binary, which covers /usr/local/bin, /usr/bin, and Homebrew prefixes.
+# ---------------------------------------------------------------------------
+NO_DOCKER_PATH="$(
+  echo "$PATH" | tr ':' '\n' | while IFS= read -r dir; do
+    if [[ -n "${dir}" ]] && [[ ! -x "${dir}/docker" ]]; then
+      echo "${dir}"
+    fi
+  done | tr '\n' ':' | sed 's/:$//'
+)"
+
+# ---------------------------------------------------------------------------
+# TEST 9 — Positive (no Docker): --topology-only must succeed via raw YAML
+#          fallback when Docker is absent from PATH.
+#          Uses a compose file with a short-form volume entry to exercise the
+#          short-form string parsing path in the invariant check.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 9: --topology-only succeeds via raw YAML fallback (no Docker in PATH) ---"
+
+NO_DOCKER_SHORTFORM_COMPOSE="${TMPDIR_TEST}/compose-no-docker-shortform.yaml"
+cat > "${NO_DOCKER_SHORTFORM_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+NO_DOCKER_OUTPUT=""
+NO_DOCKER_EXIT=0
+NO_DOCKER_OUTPUT="$(PATH="${NO_DOCKER_PATH}" COMPOSE_FILE="${NO_DOCKER_SHORTFORM_COMPOSE}" PYTHON3_BIN="${PYTHON3_BIN}" "${BASH_BIN}" deploy/validate-stack.sh --topology-only 2>&1)" || NO_DOCKER_EXIT=$?
+
+if [[ "${NO_DOCKER_EXIT}" -eq 0 ]]; then
+  pass "--topology-only exited zero via raw YAML fallback (no Docker in PATH)"
+else
+  fail "--topology-only exited non-zero (${NO_DOCKER_EXIT}) via raw YAML fallback — output: ${NO_DOCKER_OUTPUT}"
+fi
+
+if echo "${NO_DOCKER_OUTPUT}" | grep -q "workspace-repos"; then
+  pass "raw YAML fallback output confirms workspace-repos mount"
+else
+  fail "raw YAML fallback output does not confirm workspace-repos mount — output: ${NO_DOCKER_OUTPUT}"
+fi
+
+echo ""
+echo "  No-Docker-shortform-test output (stderr+stdout combined):"
+echo "${NO_DOCKER_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 10 — Negative (no Docker): --topology-only must FAIL via raw YAML
+#          fallback when workspace-repos mount is missing.
+#          Proves the invariant check still fires without Docker.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 10: --topology-only rejects missing workspace-repos via raw YAML fallback (no Docker in PATH) ---"
+
+NO_DOCKER_NO_REPOS_COMPOSE="${TMPDIR_TEST}/compose-no-docker-no-repos.yaml"
+cat > "${NO_DOCKER_NO_REPOS_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - mitmproxy-certs:/run/mitmproxy-certs:ro
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  mitmproxy-certs:
+YAML
+
+NO_DOCKER_NO_REPOS_OUTPUT=""
+NO_DOCKER_NO_REPOS_EXIT=0
+NO_DOCKER_NO_REPOS_OUTPUT="$(PATH="${NO_DOCKER_PATH}" COMPOSE_FILE="${NO_DOCKER_NO_REPOS_COMPOSE}" PYTHON3_BIN="${PYTHON3_BIN}" "${BASH_BIN}" deploy/validate-stack.sh --topology-only 2>&1)" || NO_DOCKER_NO_REPOS_EXIT=$?
+
+if [[ "${NO_DOCKER_NO_REPOS_EXIT}" -ne 0 ]]; then
+  pass "--topology-only exited non-zero (${NO_DOCKER_NO_REPOS_EXIT}) for missing workspace-repos via raw YAML fallback"
+else
+  fail "--topology-only exited ZERO for missing workspace-repos via raw YAML fallback — guard did NOT fire"
+fi
+
+if echo "${NO_DOCKER_NO_REPOS_OUTPUT}" | grep -q "/workspace/repos"; then
+  pass "raw YAML fallback failure message mentions '/workspace/repos'"
+else
+  fail "raw YAML fallback failure message does not mention '/workspace/repos' — output: ${NO_DOCKER_NO_REPOS_OUTPUT}"
+fi
+
+echo ""
+echo "  No-Docker-no-repos-test output (stderr+stdout combined):"
+echo "${NO_DOCKER_NO_REPOS_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 11 — Negative (no Docker): --topology-only must FAIL via raw YAML
+#           fallback when workspace is on a non-internal network.
+#           Proves topology invariant 4 still fires without Docker.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 11: --topology-only rejects workspace-on-egress-net via raw YAML fallback (no Docker in PATH) ---"
+
+NO_DOCKER_INSECURE_COMPOSE="${TMPDIR_TEST}/compose-no-docker-insecure.yaml"
+cat > "${NO_DOCKER_INSECURE_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+      - egress-net
+    volumes:
+      - workspace-repos:/workspace/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+NO_DOCKER_INSECURE_OUTPUT=""
+NO_DOCKER_INSECURE_EXIT=0
+NO_DOCKER_INSECURE_OUTPUT="$(PATH="${NO_DOCKER_PATH}" COMPOSE_FILE="${NO_DOCKER_INSECURE_COMPOSE}" PYTHON3_BIN="${PYTHON3_BIN}" "${BASH_BIN}" deploy/validate-stack.sh --topology-only 2>&1)" || NO_DOCKER_INSECURE_EXIT=$?
+
+if [[ "${NO_DOCKER_INSECURE_EXIT}" -ne 0 ]]; then
+  pass "--topology-only exited non-zero (${NO_DOCKER_INSECURE_EXIT}) for workspace-on-egress-net via raw YAML fallback"
+else
+  fail "--topology-only exited ZERO for workspace-on-egress-net via raw YAML fallback — guard did NOT fire"
+fi
+
+if echo "${NO_DOCKER_INSECURE_OUTPUT}" | grep -qi "egress\|non-internal\|direct internet"; then
+  pass "raw YAML fallback failure message mentions egress/non-internal violation"
+else
+  fail "raw YAML fallback failure message does not mention egress violation — output: ${NO_DOCKER_INSECURE_OUTPUT}"
+fi
+
+echo ""
+echo "  No-Docker-insecure-test output (stderr+stdout combined):"
+echo "${NO_DOCKER_INSECURE_OUTPUT}" | sed 's/^/    /'
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/docs/plans/2026-06-05-004-fix-workspace-repo-persistence-plan.md
+++ b/docs/plans/2026-06-05-004-fix-workspace-repo-persistence-plan.md
@@ -1,0 +1,294 @@
+---
+title: "fix: Persist and rehydrate workspace repos"
+type: fix
+status: active
+date: 2026-06-05
+origin: https://github.com/fro-bot/agent/issues/791
+---
+
+# fix: Persist and rehydrate workspace repos
+
+## Overview
+
+Issue #791 reports that bound Gateway repos lose their workspace checkouts after ordinary workspace container
+recreation because `/workspace/repos` is not backed by a persistent Docker volume. S3 bindings survive, so later
+mentions run against an empty workspace and `/fro-bot add-project` refuses to recreate the binding.
+
+This plan fixes both sides: persist `/workspace/repos` across deploys, and lazily rehydrate a bound repo before any
+mention execution when the checkout is absent.
+
+## Problem Frame
+
+Gateway has two state stores for a bound repo: the S3 binding record and the workspace checkout. The binding is durable;
+the checkout is currently container-local. After `docker compose up --force-recreate workspace`, the binding still points
+at `/workspace/repos/{owner}/{repo}`, but that path is empty or missing. OpenCode then starts in a directory that does not
+contain the repo, producing a successful but useless run.
+
+Fro Bot triage confirmed `deploy/compose.yaml` has no `workspace-repos` volume and proposed a named volume plus README
+warning that `docker compose down -v` destroys clones.
+
+## Requirements Trace
+
+- R1. Workspace repo checkouts survive normal workspace container recreation and daemon upgrades.
+- R2. Bound mentions never start OpenCode against a missing or empty checkout path.
+- R3. A stale binding with a missing checkout self-heals by reusing the existing workspace clone contract.
+- R4. Existing `/fro-bot add-project` partial-failure recovery through `repo-exists` remains intact.
+- R5. Operators are warned that `docker compose down -v` destroys repo clones.
+
+## Scope Boundaries
+
+- Do not add a new binding schema or S3 migration; the existing binding remains the source of truth.
+- Do not add an auto-resync or fetch-on-every-run feature; recovery is clone-or-exists only.
+- Do not attempt to protect against `docker compose down -v`; document it as destructive Docker behavior.
+- Do not expose internal paths, token/auth failures, or S3 details in Discord replies.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `deploy/compose.yaml` mounts workspace secrets and `mitmproxy-certs`, but not `/workspace/repos`.
+- `deploy/validate-stack.sh` already parses compose config for static invariants; extend it for persistence invariants.
+- `apps/workspace-agent/src/clone.ts` implements atomic clone and returns `repo-exists` when the target checkout exists.
+- `packages/gateway/src/workspace-api/client.ts` validates clone success paths with `workspaceRepoPath(owner, repo)`.
+- `packages/gateway/src/discord/commands/add-project.ts` treats `repo-exists` as resumable when clone exists but binding is absent.
+- `packages/gateway/src/discord/mentions.ts` currently trusts the binding and only checks workspace readiness before `runMention`.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/discord-slash-command-orchestration-patterns-2026-05-27.md`: add-project flows should be
+  idempotent/self-healing across partial failures, and store errors must fail closed.
+- `apps/workspace-agent/AGENTS.md`: `POST /clone` is already idempotent at the workspace boundary; `repo-exists` is a valid
+  existing-checkout signal.
+- `docs/plans/2026-05-23-001-feat-gateway-unit-5-add-project-plan.md`: workspace repo volumes were intended to survive
+  container recreation; #791 is a deploy wiring gap, not a new architecture.
+
+### External References
+
+- Skipped. Docker named volume behavior is stable, and the repo already has direct compose/test patterns to follow.
+
+## Key Technical Decisions
+
+- Persist `/workspace/repos` with a named Docker volume: This matches the existing `mitmproxy-certs` pattern and survives
+  `up --force-recreate` without binding host paths into the sandbox.
+- Rehydrate by calling `POST /clone`, not by adding a separate `exists` endpoint: the workspace agent already owns path
+  derivation, atomic clone, per-repo locking, and `repo-exists` semantics.
+- Put recovery in the mention path after binding lookup and before `readyz`/`runMention`: this repairs stale bindings before
+  OpenCode can start, while `runMention` continues to own visible execution threads, locks, heartbeat, and concurrency.
+- Use an injected `ensureWorkspaceClone` seam for mention handling: the helper can own GitHub App auth plus clone semantics,
+  while tests avoid live GitHub/workspace calls.
+- Treat `repo-exists` as success during rehydration: concurrent recovery or already-present checkouts must not produce false
+  user-facing errors.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should lazy rehydration be in scope? Yes — the user chose to include it with the volume fix.
+- Should `/fro-bot add-project` repair an existing binding? No — keep add-project binding-owned; mention execution performs
+  lazy checkout repair for already-bound repos.
+
+### Deferred to Implementation
+
+- Exact helper file/function names: choose names that fit local conventions once implementation starts.
+- Exact compose parser assertions: extend the existing shell/Python validation in the smallest readable shape.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The
+> implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart LR
+  A[@mention in bound channel] --> B[lookup binding]
+  B -->|none| C[reply: use /add-project]
+  B -->|binding| D[ensure workspace clone]
+  D -->|clone ok or repo-exists| E[check /readyz]
+  D -->|auth/clone/network failure| F[reply: workspace unavailable]
+  E -->|ready| G[runMention]
+  E -->|not ready| H[reply: workspace not reachable]
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Persist workspace repos in deploy compose**
+
+**Goal:** Add durable storage for `/workspace/repos` and pin it with static validation.
+
+**Requirements:** R1, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `deploy/compose.yaml`
+- Modify: `deploy/validate-stack.sh`
+- Modify: `deploy/validate-stack.test.sh`
+- Modify: `deploy/README.md`
+
+**Approach:**
+- Add a named `workspace-repos` volume mounted at `/workspace/repos` on the `workspace` service.
+- Extend stack validation to assert the workspace service mounts `workspace-repos` at exactly `/workspace/repos`.
+- Document that ordinary recreate/upgrade preserves clones, while `docker compose down -v` removes `workspace-repos` and
+  `mitmproxy-certs`.
+
+**Execution note:** Add the validation regression before changing compose if practical.
+
+**Patterns to follow:**
+- `deploy/compose.yaml` `mitmproxy-certs` named-volume style.
+- `deploy/validate-stack.sh` Python compose-config invariant checks.
+
+**Test scenarios:**
+- Happy path: real `deploy/compose.yaml` passes topology/persistence validation with `workspace-repos:/workspace/repos`.
+- Error path: a crafted compose file without the workspace repo volume fails with a message naming `/workspace/repos`.
+- Error path: a crafted compose file mounting the wrong volume or target path fails validation.
+
+**Verification:**
+- Static stack validation proves the persistence mount exists without requiring a live Docker stack.
+- README clearly distinguishes safe recreate from destructive `down -v`.
+
+- [x] **Unit 2: Add a gateway ensure-clone helper**
+
+**Goal:** Provide a reusable gateway seam that guarantees a workspace checkout exists for a bound repo.
+
+**Requirements:** R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/gateway/src/workspace-api/ensure-clone.ts`
+- Create: `packages/gateway/src/workspace-api/ensure-clone.test.ts`
+- Modify: `packages/gateway/src/workspace-api/client.ts`
+- Modify: `packages/gateway/src/workspace-api/types.ts`
+
+**Approach:**
+- Build a helper that takes owner/repo, a GitHub App auth dependency, the existing `WorkspaceClient`, and a logger.
+- Mint a repo-scoped installation token through the same app-client path used by `/fro-bot add-project`.
+- Call `workspaceClient.clone({owner, repo, token})` and return `workspaceRepoPath(owner, repo)` on clone success or
+  `clone-error/repo-exists`.
+- Return structured failure kinds for auth, timeout/network, clone, response mismatch, and unexpected errors so callers can
+  log precisely but reply coarsely.
+
+**Patterns to follow:**
+- `packages/gateway/src/discord/commands/add-project.ts` auth + clone handling.
+- `packages/gateway/src/workspace-api/client.ts` `workspaceRepoPath()` and `Result` style.
+
+**Test scenarios:**
+- Happy path: auth succeeds and clone succeeds -> helper returns the validated workspace path.
+- Happy path: auth succeeds and clone returns `repo-exists` -> helper returns `workspaceRepoPath(owner, repo)`.
+- Error path: GitHub App auth fails -> helper returns an auth failure and does not call clone.
+- Error path: clone timeout/network/HTTP/parse failure -> helper returns a recoverable workspace failure.
+- Error path: clone response mismatch -> helper fails closed and does not synthesize a path from the bad response.
+
+**Verification:**
+- Helper tests prove rehydration does not duplicate add-project's binding/channel behavior and treats `repo-exists` as
+  successful recovery.
+
+- [x] **Unit 3: Rehydrate before mention execution**
+
+**Goal:** Prevent mention runs from reaching OpenCode unless the bound repo checkout exists or was re-created.
+
+**Requirements:** R2, R3
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `packages/gateway/src/discord/mentions.ts`
+- Modify: `packages/gateway/src/discord/mentions.test.ts`
+- Modify: `packages/gateway/src/program.ts`
+
+**Approach:**
+- Add an injected `ensureClone` dependency to `MentionDeps` and wire it in `program.ts` using the helper from Unit 2.
+- In `handleMention`, after binding lookup and before `readyz`, call `ensureClone(binding.owner, binding.repo)`.
+- Continue to `readyz` and `runMention` only when ensure-clone succeeds.
+- On ensure-clone failure, log owner/repo/channel and structured failure kind; reply with a coarse workspace-unavailable
+  message using `safeReply`.
+- Leave `runMention` unchanged for execution lifecycle ownership.
+
+**Patterns to follow:**
+- Existing mention fail-closed readiness gate.
+- Existing no-internal-detail Discord replies.
+
+**Test scenarios:**
+- Happy path: binding exists, ensure-clone succeeds, readyz succeeds -> `runMention` is called with the original binding.
+- Happy path: ensure-clone reports recovered via `repo-exists` -> readyz and `runMention` still proceed.
+- Error path: ensure-clone fails -> `runMention` is not called, readyz is not called, and the user sees a coarse retry-later
+  message.
+- Error path: ensure-clone succeeds but readyz is false -> existing workspace-not-ready reply remains unchanged.
+- Edge case: no binding -> ensure-clone is not called.
+- Edge case: unauthorized mention -> ensure-clone is not called.
+- Integration: two mentions for the same stale repo can both call ensure-clone safely; workspace-agent's per-repo clone lock
+  and `repo-exists` semantics make the second heal a no-op.
+
+**Verification:**
+- Mention tests prove there is no path from a stale binding directly into `runMention` without clone assurance.
+
+- [x] **Unit 4: Clarify already-bound recovery UX**
+
+**Goal:** Keep `/fro-bot add-project` binding-owned while giving operators a recovery path that does not require deleting S3 keys.
+
+**Requirements:** R3, R4
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `packages/gateway/src/discord/commands/add-project.ts`
+- Modify: `packages/gateway/src/discord/commands/add-project.test.ts`
+- Modify: `deploy/README.md`
+
+**Approach:**
+- Preserve the existing already-bound short-circuit; do not make add-project rebind or delete channels.
+- Update the already-bound message to point users to the existing bound channel and state that mentioning Fro Bot there will
+  repair a missing checkout if the workspace volume was recreated.
+- Remove or soften manual S3 deletion guidance where it is no longer the correct first recovery step for #791.
+
+**Patterns to follow:**
+- Existing add-project no-`rm -rf` / no destructive-ops messaging.
+- Existing binding-is-source-of-truth behavior.
+
+**Test scenarios:**
+- Happy path: already-bound repo replies with the bound channel and no S3 deletion instruction.
+- Edge case: existing `repo-exists` partial-failure resume path still creates/binds a channel when no binding exists.
+- Error path: binding store failure still fails closed and does not attempt clone or recovery.
+
+**Verification:**
+- Add-project remains safe for partial setup recovery and no longer implies manual binding deletion is required for missing
+  checkout recovery.
+
+## System-Wide Impact
+
+- **Interaction graph:** Mentions gain an auth/clone recovery step before workspace readiness and execution. Add-project keeps
+  its current clone/channel/binding pipeline.
+- **Error propagation:** Detailed auth/clone failures stay in logs; Discord receives coarse retry-later copy.
+- **State lifecycle risks:** S3 binding remains durable state; Docker named volume becomes durable checkout state. If the
+  volume is destroyed, mention-time clone rehydrates it.
+- **API surface parity:** The workspace-agent HTTP API can remain unchanged because `/clone` already expresses both create and
+  exists states.
+- **Integration coverage:** Mention tests should prove stale bindings do not start OpenCode. Stack validation should prove the
+  persistence volume exists in rendered compose config.
+- **Unchanged invariants:** Workspace has no direct egress; repo clone path remains `/workspace/repos/{owner}/{repo}`;
+  Discord replies never expose tokens, raw paths beyond documented operator text, or internal S3 keys.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Mention recovery adds GitHub App auth latency before each run | Reuse existing app-client cache/token path; keep errors coarse and logged. |
+| Concurrent stale mentions trigger duplicate clone attempts | Rely on workspace-agent per-repo clone lock and `repo-exists` success semantics. |
+| Operators still run `docker compose down -v` | Document it as destructive and rely on lazy rehydration for recovery. |
+| Compose validation becomes brittle across Docker Compose output formats | Extend the existing parsed-config validator rather than grepping raw YAML. |
+
+## Documentation / Operational Notes
+
+- `deploy/README.md` should state that normal upgrades/recreates preserve repo checkouts through `workspace-repos`.
+- `deploy/README.md` should state that `docker compose down -v` removes cloned repos and mitmproxy CA state.
+- Recovery guidance should prefer “mention Fro Bot in the bound channel to rehydrate” over manual S3 binding deletion.
+
+## Sources & References
+
+- Origin issue: https://github.com/fro-bot/agent/issues/791
+- Triage comment: https://github.com/fro-bot/agent/issues/791#issuecomment-4634279579
+- Related code: `deploy/compose.yaml`
+- Related code: `deploy/validate-stack.sh`
+- Related code: `apps/workspace-agent/src/clone.ts`
+- Related code: `packages/gateway/src/workspace-api/client.ts`
+- Related code: `packages/gateway/src/discord/mentions.ts`
+- Related code: `packages/gateway/src/discord/commands/add-project.ts`

--- a/packages/gateway/src/discord/commands/add-project.test.ts
+++ b/packages/gateway/src/discord/commands/add-project.test.ts
@@ -379,8 +379,91 @@ describe('executeAddProject', () => {
       // #when
       await run(interaction, deps)
 
-      // #then
-      expect(lastEditReplyContent(editReply)).toContain('existing-channel')
+      // #then — reply mentions the bound channel by Discord mention token
+      const reply = lastEditReplyContent(editReply)
+      expect(reply).toContain('<#ch-existing>')
+      // #and — reply does NOT instruct the user to delete S3 keys
+      expect(reply).not.toContain('S3')
+      expect(reply).not.toContain('delete')
+      expect(reply).not.toContain('bindings/')
+    })
+
+    it('already-bound reply tells user to mention Fro Bot in the bound channel to repair a missing checkout', async () => {
+      // #given — repo is already bound; user may be hitting this after workspace volume was recreated
+      const userId = uniqueUserId()
+      const existingBinding = {
+        owner: 'testowner',
+        repo: 'testrepo',
+        channelId: 'ch-existing',
+        channelName: 'existing-channel',
+        workspacePath: '/workspace/repos/testowner/testrepo',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        createdByDiscordId: 'user-old',
+      }
+      const getBindingByRepo = vi.fn().mockResolvedValue(ok(existingBinding))
+      const {interaction, editReply} = makeInteraction({userId})
+      const deps = makeDeps({bindingsStore: makeBindingsStore({getBindingByRepo})})
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — reply points to the bound channel with exact Discord mention token
+      const reply = lastEditReplyContent(editReply)
+      expect(reply).toContain('<#ch-existing>')
+      // #and — reply explains the missing/recreated checkout context
+      expect(reply.toLowerCase()).toMatch(/recreated|missing|checkout/)
+      // #and — reply names Fro Bot as the repair mechanism (exact @mention fro-bot token)
+      expect(reply).toContain('@mention fro-bot')
+      // #and — reply says repair happens automatically (not manual steps)
+      expect(reply.toLowerCase()).toContain('automatically')
+    })
+
+    it('already-bound reply does not contain S3 deletion guidance', async () => {
+      // #given — repo is already bound
+      const userId = uniqueUserId()
+      const existingBinding = {
+        owner: 'testowner',
+        repo: 'testrepo',
+        channelId: 'ch-existing',
+        channelName: 'existing-channel',
+        workspacePath: '/workspace/repos/testowner/testrepo',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        createdByDiscordId: 'user-old',
+      }
+      const getBindingByRepo = vi.fn().mockResolvedValue(ok(existingBinding))
+      const {interaction, editReply} = makeInteraction({userId})
+      const deps = makeDeps({bindingsStore: makeBindingsStore({getBindingByRepo})})
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — no S3 deletion instructions in any reply
+      for (const content of allEditReplies(editReply)) {
+        expect(content).not.toContain('S3 key')
+        expect(content).not.toContain('manually delete')
+        expect(content).not.toContain('bindings/')
+      }
+    })
+
+    it('binding store failure during pre-flight still fails closed and does not attempt clone or recovery', async () => {
+      // #given — binding store returns an error result (not null, not a binding)
+      const userId = uniqueUserId()
+      const storeError = new Error('S3 timeout')
+      const getBindingByRepo = vi.fn().mockResolvedValue(err(storeError))
+      const clone = vi.fn()
+      const {interaction, editReply} = makeInteraction({userId})
+      const deps = makeDeps({
+        bindingsStore: makeBindingsStore({getBindingByRepo}),
+        workspaceClient: makeWorkspaceClient({clone}),
+      })
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — fails closed with internal error message
+      expect(lastEditReplyContent(editReply)).toContain('Internal error checking existing bindings')
+      // #and — clone was never called (no recovery attempted)
+      expect(clone).not.toHaveBeenCalled()
     })
   })
 
@@ -411,16 +494,39 @@ describe('executeAddProject', () => {
   })
 
   describe('CLONING: workspace-agent errors', () => {
-    const cloneErrorCases: {code: string; expectedFragment: string}[] = [
-      {code: 'clone-failed', expectedFragment: 'clone-failed'},
-      {code: 'disk-full', expectedFragment: 'out of space'},
-      {code: 'enospc', expectedFragment: 'out of space'},
-      {code: 'head-resolution-failed', expectedFragment: 'head-resolution-failed'},
-      {code: 'clone-timeout', expectedFragment: 'clone-timeout'},
+    // Internal clone error codes must NOT leak verbatim into Discord replies.
+    // Each case asserts: (a) the reply is non-empty, (b) the raw internal code
+    // does NOT appear verbatim, and (c) the reply is a coarse user-facing message.
+    const cloneErrorCases: {code: string; mustNotContain: string[]; mustContain: string}[] = [
+      {
+        code: 'clone-failed',
+        mustNotContain: ['clone-failed'],
+        mustContain: 'Clone failed',
+      },
+      {
+        code: 'disk-full',
+        mustNotContain: ['disk-full'],
+        mustContain: 'out of space',
+      },
+      {
+        code: 'enospc',
+        mustNotContain: ['enospc'],
+        mustContain: 'out of space',
+      },
+      {
+        code: 'head-resolution-failed',
+        mustNotContain: ['head-resolution-failed'],
+        mustContain: 'Clone failed',
+      },
+      {
+        code: 'clone-timeout',
+        mustNotContain: ['clone-timeout'],
+        mustContain: 'Clone failed',
+      },
     ]
 
-    for (const {code, expectedFragment} of cloneErrorCases) {
-      it(`handles clone-error code: ${code}`, async () => {
+    for (const {code, mustNotContain, mustContain} of cloneErrorCases) {
+      it(`clone-error code '${code}' produces a coarse reply without leaking the internal code`, async () => {
         // #given
         const userId = uniqueUserId()
         const clone = vi.fn().mockResolvedValue(err({kind: 'clone-error', code}))
@@ -430,12 +536,21 @@ describe('executeAddProject', () => {
         // #when
         await run(interaction, deps)
 
-        // #then
-        expect(lastEditReplyContent(editReply)).toContain(expectedFragment)
+        // #then — reply is non-empty
+        const reply = lastEditReplyContent(editReply)
+        expect(reply.length).toBeGreaterThan(0)
+
+        // #and — internal code does NOT appear verbatim in the Discord reply
+        for (const forbidden of mustNotContain) {
+          expect(reply).not.toContain(forbidden)
+        }
+
+        // #and — reply contains the expected coarse user-facing fragment
+        expect(reply).toContain(mustContain)
       })
     }
 
-    it('handles timeout from workspace client', async () => {
+    it('handles timeout from workspace client with coarse reply (no internal kind leaked)', async () => {
       // #given
       const userId = uniqueUserId()
       const clone = vi.fn().mockResolvedValue(err({kind: 'timeout'}))
@@ -445,11 +560,13 @@ describe('executeAddProject', () => {
       // #when
       await run(interaction, deps)
 
-      // #then
-      expect(lastEditReplyContent(editReply)).toContain('timed out')
+      // #then — coarse reply; internal kind 'timeout' must not appear verbatim
+      const reply = lastEditReplyContent(editReply)
+      expect(reply).toContain('timed out')
+      expect(reply).not.toContain("kind: 'timeout'")
     })
 
-    it('handles response-mismatch with internal error message', async () => {
+    it('handles response-mismatch with coarse internal error message (no raw error detail)', async () => {
       // #given
       const userId = uniqueUserId()
       const clone = vi.fn().mockResolvedValue(err({kind: 'response-mismatch'}))
@@ -459,8 +576,48 @@ describe('executeAddProject', () => {
       // #when
       await run(interaction, deps)
 
-      // #then
-      expect(lastEditReplyContent(editReply)).toContain('Internal error')
+      // #then — coarse reply; no raw error detail
+      const reply = lastEditReplyContent(editReply)
+      expect(reply).toContain('Internal error')
+      expect(reply).not.toContain('response-mismatch')
+    })
+
+    it('generic auth failure during clone does not leak raw error.message to Discord', async () => {
+      // #given — authForRepo returns a generic error (not AppNotInstalledError)
+      const userId = uniqueUserId()
+      const internalAuthDetail = 'JWT signature verification failed: secret-key-abc'
+      const authForRepo = vi.fn().mockResolvedValue(err(new Error(internalAuthDetail)))
+      const {interaction, editReply} = makeInteraction({userId})
+      const deps = makeDeps({appClient: makeAppClient({authForRepo})})
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — raw error.message must NOT appear in the Discord reply
+      const reply = lastEditReplyContent(editReply)
+      expect(reply.length).toBeGreaterThan(0)
+      expect(reply).not.toContain(internalAuthDetail)
+      expect(reply).not.toContain('JWT')
+      expect(reply).not.toContain('secret-key-abc')
+    })
+
+    it('channel creation failure does not leak raw Discord error.message to Discord reply', async () => {
+      // #given — channel creation throws a generic error (not a known Discord code)
+      const userId = uniqueUserId()
+      const internalChannelDetail = 'Internal Discord API error: shard-42 overloaded'
+      const channelError = new Error(internalChannelDetail)
+      const guild = makeGuild('bot-user-id', true, [], channelError)
+      const {interaction, editReply} = makeInteraction({guild, userId})
+      const deps = makeDeps()
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — raw error.message must NOT appear in the Discord reply
+      const reply = lastEditReplyContent(editReply)
+      expect(reply.length).toBeGreaterThan(0)
+      expect(reply).not.toContain(internalChannelDetail)
+      expect(reply).not.toContain('shard-42')
     })
   })
 
@@ -487,6 +644,33 @@ describe('executeAddProject', () => {
 
       // #then — editReply was called (not a crash)
       expect(editReply).toHaveBeenCalled()
+    })
+
+    it('permission-revoked reply does not expose absolute workspace filesystem paths', async () => {
+      // #given — appPermissions.has returns true for first two calls (PRE_FLIGHT), false thereafter
+      // This simulates permissions being revoked after clone completes but before channel creation.
+      const userId = uniqueUserId()
+      const appPermissions = {
+        has: vi.fn().mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValue(false),
+      }
+      const channelCache = {
+        filter: () => ({find: () => undefined, some: () => false}),
+      }
+      const create = vi.fn().mockResolvedValue(makeTextChannel().channel)
+      const guild = {
+        members: {fetch: vi.fn().mockResolvedValue({permissions: {has: vi.fn().mockReturnValue(true)}})},
+        channels: {cache: channelCache, create},
+      } as unknown as Guild
+      const {interaction, editReply} = makeInteraction({guild, userId, appPermissions})
+      const deps = makeDeps()
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — no absolute filesystem paths in the Discord reply
+      for (const content of allEditReplies(editReply)) {
+        expect(content).not.toContain('/workspace/repos')
+      }
     })
   })
 
@@ -520,7 +704,7 @@ describe('executeAddProject', () => {
   })
 
   describe('WRITING_BINDING: PartialWriteError', () => {
-    it('reports partial write error with recovery instructions', async () => {
+    it('reports partial write error with coarse user-facing message (no S3 keys leaked)', async () => {
       // #given
       const userId = uniqueUserId()
       const {channel} = makeTextChannel('testrepo')
@@ -537,8 +721,38 @@ describe('executeAddProject', () => {
       // #when
       await run(interaction, deps)
 
-      // #then
-      expect(lastEditReplyContent(editReply)).toContain('Partial write')
+      // #then — user-facing reply mentions partial write but does NOT expose S3 keys or paths
+      const reply = lastEditReplyContent(editReply)
+      expect(reply).toContain('Partial write')
+      // S3 internal keys must NOT appear in the Discord reply
+      expect(reply).not.toContain('bindings/testowner')
+      expect(reply).not.toContain('bindings/by-channel')
+      expect(reply).not.toContain('primaryKey')
+      expect(reply).not.toContain('indexKey')
+      expect(reply).not.toContain('S3')
+    })
+
+    it('partial write error reply does not expose absolute workspace filesystem paths', async () => {
+      // #given — partial write error after a fresh clone (workspacePath is set)
+      const userId = uniqueUserId()
+      const {channel} = makeTextChannel('testrepo')
+      const guild = makeGuild('bot-user-id', true, [], channel)
+      const partialWriteError = Object.assign(new Error('Partial write'), {
+        code: 'BINDING_PARTIAL_WRITE_ERROR',
+        primaryKey: 'bindings/testowner/testrepo/repo.json',
+        indexKey: 'bindings/by-channel/ch-123.json',
+      })
+      const createBinding = vi.fn().mockResolvedValue(err(partialWriteError))
+      const {interaction, editReply} = makeInteraction({guild, userId})
+      const deps = makeDeps({bindingsStore: makeBindingsStore({createBinding})})
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — no absolute filesystem paths in any reply
+      for (const content of allEditReplies(editReply)) {
+        expect(content).not.toContain('/workspace/repos')
+      }
     })
   })
 
@@ -743,6 +957,45 @@ describe('executeAddProject', () => {
       for (const content of allEditReplies(editReply)) {
         expect(content).not.toContain('rm -rf')
       }
+    })
+
+    it('repo-exists + binding found → reply includes missing checkout / repair / automatic recovery guidance', async () => {
+      // #given — clone fails with repo-exists; bindings store returns existing binding
+      // This path is hit when workspace was recreated and user tries add-project again.
+      // The reply must tell the user how to repair the missing checkout automatically.
+      const userId = uniqueUserId()
+      const clone = vi.fn().mockResolvedValue(err({kind: 'clone-error', code: 'repo-exists'}))
+      const existingBinding = {
+        owner: 'testowner',
+        repo: 'testrepo',
+        channelId: 'ch-bound-456',
+        channelName: 'testrepo',
+        workspacePath: '/workspace/repos/testowner/testrepo',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        createdByDiscordId: 'user-original',
+      }
+      const getBindingByRepo = vi.fn().mockResolvedValueOnce(ok(null)).mockResolvedValue(ok(existingBinding))
+      const {interaction, editReply} = makeInteraction({userId})
+      const deps = makeDeps({
+        workspaceClient: makeWorkspaceClient({clone}),
+        bindingsStore: makeBindingsStore({getBindingByRepo}),
+      })
+
+      // #when
+      await run(interaction, deps)
+
+      // #then — reply points to the bound channel with exact Discord mention token
+      const reply = lastEditReplyContent(editReply)
+      expect(reply).toContain('<#ch-bound-456>')
+      // #and — reply explains the missing/recreated checkout context
+      expect(reply.toLowerCase()).toMatch(/recreated|missing|checkout/)
+      // #and — reply names Fro Bot as the repair mechanism (exact @mention fro-bot token)
+      expect(reply).toContain('@mention fro-bot')
+      // #and — reply says repair happens automatically (not manual steps)
+      expect(reply.toLowerCase()).toContain('automatically')
+      // #and — no S3 deletion instructions
+      expect(reply).not.toContain('rm -rf')
+      expect(reply).not.toContain('S3')
     })
 
     it('repo-exists + NO binding → RESUMES: proceeds to channel creation and binding write', async () => {

--- a/packages/gateway/src/discord/commands/add-project.ts
+++ b/packages/gateway/src/discord/commands/add-project.ts
@@ -309,7 +309,10 @@ async function runAddProject(interaction: ChatInputCommandInteraction, deps: Add
   }
   if (existingResult.data !== null) {
     await interaction.editReply({
-      content: `\`${owner}/${repo}\` is already bound to #${existingResult.data.channelName}. Bindings cannot be moved in v1. To rebind, manually delete the S3 key \`bindings/${owner}/${repo}/repo.json\` and retry.`,
+      content: [
+        `\`${owner}/${repo}\` is already set up in <#${existingResult.data.channelId}>.`,
+        `If the workspace was recently recreated and the checkout is missing, @mention fro-bot in <#${existingResult.data.channelId}> — it will repair the missing checkout automatically.`,
+      ].join(' '),
     })
     return
   }
@@ -322,8 +325,9 @@ async function runAddProject(interaction: ChatInputCommandInteraction, deps: Add
         content: `The fro-bot GitHub App is not installed on \`${owner}/${repo}\`. Install it at: ${authResult.error.installUrl}`,
       })
     } else {
+      // Do NOT surface authResult.error.message — it may contain tokens or internal details.
       await interaction.editReply({
-        content: `GitHub App authentication failed: ${authResult.error.message}`,
+        content: `GitHub App authentication failed. Check that the fro-bot GitHub App is installed on \`${owner}/${repo}\` and retry.`,
       })
     }
     logger.warn('add-project: app auth failed', {
@@ -393,8 +397,14 @@ async function runAddProject(interaction: ChatInputCommandInteraction, deps: Add
         }
         if (existing.data !== null) {
           // Genuinely already bound — redirect to the bound channel. Nothing to resume.
+          // Include the same recovery guidance as the PRE_FLIGHT already-bound path:
+          // if the workspace was recreated, the user can repair the missing checkout
+          // by @mentioning fro-bot in the bound channel.
           await interaction.editReply({
-            content: `\`${owner}/${repo}\` is already set up in <#${existing.data.channelId}>.`,
+            content: [
+              `\`${owner}/${repo}\` is already set up in <#${existing.data.channelId}>.`,
+              `If the workspace was recently recreated and the checkout is missing, @mention fro-bot in <#${existing.data.channelId}> — it will repair the missing checkout automatically.`,
+            ].join(' '),
           })
           return
         }
@@ -406,8 +416,9 @@ async function runAddProject(interaction: ChatInputCommandInteraction, deps: Add
         logger.info('add-project phase', {phase: 'CLONING', outcome: 'resumed', owner, repo, correlationId})
         // fall through — do NOT return
       } else {
+        // Do NOT surface the internal code — it may confuse users and leaks implementation details.
         await interaction.editReply({
-          content: `Clone failed (${code}). Check workspace-agent logs for details.`,
+          content: `Clone failed. Check workspace-agent logs for details and retry.`,
         })
         return
       }
@@ -421,7 +432,8 @@ async function runAddProject(interaction: ChatInputCommandInteraction, deps: Add
       })
       return
     } else {
-      await interaction.editReply({content: `Clone failed (${errorKind}). Check workspace-agent connectivity.`})
+      // Do NOT surface the internal errorKind — it leaks implementation details.
+      await interaction.editReply({content: `Clone failed. Check workspace-agent connectivity and retry.`})
       return
     }
   } else {
@@ -445,18 +457,22 @@ async function runAddProject(interaction: ChatInputCommandInteraction, deps: Add
 
   // Defensive permission re-check
   if (!botHasRequiredPermissions(interaction.appPermissions)) {
-    logger.warn('add-project: permissions revoked between pre-flight and channel creation', {correlationId, phase})
+    logger.warn('add-project: permissions revoked between pre-flight and channel creation', {
+      correlationId,
+      phase,
+      workspacePath,
+    })
     await interaction.editReply({
-      content: `fro-bot lost **Manage Channels** permission. Clone is preserved at \`${workspacePath}\`. Re-grant permissions and retry.`,
+      content: `fro-bot lost **Manage Channels** permission. The clone is preserved — re-grant permissions and retry the command.`,
     })
     return
   }
 
   // Interaction window guard
   if (Date.now() - startTime > INTERACTION_WINDOW_MS) {
-    logger.warn('add-project: interaction window exhausted', {correlationId, phase, owner, repo})
+    logger.warn('add-project: interaction window exhausted', {correlationId, phase, owner, repo, workspacePath})
     await interaction.editReply({
-      content: `Interaction window expired. Clone preserved at \`${workspacePath}\`. Retry the command.`,
+      content: `Interaction window expired. The clone is preserved — retry the command.`,
     })
     return
   }
@@ -483,8 +499,9 @@ async function runAddProject(interaction: ChatInputCommandInteraction, deps: Add
         content: `fro-bot lacks permission to create channels. Re-invite at: ${installUrl}`,
       })
     } else {
+      // Do NOT surface channelResult.error.message — it may contain internal Discord API details.
       await interaction.editReply({
-        content: `Failed to create channel: ${channelResult.error.message}`,
+        content: `Failed to create channel. Check fro-bot's permissions and retry.`,
       })
     }
     return
@@ -536,9 +553,18 @@ async function runAddProject(interaction: ChatInputCommandInteraction, deps: Add
         content: `\`${owner}/${repo}\` was bound by a concurrent request. Channel #${channel.name} was created by this request — manual cleanup may be needed.`,
       })
     } else if ('code' in error && error.code === 'BINDING_PARTIAL_WRITE_ERROR') {
-      // TypeScript narrows error to PartialWriteError via the discriminant above
+      // TypeScript narrows error to PartialWriteError via the discriminant above.
+      // Log the S3 keys for operator recovery; do NOT surface them in the Discord reply.
+      logger.error('add-project: partial write — operator action required', {
+        correlationId,
+        phase,
+        owner,
+        repo,
+        primaryKey: 'primaryKey' in error ? error.primaryKey : undefined,
+        indexKey: 'indexKey' in error ? error.indexKey : undefined,
+      })
       await interaction.editReply({
-        content: `Partial write error: primary binding written but index failed. Manual S3 cleanup required:\n- Primary: \`${error.primaryKey}\`\n- Index: \`${error.indexKey}\``,
+        content: `Partial write error: the binding was partially saved. Please contact the operator to complete the setup for \`${owner}/${repo}\`.`,
       })
     } else {
       await interaction.editReply({

--- a/packages/gateway/src/discord/mentions.test.ts
+++ b/packages/gateway/src/discord/mentions.test.ts
@@ -1,10 +1,7 @@
-import type {Result} from '@fro-bot/runtime'
 import type {Guild, GuildMember, Message, TextChannel} from 'discord.js'
 import type {BindingsStore} from '../bindings/store.js'
-import type {ReadyzResponse, WorkspaceError} from '../workspace-api/types.js'
 import type {MentionDeps} from './mentions.js'
 
-import {err, ok} from '@fro-bot/runtime'
 import {PermissionsBitField} from 'discord.js'
 import {Effect} from 'effect'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
@@ -151,24 +148,13 @@ function makeRunMentionDeps(): MentionDeps['run'] {
       disposeAll: vi.fn(),
     },
     approvalMode: 'approval-required' as const,
+    ensureClone: vi.fn().mockResolvedValue({success: true as const, data: '/workspace/repos/acme/widget'}),
+    readyz: vi.fn().mockResolvedValue({success: true as const, data: {ready: true, opencode: 'ready'}}),
   }
 }
 
 function makeNoopLogger(): MentionDeps['logger'] {
   return {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
-}
-
-function makeReadyzFn(
-  result: 'ready' | 'not-ready' | 'error' | 'throws',
-  opencodeStatus: 'starting' | 'down' | 'unknown' = 'starting',
-): () => Promise<Result<ReadyzResponse, WorkspaceError>> {
-  return vi.fn(async () => {
-    if (result === 'throws') throw new Error('readyz threw unexpectedly')
-    if (result === 'ready') return ok({ready: true, opencode: 'ready'} satisfies ReadyzResponse)
-    if (result === 'not-ready') return ok({ready: false, opencode: opencodeStatus} satisfies ReadyzResponse)
-    // error
-    return err({kind: 'network-error'} satisfies WorkspaceError)
-  })
 }
 
 function makeDeps(overrides: Partial<MentionDeps> = {}): MentionDeps {
@@ -177,7 +163,6 @@ function makeDeps(overrides: Partial<MentionDeps> = {}): MentionDeps {
     triggerRoleId: overrides.triggerRoleId === undefined ? null : overrides.triggerRoleId,
     run: overrides.run ?? makeRunMentionDeps(),
     logger: overrides.logger ?? makeNoopLogger(),
-    readyz: overrides.readyz ?? makeReadyzFn('ready'),
   }
 }
 
@@ -414,115 +399,64 @@ describe('handleMention', () => {
     })
   })
 
-  // ── Readiness gate ──────────────────────────────────────────────────────────
+  // ── Concurrency storm regression ────────────────────────────────────────────
+  //
+  // Verifies that duplicate mentions for the same channel do NOT each invoke
+  // ensureClone before the busy/cap rejection fires. ensureClone is now owned
+  // by runMention (after the concurrency gate), so mentions.ts never calls it.
+  // This test confirms the ordering invariant at the mentions.ts boundary.
 
-  describe('readiness gate (after binding lookup, before runMention)', () => {
-    it('happy path: readiness=ready → runMention IS invoked', async () => {
-      // #given
+  describe('concurrency storm: duplicate mentions do not call ensureClone before rejection', () => {
+    it('runMention is called once per mention — mentions.ts does not call ensureClone directly', async () => {
+      // #given — two concurrent mentions for the same channel
       const {handleMention} = await import('./mentions.js')
       const member = makeGuildMember({hasManageChannels: true})
-      const message = makeMessage({guildMember: member})
-      const deps = makeDeps({readyz: makeReadyzFn('ready')})
+      const message1 = makeMessage({guildMember: member})
+      const message2 = makeMessage({guildMember: member})
+
+      // makeRunMentionDeps() already includes ensureClone as a vi.fn() spy.
+      // runMention is mocked at module level — it will not actually call ensureClone.
+      // The spy on run.ensureClone must remain uncalled because mentions.ts never
+      // invokes it directly; only runMention (mocked) would call it.
+      const runDeps = makeRunMentionDeps()
+      const ensureCloneSpy = runDeps.ensureClone as ReturnType<typeof vi.fn>
+      runMentionMock.mockResolvedValue(undefined)
+
+      const deps = makeDeps({run: runDeps})
+
+      // #when — both mentions fire concurrently
+      await Promise.all([
+        Effect.runPromise(handleMention(message1, BOT_USER_ID, deps)),
+        Effect.runPromise(handleMention(message2, BOT_USER_ID, deps)),
+      ])
+
+      // #then — runMention was called for both (mentions.ts delegates to runMention)
+      expect(runMentionMock).toHaveBeenCalledTimes(2)
+      // #and — ensureClone was NOT called from mentions.ts (it lives in runMention now)
+      expect(ensureCloneSpy).not.toHaveBeenCalled()
+    })
+
+    it('when runMention rejects busy, mentions.ts does not call ensureClone', async () => {
+      // #given — first mention acquires slot; second is rejected as busy by runMention
+      const {handleMention} = await import('./mentions.js')
+      const member = makeGuildMember({hasManageChannels: true})
+      const replyFn = makeReplyFn()
+      const message = makeMessage({guildMember: member, replyFn})
+
+      // makeRunMentionDeps() already includes ensureClone as a vi.fn() spy.
+      // runMention is mocked — it handles busy internally without calling ensureClone.
+      const runDeps = makeRunMentionDeps()
+      const ensureCloneSpy = runDeps.ensureClone as ReturnType<typeof vi.fn>
+      runMentionMock.mockResolvedValue(undefined)
+
+      const deps = makeDeps({run: runDeps})
 
       // #when
       await Effect.runPromise(handleMention(message, BOT_USER_ID, deps))
 
-      // #then — workspace is ready, runMention proceeds
+      // #then — mentions.ts never called ensureClone; runMention owns that
+      expect(ensureCloneSpy).not.toHaveBeenCalled()
       expect(runMentionMock).toHaveBeenCalledOnce()
-    })
-
-    it('readiness=not-ready → runMention NOT invoked, coarse reply sent', async () => {
-      // #given
-      const {handleMention} = await import('./mentions.js')
-      const member = makeGuildMember({hasManageChannels: true})
-      const replyFn = makeReplyFn()
-      const message = makeMessage({guildMember: member, replyFn})
-      const deps = makeDeps({readyz: makeReadyzFn('not-ready', 'starting')})
-
-      // #when
-      await Effect.runPromise(handleMention(message, BOT_USER_ID, deps))
-
-      // #then — workspace not ready: no runMention, coarse reply
-      expect(runMentionMock).not.toHaveBeenCalled()
-      expect(replyFn).toHaveBeenCalledOnce()
-      const call = replyFn.mock.calls[0]?.[0] as {content?: string; allowedMentions?: unknown} | undefined
-      expect(call?.content).toContain('not reachable')
-      expect(call?.allowedMentions).toEqual({parse: []})
-    })
-
-    it('readiness=error (transport error) → fail-closed: coarse reply, runMention NOT invoked', async () => {
-      // #given
-      const {handleMention} = await import('./mentions.js')
-      const member = makeGuildMember({hasManageChannels: true})
-      const replyFn = makeReplyFn()
-      const message = makeMessage({guildMember: member, replyFn})
-      const deps = makeDeps({readyz: makeReadyzFn('error')})
-
-      // #when
-      await Effect.runPromise(handleMention(message, BOT_USER_ID, deps))
-
-      // #then — transport error treated as not-ready (fail-closed)
-      expect(runMentionMock).not.toHaveBeenCalled()
-      expect(replyFn).toHaveBeenCalledOnce()
-      const call = replyFn.mock.calls[0]?.[0] as {content?: string; allowedMentions?: unknown} | undefined
-      expect(call?.content).toContain('not reachable')
-      expect(call?.allowedMentions).toEqual({parse: []})
-    })
-
-    it('readiness check throws/times out → fail-closed: coarse reply, runMention NOT invoked', async () => {
-      // #given
-      const {handleMention} = await import('./mentions.js')
-      const member = makeGuildMember({hasManageChannels: true})
-      const replyFn = makeReplyFn()
-      const message = makeMessage({guildMember: member, replyFn})
-      const deps = makeDeps({readyz: makeReadyzFn('throws')})
-
-      // #when
-      await Effect.runPromise(handleMention(message, BOT_USER_ID, deps))
-
-      // #then — thrown exception treated as not-ready (fail-closed)
-      expect(runMentionMock).not.toHaveBeenCalled()
-      expect(replyFn).toHaveBeenCalledOnce()
-      const call = replyFn.mock.calls[0]?.[0] as {content?: string; allowedMentions?: unknown} | undefined
-      expect(call?.content).toContain('not reachable')
-      expect(call?.allowedMentions).toEqual({parse: []})
-    })
-
-    it('ordering: missing binding short-circuits BEFORE readiness check (readyz never called)', async () => {
-      // #given — no binding for this channel
-      const {handleMention} = await import('./mentions.js')
-      const member = makeGuildMember({hasManageChannels: true})
-      const replyFn = makeReplyFn()
-      const message = makeMessage({guildMember: member, replyFn})
-      const readyzFn = makeReadyzFn('ready')
-      const deps = makeDeps({
-        bindingsStore: makeBindingsStore('not-found'),
-        readyz: readyzFn,
-      })
-
-      // #when
-      await Effect.runPromise(handleMention(message, BOT_USER_ID, deps))
-
-      // #then — binding lookup short-circuits before readiness check
-      expect(readyzFn).not.toHaveBeenCalled()
-      expect(runMentionMock).not.toHaveBeenCalled()
-    })
-
-    it('not-ready reply uses allowedMentions: {parse: []}', async () => {
-      // #given
-      const {handleMention} = await import('./mentions.js')
-      const member = makeGuildMember({hasManageChannels: true})
-      const replyFn = makeReplyFn()
-      const message = makeMessage({guildMember: member, replyFn})
-      const deps = makeDeps({readyz: makeReadyzFn('not-ready', 'down')})
-
-      // #when
-      await Effect.runPromise(handleMention(message, BOT_USER_ID, deps))
-
-      // #then — invariant: all replies use allowedMentions: {parse: []}
-      expect(replyFn).toHaveBeenCalledOnce()
-      const call = replyFn.mock.calls[0]?.[0] as {allowedMentions?: unknown} | undefined
-      expect(call?.allowedMentions).toEqual({parse: []})
     })
   })
 

--- a/packages/gateway/src/discord/mentions.ts
+++ b/packages/gateway/src/discord/mentions.ts
@@ -7,6 +7,7 @@
  *   configured trigger role (or guild-level ManageChannels as fallback).
  * - Binding lookup: resolve the repo binding for the source channel.
  * - Hand off to `runMention` in `execute/run.ts` for the full execution lifecycle.
+ *   `runMention` owns: concurrency gate, ensure-clone, readyz, lock, run-state, execution.
  *
  * Security invariants (MUST NOT be weakened):
  * - Authorization gate uses `guild.members.fetch()` (REST) not `members.cache.get()`
@@ -18,12 +19,10 @@
  * - No internal detail (error messages, IDs, paths) is ever posted to Discord.
  */
 
-import type {Result} from '@fro-bot/runtime'
 import type {Guild, Message} from 'discord.js'
 
 import type {BindingsStore} from '../bindings/store.js'
 import type {RunMentionDeps} from '../execute/run.js'
-import type {ReadyzResponse, WorkspaceError} from '../workspace-api/types.js'
 import type {GatewayLogger} from './client.js'
 import {PermissionFlagsBits} from 'discord.js'
 import {Effect} from 'effect'
@@ -47,13 +46,6 @@ export interface MentionDeps {
   /** Run-lifecycle deps forwarded verbatim to `runMention`. */
   readonly run: RunMentionDeps
   readonly logger: GatewayLogger
-  /**
-   * Workspace readiness check. Called after binding lookup, before runMention.
-   * Injected so tests can stub it without a live workspace.
-   *
-   * Fail-closed: any error result or thrown exception → treat as not-ready.
-   */
-  readonly readyz: () => Promise<Result<ReadyzResponse, WorkspaceError>>
 }
 
 // ---------------------------------------------------------------------------
@@ -113,9 +105,14 @@ export async function userIsAuthorized(
  *
  * Returns an `Effect` so the caller (program.ts) can handle failures uniformly.
  * Internal errors are logged; coarse user-visible messages are posted to Discord.
+ *
+ * Ordering: binding lookup → authorization → hand off to runMention.
+ * runMention owns: concurrency gate → ensure-clone → readyz → execution.
+ * This ordering ensures duplicate mentions are rejected by the concurrency gate
+ * before any GitHub App token is minted or workspace clone is attempted.
  */
 export function handleMention(message: Message, botUserId: string, deps: MentionDeps): Effect.Effect<void, Error> {
-  const {bindingsStore, triggerRoleId, run: runDeps, logger, readyz} = deps
+  const {bindingsStore, triggerRoleId, run: runDeps, logger} = deps
 
   // ── Guard 1: Skip if already in a thread ────────────────────────────────
   if (message.channel.isThread()) {
@@ -163,29 +160,9 @@ export function handleMention(message: Message, botUserId: string, deps: Mention
       const binding = bindingResult.data
       logger.info({channelId: message.channel.id, repo: `${binding.owner}/${binding.repo}`}, 'mention: binding found')
 
-      // ── Step 4: Workspace readiness gate ────────────────────────────────
-      // Fail-closed: any error result or thrown exception → treat as not-ready.
-      // This prevents creating a thread, acquiring a lock, or creating run-state
-      // for a workspace that is not yet serving OpenCode.
-      let workspaceReady = false
-      try {
-        const readyzResult = await readyz()
-        workspaceReady = readyzResult.success === true && readyzResult.data.ready === true
-      } catch {
-        // Thrown exception (e.g. timeout) → fail closed
-        workspaceReady = false
-      }
-
-      if (workspaceReady === false) {
-        logger.warn(
-          {channelId: message.channel.id, repo: `${binding.owner}/${binding.repo}`},
-          'mention: workspace not ready — aborting',
-        )
-        await safeReply(message, 'The workspace is not reachable right now. Please try again later.')
-        return
-      }
-
-      // ── Steps 5–11: Execution lifecycle (concurrency + lock + run-state) ─
+      // ── Steps 4–12: Execution lifecycle ─────────────────────────────────
+      // runMention owns: concurrency gate → ensure-clone → readyz → lock → run-state → execution.
+      // Passing the raw binding; runMention will override workspacePath with the ensured path.
       await runMention(message, binding, runDeps)
     },
     catch: (error: unknown) => (error instanceof Error ? error : new Error(String(error))),

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -169,6 +169,24 @@ function makeDefaultConcurrency() {
   }
 }
 
+function makeEnsureCloneFn(result: 'success' | 'failure' = 'success') {
+  return result === 'success'
+    ? vi.fn().mockResolvedValue({success: true as const, data: '/workspace/acme/widget'})
+    : vi.fn().mockResolvedValue({
+        success: false as const,
+        error: {kind: 'workspace-failure' as const, workspaceKind: 'network-error' as const},
+      })
+}
+
+function makeReadyzFn(result: 'ready' | 'not-ready' | 'throws' = 'ready') {
+  if (result === 'throws') {
+    return vi.fn().mockRejectedValue(new Error('readyz threw'))
+  }
+  return result === 'ready'
+    ? vi.fn().mockResolvedValue({success: true as const, data: {ready: true, opencode: 'ready'}})
+    : vi.fn().mockResolvedValue({success: true as const, data: {ready: false, opencode: 'starting'}})
+}
+
 function makeDeps(overrides: Partial<RunMentionDeps> = {}): RunMentionDeps {
   return {
     coordinationConfig: {} as CoordinationConfig,
@@ -181,6 +199,8 @@ function makeDeps(overrides: Partial<RunMentionDeps> = {}): RunMentionDeps {
     logger: overrides.logger ?? {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()},
     approvalRegistry: overrides.approvalRegistry ?? makeApprovalRegistry(),
     approvalMode: overrides.approvalMode ?? 'approval-required',
+    ensureClone: overrides.ensureClone ?? makeEnsureCloneFn('success'),
+    readyz: overrides.readyz ?? makeReadyzFn('ready'),
     ...overrides,
   }
 }
@@ -316,6 +336,254 @@ describe('runMention', () => {
       expect(call.content).toContain('already a task')
       expect(call.allowedMentions).toEqual({parse: []})
       expect(message.startThread).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── Ensure-clone gate (after concurrency, before thread/lock) ──────────
+
+  describe('ensure-clone gate', () => {
+    it('happy path: ensure-clone succeeds → proceeds to thread creation and execution', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const ensureClone = makeEnsureCloneFn('success')
+      const deps = makeDeps({ensureClone})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — ensureClone was called; execution proceeded
+      expect(ensureClone).toHaveBeenCalledWith(OWNER, REPO)
+      expect(mockRunOpenCodeCore).toHaveBeenCalledOnce()
+    })
+
+    it('ensure-clone failure → coarse reply, no thread created, concurrency slot released', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      const ensureClone = makeEnsureCloneFn('failure')
+      const releaseFn = vi.fn()
+      const deps = makeDeps({
+        ensureClone,
+        concurrency: {
+          tryAcquire: vi.fn().mockReturnValue('ok'),
+          release: releaseFn,
+          activeCount: vi.fn().mockReturnValue(1),
+          max: 3,
+        },
+      })
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — coarse reply sent via message.reply (no thread yet)
+      expect(message.reply).toHaveBeenCalledOnce()
+      const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+        content: string
+        allowedMentions: unknown
+      }
+      expect(call.content).toContain('workspace')
+      expect(call.allowedMentions).toEqual({parse: []})
+      // No thread created
+      expect(message.startThread).not.toHaveBeenCalled()
+      // Concurrency slot released in finally
+      expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
+    })
+
+    it('ensure-clone failure does not expose internal details in reply', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      const ensureClone = vi.fn().mockResolvedValue({
+        success: false as const,
+        error: {kind: 'auth-failure' as const, reason: 'auth-error' as const},
+      })
+      const deps = makeDeps({ensureClone})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — no internal detail in reply
+      const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {content: string}
+      expect(call.content).not.toContain('auth')
+      expect(call.content).not.toContain('token')
+      expect(call.content).not.toContain('clone')
+    })
+
+    it('ensure-clone is NOT called when concurrency cap is reached (storm guard)', async () => {
+      // #given — concurrency cap fires before ensure-clone
+      const {runMention} = await import('./run.js')
+      const ensureClone = makeEnsureCloneFn('success')
+      const deps = makeDeps({
+        ensureClone,
+        concurrency: {
+          tryAcquire: vi.fn().mockReturnValue('cap'),
+          release: vi.fn(),
+          activeCount: vi.fn().mockReturnValue(3),
+          max: 3,
+        },
+      })
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — cap reply sent; ensureClone never called
+      expect(message.reply).toHaveBeenCalledOnce()
+      const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {content: string}
+      expect(call.content).toContain('capacity')
+      expect(ensureClone).not.toHaveBeenCalled()
+    })
+
+    it('ensure-clone is NOT called when channel is busy (storm guard)', async () => {
+      // #given — busy fires before ensure-clone
+      const {runMention} = await import('./run.js')
+      const ensureClone = makeEnsureCloneFn('success')
+      const deps = makeDeps({
+        ensureClone,
+        concurrency: {
+          tryAcquire: vi.fn().mockReturnValue('busy'),
+          release: vi.fn(),
+          activeCount: vi.fn().mockReturnValue(1),
+          max: 3,
+        },
+      })
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — busy reply sent; ensureClone never called
+      expect(message.reply).toHaveBeenCalledOnce()
+      const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {content: string}
+      expect(call.content).toContain('already a task')
+      expect(ensureClone).not.toHaveBeenCalled()
+    })
+
+    it('runOpenCodeCore receives ensured path from ensureClone, not stale binding.workspacePath', async () => {
+      // #given — binding has a stale workspacePath; ensureClone returns the canonical path
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const canonicalPath = '/workspace/canonical/acme/widget'
+      const ensureClone = vi.fn().mockResolvedValue({success: true as const, data: canonicalPath})
+      const staleBinding = {...makeBinding(), workspacePath: '/old/stale/path'}
+      const deps = makeDeps({ensureClone})
+      const msg = makeMessage()
+
+      // #when
+      await runMention(msg, staleBinding, deps)
+
+      // #then — runOpenCodeCore called with the canonical path
+      expect(mockRunOpenCodeCore).toHaveBeenCalledOnce()
+      const coreParams = mockRunOpenCodeCore.mock.calls[0]?.[0] as {directory?: string}
+      expect(coreParams.directory).toBe(canonicalPath)
+      expect(coreParams.directory).not.toBe('/old/stale/path')
+    })
+  })
+
+  // ── Readiness gate (after ensure-clone, before thread/lock) ─────────────
+
+  describe('readiness gate', () => {
+    it('happy path: readyz=ready → proceeds to thread creation and execution', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const readyz = makeReadyzFn('ready')
+      const deps = makeDeps({readyz})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — readyz called; execution proceeded
+      expect(readyz).toHaveBeenCalledOnce()
+      expect(mockRunOpenCodeCore).toHaveBeenCalledOnce()
+    })
+
+    it('readyz=not-ready → coarse reply, no thread created, concurrency slot released', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      const readyz = makeReadyzFn('not-ready')
+      const releaseFn = vi.fn()
+      const deps = makeDeps({
+        readyz,
+        concurrency: {
+          tryAcquire: vi.fn().mockReturnValue('ok'),
+          release: releaseFn,
+          activeCount: vi.fn().mockReturnValue(1),
+          max: 3,
+        },
+      })
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — coarse reply; no thread
+      expect(message.reply).toHaveBeenCalledOnce()
+      const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+        content: string
+        allowedMentions: unknown
+      }
+      expect(call.content).toContain('not reachable')
+      expect(call.allowedMentions).toEqual({parse: []})
+      expect(message.startThread).not.toHaveBeenCalled()
+      expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
+    })
+
+    it('readyz throws → fail-closed: coarse reply, no thread created', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      const readyz = makeReadyzFn('throws')
+      const deps = makeDeps({readyz})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — thrown exception treated as not-ready (fail-closed)
+      expect(message.reply).toHaveBeenCalledOnce()
+      const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {content: string}
+      expect(call.content).toContain('not reachable')
+      expect(message.startThread).not.toHaveBeenCalled()
+    })
+
+    it('readyz is NOT called when ensure-clone fails', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      const ensureClone = makeEnsureCloneFn('failure')
+      const readyz = makeReadyzFn('ready')
+      const deps = makeDeps({ensureClone, readyz})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — ensure-clone failed: readyz never called
+      expect(readyz).not.toHaveBeenCalled()
+    })
+
+    it('readyz is NOT called when concurrency cap fires', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      const readyz = makeReadyzFn('ready')
+      const deps = makeDeps({
+        readyz,
+        concurrency: {
+          tryAcquire: vi.fn().mockReturnValue('cap'),
+          release: vi.fn(),
+          activeCount: vi.fn().mockReturnValue(3),
+          max: 3,
+        },
+      })
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — cap fires before readyz
+      expect(readyz).not.toHaveBeenCalled()
     })
   })
 
@@ -843,10 +1111,15 @@ describe('runMention', () => {
       expect(deadlineMs).toBeGreaterThan(0)
     })
 
-    it('onPending: posts approval embed+buttons to thread and calls approvalRegistry.register', async () => {
-      // #given
+    it('onPending: posts approval embed+buttons to thread and calls approvalRegistry.register with ensured canonical path', async () => {
+      // #given — binding has a stale workspacePath; ensureClone returns the canonical path.
+      // approvalRegistry.register must receive the canonical path, NOT the stale binding path.
       const {runMention} = await import('./run.js')
       setupHappyPath()
+
+      const canonicalPath = '/workspace/canonical/acme/widget'
+      const staleBinding = {...makeBinding(), workspacePath: '/old/stale/path'}
+      const ensureClone = vi.fn().mockResolvedValue({success: true as const, data: canonicalPath})
 
       const approvalRegistry = makeApprovalRegistry()
       const thread = makeThread()
@@ -854,8 +1127,7 @@ describe('runMention', () => {
       const fakeApprovalMessage = {id: 'msg-approval-1', edit: vi.fn()}
       thread.send.mockResolvedValue(fakeApprovalMessage)
       const message = makeMessage(thread)
-      const deps = makeDeps({approvalRegistry})
-      const binding = makeBinding()
+      const deps = makeDeps({approvalRegistry, ensureClone})
 
       // Capture the onPending callback from coordinator factory
       let capturedOnPending: ((req: import('../approvals/coordinator.js').PermissionRequest) => void) | undefined
@@ -870,7 +1142,7 @@ describe('runMention', () => {
       })
 
       // #when — run completes first so coordinator is created
-      await runMention(message, binding, deps)
+      await runMention(message, staleBinding, deps)
 
       expect(capturedOnPending).toBeDefined()
 
@@ -896,13 +1168,17 @@ describe('runMention', () => {
         }),
       )
 
-      // #and — approvalRegistry.register called with correct params
+      // #and — approvalRegistry.register called with the CANONICAL path from ensureClone,
+      // NOT the stale binding.workspacePath
       expect(approvalRegistry.register).toHaveBeenCalledWith(
         expect.objectContaining({
           requestID: 'req-abc-123',
           channelID: thread.id,
-          directory: binding.workspacePath,
+          directory: canonicalPath,
         }),
+      )
+      expect(approvalRegistry.register).not.toHaveBeenCalledWith(
+        expect.objectContaining({directory: '/old/stale/path'}),
       )
     })
 

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -1,9 +1,11 @@
-import type {CoordinationConfig} from '@fro-bot/runtime'
+import type {CoordinationConfig, Result} from '@fro-bot/runtime'
 import type {Message} from 'discord.js'
 import type {ApprovalRegistry} from '../approvals/registry.js'
 import type {RepoBinding} from '../bindings/types.js'
 import type {GatewayLogger} from '../discord/client.js'
 import type {SinkThread} from '../discord/streaming.js'
+import type {EnsureCloneFailure} from '../workspace-api/ensure-clone.js'
+import type {ReadyzResponse, WorkspaceError} from '../workspace-api/types.js'
 import type {ConcurrencyRegistry} from './concurrency.js'
 
 import {acquireLock, createHeartbeatController, createRun, releaseLock, transitionRun} from '@fro-bot/runtime'
@@ -42,6 +44,22 @@ export interface RunMentionDeps {
    * `autonomous-low-risk` is deferred (unsafe due to OpenCode last-match-wins evaluation).
    */
   readonly approvalMode: 'approval-required'
+  /**
+   * Ensure the workspace checkout exists for the given owner/repo.
+   * Called after the concurrency gate acquires a slot, before readyz/execution.
+   * Injected so tests can stub it without live GitHub/workspace calls.
+   *
+   * Returns ok(path) on success (fresh clone or repo-exists recovery).
+   * Returns err(EnsureCloneFailure) on auth/clone/network failure.
+   */
+  readonly ensureClone: (owner: string, repo: string) => Promise<Result<string, EnsureCloneFailure>>
+  /**
+   * Workspace readiness check. Called after ensure-clone, before execution.
+   * Injected so tests can stub it without a live workspace.
+   *
+   * Fail-closed: any error result or thrown exception → treat as not-ready.
+   */
+  readonly readyz: () => Promise<Result<ReadyzResponse, WorkspaceError>>
 }
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -117,7 +135,7 @@ export function computeApprovalDeadlineMs(remainingBudgetMs: number): number | u
  */
 export async function runMention(message: Message, binding: RepoBinding, deps: RunMentionDeps): Promise<void> {
   const {concurrency, coordinationConfig, identity, attachUrl, attachToken, runTimeoutMs, botUserId, logger} = deps
-  const {approvalRegistry, approvalMode} = deps
+  const {approvalRegistry, approvalMode, ensureClone, readyz} = deps
   const channelId = message.channel.id
   const repo = `${binding.owner}/${binding.repo}`
 
@@ -127,6 +145,9 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
   const runStartMs = Date.now()
 
   // ── Concurrency cap + per-channel in-flight guard ──────────
+  // IMPORTANT: ensureClone and readyz are called AFTER this gate so that
+  // same-channel mention storms do not each mint GitHub App tokens or call
+  // workspace clone before the busy/cap rejection fires.
 
   const slotResult = concurrency.tryAcquire(channelId)
 
@@ -142,6 +163,48 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
 
   // Slot acquired — MUST release in outer finally
   try {
+    // ── Ensure workspace checkout exists ──────────────────────────────────────────────────────
+    // Rehydrates a missing checkout (e.g. after container recreation) before OpenCode can start.
+    // Placed after the concurrency gate so duplicate mentions are rejected before any
+    // GitHub App token is minted or workspace clone is attempted.
+    const ensureCloneResult = await ensureClone(binding.owner, binding.repo)
+    if (ensureCloneResult.success === false) {
+      logger.warn(
+        {
+          channelId,
+          owner: binding.owner,
+          repo: binding.repo,
+          failureKind: ensureCloneResult.error.kind,
+        },
+        'run: workspace clone unavailable — aborting',
+      )
+      await safeReply(message, 'The workspace is not available right now. Please try again later.')
+      return
+    }
+
+    // Use the ensured (canonical) path from ensureClone, not the potentially stale
+    // workspacePath stored in the binding (e.g. after container recreation).
+    const bindingWithEnsuredPath = {...binding, workspacePath: ensureCloneResult.data}
+
+    // ── Workspace readiness gate ──────────────────────────────────────────────────────────────
+    // Fail-closed: any error result or thrown exception → treat as not-ready.
+    // This prevents creating a thread, acquiring a lock, or creating run-state
+    // for a workspace that is not yet serving OpenCode.
+    let workspaceReady = false
+    try {
+      const readyzResult = await readyz()
+      workspaceReady = readyzResult.success === true && readyzResult.data.ready === true
+    } catch {
+      // Thrown exception (e.g. timeout) → fail closed
+      workspaceReady = false
+    }
+
+    if (workspaceReady === false) {
+      logger.warn({channelId, repo}, 'run: workspace not ready — aborting')
+      await safeReply(message, 'The workspace is not reachable right now. Please try again later.')
+      return
+    }
+
     // ── Create response thread ─────────────────────────────────────────────────────────────────
 
     const runId = crypto.randomUUID()
@@ -244,8 +307,8 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
       sink = createDiscordStreamSink(thread, {logger})
       const promptText = buildDiscordPrompt({
         messageText: message.content,
-        owner: binding.owner,
-        repo: binding.repo,
+        owner: bindingWithEnsuredPath.owner,
+        repo: bindingWithEnsuredPath.repo,
         botUserId,
       })
 
@@ -309,7 +372,7 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
             requestID,
             sessionID,
             channelID: rawThread.id,
-            directory: binding.workspacePath,
+            directory: bindingWithEnsuredPath.workspacePath,
             request,
             effects: {postReply: postReplyForRequest},
             deadlineMs: approvalDeadlineMs,
@@ -387,7 +450,7 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
       try {
         await runOpenCodeCore({
           handle,
-          directory: binding.workspacePath,
+          directory: bindingWithEnsuredPath.workspacePath,
           promptText,
           sink,
           signal: timeoutSignal,

--- a/packages/gateway/src/github/app-client.test.ts
+++ b/packages/gateway/src/github/app-client.test.ts
@@ -47,6 +47,23 @@ function makeLogger() {
 }
 
 // ---------------------------------------------------------------------------
+// Test helpers for installation auth call assertions
+// ---------------------------------------------------------------------------
+
+/** Shape of the argument passed to installAuth({type:'installation',...}) */
+interface InstallationAuthCallArg {
+  readonly type: string
+  readonly repositoryNames?: string[]
+  readonly permissions?: Record<string, string>
+}
+
+function getInstallationCalls(): InstallationAuthCallArg[] {
+  return mockAuth.mock.calls
+    .filter(args => (args[0] as {type: string}).type === 'installation')
+    .map(args => args[0] as InstallationAuthCallArg)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -244,6 +261,60 @@ describe('createAppClient', () => {
       expect(line).not.toContain(PRIVATE_KEY)
       expect(line).not.toContain('fake-key')
     }
+  })
+
+  // -------------------------------------------------------------------------
+  // Security: repository-scoped installation tokens
+  // -------------------------------------------------------------------------
+
+  it('security: installAuth({type:"installation"}) receives repositoryNames:[repo] and permissions:{contents:"read"}', async () => {
+    // #given
+    const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY})
+
+    // #when
+    const result = await client.authForRepo('myorg', 'myrepo')
+
+    // #then — must succeed
+    expect(result.success).toBe(true)
+
+    // The installation-type auth call must carry repository scoping and minimal permissions.
+    const installationCalls = getInstallationCalls()
+    expect(installationCalls).toHaveLength(1)
+    const [installationCallArg] = installationCalls
+    expect(installationCallArg?.repositoryNames).toEqual(['myrepo'])
+    expect(installationCallArg?.permissions).toEqual({contents: 'read'})
+  })
+
+  it('security: second authForRepo call (cache hit) also passes repositoryNames and permissions', async () => {
+    // #given
+    const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY})
+
+    // #when — two calls; second hits the cache
+    await client.authForRepo('myorg', 'myrepo')
+    await client.authForRepo('myorg', 'myrepo')
+
+    // #then — both installation-type calls must carry scoping
+    const installationCalls = getInstallationCalls()
+    expect(installationCalls).toHaveLength(2)
+    for (const arg of installationCalls) {
+      expect(arg.repositoryNames).toEqual(['myrepo'])
+      expect(arg.permissions).toEqual({contents: 'read'})
+    }
+  })
+
+  it('security: repositoryNames uses the repo name, not the owner/repo path', async () => {
+    // #given — repo name differs from owner name
+    const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY})
+
+    // #when
+    await client.authForRepo('some-org', 'specific-repo')
+
+    // #then — repositoryNames must be just the repo name, not "some-org/specific-repo"
+    const installationCalls = getInstallationCalls()
+    expect(installationCalls).toHaveLength(1)
+    const [arg] = installationCalls
+    expect(arg?.repositoryNames).toEqual(['specific-repo'])
+    expect(arg?.repositoryNames).not.toContain('some-org/specific-repo')
   })
 
   // -------------------------------------------------------------------------

--- a/packages/gateway/src/github/app-client.ts
+++ b/packages/gateway/src/github/app-client.ts
@@ -184,11 +184,18 @@ export function createAppClient(options: AppClientOptions): AppClient {
         })
       }
 
-      // Stage 2: Mint an installation token using the discovered installationId.
+      // Stage 2: Mint a repository-scoped installation token.
+      // Narrow the token to the requested repository and the minimum required
+      // permissions (contents:read) so a compromised token cannot be used to
+      // access other repositories in the same installation.
       const installAuth = createAppAuth({appId, privateKey, installationId})
       let token: string
       try {
-        ;({token} = await installAuth({type: 'installation'}))
+        ;({token} = await installAuth({
+          type: 'installation',
+          repositoryNames: [repo],
+          permissions: {contents: 'read'},
+        }))
       } catch (mintError) {
         // Stage-2 failure means the cached installationId is no longer usable
         // (e.g. revoked installation, rotated key, transient API error).

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -65,6 +65,15 @@ vi.mock('./discord/approvals.js', () => ({
   DENY_PREFIX: 'fb-deny:',
 }))
 
+// Stub ensureWorkspaceClone so program tests can assert wiring without live GitHub/workspace calls.
+vi.mock('./workspace-api/ensure-clone.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./workspace-api/ensure-clone.js')>()
+  return {
+    ...actual,
+    ensureWorkspaceClone: vi.fn().mockResolvedValue({success: true, data: '/workspace/repos/test/repo'}),
+  }
+})
+
 const {makeDiscordClientFromConfig, makeGatewayProgram} = await import('./program.js')
 const {createDiscordClient} = await import('./discord/client.js')
 const createDiscordClientSpy = vi.mocked(createDiscordClient)
@@ -524,6 +533,38 @@ describe('makeGatewayProgram', () => {
 
     // #then — approvalMode is threaded from GatewayConfig into the mention run deps
     expect(capturedDeps.run.approvalMode).toBe('approval-required')
+  })
+
+  it('messageCreate: RunMentionDeps.ensureClone calls ensureWorkspaceClone with owner, repo, appClient, workspaceClient, and logger', async () => {
+    // #given — mock ensureWorkspaceClone so we can assert it is called through real wiring
+    const {ensureWorkspaceClone} = await import('./workspace-api/ensure-clone.js')
+    const ensureWorkspaceCloneMock = vi.mocked(ensureWorkspaceClone)
+    ensureWorkspaceCloneMock.mockResolvedValue({success: true, data: '/workspace/repos/acme/widget'})
+
+    // #when — capture the deps passed to handleMention
+    const capturedDeps = await runAndCaptureMentionDeps('approval-required')
+
+    // #then — ensureClone is now in run (after concurrency gate), not at the top level
+    expect(typeof capturedDeps.run.ensureClone).toBe('function')
+
+    // #when — invoke the ensureClone function with owner/repo
+    await capturedDeps.run.ensureClone('acme', 'widget')
+
+    // #then — ensureWorkspaceClone was called with the correct owner, repo, and non-null clients
+    expect(ensureWorkspaceCloneMock).toHaveBeenCalledOnce()
+    const callArg = ensureWorkspaceCloneMock.mock.calls[0]?.[0]
+    expect(callArg).toBeDefined()
+    if (callArg === undefined) throw new Error('ensureWorkspaceClone was not called')
+    expect(callArg.owner).toBe('acme')
+    expect(callArg.repo).toBe('widget')
+    // appClient and workspaceClient must be the program-created instances (not null/undefined)
+    expect(callArg.appClient).toBeDefined()
+    expect(callArg.workspaceClient).toBeDefined()
+    // logger must be provided (adapter from GatewayLogger to EnsureCloneDeps logger)
+    expect(callArg.logger).toBeDefined()
+    expect(typeof callArg.logger.info).toBe('function')
+    expect(typeof callArg.logger.warn).toBe('function')
+    expect(typeof callArg.logger.error).toBe('function')
   })
 
   it('announce disabled: client events (messageCreate/interactionCreate) are still wired', async () => {

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -24,6 +24,7 @@ import {recoverStaleRuns} from './execute/recovery.js'
 import {createAppClient} from './github/app-client.js'
 import {installShutdownHandlers, isShuttingDown} from './shutdown.js'
 import {createWorkspaceClient} from './workspace-api/client.js'
+import {ensureWorkspaceClone} from './workspace-api/ensure-clone.js'
 
 // ---------------------------------------------------------------------------
 // Pure helper — builds the coordination config from the shared S3 adapter and
@@ -276,10 +277,27 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           logger,
           approvalRegistry,
           approvalMode: config.approvalMode,
+          // Workspace readiness gate — uses the same :9100 base as the clone endpoint.
+          // Placed inside run so it is called after the concurrency gate, not before.
+          readyz: async () => workspaceClient.readyz(),
+          // Ensure workspace checkout exists. Called after the concurrency gate so
+          // same-channel mention storms do not each mint GitHub App tokens before
+          // the busy/cap rejection fires. Adapts GatewayLogger (context-first) to
+          // the EnsureCloneDeps logger (message-first) inline.
+          ensureClone: async (owner: string, repo: string) =>
+            ensureWorkspaceClone({
+              owner,
+              repo,
+              appClient,
+              workspaceClient,
+              logger: {
+                info: (msg, meta) => logger.info(meta ?? {}, msg),
+                warn: (msg, meta) => logger.warn(meta ?? {}, msg),
+                error: (msg, meta) => logger.error(meta ?? {}, msg),
+              },
+            }),
         },
         logger,
-        // Workspace readiness gate — uses the same :9100 base as the clone endpoint.
-        readyz: async () => workspaceClient.readyz(),
       }
 
       const runPromise: Promise<void> = Effect.runPromise(handleMention(message, client.user.id, mentionDeps)).catch(

--- a/packages/gateway/src/workspace-api/ensure-clone.test.ts
+++ b/packages/gateway/src/workspace-api/ensure-clone.test.ts
@@ -1,0 +1,569 @@
+/**
+ * Tests for ensureWorkspaceClone helper.
+ *
+ * Strict TDD: tests were written before the implementation.
+ * All tests in this file must pass GREEN after ensure-clone.ts is implemented.
+ */
+
+import type {Result} from '@fro-bot/runtime'
+
+import type {AppClient, AppClientAuthResult} from '../github/app-client.js'
+import type {WorkspaceClient} from './client.js'
+import type {EnsureCloneFailure} from './ensure-clone.js'
+import type {CloneSuccess, WorkspaceError} from './types.js'
+
+import {err, ok} from '@fro-bot/runtime'
+import {describe, expect, it, vi} from 'vitest'
+
+import {AppNotInstalledError, AuthError} from '../github/app-client.js'
+import {workspaceRepoPath} from './client.js'
+import {ensureWorkspaceClone} from './ensure-clone.js'
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+}
+
+function makeAuthResult(token = 'ghs_testtoken'): AppClientAuthResult {
+  // Use a minimal Octokit-compatible object — tests only need the token field.
+  // Avoid `{} as unknown as Octokit` to keep the type honest.
+  const minimalOctokit = {request: vi.fn(), hook: {before: vi.fn(), after: vi.fn(), error: vi.fn(), wrap: vi.fn()}}
+  return {
+    octokit: minimalOctokit as unknown as AppClientAuthResult['octokit'],
+    installationId: 42,
+    token,
+  }
+}
+
+function makeAppClient(
+  authResult: Result<AppClientAuthResult, AppNotInstalledError | AuthError> = ok(makeAuthResult()),
+): AppClient {
+  return {
+    authForRepo: vi.fn().mockResolvedValue(authResult),
+    invalidateCache: vi.fn(),
+  }
+}
+
+function makeWorkspaceClient(
+  cloneResult: Result<CloneSuccess, WorkspaceError> = ok({
+    ok: true,
+    path: workspaceRepoPath('testowner', 'testrepo'),
+    commit: 'abc123',
+  }),
+): WorkspaceClient {
+  return {
+    clone: vi.fn().mockResolvedValue(cloneResult),
+    readyz: vi.fn(),
+  }
+}
+
+/**
+ * Assert that a Result is a failure and return the typed error.
+ * Eliminates vitest/no-conditional-expect by making the assertion unconditional.
+ */
+function assertFailure<T, E>(result: Result<T, E>): E {
+  expect(result.success).toBe(false)
+  if (result.success === false) {
+    return result.error
+  }
+  // Unreachable after the expect above fails the test, but satisfies the type.
+  throw new Error('assertFailure: result was not a failure')
+}
+
+// ---------------------------------------------------------------------------
+// Happy path tests
+// ---------------------------------------------------------------------------
+
+describe('ensureWorkspaceClone', () => {
+  describe('happy path: auth succeeds and clone succeeds', () => {
+    it('returns the validated workspace path on successful clone', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const expectedPath = workspaceRepoPath(owner, repo)
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(ok({ok: true, path: expectedPath, commit: 'abc123'}))
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      expect(result).toEqual(ok(expectedPath))
+    })
+
+    it('calls authForRepo with the correct owner and repo', async () => {
+      // #given
+      const owner = 'myorg'
+      const repo = 'myrepo'
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(
+        ok({ok: true, path: workspaceRepoPath(owner, repo), commit: 'def456'}),
+      )
+      const logger = makeLogger()
+
+      // #when
+      await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      expect(appClient.authForRepo).toHaveBeenCalledWith(owner, repo)
+    })
+
+    it('calls workspaceClient.clone with owner, repo, and the minted token', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const token = 'ghs_mintedtoken'
+      const appClient = makeAppClient(ok(makeAuthResult(token)))
+      const workspaceClient = makeWorkspaceClient(
+        ok({ok: true, path: workspaceRepoPath(owner, repo), commit: 'abc123'}),
+      )
+      const logger = makeLogger()
+
+      // #when
+      await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      expect(workspaceClient.clone).toHaveBeenCalledWith({owner, repo, token})
+    })
+  })
+
+  describe('happy path: auth succeeds and clone returns repo-exists', () => {
+    it('returns workspaceRepoPath(owner, repo) when clone returns repo-exists', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(err({kind: 'clone-error', code: 'repo-exists'}))
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then — repo-exists is a successful recovery signal
+      expect(result).toEqual(ok(workspaceRepoPath(owner, repo)))
+    })
+
+    it('does not log an error when clone returns repo-exists', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(err({kind: 'clone-error', code: 'repo-exists'}))
+      const logger = makeLogger()
+
+      // #when
+      await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      expect(logger.error).not.toHaveBeenCalled()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Error path: auth failure
+  // ---------------------------------------------------------------------------
+
+  describe('error path: GitHub App auth fails', () => {
+    it('returns auth-failure and does not call clone when authForRepo fails with AuthError', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient(err(new AuthError('token mint failed')))
+      const workspaceClient = makeWorkspaceClient()
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      const failure = assertFailure(result)
+      expect(failure.kind).toBe('auth-failure')
+      expect(workspaceClient.clone).not.toHaveBeenCalled()
+    })
+
+    it('returns auth-failure with reason auth-error when authForRepo fails with AuthError', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient(err(new AuthError('token mint failed')))
+      const workspaceClient = makeWorkspaceClient()
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      const failure = assertFailure(result)
+      expect(failure).toMatchObject({kind: 'auth-failure', reason: 'auth-error'})
+    })
+
+    it('returns auth-failure and does not call clone when authForRepo fails with AppNotInstalledError', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient(
+        err(new AppNotInstalledError(owner, repo, 'https://github.com/apps/fro-bot-agent/installations/new')),
+      )
+      const workspaceClient = makeWorkspaceClient()
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      const failure = assertFailure(result)
+      expect(failure.kind).toBe('auth-failure')
+      expect(workspaceClient.clone).not.toHaveBeenCalled()
+    })
+
+    it('returns auth-failure with reason auth-error when authForRepo fails with AppNotInstalledError', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient(
+        err(new AppNotInstalledError(owner, repo, 'https://github.com/apps/fro-bot-agent/installations/new')),
+      )
+      const workspaceClient = makeWorkspaceClient()
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      const failure = assertFailure(result)
+      expect(failure).toMatchObject({kind: 'auth-failure', reason: 'auth-error'})
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Error path: clone timeout/network/HTTP/parse failure — structured details
+  // ---------------------------------------------------------------------------
+
+  describe('error path: clone timeout/network/HTTP/parse failure', () => {
+    it('returns workspace-failure with workspaceKind timeout when clone returns timeout', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(err({kind: 'timeout'}))
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      const failure = assertFailure(result)
+      expect(failure).toMatchObject({kind: 'workspace-failure', workspaceKind: 'timeout'})
+    })
+
+    it('returns workspace-failure with workspaceKind network-error when clone returns network-error', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(err({kind: 'network-error'}))
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      const failure = assertFailure(result)
+      expect(failure).toMatchObject({kind: 'workspace-failure', workspaceKind: 'network-error'})
+    })
+
+    it('returns workspace-failure with workspaceKind http-error and status when clone returns http-error', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(err({kind: 'http-error', status: 503}))
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      const failure = assertFailure(result)
+      expect(failure).toMatchObject({kind: 'workspace-failure', workspaceKind: 'http-error', status: 503})
+    })
+
+    it('returns workspace-failure with workspaceKind parse-error when clone returns parse-error', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(err({kind: 'parse-error'}))
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      const failure = assertFailure(result)
+      expect(failure).toMatchObject({kind: 'workspace-failure', workspaceKind: 'parse-error'})
+    })
+
+    it('returns workspace-failure with workspaceKind clone-error and code when clone returns a non-repo-exists clone-error', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(err({kind: 'clone-error', code: 'clone-failed'}))
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      const failure = assertFailure(result)
+      expect(failure).toMatchObject({kind: 'workspace-failure', workspaceKind: 'clone-error', code: 'clone-failed'})
+    })
+
+    it('preserves clone-error code for ops/automation (enospc)', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(err({kind: 'clone-error', code: 'enospc'}))
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      const failure = assertFailure(result)
+      expect(failure).toMatchObject({kind: 'workspace-failure', workspaceKind: 'clone-error', code: 'enospc'})
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Error path: clone response mismatch — structured detail
+  // ---------------------------------------------------------------------------
+
+  describe('error path: clone response mismatch', () => {
+    it('returns workspace-failure with workspaceKind response-mismatch and does not synthesize a path', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(err({kind: 'response-mismatch'}))
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then — must fail closed; no path synthesis from bad response
+      const failure = assertFailure(result)
+      expect(failure).toMatchObject({kind: 'workspace-failure', workspaceKind: 'response-mismatch'})
+    })
+
+    it('logs an error on response-mismatch (security signal)', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(err({kind: 'response-mismatch'}))
+      const logger = makeLogger()
+
+      // #when
+      await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      expect(logger.error).toHaveBeenCalled()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Unexpected error path
+  // ---------------------------------------------------------------------------
+
+  describe('error path: unexpected thrown error', () => {
+    it('returns unexpected-error when authForRepo throws synchronously', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient: AppClient = {
+        authForRepo: vi.fn().mockRejectedValue(new Error('unexpected crash')),
+        invalidateCache: vi.fn(),
+      }
+      const workspaceClient = makeWorkspaceClient()
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then
+      const failure = assertFailure(result)
+      expect(failure.kind).toBe('unexpected-error')
+      expect(workspaceClient.clone).not.toHaveBeenCalled()
+    })
+
+    it('unexpected-error carries no raw message (stays coarse)', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient: AppClient = {
+        authForRepo: vi.fn().mockRejectedValue(new Error('sensitive internal detail')),
+        invalidateCache: vi.fn(),
+      }
+      const workspaceClient = makeWorkspaceClient()
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then — no raw message on the returned error
+      const failure = assertFailure(result)
+      expect(failure.kind).toBe('unexpected-error')
+      // The error object must not carry any message property
+      expect(Object.keys(failure)).toEqual(['kind'])
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Auth timeout path
+  // ---------------------------------------------------------------------------
+
+  describe('error path: auth timeout', () => {
+    it('returns auth-failure with reason timeout when authForRepo never resolves and timeoutMs elapses', async () => {
+      // #given — authForRepo hangs forever; inject a very short timeout
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient: AppClient = {
+        authForRepo: vi.fn().mockReturnValue(new Promise<never>(() => {})), // never resolves
+        invalidateCache: vi.fn(),
+      }
+      const workspaceClient = makeWorkspaceClient()
+      const logger = makeLogger()
+
+      // #when — use a 10ms timeout so the test completes quickly
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger, timeoutMs: 10})
+
+      // #then — must return auth-failure with reason timeout (not hang forever)
+      const failure = assertFailure(result)
+      expect(failure).toMatchObject({kind: 'auth-failure', reason: 'timeout'})
+      // clone must NOT have been called (auth never completed)
+      expect(workspaceClient.clone).not.toHaveBeenCalled()
+    })
+
+    it('does NOT time out when authForRepo resolves before timeoutMs', async () => {
+      // #given — authForRepo resolves quickly; timeout is generous
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(
+        ok({ok: true, path: workspaceRepoPath(owner, repo), commit: 'abc123'}),
+      )
+      const logger = makeLogger()
+
+      // #when — 5000ms timeout; auth resolves immediately
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger, timeoutMs: 5000})
+
+      // #then — succeeds normally
+      expect(result).toEqual(ok(workspaceRepoPath(owner, repo)))
+    })
+
+    it('uses default timeout when timeoutMs is not provided (does not hang)', async () => {
+      // #given — authForRepo resolves quickly; no explicit timeout
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(
+        ok({ok: true, path: workspaceRepoPath(owner, repo), commit: 'abc123'}),
+      )
+      const logger = makeLogger()
+
+      // #when — no timeoutMs; should use default and succeed
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then — succeeds normally (default timeout is large enough for a fast mock)
+      expect(result).toEqual(ok(workspaceRepoPath(owner, repo)))
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Type-level: EnsureCloneFailure discriminated union
+  // ---------------------------------------------------------------------------
+
+  describe('EnsureCloneFailure type coverage', () => {
+    it('failure result carries the expected kind discriminant', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient(err(new AuthError('fail')))
+      const workspaceClient = makeWorkspaceClient()
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then — TypeScript discriminated union narrows correctly
+      const failure = assertFailure(result)
+      const typedFailure: EnsureCloneFailure = failure
+      // Runtime assertion: kind must be one of the three valid discriminants.
+      expect(typedFailure.kind).toMatch(/^(auth-failure|workspace-failure|unexpected-error)$/)
+      // Exhaustive compile-time check — the default branch is unreachable if the union is complete.
+      const assertExhaustive = (f: EnsureCloneFailure): void => {
+        switch (f.kind) {
+          case 'auth-failure':
+          case 'workspace-failure':
+          case 'unexpected-error':
+            break
+          default: {
+            const exhaustiveCheck: never = f
+            throw new Error(`Unhandled failure kind: ${JSON.stringify(exhaustiveCheck)}`)
+          }
+        }
+      }
+      assertExhaustive(typedFailure)
+    })
+
+    it('workspace-failure carries workspaceKind for ops/automation', async () => {
+      // #given
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(err({kind: 'http-error', status: 502}))
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then — workspace-failure exposes workspaceKind and status for structured ops/automation use
+      const failure = assertFailure(result)
+      expect(failure).toMatchObject({kind: 'workspace-failure', workspaceKind: 'http-error', status: 502})
+    })
+
+    it('callers can reply generically using only error.kind (coarse Discord reply still works)', async () => {
+      // #given — simulate a caller that only reads error.kind
+      const owner = 'testowner'
+      const repo = 'testrepo'
+      const appClient = makeAppClient()
+      const workspaceClient = makeWorkspaceClient(err({kind: 'http-error', status: 503}))
+      const logger = makeLogger()
+
+      // #when
+      const result = await ensureWorkspaceClone({owner, repo, appClient, workspaceClient, logger})
+
+      // #then — kind alone is sufficient for a coarse reply
+      const failure = assertFailure(result)
+      // This is the only field a Discord reply handler needs to read
+      const replyMessage =
+        failure.kind === 'auth-failure'
+          ? 'workspace auth failed'
+          : failure.kind === 'workspace-failure'
+            ? 'workspace unavailable'
+            : 'unexpected error'
+      expect(replyMessage).toBe('workspace unavailable')
+    })
+  })
+})

--- a/packages/gateway/src/workspace-api/ensure-clone.ts
+++ b/packages/gateway/src/workspace-api/ensure-clone.ts
@@ -1,0 +1,212 @@
+/**
+ * ensureWorkspaceClone — reusable gateway seam for workspace checkout rehydration.
+ *
+ * Guarantees that a workspace checkout exists for a bound repo before mention
+ * execution proceeds. Mints a repo-scoped installation token via the GitHub App
+ * client and calls workspaceClient.clone(), treating `repo-exists` as a
+ * successful recovery signal (idempotent per workspace-agent contract).
+ *
+ * SECURITY INVARIANTS:
+ * - Installation access tokens (ghs_*) are NEVER logged.
+ * - Internal paths, auth details, and S3 keys are NEVER surfaced to callers for
+ *   inclusion in Discord replies — callers receive structured failure kinds only.
+ * - Raw error messages are NEVER included in returned errors (unexpected-error stays coarse).
+ */
+
+import type {Result} from '@fro-bot/runtime'
+import type {AppClient} from '../github/app-client.js'
+import type {WorkspaceClient} from './client.js'
+import type {CloneErrorCode, WorkspaceError} from './types.js'
+
+import {err, ok} from '@fro-bot/runtime'
+import {workspaceRepoPath} from './client.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Structured failure kinds returned by ensureWorkspaceClone.
+ *
+ * - `auth-failure`: GitHub App auth failed or timed out. `reason` distinguishes
+ *   the two sub-cases for ops/automation; callers may ignore it for coarse replies.
+ * - `workspace-failure`: Clone failed. `workspaceKind` mirrors the underlying
+ *   WorkspaceError kind for structured ops/automation use. Additional fields
+ *   (`code`, `status`) are present when the underlying error carries them.
+ *   Callers may reply generically using only `error.kind`.
+ * - `unexpected-error`: Unexpected thrown exception. Stays coarse — no raw message.
+ *
+ * Discord reply handlers MUST use only `error.kind` for user-facing messages.
+ * Ops/automation MAY inspect `reason`, `workspaceKind`, `code`, and `status`.
+ */
+export type EnsureCloneFailure =
+  | {readonly kind: 'auth-failure'; readonly reason?: 'auth-error' | 'timeout'}
+  | WorkspaceFailure
+  | {readonly kind: 'unexpected-error'}
+
+/**
+ * workspace-failure sub-union — mirrors WorkspaceError kinds with structured detail.
+ * The `workspaceKind` field is the discriminant within this variant.
+ */
+export type WorkspaceFailure =
+  | {readonly kind: 'workspace-failure'; readonly workspaceKind: 'clone-error'; readonly code: CloneErrorCode}
+  | {readonly kind: 'workspace-failure'; readonly workspaceKind: 'http-error'; readonly status: number}
+  | {readonly kind: 'workspace-failure'; readonly workspaceKind: 'network-error'}
+  | {readonly kind: 'workspace-failure'; readonly workspaceKind: 'timeout'}
+  | {readonly kind: 'workspace-failure'; readonly workspaceKind: 'parse-error'}
+  | {readonly kind: 'workspace-failure'; readonly workspaceKind: 'response-mismatch'}
+
+/** Default timeout for the GitHub App auth call in milliseconds (30 seconds). */
+export const DEFAULT_ENSURE_CLONE_AUTH_TIMEOUT_MS = 30_000
+
+export interface EnsureCloneDeps {
+  readonly owner: string
+  readonly repo: string
+  readonly appClient: AppClient
+  readonly workspaceClient: WorkspaceClient
+  readonly logger: {
+    readonly info: (msg: string, meta?: Record<string, unknown>) => void
+    readonly warn: (msg: string, meta?: Record<string, unknown>) => void
+    readonly error: (msg: string, meta?: Record<string, unknown>) => void
+  }
+  /**
+   * Timeout in milliseconds for the GitHub App auth call.
+   * Defaults to DEFAULT_ENSURE_CLONE_AUTH_TIMEOUT_MS (30s).
+   * Inject a small value in tests to avoid hanging.
+   */
+  readonly timeoutMs?: number
+}
+
+// ---------------------------------------------------------------------------
+// Helper: map WorkspaceError → WorkspaceFailure
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a WorkspaceError to a WorkspaceFailure, preserving structured detail
+ * (workspaceKind, code, status) for ops/automation while keeping the outer
+ * `kind: 'workspace-failure'` coarse for Discord reply handlers.
+ */
+function toWorkspaceFailure(error: WorkspaceError): WorkspaceFailure {
+  switch (error.kind) {
+    case 'clone-error':
+      return {kind: 'workspace-failure', workspaceKind: 'clone-error', code: error.code}
+    case 'http-error':
+      return {kind: 'workspace-failure', workspaceKind: 'http-error', status: error.status}
+    case 'network-error':
+      return {kind: 'workspace-failure', workspaceKind: 'network-error'}
+    case 'timeout':
+      return {kind: 'workspace-failure', workspaceKind: 'timeout'}
+    case 'parse-error':
+      return {kind: 'workspace-failure', workspaceKind: 'parse-error'}
+    case 'response-mismatch':
+      return {kind: 'workspace-failure', workspaceKind: 'response-mismatch'}
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main function
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure a workspace checkout exists for the given owner/repo.
+ *
+ * Flow:
+ * 1. Mint a repo-scoped installation token via appClient.authForRepo().
+ * 2. Call workspaceClient.clone({owner, repo, token}).
+ * 3. On clone success: return the validated path from the clone response.
+ * 4. On clone-error/repo-exists: return workspaceRepoPath(owner, repo) — the
+ *    checkout already exists; this is a successful recovery signal.
+ * 5. On any other failure: return a structured EnsureCloneFailure.
+ *
+ * Returns:
+ * - `ok(path)` — checkout exists at the returned path.
+ * - `err({kind: 'auth-failure', reason: 'auth-error'})` — GitHub App auth failed.
+ * - `err({kind: 'auth-failure', reason: 'timeout'})` — GitHub App auth timed out.
+ * - `err({kind: 'workspace-failure', workspaceKind, ...})` — clone failed with
+ *   structured detail (workspaceKind mirrors WorkspaceError kind; http-error
+ *   includes status; clone-error includes code; response-mismatch is distinguishable).
+ * - `err({kind: 'unexpected-error'})` — unexpected thrown exception (coarse, no message).
+ *
+ * Discord reply handlers MUST use only `error.kind` for user-facing messages.
+ */
+export async function ensureWorkspaceClone(deps: EnsureCloneDeps): Promise<Result<string, EnsureCloneFailure>> {
+  const {owner, repo, appClient, workspaceClient, logger, timeoutMs = DEFAULT_ENSURE_CLONE_AUTH_TIMEOUT_MS} = deps
+
+  try {
+    // Stage 1: Mint a repo-scoped installation token with a bounded timeout.
+    // Without a timeout, a hung GitHub API call would block the mention handler indefinitely.
+    // Use a sentinel class so we can distinguish a timeout from a real thrown error.
+    class AuthTimeoutError extends Error {
+      constructor() {
+        super('auth-timeout')
+        this.name = 'AuthTimeoutError'
+      }
+    }
+    const authPromise = appClient.authForRepo(owner, repo)
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(() => reject(new AuthTimeoutError()), timeoutMs)
+    })
+    let authResult: Awaited<ReturnType<typeof appClient.authForRepo>>
+    try {
+      authResult = await Promise.race([authPromise, timeoutPromise])
+    } catch (raceError: unknown) {
+      if (raceError instanceof AuthTimeoutError) {
+        // Timeout — treat as auth-failure with reason 'timeout'.
+        logger.warn('ensure-clone: app auth timed out', {owner, repo, timeoutMs})
+        return err({kind: 'auth-failure', reason: 'timeout'})
+      }
+      // Real thrown error — re-throw so the outer catch handles it as unexpected-error.
+      throw raceError
+    } finally {
+      clearTimeout(timeoutHandle)
+    }
+    if (authResult.success === false) {
+      logger.warn('ensure-clone: app auth failed', {
+        owner,
+        repo,
+        errorKind: authResult.error.constructor.name,
+      })
+      return err({kind: 'auth-failure', reason: 'auth-error'})
+    }
+
+    // SECURITY: token is never logged.
+    const {token} = authResult.data
+
+    // Stage 2: Clone (or confirm existing checkout).
+    const cloneResult = await workspaceClient.clone({owner, repo, token})
+
+    if (cloneResult.success === true) {
+      // Fresh clone succeeded — return the validated path from the response.
+      logger.info('ensure-clone: clone succeeded', {owner, repo})
+      return ok(cloneResult.data.path)
+    }
+
+    const cloneError = cloneResult.error
+
+    // repo-exists is a successful recovery signal: the checkout already exists.
+    if (cloneError.kind === 'clone-error' && cloneError.code === 'repo-exists') {
+      logger.info('ensure-clone: repo-exists, checkout already present', {owner, repo})
+      return ok(workspaceRepoPath(owner, repo))
+    }
+
+    // response-mismatch is a security signal — log at error level, fail closed.
+    if (cloneError.kind === 'response-mismatch') {
+      logger.error('ensure-clone: response-mismatch from workspace agent', {owner, repo})
+      return err(toWorkspaceFailure(cloneError))
+    }
+
+    // All other clone failures: timeout, network-error, http-error, parse-error,
+    // or non-recoverable clone-error codes. Preserve structured detail.
+    logger.warn('ensure-clone: clone failed', {owner, repo, workspaceKind: cloneError.kind})
+    return err(toWorkspaceFailure(cloneError))
+  } catch (error) {
+    logger.error('ensure-clone: unexpected error', {
+      owner,
+      repo,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    // SECURITY: raw message is never included in the returned error.
+    return err({kind: 'unexpected-error'})
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #791 by making workspace repository checkouts durable across normal workspace container recreation and by repairing stale bound-channel checkouts before OpenCode starts.

## Changes

- Mount `/workspace/repos` on a named `workspace-repos` Docker volume and validate the topology in deploy checks.
- Document that `docker compose down -v` deletes cloned repositories and that the next bound-channel mention can rehydrate the checkout.
- Add Gateway mention-time clone assurance inside the run concurrency gate, before readiness checks and OpenCode execution.
- Use the ensured canonical workspace path for approval registration and OpenCode execution instead of trusting a stored binding path.
- Scope GitHub App installation tokens to the requested repository for clone/recovery operations.
- Harden workspace-agent `repo-exists` handling so empty, non-worktree, bare, corrupt, or escaped paths do not count as valid checkouts.
- Keep Discord replies coarse and move internal storage paths/keys/error details out of user-facing messages.

## Verification

- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `bash deploy/validate-stack.test.sh`
- `bash deploy/validate-stack.sh --topology-only`
- `pnpm --filter workspace-agent exec vitest run src/clone.test.ts`
- `pnpm --filter @fro-bot/gateway exec vitest run src/execute/run.test.ts src/discord/commands/add-project.test.ts src/program.test.ts src/discord/mentions.test.ts src/github/app-client.test.ts src/workspace-api/ensure-clone.test.ts`