### PR TITLE
feat(gateway): add daily_digest presence event

### DIFF
--- a/docs/plans/2026-06-07-002-feat-gateway-daily-digest-event-plan.md
+++ b/docs/plans/2026-06-07-002-feat-gateway-daily-digest-event-plan.md
@@ -1,0 +1,181 @@
+---
+title: "feat: Gateway daily_digest presence event"
+type: feat
+status: active
+date: 2026-06-07
+---
+
+# Gateway daily_digest presence event
+
+## Overview
+
+Add a third presence event type, `daily_digest`, to the gateway announce pipeline so the control
+plane can post the daily oversight report as the Fro Bot user (issue #765). This is the **gateway
+side** and the first of three steps: gateway variant here → `marcusrbrown/infra` redeploys → the
+`fro-bot/.github` control plane wires and enables the announce step.
+
+The change is additive: extend the closed `AnnouncePayloadSchema` union with a `daily_digest`
+variant and add its render template. The HMAC/replay/auth pipeline is untouched.
+
+## Problem Frame
+
+The gateway's `event_type` is a closed `Schema.Union` of exactly `invitation_accepted` and
+`survey_completed` (`packages/gateway/src/http/announce-schema.ts`), and the render side
+(`templates.ts`) is an equally closed accent record + per-type branch. Any `daily_digest` payload is
+rejected as `unknown_event_type` (400) until the gateway learns the variant — so this must ship
+before the control plane can emit the event.
+
+## Requirements Trace
+
+- **R1** — A signed `daily_digest` payload with a valid context decodes successfully and is no longer
+  rejected as `unknown_event_type`. (#765)
+- **R2** — `daily_digest` renders a distinct, in-character embed (a daily reflection that links the
+  report), with its own accent color, never falling through to the `survey_completed` template. (#765)
+- **R3** — Bogus event types still decode-reject as `unknown_event_type`; malformed `daily_digest`
+  bodies reject as `malformed_body`. No change to HMAC/replay/auth.
+
+## Scope Boundaries
+
+- No control-plane changes (signing/POST/detection live in `fro-bot/.github` — separate, later).
+- No deployment changes (`marcusrbrown/infra` redeploy is a separate step).
+- No `rendered_text` composition in the gateway — v1 control plane sends `rendered_text: null`; the
+  gateway renders from the template (the existing `renderEmbed` rendered_text-override path is reused
+  unchanged).
+- Context shape is exactly `{ repos_tracked, surveys_today, report_url }` — `invitations_accepted_today`
+  is omitted in v1 to match the control-plane plan.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/gateway/src/http/announce-schema.ts` — `InvitationAccepted` / `SurveyCompleted`
+  `Schema.Struct`s and `AnnouncePayloadSchema = Schema.Union(...)`. `FiredAt` (ISO-8601 pattern) and
+  `rendered_text: Schema.NullOr(Schema.String)` are shared. `classifyParseError` already maps an
+  all-`event_type` failure → `unknown_event_type`, everything else → `malformed_body` (so the new
+  variant gets correct classification for free).
+- `packages/gateway/src/http/templates.ts` — `ACCENT` record (`Record<AnnouncePayload['event_type'],
+  number>`), per-event `render*` functions, and `renderEmbed` whose `else` currently falls through to
+  `renderSurveyCompleted`. The `daily_digest` branch must be added **before** that else. A reserved
+  accent already exists in the v2-stub comments: purple `0x9b59b6`.
+- `packages/gateway/src/http/announce-schema.test.ts`, `templates.test.ts` — the Vitest suites to mirror.
+
+### Institutional Learnings
+
+- Ownership split: gateway contract + rendering live in `fro-bot/agent`; control-plane detection/POST
+  live in `fro-bot/.github`; deployment is pinned in `marcusrbrown/infra`.
+
+## Key Technical Decisions
+
+- **Context shape `{ repos_tracked: Number, surveys_today: Number, report_url: String }`.** All
+  required (no optional `invitations_accepted_today` in v1) so the schema stays simple and matches the
+  control-plane emitter exactly. `report_url` is plain `Schema.String` — consistent with the codebase
+  (only `FiredAt` is pattern-validated); the control plane is responsible for emitting a valid URL.
+- **Accent purple `0x9b59b6`** — already reserved in the stub comments; visually distinct from
+  blue/green.
+- **Reuse the `rendered_text`-override path** in `renderEmbed` unchanged — `daily_digest` with
+  `rendered_text: null` falls to `renderDailyDigest`; a non-empty override is honored like the others.
+
+## Implementation Units
+
+- [x] **Unit 1: Add the `daily_digest` schema variant**
+
+**Goal:** Extend `AnnouncePayloadSchema` so a `daily_digest` payload decodes.
+
+**Requirements:** R1, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/gateway/src/http/announce-schema.ts`
+- Test: `packages/gateway/src/http/announce-schema.test.ts`
+
+**Approach:**
+- Add a `DailyDigest = Schema.Struct({ v: Literal(1), event_type: Literal('daily_digest'), fired_at:
+  FiredAt, context: Schema.Struct({ repos_tracked: Number, surveys_today: Number, report_url: String }),
+  rendered_text: NullOr(String) })`, mirroring the other two.
+- Extend the union: `Schema.Union(InvitationAccepted, SurveyCompleted, DailyDigest)`. No change to
+  `decodeAnnounce` / `classifyParseError` — the new variant rides the existing classification.
+
+**Execution note:** Test-first — add the accepting + rejecting cases before widening the union.
+
+**Patterns to follow:** The `SurveyCompleted` struct and the existing decode tests.
+
+**Test scenarios:**
+- Happy path: a valid `daily_digest` payload (`{repos_tracked, surveys_today, report_url}`,
+  `rendered_text:null`) decodes to a `Right` with the typed context.
+- Error path: a `daily_digest` with a missing/wrong-typed context field (e.g. `repos_tracked: "x"`,
+  missing `report_url`) decodes to `Left('malformed_body')`.
+- Edge case (regression): an unknown `event_type` still yields `Left('unknown_event_type')`; the two
+  existing variants still decode.
+- Edge case: `daily_digest` with a bad `fired_at` (non-ISO) → `Left('malformed_body')`.
+
+**Verification:** New + existing schema tests pass; `pnpm --filter @fro-bot/gateway check-types` clean.
+
+- [x] **Unit 2: Render the `daily_digest` embed**
+
+**Goal:** Give `daily_digest` a distinct in-character embed + accent, never falling through to the
+survey template.
+
+**Requirements:** R2
+
+**Dependencies:** Unit 1 (the type must exist for `ACCENT` and the context extract)
+
+**Files:**
+- Modify: `packages/gateway/src/http/templates.ts`
+- Test: `packages/gateway/src/http/templates.test.ts`
+
+**Approach:**
+- Add a `DAILY_DIGEST` accent (`0x9b59b6`) and the `daily_digest` entry to the `ACCENT` record (the
+  record is keyed by `AnnouncePayload['event_type']`, so the new union member makes this required —
+  the compiler will enforce it).
+- Add `renderDailyDigest(context)` — an in-character daily reflection (a character beat: what Fro Bot
+  noticed/did today), pluralizing `surveys_today` / `repos_tracked` like the existing renderers, and
+  linking `report_url`. Read as a character moment, not a status line.
+- Add a `payload.event_type === 'daily_digest'` branch to `renderEmbed` **before** the final `else`
+  so it cannot be mis-rendered by the `survey_completed` fallthrough.
+
+**Execution note:** Test-first — assert the render output (pluralization, report link present,
+character tone) before wiring the branch.
+
+**Patterns to follow:** `renderSurveyCompleted` / `renderInvitationAccepted` pluralization; the
+`renderEmbed` branch structure and the `rendered_text`-override precedence.
+
+**Test scenarios:**
+- Happy path: `renderDailyDigest` with `surveys_today: 2` produces a string containing the count
+  (pluralized), `repos_tracked`, and the `report_url` link; reads as a reflection.
+- Edge case: singular (`surveys_today: 1`) vs plural pluralization is correct.
+- Integration: `renderEmbed` on a `daily_digest` payload selects the purple accent AND the
+  `renderDailyDigest` branch (NOT the survey fallthrough) — assert both the description content and
+  `color`.
+- Edge case: a `daily_digest` payload with a non-empty `rendered_text` override is used verbatim (the
+  override path still wins), and the accent is still purple.
+
+**Verification:** New + existing template tests pass; gateway suite green; `pnpm --filter
+@fro-bot/gateway check-types` and `lint` clean; no committed `dist/` for the gateway (gateway dist is
+gitignored).
+
+## System-Wide Impact
+
+- **API surface parity:** The `context` shape (`{repos_tracked, surveys_today, report_url}`) is the
+  cross-repo contract — the control-plane emitter in `fro-bot/.github` must send exactly this shape, or
+  decode fails `malformed_body`. Pinned here as the source of truth.
+- **Error propagation:** `classifyParseError` is unchanged; the new variant gets correct
+  `unknown_event_type` / `malformed_body` classification automatically.
+- **Unchanged invariants:** HMAC verification, replay handling, rate-limiting, and the two existing
+  event flows are untouched. The `renderEmbed` `rendered_text`-override and 4096-char truncation paths
+  are reused as-is.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Context shape drifts from the control-plane emitter | This plan pins `{repos_tracked, surveys_today, report_url}`; the `fro-bot/.github` plan references the same shape. |
+| `daily_digest` mis-rendered by the `survey_completed` else-fallthrough | Add the branch BEFORE the else; integration test asserts the correct branch + accent. |
+| Downstream not yet ready (gateway must deploy before control plane emits) | Expected — this is step 1 of 3; the control plane stays dormant until `marcusrbrown/infra` redeploys (tracked in the `fro-bot/.github` plan). |
+
+## Sources & References
+
+- Issue: `fro-bot/agent` #765 (gateway daily_digest), with Fro Bot's triage spec
+- Related code: `packages/gateway/src/http/announce-schema.ts`, `packages/gateway/src/http/templates.ts`
+- Downstream control-plane plan: `fro-bot/.github` `docs/plans/2026-06-07-001-feat-daily-digest-presence-event-plan.md`
+- Origin requirements (control plane): `fro-bot/.github` `docs/brainstorms/2026-06-04-daily-digest-presence-event-requirements.md`

--- a/packages/gateway/src/http/announce-schema.test.ts
+++ b/packages/gateway/src/http/announce-schema.test.ts
@@ -218,6 +218,135 @@ describe('decodeAnnounce — edge cases', () => {
   })
 })
 
+// ── daily_digest ──────────────────────────────────────────────────────────────
+
+const validDailyDigest = {
+  v: 1,
+  event_type: 'daily_digest',
+  fired_at: VALID_FIRED_AT,
+  context: {
+    repos_tracked: 12,
+    surveys_today: 3,
+    report_url: 'https://example.com/report/2026-05-29',
+  },
+  rendered_text: null,
+} as const
+
+describe('decodeAnnounce — daily_digest happy path', () => {
+  it('decodes a valid daily_digest payload to Right with typed context', () => {
+    // #given a well-formed daily_digest payload
+    // #when decoded
+    const result = decodeAnnounce(validDailyDigest)
+    // #then it is Right with correct shape
+    const payload = expectRight(result)
+    expect(payload.event_type).toBe('daily_digest')
+    expect(payload.v).toBe(1)
+    if (payload.event_type !== 'daily_digest') throw new Error('unreachable')
+    expect(payload.context.repos_tracked).toBe(12)
+    expect(payload.context.surveys_today).toBe(3)
+    expect(payload.context.report_url).toBe('https://example.com/report/2026-05-29')
+    expect(payload.rendered_text).toBeNull()
+  })
+
+  it('accepts rendered_text as a non-null string on daily_digest', () => {
+    // #given a daily_digest payload with a string rendered_text
+    const withText = {...validDailyDigest, rendered_text: 'Today in review...'}
+    // #when decoded
+    const result = decodeAnnounce(withText)
+    // #then it is Right with the override text
+    const payload = expectRight(result)
+    expect(payload.rendered_text).toBe('Today in review...')
+  })
+
+  it('accepts fired_at with sub-second precision on daily_digest', () => {
+    // #given a daily_digest with millisecond fired_at
+    const payload = {...validDailyDigest, fired_at: '2026-05-29T12:00:00.456Z'}
+    // #when decoded
+    expect(Either.isRight(decodeAnnounce(payload))).toBe(true)
+  })
+})
+
+describe('decodeAnnounce — daily_digest error path', () => {
+  it('returns Left(malformed_body) when repos_tracked is a string instead of number', () => {
+    // #given a daily_digest with wrong-typed repos_tracked
+    const payload = {
+      ...validDailyDigest,
+      context: {...validDailyDigest.context, repos_tracked: 'x'},
+    }
+    // #when decoded
+    const result = decodeAnnounce(payload)
+    // #then it is Left with malformed_body
+    const reason = expectLeft(result)
+    expect(reason).toBe('malformed_body')
+  })
+
+  it('returns Left(malformed_body) when report_url is missing from context', () => {
+    // #given a daily_digest missing report_url
+    const payload = {
+      ...validDailyDigest,
+      context: {repos_tracked: 12, surveys_today: 3},
+    }
+    // #when decoded
+    const result = decodeAnnounce(payload)
+    // #then it is Left with malformed_body
+    const reason = expectLeft(result)
+    expect(reason).toBe('malformed_body')
+  })
+
+  it('returns Left(malformed_body) when surveys_today is missing from context', () => {
+    // #given a daily_digest missing surveys_today
+    const payload = {
+      ...validDailyDigest,
+      context: {repos_tracked: 12, report_url: 'https://example.com/report/2026-05-29'},
+    }
+    // #when decoded
+    const result = decodeAnnounce(payload)
+    // #then it is Left with malformed_body
+    const reason = expectLeft(result)
+    expect(reason).toBe('malformed_body')
+  })
+
+  it('returns Left(malformed_body) for daily_digest with a non-ISO fired_at', () => {
+    // #given a daily_digest with a bad fired_at
+    const payload = {...validDailyDigest, fired_at: 'not-a-date'}
+    // #when decoded
+    const result = decodeAnnounce(payload)
+    // #then it is Left with malformed_body
+    const reason = expectLeft(result)
+    expect(reason).toBe('malformed_body')
+  })
+})
+
+describe('decodeAnnounce — daily_digest regression: existing variants unaffected', () => {
+  it('still decodes invitation_accepted after adding daily_digest to union', () => {
+    // #given a valid invitation_accepted payload
+    // #when decoded
+    const result = decodeAnnounce(validInvitation)
+    // #then it is Right
+    const payload = expectRight(result)
+    expect(payload.event_type).toBe('invitation_accepted')
+  })
+
+  it('still decodes survey_completed after adding daily_digest to union', () => {
+    // #given a valid survey_completed payload
+    // #when decoded
+    const result = decodeAnnounce(validSurvey)
+    // #then it is Right
+    const payload = expectRight(result)
+    expect(payload.event_type).toBe('survey_completed')
+  })
+
+  it('still returns Left(unknown_event_type) for an unrecognized event_type', () => {
+    // #given a payload with an unknown event_type
+    const payload = {...validInvitation, event_type: 'totally_unknown_event'}
+    // #when decoded
+    const result = decodeAnnounce(payload)
+    // #then it is Left with unknown_event_type
+    const reason = expectLeft(result)
+    expect(reason).toBe('unknown_event_type')
+  })
+})
+
 // ── Security: no payload echo ─────────────────────────────────────────────────
 
 describe('decodeAnnounce — security: reason string must not echo payload content', () => {

--- a/packages/gateway/src/http/announce-schema.ts
+++ b/packages/gateway/src/http/announce-schema.ts
@@ -1,7 +1,7 @@
 /**
  * Effect Schema definitions for the POST /v1/announce webhook payload.
  *
- * Validates and decodes the two v1 event types. Unknown event types and
+ * Validates and decodes the v1 event types. Unknown event types and
  * malformed shapes produce a Left with a content-free reason string —
  * payload values (context, rendered_text) are never echoed.
  */
@@ -47,7 +47,19 @@ const SurveyCompleted = Schema.Struct({
   rendered_text: Schema.NullOr(Schema.String),
 })
 
-const AnnouncePayloadSchema = Schema.Union(InvitationAccepted, SurveyCompleted)
+const DailyDigest = Schema.Struct({
+  v: Schema.Literal(1),
+  event_type: Schema.Literal('daily_digest'),
+  fired_at: FiredAt,
+  context: Schema.Struct({
+    repos_tracked: Schema.Number,
+    surveys_today: Schema.Number,
+    report_url: Schema.String,
+  }),
+  rendered_text: Schema.NullOr(Schema.String),
+})
+
+const AnnouncePayloadSchema = Schema.Union(InvitationAccepted, SurveyCompleted, DailyDigest)
 
 export type AnnouncePayload = Schema.Schema.Type<typeof AnnouncePayloadSchema>
 

--- a/packages/gateway/src/http/templates.test.ts
+++ b/packages/gateway/src/http/templates.test.ts
@@ -1,10 +1,11 @@
 import type {AnnouncePayload} from './announce-schema.js'
 import {describe, expect, it} from 'vitest'
-import {renderEmbed} from './templates.js'
+import {renderDailyDigest, renderEmbed} from './templates.js'
 
 // Accent color constants (mirror templates.ts for assertions)
 const COLOR_BLUE = 0x5865f2
 const COLOR_GREEN = 0x57f287
+const COLOR_PURPLE = 0x9b59b6
 
 const BASE = {v: 1 as const, fired_at: '2026-05-29T12:00:00Z', rendered_text: null}
 
@@ -186,6 +187,78 @@ describe('renderEmbed', () => {
       const embed = renderEmbed(payload)
       // #then
       expect(embed.description).toBe('real text')
+    })
+  })
+
+  describe('daily_digest', () => {
+    it('happy path: plural surveys_today and repos_tracked, includes report_url', () => {
+      // #given
+      const context = {surveys_today: 2, repos_tracked: 25, report_url: 'https://example.com/report/2026-06-07'}
+      // #when
+      const text = renderDailyDigest(context)
+      // #then
+      expect(text).toContain('2')
+      expect(text).toContain('25')
+      expect(text).toContain('https://example.com/report/2026-06-07')
+      // reads as a reflection, not a status line — must not be empty
+      expect(text.length).toBeGreaterThan(0)
+    })
+
+    it('edge case: singular surveys_today=1 uses singular noun', () => {
+      // #given
+      const context = {surveys_today: 1, repos_tracked: 1, report_url: 'https://example.com/report/today'}
+      // #when
+      const text = renderDailyDigest(context)
+      // #then — singular form for both counts
+      expect(text).toContain('1')
+      // should NOT contain plural forms when counts are 1
+      expect(text).not.toMatch(/\bsurveys\b/)
+      expect(text).not.toMatch(/\brepos\b/)
+    })
+
+    it('edge case: plural surveys_today=3 uses plural noun', () => {
+      // #given
+      const context = {surveys_today: 3, repos_tracked: 10, report_url: 'https://example.com/r'}
+      // #when
+      const text = renderDailyDigest(context)
+      // #then — plural form
+      expect(text).toContain('3')
+      expect(text).toContain('10')
+    })
+
+    it('integration: renderEmbed on daily_digest payload returns purple accent and daily-digest description', () => {
+      // #given
+      const payload: AnnouncePayload = {
+        ...BASE,
+        event_type: 'daily_digest',
+        context: {surveys_today: 4, repos_tracked: 30, report_url: 'https://example.com/report'},
+      }
+      // #when
+      const embed = renderEmbed(payload)
+      // #then — purple accent, NOT survey fallthrough
+      expect(embed.color).toBe(COLOR_PURPLE)
+      expect(embed.description).toContain('4')
+      expect(embed.description).toContain('30')
+      expect(embed.description).toContain('https://example.com/report')
+      // must NOT contain survey_completed template text
+      expect(embed.description).not.toContain('Surveyed')
+    })
+
+    it('integration: daily_digest with non-empty rendered_text uses override verbatim, accent still purple', () => {
+      // #given
+      const payload: AnnouncePayload = {
+        ...BASE,
+        event_type: 'daily_digest',
+        rendered_text: 'Custom daily digest override',
+        context: {surveys_today: 99, repos_tracked: 999, report_url: 'https://example.com/r'},
+      }
+      // #when
+      const embed = renderEmbed(payload)
+      // #then — override wins for description, accent is still purple
+      expect(embed.color).toBe(COLOR_PURPLE)
+      expect(embed.description).toBe('Custom daily digest override')
+      // template text must NOT appear
+      expect(embed.description).not.toContain('99')
     })
   })
 })

--- a/packages/gateway/src/http/templates.ts
+++ b/packages/gateway/src/http/templates.ts
@@ -16,13 +16,15 @@ import type {AnnouncePayload} from './announce-schema.js'
 const COLOR_BLUE = 0x5865f2
 /** Discord green — survey_completed */
 const COLOR_GREEN = 0x57f287
+/** Discord purple — daily_digest */
+const COLOR_PURPLE = 0x9b59b6
 // v2 stubs (not yet emitted — colors reserved for when templates are added):
-// reconcile_notable  → 0x9b59b6 (purple)
 // wiki_lint_findings → 0xfee75c (yellow)
 
 const ACCENT: Record<AnnouncePayload['event_type'], number> = {
   invitation_accepted: COLOR_BLUE,
   survey_completed: COLOR_GREEN,
+  daily_digest: COLOR_PURPLE,
 }
 
 // ---------------------------------------------------------------------------
@@ -31,6 +33,7 @@ const ACCENT: Record<AnnouncePayload['event_type'], number> = {
 
 type InvitationAcceptedContext = Extract<AnnouncePayload, {event_type: 'invitation_accepted'}>['context']
 type SurveyCompletedContext = Extract<AnnouncePayload, {event_type: 'survey_completed'}>['context']
+type DailyDigestContext = Extract<AnnouncePayload, {event_type: 'daily_digest'}>['context']
 
 function renderInvitationAccepted(context: InvitationAcceptedContext): string {
   const {count, repos} = context
@@ -47,6 +50,18 @@ function renderSurveyCompleted(context: SurveyCompletedContext): string {
   const pagesChanged = context.wiki_pages_changed
   const noun = pagesChanged === 1 ? 'entry' : 'entries'
   return `Surveyed ${owner}/${repo}, added ${pagesChanged} wiki ${noun}`
+}
+
+export function renderDailyDigest(context: DailyDigestContext): string {
+  const surveysToday = context.surveys_today
+  const reposTracked = context.repos_tracked
+  const reportUrl = context.report_url
+  const surveyNoun = surveysToday === 1 ? 'repo' : 'repos'
+  const trackedNoun = reposTracked === 1 ? 'repo' : 'repos'
+  return (
+    `Wrapped up today's sweep — surveyed ${surveysToday} ${surveyNoun} out of ${reposTracked} tracked ${trackedNoun}. ` +
+    `Full report: ${reportUrl}`
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -81,6 +96,8 @@ export function renderEmbed(payload: AnnouncePayload): PresenceEmbed {
     description = payload.rendered_text
   } else if (payload.event_type === 'invitation_accepted') {
     description = renderInvitationAccepted(payload.context)
+  } else if (payload.event_type === 'daily_digest') {
+    description = renderDailyDigest(payload.context)
   } else {
     description = renderSurveyCompleted(payload.context)
   }


### PR DESCRIPTION
Adds a third presence event type, `daily_digest`, to the gateway announce pipeline so the daily oversight report can post as the Fro Bot user alongside `survey_completed` and `invitation_accepted`.

Closes #765.

## Changes

- **Schema** (`announce-schema.ts`): a `daily_digest` variant joins the `AnnouncePayloadSchema` union, with context `{ repos_tracked, surveys_today, report_url }` and the shared `fired_at` / `rendered_text` contract. Decode classification (`unknown_event_type` / `malformed_body`) and the HMAC/replay/auth pipeline are unchanged.
- **Render** (`templates.ts`): `renderDailyDigest` produces an in-character daily reflection that links the report, with a distinct purple accent. The `renderEmbed` branch is placed before the `survey_completed` fallthrough so the digest is never mis-rendered, and the existing `rendered_text` override and truncation paths still apply.

Purely additive. The context shape is the cross-repo contract the control plane will emit.

## Sequencing

This is the gateway side. Once released, the deployment is updated to the new image, and then the control plane wires and enables the announce step. The control plane stays dormant until the gateway variant is live, so there is no premature posting.