### PR TITLE
feat(release): narrate published releases with the Fro Bot agent

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -65,6 +65,9 @@ jobs:
           GIT_COMMITTER_EMAIL: ${{ steps.get-user-id.outputs.user-email }}
           GIT_COMMITTER_NAME: ${{ steps.get-user-id.outputs.user-name }}
           GITHUB_TOKEN: ${{ steps.get-app-token.outputs.token }}
+          # Used by the release-notes narration successCmd to dispatch fro-bot.yaml.
+          # The App token is contents:read only; FRO_BOT_PAT carries actions:write.
+          RELEASE_NOTES_DISPATCH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
         id: semantic-release
         name: Semantic Release
         run: |

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -242,11 +242,15 @@ jobs:
           # See docs/plans/2026-04-17-001-fix-manual-delivery-mode-plan.md.
           output-mode: >-
             ${{
-              (inputs.prompt != '' && 'working-dir')
+              (github.event.inputs.correlation-id != '' && 'working-dir')
+              || (inputs.prompt != '' && 'working-dir')
               || (github.event_name == 'workflow_dispatch' && github.event.inputs.use-wiki-prompt == 'true' && 'branch-pr')
               || (github.event_name == 'schedule' && github.event.schedule == '0 20 * * 0' && 'branch-pr')
               || 'auto'
             }}
           prompt: ${{ env.PROMPT }}
-          response-mode: ${{ inputs.response-mode || 'github' }}
+          # Correlation-id-tagged dispatches (release-notes narration) post nothing to
+          # GitHub: the narrator edits the release body directly, so suppression is
+          # enforced here, not left to prompt compliance.
+          response-mode: ${{ (github.event.inputs.correlation-id != '' && 'none') || inputs.response-mode || 'github' }}
           timeout: 0

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -26,6 +26,12 @@ on:
         description: Run with the built-in Wiki update prompt
         type: boolean
         default: false
+      model:
+        description: Model override for the Fro Bot agent (e.g. anthropic/claude-haiku-4-5)
+        required: false
+      correlation-id:
+        description: Audit correlation token forwarded by an external dispatcher (e.g. the release-notes narration step)
+        required: false
   # Called by other workflows (e.g. harness-release) to run Fro Bot with a
   # specific model and/or prompt. Secrets are inherited from the caller via
   # `secrets: inherit` — no secret passthrough inputs needed.

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -1,6 +1,9 @@
 ---
 name: Fro Bot
 
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.correlation-id != '' && format('Fro Bot · release-notes · {0}', github.event.inputs.correlation-id) || 'Fro Bot' }}
+
 on:
   issue_comment:
     types: [created]

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -8,6 +8,7 @@ plugins:
 
   - - '@semantic-release/exec'
     - verifyReleaseCmd: 'echo "version=${nextRelease.version}" >> "$GITHUB_OUTPUT"'
+      successCmd: 'node --experimental-strip-types --experimental-transform-types scripts/release/dispatch-release-notes.ts "${nextRelease.gitTag}"'
 
   - '@semantic-release/npm'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,7 @@ pnpm build          # Type check + bundle to dist/ (must stay in sync)
 - **Dual action entry points**: `main.ts` (execution) and `post.ts` (durable cache save)
 - **Pre-push hook**: Runs test + lint + build + dist diff check
 - **XML-tagged prompt**: Prompt sections wrapped in XML tags (`<harness_rules>`, `<task>`, `<user_supplied_instructions>`, `<agent_context>`, etc.) with explicit authority hierarchy and Anthropic-recommended section ordering (reference data first, task/instructions last)
+- **Release-notes narration**: After a release publishes, a `@semantic-release/exec` `successCmd` (`scripts/release/dispatch-release-notes.ts`) dispatches `fro-bot.yaml` on `main` (model `anthropic/claude-haiku-4-5`) to rewrite the GitHub Release body into a `## What's new` narrative. Dispatch auth is `FRO_BOT_PAT` (`RELEASE_NOTES_DISPATCH_TOKEN`), not the read-only App token. It is idempotent (skips when the body already carries `<!-- fro-bot-narration-v1 -->`) and fail-soft: narrative-quality failures warn and never block the release, while security-relevant anomalies (off-target release edits, auth failures) fail the step.
 
 ## EXTERNAL RESOURCES
 

--- a/docs/plans/2026-06-07-001-feat-release-notes-narrative-plan.md
+++ b/docs/plans/2026-06-07-001-feat-release-notes-narrative-plan.md
@@ -1,0 +1,383 @@
+---
+title: 'feat: LLM-narrated release notes for the multi-part release flow'
+type: feat
+status: active
+date: 2026-06-07
+deepened: 2026-06-07
+origin: docs/brainstorms/2026-06-07-release-notes-narrative-requirements.md
+---
+
+# LLM-narrated release notes
+
+## Overview
+
+After a release publishes, dispatch `fro-bot.yaml` to rewrite the GitHub Release body into a
+readable `## What's new` narrative. The dispatch logic is ported from Systematic's
+`scripts/dispatch-release-notes.sh` to TypeScript under `scripts/release/`, hooked via a new
+`successCmd` in `@semantic-release/exec`. Narrative-quality failures never block the release;
+security-relevant anomalies fail the step loudly.
+
+## Problem Frame
+
+Releases publish with the flat conventional-commit list from
+`@semantic-release/release-notes-generator`. It is accurate but not readable. We want the
+Systematic-style LLM narration adapted to this repo's multi-part release flow (`next → release`
+PR merge → `auto-release.yaml`) and its TypeScript-scripts convention
+(see origin: `docs/brainstorms/2026-06-07-release-notes-narrative-requirements.md`).
+
+## Requirements Trace
+
+- R1. Pure, unit-testable TS logic for tag validation, prompt construction, run selection, and
+  outcome classification (`scripts/release/release-notes.ts`).
+- R2. A thin CLI entry runnable via `node --experimental-strip-types`, taking the target tag as an
+  argument (`scripts/release/dispatch-release-notes.ts`).
+- R3. A Vitest test port of the structural scenarios — validation, classification precedence, run
+  selection, prompt construction, idempotent short-circuit — exercising the pure logic directly.
+- R4. A `successCmd` in `.releaserc.yaml`'s `@semantic-release/exec`, invoking the CLI with
+  `${nextRelease.gitTag}`, preserving the existing `verifyReleaseCmd`.
+- R5. A `correlation-id` `workflow_dispatch` input on `fro-bot.yaml`.
+- R6. A self-contained narration prompt carrying idempotency check, rewrite instruction,
+  `gh release edit` application, and explicit scope constraints.
+- R7. Release never failed by a narrative-quality outcome; always failed by a security-relevant
+  outcome.
+- R8. New Vitest tests are executed in CI (confirm `scripts/` coverage).
+- R9. A short docs note on the narration step and its fail-soft/fail-hard contract.
+
+## Scope Boundaries
+
+- No change to which releases are cut, or to version/commit-analysis logic.
+- No rollback or re-publish — narration only edits the already-published release body.
+- No narration of historical releases (forward-only from adoption).
+
+### Deferred to Separate Tasks
+
+- A reusable `release-notes-narrative` skill (D5b): deferred. v1 inlines the procedure into the
+  prompt (D5a). Revisit only if the procedure grows.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/release/preview.ts` + `scripts/release/preview-next-release.ts` — the canonical
+  pure-logic + thin-CLI split to mirror. CLI uses `#!/usr/bin/env node`, imports the logic module
+  with a `.ts` extension (strip-types runtime), parses argv, writes `GITHUB_OUTPUT` via
+  `appendFileSync`.
+- `scripts/release/preview.test.ts` — Vitest convention: imports the logic module with a `.js`
+  extension (bundler resolution), `// #given/#when/#then` BDD comments, tests pure functions
+  directly (no subprocess spawning).
+- `scripts/tsconfig.json` — `allowImportingTsExtensions`, `rewriteRelativeImportExtensions`.
+- Invocation precedent:
+  `node --experimental-strip-types --experimental-transform-types scripts/release/<cli>.ts ...`
+  (`.github/workflows/prepare-release-pr.yaml:95`, `.github/workflows/ci.yaml:666`).
+- `.releaserc.yaml:4-20` — plugin list; `@semantic-release/exec` already present with only
+  `verifyReleaseCmd`.
+- `.github/workflows/auto-release.yaml:26-77` — `perform-release` job: App token (full
+  installation perms, no explicit `permissions:` input), `gh` available, Node+pnpm (no Bun),
+  the `pnpm semantic-release --ci false` step.
+- `.github/workflows/fro-bot.yaml:16-50` — dispatch/call inputs (`prompt`, `use-schedule/wiki-prompt`,
+  `model`, `response-mode`); no `correlation-id`.
+
+### Institutional Learnings
+
+- No `docs/solutions/` entry covers release-notes narration directly (verified). This is new
+  ground; the Systematic script + its tests are the reference design.
+
+### External References
+
+- Systematic `scripts/dispatch-release-notes.sh` and `tests/integration/release-notes-ci.test.ts`
+  at ref `836f92d` — the behavioral contract being ported.
+
+## Key Technical Decisions
+
+- **Pure-logic-first port.** Unlike the bash source (whose tests spawn the script with a mock-`gh`
+  on PATH), structure the port so validation, prompt construction, run selection, and outcome
+  classification are pure functions in `release-notes.ts`, with all `gh` calls isolated in the
+  thin CLI. Tests exercise the pure functions directly, matching `preview.test.ts`. This is
+  cleaner than porting the subprocess-mock harness and fits our convention.
+- **Classification precedence preserved (D4).** Hard-fail (exit 1, `::error::`): off-target release
+  edit, auth-failure keywords, `action_required`, `skipped`, `success`-but-short-body, unexpected
+  watch exit. Soft-warn (exit 0, `::warning::`): run-not-confirmed, watch timeout (124),
+  `cancelled`, generic `failure`, unknown conclusion. Clean exit 0: substantive `success`,
+  `neutral`.
+- **Timestamp-based run selection.** Newest `workflow_dispatch` run on the dispatch branch created
+  strictly after the pre-dispatch epoch — robust against agent boot time. `correlation-id` is an
+  audit anchor, not the matcher.
+- **Inline narration prompt (D5a).** No new skill; the prompt is self-contained.
+- **Dispatch ref = `main`.** Dispatch `fro-bot.yaml --ref main` (current agent config) to narrate
+  the `release`-tag artifact; run selection filters `--branch main`. (Q3 resolved.)
+- **Body integrity floor = 200 chars** (Systematic's value). (Q4 resolved.)
+- **Narration model = `anthropic/claude-haiku-4-5`.** The successCmd passes
+  `-f model=anthropic/claude-haiku-4-5`; this requires adding a `model` input to
+  `fro-bot.yaml`'s `workflow_dispatch` block (today it exists only on `workflow_call`).
+  `fro-bot.yaml:225` already reads `inputs.model || vars.FRO_BOT_MODEL`, so once the dispatch input
+  is declared the model flows through.
+- **Dispatch auth = `FRO_BOT_PAT`, NOT the App token (Q2 resolved).** Deepening verified the
+  `fro-bot-agent` App is **`contents: read` only** (`docs/github-app.md`), so the App token cannot
+  `gh workflow run`. But `FRO_BOT_PAT` is the same PAT Systematic uses for this exact dispatch and
+  already carries `actions: write`. The successCmd therefore dispatches using `FRO_BOT_PAT`, leaving
+  the App's read-only posture unchanged. Mechanics: the semantic-release step keeps
+  `GITHUB_TOKEN = <App token>` (which `@semantic-release/github` needs for the release itself), and
+  additionally exposes `RELEASE_NOTES_DISPATCH_TOKEN = ${{ secrets.FRO_BOT_PAT }}`; the CLI runs
+  `gh workflow run` with `GH_TOKEN` set to that PAT for the dispatch subprocess only. `FRO_BOT_PAT`
+  is **not currently referenced in `auto-release.yaml`** and must be added to that step's env
+  (Unit 4). No App-permission change is needed.
+- **Narration run's release-edit power also comes from `FRO_BOT_PAT`.** `fro-bot.yaml` auths the
+  action with `github-token: ${{ secrets.FRO_BOT_PAT }}` (`fro-bot.yaml:224`), so the narration
+  agent's `gh release edit` uses the PAT's `contents: write` — consistent with the dispatch token.
+- **Fail-soft on dispatch failure.** Any `gh workflow run` failure warns and exits 0 — never a
+  broken release.
+- **Idempotency marker = HTML comment, not the heading.** Use `<!-- fro-bot-narration-v1 -->`
+  immediately after `## What's new` as the re-run short-circuit, rather than matching the heading
+  text alone (robust against heading collision and future format changes).
+- **Body application via `--notes-file`.** The narration agent writes the rewritten body to a temp
+  file and runs `gh release edit <tag> --notes-file <file>` (never `--notes <string>`) — avoids
+  shell-escaping and multi-line-markdown breakage.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Q1 (skill vs inline): inline (D5a).
+- Q3 (dispatch ref): `main`, run selection `--branch main`.
+- Q4 (body floor): 200 chars.
+- Q2 (auth scope) — RESOLVED: dispatch with `FRO_BOT_PAT` (same PAT Systematic uses, already has
+  `actions: write`), not the read-only App token. No App-permission change. `FRO_BOT_PAT` is added
+  to the semantic-release step env (Unit 4); the CLI uses it as `GH_TOKEN` for the dispatch only.
+- Model: `anthropic/claude-haiku-4-5`, added as a `workflow_dispatch` input on `fro-bot.yaml`.
+- Idempotency marker: `<!-- fro-bot-narration-v1 -->` HTML comment.
+- Body application: `gh release edit <tag> --notes-file <file>`.
+
+### Deferred to Implementation
+
+- Whether `FRO_BOT_PAT` actually carries `contents: write` is external secret config not visible in
+  the repo; the first real narration run is the live confirmation. (High confidence — the PAT
+  already performs branch/PR mutations.)
+
+## Implementation Units
+
+- [ ] **Unit 1: Pure narration logic module**
+
+**Goal:** Tag validation, prompt construction, run selection, and outcome classification as pure
+functions.
+
+**Requirements:** R1, R6, R7
+
+**Dependencies:** None
+
+**Files:**
+- Create: `scripts/release/release-notes.ts`
+- Test: `scripts/release/release-notes.test.ts`
+
+**Approach:**
+- `validateTag(tag)` → ok/err on the `^v\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?$` shape.
+- `buildNarrationPrompt({tag, repo, correlationId})` → the self-contained prompt string. Design
+  (from deepening research):
+  - **Idempotency check first:** if the release body contains `<!-- fro-bot-narration-v1 -->`,
+    log already-applied and stop (conclusion `neutral`).
+  - **Rewrite instruction:** produce a `## What's new` narrative grouped by impact
+    (Features / Fixes / Security / Performance / Breaking), each 2-4 human-readable bullets linking
+    PR numbers; lead with a 1-2 sentence summary; preserve the original conventional-commit list
+    below under a collapsed `<details><summary>Full changelog</summary>` block. Emit the
+    `<!-- fro-bot-narration-v1 -->` marker immediately after the `## What's new` heading.
+  - **Application:** write the body to a temp file and run
+    `gh release edit <tag> --notes-file <file>` (never `--notes`).
+  - **Scope constraints (forbidden-actions framing):** the ONLY mutating operation is
+    `gh release edit <tag>`; do NOT comment on any PR/issue/discussion, open/close issues, edit any
+    other release, modify files, or create branches/tags/commits. Report tag, chars-before/after,
+    and the release URL.
+- `selectDispatchedRun(runs, dispatchEpoch)` → newest run with `createdAt` epoch strictly greater
+  than `dispatchEpoch`, or null.
+- `classifyOutcome({watchExit, conclusion, log, bodyLen, targetTag})` → a discriminated result
+  `{level: 'ok'|'warn'|'error', message, exitCode}` encoding the D4 precedence (off-target edit
+  detection scans the ANSI-stripped log for `release edit vX.Y.Z` lines not equal to the target;
+  auth-failure keyword scan; body floor 200).
+
+**Patterns to follow:** `scripts/release/preview.ts` (pure functions, no side effects, exported for
+direct unit testing).
+
+**Test scenarios:**
+- Happy path: valid tag (incl. pre-release `v1.2.3-rc.1`) passes; classify `success` + body≥200 →
+  `ok` exit 0; `neutral` → `ok` exit 0.
+- Edge case: invalid tag shape → err (no dispatch). Run selection: empty list → null; all runs
+  pre-date epoch → null; two post-epoch runs → newest selected.
+- Error path: off-target `release edit v9.9.9` (ANSI-colored) → `error` exit 1; auth keywords
+  (`HTTP 401`, `HTTP 403`+`permission denied`, `Resource not accessible`) → `error`; `success` but
+  body<200 → `error`; `action_required`/`skipped` → `error`; unexpected `watchExit=137` → `error`.
+- Edge case: `watchExit=124` → `warn` exit 0; `cancelled` → `warn`; generic `failure` → `warn`;
+  unknown conclusion → `warn`.
+- Prompt construction: includes target tag, repo, `correlation=<id>`, the
+  `<!-- fro-bot-narration-v1 -->` idempotency-marker instruction, the grouped-narrative +
+  collapsed-changelog structure, the `gh release edit <tag> --notes-file` application step, and the
+  forbidden-actions scope lines.
+
+**Verification:** All classification branches and selection cases covered; `release-notes.test.ts`
+passes under Vitest.
+
+- [ ] **Unit 2: CLI entry (dispatch + poll + watch)**
+
+**Goal:** Thin executable that wires the pure logic to `gh`.
+
+**Requirements:** R2, R6, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `scripts/release/dispatch-release-notes.ts`
+
+**Approach:**
+- `#!/usr/bin/env node`; import `./release-notes.ts` (`.ts` extension, strip-types).
+- Read target tag from argv; `validateTag` → on err print `::error::` + exit 1.
+- Generate correlation id (uuid via `node:crypto` `randomUUID`; test escape hatch env var as in
+  the source). Capture dispatch epoch (`Date.now()/1000`).
+- `gh workflow run --ref main fro-bot.yaml -f prompt=<built> -f correlation-id=<id>
+  -f model=anthropic/claude-haiku-4-5` via `execFileSync`, with the subprocess env's `GH_TOKEN`
+  set to `RELEASE_NOTES_DISPATCH_TOKEN` (the `FRO_BOT_PAT`) so the dispatch uses the PAT, not the
+  inherited App token. On non-zero → `::warning::` + exit 0 (fail-soft). The poll/watch `gh` calls
+  also use the PAT env.
+- Poll loop (budget/interval env-overridable for tests): `gh run list --workflow fro-bot.yaml
+  --branch main --event workflow_dispatch --json databaseId,createdAt` → `selectDispatchedRun`.
+  Not found in budget → `::warning::` + exit 0.
+- `gh run watch <id> --exit-status` under a hard `timeout`; capture exit. Fetch `conclusion`, the
+  ANSI-stripped `--log`, and (on success) the release body length. Call `classifyOutcome` → emit
+  its message at its level and exit with its code.
+
+**Patterns to follow:** `scripts/release/preview-next-release.ts` (shebang, `execFileSync`, argv
+parse, env-overridable knobs).
+
+**Test scenarios:** `Test expectation: none` for the thin I/O shell — all decision logic lives in
+Unit 1 and is unit-tested there. (The CLI is exercised end-to-end by the real release; a mock-`gh`
+subprocess test is explicitly out of scope given the pure-logic-first decision.)
+
+**Verification:** `node --experimental-strip-types --experimental-transform-types
+scripts/release/dispatch-release-notes.ts vX.Y.Z` runs the full flow; invalid tag exits 1 before
+any dispatch; a simulated `gh workflow run` failure exits 0 with a warning.
+
+- [ ] **Unit 3: Test port to Vitest**
+
+**Goal:** Port the 19 structural scenarios as direct unit tests of Unit 1's pure functions.
+
+**Requirements:** R3, R8
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Test: `scripts/release/release-notes.test.ts` (same file as Unit 1's tests; this unit ensures the
+  full structural-scenario coverage and CI execution)
+
+**Approach:**
+- Map each Systematic scenario to a pure-function assertion: validation (1,2), classification
+  (3-5,5b,9-18), run selection (6,7,8), prompt construction (19). Drop scenario assertions that
+  only exist because the source spawned a subprocess (PATH/mock-gh wiring) — keep the behavioral
+  intent.
+- Confirm `vitest.config.ts` includes `scripts/**` (it does — only `node_modules`, `dist`,
+  `cypress`, `.slim`, `deploy/**` excluded) so `pnpm test` / CI runs these.
+
+**Patterns to follow:** `scripts/release/preview.test.ts` (Vitest, `.js` import, `#given/#when/#then`).
+
+**Test scenarios:** This unit *is* the test coverage; it must assert every classification branch,
+every selection case, validation accept/reject, and prompt-content expectations enumerated in
+Unit 1.
+
+**Verification:** `pnpm test` (or the runtime-scoped vitest invocation) runs and passes the new
+file in CI; coverage spans all D4 branches.
+
+- [ ] **Unit 4: Wire successCmd + fro-bot.yaml inputs (correlation-id, model)**
+
+**Goal:** Integrate into the release flow and add the dispatch inputs.
+
+**Requirements:** R4, R5
+
+**Dependencies:** Units 1-2
+
+**Files:**
+- Modify: `.releaserc.yaml` (add `successCmd` to the existing `@semantic-release/exec` entry,
+  preserving `verifyReleaseCmd`)
+- Modify: `.github/workflows/auto-release.yaml` (add
+  `RELEASE_NOTES_DISPATCH_TOKEN: ${{ secrets.FRO_BOT_PAT }}` to the semantic-release step's env)
+- Modify: `.github/workflows/fro-bot.yaml` (add `correlation-id` and `model` to
+  `workflow_dispatch.inputs`)
+
+**Approach:**
+- `successCmd: 'node --experimental-strip-types --experimental-transform-types
+  scripts/release/dispatch-release-notes.ts "${nextRelease.gitTag}"'` alongside the existing
+  `verifyReleaseCmd` in the same `@semantic-release/exec` config.
+- Add `RELEASE_NOTES_DISPATCH_TOKEN: ${{ secrets.FRO_BOT_PAT }}` to the `Semantic Release` step's
+  `env:` block (`auto-release.yaml:62-68`), alongside the existing `GITHUB_TOKEN` (App token, kept
+  for `@semantic-release/github`). The CLI reads this for the dispatch `gh` subprocess.
+- Add `correlation-id` (string, not required) to `fro-bot.yaml` `workflow_dispatch.inputs` (audit
+  anchor).
+- Add `model` (string, not required) to `fro-bot.yaml` `workflow_dispatch.inputs`.
+  `fro-bot.yaml:225` already reads `inputs.model || vars.FRO_BOT_MODEL`, so declaring the dispatch
+  input is sufficient for `-f model=anthropic/claude-haiku-4-5` to take effect.
+- The successCmd passes `-f model=anthropic/claude-haiku-4-5` (Unit 2).
+
+**Patterns to follow:** existing `@semantic-release/exec` `verifyReleaseCmd` shape in `.releaserc.yaml`;
+the existing `model` input on `fro-bot.yaml`'s `workflow_call` block (mirror its shape on
+`workflow_dispatch`); the existing `secrets.FRO_BOT_PAT` usage in `fro-bot.yaml:224`.
+
+**Test scenarios:** `Test expectation: none` — config wiring. Validated by YAML lint (existing CI)
+and the real release.
+
+**Verification:** `.releaserc.yaml` parses; `verifyReleaseCmd` still present;
+`RELEASE_NOTES_DISPATCH_TOKEN` is set on the semantic-release step; `fro-bot.yaml` accepts
+`-f correlation-id=` and `-f model=` on dispatch (workflow lints clean).
+
+- [ ] **Unit 5: Documentation**
+
+**Goal:** Make the narration step and its contract discoverable.
+
+**Requirements:** R9
+
+**Dependencies:** Units 1-4
+
+**Files:**
+- Modify: `AGENTS.md` (or the release docs section) — short note on the narration step.
+
+**Approach:**
+- Document: what it does (post-release body rewrite via `fro-bot.yaml` on `main`, model
+  `anthropic/claude-haiku-4-5`, dispatched with `FRO_BOT_PAT`), the fail-soft/fail-hard contract,
+  idempotency (HTML marker), and the dispatch choice. Public-facing voice, no session/plan taxonomy.
+
+**Test scenarios:** `Test expectation: none` — docs.
+
+**Verification:** The note accurately reflects the shipped behavior and the auth requirement.
+
+## System-Wide Impact
+
+- **Interaction graph:** `successCmd` fires inside `perform-release` after publish; dispatches
+  `fro-bot.yaml` on `main`. No effect on version/commit logic or the `next → release` flow.
+- **Error propagation:** narrative failures → `::warning::`/exit 0 (release unaffected); security
+  signals → `::error::`/exit 1 (release step fails, surfacing the anomaly).
+- **State lifecycle risks:** re-dispatch is idempotent (the `## What's new` short-circuit); no
+  partial-write risk on the release body beyond what `gh release edit` does atomically.
+- **API surface parity:** the new `correlation-id` input is additive and optional; no existing
+  caller breaks.
+- **Unchanged invariants:** `.releaserc.yaml` version/branch/tag behavior, `auto-release.yaml`
+  trigger and App-token setup, and `fro-bot.yaml`'s existing inputs are unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Dispatch token lacks `actions: write` | Resolved: dispatch uses `FRO_BOT_PAT` (same PAT Systematic uses for this dispatch; confirmed to carry the scope), not the read-only App token. Fail-soft still protects the release. |
+| `FRO_BOT_PAT` not wired into the release job | Unit 4 adds `RELEASE_NOTES_DISPATCH_TOKEN: ${{ secrets.FRO_BOT_PAT }}` to the semantic-release step; the secret already exists in the repo. |
+| Narration agent edits the wrong release | Off-target detection hard-fails the step (`::error::`). |
+| Narration agent does forbidden side-effects (comments, file changes) | Forbidden-actions framing in the prompt; harness Response Protocol; the run's only intended mutation is `gh release edit <tag>`. |
+| Agent boot time exceeds poll budget | Run-not-confirmed warns (exit 0); narration still runs async; observability gap only. |
+| New tests not picked up by CI | Unit 3 confirms `vitest.config.ts` covers `scripts/**`. |
+| `successCmd` runs on every publish, including backport tags | Idempotency (HTML marker) + tag validation; narration is per-published-tag by design. |
+| Haiku model unavailable / model input rejected | `fro-bot.yaml:225` falls back to `vars.FRO_BOT_MODEL`; narration still runs on the default model. |
+
+## Documentation / Operational Notes
+
+- Unit 5 adds the release-docs note. Operationally: first real release after merge is the live
+  verification; watch for `::warning::`/`::error::` annotations in the `perform-release` log.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-06-07-release-notes-narrative-requirements.md`
+- Source being ported: Systematic `scripts/dispatch-release-notes.sh`,
+  `tests/integration/release-notes-ci.test.ts`, `.releaserc.yaml` (ref `836f92d`).
+- Our pipeline: `.releaserc.yaml`, `.github/workflows/auto-release.yaml`,
+  `.github/workflows/prepare-release-pr.yaml`, `.github/workflows/fro-bot.yaml`,
+  `scripts/release/preview*.ts`.

--- a/scripts/release/dispatch-release-notes.ts
+++ b/scripts/release/dispatch-release-notes.ts
@@ -8,7 +8,14 @@ import process from 'node:process'
 // --experimental-strip-types / --experimental-transform-types.
 // The test file (release-notes.test.ts) uses .js because it runs under
 // Vitest with bundler module resolution. Both are correct for their runtime.
-import {buildNarrationPrompt, classifyOutcome, selectDispatchedRun, validateTag} from './release-notes.ts'
+import {
+  AMBIGUOUS_RUN_SENTINEL,
+  buildNarrationPrompt,
+  classifyOutcome,
+  isAuthError,
+  selectDispatchedRun,
+  validateTag,
+} from './release-notes.ts'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -63,7 +70,7 @@ function main(): void {
   // Step 7: capture dispatch epoch BEFORE the dispatch
   const dispatchEpoch = Math.floor(Date.now() / 1000)
 
-  // Step 8: dispatch — fail-soft on any error
+  // Step 8: dispatch — CHANGE 2: auth failures hard-fail; everything else soft-warns
   try {
     execFileSync(
       'gh',
@@ -80,22 +87,34 @@ function main(): void {
         '-f',
         'model=anthropic/claude-haiku-4-5',
       ],
-      {env: childEnv, stdio: 'inherit'},
+      {env: childEnv, stdio: ['ignore', 'pipe', 'pipe']},
     )
   } catch (error: unknown) {
+    // Capture stderr/message for auth detection — do NOT echo full env or token
     const message = error instanceof Error ? error.message : String(error)
+    // Sanitize: strip anything that looks like a token (40+ hex chars or Bearer patterns)
+    const sanitized = message.replaceAll(/\b\w{40,}\b/g, '[REDACTED]').replaceAll(/Bearer\s+\S+/gi, 'Bearer [REDACTED]')
+
+    if (isAuthError(message)) {
+      // Auth/permission failure is a genuine security signal — hard-fail
+      process.stdout.write(`::error::Dispatch auth failure: ${sanitized}\n`)
+      process.exit(1)
+    }
+
+    // Everything else: soft-warn, release is unaffected
     process.stdout.write(
-      `::warning::Dispatch failed (correlation=${correlationId}): ${message}. Narration skipped; release is unaffected.\n`,
+      `::warning::Dispatch failed (correlation=${correlationId}): ${sanitized}. Narration skipped; release is unaffected.\n`,
     )
     process.exit(0)
   }
 
-  // Step 9: poll loop
+  // Step 9: poll loop — CHANGE 3: include displayTitle in gh run list for correlation
   const pollBudget = Number(process.env.RELEASE_NOTES_TEST_POLL_BUDGET_SECS ?? 180)
   const pollInterval = Number(process.env.RELEASE_NOTES_TEST_POLL_INTERVAL_SECS ?? 5)
   const pollDeadline = Date.now() + pollBudget * 1000
 
   let runId: number | null = null
+  let ambiguous = false
 
   while (Date.now() < pollDeadline) {
     try {
@@ -107,15 +126,20 @@ function main(): void {
           '--branch=main',
           '--event=workflow_dispatch',
           '--json',
-          'databaseId,createdAt',
+          'databaseId,createdAt,displayTitle',
           '--limit',
-          '10',
+          '20',
         ],
         childEnv,
       )
-      const runs = JSON.parse(raw) as readonly {databaseId: number; createdAt: string}[]
-      runId = selectDispatchedRun(runs, dispatchEpoch)
-      if (runId !== null) {
+      const runs = JSON.parse(raw) as readonly {databaseId: number; createdAt: string; displayTitle: string}[]
+      const selected = selectDispatchedRun(runs, dispatchEpoch, correlationId)
+      if (selected === AMBIGUOUS_RUN_SENTINEL) {
+        ambiguous = true
+        break
+      }
+      if (selected !== null) {
+        runId = selected
         break
       }
     } catch {
@@ -123,6 +147,13 @@ function main(): void {
     }
 
     sleep(pollInterval)
+  }
+
+  if (ambiguous) {
+    process.stdout.write(
+      `::warning::ambiguous run selection (multiple candidates for correlation ${correlationId}); narration runs async, release unaffected\n`,
+    )
+    process.exit(0)
   }
 
   if (runId === null) {

--- a/scripts/release/dispatch-release-notes.ts
+++ b/scripts/release/dispatch-release-notes.ts
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+
+import {execFileSync} from 'node:child_process'
+import {randomUUID} from 'node:crypto'
+import process from 'node:process'
+
+// This file uses .ts import because it runs directly under Node's
+// --experimental-strip-types / --experimental-transform-types.
+// The test file (release-notes.test.ts) uses .js because it runs under
+// Vitest with bundler module resolution. Both are correct for their runtime.
+import {buildNarrationPrompt, classifyOutcome, selectDispatchedRun, validateTag} from './release-notes.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ghExec(args: readonly string[], childEnv: NodeJS.ProcessEnv): string {
+  return execFileSync('gh', [...args], {
+    env: childEnv,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function sleep(seconds: number): void {
+  // Sync sleep via Atomics.wait on a shared buffer — no subprocess needed.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, seconds * 1000)
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  // Step 1: read target tag from argv
+  const tag = process.argv[2]
+  if (tag === undefined || tag === '') {
+    process.stdout.write('::error::Missing required argument: target tag\n')
+    process.exit(1)
+  }
+
+  // Step 2: validate tag shape
+  const validation = validateTag(tag)
+  if (!validation.ok) {
+    process.stdout.write(`::error::Invalid RELEASE_VERSION shape: ${tag}\n`)
+    process.exit(1)
+  }
+
+  // Step 3: correlation id (test escape hatch or fresh UUID)
+  const correlationId = process.env.RELEASE_NOTES_TEST_CORRELATION_ID ?? randomUUID()
+
+  // Step 4: repo
+  const repo = process.env.GITHUB_REPOSITORY ?? ''
+
+  // Step 5: build prompt
+  const prompt = buildNarrationPrompt({tag, repo, correlationId})
+
+  // Step 6: build child env — override GH_TOKEN with the dispatch PAT when available
+  const dispatchToken = process.env.RELEASE_NOTES_DISPATCH_TOKEN
+  const childEnv: NodeJS.ProcessEnv =
+    dispatchToken != null && dispatchToken !== '' ? {...process.env, GH_TOKEN: dispatchToken} : {...process.env}
+
+  // Step 7: capture dispatch epoch BEFORE the dispatch
+  const dispatchEpoch = Math.floor(Date.now() / 1000)
+
+  // Step 8: dispatch — fail-soft on any error
+  try {
+    execFileSync(
+      'gh',
+      [
+        'workflow',
+        'run',
+        '--ref',
+        'main',
+        'fro-bot.yaml',
+        '-f',
+        `prompt=${prompt}`,
+        '-f',
+        `correlation-id=${correlationId}`,
+        '-f',
+        'model=anthropic/claude-haiku-4-5',
+      ],
+      {env: childEnv, stdio: 'inherit'},
+    )
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    process.stdout.write(
+      `::warning::Dispatch failed (correlation=${correlationId}): ${message}. Narration skipped; release is unaffected.\n`,
+    )
+    process.exit(0)
+  }
+
+  // Step 9: poll loop
+  const pollBudget = Number(process.env.RELEASE_NOTES_TEST_POLL_BUDGET_SECS ?? 180)
+  const pollInterval = Number(process.env.RELEASE_NOTES_TEST_POLL_INTERVAL_SECS ?? 5)
+  const pollDeadline = Date.now() + pollBudget * 1000
+
+  let runId: number | null = null
+
+  while (Date.now() < pollDeadline) {
+    try {
+      const raw = ghExec(
+        [
+          'run',
+          'list',
+          '--workflow=fro-bot.yaml',
+          '--branch=main',
+          '--event=workflow_dispatch',
+          '--json',
+          'databaseId,createdAt',
+          '--limit',
+          '10',
+        ],
+        childEnv,
+      )
+      const runs = JSON.parse(raw) as readonly {databaseId: number; createdAt: string}[]
+      runId = selectDispatchedRun(runs, dispatchEpoch)
+      if (runId !== null) {
+        break
+      }
+    } catch {
+      // transient gh error — keep polling
+    }
+
+    sleep(pollInterval)
+  }
+
+  if (runId === null) {
+    process.stdout.write(
+      `::warning::Dispatch sent but run not confirmed within ${pollBudget}s (correlation=${correlationId}, dispatched_at_epoch=${dispatchEpoch}). Narration runs async; release unaffected.\n`,
+    )
+    process.exit(0)
+  }
+
+  // Step 10: watch with hard timeout
+  const watchTimeoutSecs = Number(process.env.RELEASE_NOTES_TEST_WATCH_TIMEOUT_SECS ?? 600)
+  let watchExit = 0
+  try {
+    execFileSync('timeout', [String(watchTimeoutSecs), 'gh', 'run', 'watch', String(runId), '--exit-status'], {
+      env: childEnv,
+      stdio: 'inherit',
+    })
+  } catch (error: unknown) {
+    watchExit = (error as {status?: number}).status ?? 1
+  }
+
+  // Step 11: fetch conclusion, log, and body length for classification
+  let conclusion = 'unknown'
+  try {
+    conclusion = ghExec(['run', 'view', String(runId), '--json', 'conclusion', '--jq', '.conclusion'], childEnv)
+  } catch {
+    // default 'unknown'
+  }
+
+  let log = ''
+  try {
+    log = ghExec(['run', 'view', String(runId), '--log'], childEnv)
+  } catch {
+    // default ''
+  }
+
+  let bodyLen = 0
+  if (conclusion === 'success') {
+    try {
+      const raw = ghExec(['release', 'view', tag, '--json', 'body', '--jq', '.body | length'], childEnv)
+      bodyLen = Number(raw)
+    } catch {
+      // default 0
+    }
+  }
+
+  // Step 12: classify and emit
+  const result = classifyOutcome({watchExit, conclusion, log, bodyLen, targetTag: tag})
+
+  if (result.level === 'error') {
+    process.stdout.write(`::error::${result.message}\n`)
+  } else if (result.level === 'warn') {
+    process.stdout.write(`::warning::${result.message}\n`)
+  } else {
+    process.stdout.write(`${result.message}\n`)
+  }
+
+  process.exit(result.exitCode)
+}
+
+main()

--- a/scripts/release/dispatch-release-notes.ts
+++ b/scripts/release/dispatch-release-notes.ts
@@ -12,7 +12,9 @@ import {
   AMBIGUOUS_RUN_SENTINEL,
   buildNarrationPrompt,
   classifyOutcome,
+  escapeAnnotation,
   isAuthError,
+  parseDispatchedRuns,
   selectDispatchedRun,
   validateTag,
 } from './release-notes.ts'
@@ -42,14 +44,14 @@ function main(): void {
   // Step 1: read target tag from argv
   const tag = process.argv[2]
   if (tag === undefined || tag === '') {
-    process.stdout.write('::error::Missing required argument: target tag\n')
+    process.stdout.write(`::error::${escapeAnnotation('Missing required argument: target tag')}\n`)
     process.exit(1)
   }
 
   // Step 2: validate tag shape
   const validation = validateTag(tag)
   if (!validation.ok) {
-    process.stdout.write(`::error::Invalid RELEASE_VERSION shape: ${tag}\n`)
+    process.stdout.write(`::error::${escapeAnnotation(`Invalid RELEASE_VERSION shape: ${tag}`)}\n`)
     process.exit(1)
   }
 
@@ -97,13 +99,13 @@ function main(): void {
 
     if (isAuthError(message)) {
       // Auth/permission failure is a genuine security signal — hard-fail
-      process.stdout.write(`::error::Dispatch auth failure: ${sanitized}\n`)
+      process.stdout.write(`::error::${escapeAnnotation(`Dispatch auth failure: ${sanitized}`)}\n`)
       process.exit(1)
     }
 
     // Everything else: soft-warn, release is unaffected
     process.stdout.write(
-      `::warning::Dispatch failed (correlation=${correlationId}): ${sanitized}. Narration skipped; release is unaffected.\n`,
+      `::warning::${escapeAnnotation(`Dispatch failed (correlation=${correlationId}): ${sanitized}. Narration skipped; release is unaffected.`)}\n`,
     )
     process.exit(0)
   }
@@ -132,7 +134,7 @@ function main(): void {
         ],
         childEnv,
       )
-      const runs = JSON.parse(raw) as readonly {databaseId: number; createdAt: string; displayTitle: string}[]
+      const runs = parseDispatchedRuns(raw)
       const selected = selectDispatchedRun(runs, dispatchEpoch, correlationId)
       if (selected === AMBIGUOUS_RUN_SENTINEL) {
         ambiguous = true
@@ -151,14 +153,14 @@ function main(): void {
 
   if (ambiguous) {
     process.stdout.write(
-      `::warning::ambiguous run selection (multiple candidates for correlation ${correlationId}); narration runs async, release unaffected\n`,
+      `::warning::${escapeAnnotation(`ambiguous run selection (multiple candidates for correlation ${correlationId}); narration runs async, release unaffected`)}\n`,
     )
     process.exit(0)
   }
 
   if (runId === null) {
     process.stdout.write(
-      `::warning::Dispatch sent but run not confirmed within ${pollBudget}s (correlation=${correlationId}, dispatched_at_epoch=${dispatchEpoch}). Narration runs async; release unaffected.\n`,
+      `::warning::${escapeAnnotation(`Dispatch sent but run not confirmed within ${pollBudget}s (correlation=${correlationId}, dispatched_at_epoch=${dispatchEpoch}). Narration runs async; release unaffected.`)}\n`,
     )
     process.exit(0)
   }
@@ -204,11 +206,11 @@ function main(): void {
   const result = classifyOutcome({watchExit, conclusion, log, bodyLen, targetTag: tag})
 
   if (result.level === 'error') {
-    process.stdout.write(`::error::${result.message}\n`)
+    process.stdout.write(`::error::${escapeAnnotation(result.message)}\n`)
   } else if (result.level === 'warn') {
-    process.stdout.write(`::warning::${result.message}\n`)
+    process.stdout.write(`::warning::${escapeAnnotation(result.message)}\n`)
   } else {
-    process.stdout.write(`${result.message}\n`)
+    process.stdout.write(`${escapeAnnotation(result.message)}\n`)
   }
 
   process.exit(result.exitCode)

--- a/scripts/release/release-notes.test.ts
+++ b/scripts/release/release-notes.test.ts
@@ -1,0 +1,467 @@
+import {describe, expect, it} from 'vitest'
+import {buildNarrationPrompt, classifyOutcome, selectDispatchedRun, validateTag} from './release-notes.js'
+
+describe('validateTag', () => {
+  it('accepts a standard semver tag', () => {
+    // #given
+    const tag = 'v2.23.0'
+
+    // #when
+    const result = validateTag(tag)
+
+    // #then
+    expect(result.ok).toBe(true)
+  })
+
+  it('accepts a pre-release semver tag', () => {
+    // #given
+    const tag = 'v2.23.0-rc.1'
+
+    // #when
+    const result = validateTag(tag)
+
+    // #then
+    expect(result.ok).toBe(true)
+  })
+
+  it('accepts a pre-release tag with alphanumeric identifiers', () => {
+    // #given
+    const tag = 'v1.0.0-alpha.1'
+
+    // #when
+    const result = validateTag(tag)
+
+    // #then
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects a tag without v prefix', () => {
+    // #given
+    const tag = '1.2.3'
+
+    // #when
+    const result = validateTag(tag)
+
+    // #then
+    expect(result.ok).toBe(false)
+    // result.ok is false here — access .error via type assertion to avoid conditional expect
+    expect((result as {ok: false; error: string}).error).toBeTruthy()
+  })
+
+  it('rejects a non-semver string', () => {
+    // #given
+    const tag = 'not-a-tag'
+
+    // #when
+    const result = validateTag(tag)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects an incomplete semver (missing patch)', () => {
+    // #given
+    const tag = 'v1.2'
+
+    // #when
+    const result = validateTag(tag)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects an empty string', () => {
+    // #given
+    const tag = ''
+
+    // #when
+    const result = validateTag(tag)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+})
+
+describe('classifyOutcome', () => {
+  it('returns ok exit 0 for success with sufficient body length', () => {
+    // #given
+    const input = {watchExit: 0, conclusion: 'success', log: '', bodyLen: 800, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then
+    expect(result.level).toBe('ok')
+    expect(result.exitCode).toBe(0)
+    expect(result.message).toContain('narrative applied')
+  })
+
+  it('returns ok exit 0 for neutral conclusion (idempotent short-circuit)', () => {
+    // #given
+    const input = {watchExit: 0, conclusion: 'neutral', log: '', bodyLen: 0, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then
+    expect(result.level).toBe('ok')
+    expect(result.exitCode).toBe(0)
+    expect(result.message).toContain('no-action-taken')
+  })
+
+  it('returns warn exit 0 for watchExit 124 (timeout)', () => {
+    // #given
+    const input = {watchExit: 124, conclusion: '', log: '', bodyLen: 0, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then
+    expect(result.level).toBe('warn')
+    expect(result.exitCode).toBe(0)
+    expect(result.message).toContain('timed out')
+  })
+
+  it('returns error exit 1 for unexpected watchExit (non-zero, non-124)', () => {
+    // #given
+    const input = {watchExit: 137, conclusion: '', log: '', bodyLen: 0, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then
+    expect(result.level).toBe('error')
+    expect(result.exitCode).toBe(1)
+    expect(result.message).toContain('WATCH_EXIT=137')
+  })
+
+  it('returns error exit 1 for off-target release edit (ANSI-colored log)', () => {
+    // #given — log contains ANSI escape codes around a different tag
+    const log = '\u001B[31mgh release edit v9.9.9\u001B[0m\nsome other output'
+    const input = {watchExit: 0, conclusion: 'success', log, bodyLen: 800, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then
+    expect(result.level).toBe('error')
+    expect(result.exitCode).toBe(1)
+    expect(result.message).toContain('off-target')
+  })
+
+  it('does NOT flag off-target when the log contains the correct target tag', () => {
+    // #given — log contains the same tag as targetTag
+    const log = 'gh release edit v2.23.0 succeeded'
+    const input = {watchExit: 0, conclusion: 'success', log, bodyLen: 800, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then — should fall through to conclusion-based branch, not off-target
+    expect(result.level).toBe('ok')
+    expect(result.exitCode).toBe(0)
+  })
+
+  it('returns error exit 1 for HTTP 401 auth failure', () => {
+    // #given
+    const log = 'HTTP 401: Bad credentials'
+    const input = {watchExit: 0, conclusion: 'failure', log, bodyLen: 0, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then
+    expect(result.level).toBe('error')
+    expect(result.exitCode).toBe(1)
+    expect(result.message).toContain('auth failure')
+  })
+
+  it('returns error exit 1 for HTTP 403 + permission denied auth failure', () => {
+    // #given
+    const log = 'HTTP 403\npermission denied'
+    const input = {watchExit: 0, conclusion: 'failure', log, bodyLen: 0, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then
+    expect(result.level).toBe('error')
+    expect(result.exitCode).toBe(1)
+    expect(result.message).toContain('auth failure')
+  })
+
+  it('returns error exit 1 for Resource not accessible auth failure', () => {
+    // #given
+    const log = 'Resource not accessible by integration'
+    const input = {watchExit: 0, conclusion: 'failure', log, bodyLen: 0, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then
+    expect(result.level).toBe('error')
+    expect(result.exitCode).toBe(1)
+    expect(result.message).toContain('auth failure')
+  })
+
+  it('returns error exit 1 for action_required conclusion', () => {
+    // #given
+    const input = {watchExit: 0, conclusion: 'action_required', log: '', bodyLen: 0, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then
+    expect(result.level).toBe('error')
+    expect(result.exitCode).toBe(1)
+    expect(result.message).toContain('manual intervention')
+  })
+
+  it('returns error exit 1 for skipped conclusion', () => {
+    // #given
+    const input = {watchExit: 0, conclusion: 'skipped', log: '', bodyLen: 0, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then
+    expect(result.level).toBe('error')
+    expect(result.exitCode).toBe(1)
+    expect(result.message).toContain('policy/branch protection')
+  })
+
+  it('returns error exit 1 for success with body length below 200', () => {
+    // #given
+    const input = {watchExit: 0, conclusion: 'success', log: '', bodyLen: 50, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then
+    expect(result.level).toBe('error')
+    expect(result.exitCode).toBe(1)
+    expect(result.message).toContain('body integrity check failed')
+    expect(result.message).toContain('BODY_LEN=50')
+  })
+
+  it('returns warn exit 0 for cancelled conclusion', () => {
+    // #given
+    const input = {watchExit: 0, conclusion: 'cancelled', log: '', bodyLen: 0, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then
+    expect(result.level).toBe('warn')
+    expect(result.exitCode).toBe(0)
+  })
+
+  it('returns warn exit 0 for generic failure (no auth/off-target keywords)', () => {
+    // #given
+    const input = {watchExit: 0, conclusion: 'failure', log: 'some generic error', bodyLen: 0, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then
+    expect(result.level).toBe('warn')
+    expect(result.exitCode).toBe(0)
+    expect(result.message).toContain('narrative-failure')
+  })
+
+  it('returns warn exit 0 for unknown conclusion', () => {
+    // #given
+    const input = {watchExit: 0, conclusion: 'some_new_value', log: '', bodyLen: 0, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then
+    expect(result.level).toBe('warn')
+    expect(result.exitCode).toBe(0)
+    expect(result.message).toContain('unknown conclusion')
+    expect(result.message).toContain('some_new_value')
+  })
+
+  it('watchExit checks take precedence over log-based checks', () => {
+    // #given — log has auth keywords but watchExit is 137 (unexpected exit wins)
+    const log = 'HTTP 401: Bad credentials'
+    const input = {watchExit: 137, conclusion: 'failure', log, bodyLen: 0, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then — watchExit=137 fires first (rule 2), not auth failure (rule 4)
+    expect(result.message).toContain('WATCH_EXIT=137')
+  })
+})
+
+describe('selectDispatchedRun', () => {
+  it('returns null for an empty list', () => {
+    // #given
+    const runs: readonly {databaseId: number; createdAt: string}[] = []
+    const dispatchEpochSeconds = 1_700_000_000
+
+    // #when
+    const result = selectDispatchedRun(runs, dispatchEpochSeconds)
+
+    // #then
+    expect(result).toBeNull()
+  })
+
+  it('returns null when all runs predate the dispatch epoch', () => {
+    // #given
+    const runs = [
+      {databaseId: 1, createdAt: '2023-11-14T22:13:00Z'}, // epoch 1700000000 - 20s
+      {databaseId: 2, createdAt: '2023-11-14T22:12:00Z'}, // even earlier
+    ]
+    const dispatchEpochSeconds = 1_700_000_020 // after both
+
+    // #when
+    const result = selectDispatchedRun(runs, dispatchEpochSeconds)
+
+    // #then
+    expect(result).toBeNull()
+  })
+
+  it('returns null when a run is exactly equal to the dispatch epoch (strictly greater required)', () => {
+    // #given — createdAt exactly equals dispatchEpochSeconds
+    // 2023-11-14T22:13:20Z = 1700000000
+    const runs = [{databaseId: 42, createdAt: '2023-11-14T22:13:20Z'}]
+    const dispatchEpochSeconds = 1_700_000_000
+
+    // #when
+    const result = selectDispatchedRun(runs, dispatchEpochSeconds)
+
+    // #then
+    expect(result).toBeNull()
+  })
+
+  it('returns the newest databaseId when two runs are both after the epoch', () => {
+    // #given — two runs after epoch; run 2 is newer
+    const runs = [
+      {databaseId: 100, createdAt: '2023-11-14T22:13:25Z'}, // +5s after epoch
+      {databaseId: 200, createdAt: '2023-11-14T22:13:30Z'}, // +10s after epoch (newest)
+    ]
+    const dispatchEpochSeconds = 1_700_000_000
+
+    // #when
+    const result = selectDispatchedRun(runs, dispatchEpochSeconds)
+
+    // #then
+    expect(result).toBe(200)
+  })
+
+  it('returns the single post-epoch run when only one qualifies', () => {
+    // #given
+    const runs = [
+      {databaseId: 10, createdAt: '2023-11-14T22:13:00Z'}, // before epoch
+      {databaseId: 20, createdAt: '2023-11-14T22:13:25Z'}, // after epoch
+    ]
+    const dispatchEpochSeconds = 1_700_000_000
+
+    // #when
+    const result = selectDispatchedRun(runs, dispatchEpochSeconds)
+
+    // #then
+    expect(result).toBe(20)
+  })
+})
+
+describe('buildNarrationPrompt', () => {
+  const opts = {tag: 'v2.23.0', repo: 'fro-bot/agent', correlationId: 'test-corr-id-123'}
+
+  it('starts with correlation= on the first line', () => {
+    // #given / #when
+    const prompt = buildNarrationPrompt(opts)
+
+    // #then
+    const firstLine = prompt.split('\n')[0]
+    expect(firstLine).toBe('correlation=test-corr-id-123')
+  })
+
+  it('includes the target tag verbatim', () => {
+    // #given / #when
+    const prompt = buildNarrationPrompt(opts)
+
+    // #then
+    expect(prompt).toContain('v2.23.0')
+  })
+
+  it('includes the repo verbatim', () => {
+    // #given / #when
+    const prompt = buildNarrationPrompt(opts)
+
+    // #then
+    expect(prompt).toContain('fro-bot/agent')
+  })
+
+  it('includes the idempotency marker HTML comment', () => {
+    // #given / #when
+    const prompt = buildNarrationPrompt(opts)
+
+    // #then
+    expect(prompt).toContain('<!-- fro-bot-narration-v1 -->')
+  })
+
+  it("includes the ## What's new heading", () => {
+    // #given / #when
+    const prompt = buildNarrationPrompt(opts)
+
+    // #then
+    expect(prompt).toContain("## What's new")
+  })
+
+  it('includes gh release edit command', () => {
+    // #given / #when
+    const prompt = buildNarrationPrompt(opts)
+
+    // #then
+    expect(prompt).toContain('gh release edit')
+  })
+
+  it('uses --notes-file (never --notes)', () => {
+    // #given / #when
+    const prompt = buildNarrationPrompt(opts)
+
+    // #then
+    expect(prompt).toContain('--notes-file')
+    // Ensure bare --notes is not used (--notes-file is fine, --notes <string> is not)
+    // We check that the only occurrence of --notes is as --notes-file
+    const notesOccurrences = prompt.match(/--notes(?!-file)/g)
+    expect(notesOccurrences).toBeNull()
+  })
+
+  it('includes forbidden-actions scope constraints (no PR/issue comments)', () => {
+    // #given / #when
+    const prompt = buildNarrationPrompt(opts)
+
+    // #then — must mention not commenting on PRs/issues (under "you must not:" list)
+    expect(prompt).toMatch(/comment on any (?:pr|issue)|must not[\s\S]*comment/i)
+  })
+
+  it('includes forbidden-actions constraint against editing other releases', () => {
+    // #given / #when
+    const prompt = buildNarrationPrompt(opts)
+
+    // #then
+    expect(prompt).toMatch(/do not.*edit.*other|not.*other.*release|only.*mutating.*operation|only.*gh release edit/i)
+  })
+
+  it('does NOT contain GitHub Actions workflow-expression syntax', () => {
+    // #given / #when
+    const prompt = buildNarrationPrompt(opts)
+
+    // #then — no ${{ ... }} expressions
+    expect(prompt).not.toContain('${{')
+  })
+
+  it('includes the collapsed Full changelog details block instruction', () => {
+    // #given / #when
+    const prompt = buildNarrationPrompt(opts)
+
+    // #then
+    expect(prompt).toContain('<details>')
+    expect(prompt).toContain('Full changelog')
+  })
+})

--- a/scripts/release/release-notes.test.ts
+++ b/scripts/release/release-notes.test.ts
@@ -1,5 +1,11 @@
 import {describe, expect, it} from 'vitest'
-import {buildNarrationPrompt, classifyOutcome, selectDispatchedRun, validateTag} from './release-notes.js'
+import {
+  AMBIGUOUS_RUN_SENTINEL,
+  buildNarrationPrompt,
+  classifyOutcome,
+  selectDispatchedRun,
+  validateTag,
+} from './release-notes.js'
 
 describe('validateTag', () => {
   it('accepts a standard semver tag', () => {
@@ -80,6 +86,40 @@ describe('validateTag', () => {
     // #then
     expect(result.ok).toBe(false)
   })
+
+  // CHANGE 5 ADD: injection-shaped rejection
+  it('rejects a tag with a semicolon (injection attempt)', () => {
+    // #given
+    const tag = 'v1.2.3; rm -rf /'
+
+    // #when
+    const result = validateTag(tag)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a tag with a space (injection attempt)', () => {
+    // #given
+    const tag = 'v1.2.3 extra'
+
+    // #when
+    const result = validateTag(tag)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a tag with a newline (injection attempt)', () => {
+    // #given
+    const tag = 'v1.2.3\nmalicious'
+
+    // #when
+    const result = validateTag(tag)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
 })
 
 describe('classifyOutcome', () => {
@@ -122,20 +162,22 @@ describe('classifyOutcome', () => {
     expect(result.message).toContain('timed out')
   })
 
-  it('returns error exit 1 for unexpected watchExit (non-zero, non-124)', () => {
+  // CHANGE 5 FLIP: non-zero non-124 watchExit is now warn/exit 0 (not error/exit 1)
+  it('returns warn exit 0 for unexpected watchExit (non-zero, non-124)', () => {
     // #given
     const input = {watchExit: 137, conclusion: '', log: '', bodyLen: 0, targetTag: 'v2.23.0'}
 
     // #when
     const result = classifyOutcome(input)
 
-    // #then
-    expect(result.level).toBe('error')
-    expect(result.exitCode).toBe(1)
+    // #then — gh run watch --exit-status returns non-zero when the run fails; that's narrative, not release
+    expect(result.level).toBe('warn')
+    expect(result.exitCode).toBe(0)
     expect(result.message).toContain('WATCH_EXIT=137')
   })
 
-  it('returns error exit 1 for off-target release edit (ANSI-colored log)', () => {
+  // CHANGE 5 FLIP: off-target is now warn/exit 0 (not error/exit 1)
+  it('returns warn exit 0 for off-target release edit (ANSI-colored log)', () => {
     // #given — log contains ANSI escape codes around a different tag
     const log = '\u001B[31mgh release edit v9.9.9\u001B[0m\nsome other output'
     const input = {watchExit: 0, conclusion: 'success', log, bodyLen: 800, targetTag: 'v2.23.0'}
@@ -143,9 +185,9 @@ describe('classifyOutcome', () => {
     // #when
     const result = classifyOutcome(input)
 
-    // #then
-    expect(result.level).toBe('error')
-    expect(result.exitCode).toBe(1)
+    // #then — demoted to best-effort warn; log-forensics is not a sound security boundary
+    expect(result.level).toBe('warn')
+    expect(result.exitCode).toBe(0)
     expect(result.message).toContain('off-target')
   })
 
@@ -204,7 +246,38 @@ describe('classifyOutcome', () => {
     expect(result.message).toContain('auth failure')
   })
 
-  it('returns error exit 1 for action_required conclusion', () => {
+  // CHANGE 5 ADD: auth failure takes precedence over timeout
+  it('auth failure takes precedence over watchExit 124 (timeout)', () => {
+    // #given — log has auth keywords AND watchExit is 124 (timeout)
+    const log = 'HTTP 401: Bad credentials'
+    const input = {watchExit: 124, conclusion: '', log, bodyLen: 0, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then — auth check fires FIRST (rule 1), not timeout (rule 2)
+    expect(result.level).toBe('error')
+    expect(result.exitCode).toBe(1)
+    expect(result.message).toContain('auth failure')
+  })
+
+  // CHANGE 5 ADD: auth failure takes precedence over non-zero watchExit
+  it('auth failure takes precedence over non-zero non-124 watchExit', () => {
+    // #given — log has auth keywords AND watchExit is 137
+    const log = 'HTTP 401: Bad credentials'
+    const input = {watchExit: 137, conclusion: 'failure', log, bodyLen: 0, targetTag: 'v2.23.0'}
+
+    // #when
+    const result = classifyOutcome(input)
+
+    // #then — auth check fires FIRST (rule 1), not watchExit (rule 3)
+    expect(result.level).toBe('error')
+    expect(result.exitCode).toBe(1)
+    expect(result.message).toContain('auth failure')
+  })
+
+  // CHANGE 5 FLIP: action_required is now warn/exit 0 (not error/exit 1)
+  it('returns warn exit 0 for action_required conclusion', () => {
     // #given
     const input = {watchExit: 0, conclusion: 'action_required', log: '', bodyLen: 0, targetTag: 'v2.23.0'}
 
@@ -212,12 +285,13 @@ describe('classifyOutcome', () => {
     const result = classifyOutcome(input)
 
     // #then
-    expect(result.level).toBe('error')
-    expect(result.exitCode).toBe(1)
-    expect(result.message).toContain('manual intervention')
+    expect(result.level).toBe('warn')
+    expect(result.exitCode).toBe(0)
+    expect(result.message).toContain('action_required')
   })
 
-  it('returns error exit 1 for skipped conclusion', () => {
+  // CHANGE 5 FLIP: skipped is now warn/exit 0 (not error/exit 1)
+  it('returns warn exit 0 for skipped conclusion', () => {
     // #given
     const input = {watchExit: 0, conclusion: 'skipped', log: '', bodyLen: 0, targetTag: 'v2.23.0'}
 
@@ -225,22 +299,23 @@ describe('classifyOutcome', () => {
     const result = classifyOutcome(input)
 
     // #then
-    expect(result.level).toBe('error')
-    expect(result.exitCode).toBe(1)
-    expect(result.message).toContain('policy/branch protection')
+    expect(result.level).toBe('warn')
+    expect(result.exitCode).toBe(0)
+    expect(result.message).toContain('skipped')
   })
 
-  it('returns error exit 1 for success with body length below 200', () => {
+  // CHANGE 5 FLIP: below-floor body is now warn/exit 0 (not error/exit 1)
+  it('returns warn exit 0 for success with body length below MIN_RELEASE_BODY_LENGTH', () => {
     // #given
     const input = {watchExit: 0, conclusion: 'success', log: '', bodyLen: 50, targetTag: 'v2.23.0'}
 
     // #when
     const result = classifyOutcome(input)
 
-    // #then
-    expect(result.level).toBe('error')
-    expect(result.exitCode).toBe(1)
-    expect(result.message).toContain('body integrity check failed')
+    // #then — short body is quality signal, not security signal
+    expect(result.level).toBe('warn')
+    expect(result.exitCode).toBe(0)
+    expect(result.message).toContain('body shorter than expected')
     expect(result.message).toContain('BODY_LEN=50')
   })
 
@@ -282,28 +357,19 @@ describe('classifyOutcome', () => {
     expect(result.message).toContain('unknown conclusion')
     expect(result.message).toContain('some_new_value')
   })
-
-  it('watchExit checks take precedence over log-based checks', () => {
-    // #given — log has auth keywords but watchExit is 137 (unexpected exit wins)
-    const log = 'HTTP 401: Bad credentials'
-    const input = {watchExit: 137, conclusion: 'failure', log, bodyLen: 0, targetTag: 'v2.23.0'}
-
-    // #when
-    const result = classifyOutcome(input)
-
-    // #then — watchExit=137 fires first (rule 2), not auth failure (rule 4)
-    expect(result.message).toContain('WATCH_EXIT=137')
-  })
 })
 
 describe('selectDispatchedRun', () => {
+  // Epoch for 2023-11-14T22:13:20Z = 1700000000
+  const BASE_EPOCH = 1_700_000_000
+  const CORR_ID = 'release-notes-abc123'
+
   it('returns null for an empty list', () => {
     // #given
-    const runs: readonly {databaseId: number; createdAt: string}[] = []
-    const dispatchEpochSeconds = 1_700_000_000
+    const runs: readonly {databaseId: number; createdAt: string; displayTitle: string}[] = []
 
     // #when
-    const result = selectDispatchedRun(runs, dispatchEpochSeconds)
+    const result = selectDispatchedRun(runs, BASE_EPOCH, CORR_ID)
 
     // #then
     expect(result).toBeNull()
@@ -312,59 +378,87 @@ describe('selectDispatchedRun', () => {
   it('returns null when all runs predate the dispatch epoch', () => {
     // #given
     const runs = [
-      {databaseId: 1, createdAt: '2023-11-14T22:13:00Z'}, // epoch 1700000000 - 20s
-      {databaseId: 2, createdAt: '2023-11-14T22:12:00Z'}, // even earlier
+      {databaseId: 1, createdAt: '2023-11-14T22:13:00Z', displayTitle: `Fro Bot · release-notes · ${CORR_ID}`},
+      {databaseId: 2, createdAt: '2023-11-14T22:12:00Z', displayTitle: `Fro Bot · release-notes · ${CORR_ID}`},
     ]
-    const dispatchEpochSeconds = 1_700_000_020 // after both
+    const dispatchEpochSeconds = BASE_EPOCH + 20 // after both
 
     // #when
-    const result = selectDispatchedRun(runs, dispatchEpochSeconds)
+    const result = selectDispatchedRun(runs, dispatchEpochSeconds, CORR_ID)
 
     // #then
     expect(result).toBeNull()
   })
 
-  it('returns null when a run is exactly equal to the dispatch epoch (strictly greater required)', () => {
+  // CHANGE 5: same-second (createdAt epoch == dispatchEpoch) with matching correlation → selected (>= not >)
+  it('returns the databaseId when createdAt epoch equals dispatchEpoch (same-second, >= semantics)', () => {
     // #given — createdAt exactly equals dispatchEpochSeconds
     // 2023-11-14T22:13:20Z = 1700000000
-    const runs = [{databaseId: 42, createdAt: '2023-11-14T22:13:20Z'}]
-    const dispatchEpochSeconds = 1_700_000_000
+    const runs = [
+      {databaseId: 42, createdAt: '2023-11-14T22:13:20Z', displayTitle: `Fro Bot · release-notes · ${CORR_ID}`},
+    ]
 
     // #when
-    const result = selectDispatchedRun(runs, dispatchEpochSeconds)
+    const result = selectDispatchedRun(runs, BASE_EPOCH, CORR_ID)
 
-    // #then
+    // #then — same-second is now included (>= not >)
+    expect(result).toBe(42)
+  })
+
+  it('returns null when run is at epoch but correlationId does not match', () => {
+    // #given
+    const runs = [
+      {databaseId: 42, createdAt: '2023-11-14T22:13:20Z', displayTitle: 'Fro Bot · release-notes · other-id'},
+    ]
+
+    // #when
+    const result = selectDispatchedRun(runs, BASE_EPOCH, CORR_ID)
+
+    // #then — no correlation match
     expect(result).toBeNull()
   })
 
-  it('returns the newest databaseId when two runs are both after the epoch', () => {
-    // #given — two runs after epoch; run 2 is newer
-    const runs = [
-      {databaseId: 100, createdAt: '2023-11-14T22:13:25Z'}, // +5s after epoch
-      {databaseId: 200, createdAt: '2023-11-14T22:13:30Z'}, // +10s after epoch (newest)
-    ]
-    const dispatchEpochSeconds = 1_700_000_000
-
-    // #when
-    const result = selectDispatchedRun(runs, dispatchEpochSeconds)
-
-    // #then
-    expect(result).toBe(200)
-  })
-
-  it('returns the single post-epoch run when only one qualifies', () => {
+  it('returns the single matching databaseId when exactly one run matches correlation and epoch', () => {
     // #given
     const runs = [
-      {databaseId: 10, createdAt: '2023-11-14T22:13:00Z'}, // before epoch
-      {databaseId: 20, createdAt: '2023-11-14T22:13:25Z'}, // after epoch
+      {databaseId: 10, createdAt: '2023-11-14T22:13:00Z', displayTitle: `Fro Bot · release-notes · ${CORR_ID}`}, // before epoch
+      {databaseId: 20, createdAt: '2023-11-14T22:13:25Z', displayTitle: `Fro Bot · release-notes · ${CORR_ID}`}, // after epoch
     ]
-    const dispatchEpochSeconds = 1_700_000_000
 
     // #when
-    const result = selectDispatchedRun(runs, dispatchEpochSeconds)
+    const result = selectDispatchedRun(runs, BASE_EPOCH, CORR_ID)
 
     // #then
     expect(result).toBe(20)
+  })
+
+  // CHANGE 5 ADD: >1 matches → AMBIGUOUS_RUN_SENTINEL
+  it('returns AMBIGUOUS_RUN_SENTINEL when multiple runs match correlation and epoch', () => {
+    // #given — two runs after epoch, both with matching correlationId
+    const runs = [
+      {databaseId: 100, createdAt: '2023-11-14T22:13:25Z', displayTitle: `Fro Bot · release-notes · ${CORR_ID}`},
+      {databaseId: 200, createdAt: '2023-11-14T22:13:30Z', displayTitle: `Fro Bot · release-notes · ${CORR_ID}`},
+    ]
+
+    // #when
+    const result = selectDispatchedRun(runs, BASE_EPOCH, CORR_ID)
+
+    // #then — ambiguous, not a specific run
+    expect(result).toBe(AMBIGUOUS_RUN_SENTINEL)
+  })
+
+  it('returns null when post-epoch runs exist but none match the correlationId', () => {
+    // #given — runs are after epoch but have a different correlationId
+    const runs = [
+      {databaseId: 100, createdAt: '2023-11-14T22:13:25Z', displayTitle: 'Fro Bot · release-notes · different-id'},
+      {databaseId: 200, createdAt: '2023-11-14T22:13:30Z', displayTitle: 'Fro Bot'},
+    ]
+
+    // #when
+    const result = selectDispatchedRun(runs, BASE_EPOCH, CORR_ID)
+
+    // #then — no correlation match → null (not ambiguous, not a run id)
+    expect(result).toBeNull()
   })
 })
 

--- a/scripts/release/release-notes.test.ts
+++ b/scripts/release/release-notes.test.ts
@@ -3,6 +3,8 @@ import {
   AMBIGUOUS_RUN_SENTINEL,
   buildNarrationPrompt,
   classifyOutcome,
+  escapeAnnotation,
+  parseDispatchedRuns,
   selectDispatchedRun,
   validateTag,
 } from './release-notes.js'
@@ -557,5 +559,263 @@ describe('buildNarrationPrompt', () => {
     // #then
     expect(prompt).toContain('<details>')
     expect(prompt).toContain('Full changelog')
+  })
+})
+
+describe('parseDispatchedRuns', () => {
+  it('returns a valid array from well-formed JSON', () => {
+    // #given
+    const raw = JSON.stringify([
+      {databaseId: 1, createdAt: '2024-01-01T00:00:00Z', displayTitle: 'Fro Bot · release-notes · abc'},
+      {databaseId: 2, createdAt: '2024-01-02T00:00:00Z', displayTitle: 'Fro Bot · release-notes · def'},
+    ])
+
+    // #when
+    const result = parseDispatchedRuns(raw)
+
+    // #then
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({
+      databaseId: 1,
+      createdAt: '2024-01-01T00:00:00Z',
+      displayTitle: 'Fro Bot · release-notes · abc',
+    })
+    expect(result[1]).toEqual({
+      databaseId: 2,
+      createdAt: '2024-01-02T00:00:00Z',
+      displayTitle: 'Fro Bot · release-notes · def',
+    })
+  })
+
+  it('returns empty array for an empty string', () => {
+    // #given
+    const raw = ''
+
+    // #when
+    const result = parseDispatchedRuns(raw)
+
+    // #then
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array for non-JSON garbage', () => {
+    // #given
+    const raw = 'error: could not connect to github.com'
+
+    // #when
+    const result = parseDispatchedRuns(raw)
+
+    // #then
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array when JSON is a non-array value (object)', () => {
+    // #given
+    const raw = JSON.stringify({databaseId: 1, createdAt: '2024-01-01T00:00:00Z', displayTitle: 'title'})
+
+    // #when
+    const result = parseDispatchedRuns(raw)
+
+    // #then
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array when JSON is a non-array value (null)', () => {
+    // #given
+    const raw = 'null'
+
+    // #when
+    const result = parseDispatchedRuns(raw)
+
+    // #then
+    expect(result).toEqual([])
+  })
+
+  it('filters out rows with missing databaseId', () => {
+    // #given
+    const raw = JSON.stringify([{createdAt: '2024-01-01T00:00:00Z', displayTitle: 'title'}])
+
+    // #when
+    const result = parseDispatchedRuns(raw)
+
+    // #then
+    expect(result).toEqual([])
+  })
+
+  it('filters out rows with wrong-typed databaseId (string instead of number)', () => {
+    // #given
+    const raw = JSON.stringify([{databaseId: '123', createdAt: '2024-01-01T00:00:00Z', displayTitle: 'title'}])
+
+    // #when
+    const result = parseDispatchedRuns(raw)
+
+    // #then
+    expect(result).toEqual([])
+  })
+
+  it('filters out rows with missing createdAt', () => {
+    // #given
+    const raw = JSON.stringify([{databaseId: 1, displayTitle: 'title'}])
+
+    // #when
+    const result = parseDispatchedRuns(raw)
+
+    // #then
+    expect(result).toEqual([])
+  })
+
+  it('filters out rows with empty createdAt string', () => {
+    // #given
+    const raw = JSON.stringify([{databaseId: 1, createdAt: '', displayTitle: 'title'}])
+
+    // #when
+    const result = parseDispatchedRuns(raw)
+
+    // #then
+    expect(result).toEqual([])
+  })
+
+  it('filters out rows with missing displayTitle', () => {
+    // #given
+    const raw = JSON.stringify([{databaseId: 1, createdAt: '2024-01-01T00:00:00Z'}])
+
+    // #when
+    const result = parseDispatchedRuns(raw)
+
+    // #then
+    expect(result).toEqual([])
+  })
+
+  it('filters out null entries in the array', () => {
+    // #given
+    const raw = JSON.stringify([null, {databaseId: 1, createdAt: '2024-01-01T00:00:00Z', displayTitle: 'title'}])
+
+    // #when
+    const result = parseDispatchedRuns(raw)
+
+    // #then
+    expect(result).toHaveLength(1)
+    expect(result[0]?.databaseId).toBe(1)
+  })
+
+  it('keeps valid rows and drops invalid rows in a mixed array', () => {
+    // #given
+    const raw = JSON.stringify([
+      {databaseId: 10, createdAt: '2024-01-01T00:00:00Z', displayTitle: 'good'},
+      {databaseId: 'bad', createdAt: '2024-01-01T00:00:00Z', displayTitle: 'bad-type'},
+      null,
+      {databaseId: 20, createdAt: '2024-01-02T00:00:00Z', displayTitle: 'also-good'},
+      {createdAt: '2024-01-03T00:00:00Z', displayTitle: 'missing-id'},
+    ])
+
+    // #when
+    const result = parseDispatchedRuns(raw)
+
+    // #then — only the two fully-valid rows survive
+    expect(result).toHaveLength(2)
+    expect(result[0]?.databaseId).toBe(10)
+    expect(result[1]?.databaseId).toBe(20)
+  })
+
+  it('filters out rows with non-finite databaseId (null, as JSON cannot represent Infinity)', () => {
+    // #given — JSON cannot represent Infinity/NaN; they serialize as null.
+    // Test the isFinite guard via a raw string with null databaseId.
+    const raw = '[{"databaseId":null,"createdAt":"2024-01-01T00:00:00Z","displayTitle":"title"}]'
+
+    // #when
+    const result = parseDispatchedRuns(raw)
+
+    // #then
+    expect(result).toEqual([])
+  })
+})
+
+describe('escapeAnnotation', () => {
+  it('leaves normal text unchanged', () => {
+    // #given
+    const message = 'narrative applied successfully'
+
+    // #when
+    const result = escapeAnnotation(message)
+
+    // #then
+    expect(result).toBe('narrative applied successfully')
+  })
+
+  it('escapes % as %25', () => {
+    // #given
+    const message = '50% complete'
+
+    // #when
+    const result = escapeAnnotation(message)
+
+    // #then
+    expect(result).toBe('50%25 complete')
+  })
+
+  it(String.raw`escapes CR (\r) as %0D`, () => {
+    // #given
+    const message = 'line one\rline two'
+
+    // #when
+    const result = escapeAnnotation(message)
+
+    // #then
+    expect(result).toBe('line one%0Dline two')
+  })
+
+  it(String.raw`escapes LF (\n) as %0A`, () => {
+    // #given
+    const message = 'line one\nline two'
+
+    // #when
+    const result = escapeAnnotation(message)
+
+    // #then
+    expect(result).toBe('line one%0Aline two')
+  })
+
+  it('escapes % before CR/LF to avoid double-encoding', () => {
+    // #given — if % were encoded after \n, the %0A would become %250A
+    const message = '%\n'
+
+    // #when
+    const result = escapeAnnotation(message)
+
+    // #then — % → %25 first, then \n → %0A; result is %25%0A not %250A
+    expect(result).toBe('%25%0A')
+  })
+
+  it('escapes all three special characters in a single string', () => {
+    // #given
+    const message = 'err: 100% failed\r\ncheck logs'
+
+    // #when
+    const result = escapeAnnotation(message)
+
+    // #then
+    expect(result).toBe('err: 100%25 failed%0D%0Acheck logs')
+  })
+
+  it('handles an empty string', () => {
+    // #given
+    const message = ''
+
+    // #when
+    const result = escapeAnnotation(message)
+
+    // #then
+    expect(result).toBe('')
+  })
+
+  it('handles multiple consecutive special characters', () => {
+    // #given
+    const message = '%%\n\n\r\r'
+
+    // #when
+    const result = escapeAnnotation(message)
+
+    // #then
+    expect(result).toBe('%25%25%0A%0A%0D%0D')
   })
 })

--- a/scripts/release/release-notes.ts
+++ b/scripts/release/release-notes.ts
@@ -1,0 +1,214 @@
+const TAG_PATTERN = /^v\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?$/
+
+// eslint-disable-next-line no-control-regex -- ANSI escape stripping requires the ESC control character
+const ANSI_ESCAPE_PATTERN = /\u001B\[[0-9;]*m/g
+
+const RELEASE_EDIT_PATTERN = /release edit (v\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?)/g
+
+const AUTH_FAILURE_PATTERNS = [
+  /HTTP 401/,
+  /HTTP 403/,
+  /Bad credentials/,
+  /Resource not accessible/,
+  /requires authentication/,
+  /permission denied/i,
+]
+
+export type ValidateTagResult = {ok: true} | {ok: false; error: string}
+
+export function validateTag(tag: string): ValidateTagResult {
+  if (TAG_PATTERN.test(tag)) {
+    return {ok: true}
+  }
+  return {ok: false, error: `Invalid tag format: "${tag}". Expected v<major>.<minor>.<patch>[-prerelease]`}
+}
+
+export interface NarrationPromptOpts {
+  readonly tag: string
+  readonly repo: string
+  readonly correlationId: string
+}
+
+export function buildNarrationPrompt(opts: NarrationPromptOpts): string {
+  const {tag, repo, correlationId} = opts
+
+  return `correlation=${correlationId}
+
+You are narrating the GitHub Release body for ${repo} tag ${tag}.
+
+## Idempotency check
+
+Before doing anything else, fetch the current release body for tag ${tag} in repo ${repo}:
+
+  gh release view ${tag} --repo ${repo} --json body --jq '.body'
+
+If the body already contains the marker <!-- fro-bot-narration-v1 -->, log "already-applied" and stop immediately. Do not make any edits. Exit with conclusion neutral.
+
+## Rewrite instruction
+
+Rewrite the release body to produce a human-readable narrative. The output MUST follow this exact structure:
+
+1. A \`## What's new\` heading on its own line.
+2. Immediately after the heading, the idempotency marker on its own line: <!-- fro-bot-narration-v1 -->
+3. A 1-2 sentence summary of the release.
+4. Highlights grouped by impact category. Only include categories that have entries:
+   - **Features** — new capabilities
+   - **Fixes** — bug fixes
+   - **Security** — security improvements
+   - **Performance** — performance improvements
+   - **Breaking** — breaking changes
+   Each entry should be a human-readable bullet linking the PR number (e.g. [#123](https://github.com/${repo}/pull/123)).
+5. The original conventional-commit list preserved below under a collapsed block:
+
+<details><summary>Full changelog</summary>
+
+(paste the original commit list here verbatim)
+
+</details>
+
+## Application instruction
+
+Once you have composed the new body:
+
+1. Write the full new body text to a temporary file (e.g. /tmp/release-notes-${tag}.md).
+2. Apply it with:
+
+   gh release edit ${tag} --repo ${repo} --notes-file /tmp/release-notes-${tag}.md
+
+3. Verify the edit succeeded by fetching the release body again and confirming it contains <!-- fro-bot-narration-v1 -->.
+4. Report: tag applied, chars-before, chars-after, and the release URL.
+
+## Scope constraints (forbidden actions)
+
+The ONLY mutating operation permitted is \`gh release edit ${tag}\` on repo ${repo}.
+
+You MUST NOT:
+- Comment on any PR, issue, or discussion
+- Open or close any issue
+- Edit any other release (any tag other than ${tag})
+- Modify any file in the repository
+- Create any branch, tag, or commit
+- Perform any action not explicitly listed above
+
+If you find yourself about to do any of the above, stop and report the anomaly instead.
+`
+}
+
+export interface DispatchedRun {
+  readonly databaseId: number
+  readonly createdAt: string
+}
+
+export function selectDispatchedRun(runs: readonly DispatchedRun[], dispatchEpochSeconds: number): number | null {
+  let newestEpoch = -Infinity
+  let newestId: number | null = null
+
+  for (const run of runs) {
+    const runEpoch = Math.floor(new Date(run.createdAt).getTime() / 1000)
+    if (runEpoch > dispatchEpochSeconds && runEpoch > newestEpoch) {
+      newestEpoch = runEpoch
+      newestId = run.databaseId
+    }
+  }
+
+  return newestId
+}
+
+export interface ClassifyOutcomeInput {
+  readonly watchExit: number
+  readonly conclusion: string
+  readonly log: string
+  readonly bodyLen: number
+  readonly targetTag: string
+}
+
+export interface ClassifyOutcomeResult {
+  readonly level: 'ok' | 'warn' | 'error'
+  readonly message: string
+  readonly exitCode: 0 | 1
+}
+
+function stripAnsi(text: string): string {
+  return text.replaceAll(ANSI_ESCAPE_PATTERN, '')
+}
+
+function hasOffTargetEdit(log: string, targetTag: string): boolean {
+  const stripped = stripAnsi(log)
+  RELEASE_EDIT_PATTERN.lastIndex = 0
+  let match = RELEASE_EDIT_PATTERN.exec(stripped)
+  while (match !== null) {
+    const foundTag = match[1]
+    if (foundTag !== targetTag) {
+      return true
+    }
+    match = RELEASE_EDIT_PATTERN.exec(stripped)
+  }
+  return false
+}
+
+function hasAuthFailure(log: string): boolean {
+  const stripped = stripAnsi(log)
+  return AUTH_FAILURE_PATTERNS.some(pattern => pattern.test(stripped))
+}
+
+export function classifyOutcome(input: ClassifyOutcomeInput): ClassifyOutcomeResult {
+  const {watchExit, conclusion, log, bodyLen, targetTag} = input
+
+  // Rule 1: timeout
+  if (watchExit === 124) {
+    return {level: 'warn', exitCode: 0, message: 'timed out waiting for run to complete'}
+  }
+
+  // Rule 2: unexpected watch exit
+  if (watchExit !== 0) {
+    return {level: 'error', exitCode: 1, message: `unexpected gh run watch exit (WATCH_EXIT=${watchExit})`}
+  }
+
+  // Rule 3: off-target release edit (scan ANSI-stripped log)
+  if (hasOffTargetEdit(log, targetTag)) {
+    return {level: 'error', exitCode: 1, message: `off-target release edit detected in run log`}
+  }
+
+  // Rule 4: auth failure keywords
+  if (hasAuthFailure(log)) {
+    return {level: 'error', exitCode: 1, message: 'auth failure detected in run log'}
+  }
+
+  // Rule 5: action_required
+  if (conclusion === 'action_required') {
+    return {level: 'error', exitCode: 1, message: 'run requires manual intervention (action_required)'}
+  }
+
+  // Rule 6: skipped
+  if (conclusion === 'skipped') {
+    return {level: 'error', exitCode: 1, message: 'run was skipped (policy/branch protection)'}
+  }
+
+  // Rule 7: success but body too short
+  if (conclusion === 'success' && bodyLen < 200) {
+    return {level: 'error', exitCode: 1, message: `body integrity check failed (BODY_LEN=${bodyLen})`}
+  }
+
+  // Rule 8: success with sufficient body
+  if (conclusion === 'success') {
+    return {level: 'ok', exitCode: 0, message: 'narrative applied successfully'}
+  }
+
+  // Rule 9: neutral (idempotent short-circuit)
+  if (conclusion === 'neutral') {
+    return {level: 'ok', exitCode: 0, message: 'no-action-taken (already-applied idempotent short-circuit)'}
+  }
+
+  // Rule 10: cancelled
+  if (conclusion === 'cancelled') {
+    return {level: 'warn', exitCode: 0, message: 'run was cancelled'}
+  }
+
+  // Rule 11: generic failure
+  if (conclusion === 'failure') {
+    return {level: 'warn', exitCode: 0, message: 'narrative-failure: run concluded with failure'}
+  }
+
+  // Rule 12: unknown conclusion
+  return {level: 'warn', exitCode: 0, message: `unknown conclusion: ${conclusion}`}
+}

--- a/scripts/release/release-notes.ts
+++ b/scripts/release/release-notes.ts
@@ -14,6 +14,10 @@ const AUTH_FAILURE_PATTERNS = [
   /permission denied/i,
 ]
 
+// CHANGE 4: extracted constants
+export const NARRATION_MARKER = '<!-- fro-bot-narration-v1 -->'
+export const MIN_RELEASE_BODY_LENGTH = 200
+
 export type ValidateTagResult = {ok: true} | {ok: false; error: string}
 
 export function validateTag(tag: string): ValidateTagResult {
@@ -42,14 +46,14 @@ Before doing anything else, fetch the current release body for tag ${tag} in rep
 
   gh release view ${tag} --repo ${repo} --json body --jq '.body'
 
-If the body already contains the marker <!-- fro-bot-narration-v1 -->, log "already-applied" and stop immediately. Do not make any edits. Exit with conclusion neutral.
+If the body already contains the marker ${NARRATION_MARKER}, log "already-applied" and stop immediately. Do not make any edits. Exit with conclusion neutral.
 
 ## Rewrite instruction
 
 Rewrite the release body to produce a human-readable narrative. The output MUST follow this exact structure:
 
 1. A \`## What's new\` heading on its own line.
-2. Immediately after the heading, the idempotency marker on its own line: <!-- fro-bot-narration-v1 -->
+2. Immediately after the heading, the idempotency marker on its own line: ${NARRATION_MARKER}
 3. A 1-2 sentence summary of the release.
 4. Highlights grouped by impact category. Only include categories that have entries:
    - **Features** — new capabilities
@@ -75,7 +79,7 @@ Once you have composed the new body:
 
    gh release edit ${tag} --repo ${repo} --notes-file /tmp/release-notes-${tag}.md
 
-3. Verify the edit succeeded by fetching the release body again and confirming it contains <!-- fro-bot-narration-v1 -->.
+3. Verify the edit succeeded by fetching the release body again and confirming it contains ${NARRATION_MARKER}.
 4. Report: tag applied, chars-before, chars-after, and the release URL.
 
 ## Scope constraints (forbidden actions)
@@ -97,21 +101,36 @@ If you find yourself about to do any of the above, stop and report the anomaly i
 export interface DispatchedRun {
   readonly databaseId: number
   readonly createdAt: string
+  readonly displayTitle: string
 }
 
-export function selectDispatchedRun(runs: readonly DispatchedRun[], dispatchEpochSeconds: number): number | null {
-  let newestEpoch = -Infinity
-  let newestId: number | null = null
+// CHANGE 3: correlated run selection — filters by correlationId in displayTitle AND createdAt >= dispatchEpoch.
+// Returns:
+//   - null  → 0 matches (run not confirmed) OR >1 matches (ambiguous)
+//   - number → exactly 1 match (the databaseId)
+// Callers must distinguish null-from-zero vs null-from-ambiguous via the exported sentinel.
+export const AMBIGUOUS_RUN_SENTINEL = Symbol('ambiguous')
 
-  for (const run of runs) {
+export function selectDispatchedRun(
+  runs: readonly DispatchedRun[],
+  dispatchEpochSeconds: number,
+  correlationId: string,
+): number | null | typeof AMBIGUOUS_RUN_SENTINEL {
+  const candidates = runs.filter(run => {
     const runEpoch = Math.floor(new Date(run.createdAt).getTime() / 1000)
-    if (runEpoch > dispatchEpochSeconds && runEpoch > newestEpoch) {
-      newestEpoch = runEpoch
-      newestId = run.databaseId
-    }
-  }
+    return runEpoch >= dispatchEpochSeconds && run.displayTitle.includes(correlationId)
+  })
 
-  return newestId
+  if (candidates.length === 0) {
+    return null
+  }
+  if (candidates.length === 1) {
+    // candidates[0] is guaranteed by the length === 1 check above
+    const only = candidates[0]
+    return only === undefined ? null : only.databaseId
+  }
+  // >1 matches — ambiguous
+  return AMBIGUOUS_RUN_SENTINEL
 }
 
 export interface ClassifyOutcomeInput {
@@ -146,69 +165,94 @@ function hasOffTargetEdit(log: string, targetTag: string): boolean {
   return false
 }
 
-function hasAuthFailure(log: string): boolean {
+export function hasAuthFailure(log: string): boolean {
   const stripped = stripAnsi(log)
   return AUTH_FAILURE_PATTERNS.some(pattern => pattern.test(stripped))
 }
 
+// CHANGE 2: exported so dispatch-release-notes.ts can reuse it for dispatch-time auth detection
+export function isAuthError(text: string): boolean {
+  return hasAuthFailure(text)
+}
+
+// CHANGE 1: rewritten classifyOutcome with correct precedence
 export function classifyOutcome(input: ClassifyOutcomeInput): ClassifyOutcomeResult {
   const {watchExit, conclusion, log, bodyLen, targetTag} = input
 
-  // Rule 1: timeout
-  if (watchExit === 124) {
-    return {level: 'warn', exitCode: 0, message: 'timed out waiting for run to complete'}
-  }
-
-  // Rule 2: unexpected watch exit
-  if (watchExit !== 0) {
-    return {level: 'error', exitCode: 1, message: `unexpected gh run watch exit (WATCH_EXIT=${watchExit})`}
-  }
-
-  // Rule 3: off-target release edit (scan ANSI-stripped log)
-  if (hasOffTargetEdit(log, targetTag)) {
-    return {level: 'error', exitCode: 1, message: `off-target release edit detected in run log`}
-  }
-
-  // Rule 4: auth failure keywords
+  // Rule 1 (FIRST): auth failure — the ONLY hard-fail path derived from log scanning.
+  // Must come before timeout/watch-exit so a timed-out run that also shows auth failure still hard-fails.
   if (hasAuthFailure(log)) {
     return {level: 'error', exitCode: 1, message: 'auth failure detected in run log'}
   }
 
-  // Rule 5: action_required
-  if (conclusion === 'action_required') {
-    return {level: 'error', exitCode: 1, message: 'run requires manual intervention (action_required)'}
+  // Rule 2: timeout (watchExit === 124)
+  if (watchExit === 124) {
+    return {level: 'warn', exitCode: 0, message: 'timed out waiting for run to complete'}
   }
 
-  // Rule 6: skipped
-  if (conclusion === 'skipped') {
-    return {level: 'error', exitCode: 1, message: 'run was skipped (policy/branch protection)'}
+  // Rule 3: any other non-zero watchExit — observation only, NOT a hard-fail.
+  // gh run watch --exit-status returns non-zero when the watched run fails; that's a narrative
+  // failure, not a release failure.
+  if (watchExit !== 0) {
+    return {
+      level: 'warn',
+      exitCode: 0,
+      message: `run watch reported non-zero exit (WATCH_EXIT=${watchExit}); see run conclusion`,
+    }
   }
 
-  // Rule 7: success but body too short
-  if (conclusion === 'success' && bodyLen < 200) {
-    return {level: 'error', exitCode: 1, message: `body integrity check failed (BODY_LEN=${bodyLen})`}
+  // Rule 4: off-target release edit — DEMOTED to warn (best-effort signal only).
+  // Log-forensics is not a sound security boundary; real prevention is PAT scope + prompt.
+  if (hasOffTargetEdit(log, targetTag)) {
+    return {
+      level: 'warn',
+      exitCode: 0,
+      message: 'possible off-target release edit detected in run log (best-effort signal)',
+    }
   }
 
-  // Rule 8: success with sufficient body
+  // Rule 5: success — prefer positive proof
   if (conclusion === 'success') {
-    return {level: 'ok', exitCode: 0, message: 'narrative applied successfully'}
+    if (bodyLen >= MIN_RELEASE_BODY_LENGTH) {
+      return {level: 'ok', exitCode: 0, message: 'narrative applied successfully'}
+    }
+    // Short body is a quality signal, not a security signal — soft-warn
+    return {
+      level: 'warn',
+      exitCode: 0,
+      message: `narrative applied but body shorter than expected (BODY_LEN=${bodyLen})`,
+    }
   }
 
-  // Rule 9: neutral (idempotent short-circuit)
+  // Rule 6: neutral (idempotent short-circuit)
   if (conclusion === 'neutral') {
     return {level: 'ok', exitCode: 0, message: 'no-action-taken (already-applied idempotent short-circuit)'}
   }
 
-  // Rule 10: cancelled
+  // Rule 7: action_required — soft-warn, not hard-fail
+  if (conclusion === 'action_required') {
+    return {
+      level: 'warn',
+      exitCode: 0,
+      message: 'run requires manual intervention (action_required); narration skipped',
+    }
+  }
+
+  // Rule 8: skipped — soft-warn, not hard-fail
+  if (conclusion === 'skipped') {
+    return {level: 'warn', exitCode: 0, message: 'run was skipped; narration skipped'}
+  }
+
+  // Rule 9: cancelled — soft-warn
   if (conclusion === 'cancelled') {
     return {level: 'warn', exitCode: 0, message: 'run was cancelled'}
   }
 
-  // Rule 11: generic failure
+  // Rule 10: generic failure — soft-warn
   if (conclusion === 'failure') {
     return {level: 'warn', exitCode: 0, message: 'narrative-failure: run concluded with failure'}
   }
 
-  // Rule 12: unknown conclusion
+  // Rule 11: unknown conclusion — soft-warn
   return {level: 'warn', exitCode: 0, message: `unknown conclusion: ${conclusion}`}
 }

--- a/scripts/release/release-notes.ts
+++ b/scripts/release/release-notes.ts
@@ -111,6 +111,39 @@ export interface DispatchedRun {
 // Callers must distinguish null-from-zero vs null-from-ambiguous via the exported sentinel.
 export const AMBIGUOUS_RUN_SENTINEL = Symbol('ambiguous')
 
+// CHANGE A: safe parser — never throws; returns empty array on any malformed input
+export function parseDispatchedRuns(raw: string): readonly DispatchedRun[] {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (!Array.isArray(parsed)) return []
+  const out: DispatchedRun[] = []
+  for (const item of parsed) {
+    if (item == null || typeof item !== 'object') continue
+    const rec = item as Record<string, unknown>
+    const {databaseId, createdAt, displayTitle} = rec
+    if (
+      typeof databaseId === 'number' &&
+      Number.isFinite(databaseId) &&
+      typeof createdAt === 'string' &&
+      createdAt !== '' &&
+      typeof displayTitle === 'string'
+    ) {
+      out.push({databaseId, createdAt, displayTitle})
+    }
+  }
+  return out
+}
+
+// CHANGE B: escape GitHub Actions annotation message bodies
+// % → %25 must come first to avoid double-encoding CR/LF escapes
+export function escapeAnnotation(message: string): string {
+  return message.replaceAll('%', '%25').replaceAll('\r', '%0D').replaceAll('\n', '%0A')
+}
+
 export function selectDispatchedRun(
   runs: readonly DispatchedRun[],
   dispatchEpochSeconds: number,

--- a/scripts/release/release-notes.ts
+++ b/scripts/release/release-notes.ts
@@ -3,6 +3,8 @@ const TAG_PATTERN = /^v\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?$/
 // eslint-disable-next-line no-control-regex -- ANSI escape stripping requires the ESC control character
 const ANSI_ESCAPE_PATTERN = /\u001B\[[0-9;]*m/g
 
+// Module-scoped /g regex: hasOffTargetEdit() must reset lastIndex before each scan
+// (it does) — the global flag is stateful across calls and would otherwise skip matches.
 const RELEASE_EDIT_PATTERN = /release edit (v\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?)/g
 
 const AUTH_FAILURE_PATTERNS = [
@@ -151,6 +153,8 @@ export function selectDispatchedRun(
 ): number | null | typeof AMBIGUOUS_RUN_SENTINEL {
   const candidates = runs.filter(run => {
     const runEpoch = Math.floor(new Date(run.createdAt).getTime() / 1000)
+    // correlationId is a randomUUID; substring match is safe because UUID prefix
+    // collisions across concurrent dispatches are negligible.
     return runEpoch >= dispatchEpochSeconds && run.displayTitle.includes(correlationId)
   })
 


### PR DESCRIPTION
## Summary

Narrate published GitHub Releases with an LLM. After a release publishes, a `@semantic-release/exec` `successCmd` dispatches the Fro Bot agent to rewrite the release body into a readable `## What's new` narrative, keeping the raw changelog collapsed below it. The dispatch is idempotent (skips a release that already carries the narration marker) and runs the narrator on `anthropic/claude-haiku-4-5`.

## How it works

- `scripts/release/release-notes.ts` — pure, unit-tested logic: tag validation, narration prompt construction, dispatched-run selection, and outcome classification.
- `scripts/release/dispatch-release-notes.ts` — the thin CLI that dispatches `fro-bot.yaml`, finds the run, watches it, and classifies the result.
- `.releaserc.yaml` — wires the `successCmd` into the existing `@semantic-release/exec` plugin.
- `fro-bot.yaml` — gains `model` and `correlation-id` dispatch inputs plus a `run-name` that embeds the correlation id, so the dispatched run can be identified unambiguously.

## Safety contract

The `successCmd` runs inside `semantic-release`, so a non-zero exit would fail the release step. The classification is deliberately conservative:

- **Hard-fail only on auth/permission failures.**
- **Soft-warn on everything else** — narration failures, run failures, timeouts, short bodies, cancelled/skipped runs. A published release is never failed because its cosmetic narration didn't land.
- Run selection is bound to the dispatch correlation id; ambiguous or unconfirmed matches soft-warn rather than risk classifying the wrong run.

Auth uses `FRO_BOT_PAT` (`RELEASE_NOTES_DISPATCH_TOKEN`) for the dispatch, since the App token is read-only. The token is passed via the subprocess environment, never the prompt or argv.

Ported from the equivalent flow in `marcusrbrown/systematic`, adapted to this repo's multi-part release pipeline and rewritten in TypeScript with the existing `scripts/release/` conventions.
