### PR TITLE
fix(gateway): clarify timeout after visible output

### DIFF
--- a/docs/plans/2026-06-06-001-fix-discord-timeout-partial-output-plan.md
+++ b/docs/plans/2026-06-06-001-fix-discord-timeout-partial-output-plan.md
@@ -1,0 +1,210 @@
+---
+title: fix: Improve Discord timeout messaging after partial output
+type: fix
+status: active
+date: 2026-06-06
+---
+
+# fix: Improve Discord timeout messaging after partial output
+
+## Overview
+
+Discord mention runs that hit the gateway wall-clock timeout after delivering visible output currently end with the same generic timeout message used for no-output failures. This plan keeps the existing timeout/failure semantics, but makes the terminal Discord message reflect whether useful partial output was already delivered and includes the configured timeout duration.
+
+## Problem Frame
+
+Issue #801 reports a Discord mention run that produced useful partial output and tool activity, then posted `The task timed out. Please try again.` after the 10-minute gateway deadline. That message makes a partial-success timeout look like a total failure and gives poor continuation guidance.
+
+Fro Bot’s triage identified the likely seam: the mention run already has access to output visibility state through the Discord stream sink, and the timeout message is selected in `packages/gateway/src/execute/run.ts` after the failure-path flush.
+
+## Requirements Trace
+
+- R1. Timeout messages distinguish runs that already delivered visible partial output from runs that delivered no visible output.
+- R2. Timeout messages include the configured gateway run timeout duration instead of a hardcoded or absent limit.
+- R3. Run lifecycle semantics stay unchanged: a gateway timeout remains a failed run and keeps the existing flush-before-error-message sequence.
+- R4. User-facing timeout text stays coarse and non-leaky; it must not expose internal paths, stack traces, provider details, or low-level gateway state.
+- R5. Active-streaming timeout extensions and alternate success/partial-success states are deferred.
+
+## Scope Boundaries
+
+- This plan only changes Discord mention timeout classification and copy.
+- This plan does not extend the run timeout, add heartbeat-based timeout policy, or change the default timeout.
+- This plan does not change stored run phase/state semantics; timeout remains failure.
+- This plan does not change premature stream-close (`stream-ended`) messaging.
+- This plan does not suppress the existing no-output flush behavior on error paths.
+
+### Deferred to Separate Tasks
+
+- Active streaming/heartbeat timeout policy: decide separately whether actively producing runs should get a longer deadline.
+- Error-path empty-output suppression: decide separately whether `_(no output)_` should be omitted when an error message follows.
+- `stream-ended` partial-output messaging: adjacent behavior, but out of scope for #801’s timeout-specific fix.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/gateway/src/execute/run.ts`: owns `runMention()` lifecycle, failure-path sink flush, and user-facing error message selection.
+- `packages/gateway/src/discord/streaming.ts`: owns buffered output flushing and `markVisibleOutputSent()` visibility tracking.
+- `packages/gateway/src/execute/run-core.ts`: throws `RunCoreError('timeout', ...)` when the gateway deadline aborts execution.
+- `packages/gateway/src/execute/run.test.ts`: existing run-level timeout/error-path coverage.
+- `packages/gateway/src/discord/streaming.test.ts`: sink behavior coverage.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/gateway-opencode-mention-loop-best-practices-2026-05-30.md`: failure paths should flush buffered output before the coarse error reply; partial output must be best-effort and must not mask the original error.
+- `packages/gateway/AGENTS.md`: Discord failure replies should stay generic and non-leaky.
+- `docs/plans/2026-05-30-001-feat-gateway-unit-6-mention-loop-plan.md`: mention-loop output cadence is final flush on completion plus failure-path flush for partial progress, not chatty incremental streaming.
+
+### External References
+
+- None. Local Gateway patterns are sufficient for this focused behavior change.
+
+## Key Technical Decisions
+
+- Capture output visibility before choosing timeout copy: the timeout message should be based on the sink’s visible-output state after the failure-path flush completes.
+- Append a terminal timeout note even when partial output was delivered: users need a clear signal that the run ended and that a follow-up message can continue the work.
+- Include timeout duration in both timeout branches: operator-configured limits should be visible to users without implying an internal failure.
+- Do not reclassify timeout as success or partial success: preserving `FAILED` avoids changing run coordination, cleanup, and downstream monitoring semantics.
+- Do not broaden to `stream-ended`: although the flow is adjacent, issue #801 and Fro Bot triage are timeout-specific.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should timeout messages always be posted after partial output? Yes — append a context-aware terminal timeout note rather than suppressing it.
+- Should `stream-ended` be included? No — defer it to keep this plan tight.
+- Should empty-output suppression be included? No — keep current no-output flush behavior and only improve timeout copy.
+
+### Deferred to Implementation
+
+- Exact timeout duration formatting: implement using the simplest readable helper that keeps configured values accurate and testable.
+  - **Resolved:** `formatTimeoutDuration` produces compound minute+second strings for non-integral minutes (e.g. 90_000 → "1 minute 30 seconds", 600_000 → "10 minutes", 45_000 → "45 seconds"). Exported for direct unit testing.
+- Exact message wording: keep the issue's intent, but allow implementation to tune copy for clarity and current project style.
+  - **Resolved:** Visible-output branch: "The task reached the `<duration>` time limit after posting updates above. Start a new @fro-bot request with what to do next and include any needed context from the output above." No-output branch: "The task reached the `<duration>` time limit. Please try again." Both branches avoid "gateway timeout" and internal implementation terms.
+
+## Implementation Units
+
+- [x] **Unit 1: Expose sink visible-output state**
+
+**Goal:** Make the Discord stream sink’s existing visible-output tracking readable by the mention run error classifier.
+
+**Requirements:** R1, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/gateway/src/discord/streaming.ts`
+- Test: `packages/gateway/src/discord/streaming.test.ts`
+
+**Approach:**
+- Extend the existing sink contract with a read-only predicate/accessor for whether visible output has been sent.
+- Reuse the state already updated by `markVisibleOutputSent()`; do not add a second visibility flag with different semantics.
+- Keep visibility one-way for a run: once visible output has been marked, later flush results should not reset it.
+
+**Execution note:** Implement the sink behavior test-first.
+
+**Patterns to follow:**
+- Existing sink methods in `packages/gateway/src/discord/streaming.ts`.
+- Existing visibility tests around `markVisibleOutputSent()` and skipped visible output behavior.
+
+**Test scenarios:**
+- Happy path: newly created sink reports no visible output.
+- Happy path: after `markVisibleOutputSent()`, the sink reports visible output.
+- Edge case: flushing an empty buffer does not itself reset visible-output state.
+
+**Verification:**
+- Sink tests prove the accessor reflects the existing visibility marker without changing flush behavior.
+
+- [x] **Unit 2: Branch timeout copy using visibility state**
+
+**Goal:** Make timeout failure messages context-aware while preserving failure semantics and message ordering.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/gateway/src/execute/run.ts`
+- Test: `packages/gateway/src/execute/run.test.ts`
+
+**Approach:**
+- Keep the current error path order: flush buffered output first, then send the terminal error message.
+- For `RunCoreError('timeout')`, inspect visible-output state after the flush attempt.
+- When visible output exists, send timeout copy that says the time limit was hit after posting updates and tells the user to start a new @fro-bot request with the next instruction/context.
+- When visible output does not exist, send timeout copy that includes the configured duration and keeps retry guidance generic.
+- Keep non-timeout error messages unchanged.
+
+**Execution note:** Add failing run-level tests for both timeout branches before changing the classifier.
+
+**Patterns to follow:**
+- Existing `RunCoreError` type checks in `packages/gateway/src/execute/run.ts`.
+- Existing Discord send safety (`allowedMentions: { parse: [] }`) in run-level replies.
+- Existing timeout-duration tests around approval deadline/hard abort behavior.
+
+**Test scenarios:**
+- Timeout with partial text output flushed: final message acknowledges partial output and continuation guidance.
+- Timeout with attachment output flushed: final message follows the partial-output branch.
+- Timeout after only visibility marker output, such as an approval waiting/status message: final message follows the partial-output branch without changing approval settlement behavior.
+- Timeout with no visible output: final message includes the configured duration and does not use partial-output continuation wording.
+- Error path ordering: flush completes before the timeout message is sent.
+- Regression: reachability, empty prompt, stream-ended, and generic failure messages remain unchanged.
+
+**Verification:**
+- Run-level tests prove timeout copy branches on visibility while preserving existing error classifications.
+
+- [x] **Unit 3: Document deferred timeout-policy scope**
+
+**Goal:** Make it clear in the durable plan/issue context that #801 fixes messaging only, not timeout policy.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `docs/plans/2026-06-06-001-fix-discord-timeout-partial-output-plan.md`
+
+**Approach:**
+- Keep this plan’s scope boundary explicit so implementation review does not expand into timeout extension or success-state changes.
+- If implementation discovers useful follow-up work, track it separately rather than folding it into this fix.
+
+**Patterns to follow:**
+- Existing plan scope-boundary style in `docs/plans/`.
+
+**Test scenarios:**
+- Test expectation: none — documentation/scope tracking only.
+
+**Verification:**
+- The plan remains aligned with issue #801 and Fro Bot’s triage after implementation updates.
+
+## System-Wide Impact
+
+- **Interaction graph:** Discord mention error path only; no change to workspace clone, binding lookup, OpenCode execution, or approval reply APIs.
+- **Error propagation:** Timeout remains a `RunCoreError('timeout')` and still reports as failed; only the terminal Discord message changes.
+- **State lifecycle risks:** Partial-output visibility is read-only from the classifier; it should not alter flush buffering, run storage, or lock cleanup.
+- **API surface parity:** No public API or environment variable changes.
+- **Integration coverage:** Run-level tests should cover the end-to-end failure path from simulated timeout through flush and Discord reply.
+- **Unchanged invariants:** Failure-path partial output is best-effort; flush failures must not mask the original timeout.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Timeout copy leaks implementation detail | Keep text coarse: mention configured gateway timeout and continuation guidance only. |
+| Visibility accessor drifts from flush result semantics | Reuse the existing sink visibility flag rather than deriving a second state. |
+| Tests overfit exact copy | Assert key behavioral phrases/duration/branching while allowing minor wording adjustments. |
+| Scope creep into timeout policy | Keep timeout extension and success-state changes deferred. |
+
+## Documentation / Operational Notes
+
+- No operator docs are required for the messaging-only fix.
+- If a future timeout-policy change is planned, it should start from issue #801’s deferred notes but land separately.
+
+## Sources & References
+
+- Issue: [#801 Improve Discord mention timeout messaging after partial output](https://github.com/fro-bot/agent/issues/801)
+- Fro Bot triage comment on #801
+- Related code: `packages/gateway/src/execute/run.ts`
+- Related code: `packages/gateway/src/discord/streaming.ts`
+- Related tests: `packages/gateway/src/execute/run.test.ts`
+- Related tests: `packages/gateway/src/discord/streaming.test.ts`
+- Related learning: `docs/solutions/best-practices/gateway-opencode-mention-loop-best-practices-2026-05-30.md`

--- a/packages/gateway/src/discord/streaming.test.ts
+++ b/packages/gateway/src/discord/streaming.test.ts
@@ -281,6 +281,124 @@ describe('createDiscordStreamSink', () => {
 
   // ── Unit 4: markVisibleOutputSent — approval status prevents _(no output)_ ──
 
+  // ── Unit 1: hasVisibleOutput() — read-only predicate for visible-output state ──
+
+  describe('hasVisibleOutput()', () => {
+    it('returns false on a newly created sink', () => {
+      // #given
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+
+      // #when / #then
+      expect(sink.hasVisibleOutput()).toBe(false)
+    })
+
+    it('returns true after markVisibleOutputSent() is called', () => {
+      // #given
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      sink.markVisibleOutputSent()
+
+      // #when / #then
+      expect(sink.hasVisibleOutput()).toBe(true)
+    })
+
+    it('flushing an empty buffer does not reset visible-output state to false', async () => {
+      // #given — mark visible output, then flush an empty buffer
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      sink.markVisibleOutputSent()
+      await sink.flush() // returns skipped-visible; must not reset the flag
+
+      // #when / #then — still true after flush
+      expect(sink.hasVisibleOutput()).toBe(true)
+    })
+
+    it('flushing buffered text does not reset visible-output state', async () => {
+      // #given — mark visible output, append text, flush
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      sink.markVisibleOutputSent()
+      sink.append('some output')
+      await sink.flush()
+
+      // #when / #then — still true after flush
+      expect(sink.hasVisibleOutput()).toBe(true)
+    })
+
+    // ── flush() sets hasVisibleOutput — the core missing cases ──
+
+    it('returns true after flush() returns {kind:"sent"}', async () => {
+      // #given — short text, no prior markVisibleOutputSent
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      sink.append(SHORT_TEXT)
+
+      // #when
+      const result = await sink.flush()
+
+      // #then — flush succeeded with sent, so visible output is now true
+      expect(result.kind).toBe('sent')
+      expect(sink.hasVisibleOutput()).toBe(true)
+    })
+
+    it('returns true after flush() returns {kind:"attachment"}', async () => {
+      // #given — long text triggers attachment path
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      sink.append(LONG_TEXT)
+
+      // #when
+      const result = await sink.flush()
+
+      // #then — attachment was sent, so visible output is now true
+      expect(result.kind).toBe('attachment')
+      expect(sink.hasVisibleOutput()).toBe(true)
+    })
+
+    it('remains false after flush() returns {kind:"empty"}', async () => {
+      // #given — empty buffer, no prior markVisibleOutputSent
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+
+      // #when
+      const result = await sink.flush()
+
+      // #then — _(no output)_ is not "visible output" from the agent
+      expect(result.kind).toBe('empty')
+      expect(sink.hasVisibleOutput()).toBe(false)
+    })
+
+    it('remains true after flush() returns {kind:"skipped-visible"}', async () => {
+      // #given — visible output already marked, empty buffer
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      sink.markVisibleOutputSent()
+
+      // #when
+      const result = await sink.flush()
+
+      // #then — skipped-visible means output was already sent; flag stays true
+      expect(result.kind).toBe('skipped-visible')
+      expect(sink.hasVisibleOutput()).toBe(true)
+    })
+
+    it('remains false after flush() returns {kind:"error"} on a failed send', async () => {
+      // #given — send fails; no visible output was actually delivered
+      const sendFn = vi.fn().mockRejectedValue(new Error('Missing Permissions'))
+      const thread = makeThread(sendFn)
+      const sink = createDiscordStreamSink(thread)
+      sink.append(SHORT_TEXT)
+
+      // #when
+      const result = await sink.flush()
+
+      // #then — error means nothing was delivered; flag stays false
+      expect(result.kind).toBe('error')
+      expect(sink.hasVisibleOutput()).toBe(false)
+    })
+  })
+
   describe('markVisibleOutputSent()', () => {
     it('flush returns {kind:"skipped-visible"} instead of posting _(no output)_ when visible output was already sent', async () => {
       // #given — nothing appended to buffer, but visible output was already posted (e.g. approval status)

--- a/packages/gateway/src/discord/streaming.ts
+++ b/packages/gateway/src/discord/streaming.ts
@@ -116,6 +116,15 @@ export interface DiscordStreamSink {
    * Has no effect when the buffer contains non-whitespace text (text always flushes normally).
    */
   readonly markVisibleOutputSent: () => void
+  /**
+   * Returns `true` if visible output has been sent to the thread — either via
+   * `markVisibleOutputSent()` or via a successful flush of buffered text.
+   * Read-only; never resets once set.
+   *
+   * Use this to decide whether a timeout or error message should acknowledge
+   * partial output rather than treating the run as having produced nothing.
+   */
+  readonly hasVisibleOutput: () => boolean
 }
 
 /**
@@ -138,6 +147,8 @@ export function createDiscordStreamSink(thread: SinkThread, deps: StreamSinkDeps
   const markVisibleOutputSent = (): void => {
     visibleOutputSent = true
   }
+
+  const hasVisibleOutput = (): boolean => visibleOutputSent
 
   const flush = async (): Promise<FlushResult> => {
     const text = buffer
@@ -164,6 +175,7 @@ export function createDiscordStreamSink(thread: SinkThread, deps: StreamSinkDeps
       try {
         const attachment = new AttachmentBuilder(Buffer.from(text, 'utf-8'), {name: 'response.md'})
         await safeSend(thread, {content: LONG_OUTPUT_SUMMARY, files: [attachment]})
+        visibleOutputSent = true
         return {kind: 'attachment', charCount: text.length}
       } catch (sendError) {
         const message = sendError instanceof Error ? sendError.message : String(sendError)
@@ -175,6 +187,7 @@ export function createDiscordStreamSink(thread: SinkThread, deps: StreamSinkDeps
     // Short output → single message
     try {
       await safeSend(thread, {content: text})
+      visibleOutputSent = true
       return {kind: 'sent', charCount: text.length}
     } catch (sendError) {
       const message = sendError instanceof Error ? sendError.message : String(sendError)
@@ -183,5 +196,5 @@ export function createDiscordStreamSink(thread: SinkThread, deps: StreamSinkDeps
     }
   }
 
-  return {append, flush, buffered, markVisibleOutputSent}
+  return {append, flush, buffered, markVisibleOutputSent, hasVisibleOutput}
 }

--- a/packages/gateway/src/execute/run-core.test.ts
+++ b/packages/gateway/src/execute/run-core.test.ts
@@ -34,6 +34,7 @@ function makeSink(): DiscordStreamSink & {readonly _appended: string[]} {
     flush: vi.fn().mockResolvedValue({kind: 'sent', charCount: buffer.length}),
     buffered: () => buffer,
     markVisibleOutputSent: vi.fn(),
+    hasVisibleOutput: vi.fn().mockReturnValue(false),
   }
 }
 

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -12,6 +12,7 @@ import * as streamingModule from '../discord/streaming.js'
 import * as attachModule from './opencode-attach.js'
 import * as promptModule from './prompt.js'
 import * as runCoreModule from './run-core.js'
+import {formatTimeoutDuration} from './run.js'
 
 // ---------------------------------------------------------------------------
 // Mock external collaborators so run.test.ts does not need real AWS/S3/Discord
@@ -61,6 +62,7 @@ vi.mock('../discord/streaming.js', () => ({
     flush: vi.fn().mockResolvedValue({kind: 'sent', charCount: 10}),
     buffered: vi.fn().mockReturnValue(''),
     markVisibleOutputSent: vi.fn(),
+    hasVisibleOutput: vi.fn().mockReturnValue(false),
   }),
 }))
 
@@ -169,6 +171,60 @@ function makeDefaultConcurrency() {
   }
 }
 
+/**
+ * Build a stream-sink mock with sensible defaults. Pass overrides to customise
+ * individual methods without repeating the full literal in every test.
+ */
+function makeStreamSinkMock(
+  overrides: {
+    append?: ReturnType<typeof vi.fn>
+    flush?: ReturnType<typeof vi.fn>
+    buffered?: ReturnType<typeof vi.fn>
+    markVisibleOutputSent?: ReturnType<typeof vi.fn>
+    hasVisibleOutput?: ReturnType<typeof vi.fn>
+  } = {},
+) {
+  return {
+    append: overrides.append ?? vi.fn(),
+    flush: overrides.flush ?? vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 10}),
+    buffered: overrides.buffered ?? vi.fn().mockReturnValue(''),
+    markVisibleOutputSent: overrides.markVisibleOutputSent ?? vi.fn(),
+    hasVisibleOutput: overrides.hasVisibleOutput ?? vi.fn().mockReturnValue(false),
+  }
+}
+
+/**
+ * Build a stateful stream-sink mock where flush() sets the visible flag and
+ * hasVisibleOutput() reads it. Simulates the real sink's post-flush visibility
+ * state so tests can prove the timeout classifier reads state AFTER flush.
+ *
+ * @param flushKind - the kind returned by flush() (determines whether visible is set)
+ * @param flushShouldSetVisible - when true, flush() sets visible=true (simulates sent/attachment)
+ */
+function makeStatefulSinkMock(
+  flushKind: 'sent' | 'attachment' | 'empty' | 'skipped-visible',
+  flushShouldSetVisible: boolean,
+) {
+  let visible = false
+  const flushFn = vi.fn().mockImplementation(async () => {
+    if (flushShouldSetVisible) visible = true
+    if (flushKind === 'sent') return {kind: 'sent' as const, charCount: 10}
+    if (flushKind === 'attachment') return {kind: 'attachment' as const, charCount: 3000}
+    if (flushKind === 'skipped-visible') return {kind: 'skipped-visible' as const}
+    return {kind: 'empty' as const}
+  })
+  const hasVisibleOutputFn = vi.fn().mockImplementation(() => visible)
+  return {
+    append: vi.fn(),
+    flush: flushFn,
+    buffered: vi.fn().mockReturnValue(''),
+    markVisibleOutputSent: vi.fn().mockImplementation(() => {
+      visible = true
+    }),
+    hasVisibleOutput: hasVisibleOutputFn,
+  }
+}
+
 function makeEnsureCloneFn(result: 'success' | 'failure' = 'success') {
   return result === 'success'
     ? vi.fn().mockResolvedValue({success: true as const, data: '/workspace/acme/widget'})
@@ -229,12 +285,9 @@ function setupHappyPath(heartbeatOverrides?: {start?: ReturnType<typeof vi.fn>; 
       })) as unknown as HeartbeatController['stop'],
     isRunning: false,
   })
-  mockCreateDiscordStreamSink.mockReturnValue({
-    append: vi.fn(),
-    flush: vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 10}),
-    buffered: vi.fn().mockReturnValue(''),
-    markVisibleOutputSent: vi.fn(),
-  })
+  mockCreateDiscordStreamSink.mockReturnValue(
+    makeStreamSinkMock() as unknown as ReturnType<typeof streamingModule.createDiscordStreamSink>,
+  )
   mockRunOpenCodeCore.mockResolvedValue(undefined)
   vi.mocked(attachModule.attachOpencode).mockReturnValue({
     server: {url: 'http://workspace:9200'},
@@ -662,6 +715,7 @@ describe('runMention', () => {
         flush: flushMock,
         buffered: vi.fn().mockReturnValue(''),
         markVisibleOutputSent: vi.fn(),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
       })
 
       const deps = makeDeps()
@@ -829,6 +883,7 @@ describe('runMention', () => {
         flush: flushMock,
         buffered: vi.fn().mockReturnValue('partial output'),
         markVisibleOutputSent: vi.fn(),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
 
@@ -841,9 +896,268 @@ describe('runMention', () => {
 
       // #then — flush called on error path
       expect(flushMock).toHaveBeenCalledOnce()
-      // #and — error message sent after flush
+      // #and — error message sent after flush (last send is the timeout message)
       const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
-      expect(lastCall.content).toContain('timed out')
+      expect(lastCall.content).toMatch(/time.?limit|timed? ?out/i)
+    })
+
+    // ── Timeout copy branching (Unit 2) ─────────────────────────────────────
+
+    it('timeout with no visible output: message includes configured duration and generic retry guidance', async () => {
+      // #given — no visible output; runTimeoutMs = 600_000 (10 min)
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: vi.fn().mockResolvedValue({kind: 'empty' as const}),
+        buffered: vi.fn().mockReturnValue(''),
+        markVisibleOutputSent: vi.fn(),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
+      })
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({runTimeoutMs: 600_000})
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — message includes the configured timeout duration
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).toMatch(/10.?min/i)
+      // #and — does NOT use partial-output continuation wording
+      expect(lastCall.content).not.toMatch(/partial|continue|follow.?up/i)
+    })
+
+    it('timeout with no visible output: message does not leak internal error detail', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: vi.fn().mockResolvedValue({kind: 'empty' as const}),
+        buffered: vi.fn().mockReturnValue(''),
+        markVisibleOutputSent: vi.fn(),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
+      })
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'AbortError: signal timed out'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — no internal error detail in message
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).not.toContain('AbortError')
+      expect(lastCall.content).not.toContain('signal timed out')
+    })
+
+    it('timeout with visible text output: message acknowledges visible updates and gives new-request guidance', async () => {
+      // #given — visible output was flushed (text sent to thread)
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 42}),
+        buffered: vi.fn().mockReturnValue('some partial output'),
+        markVisibleOutputSent: vi.fn(),
+        hasVisibleOutput: vi.fn().mockReturnValue(true),
+      })
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({runTimeoutMs: 600_000})
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — message acknowledges visible updates
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).toMatch(/updates above/i)
+      // #and — gives explicit new-request guidance
+      expect(lastCall.content).toMatch(/new.*@fro-bot request|what to do next/i)
+      // #and — includes configured timeout duration
+      expect(lastCall.content).toMatch(/10.?min/i)
+    })
+
+    it('timeout with visible attachment output: message follows the visible-output branch', async () => {
+      // #given — visible output was flushed as an attachment
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: vi.fn().mockResolvedValue({kind: 'attachment' as const, charCount: 3000}),
+        buffered: vi.fn().mockReturnValue('x'.repeat(3000)),
+        markVisibleOutputSent: vi.fn(),
+        hasVisibleOutput: vi.fn().mockReturnValue(true),
+      })
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({runTimeoutMs: 600_000})
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — visible-output branch: new-request guidance present
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).toMatch(/new.*@fro-bot request|what to do next/i)
+      // #and — does NOT use no-output wording
+      expect(lastCall.content).not.toMatch(/try again/i)
+    })
+
+    it('timeout with approval-status visible output: message follows the visible-output branch', async () => {
+      // #given — approval waiting status was sent (markVisibleOutputSent called), no buffered text
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: vi.fn().mockResolvedValue({kind: 'skipped-visible' as const}),
+        buffered: vi.fn().mockReturnValue(''),
+        markVisibleOutputSent: vi.fn(),
+        hasVisibleOutput: vi.fn().mockReturnValue(true),
+      })
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({runTimeoutMs: 600_000})
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — visible-output branch: new-request guidance present
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).toMatch(/new.*@fro-bot request|what to do next/i)
+    })
+
+    it('timeout: flush completes before the timeout message is sent (ordering invariant)', async () => {
+      // #given — track call order
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      const callOrder: string[] = []
+      const flushMock = vi.fn().mockImplementation(async () => {
+        callOrder.push('flush')
+        return {kind: 'sent' as const, charCount: 5}
+      })
+      const thread = makeThread()
+      thread.send.mockImplementation((opts: unknown) => {
+        callOrder.push('send')
+        return opts
+      })
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: flushMock,
+        buffered: vi.fn().mockReturnValue('partial'),
+        markVisibleOutputSent: vi.fn(),
+        hasVisibleOutput: vi.fn().mockReturnValue(true),
+      })
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
+
+      const message = makeMessage(thread)
+      const deps = makeDeps()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — flush happened before the final send
+      const flushIdx = callOrder.indexOf('flush')
+      const lastSendIdx = callOrder.lastIndexOf('send')
+      expect(flushIdx).toBeGreaterThanOrEqual(0)
+      expect(lastSendIdx).toBeGreaterThan(flushIdx)
+    })
+
+    it('regression: stream-ended message is unchanged by timeout branching', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 5}),
+        buffered: vi.fn().mockReturnValue('partial'),
+        markVisibleOutputSent: vi.fn(),
+        hasVisibleOutput: vi.fn().mockReturnValue(true), // visible output present — but stream-ended, not timeout
+      })
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('stream-ended', 'stream closed'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — stream-ended message is unchanged
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).toContain('stream closed unexpectedly')
+      // #and — does NOT use timeout-specific wording
+      expect(lastCall.content).not.toMatch(/timed? ?out/i)
+    })
+
+    it('regression: generic failure message is unchanged by timeout branching', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 5}),
+        buffered: vi.fn().mockReturnValue('partial'),
+        markVisibleOutputSent: vi.fn(),
+        hasVisibleOutput: vi.fn().mockReturnValue(true),
+      })
+      mockRunOpenCodeCore.mockRejectedValue(new Error('some unknown error'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — generic failure message unchanged
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).toContain('failed')
+      expect(lastCall.content).not.toMatch(/timed? ?out/i)
+    })
+
+    it('timeout: FAILED run-state transition still occurs regardless of visible-output branch', async () => {
+      // #given — visible output present
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 10}),
+        buffered: vi.fn().mockReturnValue('output'),
+        markVisibleOutputSent: vi.fn(),
+        hasVisibleOutput: vi.fn().mockReturnValue(true),
+      })
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — run still transitions to FAILED (timeout is always a failure)
+      const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+      expect(transitionPhases).toContain('FAILED')
+      expect(transitionPhases).not.toContain('COMPLETED')
     })
 
     it('flushes partial sink output on stream-ended path before posting error', async () => {
@@ -857,6 +1171,7 @@ describe('runMention', () => {
         flush: flushMock,
         buffered: vi.fn().mockReturnValue('partial'),
         markVisibleOutputSent: vi.fn(),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('stream-ended', 'stream closed'))
 
@@ -882,6 +1197,7 @@ describe('runMention', () => {
         flush: flushMock,
         buffered: vi.fn().mockReturnValue('partial'),
         markVisibleOutputSent: vi.fn(),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('session-error', 'LLM quota exceeded'))
 
@@ -907,6 +1223,7 @@ describe('runMention', () => {
         flush: flushMock,
         buffered: vi.fn().mockReturnValue(''),
         markVisibleOutputSent: vi.fn(),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
       })
       setupHappyPath()
       // Make EXECUTING transition fail — error caught before sink is created
@@ -926,6 +1243,111 @@ describe('runMention', () => {
 
       // #then — flush NOT called because sink was never initialized
       expect(flushMock).not.toHaveBeenCalled()
+    })
+
+    // ── Stateful sink: timeout copy reads visibility AFTER flush ────────────
+
+    it('timeout: visible-output branch fires when flush() sets visible=true (stateful sink — sent)', async () => {
+      // #given — sink starts with visible=false; flush() sets visible=true (simulates sent output)
+      // This proves the classifier reads hasVisibleOutput() AFTER the error-path flush completes.
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      const statefulSink = makeStatefulSinkMock('sent', /* flushShouldSetVisible */ true)
+      mockCreateDiscordStreamSink.mockReturnValue(statefulSink)
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({runTimeoutMs: 600_000})
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — flush was called and set visible=true
+      expect(statefulSink.flush).toHaveBeenCalledOnce()
+      // #and — visible-output branch used (new-request guidance present)
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).toMatch(/what to do next|new.*@fro-bot/i)
+      // #and — does NOT use no-output retry wording
+      expect(lastCall.content).not.toMatch(/please try again/i)
+    })
+
+    it('timeout: visible-output branch fires when flush() sets visible=true (stateful sink — attachment)', async () => {
+      // #given — sink starts with visible=false; flush() sets visible=true (simulates attachment output)
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      const statefulSink = makeStatefulSinkMock('attachment', /* flushShouldSetVisible */ true)
+      mockCreateDiscordStreamSink.mockReturnValue(statefulSink)
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({runTimeoutMs: 600_000})
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — visible-output branch used
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).toMatch(/what to do next|new.*@fro-bot/i)
+    })
+
+    it('timeout: generic branch fires when flush() leaves visible=false (stateful sink — empty)', async () => {
+      // #given — sink starts with visible=false; flush() does NOT set visible (empty flush)
+      // This is the inverse case: flush errors or produces no visible output → generic timeout.
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      const statefulSink = makeStatefulSinkMock('empty', /* flushShouldSetVisible */ false)
+      mockCreateDiscordStreamSink.mockReturnValue(statefulSink)
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({runTimeoutMs: 600_000})
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — generic branch used (no new-request guidance)
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).not.toMatch(/what to do next|new.*@fro-bot/i)
+      // #and — includes configured duration
+      expect(lastCall.content).toMatch(/10.?min/i)
+    })
+
+    it('timeout: generic branch fires when flush() throws (stateful sink — flush error)', async () => {
+      // #given — flush throws; visible stays false → generic timeout branch
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      let visible = false
+      const flushFn = vi.fn().mockRejectedValue(new Error('flush network error'))
+      const hasVisibleOutputFn = vi.fn().mockImplementation(() => visible)
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: flushFn,
+        buffered: vi.fn().mockReturnValue(''),
+        markVisibleOutputSent: vi.fn().mockImplementation(() => {
+          visible = true
+        }),
+        hasVisibleOutput: hasVisibleOutputFn,
+      })
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({runTimeoutMs: 600_000})
+
+      // #when — must not throw (flush failure is best-effort)
+      await expect(runMention(message, makeBinding(), deps)).resolves.toBeUndefined()
+
+      // #then — generic branch used (visible stayed false after flush threw)
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).not.toMatch(/what to do next|new.*@fro-bot/i)
+      expect(lastCall.content).toMatch(/10.?min/i)
     })
   })
 
@@ -1471,6 +1893,7 @@ describe('runMention', () => {
         flush: vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 10}),
         buffered: vi.fn().mockReturnValue(''),
         markVisibleOutputSent: markVisibleOutputSentFn,
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
       })
 
       const thread = makeThread()
@@ -1689,5 +2112,43 @@ describe('runMention', () => {
       expect(signalBudgetMs).toBeLessThanOrEqual(runTimeoutMs - SIMULATED_ELAPSED_MS + 100) // +100ms tolerance
       expect(signalBudgetMs).toBeGreaterThan(0)
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatTimeoutDuration — unit tests for the exported helper
+// ---------------------------------------------------------------------------
+
+describe('formatTimeoutDuration', () => {
+  it('45_000 ms → "45 seconds"', () => {
+    expect(formatTimeoutDuration(45_000)).toBe('45 seconds')
+  })
+
+  it('1_000 ms → "1 second"', () => {
+    expect(formatTimeoutDuration(1_000)).toBe('1 second')
+  })
+
+  it('60_000 ms → "1 minute" (no trailing seconds)', () => {
+    expect(formatTimeoutDuration(60_000)).toBe('1 minute')
+  })
+
+  it('90_000 ms → "1 minute 30 seconds" (non-integral minute)', () => {
+    expect(formatTimeoutDuration(90_000)).toBe('1 minute 30 seconds')
+  })
+
+  it('120_000 ms → "2 minutes" (no trailing seconds)', () => {
+    expect(formatTimeoutDuration(120_000)).toBe('2 minutes')
+  })
+
+  it('600_000 ms → "10 minutes"', () => {
+    expect(formatTimeoutDuration(600_000)).toBe('10 minutes')
+  })
+
+  it('61_000 ms → "1 minute 1 second" (singular second)', () => {
+    expect(formatTimeoutDuration(61_000)).toBe('1 minute 1 second')
+  })
+
+  it('125_000 ms → "2 minutes 5 seconds"', () => {
+    expect(formatTimeoutDuration(125_000)).toBe('2 minutes 5 seconds')
   })
 })

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -66,6 +66,29 @@ export interface RunMentionDeps {
 // ---------------------------------------------------------------------------
 
 /**
+ * Format a millisecond duration as a human-readable string for user-facing
+ * timeout messages. Produces accurate compound minute+second strings for
+ * non-integral minutes; falls back to seconds for sub-minute values.
+ *
+ * Examples:
+ *   45_000  → "45 seconds"
+ *   60_000  → "1 minute"
+ *   90_000  → "1 minute 30 seconds"
+ *   600_000 → "10 minutes"
+ */
+export function formatTimeoutDuration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const remainingSeconds = totalSeconds % 60
+  if (minutes >= 1) {
+    const minutePart = `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`
+    if (remainingSeconds === 0) return minutePart
+    return `${minutePart} ${remainingSeconds} ${remainingSeconds === 1 ? 'second' : 'seconds'}`
+  }
+  return `${totalSeconds} ${totalSeconds === 1 ? 'second' : 'seconds'}`
+}
+
+/**
  * Send a message to a Discord channel/thread with mentions disabled.
  * ALL Discord sends in this module MUST go through this helper — never call
  * `.send()` directly with user-controlled content.
@@ -549,9 +572,13 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
       }
 
       // Coarse user message — no internal detail
+      const timeoutDuration = formatTimeoutDuration(runTimeoutMs)
+      const hasVisibleOutput = sink !== null && sink.hasVisibleOutput() === true
       const userMessage =
         isTimeout === true
-          ? 'The task timed out. Please try again.'
+          ? hasVisibleOutput === true
+            ? `The task reached the ${timeoutDuration} time limit after posting updates above. Start a new @fro-bot request with what to do next and include any needed context from the output above.`
+            : `The task reached the ${timeoutDuration} time limit. Please try again.`
           : isReachability === true
             ? 'The workspace is not reachable right now. Please try again later.'
             : isEmptyPrompt === true


### PR DESCRIPTION
## Summary

Fixes the Discord timeout message for Gateway mention runs that already posted visible output before hitting the run time limit.

## Changes

- Track whether the Discord stream sink has sent visible output.
- After timeout failures, flush buffered output first, then choose timeout copy from post-flush visibility state.
- Include the configured timeout duration in both timeout branches.
- Clarify that follow-up work starts a new `@fro-bot` request with needed context from the prior output.
- Add regression coverage for text, attachment, approval-status, empty-output, and flush-failure timeout paths.

## Verification

- `pnpm --filter @fro-bot/gateway test -- run.test.ts streaming.test.ts`
- `pnpm --filter @fro-bot/gateway lint`
- `pnpm --filter @fro-bot/gateway check-types`
- `pnpm build && git diff --quiet dist`

## Deferred

- Approval/status visible-output race is tracked locally as a Systematic todo; it is intentionally out of scope for this PR.
