### PR TITLE
fix(release): disable oMo for release-notes narration runs

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -232,8 +232,11 @@ jobs:
           auth-json: ${{ secrets.AUTH_JSON }}
           github-token: ${{ secrets.FRO_BOT_PAT }}
           model: ${{ inputs.model || vars.FRO_BOT_MODEL }}
-          enable-omo: true
-          omo-providers: ${{ secrets.OMO_PROVIDERS }}
+          # Release-notes narration (correlation-id-tagged) runs on stock OpenCode with
+          # an explicit model override; oMo is skipped so its provider routing does not
+          # interfere with the narration model.
+          enable-omo: ${{ github.event.inputs.correlation-id != '' && 'false' || 'true' }}
+          omo-providers: ${{ github.event.inputs.correlation-id != '' && '' || secrets.OMO_PROVIDERS }}
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}
           # Wiki paths opt into branch-pr explicitly so delivery contract is
           # self-documenting and decoupled from prompt-wording drift. All other


### PR DESCRIPTION
## Summary

Disable oMo for release-notes narration runs. Narration dispatches run on stock OpenCode with an explicit model override (`anthropic/claude-haiku-4-5`); skipping oMo's setup and provider routing for these runs avoids interference with the narration model.

## Change

The dogfood `fro-bot.yaml` workflow gates `enable-omo` and `omo-providers` on the dispatch `correlation-id`:

- **Correlation-id-tagged dispatches** (release-notes narration) → `enable-omo: false`, no `omo-providers`.
- **All other runs** (issues, PRs, comments, schedule, wiki) → unchanged: `enable-omo: true` with the configured providers.

This mirrors the existing `correlation-id`-based guards already used for `output-mode` and `response-mode` on the narration path.
