### PR TITLE
test(gateway): stabilize approval deadline budget test

### DIFF
--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -1587,14 +1587,14 @@ describe('runMention', () => {
       setupHappyPath()
 
       const SIMULATED_ELAPSED_MS = 5_000 // 5 s of simulated setup time
+      const SIMULATED_START_MS = 1_700_000_000_000
       const runTimeoutMs = 600_000
       let callCount = 0
-      const originalDateNow = Date.now.bind(Date)
       const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => {
         // First call: runStartMs capture at run entry → return base time
         // Subsequent calls: simulate elapsed setup time
         callCount++
-        return callCount === 1 ? originalDateNow() : originalDateNow() + SIMULATED_ELAPSED_MS
+        return callCount === 1 ? SIMULATED_START_MS : SIMULATED_START_MS + SIMULATED_ELAPSED_MS
       })
 
       const thread = makeThread()
@@ -1655,14 +1655,14 @@ describe('runMention', () => {
       setupHappyPath()
 
       const SIMULATED_ELAPSED_MS = 5_000 // 5 s of simulated setup time
+      const SIMULATED_START_MS = 1_700_000_000_000
       const runTimeoutMs = 600_000
       let callCount = 0
-      const originalDateNow = Date.now.bind(Date)
       const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => {
         // First call: runStartMs capture at run entry → return base time
         // Subsequent calls: simulate elapsed setup time
         callCount++
-        return callCount === 1 ? originalDateNow() : originalDateNow() + SIMULATED_ELAPSED_MS
+        return callCount === 1 ? SIMULATED_START_MS : SIMULATED_START_MS + SIMULATED_ELAPSED_MS
       })
 
       const abortTimeoutSpy = vi.spyOn(AbortSignal, 'timeout')


### PR DESCRIPTION
## Summary

Fixes a flaky Gateway approval-deadline test that breaks `main` CI by removing real wall-clock drift from the mocked `Date.now()` sequence.

## What changed

- Uses a fixed simulated start timestamp in the approval-deadline budget test.
- Applies the same deterministic clock setup to the adjacent hard-abort budget test.
- Keeps production code unchanged.

## Verification

- Reproduced the flaky assertion locally: expected `297500`, received `297498`.
- `pnpm exec vitest run packages/gateway/src/execute/run.test.ts -t "approval deadline uses remaining budget"`
- `pnpm exec vitest run packages/gateway/src/execute/run.test.ts -t "hard abort signal and approval deadline"`
- `pnpm exec vitest run packages/gateway/src/execute/run.test.ts`
- `pnpm --filter @fro-bot/gateway check-types`
- `pnpm --filter @fro-bot/gateway lint`
- `pnpm --filter @fro-bot/gateway test -- packages/gateway/src/execute/run.test.ts`