### PR TITLE
fix(deploy): harden compose topology guard against network_mode and multi-file overrides

### DIFF
--- a/deploy/validate-stack.sh
+++ b/deploy/validate-stack.sh
@@ -46,11 +46,23 @@ import os
 import subprocess
 import sys
 
-compose_file = os.environ.get("COMPOSE_FILE", "deploy/compose.yaml")
+compose_file_env = os.environ.get("COMPOSE_FILE", "deploy/compose.yaml")
+
+# Support Docker's native multi-file COMPOSE_FILE: files are separated by
+# COMPOSE_PATH_SEPARATOR (default ':' on Linux/macOS, ';' on Windows).
+# When multiple files are specified, docker compose merges them in order
+# (later files override earlier ones), exactly as `docker compose -f a -f b`.
+path_sep = os.environ.get("COMPOSE_PATH_SEPARATOR", ":")
+compose_files = [f for f in compose_file_env.split(path_sep) if f]
+
+# Build the list of -f args for docker compose invocations.
+# Single-file case produces exactly ["-f", "<file>"] — byte-for-byte identical
+# to the previous behaviour.
+f_args = sum([["-f", f] for f in compose_files], [])
 
 try:
     result = subprocess.run(
-        ["docker", "compose", "-f", compose_file, "config", "--format", "json"],
+        ["docker", "compose"] + f_args + ["config", "--format", "json"],
         capture_output=True,
         text=True,
         check=True,
@@ -66,15 +78,31 @@ except (subprocess.CalledProcessError, OSError):
         import yaml
         try:
             result2 = subprocess.run(
-                ["docker", "compose", "-f", compose_file, "config"],
+                ["docker", "compose"] + f_args + ["config"],
                 capture_output=True,
                 text=True,
                 check=True,
             )
             cfg = yaml.safe_load(result2.stdout)
         except (subprocess.CalledProcessError, OSError):
-            # docker compose unavailable — parse the raw YAML file directly.
-            with open(compose_file) as fh:
+            # docker compose unavailable — parse the raw YAML file(s) directly.
+            # docker-present multi-file: `docker compose -f a -f b config` performs
+            #   an authoritative merge (stays correct above in the docker-present path).
+            # docker-absent single-file: parse the raw YAML directly (safe).
+            # docker-absent multi-file: FAIL CLOSED — raw YAML shallow-merge replaces
+            #   whole service dicts and cannot faithfully reproduce Docker Compose merge
+            #   semantics; a partial override would be misread as a full replacement,
+            #   producing false failures on valid configs.
+            if len(compose_files) > 1:
+                print(
+                    "ERROR: COMPOSE_FILE lists multiple files but docker compose is "
+                    "unavailable. The raw-YAML fallback cannot faithfully reproduce "
+                    "Docker Compose merge semantics. Install docker compose, or "
+                    "validate a single fully-rendered compose file.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            with open(compose_files[0]) as fh:
                 cfg = yaml.safe_load(fh)
     except Exception as e2:
         print(f"ERROR: could not parse compose config: {e2}", file=sys.stderr)
@@ -123,9 +151,38 @@ workspace_nets = service_networks("workspace")
 mitmproxy_nets = service_networks("mitmproxy")
 
 # ------------------------------------------------------------------
-# Invariant 2: workspace is attached to sandbox-net only
+# Invariant 1b: NO service may declare network_mode.
+#
+# A compose override can set network_mode: host (or service:<x> /
+# container:<x>) on any service.  Such a service has NO 'networks' key,
+# so the network-attachment invariants below pass VACUOUSLY while the
+# container actually has host/shared networking — bypassing containment
+# entirely.  Reject any network_mode declaration on ANY service,
+# regardless of value.  Service names are sorted for deterministic output.
+#
+# Capture the set of services that declare network_mode so that the
+# per-service network-attachment invariants below can skip them — a
+# service with network_mode produces EXACTLY ONE failure line (this one),
+# not confusing secondary attachment messages.
 # ------------------------------------------------------------------
-if workspace_nets != {"sandbox-net"}:
+network_mode_services = set()
+for _svc in sorted(services.keys()):
+    _svc_cfg = services.get(_svc) or {}
+    _nm = _svc_cfg.get("network_mode")
+    if _nm:
+        network_mode_services.add(_svc)
+        failures.append(
+            f"FAIL: service '{_svc}' declares network_mode '{_nm}' — "
+            "network_mode bypasses the sandbox/egress network-attachment model "
+            "and is not permitted."
+        )
+
+# ------------------------------------------------------------------
+# Invariant 2: workspace is attached to sandbox-net only
+# (skipped when workspace declares network_mode — Invariant 1b already
+# covers that case and workspace_nets would be empty/misleading)
+# ------------------------------------------------------------------
+if "workspace" not in network_mode_services and workspace_nets != {"sandbox-net"}:
     failures.append(
         f"FAIL: workspace is attached to networks {sorted(workspace_nets)!r} "
         f"but must be attached to exactly ['sandbox-net']."
@@ -134,14 +191,16 @@ if workspace_nets != {"sandbox-net"}:
 # ------------------------------------------------------------------
 # Invariant 3: mitmproxy is attached to sandbox-net AND at least one
 # non-internal network (its upstream leg).
+# (skipped when mitmproxy declares network_mode — Invariant 1b covers it)
 # ------------------------------------------------------------------
-if "sandbox-net" not in mitmproxy_nets:
-    failures.append(
-        "FAIL: mitmproxy is not attached to sandbox-net — it cannot receive "
-        "workspace traffic."
-    )
+if "mitmproxy" not in network_mode_services:
+    if "sandbox-net" not in mitmproxy_nets:
+        failures.append(
+            "FAIL: mitmproxy is not attached to sandbox-net — it cannot receive "
+            "workspace traffic."
+        )
 mitmproxy_egress_nets = mitmproxy_nets & non_internal_nets
-if not mitmproxy_egress_nets:
+if "mitmproxy" not in network_mode_services and not mitmproxy_egress_nets:
     failures.append(
         f"FAIL: mitmproxy is attached only to internal networks {sorted(mitmproxy_nets)!r}. "
         "It needs at least one non-internal network as its upstream leg so it "
@@ -150,9 +209,10 @@ if not mitmproxy_egress_nets:
 
 # ------------------------------------------------------------------
 # Invariant 4: workspace is attached to NO non-internal network
+# (skipped when workspace declares network_mode — Invariant 1b covers it)
 # ------------------------------------------------------------------
 workspace_egress_nets = workspace_nets & non_internal_nets
-if workspace_egress_nets:
+if "workspace" not in network_mode_services and workspace_egress_nets:
     failures.append(
         f"FAIL: workspace is attached to non-internal network(s) "
         f"{sorted(workspace_egress_nets)!r} — it has direct internet egress, "
@@ -162,6 +222,8 @@ if workspace_egress_nets:
 # ------------------------------------------------------------------
 # Invariant 5: each non-internal network that mitmproxy uses must have
 # EXACTLY ONE attached service (mitmproxy itself).
+# (mitmproxy_egress_nets is empty when mitmproxy has network_mode, so
+# this loop is a no-op in that case — no explicit skip needed)
 # ------------------------------------------------------------------
 for egress_net in mitmproxy_egress_nets:
     attached = [

--- a/deploy/validate-stack.test.sh
+++ b/deploy/validate-stack.test.sh
@@ -13,6 +13,15 @@
 #   (f) EXITS NON-ZERO for long-form bind mounts at /workspace/repos.
 #   (g) EXITS NON-ZERO for --topology-only without Docker when workspace-repos
 #       mount is missing (raw YAML fallback must still catch the invariant).
+#   (h) EXITS NON-ZERO when ANY service (not just workspace/mitmproxy) declares
+#       network_mode (broadened Invariant 1b scope).
+#   (i) EXITS NON-ZERO (fail-closed) when docker is absent and COMPOSE_FILE lists
+#       multiple files — raw-YAML shallow-merge cannot reproduce Docker Compose
+#       merge semantics and must not silently produce wrong results.
+#   (j) When docker IS available, multi-file topology violations are still caught
+#       via the authoritative docker compose merge (gated on docker presence).
+#   (k) Single-file raw YAML fallback (no docker) is unchanged — still exits zero
+#       for a valid single compose file.
 #
 # Run from repo root:
 #   bash deploy/validate-stack.test.sh
@@ -572,6 +581,418 @@ fi
 echo ""
 echo "  No-Docker-insecure-test output (stderr+stdout combined):"
 echo "${NO_DOCKER_INSECURE_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 12 — Negative: network_mode:host on workspace must be rejected.
+#
+# An override can set network_mode: host on workspace, giving it full host
+# networking.  Because network_mode replaces the 'networks' key entirely,
+# the existing network-attachment invariants would pass vacuously.  The new
+# Invariant 1b must catch this regardless of the docker/no-docker path.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 12: topology guard rejects workspace with network_mode:host ---"
+
+NM_WORKSPACE_COMPOSE="${TMPDIR_TEST}/compose-nm-workspace.yaml"
+cat > "${NM_WORKSPACE_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    network_mode: host
+    volumes:
+      - workspace-repos:/workspace/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+NM_WORKSPACE_OUTPUT=""
+NM_WORKSPACE_EXIT=0
+NM_WORKSPACE_OUTPUT="$(COMPOSE_FILE="${NM_WORKSPACE_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || NM_WORKSPACE_EXIT=$?
+
+if [[ "${NM_WORKSPACE_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${NM_WORKSPACE_EXIT}) for workspace with network_mode:host"
+else
+  fail "validate-stack.sh exited ZERO for workspace with network_mode:host — guard did NOT fire"
+fi
+
+if echo "${NM_WORKSPACE_OUTPUT}" | grep -qi "network_mode"; then
+  pass "failure message mentions 'network_mode'"
+else
+  fail "failure message does not mention 'network_mode' — output: ${NM_WORKSPACE_OUTPUT}"
+fi
+
+# Blocking fix: network_mode services must NOT produce misleading secondary
+# attachment failures — exactly ONE failure line (the 1b network_mode FAIL).
+if echo "${NM_WORKSPACE_OUTPUT}" | grep -q "must be attached to exactly"; then
+  fail "workspace network_mode test: spurious Invariant 2 message 'must be attached to exactly' present — secondary failure not suppressed"
+else
+  pass "workspace network_mode test: no spurious 'must be attached to exactly' message (Invariant 2 correctly skipped)"
+fi
+
+echo ""
+echo "  network_mode-workspace-test output (stderr+stdout combined):"
+echo "${NM_WORKSPACE_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 13 — Negative: network_mode:host on mitmproxy must be rejected.
+#
+# Same bypass vector as TEST 12 but targeting mitmproxy.  An operator could
+# set network_mode: host on mitmproxy to give it unrestricted host networking,
+# which also breaks the containment model.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 13: topology guard rejects mitmproxy with network_mode:host ---"
+
+NM_MITM_COMPOSE="${TMPDIR_TEST}/compose-nm-mitm.yaml"
+cat > "${NM_MITM_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    network_mode: host
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+NM_MITM_OUTPUT=""
+NM_MITM_EXIT=0
+NM_MITM_OUTPUT="$(COMPOSE_FILE="${NM_MITM_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || NM_MITM_EXIT=$?
+
+if [[ "${NM_MITM_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${NM_MITM_EXIT}) for mitmproxy with network_mode:host"
+else
+  fail "validate-stack.sh exited ZERO for mitmproxy with network_mode:host — guard did NOT fire"
+fi
+
+if echo "${NM_MITM_OUTPUT}" | grep -qi "network_mode"; then
+  pass "failure message mentions 'network_mode'"
+else
+  fail "failure message does not mention 'network_mode' — output: ${NM_MITM_OUTPUT}"
+fi
+
+# Blocking fix: network_mode services must NOT produce misleading secondary
+# attachment failures — exactly ONE failure line (the 1b network_mode FAIL).
+if echo "${NM_MITM_OUTPUT}" | grep -q "is not attached to sandbox-net"; then
+  fail "mitmproxy network_mode test: spurious Invariant 3 message 'is not attached to sandbox-net' present — secondary failure not suppressed"
+else
+  pass "mitmproxy network_mode test: no spurious 'is not attached to sandbox-net' message (Invariant 3 correctly skipped)"
+fi
+
+echo ""
+echo "  network_mode-mitmproxy-test output (stderr+stdout combined):"
+echo "${NM_MITM_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 14 — Negative: network_mode:host on a non-workspace/mitmproxy service
+#           (e.g. a sidecar) must be rejected.
+#
+# Proves the broadened Invariant 1b scope: ANY service with network_mode is
+# rejected, not just workspace and mitmproxy.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 14: topology guard rejects sidecar service with network_mode:host ---"
+
+NM_SIDECAR_COMPOSE="${TMPDIR_TEST}/compose-nm-sidecar.yaml"
+cat > "${NM_SIDECAR_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+  sidecar:
+    image: ubuntu:22.04
+    network_mode: host
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+NM_SIDECAR_OUTPUT=""
+NM_SIDECAR_EXIT=0
+NM_SIDECAR_OUTPUT="$(COMPOSE_FILE="${NM_SIDECAR_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || NM_SIDECAR_EXIT=$?
+
+if [[ "${NM_SIDECAR_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${NM_SIDECAR_EXIT}) for sidecar with network_mode:host"
+else
+  fail "validate-stack.sh exited ZERO for sidecar with network_mode:host — broadened guard did NOT fire"
+fi
+
+if echo "${NM_SIDECAR_OUTPUT}" | grep -qi "network_mode"; then
+  pass "failure message mentions 'network_mode' for sidecar service"
+else
+  fail "failure message does not mention 'network_mode' — output: ${NM_SIDECAR_OUTPUT}"
+fi
+
+echo ""
+echo "  network_mode-sidecar-test output (stderr+stdout combined):"
+echo "${NM_SIDECAR_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 18 — Negative: network_mode:service:<x> on a service must be rejected.
+#
+# Confirms the guard is value-agnostic: any truthy network_mode string is
+# rejected, not just "host".
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 18: topology guard rejects service with network_mode:service:mitmproxy ---"
+
+NM_SERVICE_COMPOSE="${TMPDIR_TEST}/compose-nm-service.yaml"
+cat > "${NM_SERVICE_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    network_mode: "service:mitmproxy"
+    volumes:
+      - workspace-repos:/workspace/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+NM_SERVICE_OUTPUT=""
+NM_SERVICE_EXIT=0
+NM_SERVICE_OUTPUT="$(COMPOSE_FILE="${NM_SERVICE_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || NM_SERVICE_EXIT=$?
+
+if [[ "${NM_SERVICE_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${NM_SERVICE_EXIT}) for network_mode:service:mitmproxy"
+else
+  fail "validate-stack.sh exited ZERO for network_mode:service:mitmproxy — guard did NOT fire"
+fi
+
+if echo "${NM_SERVICE_OUTPUT}" | grep -qi "network_mode"; then
+  pass "failure message mentions 'network_mode' for service:<x> value"
+else
+  fail "failure message does not mention 'network_mode' — output: ${NM_SERVICE_OUTPUT}"
+fi
+
+echo ""
+echo "  network_mode-service-test output (stderr+stdout combined):"
+echo "${NM_SERVICE_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 19 — Negative: network_mode:container:<x> on a service must be rejected.
+#
+# Confirms the guard is value-agnostic for the container:<x> form as well.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 19: topology guard rejects service with network_mode:container:foo ---"
+
+NM_CONTAINER_COMPOSE="${TMPDIR_TEST}/compose-nm-container.yaml"
+cat > "${NM_CONTAINER_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    network_mode: "container:foo"
+    volumes:
+      - workspace-repos:/workspace/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+NM_CONTAINER_OUTPUT=""
+NM_CONTAINER_EXIT=0
+NM_CONTAINER_OUTPUT="$(COMPOSE_FILE="${NM_CONTAINER_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || NM_CONTAINER_EXIT=$?
+
+if [[ "${NM_CONTAINER_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${NM_CONTAINER_EXIT}) for network_mode:container:foo"
+else
+  fail "validate-stack.sh exited ZERO for network_mode:container:foo — guard did NOT fire"
+fi
+
+if echo "${NM_CONTAINER_OUTPUT}" | grep -qi "network_mode"; then
+  pass "failure message mentions 'network_mode' for container:<x> value"
+else
+  fail "failure message does not mention 'network_mode' — output: ${NM_CONTAINER_OUTPUT}"
+fi
+
+echo ""
+echo "  network_mode-container-test output (stderr+stdout combined):"
+echo "${NM_CONTAINER_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# Shared fixture for multi-file tests (base compose with valid topology).
+# ---------------------------------------------------------------------------
+MULTI_BASE_COMPOSE="${TMPDIR_TEST}/compose-multi-base.yaml"
+cat > "${MULTI_BASE_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+# ---------------------------------------------------------------------------
+# TEST 15 — Negative (multi-file, docker-present): override attaches workspace
+#           to egress-net → must be rejected via docker compose real merge.
+#
+# When docker compose is available it performs the authoritative merge and the
+# guard must catch the topology violation in the merged result.
+# Skipped with a clear message when docker is absent from PATH.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 15: multi-file (docker-present) — override attaches workspace to egress-net (must be rejected) ---"
+
+MULTI_OVERRIDE_COMPOSE="${TMPDIR_TEST}/compose-multi-override.yaml"
+cat > "${MULTI_OVERRIDE_COMPOSE}" <<'YAML'
+services:
+  workspace:
+    networks:
+      - sandbox-net
+      - egress-net
+    volumes:
+      - workspace-repos:/workspace/repos
+YAML
+
+if command -v docker &>/dev/null; then
+  MULTI_OUTPUT=""
+  MULTI_EXIT=0
+  MULTI_OUTPUT="$(COMPOSE_FILE="${MULTI_BASE_COMPOSE}:${MULTI_OVERRIDE_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || MULTI_EXIT=$?
+
+  if [[ "${MULTI_EXIT}" -ne 0 ]]; then
+    pass "multi-file (docker): validate-stack.sh exited non-zero (${MULTI_EXIT}) for override attaching workspace to egress-net"
+  else
+    fail "multi-file (docker): validate-stack.sh exited ZERO — merged topology violation was NOT caught"
+  fi
+
+  if echo "${MULTI_OUTPUT}" | grep -qi "egress\|non-internal\|direct internet"; then
+    pass "multi-file (docker): failure message mentions egress/non-internal violation"
+  else
+    fail "multi-file (docker): failure message does not mention egress violation — output: ${MULTI_OUTPUT}"
+  fi
+
+  echo ""
+  echo "  multi-file-docker-test output (stderr+stdout combined):"
+  echo "${MULTI_OUTPUT}" | sed 's/^/    /'
+else
+  echo "  SKIP: multi-file (docker): docker not in PATH — docker-present multi-file test requires docker compose"
+fi
+
+# ---------------------------------------------------------------------------
+# TEST 16 — Negative (multi-file, docker-absent): fail-closed when docker is
+#           unavailable and COMPOSE_FILE lists multiple files.
+#
+# The raw-YAML fallback cannot faithfully reproduce Docker Compose merge
+# semantics (shallow dict-update replaces whole service dicts, producing
+# false failures on valid partial overrides).  The guard must exit non-zero
+# with a clear error message mentioning "multiple files" and
+# "docker compose is unavailable".
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 16: multi-file (no docker) — fail-closed with clear error message ---"
+
+MULTI_NODOCK_OUTPUT=""
+MULTI_NODOCK_EXIT=0
+MULTI_NODOCK_OUTPUT="$(PATH="${NO_DOCKER_PATH}" COMPOSE_FILE="${MULTI_BASE_COMPOSE}:${MULTI_OVERRIDE_COMPOSE}" PYTHON3_BIN="${PYTHON3_BIN}" "${BASH_BIN}" deploy/validate-stack.sh --topology-only 2>&1)" || MULTI_NODOCK_EXIT=$?
+
+if [[ "${MULTI_NODOCK_EXIT}" -ne 0 ]]; then
+  pass "multi-file (no docker): validate-stack.sh exited non-zero (${MULTI_NODOCK_EXIT}) — fail-closed as expected"
+else
+  fail "multi-file (no docker): validate-stack.sh exited ZERO — should have failed closed"
+fi
+
+if echo "${MULTI_NODOCK_OUTPUT}" | grep -qi "multiple files\|docker compose is unavailable"; then
+  pass "multi-file (no docker): error message mentions 'multiple files' / 'docker compose is unavailable'"
+else
+  fail "multi-file (no docker): error message missing expected text — output: ${MULTI_NODOCK_OUTPUT}"
+fi
+
+echo ""
+echo "  multi-file-no-docker-test output (stderr+stdout combined):"
+echo "${MULTI_NODOCK_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 17 — Positive (single-file, no docker): single-file raw YAML fallback
+#           must still succeed for a valid compose file when docker is absent.
+#
+# Confirms the single-file path is byte-for-byte unchanged by the fail-closed
+# multi-file change.  Uses the real deploy/compose.yaml as the positive control.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 17: single-file (no docker) — raw YAML fallback still exits zero for real compose.yaml ---"
+
+SINGLE_NODOCK_OUTPUT=""
+SINGLE_NODOCK_EXIT=0
+SINGLE_NODOCK_OUTPUT="$(PATH="${NO_DOCKER_PATH}" COMPOSE_FILE="deploy/compose.yaml" PYTHON3_BIN="${PYTHON3_BIN}" "${BASH_BIN}" deploy/validate-stack.sh --topology-only 2>&1)" || SINGLE_NODOCK_EXIT=$?
+
+if [[ "${SINGLE_NODOCK_EXIT}" -eq 0 ]]; then
+  pass "single-file (no docker): validate-stack.sh exited zero for real compose.yaml via raw YAML fallback"
+else
+  fail "single-file (no docker): validate-stack.sh exited non-zero (${SINGLE_NODOCK_EXIT}) — output: ${SINGLE_NODOCK_OUTPUT}"
+fi
+
+echo ""
+echo "  single-file-no-docker-test output (stderr+stdout combined):"
+echo "${SINGLE_NODOCK_OUTPUT}" | sed 's/^/    /'
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
Hardens the compose topology guard against two override-based weaknesses, part of the egress-containment work in #746.

## network_mode rejection

A compose override can set `network_mode: host` (or `service:`/`container:`) on a service. Such a service carries no `networks` key, so the network-attachment invariants pass vacuously while the container actually has host networking and full egress. The guard now rejects `network_mode` on any service.

## Multi-file COMPOSE_FILE

The guard previously validated only a single compose file. It now splits Docker's native `COMPOSE_FILE` (path-separator delimited) and validates the merged set, so an operator deploying with `-f base -f override` validates what they actually deploy. When docker compose is available, the merge is authoritative. When it is not, multi-file validation fails closed with a clear message rather than approximating the merge — a raw-YAML shallow merge cannot faithfully reproduce Compose's merge semantics, and a wrong approximation could either block a valid deploy or pass an invalid one. Single-file validation (including the no-docker raw-YAML path used by CI) is unchanged.

## Tests

Added coverage for `network_mode` rejection across services (including a non-workspace service), the docker-present multi-file merge catching an override that grants the workspace direct egress, the docker-absent multi-file fail-closed path, and a single-file no-docker positive control. Full suite passes (`bash deploy/validate-stack.test.sh`).

## Not included

A separate gap — a sidecar service bridging the sandbox network to a non-internal network other than mitmproxy's — is tracked in #814, because closing it correctly depends on a deliberate decision about the gateway's network posture.
