### PR TITLE
fix(deploy): bound egress DNS resolution with a timeout

### DIFF
--- a/deploy/mitmproxy/allowlist.py
+++ b/deploy/mitmproxy/allowlist.py
@@ -35,6 +35,7 @@ WORKSPACE_EGRESS_HOSTS
     (fail-closed default).
 """
 
+import concurrent.futures
 import ipaddress
 import os
 import socket
@@ -54,6 +55,12 @@ from mitmproxy import http
 _NAT64_WKP = ipaddress.ip_network("64:ff9b::/96")
 _IPV4_COMPAT = ipaddress.ip_network("::/96")
 _EMBEDDED_V4_PREFIXES = (_NAT64_WKP, _IPV4_COMPAT)
+
+# Hard timeout for DNS resolution in _resolve_has_disallowed_ip. getaddrinfo(3)
+# does NOT honor socket.setdefaulttimeout() on Linux/glibc (uses the C resolver),
+# so we bound it via a worker thread + future.result(timeout=...). On timeout we
+# fail closed (block the request) — same policy as a resolution error.
+_DNS_RESOLVE_TIMEOUT_S: float = 5.0
 
 # ---------------------------------------------------------------------------
 # Allowlist — production-safe defaults for fro-bot v1.
@@ -295,16 +302,27 @@ def _is_allowed(host: str) -> bool:
 def _resolve_has_disallowed_ip(host: str) -> bool:
     """Resolve *host* and return True if ANY resolved address is disallowed.
 
-    Fails closed: if resolution raises (DNS error, timeout, or encoding
-    failure), returns True (block the request).
+    Fails closed: if resolution raises (DNS error or encoding failure), OR if
+    resolution does not complete within _DNS_RESOLVE_TIMEOUT_S seconds, returns
+    True (block the request). The 5-second budget bounds proxy stalls caused by
+    a slow or hanging system resolver — getaddrinfo(3) does not honor
+    socket.setdefaulttimeout() on Linux/glibc.
 
     Note: this check runs at the addon hook layer. mitmproxy performs its own
     independent resolution for the upstream dial (TOCTOU gap). This is
     defense-in-depth against operator misconfiguration and naive DNS rebinding,
     not a hermetic guarantee.
     """
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    future = executor.submit(socket.getaddrinfo, host, None)
+    # Detach immediately — do NOT wait for the thread on shutdown. If the
+    # future times out the worker thread may keep running briefly in the
+    # background; that is acceptable (daemon-ish). We must not block here.
+    executor.shutdown(wait=False)
     try:
-        results = socket.getaddrinfo(host, None)
+        results = future.result(timeout=_DNS_RESOLVE_TIMEOUT_S)
+    except concurrent.futures.TimeoutError:
+        return True  # fail closed — resolution hung, block the request
     except (OSError, UnicodeError):
         return True  # fail closed — resolution failure blocks the request
     for _family, _type, _proto, _canonname, sockaddr in results:

--- a/deploy/mitmproxy/test_allowlist.py
+++ b/deploy/mitmproxy/test_allowlist.py
@@ -962,6 +962,54 @@ def test_dns_rebinding_request_hook_also_enforced():
     assert call_args[0][0] == 403
 
 
+def test_dns_resolve_timeout_fails_closed():
+    """getaddrinfo hanging longer than _DNS_RESOLVE_TIMEOUT_S → fail closed, bounded wall time."""
+    import time
+    import unittest.mock as mock
+
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    # Patch the timeout constant to 0.2s so the test stays fast.
+    mod._DNS_RESOLVE_TIMEOUT_S = 0.2
+
+    def slow_getaddrinfo(host, port):
+        time.sleep(1.0)  # sleeps well past the 0.2s budget
+        return [(None, None, None, None, ("8.8.8.8", 0))]
+
+    mod.socket = mock.MagicMock()
+    mod.socket.getaddrinfo.side_effect = slow_getaddrinfo
+
+    start = time.monotonic()
+    result = mod._resolve_has_disallowed_ip("cliproxy.fro.bot")
+    elapsed = time.monotonic() - start
+
+    assert result is True, "should fail closed on timeout"
+    assert elapsed < 0.8, f"should return well before the 1s sleep, got {elapsed:.3f}s"
+
+
+def test_dns_resolve_fast_public_ip_allowed():
+    """Fast resolution to a public IP is allowed (timeout path does not interfere)."""
+    import unittest.mock as mock
+
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    mod.socket = mock.MagicMock()
+    mod.socket.getaddrinfo.return_value = [(None, None, None, None, ("8.8.8.8", 0))]
+
+    result = mod._resolve_has_disallowed_ip("cliproxy.fro.bot")
+    assert result is False, "public IP should be allowed"
+
+
+def test_dns_resolve_oserror_still_fails_closed_with_threading():
+    """OSError from getaddrinfo inside the worker thread still fails closed."""
+    import unittest.mock as mock
+
+    mod = _load_allowlist({"WORKSPACE_EGRESS_HOSTS": "cliproxy.fro.bot"})
+    mod.socket = mock.MagicMock()
+    mod.socket.getaddrinfo.side_effect = OSError("network unreachable")
+
+    result = mod._resolve_has_disallowed_ip("cliproxy.fro.bot")
+    assert result is True, "OSError should fail closed"
+
+
 # ===========================================================================
 # NAT64 Well-Known Prefix (64:ff9b::/96) embedded-IPv4 bypass — RFC 6052
 # ===========================================================================


### PR DESCRIPTION
Addresses a residual reliability gap tracked in #746.

## Problem

The workspace egress allowlist resolves operator-supplied hosts at enforcement time (to defend against DNS rebinding) using `socket.getaddrinfo`, which has no timeout. `getaddrinfo` does not honor `socket.setdefaulttimeout()` on Linux, so a slow or hanging system resolver blocks the mitmproxy enforcement hook indefinitely and stalls proxy throughput. The function's docstring also claimed it failed closed on "timeout," which was not actually true.

## Fix

Resolution now runs in a worker thread bounded by a 5-second budget (`future.result(timeout=...)`). A timeout fails closed — the request is blocked — matching the existing fail-closed behavior on resolution errors. The executor is detached immediately so a hung resolver thread cannot block the hook through the executor's own shutdown. The docstring now accurately describes both the error and timeout fail-closed paths.

## Tests

Added coverage proving the bound fires: with the timeout patched low and the resolver made to sleep well past it, resolution returns blocked within the budget rather than at the sleep duration. Existing behavior is confirmed unchanged — fast public resolution stays allowed, and resolution errors still fail closed. Full suite passes (`python3 deploy/mitmproxy/test_allowlist.py`).
