### PR TITLE
fix(gateway): keep timeout messaging accurate when an approval send is in flight

### DIFF
--- a/docs/plans/2026-06-06-002-fix-approval-visible-output-race-plan.md
+++ b/docs/plans/2026-06-06-002-fix-approval-visible-output-race-plan.md
@@ -1,0 +1,158 @@
+---
+title: "fix: Resolve gateway approval/status visible-output race in timeout classification"
+type: fix
+status: active
+date: 2026-06-06
+---
+
+# fix: Resolve gateway approval/status visible-output race in timeout classification
+
+## Overview
+
+The gateway mention loop posts approval/status messages to Discord (waiting-for-approval status, the approval embed, and the deadline-settled notice) through fire-and-forget sends. Each send marks the stream sink as having produced visible output only *after* the Discord send resolves. The hard-timeout error path reads `sink.hasVisibleOutput()` synchronously to choose between two timeout messages. When the timeout fires while one of these sends is still in flight, classification sees `false` and picks the misleading "no output" timeout copy — even though Discord shows the approval marker milliseconds later.
+
+This plan adds a pending-attempt counter to the sink so an in-flight approval/status send counts as visible context at classification time, while a *failed* send never falsely claims output.
+
+## Problem Frame
+
+Found by adversarial review during issue #801 and deferred as a P2 to avoid expanding that PR's scope (todo `001-pending-p2-gateway-approval-visible-output-race`).
+
+Current behavior in `packages/gateway/src/execute/run.ts`:
+- The waiting-status send (`void safeSend(...).then(() => sink?.markVisibleOutputSent())`) and the embed send (`void rawThread.send(...).then(() => sink?.markVisibleOutputSent())`) are fire-and-forget. `markVisibleOutputSent()` runs only on the `.then()`.
+- The deadline-settled handler `await`s its `safeSend` before marking, so it is less racy, but shares the same "mark only on success" pattern.
+- The error path computes `hasVisibleOutput = sink.hasVisibleOutput() === true` synchronously after the failure-path flush, then branches the timeout copy on it.
+
+The race: timeout fires → classification reads `hasVisibleOutput()` → an approval/status send is mid-flight → returns `false` → user gets `The task reached the N time limit. Please try again.` instead of the visible-output variant, while the approval marker lands on Discord immediately after.
+
+## Requirements Trace
+
+- R1. Timeout classification must not take the no-output branch *solely* because an approval/status visible message is still pending (in flight).
+- R2. A failed Discord send must never cause classification to claim visible output that was not delivered.
+- R3. The fix must not meaningfully extend the hard run timeout (no awaiting Discord sends in the timeout path).
+- R4. Existing text/attachment flush visibility behavior and timeout failure semantics (timeout is still a failure, not partial success) remain unchanged.
+
+## Scope Boundaries
+
+- Does not change the timeout duration, retry behavior, or the fact that a timeout is a failure.
+- Does not change the approval coordinator lifecycle, registry settlement, or deadline computation.
+- Does not alter text/attachment streaming flush behavior — only adds a parallel pending-visibility signal for the out-of-band approval/status sends.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/gateway/src/discord/streaming.ts` — `DiscordStreamSink` interface + `createDiscordStreamSink()`. Current visible-output state is a single `let visibleOutputSent = false`, set by `markVisibleOutputSent()` and by successful text/attachment flush; read by `hasVisibleOutput()`. This is the single seam to extend.
+- `packages/gateway/src/execute/run.ts`:
+  - Waiting-status send (`void safeSend(rawThread, 'Waiting for tool approval…').then(...)`).
+  - Embed send (`void rawThread.send({embeds, components, ...}).then(...)`).
+  - Deadline-settled handler (`onDeadlineSettled: async () => { await safeSend(...); sink?.markVisibleOutputSent() }`).
+  - Error classification block: `const hasVisibleOutput = sink !== null && sink.hasVisibleOutput() === true` feeding the timeout-copy ternary.
+
+### Institutional Learnings
+
+- Discord requires interaction ACK within 3s; approval sends are deliberately fire-and-forget so they never block `onPending` (memory 4691/4722). The fix must preserve that — no awaiting in the send path or the timeout path.
+- The `(no output)` / `skipped-visible` flush contract (issue #801) is the sibling behavior; this plan reuses the same "visible output already surfaced" intent for the out-of-band sends.
+
+## Key Technical Decisions
+
+- **Pending-attempt counter on the sink (chosen over awaiting settlement).** Add a pending counter that an approval/status send increments synchronously *before* its Discord send and resolves after. `hasVisibleOutput()` returns `delivered || pending > 0`. This satisfies R1 (pending counts as visible) and R3 (no awaiting in the timeout path), and by decrementing on failure satisfies R2 (a failed send retracts its pending claim and never becomes "delivered").
+- **Settle handle API shape.** `markVisibleOutputPending()` returns a one-shot settle function `(delivered: boolean) => void`: call `settle(true)` on send success (promotes to permanently visible, same as today's `markVisibleOutputSent`), `settle(false)` on send failure (decrements the pending count without marking delivered). Idempotent — a second call is a no-op — to avoid double-decrement.
+- **`hasVisibleOutput()` semantics.** Returns `true` when either permanent visible output exists (`visibleOutputSent`) OR `pendingVisibleOutput > 0`. A still-pending send at classification time therefore reads as visible context; if it later fails, that only matters for *future* reads, and the timeout message has already been chosen correctly (the run genuinely surfaced a blocking interaction the user will see attempted).
+- **Deadline-settled handler.** Keep its `await safeSend(...)` then `markVisibleOutputSent()` as-is — it is not in the racy fire-and-forget path. Optionally route it through the same pending/settle API for consistency, but not required for correctness.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should the timeout path await pending sends? No — R3 forbids meaningfully extending the timeout. The pending counter makes awaiting unnecessary.
+- Does a failed send leave a permanent false-positive? No — `settle(false)` decrements; only `settle(true)` sets the permanent `visibleOutputSent` flag.
+
+### Deferred to Implementation
+
+- Exact field names (`pendingVisibleOutput`, `markVisibleOutputPending`) — finalize at implementation; mirror existing naming in `streaming.ts`.
+- Whether to also route `onDeadlineSettled` through the new API for uniformity — implementer's call; behavior is already correct there.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add pending-visibility counter to the sink**
+
+**Goal:** Extend `DiscordStreamSink` so out-of-band sends can mark visibility as *pending* before delivery, and resolve it on success/failure, with `hasVisibleOutput()` treating pending as visible.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/gateway/src/discord/streaming.ts`
+- Test: `packages/gateway/src/discord/streaming.test.ts`
+
+**Approach:**
+- Add `let pendingVisibleOutput = 0` alongside `visibleOutputSent`.
+- Add `markVisibleOutputPending()` to the interface, returning a one-shot settle function: increments `pendingVisibleOutput`; the returned `settle(delivered: boolean)` decrements once (guard against double-settle), and when `delivered === true` also sets `visibleOutputSent = true`.
+- Change `hasVisibleOutput()` to return `visibleOutputSent || pendingVisibleOutput > 0`.
+- Leave `markVisibleOutputSent()`, `append`, `flush`, `buffered` unchanged; document the new method in the interface JSDoc consistent with existing style.
+
+**Patterns to follow:**
+- The existing `markVisibleOutputSent` / `hasVisibleOutput` closure-over-`let` pattern in `createDiscordStreamSink()`.
+
+**Test scenarios:**
+- Happy path: `markVisibleOutputPending()` makes `hasVisibleOutput()` return `true` immediately (before settle).
+- Happy path: `settle(true)` keeps `hasVisibleOutput()` true and persists it after the pending count would drop.
+- Error path: `settle(false)` with no other output makes `hasVisibleOutput()` return `false` again (pending retracted, not promoted to delivered).
+- Edge case: two concurrent `markVisibleOutputPending()` handles; settling one `false` keeps `hasVisibleOutput()` true while the other is still pending.
+- Edge case: calling a settle handle twice is a no-op (no double-decrement / no negative count).
+- Integration: empty-buffer `flush()` after `settle(true)` returns `{kind:'skipped-visible'}` (existing contract still holds via `visibleOutputSent`).
+
+**Verification:**
+- The sink exposes `markVisibleOutputPending`; `hasVisibleOutput()` reflects pending-as-visible and failure-retraction; all existing streaming tests still pass.
+
+- [ ] **Unit 2: Wire approval/status sends through the pending API in run.ts**
+
+**Goal:** Make the waiting-status and embed sends mark visibility *pending* synchronously before their Discord send, settling true/false on resolution, so timeout classification sees in-flight sends as visible context.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/gateway/src/execute/run.ts`
+- Test: `packages/gateway/src/execute/run.test.ts`
+
+**Approach:**
+- Waiting-status send: before `void safeSend(...)`, capture `const settle = sink?.markVisibleOutputPending()`; in `.then()` call `settle?.(true)`, in `.catch()` call `settle?.(false)` (in addition to the existing warn log).
+- Embed send: same pattern — `const settle = sink?.markVisibleOutputPending()` before `void rawThread.send(...)`; `.then()` → `settle?.(true)` (plus the existing `attachMessage` wiring), `.catch()` → `settle?.(false)` (plus the existing `markMessagePostFailed` + warn).
+- Keep `onDeadlineSettled` as-is (already awaits before marking) — no race there.
+- Do not await anything new in the error/timeout path; classification continues to read `sink.hasVisibleOutput()` synchronously.
+
+**Patterns to follow:**
+- The existing fire-and-forget `void ... .then().catch()` structure already in `run.ts`; only add the synchronous pending-capture and the settle calls.
+
+**Test scenarios:**
+- Integration: approval send started but unresolved when timeout fires → classification chooses the visible-output timeout copy (not the no-output copy). (Drive by leaving the send promise pending until after classification.)
+- Integration: approval send rejects, then timeout fires → classification chooses the no-output copy (failed send did not falsely claim output).
+- Integration: approval send resolves successfully before timeout → visible-output copy (existing behavior preserved).
+- Edge case: no approval ever requested + empty output + timeout → no-output copy (unchanged from #801).
+
+**Verification:**
+- A pending approval/status send at timeout yields the visible-output message; a failed send yields the no-output message; successful and no-approval paths are unchanged; failure semantics (timeout is still a failure) unchanged.
+
+## System-Wide Impact
+
+- **Interaction graph:** Only the approval/status send sites in `run.ts` and the sink's visibility state are touched. The coordinator, registry, deadline timer, and streaming text/attachment path are unchanged.
+- **Error propagation:** A failed Discord send now decrements pending rather than silently leaving a flag unset; it must not promote to delivered. The original timeout error is still surfaced and still classified as failure.
+- **State lifecycle risks:** Double-settle and negative counts are guarded by the one-shot settle handle. No persistent state beyond the run.
+- **Unchanged invariants:** `markVisibleOutputSent()`, `flush()` `skipped-visible`/`no-output` behavior, and timeout-is-failure semantics are preserved. `hasVisibleOutput()` only widens to include pending.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| A pending send that ultimately fails momentarily reads as visible | Acceptable per R1 framing — the run genuinely reached a blocking interaction; classification only needs to not mislead when output *will* appear. The failed send retracts via `settle(false)` for any later read. |
+| Double-settle causing negative pending count | One-shot idempotent settle handle (Unit 1 test pins this). |
+| Awaiting sends sneaks into the timeout path | Explicitly forbidden (R3); Unit 2 keeps classification synchronous. |
+
+## Sources & References
+
+- Deferred todo: `.context/systematic/todos/001-pending-p2-gateway-approval-visible-output-race.md`
+- Related plan: `docs/plans/2026-06-06-001-fix-discord-timeout-partial-output-plan.md`
+- Related: issue #801 / PR #803 (timeout copy after visible output)

--- a/docs/plans/2026-06-06-002-fix-approval-visible-output-race-plan.md
+++ b/docs/plans/2026-06-06-002-fix-approval-visible-output-race-plan.md
@@ -1,8 +1,9 @@
 ---
 title: "fix: Resolve gateway approval/status visible-output race in timeout classification"
 type: fix
-status: active
+status: completed
 date: 2026-06-06
+completed: 2026-06-06
 ---
 
 # fix: Resolve gateway approval/status visible-output race in timeout classification
@@ -74,7 +75,7 @@ The race: timeout fires → classification reads `hasVisibleOutput()` → an app
 
 ## Implementation Units
 
-- [ ] **Unit 1: Add pending-visibility counter to the sink**
+- [x] **Unit 1: Add pending-visibility counter to the sink**
 
 **Goal:** Extend `DiscordStreamSink` so out-of-band sends can mark visibility as *pending* before delivery, and resolve it on success/failure, with `hasVisibleOutput()` treating pending as visible.
 
@@ -106,7 +107,7 @@ The race: timeout fires → classification reads `hasVisibleOutput()` → an app
 **Verification:**
 - The sink exposes `markVisibleOutputPending`; `hasVisibleOutput()` reflects pending-as-visible and failure-retraction; all existing streaming tests still pass.
 
-- [ ] **Unit 2: Wire approval/status sends through the pending API in run.ts**
+- [x] **Unit 2: Wire approval/status sends through the pending API in run.ts**
 
 **Goal:** Make the waiting-status and embed sends mark visibility *pending* synchronously before their Discord send, settling true/false on resolution, so timeout classification sees in-flight sends as visible context.
 

--- a/packages/gateway/src/discord/streaming.test.ts
+++ b/packages/gateway/src/discord/streaming.test.ts
@@ -399,6 +399,111 @@ describe('createDiscordStreamSink', () => {
     })
   })
 
+  // ── Unit: markVisibleOutputPending() — pending-visibility counter ──
+
+  describe('markVisibleOutputPending()', () => {
+    it('happy path: makes hasVisibleOutput() return true immediately before settle', () => {
+      // #given
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+
+      // #when — mark pending, do NOT settle yet
+      sink.markVisibleOutputPending()
+
+      // #then — pending counts as visible
+      expect(sink.hasVisibleOutput()).toBe(true)
+    })
+
+    it('happy path: settle(true) keeps hasVisibleOutput() true after pending drops to 0', () => {
+      // #given
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      const settle = sink.markVisibleOutputPending()
+
+      // #when — settle as delivered
+      settle(true)
+
+      // #then — permanently visible (visibleOutputSent promoted)
+      expect(sink.hasVisibleOutput()).toBe(true)
+    })
+
+    it('error path: settle(false) with no other visible output makes hasVisibleOutput() return false', () => {
+      // #given
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      const settle = sink.markVisibleOutputPending()
+
+      // #when — settle as failed
+      settle(false)
+
+      // #then — pending retracted, not promoted to delivered
+      expect(sink.hasVisibleOutput()).toBe(false)
+    })
+
+    it('edge case: two concurrent handles — settle one false keeps hasVisibleOutput() true while other is still pending', () => {
+      // #given
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      const settle1 = sink.markVisibleOutputPending()
+      const settle2 = sink.markVisibleOutputPending()
+
+      // #when — settle first as failed
+      settle1(false)
+
+      // #then — second is still pending, so still visible
+      expect(sink.hasVisibleOutput()).toBe(true)
+
+      // #when — settle second as failed too
+      settle2(false)
+
+      // #then — both retracted, no other visible output
+      expect(sink.hasVisibleOutput()).toBe(false)
+    })
+
+    it('edge case: double-settle is a no-op — pending→settle(false)→settle(false) leaves hasVisibleOutput false (no negative count)', () => {
+      // #given
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      const settle = sink.markVisibleOutputPending()
+
+      // #when — settle twice with false
+      settle(false)
+      settle(false) // must be a no-op, not decrement again
+
+      // #then — still false, count not negative
+      expect(sink.hasVisibleOutput()).toBe(false)
+    })
+
+    it('edge case: double-settle — first settle wins; pending→settle(false)→settle(true) does NOT promote to delivered', () => {
+      // #given
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      const settle = sink.markVisibleOutputPending()
+
+      // #when — first settle false, then try to promote with true
+      settle(false)
+      settle(true) // must be a no-op; first settle already won
+
+      // #then — not promoted to delivered
+      expect(sink.hasVisibleOutput()).toBe(false)
+    })
+
+    it('integration: empty-buffer flush() after settle(true) returns {kind:"skipped-visible"}', async () => {
+      // #given — settle(true) promotes to visibleOutputSent; buffer is empty
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      const settle = sink.markVisibleOutputPending()
+      settle(true)
+
+      // #when
+      const result = await sink.flush()
+
+      // #then — existing skipped-visible contract still holds
+      expect(result.kind).toBe('skipped-visible')
+      expect(thread._send).not.toHaveBeenCalled()
+    })
+  })
+
   describe('markVisibleOutputSent()', () => {
     it('flush returns {kind:"skipped-visible"} instead of posting _(no output)_ when visible output was already sent', async () => {
       // #given — nothing appended to buffer, but visible output was already posted (e.g. approval status)

--- a/packages/gateway/src/discord/streaming.test.ts
+++ b/packages/gateway/src/discord/streaming.test.ts
@@ -502,6 +502,25 @@ describe('createDiscordStreamSink', () => {
       expect(result.kind).toBe('skipped-visible')
       expect(thread._send).not.toHaveBeenCalled()
     })
+
+    it('fix 1 regression: empty-buffer flush() while send is still PENDING (not yet settled) returns {kind:"skipped-visible"} — does NOT post _(no output)_', async () => {
+      // This is the core regression guard for FIX 1.
+      // Race: approval send is in-flight (pending) when flush() is called on an empty buffer.
+      // Before FIX 1, flush() only checked visibleOutputSent (false) and would post _(no output)_.
+      // After FIX 1, flush() also checks pendingVisibleOutput > 0 and returns skipped-visible.
+      // #given — pending send in-flight; buffer empty; NOT yet settled
+      const thread = makeThread()
+      const sink = createDiscordStreamSink(thread)
+      sink.markVisibleOutputPending() // increments pendingVisibleOutput; NOT settled
+
+      // #when — flush while send is still pending
+      const result = await sink.flush()
+
+      // #then — skipped-visible (pending suppresses _(no output)_)
+      expect(result.kind).toBe('skipped-visible')
+      // #and — _(no output)_ was NOT sent to Discord
+      expect(thread._send).not.toHaveBeenCalled()
+    })
   })
 
   describe('markVisibleOutputSent()', () => {

--- a/packages/gateway/src/discord/streaming.ts
+++ b/packages/gateway/src/discord/streaming.ts
@@ -167,7 +167,7 @@ export function createDiscordStreamSink(thread: SinkThread, deps: StreamSinkDeps
     pendingVisibleOutput += 1
     let settled = false
     return (delivered: boolean): void => {
-      if (settled) {
+      if (settled === true) {
         return
       }
       settled = true
@@ -178,15 +178,18 @@ export function createDiscordStreamSink(thread: SinkThread, deps: StreamSinkDeps
     }
   }
 
-  const hasVisibleOutput = (): boolean => visibleOutputSent || pendingVisibleOutput > 0
+  const hasVisibleOutput = (): boolean => visibleOutputSent === true || pendingVisibleOutput > 0
 
   const flush = async (): Promise<FlushResult> => {
     const text = buffer
 
     // Empty / whitespace — check if visible output was already sent outside the buffer
     if (text.trim().length === 0) {
-      // Visible output already sent (e.g. approval waiting status) → skip _(no output)_
-      if (visibleOutputSent) {
+      // Visible output already delivered OR an out-of-band send is still in-flight (pending).
+      // A pending send that later fails will retract via settle(false) for future reads, but
+      // suppressing _(no output)_ here avoids a contradictory "(no output) + updates above"
+      // pair in the timeout race where flush() runs before classification reads hasVisibleOutput().
+      if (visibleOutputSent === true || pendingVisibleOutput > 0) {
         return {kind: 'skipped-visible'}
       }
       // Genuinely empty run → post the "no output" fallback

--- a/packages/gateway/src/discord/streaming.ts
+++ b/packages/gateway/src/discord/streaming.ts
@@ -117,9 +117,23 @@ export interface DiscordStreamSink {
    */
   readonly markVisibleOutputSent: () => void
   /**
+   * Marks an out-of-band visible send as in-flight so timeout/error
+   * classification treats it as visible context while the Discord send is
+   * pending. Returns a one-shot settle handle:
+   * - `settle(true)` — send succeeded; promotes to permanently delivered
+   *   (same effect as `markVisibleOutputSent()`).
+   * - `settle(false)` — send failed; retracts the pending claim without
+   *   marking delivered.
+   * The handle is one-shot: calling it a second time is a no-op (guards
+   * against double-decrement and prevents a late `settle(true)` from
+   * overriding an earlier `settle(false)`).
+   */
+  readonly markVisibleOutputPending: () => (delivered: boolean) => void
+  /**
    * Returns `true` if visible output has been sent to the thread — either via
-   * `markVisibleOutputSent()` or via a successful flush of buffered text.
-   * Read-only; never resets once set.
+   * `markVisibleOutputSent()`, via a successful flush of buffered text, or via
+   * a pending out-of-band send that has not yet settled.
+   * Read-only; never resets once permanently set.
    *
    * Use this to decide whether a timeout or error message should acknowledge
    * partial output rather than treating the run as having produced nothing.
@@ -137,6 +151,7 @@ export function createDiscordStreamSink(thread: SinkThread, deps: StreamSinkDeps
   const {logger} = deps
   let buffer = ''
   let visibleOutputSent = false
+  let pendingVisibleOutput = 0
 
   const append = (text: string): void => {
     buffer += text
@@ -148,7 +163,22 @@ export function createDiscordStreamSink(thread: SinkThread, deps: StreamSinkDeps
     visibleOutputSent = true
   }
 
-  const hasVisibleOutput = (): boolean => visibleOutputSent
+  const markVisibleOutputPending = (): ((delivered: boolean) => void) => {
+    pendingVisibleOutput += 1
+    let settled = false
+    return (delivered: boolean): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      pendingVisibleOutput -= 1
+      if (delivered === true) {
+        visibleOutputSent = true
+      }
+    }
+  }
+
+  const hasVisibleOutput = (): boolean => visibleOutputSent || pendingVisibleOutput > 0
 
   const flush = async (): Promise<FlushResult> => {
     const text = buffer
@@ -196,5 +226,5 @@ export function createDiscordStreamSink(thread: SinkThread, deps: StreamSinkDeps
     }
   }
 
-  return {append, flush, buffered, markVisibleOutputSent, hasVisibleOutput}
+  return {append, flush, buffered, markVisibleOutputSent, markVisibleOutputPending, hasVisibleOutput}
 }

--- a/packages/gateway/src/execute/run-core.test.ts
+++ b/packages/gateway/src/execute/run-core.test.ts
@@ -34,6 +34,7 @@ function makeSink(): DiscordStreamSink & {readonly _appended: string[]} {
     flush: vi.fn().mockResolvedValue({kind: 'sent', charCount: buffer.length}),
     buffered: () => buffer,
     markVisibleOutputSent: vi.fn(),
+    markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
     hasVisibleOutput: vi.fn().mockReturnValue(false),
   }
 }

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -62,6 +62,7 @@ vi.mock('../discord/streaming.js', () => ({
     flush: vi.fn().mockResolvedValue({kind: 'sent', charCount: 10}),
     buffered: vi.fn().mockReturnValue(''),
     markVisibleOutputSent: vi.fn(),
+    markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
     hasVisibleOutput: vi.fn().mockReturnValue(false),
   }),
 }))
@@ -181,6 +182,7 @@ function makeStreamSinkMock(
     flush?: ReturnType<typeof vi.fn>
     buffered?: ReturnType<typeof vi.fn>
     markVisibleOutputSent?: ReturnType<typeof vi.fn>
+    markVisibleOutputPending?: ReturnType<typeof vi.fn>
     hasVisibleOutput?: ReturnType<typeof vi.fn>
   } = {},
 ) {
@@ -189,6 +191,7 @@ function makeStreamSinkMock(
     flush: overrides.flush ?? vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 10}),
     buffered: overrides.buffered ?? vi.fn().mockReturnValue(''),
     markVisibleOutputSent: overrides.markVisibleOutputSent ?? vi.fn(),
+    markVisibleOutputPending: overrides.markVisibleOutputPending ?? vi.fn().mockReturnValue(vi.fn()),
     hasVisibleOutput: overrides.hasVisibleOutput ?? vi.fn().mockReturnValue(false),
   }
 }
@@ -221,6 +224,7 @@ function makeStatefulSinkMock(
     markVisibleOutputSent: vi.fn().mockImplementation(() => {
       visible = true
     }),
+    markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
     hasVisibleOutput: hasVisibleOutputFn,
   }
 }
@@ -715,6 +719,7 @@ describe('runMention', () => {
         flush: flushMock,
         buffered: vi.fn().mockReturnValue(''),
         markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: vi.fn().mockReturnValue(false),
       })
 
@@ -883,6 +888,7 @@ describe('runMention', () => {
         flush: flushMock,
         buffered: vi.fn().mockReturnValue('partial output'),
         markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: vi.fn().mockReturnValue(false),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
@@ -913,6 +919,7 @@ describe('runMention', () => {
         flush: vi.fn().mockResolvedValue({kind: 'empty' as const}),
         buffered: vi.fn().mockReturnValue(''),
         markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: vi.fn().mockReturnValue(false),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
@@ -941,6 +948,7 @@ describe('runMention', () => {
         flush: vi.fn().mockResolvedValue({kind: 'empty' as const}),
         buffered: vi.fn().mockReturnValue(''),
         markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: vi.fn().mockReturnValue(false),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'AbortError: signal timed out'))
@@ -968,6 +976,7 @@ describe('runMention', () => {
         flush: vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 42}),
         buffered: vi.fn().mockReturnValue('some partial output'),
         markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: vi.fn().mockReturnValue(true),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
@@ -998,6 +1007,7 @@ describe('runMention', () => {
         flush: vi.fn().mockResolvedValue({kind: 'attachment' as const, charCount: 3000}),
         buffered: vi.fn().mockReturnValue('x'.repeat(3000)),
         markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: vi.fn().mockReturnValue(true),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
@@ -1026,6 +1036,7 @@ describe('runMention', () => {
         flush: vi.fn().mockResolvedValue({kind: 'skipped-visible' as const}),
         buffered: vi.fn().mockReturnValue(''),
         markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: vi.fn().mockReturnValue(true),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
@@ -1062,6 +1073,7 @@ describe('runMention', () => {
         flush: flushMock,
         buffered: vi.fn().mockReturnValue('partial'),
         markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: vi.fn().mockReturnValue(true),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
@@ -1089,6 +1101,7 @@ describe('runMention', () => {
         flush: vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 5}),
         buffered: vi.fn().mockReturnValue('partial'),
         markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: vi.fn().mockReturnValue(true), // visible output present — but stream-ended, not timeout
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('stream-ended', 'stream closed'))
@@ -1116,6 +1129,7 @@ describe('runMention', () => {
         flush: vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 5}),
         buffered: vi.fn().mockReturnValue('partial'),
         markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: vi.fn().mockReturnValue(true),
       })
       mockRunOpenCodeCore.mockRejectedValue(new Error('some unknown error'))
@@ -1143,6 +1157,7 @@ describe('runMention', () => {
         flush: vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 10}),
         buffered: vi.fn().mockReturnValue('output'),
         markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: vi.fn().mockReturnValue(true),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
@@ -1171,6 +1186,7 @@ describe('runMention', () => {
         flush: flushMock,
         buffered: vi.fn().mockReturnValue('partial'),
         markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: vi.fn().mockReturnValue(false),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('stream-ended', 'stream closed'))
@@ -1197,6 +1213,7 @@ describe('runMention', () => {
         flush: flushMock,
         buffered: vi.fn().mockReturnValue('partial'),
         markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: vi.fn().mockReturnValue(false),
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('session-error', 'LLM quota exceeded'))
@@ -1223,6 +1240,7 @@ describe('runMention', () => {
         flush: flushMock,
         buffered: vi.fn().mockReturnValue(''),
         markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: vi.fn().mockReturnValue(false),
       })
       setupHappyPath()
@@ -1333,6 +1351,7 @@ describe('runMention', () => {
         markVisibleOutputSent: vi.fn().mockImplementation(() => {
           visible = true
         }),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: hasVisibleOutputFn,
       })
       mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
@@ -1893,6 +1912,7 @@ describe('runMention', () => {
         flush: vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 10}),
         buffered: vi.fn().mockReturnValue(''),
         markVisibleOutputSent: markVisibleOutputSentFn,
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
         hasVisibleOutput: vi.fn().mockReturnValue(false),
       })
 

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -233,16 +233,22 @@ function makeStatefulSinkMock(
  * Build a stateful sink mock that properly tracks pending-visibility state
  * via markVisibleOutputPending(), mirroring the real sink's closure semantics.
  * Used to prove that in-flight sends count as visible context at classification time.
+ *
+ * flush() faithfully emulates the real createDiscordStreamSink empty-buffer semantics
+ * after FIX 1: when the buffer is empty, returns {kind:'skipped-visible'} if
+ * visibleOutputSent === true || pendingVisibleOutput > 0, else records that the
+ * _(no output)_ message was posted and returns {kind:'empty'}.
  */
 function makeStatefulPendingSinkMock() {
   let visibleOutputSent = false
   let pendingVisibleOutput = 0
+  let noOutputPosted = false
 
   const markVisibleOutputPending = vi.fn().mockImplementation(() => {
     pendingVisibleOutput += 1
     let settled = false
     return (delivered: boolean): void => {
-      if (settled) {
+      if (settled === true) {
         return
       }
       settled = true
@@ -253,15 +259,28 @@ function makeStatefulPendingSinkMock() {
     }
   })
 
+  const flushFn = vi.fn().mockImplementation(async () => {
+    // Emulate real sink empty-buffer path (FIX 1 semantics):
+    // skip _(no output)_ when either delivered OR pending visible output exists.
+    if (visibleOutputSent === true || pendingVisibleOutput > 0) {
+      return {kind: 'skipped-visible' as const}
+    }
+    // Genuinely empty — record that _(no output)_ would be posted
+    noOutputPosted = true
+    return {kind: 'empty' as const}
+  })
+
   return {
     append: vi.fn(),
-    flush: vi.fn().mockResolvedValue({kind: 'empty' as const}),
+    flush: flushFn,
     buffered: vi.fn().mockReturnValue(''),
     markVisibleOutputSent: vi.fn().mockImplementation(() => {
       visibleOutputSent = true
     }),
     markVisibleOutputPending,
-    hasVisibleOutput: vi.fn().mockImplementation(() => visibleOutputSent || pendingVisibleOutput > 0),
+    hasVisibleOutput: vi.fn().mockImplementation(() => visibleOutputSent === true || pendingVisibleOutput > 0),
+    /** Test-only: true if flush() posted the _(no output)_ fallback message. */
+    _noOutputPosted: () => noOutputPosted,
   }
 }
 
@@ -1468,6 +1487,81 @@ describe('runMention', () => {
       expect(lastCall.content).toMatch(/new.*@fro-bot request|what to do next/i)
       // #and — does NOT use no-output retry wording
       expect(lastCall.content).not.toMatch(/please try again/i)
+      // #and — the _(no output)_ fallback was NOT posted (flush returned skipped-visible)
+      // This is the FIX 1 regression guard: flush() must not post _(no output)_ when a
+      // pending send is in-flight, preventing the contradictory "(no output) + updates above" pair.
+      expect(statefulSink._noOutputPosted()).toBe(false)
+      // Verify flush returned skipped-visible (not empty)
+      const flushResult = await ((statefulSink.flush as ReturnType<typeof vi.fn>).mock.results[0]?.value as Promise<{
+        kind: string
+      }>)
+      expect(flushResult).toEqual({kind: 'skipped-visible'})
+    })
+
+    it('approval send PENDING at timeout + empty buffer → flush returns skipped-visible (no _(no output)_ posted) AND visible-output copy chosen', async () => {
+      // Regression test for FIX 1: the flush/classification contradiction race.
+      // When an approval send is still PENDING (not yet delivered) and the buffer is empty,
+      // flush() must return {kind:'skipped-visible'} — NOT post _(no output)_ — so that
+      // classification can then post the "updates above" copy without contradiction.
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+
+      const statefulSink = makeStatefulPendingSinkMock()
+      mockCreateDiscordStreamSink.mockReturnValue(statefulSink)
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({runTimeoutMs: 600_000})
+
+      let capturedOnPending: ((req: import('../approvals/coordinator.js').PermissionRequest) => void) | undefined
+      mockCreatePermissionCoordinator.mockImplementation(coordinatorDeps => {
+        capturedOnPending = coordinatorDeps.onPending
+        return {
+          onPermissionAsked: vi.fn(),
+          onPermissionReplied: vi.fn(),
+          pending: vi.fn().mockReturnValue([]),
+          dispose: vi.fn(),
+        }
+      })
+
+      // The approval send never resolves — it is still PENDING when timeout fires.
+      const neverResolves = new Promise<never>(() => {
+        /* intentionally never resolves */
+      })
+      thread.send.mockReturnValueOnce(neverResolves).mockReturnValueOnce(neverResolves).mockResolvedValue(undefined)
+
+      mockRunOpenCodeCore.mockImplementation(async () => {
+        if (capturedOnPending !== undefined) {
+          capturedOnPending({
+            requestID: 'req-fix1-regression',
+            sessionID: 'sess-fix1',
+            permission: 'bash',
+            patterns: [],
+            title: 'Run command: ls',
+          })
+        }
+        throw new RunCoreError('timeout', 'timed out')
+      })
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — flush returned skipped-visible (pending send suppressed _(no output)_)
+      expect(statefulSink._noOutputPosted()).toBe(false)
+      const flushResult = await ((statefulSink.flush as ReturnType<typeof vi.fn>).mock.results[0]?.value as Promise<{
+        kind: string
+      }>)
+      expect(flushResult).toEqual({kind: 'skipped-visible'})
+
+      // #and — classification chose the visible-output branch ("updates above" copy)
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).toMatch(/updates above/i)
+      expect(lastCall.content).toMatch(/new.*@fro-bot request|what to do next/i)
+
+      // #and — the contradictory _(no output)_ message was NOT sent at any point
+      const allContents = thread.send.mock.calls.map(c => (c[0] as {content?: string}).content ?? '')
+      expect(allContents.some(c => c.includes('_(no output)_'))).toBe(false)
     })
 
     it('approval send REJECTS before timeout fires → no-output timeout copy chosen', async () => {
@@ -1614,6 +1708,80 @@ describe('runMention', () => {
       expect(lastCall.content).not.toMatch(/what to do next/i)
       // #and — includes configured duration
       expect(lastCall.content).toMatch(/10.?min/i)
+    })
+  })
+
+  // ── onDeadlineSettled path ───────────────────────────────────────────────
+
+  describe('onDeadlineSettled path', () => {
+    it('deadline-settled send marks visible output on the sink (markVisibleOutputSent called after send)', async () => {
+      // Exercises the onDeadlineSettled path: when the deadline fires, run.ts calls
+      // safeSend then sink.markVisibleOutputSent(). This test asserts that after
+      // onDeadlineSettled completes, the sink reports visible output.
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const thread = makeThread()
+      const fakeApprovalMessage = {id: 'msg-deadline-vis', edit: vi.fn()}
+      thread.send.mockResolvedValue(fakeApprovalMessage)
+      const message = makeMessage(thread)
+      const approvalRegistry = makeApprovalRegistry()
+
+      // Use a stateful sink so we can observe markVisibleOutputSent
+      let visibleMarked = false
+      const sinkMock = makeStreamSinkMock({
+        markVisibleOutputSent: vi.fn().mockImplementation(() => {
+          visibleMarked = true
+        }),
+        hasVisibleOutput: vi.fn().mockImplementation(() => visibleMarked),
+      })
+      mockCreateDiscordStreamSink.mockReturnValue(
+        sinkMock as unknown as ReturnType<typeof streamingModule.createDiscordStreamSink>,
+      )
+
+      const deps = makeDeps({approvalRegistry})
+
+      let capturedOnPending: ((req: import('../approvals/coordinator.js').PermissionRequest) => void) | undefined
+      mockCreatePermissionCoordinator.mockImplementation(coordinatorDeps => {
+        capturedOnPending = coordinatorDeps.onPending
+        return {
+          onPermissionAsked: vi.fn(),
+          onPermissionReplied: vi.fn(),
+          pending: vi.fn().mockReturnValue([]),
+          dispose: vi.fn(),
+        }
+      })
+
+      await runMention(message, makeBinding(), deps)
+
+      expect(capturedOnPending).toBeDefined()
+      if (capturedOnPending === undefined) throw new Error('onPending not captured')
+
+      capturedOnPending({
+        requestID: 'req-deadline-vis-1',
+        sessionID: 'sess-deadline-vis',
+        permission: 'bash',
+        patterns: [],
+        title: 'Run command',
+      })
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // Extract the onDeadlineSettled callback from the register call
+      const registerCall = (approvalRegistry.register as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
+        | {onDeadlineSettled?: () => void | Promise<void>}
+        | undefined
+      expect(registerCall?.onDeadlineSettled).toBeDefined()
+
+      // #when — simulate deadline firing
+      if (registerCall?.onDeadlineSettled !== undefined) {
+        await registerCall.onDeadlineSettled()
+      }
+
+      // #then — after onDeadlineSettled completes, the sink reports visible output
+      // (markVisibleOutputSent was called after the safeSend succeeded)
+      expect(visibleMarked).toBe(true)
+      // markVisibleOutputSent was called exactly once (by onDeadlineSettled)
+      expect(sinkMock.markVisibleOutputSent).toHaveBeenCalledOnce()
     })
   })
 

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -229,6 +229,42 @@ function makeStatefulSinkMock(
   }
 }
 
+/**
+ * Build a stateful sink mock that properly tracks pending-visibility state
+ * via markVisibleOutputPending(), mirroring the real sink's closure semantics.
+ * Used to prove that in-flight sends count as visible context at classification time.
+ */
+function makeStatefulPendingSinkMock() {
+  let visibleOutputSent = false
+  let pendingVisibleOutput = 0
+
+  const markVisibleOutputPending = vi.fn().mockImplementation(() => {
+    pendingVisibleOutput += 1
+    let settled = false
+    return (delivered: boolean): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      pendingVisibleOutput -= 1
+      if (delivered === true) {
+        visibleOutputSent = true
+      }
+    }
+  })
+
+  return {
+    append: vi.fn(),
+    flush: vi.fn().mockResolvedValue({kind: 'empty' as const}),
+    buffered: vi.fn().mockReturnValue(''),
+    markVisibleOutputSent: vi.fn().mockImplementation(() => {
+      visibleOutputSent = true
+    }),
+    markVisibleOutputPending,
+    hasVisibleOutput: vi.fn().mockImplementation(() => visibleOutputSent || pendingVisibleOutput > 0),
+  }
+}
+
 function makeEnsureCloneFn(result: 'success' | 'failure' = 'success') {
   return result === 'success'
     ? vi.fn().mockResolvedValue({success: true as const, data: '/workspace/acme/widget'})
@@ -1370,6 +1406,217 @@ describe('runMention', () => {
     })
   })
 
+  // ── Approval pending-visibility race (Unit 2) ───────────────────────────
+
+  describe('approval pending-visibility race', () => {
+    it('approval send STARTED but UNRESOLVED when timeout fires → visible-output timeout copy chosen', async () => {
+      // #given — the approval send promise never resolves before the timeout fires.
+      // This is the core race: onPending fires (marking pending), runOpenCodeCore throws
+      // timeout, classification reads hasVisibleOutput() → true (pending counts as visible).
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+
+      const statefulSink = makeStatefulPendingSinkMock()
+      mockCreateDiscordStreamSink.mockReturnValue(statefulSink)
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({runTimeoutMs: 600_000})
+
+      // Capture onPending from the coordinator factory
+      let capturedOnPending: ((req: import('../approvals/coordinator.js').PermissionRequest) => void) | undefined
+      mockCreatePermissionCoordinator.mockImplementation(coordinatorDeps => {
+        capturedOnPending = coordinatorDeps.onPending
+        return {
+          onPermissionAsked: vi.fn(),
+          onPermissionReplied: vi.fn(),
+          pending: vi.fn().mockReturnValue([]),
+          dispose: vi.fn(),
+        }
+      })
+
+      // thread.send returns a never-resolving promise for the first 2 calls
+      // (waiting-status send + embed send) so they are still in-flight when
+      // the timeout fires. The 3rd call (error message) resolves immediately.
+      const neverResolves = new Promise<never>(() => {
+        /* intentionally never resolves — simulates in-flight Discord send */
+      })
+      thread.send.mockReturnValueOnce(neverResolves).mockReturnValueOnce(neverResolves).mockResolvedValue(undefined)
+
+      // runOpenCodeCore calls onPending (triggering the fire-and-forget sends)
+      // then throws a timeout error — simulating the race condition.
+      mockRunOpenCodeCore.mockImplementation(async () => {
+        if (capturedOnPending !== undefined) {
+          capturedOnPending({
+            requestID: 'req-race-1',
+            sessionID: 'sess-race',
+            permission: 'bash',
+            patterns: [],
+            title: 'Run command: ls',
+          })
+        }
+        throw new RunCoreError('timeout', 'timed out')
+      })
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — visible-output branch chosen (pending send counts as visible context)
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).toMatch(/updates above/i)
+      expect(lastCall.content).toMatch(/new.*@fro-bot request|what to do next/i)
+      // #and — does NOT use no-output retry wording
+      expect(lastCall.content).not.toMatch(/please try again/i)
+    })
+
+    it('approval send REJECTS before timeout fires → no-output timeout copy chosen', async () => {
+      // #given — the approval send rejects (settle(false) retracts the pending claim).
+      // After rejection, hasVisibleOutput() returns false → no-output branch.
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+
+      const statefulSink = makeStatefulPendingSinkMock()
+      mockCreateDiscordStreamSink.mockReturnValue(statefulSink)
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({runTimeoutMs: 600_000})
+
+      let capturedOnPending: ((req: import('../approvals/coordinator.js').PermissionRequest) => void) | undefined
+      mockCreatePermissionCoordinator.mockImplementation(coordinatorDeps => {
+        capturedOnPending = coordinatorDeps.onPending
+        return {
+          onPermissionAsked: vi.fn(),
+          onPermissionReplied: vi.fn(),
+          pending: vi.fn().mockReturnValue([]),
+          dispose: vi.fn(),
+        }
+      })
+
+      // thread.send rejects for the first 2 calls (approval sends fail).
+      // The 3rd call (error message) resolves immediately.
+      const sendRejected = Promise.reject(new Error('Discord send failed'))
+      // Attach a no-op catch so the unhandled rejection doesn't leak in test output
+      sendRejected.catch(() => undefined)
+      thread.send.mockReturnValueOnce(sendRejected).mockReturnValueOnce(sendRejected).mockResolvedValue(undefined)
+
+      // runOpenCodeCore calls onPending then throws timeout.
+      // The approval sends reject first (microtask queue), then timeout is classified.
+      mockRunOpenCodeCore.mockImplementation(async () => {
+        if (capturedOnPending !== undefined) {
+          capturedOnPending({
+            requestID: 'req-reject-1',
+            sessionID: 'sess-reject',
+            permission: 'bash',
+            patterns: [],
+            title: 'Run command: ls',
+          })
+        }
+        // Yield to the microtask queue so the rejection .catch() handlers run
+        // and settle(false) retracts the pending claim before the timeout is thrown.
+        await new Promise(resolve => setTimeout(resolve, 0))
+        throw new RunCoreError('timeout', 'timed out')
+      })
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — no-output branch chosen (failed send retracted the pending claim)
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).toMatch(/please try again/i)
+      // #and — does NOT use visible-output wording
+      expect(lastCall.content).not.toMatch(/updates above/i)
+      expect(lastCall.content).not.toMatch(/what to do next/i)
+    })
+
+    it('approval send RESOLVES before timeout fires → visible-output timeout copy chosen', async () => {
+      // #given — the approval send resolves successfully (settle(true) promotes to delivered).
+      // This is the existing behavior preserved: successful send → visible-output branch.
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+
+      const statefulSink = makeStatefulPendingSinkMock()
+      mockCreateDiscordStreamSink.mockReturnValue(statefulSink)
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({runTimeoutMs: 600_000})
+
+      let capturedOnPending: ((req: import('../approvals/coordinator.js').PermissionRequest) => void) | undefined
+      mockCreatePermissionCoordinator.mockImplementation(coordinatorDeps => {
+        capturedOnPending = coordinatorDeps.onPending
+        return {
+          onPermissionAsked: vi.fn(),
+          onPermissionReplied: vi.fn(),
+          pending: vi.fn().mockReturnValue([]),
+          dispose: vi.fn(),
+        }
+      })
+
+      // thread.send resolves immediately for all calls (approval sends succeed).
+      const fakeApprovalMessage = {id: 'msg-approval-race', edit: vi.fn()}
+      thread.send.mockResolvedValue(fakeApprovalMessage)
+
+      // runOpenCodeCore calls onPending, yields so sends resolve, then throws timeout.
+      mockRunOpenCodeCore.mockImplementation(async () => {
+        if (capturedOnPending !== undefined) {
+          capturedOnPending({
+            requestID: 'req-resolve-1',
+            sessionID: 'sess-resolve',
+            permission: 'bash',
+            patterns: [],
+            title: 'Run command: ls',
+          })
+        }
+        // Yield so the .then() handlers run and settle(true) promotes to delivered
+        await new Promise(resolve => setTimeout(resolve, 0))
+        throw new RunCoreError('timeout', 'timed out')
+      })
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — visible-output branch chosen (send resolved → permanently delivered)
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).toMatch(/updates above/i)
+      expect(lastCall.content).toMatch(/new.*@fro-bot request|what to do next/i)
+      // #and — does NOT use no-output retry wording
+      expect(lastCall.content).not.toMatch(/please try again/i)
+    })
+
+    it('no approval requested + empty output + timeout → no-output copy (unchanged baseline)', async () => {
+      // #given — no onPending ever called; sink has no visible output; timeout fires.
+      // Verifies the baseline no-output path is unchanged by the pending-visibility feature.
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+
+      const statefulSink = makeStatefulPendingSinkMock()
+      mockCreateDiscordStreamSink.mockReturnValue(statefulSink)
+
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({runTimeoutMs: 600_000})
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — no-output branch chosen (no approval, no visible output)
+      const lastCall = thread.send.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastCall.content).toMatch(/please try again/i)
+      // #and — does NOT use visible-output wording
+      expect(lastCall.content).not.toMatch(/updates above/i)
+      expect(lastCall.content).not.toMatch(/what to do next/i)
+      // #and — includes configured duration
+      expect(lastCall.content).toMatch(/10.?min/i)
+    })
+  })
+
   // ── Security invariants ──────────────────────────────────────────────────
 
   describe('security invariants', () => {
@@ -1901,18 +2148,21 @@ describe('runMention', () => {
       expect(statusSend?.content).toContain('Waiting for tool approval')
     })
 
-    it('onPending: sink.markVisibleOutputSent() is called so flush cannot add _(no output)_ after approval status', async () => {
-      // #given
+    it('onPending: sink.markVisibleOutputPending() is called and settle(true) fires on success so flush cannot add _(no output)_ after approval status', async () => {
+      // #given — verifies the pending-visibility API is used: markVisibleOutputPending()
+      // is called synchronously before the send, and the returned settle handle is called
+      // with true on success (promoting to permanently delivered).
       const {runMention} = await import('./run.js')
       setupHappyPath()
 
-      const markVisibleOutputSentFn = vi.fn()
+      const settleFn = vi.fn()
+      const markVisibleOutputPendingFn = vi.fn().mockReturnValue(settleFn)
       mockCreateDiscordStreamSink.mockReturnValue({
         append: vi.fn(),
         flush: vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 10}),
         buffered: vi.fn().mockReturnValue(''),
-        markVisibleOutputSent: markVisibleOutputSentFn,
-        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
+        markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: markVisibleOutputPendingFn,
         hasVisibleOutput: vi.fn().mockReturnValue(false),
       })
 
@@ -1947,8 +2197,10 @@ describe('runMention', () => {
       })
       await new Promise(resolve => setTimeout(resolve, 0))
 
-      // #then — markVisibleOutputSent was called on the sink
-      expect(markVisibleOutputSentFn).toHaveBeenCalled()
+      // #then — markVisibleOutputPending was called (once per send: waiting-status + embed)
+      expect(markVisibleOutputPendingFn).toHaveBeenCalled()
+      // #and — the settle handle was called with true (sends succeeded → permanently delivered)
+      expect(settleFn).toHaveBeenCalledWith(true)
     })
 
     it('deadline settlement: posts visible timed-out/denied status to thread with allowedMentions:{parse:[]}', async () => {

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -411,18 +411,29 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
           // user sees the run is blocked even if the embed send is slow.
           // Fire-and-forget: status is best-effort; must not block onPending.
           // .catch() prevents an unhandled rejection if the Discord send fails.
+          //
+          // Pending-visibility: mark the send as in-flight BEFORE the void send so
+          // timeout classification sees it as visible context even if the Discord
+          // round-trip has not completed yet. settle(true) on success promotes to
+          // permanently delivered; settle(false) on failure retracts the claim.
+          const settleWaitingStatus = sink?.markVisibleOutputPending()
           // eslint-disable-next-line no-void
           void safeSend(rawThread, 'Waiting for tool approval…')
             .then(() => {
-              sink?.markVisibleOutputSent()
+              settleWaitingStatus?.(true)
             })
             .catch((error: unknown) => {
+              settleWaitingStatus?.(false)
               logger.warn({requestID, err: String(error)}, 'run: failed to post waiting-for-approval status')
             })
 
           // Fire-and-forget: send the embed then attach the render function.
           // rawThread has the full Discord.js API (embeds, components, edit).
           // onPending must not throw (coordinator catches internally anyway).
+          //
+          // Pending-visibility: same pattern as the waiting-status send above —
+          // mark in-flight before the void send, settle on resolution.
+          const settleEmbed = sink?.markVisibleOutputPending()
           // eslint-disable-next-line no-void
           void rawThread
             .send({
@@ -431,9 +442,9 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
               allowedMentions: {parse: []},
             })
             .then(postedMessage => {
-              // Embed send succeeded — mark sink visible so flush() does not add
-              // a misleading _(no output)_ even if the waiting-status send failed.
-              sink?.markVisibleOutputSent()
+              // Embed send succeeded — settle pending claim as delivered so
+              // flush() does not add a misleading _(no output)_.
+              settleEmbed?.(true)
               // Attach the render function now that we have a message reference.
               approvalRegistry.attachMessage(
                 requestID,
@@ -455,6 +466,7 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
               )
             })
             .catch((error: unknown) => {
+              settleEmbed?.(false)
               logger.warn({requestID, err: String(error)}, 'run: failed to post approval embed')
               approvalRegistry.markMessagePostFailed(requestID)
             })


### PR DESCRIPTION
## Summary

Follow-up to the v0.55.3 timeout-messaging fix. When a Discord mention run times out while an approval or status message is still in flight to Discord, the timeout copy could fall back to the "no output" wording even though the approval marker lands moments later — and in the worst case the user could see both the "no output" line and the "posted updates above" line together.

## What changed

- The Discord stream sink now tracks visibility that has been *initiated but not yet delivered*. An approval/status send marks visibility pending synchronously before it fires, then settles as delivered on success or retracts on failure.
- Timeout classification treats an in-flight send as visible context, so the message no longer claims "no output" when an approval prompt is on its way.
- A failed send retracts its claim, so the "no output" wording is still correct when nothing was actually delivered.
- The empty-output fallback is suppressed while a send is pending, so a timeout in that window can't post a contradictory "no output" + "updates above" pair.

A timeout is still treated as a failure — this only makes the messaging accurate.

## Tests

- Pending send unresolved at timeout → visible-output copy, and no "no output" message posted.
- Send rejects → no-output copy (a failed send never claims output).
- Send resolves before timeout → visible-output copy (unchanged).
- No approval + empty output + timeout → no-output copy (unchanged).
- Sink-level coverage for the pending counter: pending-as-visible, settle-true persistence, settle-false retraction, concurrent handles, one-shot settle (no negative count), and empty-buffer flush skipping the fallback while pending.
