### PR TITLE
fix(deploy): block IPv6 literals that smuggle private IPv4 past the egress allowlist

### DIFF
--- a/deploy/mitmproxy/allowlist.py
+++ b/deploy/mitmproxy/allowlist.py
@@ -42,12 +42,18 @@ import sys
 from mitmproxy import http
 
 # ---------------------------------------------------------------------------
-# NAT64 Well-Known Prefix (RFC 6052 §2.1).
+# Embedded-IPv4 IPv6 prefixes whose low 32 bits encode an IPv4 address.
 # Python's ipaddress does NOT decode the embedded IPv4 from these addresses,
-# so 64:ff9b::a00:1 (embedding 10.0.0.1) incorrectly reports is_global=True.
-# _ip_is_disallowed extracts and checks the embedded IPv4 for this prefix.
+# so e.g. 64:ff9b::a00:1 (embedding 10.0.0.1) incorrectly reports is_global=True.
+# _ip_is_disallowed extracts and checks the embedded IPv4 for both prefixes.
+#
+# _NAT64_WKP  — NAT64 Well-Known Prefix 64:ff9b::/96 (RFC 6052 §2.1)
+# _IPV4_COMPAT — IPv4-compatible IPv6 ::/96 (RFC 4291 §2.5.5.1, deprecated
+#                but still parseable; e.g. ::10.0.0.1 → is_global=True in Python)
 # ---------------------------------------------------------------------------
 _NAT64_WKP = ipaddress.ip_network("64:ff9b::/96")
+_IPV4_COMPAT = ipaddress.ip_network("::/96")
+_EMBEDDED_V4_PREFIXES = (_NAT64_WKP, _IPV4_COMPAT)
 
 # ---------------------------------------------------------------------------
 # Allowlist — production-safe defaults for fro-bot v1.
@@ -97,11 +103,14 @@ def _ip_is_disallowed(ip_str: str) -> bool:
       - documentation ranges (192.0.2/24, 198.51.100/24, 203.0.113/24, 2001:db8::/32)
       - benchmarking (198.18/15)
       - multicast, unspecified (0.0.0.0, ::), site-local, unique local IPv6 (fc00::/7)
-      - NAT64 Well-Known Prefix 64:ff9b::/96 (RFC 6052) embedding a non-global IPv4:
-        Python's ipaddress does not decode the embedded IPv4, so the raw IPv6
-        is_global check would incorrectly pass addresses like 64:ff9b::a00:1
-        (which embeds 10.0.0.1). The embedded IPv4 is extracted from the low
-        32 bits of the address integer and evaluated with the same is_global rule.
+      - Embedded-IPv4 IPv6 prefixes where Python's ipaddress does not decode the
+        embedded IPv4 and the raw is_global check would incorrectly pass:
+          * NAT64 Well-Known Prefix 64:ff9b::/96 (RFC 6052) — e.g. 64:ff9b::a00:1
+            embeds 10.0.0.1 but reports is_global=True
+          * IPv4-compatible IPv6 ::/96 (RFC 4291 §2.5.5.1, deprecated) — e.g.
+            ::10.0.0.1 (::a00:1) embeds 10.0.0.1 but reports is_global=True
+        For both prefixes the embedded IPv4 is extracted from the low 32 bits of
+        the address integer and evaluated with the same is_global rule.
 
     Returns False for globally-routable public IPs (accepted for self-hosted
     MinIO deployments and similar use cases).
@@ -111,8 +120,8 @@ def _ip_is_disallowed(ip_str: str) -> bool:
     except ValueError:
         # Not a parseable IP address — not our concern here.
         return False
-    # NAT64 Well-Known Prefix: extract and check the embedded IPv4 (low 32 bits).
-    if isinstance(ip, ipaddress.IPv6Address) and ip in _NAT64_WKP:
+    # Embedded-IPv4 prefixes: extract and check the embedded IPv4 (low 32 bits).
+    if isinstance(ip, ipaddress.IPv6Address) and any(ip in net for net in _EMBEDDED_V4_PREFIXES):
         embedded_v4 = ipaddress.IPv4Address(int(ip) & 0xFFFFFFFF)
         if not embedded_v4.is_global:
             return True

--- a/deploy/mitmproxy/allowlist.py
+++ b/deploy/mitmproxy/allowlist.py
@@ -42,6 +42,14 @@ import sys
 from mitmproxy import http
 
 # ---------------------------------------------------------------------------
+# NAT64 Well-Known Prefix (RFC 6052 §2.1).
+# Python's ipaddress does NOT decode the embedded IPv4 from these addresses,
+# so 64:ff9b::a00:1 (embedding 10.0.0.1) incorrectly reports is_global=True.
+# _ip_is_disallowed extracts and checks the embedded IPv4 for this prefix.
+# ---------------------------------------------------------------------------
+_NAT64_WKP = ipaddress.ip_network("64:ff9b::/96")
+
+# ---------------------------------------------------------------------------
 # Allowlist — production-safe defaults for fro-bot v1.
 # Entries starting with "*." match any subdomain of the given domain.
 #
@@ -89,6 +97,11 @@ def _ip_is_disallowed(ip_str: str) -> bool:
       - documentation ranges (192.0.2/24, 198.51.100/24, 203.0.113/24, 2001:db8::/32)
       - benchmarking (198.18/15)
       - multicast, unspecified (0.0.0.0, ::), site-local, unique local IPv6 (fc00::/7)
+      - NAT64 Well-Known Prefix 64:ff9b::/96 (RFC 6052) embedding a non-global IPv4:
+        Python's ipaddress does not decode the embedded IPv4, so the raw IPv6
+        is_global check would incorrectly pass addresses like 64:ff9b::a00:1
+        (which embeds 10.0.0.1). The embedded IPv4 is extracted from the low
+        32 bits of the address integer and evaluated with the same is_global rule.
 
     Returns False for globally-routable public IPs (accepted for self-hosted
     MinIO deployments and similar use cases).
@@ -98,6 +111,11 @@ def _ip_is_disallowed(ip_str: str) -> bool:
     except ValueError:
         # Not a parseable IP address — not our concern here.
         return False
+    # NAT64 Well-Known Prefix: extract and check the embedded IPv4 (low 32 bits).
+    if isinstance(ip, ipaddress.IPv6Address) and ip in _NAT64_WKP:
+        embedded_v4 = ipaddress.IPv4Address(int(ip) & 0xFFFFFFFF)
+        if not embedded_v4.is_global:
+            return True
     return not ip.is_global
 
 

--- a/deploy/mitmproxy/test_allowlist.py
+++ b/deploy/mitmproxy/test_allowlist.py
@@ -963,6 +963,77 @@ def test_dns_rebinding_request_hook_also_enforced():
 
 
 # ===========================================================================
+# NAT64 Well-Known Prefix (64:ff9b::/96) embedded-IPv4 bypass — RFC 6052
+# ===========================================================================
+
+
+def test_ip_is_disallowed_nat64_embeds_rfc1918_10():
+    """64:ff9b::a00:1 embeds 10.0.0.1 (RFC 1918) — must be disallowed."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("64:ff9b::a00:1") is True
+
+
+def test_ip_is_disallowed_nat64_embeds_loopback():
+    """64:ff9b::7f00:1 embeds 127.0.0.1 (loopback) — must be disallowed."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("64:ff9b::7f00:1") is True
+
+
+def test_ip_is_disallowed_nat64_embeds_link_local():
+    """64:ff9b::a9fe:1 embeds 169.254.0.1 (link-local) — must be disallowed."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("64:ff9b::a9fe:1") is True
+
+
+def test_ip_is_disallowed_nat64_embeds_cgnat():
+    """64:ff9b::6440:1 embeds 100.64.0.1 (CGNAT / RFC 6598) — must be disallowed."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("64:ff9b::6440:1") is True
+
+
+def test_ip_is_disallowed_nat64_embeds_public_allowed():
+    """64:ff9b::808:808 embeds 8.8.8.8 (public) — must NOT be disallowed."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("64:ff9b::808:808") is False
+
+
+def test_ip_is_disallowed_nat64_regression_6to4_still_blocked():
+    """2002:0a00:0001:: (6to4 embedding 10.0.0.1) — already blocked, must stay True."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("2002:0a00:0001::") is True
+
+
+def test_ip_is_disallowed_nat64_regression_v4mapped_still_blocked():
+    """::ffff:10.0.0.1 (v4-mapped) — already blocked, must stay True."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("::ffff:10.0.0.1") is True
+
+
+def test_ip_is_disallowed_nat64_regression_rfc8215_still_blocked():
+    """64:ff9b:1::a00:1 (RFC 8215 local NAT64 prefix) — already blocked, must stay True."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("64:ff9b:1::a00:1") is True
+
+
+def test_ip_is_disallowed_nat64_regression_public_ipv6_allowed():
+    """2606:4700::1111 (Cloudflare public IPv6) — must NOT be disallowed."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("2606:4700::1111") is False
+
+
+def test_ip_is_disallowed_nat64_embeds_private_172():
+    """64:ff9b::ac10:1 embeds 172.16.0.1 (RFC 1918) — must be disallowed."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("64:ff9b::ac10:1") is True
+
+
+def test_ip_is_disallowed_nat64_embeds_private_192_168():
+    """64:ff9b::c0a8:101 embeds 192.168.1.1 (RFC 1918) — must be disallowed."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("64:ff9b::c0a8:101") is True
+
+
+# ===========================================================================
 # Standalone runner (no pytest required)
 # ===========================================================================
 

--- a/deploy/mitmproxy/test_allowlist.py
+++ b/deploy/mitmproxy/test_allowlist.py
@@ -1034,6 +1034,65 @@ def test_ip_is_disallowed_nat64_embeds_private_192_168():
 
 
 # ===========================================================================
+# IPv4-compatible IPv6 addresses (::/96) embedded-IPv4 bypass — RFC 4291 §2.5.5.1
+# ===========================================================================
+
+
+def test_ip_is_disallowed_ipv4compat_embeds_rfc1918_10():
+    """::10.0.0.1 (::a00:1) embeds 10.0.0.1 (RFC 1918) — must be disallowed."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("::a00:1") is True
+
+
+def test_ip_is_disallowed_ipv4compat_embeds_loopback():
+    """::127.0.0.1 (::7f00:1) embeds 127.0.0.1 (loopback) — must be disallowed."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("::7f00:1") is True
+
+
+def test_ip_is_disallowed_ipv4compat_embeds_link_local():
+    """::169.254.0.1 (::a9fe:1) embeds 169.254.0.1 (link-local) — must be disallowed."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("::a9fe:1") is True
+
+
+def test_ip_is_disallowed_ipv4compat_embeds_public_allowed():
+    """::8.8.8.8 (::808:808) embeds 8.8.8.8 (public) — must NOT be disallowed."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("::808:808") is False
+
+
+def test_ip_is_disallowed_ipv4compat_regression_loopback_still_blocked():
+    """::1 (IPv6 loopback) — already is_global=False, must stay True (unaffected)."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("::1") is True
+
+
+def test_ip_is_disallowed_ipv4compat_regression_unspecified_still_blocked():
+    """:: (unspecified) — already is_global=False, must stay True (unaffected)."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("::") is True
+
+
+def test_ip_is_disallowed_ipv4compat_regression_v4mapped_still_blocked():
+    """::ffff:10.0.0.1 (v4-mapped, ::ffff:0:0/96) — different prefix, already blocked."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("::ffff:10.0.0.1") is True
+
+
+def test_ip_is_disallowed_nat64_wkp_network_address_blocked():
+    """64:ff9b:: (NAT64 WKP network address, embeds 0.0.0.0) — must be disallowed."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("64:ff9b::") is True
+
+
+def test_ip_is_disallowed_public_ipv6_outside_nat64_allowed():
+    """2606:4700::1111 (Cloudflare public IPv6, outside NAT64/compat prefixes) — must NOT be disallowed."""
+    mod = _load_allowlist()
+    assert mod._ip_is_disallowed("2606:4700::1111") is False
+
+
+# ===========================================================================
 # Standalone runner (no pytest required)
 # ===========================================================================
 


### PR DESCRIPTION
Addresses the IPv6 literal bypass tracked in #746.

## Problem

The workspace egress allowlist rejects destinations that resolve to private or reserved IPs by checking `not ip.is_global`. Two IPv6 forms that embed an IPv4 address slip past that check, because Python's `ipaddress` reports them as globally routable without decoding the embedded IPv4:

- NAT64 Well-Known Prefix `64:ff9b::/96` (RFC 6052) — `64:ff9b::a00:1` embeds `10.0.0.1` but reports `is_global = True`.
- IPv4-compatible IPv6 `::/96` (RFC 4291, deprecated but still parseable) — `::10.0.0.1` embeds `10.0.0.1` and likewise reports `is_global = True`.

A request to such a literal (or a hostname resolving to one, since the resolved-IP path runs the same check) could reach private/reserved space the allowlist is meant to contain.

## Fix

For both prefixes, the disallow check now extracts the embedded IPv4 from the low 32 bits and applies the same `is_global` rule. Addresses embedding a private, loopback, link-local, CGNAT, or other non-global IPv4 are blocked; addresses embedding a genuinely public IPv4 (for example `64:ff9b::8.8.8.8`) remain allowed, so legitimate NAT64-to-public traffic is unaffected. The change is confined to the IP classifier, so it covers both the literal-host and resolved-DNS enforcement paths.

## Tests

The allowlist suite adds coverage for both prefixes: each embedded-private form is asserted blocked, the public-embedded forms asserted allowed, and regressions (IPv4-mapped `::ffff:`, RFC 8215 local NAT64, plain public IPv6, raw private/public IPv4) confirmed unchanged. Full suite passes (`python3 deploy/mitmproxy/test_allowlist.py`).
