### PR TITLE
feat(gateway): clean mention output rendering + Fro Bot persona

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -100,6 +100,16 @@ touch deploy/secrets/workspace-opencode-auth
 touch deploy/secrets/gateway-trigger-role-id
 # echo -n 'YOUR_ROLE_ID' > deploy/secrets/gateway-trigger-role-id
 
+# Optional — canonical Fro Bot persona for the @-mention loop. When set, the
+# persona text is prepended to the Discord agent prompt so responses carry Fro
+# Bot's voice; if unset, the loop falls back to built-in Discord guidance
+# (fail-soft). Provision the canonical file from fro-bot/.github
+# persona/fro-bot-persona.md, then uncomment GATEWAY_PERSONA_FILE + its bind-mount
+# in compose.yaml. (Mention replies hide chain-of-thought and read-only tool
+# noise, and summarize tool actions, regardless of whether the persona is set.)
+touch deploy/secrets/gateway-persona
+# cp /path/to/fro-bot-persona.md deploy/secrets/gateway-persona
+
 # Optional — announce/presence endpoint (opt-in). The gateway exposes an
 # HMAC-verified POST /v1/announce presence webhook ONLY when BOTH of these are
 # set; set NEITHER to leave it disabled (the default). Setting exactly one

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -42,7 +42,11 @@ services:
       # (the endpoint stays disabled). Uncomment both lines AND both bind-mounts below.
       # GATEWAY_WEBHOOK_SECRET_FILE: /run/secrets/gateway_webhook_secret
       # GATEWAY_PRESENCE_CHANNEL_ID_FILE: /run/secrets/gateway_presence_channel_id
-      # Egress proxy (regular proxy mode — NOT transparent)
+      # Optional — canonical Fro Bot persona for the @-mention loop. When set, the
+      # persona text is prepended to the Discord agent prompt (voice + behavior).
+      # Absent → the loop falls back to built-in Discord guidance (fail-soft).
+      # Provision the file from fro-bot/.github persona/fro-bot-persona.md.
+      # GATEWAY_PERSONA_FILE: /run/secrets/gateway_persona
       HTTPS_PROXY: http://mitmproxy:8080
       HTTP_PROXY: http://mitmproxy:8080
       NO_PROXY: workspace,localhost,127.0.0.1
@@ -171,6 +175,13 @@ services:
       # - type: bind
       #   source: ./secrets/gateway-presence-channel-id
       #   target: /run/secrets/gateway_presence_channel_id
+      #   read_only: true
+      #   bind:
+      #     create_host_path: false
+      # Optional — Fro Bot persona for the @-mention loop (see GATEWAY_PERSONA_FILE above).
+      # - type: bind
+      #   source: ./secrets/gateway-persona
+      #   target: /run/secrets/gateway_persona
       #   read_only: true
       #   bind:
       #     create_host_path: false

--- a/docs/plans/2026-06-07-003-feat-mention-loop-rendering-persona-plan.md
+++ b/docs/plans/2026-06-07-003-feat-mention-loop-rendering-persona-plan.md
@@ -1,0 +1,360 @@
+---
+title: "feat: Mention-loop clean rendering + Discord persona (Phase 1)"
+type: feat
+status: active
+date: 2026-06-07
+origin: docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md
+deepened: 2026-06-07
+---
+
+# Mention-loop clean rendering + Discord persona (Phase 1)
+
+## Overview
+
+The `@Fro Bot` Discord mention loop streams raw agent reasoning (chain-of-thought) and dumps every
+tool call verbatim, and prompts the agent with nothing Discord-specific. This plan implements **Phase 1**
+of the production-ready effort (see origin): a `formatPart`-style output-rendering layer that suppresses
+reasoning, summarizes tool calls, and hides read-only tools; plus a Discord persona prompt built from
+the canonical `fro-bot-persona.md`. This is the foundation the later phases (working-state UX, queue,
+commands, approval UX) build on, and it resolves the core pain on its own (SC1-SC3).
+
+## Problem Frame
+
+Verified against source:
+
+- `packages/gateway/src/execute/run-core.ts` streams text deltas with **no part-type filter** — it
+  appends any `message.part.delta` / `session.next.text.delta` whose field is `text` (lines ~293-314),
+  so OpenCode's `ReasoningPart` content leaks as conversational text. It renders every completed tool
+  via `sink.append(...)` with a `🔧 ${tool}: ${title}` line at two sites (the `message.part.updated` tool
+  branch ~338 and the legacy `session.next.tool.success` branch ~373; `session.next.tool.called` is
+  cache-only correlation, not a render site).
+- `packages/gateway/src/execute/prompt.ts` `buildDiscordPrompt()` is bare: `Repository: owner/repo`
+  plus the raw message. No persona, no "be concise / don't narrate process / format for chat."
+
+The mention loop should read like a capable teammate — **low-noise but inspectable**: reasoning hidden,
+read-only tool noise hidden, essential actions shown as collapsed one-line summaries, in Fro Bot's
+established voice (see origin).
+
+## Requirements Trace
+
+- **R1 (SC1)** — A simple mention produces a clean response with **no chain-of-thought** and **no raw
+  tool dump** — at most collapsed action summaries plus the answer.
+- **R2 (SC2)** — A "what files are in this repo" mention answers conversationally without dumping
+  `git ls-files` output or a `🔧 bash:` line; long output is summarized/attached, not inlined.
+- **R3 (SC3)** — Responses read in **Fro Bot's voice** because the canonical persona is in the prompt.
+- **R4 (SC7)** — A missing persona file does not break the loop (fail-soft to mechanical guidance).
+- **R5** — Reasoning is **fully suppressed** (no visible marker) — confirmed decision, not Kimaki's
+  `┣ thinking` marker.
+
+## Scope Boundaries
+
+- **Reasoning fully suppressed** — no "thinking" marker (origin OQ3, resolved).
+- **Verbosity is fixed** — one "clean conversational" verbosity (text + essential tools; read-only
+  tools hidden). No user-facing verbosity config; only the *minimal* rendering logic the fixed shape
+  needs is ported from Kimaki, not its configurable verbosity system.
+- This plan does not change run lifecycle, locking, or concurrency behavior.
+
+### Deferred to Separate Tasks
+
+- **Working-state UX** (live status-message manager + typing indicator, the typing-only mode):
+  brainstorm Phase 2 — separate plan. Note: the current sink has no edit surface; that work is its own
+  component.
+- **Serial per-channel queue** (Phase 3), **core commands + native approval UX** (Phase 4): separate plans.
+- **Footer/turn-terminator** and **expandable full action trace**: origin OQ6/OQ7, deferred.
+- **Interaction-state UX** (failure/timeout presentation, final-answer transition mechanics,
+  empty-response handling): these become concrete when the working-state UX lands (Phase 2). This plan
+  keeps the existing sink flush/transition behavior; it only changes *what content* the sink receives.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/gateway/src/execute/run-core.ts` — the event loop. Text-delta append sites (~293-314) and
+  the two tool-render sites (~338 and ~373). The wiring target for the new renderer.
+- `packages/gateway/src/discord/streaming.ts` — `createDiscordStreamSink`: `append()` buffers,
+  `flush()` writes; 2000-char → file attachment; empty → `_(no output)_`. **Unchanged by this plan** —
+  it still receives `append()` calls; we only change what text is appended (filtered/summarized).
+- `packages/gateway/src/execute/prompt.ts` — `buildDiscordPrompt()`, the persona injection point.
+- `packages/gateway/src/config.ts` — `readSecret` / `readOptionalSecret` (`_FILE` bind-mount support).
+  The pattern for `GATEWAY_PERSONA_FILE`.
+- Action-tier persona layering — `fro-bot.yaml` passes `PERSONA` to the action; the runtime prepends it.
+  Mirror that persona-then-task ordering for the Discord prompt.
+- OpenCode SDK part model — `.slim/clonedeps/repos/anomalyco__opencode/packages/sdk/js/src/gen/types.gen.ts`:
+  `Part` discriminated union incl. `ReasoningPart` (`type: 'reasoning'`), `ToolPart` with
+  `ToolState` (`pending`/`running`/`completed`/`error`). `message.part.updated` carries the full `Part`.
+
+### External References
+
+- **Kimaki** (`remorses/kimaki`, MIT) — `cli/src/message-formatting.ts` (`formatPart`,
+  `getToolSummaryText`), `cli/src/external-opencode-sync.ts` (essential-tool / verbosity filter). The
+  rendering logic is ported, adapted to our event-extraction helpers and types. Credit MIT.
+
+### Institutional Learnings
+
+- Gateway uses `message.part.updated` (partType:'tool', state.status:'completed') for tool lifecycle on
+  OpenCode 1.15.13; `session.next.tool.*` are inert fallbacks. The renderer must handle the live path
+  and keep the legacy branches consistent.
+
+## Key Technical Decisions
+
+- **Port Kimaki's `formatPart`/`getToolSummaryText`/essential-tool filter, adapted to our types.** The
+  tool→summary mapping (`edit *file* (+N-M)`, `read *file*`, `grep *pattern*`, bash inline ≤100 chars
+  else description, MCP args truncated) is the hard-won part; reuse it.
+- **Reasoning fully suppressed via partID correlation.** Verified against the SDK: `EventMessagePartDelta`
+  carries `{sessionID, messageID, partID, field, delta}` with **no part kind**, so a reasoning delta is
+  indistinguishable from a text delta at the delta site alone. But `ReasoningPart` has `id` and arrives
+  via `message.part.updated` (`part.type === 'reasoning'`). Mechanism: track reasoning part IDs as they
+  appear on `message.part.updated`; on `message.part.delta`, suppress any delta whose `partID` is a known
+  reasoning part. No marker. (The current `message.part.updated` branch only handles `partType === 'tool'`
+  — a reasoning-part branch must be added to populate the set.)
+- **Verbosity = fixed essential-tools allowlist.** Show: edits, writes, `apply_patch`, side-effecting
+  bash, `todowrite`, subagent `task`, MCP tools. Hide: `read`, `grep`, `glob`, `list`, non-side-effect
+  bash. A pure-function predicate, not a config surface.
+- **Tool summaries replace the `🔧 <tool>: <title>` lines** at the **two** render sites (the
+  `message.part.updated` tool branch and the `session.next.tool.success` branch) with a single
+  `formatToolPart`-derived one-liner; hidden tools append nothing. (`session.next.tool.called` is
+  cache-only correlation, not a render site — left unchanged.)
+- **Persona = canonical `fro-bot-persona.md` + Discord-mechanical guidance, fail-soft.** Read via
+  `GATEWAY_PERSONA_FILE` (optional secret/file). Compose: persona → Discord-mechanical guidance →
+  `Repository: owner/repo` → user message. Missing persona file → mechanical guidance only (no failure).
+- **Renderer is a pure module** for *tool* summarization (input: extracted tool shape; output: a string
+  or null-to-hide), unit-tested independently. **Reasoning suppression is owned by the wiring layer**
+  (Unit 2), not the pure renderer — it requires the partID-correlation state that only the event loop
+  sees. The renderer handles text-passthrough and tool-summary; it does not see deltas.
+- **SC2 (no wall-of-files) needs the prompt, not just hiding.** Hiding the read-only `git ls-files`
+  tool line does not stop the agent from pasting the file list as its text answer. The Discord-mechanical
+  guidance (Unit 3) must instruct: summarize/cap long enumerations, attach or link full listings rather
+  than inlining. This is an explicit, tested dependency, not an assumption.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Reasoning marker** → fully suppress, no marker (user-confirmed).
+- **Verbosity** → fixed essential-tools allowlist, no config.
+- **Persona composition order** → persona → Discord-mechanical guidance → repo context → user message
+  (mirrors Action-tier persona-then-task).
+- **Kimaki port** → port the rendering logic adapted to our types; MIT credit.
+- **Reasoning-detection mechanism** → partID correlation (verified against SDK): track reasoning `part.id`
+  from `message.part.updated` (`type === 'reasoning'`), suppress `message.part.delta` whose `partID` is in
+  the set. Not a deferral — a concrete mechanism (Unit 2).
+- **Render-site count** → two (`message.part.updated` tool branch + `session.next.tool.success`);
+  `session.next.tool.called` is cache-only.
+- **SC2 resolution** → the Discord-mechanical guidance's long-enumeration response policy (Unit 3), tested
+  — not hiding alone.
+
+### Deferred to Implementation
+
+- **Live-stream confirmation:** capture a real 1.15.13 reasoning event during implementation to confirm
+  the partID correlation fires as expected for the configured model (the mechanism is correct per the SDK
+  types; the live capture validates ordering).
+- **Exact Discord-mechanical guidance wording** — drafted during implementation, kept terse, reinforcing
+  the persona's existing anti-patterns (no sycophancy, no sign-offs, no process narration).
+- **Whether the renderer lives in `discord/` or `execute/`** — placement decided for cleanest import
+  graph during implementation.
+
+## Implementation Units
+
+- [ ] **Unit 1: Part renderer + essential-tool filter (pure module)**
+
+**Goal:** A pure, tested module that turns an extracted **tool** shape into a clean Discord line: essential
+tool → one-line summary; non-essential (read-only) tool → null. (Reasoning suppression and text passthrough
+are the wiring layer's job in Unit 2 — this module is tool-only.)
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/gateway/src/execute/format-part.ts` (name/placement TBD — `formatToolPart`,
+  `isEssentialTool`, `summarizeTool`)
+- Create: `packages/gateway/src/execute/format-part.test.ts`
+
+**Approach:**
+- Port Kimaki's `getToolSummaryText` mapping adapted to our extracted tool shape (`tool`, `state.input`,
+  `state.title`), scoped to the tool types actually emitted today: `edit`/`write`/`apply_patch` →
+  `*file* (+N-M)` / `*file* (N lines)`; `bash` → inline command if single-line ≤100 chars else its
+  description; `skill` → `_name_`; `task` (subagent) → labeled; unknown/MCP → a minimal truncated
+  fallback. Status glyph for completed vs error. (Defer rich `todowrite` checklist rendering and elaborate
+  MCP arg formatting unless a concrete v1 output needs them — keep the fallback minimal.)
+- `isEssentialTool(tool)`: allowlist (edit/write/apply_patch/side-effecting-bash/`task`/MCP) → shown;
+  read/grep/glob/list/non-side-effect bash → hidden (return null).
+
+**Mapping-contract note:** before implementing, enumerate each supported part shape and the exact fields
+used (`state.input.filePath`, patch text, `state.input.command`, etc.) so a shape mismatch with our
+extracted events surfaces as a test failure, not a silent fallback summary.
+
+**Execution note:** Test-first — the tool→summary mapping and the essential-tool predicate are the
+load-bearing rules.
+
+**Patterns to follow:** Kimaki `cli/src/message-formatting.ts` `getToolSummaryText`; the existing
+title-resolution logic in `run-core.ts` (state.title → input.title → bash command → tool).
+
+**Test scenarios:**
+- Happy path: `edit` part with a patch → `*file.ts* (+12-3)`; `write` → `*file.ts* (40 lines)`;
+  `read` → null (hidden); `grep` → null; `bash` short cmd → inline; `bash` long → description.
+- Edge case: missing title/input falls back to the tool name; MCP tool args truncated to 50 chars.
+- Edge case: error-status tool renders with the error glyph, still summarized (not dumped).
+- Edge case: unknown tool → generic truncated arg summary, never raw dump.
+
+**Verification:** Module tests pass; `pnpm --filter @fro-bot/gateway check-types` + `lint` clean.
+
+- [ ] **Unit 2: Wire the renderer into run-core (reasoning suppression + tool summaries)**
+
+**Goal:** Replace the raw `🔧 <tool>: <title>` appends with the Unit 1 summaries, and suppress reasoning
+content so it never reaches the sink.
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/gateway/src/execute/run-core.ts`
+- Test: `packages/gateway/src/execute/run-core.test.ts`
+
+**Approach:**
+- **Add a reasoning-part branch** to `message.part.updated`: when `part.type === 'reasoning'`, record
+  `part.id` in a per-run `reasoningPartIds` set (render nothing). This is new — the branch currently only
+  handles `partType === 'tool'`.
+- **At the text-delta sites (~293-314):** suppress a delta when its `partID` is in `reasoningPartIds`;
+  otherwise pass the text through unchanged. This is the concrete suppression mechanism (verified: deltas
+  carry `partID`; reasoning parts carry `id`).
+- **At the two tool-render sites (lines 338 and 373):** replace `sink.append(\`\n🔧 ${tool}: ${title}\n\`)`
+  with the Unit 1 summarizer — `isEssentialTool` → append the one-line summary; else append nothing. Leave
+  the `session.next.tool.called` cache-only branch unchanged.
+- The wiring layer owns reasoning suppression (it holds the `reasoningPartIds` set); the Unit 1 module is
+  tool-only.
+- No change to `streaming.ts` — it still receives `append()`; only the content changes.
+
+**Execution note:** Test-first — add a regression that a reasoning part produces no sink output and that
+a `read` tool produces no `🔧` line, while an `edit` produces a summary.
+
+**Patterns to follow:** The existing event-extraction helpers (`getObjectProperty`, `getStringProperty`,
+`getEventSessionID`) and session-ID gating already in `run-core.ts`.
+
+**Test scenarios:**
+- Happy path: a tool-completed `edit` event → sink receives the summary line, not `🔧 edit: …`.
+- Edge case (R5 regression, the load-bearing one): a `message.part.updated` reasoning part registers its
+  `id`; subsequent `message.part.delta` events with that `partID` → sink receives nothing. A reasoning
+  part whose deltas arrive interleaved with a separate text part's deltas → only the text deltas pass.
+- Edge case: a text delta whose `partID` is NOT a reasoning part → passed through unchanged (the answer
+  still streams).
+- Edge case: a `read`/`grep` completed tool → sink receives nothing (hidden); an `edit` → summary.
+- Integration: the `session.next.tool.success` path and the `message.part.updated` tool path produce
+  identical summary output for the same tool.
+
+**Verification:** New + existing run-core tests pass; no `🔧 <tool>: <title>` raw format remains;
+gateway suite green; check-types + lint clean.
+
+- [ ] **Unit 3: Discord persona config + prompt composition**
+
+**Goal:** The mention prompt prepends the canonical persona + Discord-mechanical guidance, delivered via
+`GATEWAY_PERSONA_FILE`, fail-soft when absent.
+
+**Requirements:** R3, R4
+
+**Dependencies:** None (parallel to Units 1-2)
+
+**Files:**
+- Modify: `packages/gateway/src/config.ts` (add `GATEWAY_PERSONA_FILE` optional read)
+- Modify: `packages/gateway/src/execute/prompt.ts` (`buildDiscordPrompt` composition)
+- Test: `packages/gateway/src/execute/prompt.test.ts`
+- Test: `packages/gateway/src/config.test.ts` (persona read)
+
+**Approach:**
+- Add `persona: string | null` to the gateway config via `readOptionalSecret('GATEWAY_PERSONA_FILE')`
+  (env or `_FILE` bind-mount), trimmed; absent/empty/whitespace → null.
+- Extend `DiscordPromptParams` with `persona?: string | null` (current params: `messageText`, `owner`,
+  `repo`, `botUserId?`) and thread `config.persona` from the call site that invokes `buildDiscordPrompt`.
+- `buildDiscordPrompt` composes in order: `[persona]` (if present) → Discord-mechanical guidance →
+  `Repository: owner/repo` → the user message.
+- **Discord-mechanical guidance (terse) must include the SC2 response policy:** you're in a Discord
+  thread talking to humans; be concise; do not narrate your internal process or reasoning; format for chat
+  (short, markdown, code blocks for code); **for long enumerations (file lists, search results, logs),
+  summarize or attach — never paste a long raw list inline.** (This is what actually resolves SC2 — hiding
+  the tool line alone does not.)
+- Fail-soft: missing persona → mechanical guidance + repo + message only.
+
+**Execution note:** Test-first — assert composition order and the fail-soft path.
+
+**Patterns to follow:** `config.ts` `readOptionalSecret`/`_FILE` pattern; the Action-tier
+persona-then-task layering; the persona's own anti-patterns (no sign-offs/sycophancy) reinforce the
+mechanical guidance.
+
+**Test scenarios:**
+- Happy path: persona present → prompt is `persona` + mechanical guidance + repo + message, in order.
+- Edge case (R4): persona absent/empty/whitespace → mechanical guidance + repo + message, no error.
+- Edge case: persona file via `_FILE` mount is read and trimmed.
+- Edge case: the user message is preserved verbatim after the prepended sections.
+- Happy path (SC2): the composed prompt contains the long-enumeration response policy (summarize/attach,
+  no inline raw lists) — assert the guidance string includes it so the agent is actually instructed.
+
+**Verification:** Prompt + config tests pass; check-types + lint clean.
+
+- [ ] **Unit 4: Deploy wiring + docs**
+
+**Goal:** Make `GATEWAY_PERSONA_FILE` deployable and document the new rendering + persona behavior.
+
+**Requirements:** R3
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `deploy/compose.yaml` (optional `GATEWAY_PERSONA_FILE` secret/env, following the existing
+  optional-secret pattern)
+- Modify: `deploy/README.md` and/or `packages/gateway/AGENTS.md` (persona delivery + rendering behavior)
+
+**Approach:**
+- Add a **minimal optional** `GATEWAY_PERSONA_FILE` entry to `deploy/compose.yaml` following the existing
+  optional-secret pattern (documenting the contract), but the **actual persona file provisioning is owned
+  by `marcusrbrown/infra`** (it supplies the canonical `fro-bot-persona.md` from `fro-bot/.github`). Keep
+  this repo's change to the config contract + docs; do not assume infra's mount details.
+- Document: the clean-rendering behavior (reasoning hidden, read-only tools hidden, tools summarized),
+  the persona delivery mechanism, and the fail-soft default.
+
+**Test scenarios:** Test expectation: none — deploy config + docs. Validate compose with the existing
+deploy validation; the persona-read behavior is covered by Unit 3 tests.
+
+**Verification:** Compose validates; docs render; no committed gateway `dist/` (gitignored).
+
+## System-Wide Impact
+
+- **Interaction graph:** The renderer sits between the SDK event stream and the existing sink. No change
+  to the sink, run lifecycle, locking, or the SDK subscription. `streaming.ts` still receives
+  `append()`/`flush()` — only the content changes.
+- **Error propagation:** A missing persona file is fail-soft (R4). The renderer must never throw on an
+  unexpected part shape — unknown/malformed parts degrade to a safe summary or suppression, never a crash
+  that breaks the run.
+- **API surface parity:** The legacy `session.next.tool.*` branches must use the same summarizer/filter
+  as the `message.part.updated` branch so output is identical regardless of which OpenCode path fires.
+- **Unchanged invariants:** The sink's flush/attachment/`_(no output)_` behavior, the run lifecycle,
+  approval flow, queue/reject behavior, and the SDK transport are all untouched by this plan.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Reasoning is not distinguishable on the delta path (deltas carry no part kind) | Resolved: correlate by `partID` — track reasoning `part.id` from `message.part.updated`, suppress deltas with that `partID`. Confirm ordering against a live 1.15.13 capture. |
+| SC2 (wall-of-files) not actually fixed by hiding the tool | Resolved: the Discord-mechanical guidance carries a long-enumeration response policy (summarize/attach), tested. Hiding the tool line is necessary but not sufficient. |
+| Canonical persona is GitHub-flavored; may sound wrong in chat | The persona already defines a "Social (Discord/BlueSky)" register; the Discord-mechanical guidance adds chat-specific constraints. Validate tone against a few mention scenarios during implementation. |
+| Over-hiding tools makes the loop feel opaque | Essential-tools allowlist keeps edits/writes/bash/MCP visible (the audit trace); only read-only noise is hidden (origin: clean-but-inspectable). |
+| Persona file shape/encoding surprises | Trim + fail-soft; treat any read failure as absent persona. |
+| Kimaki port type-mismatch (its Part model differs) | Port the *logic* against our extracted part shape + event helpers, not its types; unit-tested in isolation. |
+| Renderer regresses the streamed answer | Text deltas pass through unchanged; explicit test that the answer still streams. |
+
+## Documentation / Operational Notes
+
+- `GATEWAY_PERSONA_FILE` is optional; absent → mechanical guidance only. `marcusrbrown/infra` supplies
+  the canonical persona from `fro-bot/.github` `persona/fro-bot-persona.md` (single source of truth).
+- This is Phase 1 of the production-ready mention loop; Phases 2-4 (working-state UX, queue,
+  commands/approvals) follow as separate plans and build on this renderer.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md`
+- Related code: `packages/gateway/src/execute/run-core.ts`, `packages/gateway/src/execute/prompt.ts`,
+  `packages/gateway/src/discord/streaming.ts`, `packages/gateway/src/config.ts`
+- Persona: `fro-bot/.github` `persona/fro-bot-persona.md`
+- Reference impl: `remorses/kimaki` (MIT) — `cli/src/message-formatting.ts`,
+  `cli/src/external-opencode-sync.ts`
+- OpenCode SDK part model: `.slim/clonedeps/repos/anomalyco__opencode/packages/sdk/js/src/gen/types.gen.ts`

--- a/docs/plans/2026-06-07-003-feat-mention-loop-rendering-persona-plan.md
+++ b/docs/plans/2026-06-07-003-feat-mention-loop-rendering-persona-plan.md
@@ -155,7 +155,7 @@ established voice (see origin).
 
 ## Implementation Units
 
-- [ ] **Unit 1: Part renderer + essential-tool filter (pure module)**
+- [x] **Unit 1: Part renderer + essential-tool filter (pure module)**
 
 **Goal:** A pure, tested module that turns an extracted **tool** shape into a clean Discord line: essential
 tool → one-line summary; non-essential (read-only) tool → null. (Reasoning suppression and text passthrough
@@ -199,7 +199,7 @@ title-resolution logic in `run-core.ts` (state.title → input.title → bash co
 
 **Verification:** Module tests pass; `pnpm --filter @fro-bot/gateway check-types` + `lint` clean.
 
-- [ ] **Unit 2: Wire the renderer into run-core (reasoning suppression + tool summaries)**
+- [x] **Unit 2: Wire the renderer into run-core (reasoning suppression + tool summaries)**
 
 **Goal:** Replace the raw `🔧 <tool>: <title>` appends with the Unit 1 summaries, and suppress reasoning
 content so it never reaches the sink.
@@ -246,7 +246,7 @@ a `read` tool produces no `🔧` line, while an `edit` produces a summary.
 **Verification:** New + existing run-core tests pass; no `🔧 <tool>: <title>` raw format remains;
 gateway suite green; check-types + lint clean.
 
-- [ ] **Unit 3: Discord persona config + prompt composition**
+- [x] **Unit 3: Discord persona config + prompt composition**
 
 **Goal:** The mention prompt prepends the canonical persona + Discord-mechanical guidance, delivered via
 `GATEWAY_PERSONA_FILE`, fail-soft when absent.
@@ -291,7 +291,7 @@ mechanical guidance.
 
 **Verification:** Prompt + config tests pass; check-types + lint clean.
 
-- [ ] **Unit 4: Deploy wiring + docs**
+- [x] **Unit 4: Deploy wiring + docs**
 
 **Goal:** Make `GATEWAY_PERSONA_FILE` deployable and document the new rendering + persona behavior.
 

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -66,6 +66,8 @@ beforeEach(() => {
     'GATEWAY_MAX_CONCURRENT_RUNS',
     'GATEWAY_APPROVAL_MODE',
     'GATEWAY_APPROVAL_MODE_FILE',
+    'GATEWAY_PERSONA',
+    'GATEWAY_PERSONA_FILE',
   ]) {
     delete process.env[key]
   }
@@ -1398,5 +1400,111 @@ describe('loadGatewayConfig — GATEWAY_APPROVAL_MODE', () => {
     expect(() => loadGatewayConfig()).toThrow(
       'Invalid GATEWAY_APPROVAL_MODE value: "full-auto" (valid values: approval-required)',
     )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GATEWAY_PERSONA_FILE
+// ---------------------------------------------------------------------------
+
+describe('loadGatewayConfig — GATEWAY_PERSONA_FILE (persona)', () => {
+  it('happy path: GATEWAY_PERSONA_FILE unset → config.persona is null', () => {
+    // #given — no persona env var or file
+    setRequiredEnv()
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.persona).toBeNull()
+  })
+
+  it('happy path: GATEWAY_PERSONA_FILE set to a file with content → config.persona is the trimmed content', () => {
+    // #given — persona file with multi-line markdown content
+    setRequiredEnv()
+    const personaFile = join(tmpDir, 'persona.md')
+    writeFileSync(
+      personaFile,
+      '# Fro Bot\n\nYou are Fro Bot, a capable engineering assistant.\n\nBe direct and concise.\n',
+      {mode: 0o600},
+    )
+    process.env.GATEWAY_PERSONA_FILE = personaFile
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then — content is read and trailing whitespace trimmed
+    expect(config.persona).toBe(
+      '# Fro Bot\n\nYou are Fro Bot, a capable engineering assistant.\n\nBe direct and concise.',
+    )
+  })
+
+  it('edge: GATEWAY_PERSONA_FILE points to empty file → config.persona is null', () => {
+    // #given — empty file is treated as absent
+    setRequiredEnv()
+    const personaFile = join(tmpDir, 'persona-empty.md')
+    writeFileSync(personaFile, '', {mode: 0o600})
+    process.env.GATEWAY_PERSONA_FILE = personaFile
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.persona).toBeNull()
+  })
+
+  it('edge: GATEWAY_PERSONA_FILE points to whitespace-only file → config.persona is null', () => {
+    // #given — whitespace-only file is treated as absent
+    setRequiredEnv()
+    const personaFile = join(tmpDir, 'persona-ws.md')
+    writeFileSync(personaFile, '   \n  \n', {mode: 0o600})
+    process.env.GATEWAY_PERSONA_FILE = personaFile
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.persona).toBeNull()
+  })
+
+  it('edge: GATEWAY_PERSONA_FILE content is trimmed (trailing newline stripped)', () => {
+    // #given — file with trailing newline (common in text editors)
+    setRequiredEnv()
+    const personaFile = join(tmpDir, 'persona-trailing.md')
+    writeFileSync(personaFile, 'You are Fro Bot.\n', {mode: 0o600})
+    process.env.GATEWAY_PERSONA_FILE = personaFile
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then — trailing newline stripped
+    expect(config.persona).toBe('You are Fro Bot.')
+  })
+
+  it('edge: GATEWAY_PERSONA_FILE points to non-existent file → config.persona is null (fail-soft)', () => {
+    // #given — _FILE points to a missing path, no env var fallback
+    setRequiredEnv()
+    process.env.GATEWAY_PERSONA_FILE = join(tmpDir, 'does-not-exist.md')
+
+    // #when / #then — must NOT throw; absent persona is fail-soft
+    let config: import('./config.js').GatewayConfig | undefined
+    expect(() => {
+      config = loadGatewayConfig()
+    }).not.toThrow()
+    expect(config?.persona).toBeNull()
+  })
+
+  it('edge: GATEWAY_PERSONA env var set → config.persona is the value (env var path)', () => {
+    // #given — persona provided directly via env var (single-line for readOptionalMultilineSecret)
+    setRequiredEnv()
+    process.env.GATEWAY_PERSONA = 'You are Fro Bot, a capable engineering assistant.'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.persona).toBe('You are Fro Bot, a capable engineering assistant.')
+
+    delete process.env.GATEWAY_PERSONA
   })
 })

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -1507,4 +1507,50 @@ describe('loadGatewayConfig — GATEWAY_PERSONA_FILE (persona)', () => {
 
     delete process.env.GATEWAY_PERSONA
   })
+
+  it('fail-soft: GATEWAY_PERSONA_FILE points to a directory → persona is null, startup continues', () => {
+    // #given — _FILE points to a directory (Docker bind-mount misconfiguration)
+    setRequiredEnv()
+    const dirPath = mkdtempSync(join(tmpDir, 'persona-dir-'))
+    process.env.GATEWAY_PERSONA_FILE = dirPath
+
+    // #when / #then — must NOT throw; persona degrades to null
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    let config: import('./config.js').GatewayConfig | undefined
+    expect(() => {
+      config = loadGatewayConfig()
+    }).not.toThrow()
+    expect(config?.persona).toBeNull()
+    consoleSpy.mockRestore()
+  })
+
+  it('fail-soft: GATEWAY_PERSONA_FILE points to oversized file → persona is null, startup continues', () => {
+    // #given — file exceeds MAX_SECRET_BYTES (4096)
+    setRequiredEnv()
+    const largePath = join(tmpDir, 'persona-large.md')
+    writeFileSync(largePath, 'x'.repeat(5000), {mode: 0o600})
+    process.env.GATEWAY_PERSONA_FILE = largePath
+
+    // #when / #then — must NOT throw; persona degrades to null
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    let config: import('./config.js').GatewayConfig | undefined
+    expect(() => {
+      config = loadGatewayConfig()
+    }).not.toThrow()
+    expect(config?.persona).toBeNull()
+    consoleSpy.mockRestore()
+  })
+
+  it('fail-soft: GATEWAY_PERSONA_FILE points to non-existent file → persona is null, no warning (ENOENT is normal)', () => {
+    // #given — _FILE points to a missing path, no env var fallback
+    setRequiredEnv()
+    process.env.GATEWAY_PERSONA_FILE = join(tmpDir, 'does-not-exist-2.md')
+
+    // #when / #then — must NOT throw; absent persona is fail-soft (ENOENT falls through to null)
+    let config: import('./config.js').GatewayConfig | undefined
+    expect(() => {
+      config = loadGatewayConfig()
+    }).not.toThrow()
+    expect(config?.persona).toBeNull()
+  })
 })

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -57,6 +57,13 @@ export interface GatewayConfig {
    */
   readonly approvalMode: 'approval-required'
   /**
+   * Canonical Fro Bot persona text, read from `GATEWAY_PERSONA_FILE` (or `GATEWAY_PERSONA` env var).
+   * Prepended to every Discord mention prompt before the Discord-mechanical guidance.
+   * `null` when unset, empty, or whitespace-only — the mention loop degrades gracefully to
+   * mechanical guidance only (R4 fail-soft).
+   */
+  readonly persona: string | null
+  /**
    * Announce/presence endpoint configuration. Present only when both
    * `GATEWAY_WEBHOOK_SECRET` and `GATEWAY_PRESENCE_CHANNEL_ID` are set.
    * When absent, the announce HTTP server is not started.
@@ -394,6 +401,11 @@ export function loadGatewayConfig(): GatewayConfig {
     throw new Error(`Invalid GATEWAY_RUN_TIMEOUT_MS value: "${rawRunTimeout}" (must be a positive integer)`)
   }
 
+  // Persona — optional multi-line markdown file (e.g. fro-bot-persona.md).
+  // Uses readOptionalMultilineSecret because persona files contain embedded newlines.
+  // Absent/empty/whitespace → null (R4 fail-soft: the mention loop degrades gracefully).
+  const persona = readOptionalMultilineSecret('GATEWAY_PERSONA')
+
   // Announce/presence endpoint — opt-in: both secrets must be set together, or neither.
   // Mirrors the AWS credential pair-validation block above.
   const gatewayWebhookSecret = readOptionalSecret('GATEWAY_WEBHOOK_SECRET')
@@ -438,6 +450,7 @@ export function loadGatewayConfig(): GatewayConfig {
     logLevel,
     privilegedIntents,
     approvalMode,
+    persona,
     githubAppId,
     githubAppPrivateKey,
     gatewayGitHubAppInstallUrl,

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -404,7 +404,21 @@ export function loadGatewayConfig(): GatewayConfig {
   // Persona — optional multi-line markdown file (e.g. fro-bot-persona.md).
   // Uses readOptionalMultilineSecret because persona files contain embedded newlines.
   // Absent/empty/whitespace → null (R4 fail-soft: the mention loop degrades gracefully).
-  const persona = readOptionalMultilineSecret('GATEWAY_PERSONA')
+  // Fail-soft: any read error (permission-denied, directory, oversized, etc.) logs a warning
+  // and resolves to null — a persona read failure must never crash gateway startup.
+  let persona: string | null = null
+  try {
+    persona = readOptionalMultilineSecret('GATEWAY_PERSONA')
+  } catch {
+    // Intentionally broad catch: permission-denied, directory, oversized, symlink, etc.
+    // Log a warning WITHOUT file contents (no secret leakage) and continue with null.
+    console.warn(
+      JSON.stringify({
+        level: 'warn',
+        msg: 'GATEWAY_PERSONA read failed — persona will be null; gateway startup continues. Check GATEWAY_PERSONA_FILE path and permissions.',
+      }),
+    )
+  }
 
   // Announce/presence endpoint — opt-in: both secrets must be set together, or neither.
   // Mirrors the AWS credential pair-validation block above.

--- a/packages/gateway/src/discord/mentions.test.ts
+++ b/packages/gateway/src/discord/mentions.test.ts
@@ -148,6 +148,7 @@ function makeRunMentionDeps(): MentionDeps['run'] {
       disposeAll: vi.fn(),
     },
     approvalMode: 'approval-required' as const,
+    persona: null,
     ensureClone: vi.fn().mockResolvedValue({success: true as const, data: '/workspace/repos/acme/widget'}),
     readyz: vi.fn().mockResolvedValue({success: true as const, data: {ready: true, opencode: 'ready'}}),
   }

--- a/packages/gateway/src/execute/format-part.test.ts
+++ b/packages/gateway/src/execute/format-part.test.ts
@@ -9,7 +9,7 @@
 
 import {describe, expect, it} from 'vitest'
 
-import {formatToolPart, isEssentialTool, summarizeTool} from './format-part.js'
+import {formatToolPart, isEssentialTool, isReadOnlyBashCommand, summarizeTool} from './format-part.js'
 
 // ---------------------------------------------------------------------------
 // Shape helpers
@@ -55,27 +55,34 @@ describe('summarizeTool', () => {
     })
 
     it('uses only the basename of filePath', () => {
+      // #given
       const part = completedTool('edit', {
         filePath: 'packages/gateway/src/execute/run-core.ts',
         newString: 'line1\nline2',
         oldString: 'old',
       })
+
+      // #when / #then
       expect(summarizeTool(part)).toBe('*run-core.ts* (+2-1)')
     })
 
     it('falls back to tool name when filePath is absent', () => {
+      // #given
       const part = completedTool('edit', {newString: 'a', oldString: 'b'})
-      // No filePath → no filename → fallback to tool name
+
+      // #when / #then — No filePath → no filename → fallback to tool name
       expect(summarizeTool(part)).toBe('edit')
     })
 
     it('escapes markdown special chars in filename', () => {
+      // #given
       const part = completedTool('edit', {
         filePath: 'src/foo_bar.ts',
         newString: 'a',
         oldString: 'b',
       })
-      // underscore in filename must be escaped so Discord doesn't italicize
+
+      // #when / #then — underscore in filename must be escaped so Discord doesn't italicize
       expect(summarizeTool(part)).toContain(String.raw`foo\_bar.ts`)
     })
   })
@@ -96,18 +103,20 @@ describe('summarizeTool', () => {
     })
 
     it('uses singular "line" for 1-line content', () => {
+      // #given / #when / #then
       const part = completedTool('write', {filePath: 'src/x.ts', content: 'single'})
       expect(summarizeTool(part)).toBe('*x.ts* (1 line)')
     })
 
     it('falls back to tool name when filePath is absent', () => {
+      // #given / #when / #then
       const part = completedTool('write', {content: 'hello'})
       expect(summarizeTool(part)).toBe('write')
     })
   })
 
   describe('apply_patch tool', () => {
-    it('renders *filename* (+added-removed) from patchText', () => {
+    it('renders *filename* (+added-removed) from unified diff patchText', () => {
       // #given — a minimal unified diff with 3 additions and 1 deletion
       const patchText = [
         '--- a/src/app.ts',
@@ -126,12 +135,34 @@ describe('summarizeTool', () => {
       const result = summarizeTool(part)
 
       // #then — fields consumed: state.input.patchText
-      expect(result).toContain('app.ts')
-      expect(result).toContain('+')
-      expect(result).toContain('-')
+      expect(result).toBe('*app.ts* (+3-1)')
+    })
+
+    it('renders *filename* (+added-removed) from OpenCode *** Begin Patch envelope', () => {
+      // #given — OpenCode apply_patch envelope format
+      const patchText = [
+        '*** Begin Patch',
+        '*** Update File: src/app.ts',
+        '@@ -1,3 +1,5 @@',
+        ' context',
+        '-removed',
+        '+added1',
+        '+added2',
+        '+added3',
+        ' context2',
+        '*** End Patch',
+      ].join('\n')
+      const part = completedTool('apply_patch', {patchText})
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then — OpenCode envelope parsed correctly
+      expect(result).toBe('*app.ts* (+3-1)')
     })
 
     it('falls back to tool name when patchText is absent', () => {
+      // #given / #when / #then
       const part = completedTool('apply_patch', {})
       expect(summarizeTool(part)).toBe('apply_patch')
     })
@@ -150,17 +181,17 @@ describe('summarizeTool', () => {
     })
 
     it('renders description when command is multi-line', () => {
-      // #given — multi-line command with a description
+      // #given — multi-line side-effecting command with a description
       const part = completedTool('bash', {
-        command: 'echo line1\necho line2\necho line3',
-        description: 'Print lines',
+        command: 'pnpm build\npnpm test\npnpm lint',
+        description: 'Build and test',
       })
 
       // #when
       const result = summarizeTool(part)
 
       // #then — fields consumed: state.input.description (fallback from multi-line command)
-      expect(result).toBe('Print lines')
+      expect(result).toBe('Build and test')
     })
 
     it('renders description when command exceeds 100 chars', () => {
@@ -176,19 +207,120 @@ describe('summarizeTool', () => {
     })
 
     it('falls back to tool name when command and description are absent', () => {
+      // #given / #when / #then
       const part = completedTool('bash', {})
       expect(summarizeTool(part)).toBe('bash')
     })
 
     it('falls back to tool name when command is long and description is absent', () => {
+      // #given / #when / #then
       const part = completedTool('bash', {command: 'x'.repeat(101)})
       expect(summarizeTool(part)).toBe('bash')
     })
 
     it('also accepts cmd field (alias for command)', () => {
-      // run-core.ts uses getObjectProperty(stateInput, 'cmd') as a fallback
+      // #given — run-core.ts uses getObjectProperty(stateInput, 'cmd') as a fallback
       const part = completedTool('bash', {cmd: 'git status'})
-      expect(summarizeTool(part)).toBe('`git status`')
+
+      // #when / #then — git status is read-only → hidden
+      expect(summarizeTool(part)).toBeNull()
+    })
+
+    describe('read-only bash hiding (P2.4)', () => {
+      it('git ls-files → hidden (null)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'git ls-files'}))).toBeNull()
+      })
+
+      it('git status → hidden (null)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'git status'}))).toBeNull()
+      })
+
+      it('git log → hidden (null)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'git log --oneline -5'}))).toBeNull()
+      })
+
+      it('git diff → hidden (null)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'git diff HEAD'}))).toBeNull()
+      })
+
+      it('ls → hidden (null)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'ls -la'}))).toBeNull()
+      })
+
+      it('cat → hidden (null)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'cat src/foo.ts'}))).toBeNull()
+      })
+
+      it('find → hidden (null)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'find . -name "*.ts"'}))).toBeNull()
+      })
+
+      it('grep → hidden (null)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'grep -r TODO src/'}))).toBeNull()
+      })
+
+      it('rg → hidden (null)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'rg "TODO" src/'}))).toBeNull()
+      })
+
+      it('pwd → hidden (null)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'pwd'}))).toBeNull()
+      })
+
+      it('head → hidden (null)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'head -20 src/foo.ts'}))).toBeNull()
+      })
+
+      it('tail → hidden (null)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'tail -f logs/app.log'}))).toBeNull()
+      })
+
+      it('wc → hidden (null)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'wc -l src/foo.ts'}))).toBeNull()
+      })
+
+      it('which → hidden (null)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'which node'}))).toBeNull()
+      })
+
+      it('echo → hidden (null)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'echo hello'}))).toBeNull()
+      })
+
+      it('npm test → shown (side-effecting)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'npm test'}))).not.toBeNull()
+      })
+
+      it('rm → shown (side-effecting)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'rm -rf dist/'}))).not.toBeNull()
+      })
+
+      it('git commit → shown (side-effecting)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'git commit -m "fix"'}))).not.toBeNull()
+      })
+
+      it('pnpm build → shown (side-effecting)', () => {
+        // #given / #when / #then
+        expect(summarizeTool(completedTool('bash', {command: 'pnpm build'}))).not.toBeNull()
+      })
     })
   })
 
@@ -196,10 +328,13 @@ describe('summarizeTool', () => {
     it('renders _name_ from input.name', () => {
       // #given — fields consumed: state.input.name
       const part = completedTool('skill', {name: 'ce:review'})
+
+      // #when / #then
       expect(summarizeTool(part)).toBe('_ce:review_')
     })
 
     it('falls back to tool name when name is absent', () => {
+      // #given / #when / #then
       const part = completedTool('skill', {})
       expect(summarizeTool(part)).toBe('skill')
     })
@@ -209,40 +344,48 @@ describe('summarizeTool', () => {
     it('renders a labeled summary from input', () => {
       // #given — fields consumed: state.input (any available label)
       const part = completedTool('task', {description: 'Implement feature X'})
+
+      // #when
       const result = summarizeTool(part)
-      // Must contain some reference to the task description
+
+      // #then — Must contain some reference to the task description
       expect(result).toContain('Implement feature X')
     })
 
     it('falls back to tool name when no description', () => {
+      // #given / #when / #then
       const part = completedTool('task', {})
       expect(summarizeTool(part)).toBe('task')
     })
   })
 
   describe('read tool (hidden)', () => {
-    it('returns null — read is a hidden (non-essential) tool', () => {
+    it('returns null — read is a hidden (non-essential) tool when successful', () => {
+      // #given / #when / #then
       const part = completedTool('read', {filePath: 'src/foo.ts'})
       expect(summarizeTool(part)).toBeNull()
     })
   })
 
   describe('grep tool (hidden)', () => {
-    it('returns null — grep is a hidden (non-essential) tool', () => {
+    it('returns null — grep is a hidden (non-essential) tool when successful', () => {
+      // #given / #when / #then
       const part = completedTool('grep', {pattern: 'TODO'})
       expect(summarizeTool(part)).toBeNull()
     })
   })
 
   describe('glob tool (hidden)', () => {
-    it('returns null — glob is a hidden (non-essential) tool', () => {
+    it('returns null — glob is a hidden (non-essential) tool when successful', () => {
+      // #given / #when / #then
       const part = completedTool('glob', {pattern: '**/*.ts'})
       expect(summarizeTool(part)).toBeNull()
     })
   })
 
   describe('list tool (hidden)', () => {
-    it('returns null — list is a hidden (non-essential) tool', () => {
+    it('returns null — list is a hidden (non-essential) tool when successful', () => {
+      // #given / #when / #then
       const part = completedTool('list', {path: 'src/'})
       expect(summarizeTool(part)).toBeNull()
     })
@@ -266,15 +409,73 @@ describe('summarizeTool', () => {
       expect(result).toContain('broken.ts')
     })
 
-    it('error-status read tool still returns null (hidden)', () => {
-      // Hidden tools stay hidden even on error
+    it('error-status read tool renders terse error line (P2.5 — aids debugging)', () => {
+      // #given — hidden tool with error status
       const part = errorTool('read', {filePath: 'src/foo.ts'})
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then — errored hidden tool renders terse error line, not null
+      expect(result).not.toBeNull()
+      expect(result).toContain('⨯')
+      expect(result).toContain('read')
+      expect(result).toContain('src/foo.ts')
+    })
+
+    it('error-status grep tool renders terse error line with pattern', () => {
+      // #given
+      const part = errorTool('grep', {pattern: 'TODO'})
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then
+      expect(result).not.toBeNull()
+      expect(result).toContain('⨯')
+      expect(result).toContain('grep')
+      expect(result).toContain('TODO')
+    })
+
+    it('error-status glob tool renders terse error line with path', () => {
+      // #given
+      const part = errorTool('glob', {pattern: '**/*.ts'})
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then
+      expect(result).not.toBeNull()
+      expect(result).toContain('⨯')
+      expect(result).toContain('glob')
+    })
+
+    it('error-status list tool renders terse error line with path', () => {
+      // #given
+      const part = errorTool('list', {path: 'src/'})
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then
+      expect(result).not.toBeNull()
+      expect(result).toContain('⨯')
+      expect(result).toContain('list')
+      expect(result).toContain('src/')
+    })
+
+    it('successful read tool still returns null (P2.5 — only errored hidden tools show)', () => {
+      // #given / #when / #then
+      const part = completedTool('read', {filePath: 'src/foo.ts'})
       expect(summarizeTool(part)).toBeNull()
     })
 
     it('error-status bash tool renders with error glyph', () => {
+      // #given / #when
       const part = errorTool('bash', {command: 'pnpm test'})
       const result = summarizeTool(part)
+
+      // #then
       expect(result).not.toBeNull()
       expect(result).toContain('⨯')
     })
@@ -298,14 +499,17 @@ describe('summarizeTool', () => {
     })
 
     it('truncates MCP tool args to ~50 chars', () => {
+      // #given / #when
       const part = completedTool('mcp_tool', {query: 'a'.repeat(100)})
       const result = summarizeTool(part)
+
+      // #then — The truncated arg should be ≤50 chars + ellipsis
       expect(result).not.toBeNull()
-      // The truncated arg should be ≤50 chars + ellipsis
       expect(result).toContain('…')
     })
 
     it('renders tool name as fallback when input is empty', () => {
+      // #given / #when / #then
       const part = completedTool('unknown_tool', {})
       expect(summarizeTool(part)).toBe('unknown_tool')
     })
@@ -313,14 +517,19 @@ describe('summarizeTool', () => {
 
   describe('missing title/input fallbacks', () => {
     it('falls back to tool name when state.input is empty and no title', () => {
+      // #given / #when / #then
       const part = completedTool('edit', {})
       expect(summarizeTool(part)).toBe('edit')
     })
 
     it('uses state.title as a fallback label when available', () => {
-      // For tools without specific field handling, title is used
+      // #given — For tools without specific field handling, title is used
       const part = completedTool('some_tool', {}, 'My title')
+
+      // #when
       const result = summarizeTool(part)
+
+      // #then
       expect(result).not.toBeNull()
       expect(result).toContain('My title')
     })
@@ -334,15 +543,18 @@ describe('summarizeTool', () => {
 describe('isEssentialTool', () => {
   describe('essential (shown) tools', () => {
     it.each(['edit', 'write', 'apply_patch', 'task', 'skill'])('%s is essential', tool => {
+      // #given / #when / #then
       expect(isEssentialTool(tool)).toBe(true)
     })
 
     it('bash is treated as essential (side-effecting by default)', () => {
-      // Design choice: bash is always shown; a follow-up can refine with hasSideEffect
+      // #given — Design choice: bash is always shown at the isEssentialTool level;
+      // read-only bash is filtered in summarizeTool based on command content
       expect(isEssentialTool('bash')).toBe(true)
     })
 
     it('unknown / MCP tools are essential (shown)', () => {
+      // #given / #when / #then
       expect(isEssentialTool('some_mcp_tool')).toBe(true)
       expect(isEssentialTool('mcp_search')).toBe(true)
     })
@@ -350,7 +562,60 @@ describe('isEssentialTool', () => {
 
   describe('non-essential (hidden) tools', () => {
     it.each(['read', 'grep', 'glob', 'list'])('%s is non-essential', tool => {
+      // #given / #when / #then
       expect(isEssentialTool(tool)).toBe(false)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isReadOnlyBashCommand
+// ---------------------------------------------------------------------------
+
+describe('isReadOnlyBashCommand', () => {
+  describe('read-only commands → true', () => {
+    it.each([
+      'git ls-files',
+      'git ls-files --others',
+      'git status',
+      'git status --short',
+      'git log',
+      'git log --oneline -5',
+      'git diff',
+      'git diff HEAD',
+      'ls',
+      'ls -la',
+      'cat src/foo.ts',
+      'find . -name "*.ts"',
+      'grep -r TODO src/',
+      'rg "TODO" src/',
+      'pwd',
+      'head -20 src/foo.ts',
+      'tail -f logs/app.log',
+      'wc -l src/foo.ts',
+      'which node',
+      'echo hello',
+    ])('%s → true', command => {
+      // #given / #when / #then
+      expect(isReadOnlyBashCommand(command)).toBe(true)
+    })
+  })
+
+  describe('side-effecting commands → false', () => {
+    it.each([
+      'npm test',
+      'rm -rf dist/',
+      'git commit -m "fix"',
+      'git push',
+      'pnpm build',
+      'pnpm install',
+      'mkdir -p dist',
+      'cp src/foo.ts dist/',
+      'mv old.ts new.ts',
+      'chmod +x script.sh',
+    ])('%s → false', command => {
+      // #given / #when / #then
+      expect(isReadOnlyBashCommand(command)).toBe(false)
     })
   })
 })
@@ -361,38 +626,63 @@ describe('isEssentialTool', () => {
 
 describe('formatToolPart', () => {
   it('returns the summary string for an essential tool', () => {
+    // #given
     const part = completedTool('edit', {
       filePath: 'src/app.ts',
       newString: 'a\nb',
       oldString: 'c',
     })
+
+    // #when / #then
     const result = formatToolPart(part)
     expect(result).toBe('*app.ts* (+2-1)')
   })
 
-  it('returns null for a non-essential (hidden) tool', () => {
+  it('returns null for a non-essential (hidden) successful tool', () => {
+    // #given / #when / #then
     const part = completedTool('read', {filePath: 'src/app.ts'})
     expect(formatToolPart(part)).toBeNull()
   })
 
-  it('returns null for grep (hidden)', () => {
+  it('returns null for grep (hidden, successful)', () => {
+    // #given / #when / #then
     const part = completedTool('grep', {pattern: 'TODO'})
     expect(formatToolPart(part)).toBeNull()
   })
 
-  it('returns a summary for bash (essential)', () => {
-    const part = completedTool('bash', {command: 'git status'})
+  it('returns a summary for bash (essential, side-effecting)', () => {
+    // #given / #when / #then
+    const part = completedTool('bash', {command: 'pnpm build'})
     expect(formatToolPart(part)).not.toBeNull()
   })
 
-  it('returns null for a non-essential error-status tool', () => {
-    const part = errorTool('read', {filePath: 'src/foo.ts'})
+  it('returns null for read-only bash (git status)', () => {
+    // #given / #when / #then
+    const part = completedTool('bash', {command: 'git status'})
     expect(formatToolPart(part)).toBeNull()
   })
 
-  it('returns an error-prefixed summary for an essential error-status tool', () => {
-    const part = errorTool('edit', {filePath: 'src/app.ts', newString: 'a', oldString: 'b'})
+  it('returns terse error line for errored hidden tool (P2.5)', () => {
+    // #given
+    const part = errorTool('read', {filePath: 'src/foo.ts'})
+
+    // #when
     const result = formatToolPart(part)
+
+    // #then — errored hidden tool renders terse error line
+    expect(result).not.toBeNull()
+    expect(result).toContain('⨯')
+    expect(result).toContain('read')
+  })
+
+  it('returns an error-prefixed summary for an essential error-status tool', () => {
+    // #given
+    const part = errorTool('edit', {filePath: 'src/app.ts', newString: 'a', oldString: 'b'})
+
+    // #when
+    const result = formatToolPart(part)
+
+    // #then
     expect(result).not.toBeNull()
     expect(result).toContain('⨯')
   })

--- a/packages/gateway/src/execute/format-part.test.ts
+++ b/packages/gateway/src/execute/format-part.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Tests for `summarizeTool`, `formatToolPart`, and `isEssentialTool`.
+ *
+ * Mapping contract: each test names the exact input fields consumed so a shape
+ * mismatch surfaces as a test failure, not a silent fallback.
+ *
+ * TDD: these tests were written BEFORE the implementation.
+ */
+
+import {describe, expect, it} from 'vitest'
+
+import {formatToolPart, isEssentialTool, summarizeTool} from './format-part.js'
+
+// ---------------------------------------------------------------------------
+// Shape helpers
+// ---------------------------------------------------------------------------
+
+/** Build a completed tool shape (the canonical input to summarizeTool). */
+function completedTool(
+  tool: string,
+  input: Record<string, unknown> = {},
+  title?: string,
+): {tool: string; state: {input: Record<string, unknown>; title?: string; status: 'completed'}} {
+  return {tool, state: {input, title, status: 'completed'}}
+}
+
+/** Build an error-status tool shape. */
+function errorTool(
+  tool: string,
+  input: Record<string, unknown> = {},
+  title?: string,
+): {tool: string; state: {input: Record<string, unknown>; title?: string; status: 'error'}} {
+  return {tool, state: {input, title, status: 'error'}}
+}
+
+// ---------------------------------------------------------------------------
+// summarizeTool — happy paths
+// ---------------------------------------------------------------------------
+
+describe('summarizeTool', () => {
+  describe('edit tool', () => {
+    it('renders *filename* (+added-removed) from filePath + newString + oldString', () => {
+      // #given — edit with 12 new lines and 3 old lines
+      const part = completedTool('edit', {
+        filePath: 'src/foo.ts',
+        newString: 'a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl', // 12 lines
+        oldString: 'x\ny\nz', // 3 lines
+      })
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then — fields consumed: state.input.filePath, state.input.newString, state.input.oldString
+      expect(result).toBe('*foo.ts* (+12-3)')
+    })
+
+    it('uses only the basename of filePath', () => {
+      const part = completedTool('edit', {
+        filePath: 'packages/gateway/src/execute/run-core.ts',
+        newString: 'line1\nline2',
+        oldString: 'old',
+      })
+      expect(summarizeTool(part)).toBe('*run-core.ts* (+2-1)')
+    })
+
+    it('falls back to tool name when filePath is absent', () => {
+      const part = completedTool('edit', {newString: 'a', oldString: 'b'})
+      // No filePath → no filename → fallback to tool name
+      expect(summarizeTool(part)).toBe('edit')
+    })
+
+    it('escapes markdown special chars in filename', () => {
+      const part = completedTool('edit', {
+        filePath: 'src/foo_bar.ts',
+        newString: 'a',
+        oldString: 'b',
+      })
+      // underscore in filename must be escaped so Discord doesn't italicize
+      expect(summarizeTool(part)).toContain(String.raw`foo\_bar.ts`)
+    })
+  })
+
+  describe('write tool', () => {
+    it('renders *filename* (N lines) from filePath + content', () => {
+      // #given — write with 40 lines
+      const part = completedTool('write', {
+        filePath: 'src/output.ts',
+        content: Array.from({length: 40}, (_, i) => `line${i}`).join('\n'),
+      })
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then — fields consumed: state.input.filePath, state.input.content
+      expect(result).toBe('*output.ts* (40 lines)')
+    })
+
+    it('uses singular "line" for 1-line content', () => {
+      const part = completedTool('write', {filePath: 'src/x.ts', content: 'single'})
+      expect(summarizeTool(part)).toBe('*x.ts* (1 line)')
+    })
+
+    it('falls back to tool name when filePath is absent', () => {
+      const part = completedTool('write', {content: 'hello'})
+      expect(summarizeTool(part)).toBe('write')
+    })
+  })
+
+  describe('apply_patch tool', () => {
+    it('renders *filename* (+added-removed) from patchText', () => {
+      // #given — a minimal unified diff with 3 additions and 1 deletion
+      const patchText = [
+        '--- a/src/app.ts',
+        '+++ b/src/app.ts',
+        '@@ -1,3 +1,5 @@',
+        ' context',
+        '-removed',
+        '+added1',
+        '+added2',
+        '+added3',
+        ' context2',
+      ].join('\n')
+      const part = completedTool('apply_patch', {patchText})
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then — fields consumed: state.input.patchText
+      expect(result).toContain('app.ts')
+      expect(result).toContain('+')
+      expect(result).toContain('-')
+    })
+
+    it('falls back to tool name when patchText is absent', () => {
+      const part = completedTool('apply_patch', {})
+      expect(summarizeTool(part)).toBe('apply_patch')
+    })
+  })
+
+  describe('bash tool', () => {
+    it('renders inline command when single-line and ≤100 chars', () => {
+      // #given — short single-line command
+      const part = completedTool('bash', {command: 'pnpm test', description: 'Run tests'})
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then — fields consumed: state.input.command
+      expect(result).toBe('`pnpm test`')
+    })
+
+    it('renders description when command is multi-line', () => {
+      // #given — multi-line command with a description
+      const part = completedTool('bash', {
+        command: 'echo line1\necho line2\necho line3',
+        description: 'Print lines',
+      })
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then — fields consumed: state.input.description (fallback from multi-line command)
+      expect(result).toBe('Print lines')
+    })
+
+    it('renders description when command exceeds 100 chars', () => {
+      // #given — command longer than 100 chars
+      const longCmd = 'x'.repeat(101)
+      const part = completedTool('bash', {command: longCmd, description: 'Long command'})
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then — fields consumed: state.input.description (fallback from long command)
+      expect(result).toBe('Long command')
+    })
+
+    it('falls back to tool name when command and description are absent', () => {
+      const part = completedTool('bash', {})
+      expect(summarizeTool(part)).toBe('bash')
+    })
+
+    it('falls back to tool name when command is long and description is absent', () => {
+      const part = completedTool('bash', {command: 'x'.repeat(101)})
+      expect(summarizeTool(part)).toBe('bash')
+    })
+
+    it('also accepts cmd field (alias for command)', () => {
+      // run-core.ts uses getObjectProperty(stateInput, 'cmd') as a fallback
+      const part = completedTool('bash', {cmd: 'git status'})
+      expect(summarizeTool(part)).toBe('`git status`')
+    })
+  })
+
+  describe('skill tool', () => {
+    it('renders _name_ from input.name', () => {
+      // #given — fields consumed: state.input.name
+      const part = completedTool('skill', {name: 'ce:review'})
+      expect(summarizeTool(part)).toBe('_ce:review_')
+    })
+
+    it('falls back to tool name when name is absent', () => {
+      const part = completedTool('skill', {})
+      expect(summarizeTool(part)).toBe('skill')
+    })
+  })
+
+  describe('task (subagent) tool', () => {
+    it('renders a labeled summary from input', () => {
+      // #given — fields consumed: state.input (any available label)
+      const part = completedTool('task', {description: 'Implement feature X'})
+      const result = summarizeTool(part)
+      // Must contain some reference to the task description
+      expect(result).toContain('Implement feature X')
+    })
+
+    it('falls back to tool name when no description', () => {
+      const part = completedTool('task', {})
+      expect(summarizeTool(part)).toBe('task')
+    })
+  })
+
+  describe('read tool (hidden)', () => {
+    it('returns null — read is a hidden (non-essential) tool', () => {
+      const part = completedTool('read', {filePath: 'src/foo.ts'})
+      expect(summarizeTool(part)).toBeNull()
+    })
+  })
+
+  describe('grep tool (hidden)', () => {
+    it('returns null — grep is a hidden (non-essential) tool', () => {
+      const part = completedTool('grep', {pattern: 'TODO'})
+      expect(summarizeTool(part)).toBeNull()
+    })
+  })
+
+  describe('glob tool (hidden)', () => {
+    it('returns null — glob is a hidden (non-essential) tool', () => {
+      const part = completedTool('glob', {pattern: '**/*.ts'})
+      expect(summarizeTool(part)).toBeNull()
+    })
+  })
+
+  describe('list tool (hidden)', () => {
+    it('returns null — list is a hidden (non-essential) tool', () => {
+      const part = completedTool('list', {path: 'src/'})
+      expect(summarizeTool(part)).toBeNull()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Edge cases
+  // ---------------------------------------------------------------------------
+
+  describe('error-status tools', () => {
+    it('prefixes with error glyph and still summarizes (not dumped)', () => {
+      // #given — edit tool that errored
+      const part = errorTool('edit', {filePath: 'src/broken.ts', newString: 'a', oldString: 'b'})
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then — must have error indicator AND still be summarized
+      expect(result).not.toBeNull()
+      expect(result).toContain('⨯')
+      expect(result).toContain('broken.ts')
+    })
+
+    it('error-status read tool still returns null (hidden)', () => {
+      // Hidden tools stay hidden even on error
+      const part = errorTool('read', {filePath: 'src/foo.ts'})
+      expect(summarizeTool(part)).toBeNull()
+    })
+
+    it('error-status bash tool renders with error glyph', () => {
+      const part = errorTool('bash', {command: 'pnpm test'})
+      const result = summarizeTool(part)
+      expect(result).not.toBeNull()
+      expect(result).toContain('⨯')
+    })
+  })
+
+  describe('unknown / MCP tools', () => {
+    it('renders a minimal truncated fallback — never a raw dump', () => {
+      // #given — unknown tool with some input
+      const part = completedTool('some_mcp_tool', {
+        longArg: 'a'.repeat(200),
+        anotherArg: 'value',
+      })
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then — must not be null (MCP tools are essential), must be truncated
+      expect(result).not.toBeNull()
+      // Must not contain the full 200-char arg
+      expect(typeof result === 'string' && result.length).toBeLessThan(150)
+    })
+
+    it('truncates MCP tool args to ~50 chars', () => {
+      const part = completedTool('mcp_tool', {query: 'a'.repeat(100)})
+      const result = summarizeTool(part)
+      expect(result).not.toBeNull()
+      // The truncated arg should be ≤50 chars + ellipsis
+      expect(result).toContain('…')
+    })
+
+    it('renders tool name as fallback when input is empty', () => {
+      const part = completedTool('unknown_tool', {})
+      expect(summarizeTool(part)).toBe('unknown_tool')
+    })
+  })
+
+  describe('missing title/input fallbacks', () => {
+    it('falls back to tool name when state.input is empty and no title', () => {
+      const part = completedTool('edit', {})
+      expect(summarizeTool(part)).toBe('edit')
+    })
+
+    it('uses state.title as a fallback label when available', () => {
+      // For tools without specific field handling, title is used
+      const part = completedTool('some_tool', {}, 'My title')
+      const result = summarizeTool(part)
+      expect(result).not.toBeNull()
+      expect(result).toContain('My title')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isEssentialTool
+// ---------------------------------------------------------------------------
+
+describe('isEssentialTool', () => {
+  describe('essential (shown) tools', () => {
+    it.each(['edit', 'write', 'apply_patch', 'task', 'skill'])('%s is essential', tool => {
+      expect(isEssentialTool(tool)).toBe(true)
+    })
+
+    it('bash is treated as essential (side-effecting by default)', () => {
+      // Design choice: bash is always shown; a follow-up can refine with hasSideEffect
+      expect(isEssentialTool('bash')).toBe(true)
+    })
+
+    it('unknown / MCP tools are essential (shown)', () => {
+      expect(isEssentialTool('some_mcp_tool')).toBe(true)
+      expect(isEssentialTool('mcp_search')).toBe(true)
+    })
+  })
+
+  describe('non-essential (hidden) tools', () => {
+    it.each(['read', 'grep', 'glob', 'list'])('%s is non-essential', tool => {
+      expect(isEssentialTool(tool)).toBe(false)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatToolPart — integration (summarizeTool + isEssentialTool combined)
+// ---------------------------------------------------------------------------
+
+describe('formatToolPart', () => {
+  it('returns the summary string for an essential tool', () => {
+    const part = completedTool('edit', {
+      filePath: 'src/app.ts',
+      newString: 'a\nb',
+      oldString: 'c',
+    })
+    const result = formatToolPart(part)
+    expect(result).toBe('*app.ts* (+2-1)')
+  })
+
+  it('returns null for a non-essential (hidden) tool', () => {
+    const part = completedTool('read', {filePath: 'src/app.ts'})
+    expect(formatToolPart(part)).toBeNull()
+  })
+
+  it('returns null for grep (hidden)', () => {
+    const part = completedTool('grep', {pattern: 'TODO'})
+    expect(formatToolPart(part)).toBeNull()
+  })
+
+  it('returns a summary for bash (essential)', () => {
+    const part = completedTool('bash', {command: 'git status'})
+    expect(formatToolPart(part)).not.toBeNull()
+  })
+
+  it('returns null for a non-essential error-status tool', () => {
+    const part = errorTool('read', {filePath: 'src/foo.ts'})
+    expect(formatToolPart(part)).toBeNull()
+  })
+
+  it('returns an error-prefixed summary for an essential error-status tool', () => {
+    const part = errorTool('edit', {filePath: 'src/app.ts', newString: 'a', oldString: 'b'})
+    const result = formatToolPart(part)
+    expect(result).not.toBeNull()
+    expect(result).toContain('⨯')
+  })
+})

--- a/packages/gateway/src/execute/format-part.ts
+++ b/packages/gateway/src/execute/format-part.ts
@@ -3,7 +3,8 @@
  *
  * Turns an extracted tool shape into a clean Discord summary line:
  * - Essential tool → one-line summary string
- * - Non-essential (read-only) tool → null (caller appends nothing)
+ * - Non-essential (read-only) tool, successful → null (caller appends nothing)
+ * - Non-essential (read-only) tool, errored → terse error line (aids debugging)
  *
  * No SDK imports. No Discord imports. Pure functions only.
  *
@@ -20,13 +21,7 @@
 /**
  * The extracted tool shape that run-core.ts pulls from a completed tool part.
  *
- * Field mapping (from run-core.ts lines ~315-340):
- *   tool        ← part.tool (string)
- *   state.title ← getStringProperty(toolState, 'title')
- *   state.input ← getObjectProperty(toolState, 'input')
- *   state.status← getStringProperty(toolState, 'status')
- *
- * Specific input fields consumed per tool:
+ * Fields consumed per tool:
  *   edit        → state.input.filePath, state.input.newString, state.input.oldString
  *   write       → state.input.filePath, state.input.content
  *   apply_patch → state.input.patchText
@@ -53,10 +48,34 @@ const MAX_MCP_ARG_LENGTH = 50
 const ERROR_GLYPH = '⨯'
 
 /**
- * Tools that are always hidden (non-essential / read-only).
+ * Tools that are always hidden (non-essential / read-only) when successful.
  * Everything NOT in this set is treated as essential (shown).
+ * Errored hidden tools still render a terse error line for debugging.
  */
 const HIDDEN_TOOLS = new Set(['read', 'grep', 'glob', 'list'])
+
+/**
+ * Read-only bash command prefixes that are hidden like other read-only tools.
+ * Matched against the first command token (leading word) of the bash command.
+ * If uncertain or compound, treat as essential (shown) — conservative default.
+ */
+const READ_ONLY_BASH_PREFIXES = new Set([
+  'git ls-files',
+  'git status',
+  'git log',
+  'git diff',
+  'ls',
+  'cat',
+  'find',
+  'grep',
+  'rg',
+  'pwd',
+  'head',
+  'tail',
+  'wc',
+  'which',
+  'echo',
+])
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -92,13 +111,33 @@ function str(input: Record<string, unknown> | undefined, key: string): string {
   return typeof val === 'string' ? val : ''
 }
 
+/**
+ * Returns true if the bash command is read-only (should be hidden like other read-only tools).
+ * Matches on the first command token or known multi-word read-only prefixes.
+ * Conservative: if uncertain, returns false (treat as essential = shown).
+ */
+function isReadOnlyBashCommand(command: string): boolean {
+  const trimmed = command.trim()
+  // Check multi-word prefixes first (e.g. "git ls-files", "git status")
+  for (const prefix of READ_ONLY_BASH_PREFIXES) {
+    if (trimmed === prefix || trimmed.startsWith(`${prefix} `) || trimmed.startsWith(`${prefix}\t`)) {
+      return true
+    }
+  }
+  return false
+}
+
 // ---------------------------------------------------------------------------
-// Patch line-count parser (minimal — counts +/- lines in unified diff)
+// Patch line-count parser
 // ---------------------------------------------------------------------------
 
 /**
- * Count added and removed lines in a unified diff patch text.
- * Returns { additions, deletions } for the first file found.
+ * Count added and removed lines in a patch text.
+ *
+ * Supports two formats:
+ * 1. Unified diff (`+++ b/file` headers) — standard git/diff output
+ * 2. OpenCode `*** Begin Patch` / `*** Update File:` envelope — OpenCode's apply_patch format
+ *
  * Falls back to { additions: 0, deletions: 0 } if unparseable.
  */
 function parsePatchCounts(patchText: string): {
@@ -112,17 +151,25 @@ function parsePatchCounts(patchText: string): {
   let deletions = 0
 
   for (const line of patchText.split('\n')) {
-    if (line.startsWith('+++ b/') || line.startsWith('+++ ')) {
-      // Flush previous file if any
+    // OpenCode envelope: *** Update File: path/to/file
+    if (line.startsWith('*** Update File:')) {
+      if (currentFile !== '') {
+        results.push({fileName: basename(currentFile), additions, deletions})
+      }
+      currentFile = line.replace(/^\*\*\* Update File:\s*/, '').trim()
+      additions = 0
+      deletions = 0
+    } else if (line.startsWith('+++ b/') || line.startsWith('+++ ')) {
+      // Unified diff header
       if (currentFile !== '') {
         results.push({fileName: basename(currentFile), additions, deletions})
       }
       currentFile = line.replace(/^\+\+\+ (?:b\/)?/, '')
       additions = 0
       deletions = 0
-    } else if (line.startsWith('+') && !line.startsWith('+++')) {
+    } else if (line.startsWith('+') && !line.startsWith('+++') && !line.startsWith('*** ')) {
       additions++
-    } else if (line.startsWith('-') && !line.startsWith('---')) {
+    } else if (line.startsWith('-') && !line.startsWith('---') && !line.startsWith('*** ')) {
       deletions++
     }
   }
@@ -142,11 +189,9 @@ function parsePatchCounts(patchText: string): {
 /**
  * Returns true if the tool should be shown in the Discord output.
  *
- * Design choice: bash is always treated as essential (shown). A follow-up
- * can refine this with a `hasSideEffect` field check if needed.
- *
  * Hidden tools: read, grep, glob, list.
- * Everything else (edit, write, apply_patch, bash, skill, task, MCP, unknown) → shown.
+ * Read-only bash commands are also hidden (see isReadOnlyBashCommand).
+ * Everything else (edit, write, apply_patch, side-effecting bash, skill, task, MCP, unknown) → shown.
  */
 export function isEssentialTool(tool: string): boolean {
   return !HIDDEN_TOOLS.has(tool)
@@ -160,8 +205,8 @@ export function isEssentialTool(tool: string): boolean {
  * Summarize a completed (or errored) tool part into a single Discord line.
  *
  * Returns:
- * - `null`   — tool is non-essential (hidden); caller appends nothing
- * - `string` — one-line summary to append
+ * - `null`   — tool is non-essential (hidden) AND successful; caller appends nothing
+ * - `string` — one-line summary to append (essential tools, or errored hidden tools)
  *
  * Never throws on unexpected input shapes — unknown/malformed parts degrade
  * to a safe minimal summary or null.
@@ -170,12 +215,26 @@ export function summarizeTool(part: ExtractedToolPart): string | null {
   const {tool, state} = part
   const {input, title, status} = state
 
-  // Hidden tools → null regardless of status
+  const isError = status === 'error'
+
+  // Hidden tools (read, grep, glob, list): successful → null; errored → terse error line
   if (!isEssentialTool(tool)) {
+    if (isError) {
+      // Terse error line: ⨯ <tool>: <target> (no raw content)
+      const target = str(input, 'filePath') || str(input, 'pattern') || str(input, 'path') || str(input, 'query')
+      return target.length > 0 ? `${ERROR_GLYPH} ${tool}: ${target}` : `${ERROR_GLYPH} ${tool}`
+    }
     return null
   }
 
-  const isError = status === 'error'
+  // Read-only bash: hide successful invocations (same as hidden tools).
+  // Side-effecting bash stays shown. Errored read-only bash still shows (debugging aid).
+  if (tool === 'bash' && !isError) {
+    const command = str(input, 'command') || str(input, 'cmd')
+    if (command.length > 0 && isReadOnlyBashCommand(command)) {
+      return null
+    }
+  }
 
   // Compute the core summary text (without error prefix)
   const summary = computeSummary(tool, input, title)
@@ -197,11 +256,11 @@ function computeSummary(tool: string, input: Record<string, unknown> | undefined
   if (tool === 'edit') {
     const filePath = str(input, 'filePath')
     const fileName = basename(filePath)
-    if (!fileName) return tool
+    if (fileName.length === 0) return tool
     const newString = str(input, 'newString')
     const oldString = str(input, 'oldString')
-    const added = newString ? newString.split('\n').length : 0
-    const removed = oldString ? oldString.split('\n').length : 0
+    const added = newString.length > 0 ? newString.split('\n').length : 0
+    const removed = oldString.length > 0 ? oldString.split('\n').length : 0
     return `*${escapeInlineMarkdown(fileName)}* (+${added}-${removed})`
   }
 
@@ -209,21 +268,23 @@ function computeSummary(tool: string, input: Record<string, unknown> | undefined
   if (tool === 'write') {
     const filePath = str(input, 'filePath')
     const fileName = basename(filePath)
-    if (!fileName) return tool
+    if (fileName.length === 0) return tool
     const content = str(input, 'content')
-    const lines = content ? content.split('\n').length : 0
+    const lines = content.length > 0 ? content.split('\n').length : 0
     return `*${escapeInlineMarkdown(fileName)}* (${lines} ${lines === 1 ? 'line' : 'lines'})`
   }
 
   // --- apply_patch ---
   if (tool === 'apply_patch') {
     const patchText = str(input, 'patchText')
-    if (!patchText) return tool
+    if (patchText.length === 0) return tool
     const files = parsePatchCounts(patchText)
     if (files.length === 0) return tool
     return files
       .map(({fileName, additions, deletions}) =>
-        fileName ? `*${escapeInlineMarkdown(fileName)}* (+${additions}-${deletions})` : `(+${additions}-${deletions})`,
+        fileName.length > 0
+          ? `*${escapeInlineMarkdown(fileName)}* (+${additions}-${deletions})`
+          : `(+${additions}-${deletions})`,
       )
       .join(', ')
   }
@@ -232,7 +293,9 @@ function computeSummary(tool: string, input: Record<string, unknown> | undefined
   if (tool === 'bash') {
     const command = str(input, 'command') || str(input, 'cmd')
     const description = str(input, 'description')
-    if (command) {
+    if (command.length > 0) {
+      // Read-only bash commands are hidden (return tool name as minimal fallback;
+      // caller checks isEssentialTool separately — this path is only reached for essential tools)
       const isSingleLine = !command.includes('\n')
       if (isSingleLine && command.length <= MAX_BASH_COMMAND_INLINE_LENGTH) {
         return `\`${command}\``
@@ -245,13 +308,13 @@ function computeSummary(tool: string, input: Record<string, unknown> | undefined
   // --- skill ---
   if (tool === 'skill') {
     const name = str(input, 'name')
-    return name ? `_${escapeInlineMarkdown(name)}_` : tool
+    return name.length > 0 ? `_${escapeInlineMarkdown(name)}_` : tool
   }
 
   // --- task (subagent) ---
   if (tool === 'task') {
     const description = str(input, 'description') || str(input, 'prompt')
-    if (description) return `task: ${description}`
+    if (description.length > 0) return `task: ${description}`
     return title !== undefined && title.length > 0 ? title : tool
   }
 
@@ -261,7 +324,7 @@ function computeSummary(tool: string, input: Record<string, unknown> | undefined
     return title.length > MAX_MCP_ARG_LENGTH ? `${title.slice(0, MAX_MCP_ARG_LENGTH)}…` : title
   }
 
-  if (input && Object.keys(input).length > 0) {
+  if (input !== undefined && Object.keys(input).length > 0) {
     const fields = Object.entries(input)
       .map(([key, value]) => {
         if (value === null || value === undefined) return null
@@ -286,13 +349,24 @@ function computeSummary(tool: string, input: Record<string, unknown> | undefined
 // ---------------------------------------------------------------------------
 
 /**
- * The primary entry point for the wiring layer (Unit 2).
+ * The primary entry point for the wiring layer.
  *
  * Returns the summary string to append for an essential tool, or null to
- * append nothing (hidden tool or non-essential).
+ * append nothing (successful hidden tool).
+ * Errored hidden tools return a terse error line for debugging.
  *
  * This is a pure function — no SDK imports, no Discord imports.
  */
 export function formatToolPart(part: ExtractedToolPart): string | null {
   return summarizeTool(part)
 }
+
+// ---------------------------------------------------------------------------
+// isReadOnlyBash — exported for testing
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the bash command is read-only (should be hidden).
+ * Exported for testing; run-core.ts uses this via formatToolPart indirectly.
+ */
+export {isReadOnlyBashCommand}

--- a/packages/gateway/src/execute/format-part.ts
+++ b/packages/gateway/src/execute/format-part.ts
@@ -1,0 +1,298 @@
+/**
+ * Pure tool-part renderer for the Discord mention loop.
+ *
+ * Turns an extracted tool shape into a clean Discord summary line:
+ * - Essential tool → one-line summary string
+ * - Non-essential (read-only) tool → null (caller appends nothing)
+ *
+ * No SDK imports. No Discord imports. Pure functions only.
+ *
+ * Rendering logic ported from Kimaki (remorses/kimaki, MIT):
+ *   cli/src/message-formatting.ts  — getToolSummaryText, formatPart
+ *   cli/src/session-handler/thread-session-runtime.ts — isEssentialToolName
+ * Adapted to our extracted tool shape (not Kimaki's Part types).
+ */
+
+// ---------------------------------------------------------------------------
+// Input shape
+// ---------------------------------------------------------------------------
+
+/**
+ * The extracted tool shape that run-core.ts pulls from a completed tool part.
+ *
+ * Field mapping (from run-core.ts lines ~315-340):
+ *   tool        ← part.tool (string)
+ *   state.title ← getStringProperty(toolState, 'title')
+ *   state.input ← getObjectProperty(toolState, 'input')
+ *   state.status← getStringProperty(toolState, 'status')
+ *
+ * Specific input fields consumed per tool:
+ *   edit        → state.input.filePath, state.input.newString, state.input.oldString
+ *   write       → state.input.filePath, state.input.content
+ *   apply_patch → state.input.patchText
+ *   bash        → state.input.command (or state.input.cmd), state.input.description
+ *   skill       → state.input.name
+ *   task        → state.input.description
+ *   MCP/unknown → all state.input fields (truncated)
+ */
+export interface ExtractedToolPart {
+  readonly tool: string
+  readonly state: {
+    readonly input?: Record<string, unknown>
+    readonly title?: string
+    readonly status: 'completed' | 'error'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_BASH_COMMAND_INLINE_LENGTH = 100
+const MAX_MCP_ARG_LENGTH = 50
+const ERROR_GLYPH = '⨯'
+
+/**
+ * Tools that are always hidden (non-essential / read-only).
+ * Everything NOT in this set is treated as essential (shown).
+ */
+const HIDDEN_TOOLS = new Set(['read', 'grep', 'glob', 'list'])
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape Discord inline markdown special characters so dynamic content
+ * doesn't break formatting when wrapped in *, _, **, etc.
+ */
+function escapeInlineMarkdown(text: string): string {
+  return text.replaceAll(/([*_~|`\\])/g, String.raw`\$1`)
+}
+
+/**
+ * Normalize whitespace: convert newlines to spaces and collapse consecutive spaces.
+ */
+function normalizeWhitespace(text: string): string {
+  return text.replaceAll(/[\r\n]+/g, ' ').replaceAll(/\s+/g, ' ')
+}
+
+/**
+ * Extract the basename from a file path (last path segment).
+ */
+function basename(filePath: string): string {
+  return filePath.split('/').pop() ?? ''
+}
+
+/**
+ * Safely read a string property from an unknown input object.
+ */
+function str(input: Record<string, unknown> | undefined, key: string): string {
+  const val = input?.[key]
+  return typeof val === 'string' ? val : ''
+}
+
+// ---------------------------------------------------------------------------
+// Patch line-count parser (minimal — counts +/- lines in unified diff)
+// ---------------------------------------------------------------------------
+
+/**
+ * Count added and removed lines in a unified diff patch text.
+ * Returns { additions, deletions } for the first file found.
+ * Falls back to { additions: 0, deletions: 0 } if unparseable.
+ */
+function parsePatchCounts(patchText: string): {
+  fileName: string
+  additions: number
+  deletions: number
+}[] {
+  const results: {fileName: string; additions: number; deletions: number}[] = []
+  let currentFile = ''
+  let additions = 0
+  let deletions = 0
+
+  for (const line of patchText.split('\n')) {
+    if (line.startsWith('+++ b/') || line.startsWith('+++ ')) {
+      // Flush previous file if any
+      if (currentFile !== '') {
+        results.push({fileName: basename(currentFile), additions, deletions})
+      }
+      currentFile = line.replace(/^\+\+\+ (?:b\/)?/, '')
+      additions = 0
+      deletions = 0
+    } else if (line.startsWith('+') && !line.startsWith('+++')) {
+      additions++
+    } else if (line.startsWith('-') && !line.startsWith('---')) {
+      deletions++
+    }
+  }
+
+  // Flush last file
+  if (currentFile !== '') {
+    results.push({fileName: basename(currentFile), additions, deletions})
+  }
+
+  return results
+}
+
+// ---------------------------------------------------------------------------
+// isEssentialTool
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the tool should be shown in the Discord output.
+ *
+ * Design choice: bash is always treated as essential (shown). A follow-up
+ * can refine this with a `hasSideEffect` field check if needed.
+ *
+ * Hidden tools: read, grep, glob, list.
+ * Everything else (edit, write, apply_patch, bash, skill, task, MCP, unknown) → shown.
+ */
+export function isEssentialTool(tool: string): boolean {
+  return !HIDDEN_TOOLS.has(tool)
+}
+
+// ---------------------------------------------------------------------------
+// summarizeTool
+// ---------------------------------------------------------------------------
+
+/**
+ * Summarize a completed (or errored) tool part into a single Discord line.
+ *
+ * Returns:
+ * - `null`   — tool is non-essential (hidden); caller appends nothing
+ * - `string` — one-line summary to append
+ *
+ * Never throws on unexpected input shapes — unknown/malformed parts degrade
+ * to a safe minimal summary or null.
+ */
+export function summarizeTool(part: ExtractedToolPart): string | null {
+  const {tool, state} = part
+  const {input, title, status} = state
+
+  // Hidden tools → null regardless of status
+  if (!isEssentialTool(tool)) {
+    return null
+  }
+
+  const isError = status === 'error'
+
+  // Compute the core summary text (without error prefix)
+  const summary = computeSummary(tool, input, title)
+
+  if (isError) {
+    // Error: prefix with glyph, still summarized
+    return `${ERROR_GLYPH} ${summary}`
+  }
+
+  return summary
+}
+
+/**
+ * Compute the core summary string for a tool (no error prefix).
+ * Falls back to the tool name if no meaningful summary can be produced.
+ */
+function computeSummary(tool: string, input: Record<string, unknown> | undefined, title: string | undefined): string {
+  // --- edit ---
+  if (tool === 'edit') {
+    const filePath = str(input, 'filePath')
+    const fileName = basename(filePath)
+    if (!fileName) return tool
+    const newString = str(input, 'newString')
+    const oldString = str(input, 'oldString')
+    const added = newString ? newString.split('\n').length : 0
+    const removed = oldString ? oldString.split('\n').length : 0
+    return `*${escapeInlineMarkdown(fileName)}* (+${added}-${removed})`
+  }
+
+  // --- write ---
+  if (tool === 'write') {
+    const filePath = str(input, 'filePath')
+    const fileName = basename(filePath)
+    if (!fileName) return tool
+    const content = str(input, 'content')
+    const lines = content ? content.split('\n').length : 0
+    return `*${escapeInlineMarkdown(fileName)}* (${lines} ${lines === 1 ? 'line' : 'lines'})`
+  }
+
+  // --- apply_patch ---
+  if (tool === 'apply_patch') {
+    const patchText = str(input, 'patchText')
+    if (!patchText) return tool
+    const files = parsePatchCounts(patchText)
+    if (files.length === 0) return tool
+    return files
+      .map(({fileName, additions, deletions}) =>
+        fileName ? `*${escapeInlineMarkdown(fileName)}* (+${additions}-${deletions})` : `(+${additions}-${deletions})`,
+      )
+      .join(', ')
+  }
+
+  // --- bash ---
+  if (tool === 'bash') {
+    const command = str(input, 'command') || str(input, 'cmd')
+    const description = str(input, 'description')
+    if (command) {
+      const isSingleLine = !command.includes('\n')
+      if (isSingleLine && command.length <= MAX_BASH_COMMAND_INLINE_LENGTH) {
+        return `\`${command}\``
+      }
+      return description.length > 0 ? description : (title ?? tool)
+    }
+    return description.length > 0 ? description : (title ?? tool)
+  }
+
+  // --- skill ---
+  if (tool === 'skill') {
+    const name = str(input, 'name')
+    return name ? `_${escapeInlineMarkdown(name)}_` : tool
+  }
+
+  // --- task (subagent) ---
+  if (tool === 'task') {
+    const description = str(input, 'description') || str(input, 'prompt')
+    if (description) return `task: ${description}`
+    return title !== undefined && title.length > 0 ? title : tool
+  }
+
+  // --- unknown / MCP fallback ---
+  // Minimal truncated summary — never a raw dump
+  if (title !== undefined && title.length > 0) {
+    return title.length > MAX_MCP_ARG_LENGTH ? `${title.slice(0, MAX_MCP_ARG_LENGTH)}…` : title
+  }
+
+  if (input && Object.keys(input).length > 0) {
+    const fields = Object.entries(input)
+      .map(([key, value]) => {
+        if (value === null || value === undefined) return null
+        const stringValue = typeof value === 'string' ? value : JSON.stringify(value)
+        const normalized = normalizeWhitespace(stringValue)
+        const truncated =
+          normalized.length > MAX_MCP_ARG_LENGTH ? `${normalized.slice(0, MAX_MCP_ARG_LENGTH)}…` : normalized
+        return `${key}: ${truncated}`
+      })
+      .filter((f): f is string => f !== null)
+
+    if (fields.length > 0) {
+      return `(${fields.join(', ')})`
+    }
+  }
+
+  return tool
+}
+
+// ---------------------------------------------------------------------------
+// formatToolPart — combined entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * The primary entry point for the wiring layer (Unit 2).
+ *
+ * Returns the summary string to append for an essential tool, or null to
+ * append nothing (hidden tool or non-essential).
+ *
+ * This is a pure function — no SDK imports, no Discord imports.
+ */
+export function formatToolPart(part: ExtractedToolPart): string | null {
+  return summarizeTool(part)
+}

--- a/packages/gateway/src/execute/prompt.test.ts
+++ b/packages/gateway/src/execute/prompt.test.ts
@@ -4,7 +4,7 @@
 
 import {describe, expect, it} from 'vitest'
 
-import {buildDiscordPrompt, EmptyPromptError} from './prompt.js'
+import {buildDiscordPrompt, DISCORD_MECHANICAL_GUIDANCE, EmptyPromptError} from './prompt.js'
 
 describe('buildDiscordPrompt', () => {
   describe('happy path', () => {
@@ -25,12 +25,152 @@ describe('buildDiscordPrompt', () => {
       expect(result).not.toContain('  Fix')
     })
 
-    it('structures prompt with repo header then user text', () => {
+    it('structures prompt with mechanical guidance then repo header then user text (no persona)', () => {
       // #given / #when
       const result = buildDiscordPrompt({messageText: 'Do the thing', owner: 'org', repo: 'myrepo'})
 
-      // #then
-      expect(result).toBe('Repository: org/myrepo\n\nDo the thing')
+      // #then — mechanical guidance + repo + message, in that order
+      const guidanceIdx = result.indexOf(DISCORD_MECHANICAL_GUIDANCE)
+      const repoIdx = result.indexOf('Repository: org/myrepo')
+      const msgIdx = result.indexOf('Do the thing')
+      expect(guidanceIdx).toBeGreaterThanOrEqual(0)
+      expect(repoIdx).toBeGreaterThan(guidanceIdx)
+      expect(msgIdx).toBeGreaterThan(repoIdx)
+    })
+  })
+
+  describe('persona composition', () => {
+    it('happy path: persona present → prompt is persona + mechanical guidance + repo + message, in order', () => {
+      // #given
+      const persona = 'You are Fro Bot, a capable engineering assistant.'
+
+      // #when
+      const result = buildDiscordPrompt({
+        messageText: 'List the files',
+        owner: 'org',
+        repo: 'myrepo',
+        persona,
+      })
+
+      // #then — persona first, then guidance, then repo, then message
+      const personaIdx = result.indexOf(persona)
+      const guidanceIdx = result.indexOf(DISCORD_MECHANICAL_GUIDANCE)
+      const repoIdx = result.indexOf('Repository: org/myrepo')
+      const msgIdx = result.indexOf('List the files')
+
+      expect(personaIdx).toBeGreaterThanOrEqual(0)
+      expect(guidanceIdx).toBeGreaterThan(personaIdx)
+      expect(repoIdx).toBeGreaterThan(guidanceIdx)
+      expect(msgIdx).toBeGreaterThan(repoIdx)
+    })
+
+    it('edge (R4 fail-soft): persona absent → mechanical guidance + repo + message, no error', () => {
+      // #given — no persona param
+
+      // #when / #then — must not throw
+      expect(() => buildDiscordPrompt({messageText: 'Do the thing', owner: 'org', repo: 'myrepo'})).not.toThrow()
+
+      const result = buildDiscordPrompt({messageText: 'Do the thing', owner: 'org', repo: 'myrepo'})
+      expect(result).toContain(DISCORD_MECHANICAL_GUIDANCE)
+      expect(result).toContain('Repository: org/myrepo')
+      expect(result).toContain('Do the thing')
+    })
+
+    it('edge (R4 fail-soft): persona null → mechanical guidance + repo + message, no error', () => {
+      // #given
+      const result = buildDiscordPrompt({
+        messageText: 'Do the thing',
+        owner: 'org',
+        repo: 'myrepo',
+        persona: null,
+      })
+
+      // #then — no persona section, guidance still present
+      expect(result).toContain(DISCORD_MECHANICAL_GUIDANCE)
+      expect(result).toContain('Repository: org/myrepo')
+      expect(result).toContain('Do the thing')
+    })
+
+    it('edge (R4 fail-soft): persona empty string → treated as absent, no error', () => {
+      // #given
+      const result = buildDiscordPrompt({
+        messageText: 'Do the thing',
+        owner: 'org',
+        repo: 'myrepo',
+        persona: '',
+      })
+
+      // #then — empty persona is ignored; guidance still present
+      expect(result).toContain(DISCORD_MECHANICAL_GUIDANCE)
+      expect(result).toContain('Repository: org/myrepo')
+      expect(result).toContain('Do the thing')
+    })
+
+    it('edge (R4 fail-soft): persona whitespace-only → treated as absent, no error', () => {
+      // #given
+      const result = buildDiscordPrompt({
+        messageText: 'Do the thing',
+        owner: 'org',
+        repo: 'myrepo',
+        persona: '   \n  ',
+      })
+
+      // #then — whitespace-only persona is ignored
+      expect(result).toContain(DISCORD_MECHANICAL_GUIDANCE)
+      expect(result).toContain('Repository: org/myrepo')
+      expect(result).toContain('Do the thing')
+    })
+
+    it('edge: user message is preserved verbatim after prepended sections', () => {
+      // #given — message with special characters and formatting
+      const verbatimMessage = 'Fix `src/foo.ts` — it has a bug on line 42!\n\nDetails:\n- step 1\n- step 2'
+
+      // #when
+      const result = buildDiscordPrompt({
+        messageText: verbatimMessage,
+        owner: 'org',
+        repo: 'myrepo',
+        persona: 'You are Fro Bot.',
+      })
+
+      // #then — the message appears verbatim at the end
+      expect(result.endsWith(verbatimMessage)).toBe(true)
+    })
+
+    it('happy path (SC2): composed prompt contains the long-enumeration response policy', () => {
+      // #given / #when
+      const result = buildDiscordPrompt({
+        messageText: 'What files are in this repo?',
+        owner: 'org',
+        repo: 'myrepo',
+      })
+
+      // #then — the guidance must instruct the agent to summarize/attach long lists
+      // This is the SC2 resolution: hiding the tool line alone is not enough.
+      expect(result).toMatch(/summarize|attach/i)
+      expect(result).toMatch(/inline/i)
+    })
+
+    it('happy path (SC2): guidance explicitly addresses long enumerations (file lists, search results, logs)', () => {
+      // #given / #when — assert the DISCORD_MECHANICAL_GUIDANCE constant itself carries the policy
+      expect(DISCORD_MECHANICAL_GUIDANCE).toMatch(/summarize|attach/i)
+      expect(DISCORD_MECHANICAL_GUIDANCE).toMatch(/inline/i)
+    })
+  })
+
+  describe('bot mention stripping (unchanged behavior)', () => {
+    it('strips leading bot mention when botUserId is provided', () => {
+      // #given / #when
+      const result = buildDiscordPrompt({
+        messageText: '<@123> Fix the bug',
+        owner: 'org',
+        repo: 'repo',
+        botUserId: '123',
+      })
+
+      // #then — mention stripped, message preserved
+      expect(result).toContain('Fix the bug')
+      expect(result).not.toContain('<@123>')
     })
   })
 

--- a/packages/gateway/src/execute/prompt.test.ts
+++ b/packages/gateway/src/execute/prompt.test.ts
@@ -40,7 +40,7 @@ describe('buildDiscordPrompt', () => {
   })
 
   describe('persona composition', () => {
-    it('happy path: persona present → prompt is persona + mechanical guidance + repo + message, in order', () => {
+    it('happy path: persona present → prompt is scoped-persona + mechanical guidance + repo + message, in order', () => {
       // #given
       const persona = 'You are Fro Bot, a capable engineering assistant.'
 
@@ -52,7 +52,7 @@ describe('buildDiscordPrompt', () => {
         persona,
       })
 
-      // #then — persona first, then guidance, then repo, then message
+      // #then — scoped persona first, then guidance, then repo, then message
       const personaIdx = result.indexOf(persona)
       const guidanceIdx = result.indexOf(DISCORD_MECHANICAL_GUIDANCE)
       const repoIdx = result.indexOf('Repository: org/myrepo')
@@ -62,6 +62,27 @@ describe('buildDiscordPrompt', () => {
       expect(guidanceIdx).toBeGreaterThan(personaIdx)
       expect(repoIdx).toBeGreaterThan(guidanceIdx)
       expect(msgIdx).toBeGreaterThan(repoIdx)
+    })
+
+    it('persona scoping: persona is wrapped in a voice/style-only header so it cannot override Discord guidance', () => {
+      // #given
+      const persona = 'You are Fro Bot.'
+
+      // #when
+      const result = buildDiscordPrompt({
+        messageText: 'Do the thing',
+        owner: 'org',
+        repo: 'myrepo',
+        persona,
+      })
+
+      // #then — persona is wrapped in a scoped header
+      expect(result).toContain('--- Persona (voice and style only) ---')
+      expect(result).toContain('--- End Persona ---')
+      // Discord guidance appears AFTER the persona section
+      const personaSectionEnd = result.indexOf('--- End Persona ---')
+      const guidanceIdx = result.indexOf(DISCORD_MECHANICAL_GUIDANCE)
+      expect(guidanceIdx).toBeGreaterThan(personaSectionEnd)
     })
 
     it('edge (R4 fail-soft): persona absent → mechanical guidance + repo + message, no error', () => {
@@ -155,6 +176,42 @@ describe('buildDiscordPrompt', () => {
       // #given / #when — assert the DISCORD_MECHANICAL_GUIDANCE constant itself carries the policy
       expect(DISCORD_MECHANICAL_GUIDANCE).toMatch(/summarize|attach/i)
       expect(DISCORD_MECHANICAL_GUIDANCE).toMatch(/inline/i)
+    })
+
+    it('persona wiring (P2.8): non-empty persona flows into the built prompt', () => {
+      // #given — persona provided via deps
+      const persona = 'You are Fro Bot, a capable engineering assistant. Be direct.'
+
+      // #when
+      const result = buildDiscordPrompt({
+        messageText: 'Fix the bug',
+        owner: 'org',
+        repo: 'myrepo',
+        persona,
+      })
+
+      // #then — persona content appears in the prompt
+      expect(result).toContain(persona)
+      // And the scoped header is present
+      expect(result).toContain('--- Persona (voice and style only) ---')
+    })
+
+    it('persona wiring (P2.8): null persona → prompt contains only guidance + repo + message', () => {
+      // #given — null persona (config.persona is null when unset)
+
+      // #when
+      const result = buildDiscordPrompt({
+        messageText: 'Fix the bug',
+        owner: 'org',
+        repo: 'myrepo',
+        persona: null,
+      })
+
+      // #then — no persona section in prompt
+      expect(result).not.toContain('--- Persona')
+      expect(result).toContain(DISCORD_MECHANICAL_GUIDANCE)
+      expect(result).toContain('Repository: org/myrepo')
+      expect(result).toContain('Fix the bug')
     })
   })
 

--- a/packages/gateway/src/execute/prompt.ts
+++ b/packages/gateway/src/execute/prompt.ts
@@ -6,6 +6,21 @@
  * formatting concerns.
  */
 
+/**
+ * Discord-mechanical guidance prepended to every mention prompt.
+ *
+ * Instructs the agent on chat-appropriate behavior:
+ * - Concise, direct responses (no process narration)
+ * - Chat-native formatting (markdown, code blocks)
+ * - SC2 resolution: summarize or attach long enumerations — never paste raw lists inline
+ * - Persona anti-patterns: no sycophancy, no sign-offs, no apologies
+ */
+export const DISCORD_MECHANICAL_GUIDANCE = `You are responding in a Discord thread. Follow these rules:
+- Be concise and direct. Do not narrate your internal process or reasoning steps.
+- Format for chat: use markdown, code blocks for code, short paragraphs.
+- For long enumerations (file lists, search results, logs, command output): summarize the key points or attach the full content — never paste a long raw list inline.
+- No sycophancy, no sign-offs, no apologies. Get to the point.`
+
 /** Parameters for building a Discord agent prompt. */
 export interface DiscordPromptParams {
   /** Raw message text from the Discord mention (treated as untrusted input). */
@@ -21,6 +36,12 @@ export interface DiscordPromptParams {
    * dispatching a no-op run.
    */
   readonly botUserId?: string
+  /**
+   * Optional canonical persona text (e.g. from `GATEWAY_PERSONA_FILE`).
+   * When present and non-empty, prepended before the Discord-mechanical guidance.
+   * Absent, null, empty, or whitespace-only → omitted (fail-soft).
+   */
+  readonly persona?: string | null
 }
 
 /**
@@ -53,21 +74,48 @@ function stripLeadingMentions(text: string, botUserId: string): string {
 }
 
 /**
- * Build a minimal Discord prompt for the OpenCode agent.
+ * Build a Discord prompt for the OpenCode agent.
+ *
+ * Composition order (persona-then-task, mirrors Action-tier layering):
+ * 1. Persona (if present and non-empty) — canonical Fro Bot voice
+ * 2. Discord-mechanical guidance — conciseness, formatting, SC2 long-enumeration policy
+ * 3. Repository context — `Repository: owner/repo`
+ * 4. User message — verbatim (after stripping leading bot-mention tokens)
  *
  * The user text is stripped of leading bot-mention tokens (e.g. `<@1234>`)
  * and trimmed before use. If the remaining text is empty, `EmptyPromptError`
  * is thrown so callers can reply with a coarse "nothing to do" message
  * without dispatching a run.
  *
+ * Fail-soft: missing/null/empty/whitespace-only persona → mechanical guidance
+ * + repo + message only (no error thrown).
+ *
  * @throws {EmptyPromptError} if `messageText` is empty, whitespace-only, or
  *   contains only bot mention token(s) after stripping.
  */
 export function buildDiscordPrompt(params: DiscordPromptParams): string {
-  const {messageText, owner, repo, botUserId} = params
+  const {messageText, owner, repo, botUserId, persona} = params
   const stripped = botUserId === undefined ? messageText.trim() : stripLeadingMentions(messageText, botUserId)
   if (stripped.length === 0) {
     throw new EmptyPromptError()
   }
-  return `Repository: ${owner}/${repo}\n\n${stripped}`
+
+  const sections: string[] = []
+
+  // 1. Persona (fail-soft: absent/null/empty/whitespace → omit)
+  const trimmedPersona = persona?.trim() ?? ''
+  if (trimmedPersona.length > 0) {
+    sections.push(trimmedPersona)
+  }
+
+  // 2. Discord-mechanical guidance (always present)
+  sections.push(DISCORD_MECHANICAL_GUIDANCE)
+
+  // 3. Repository context
+  sections.push(`Repository: ${owner}/${repo}`)
+
+  // 4. User message (verbatim after stripping)
+  sections.push(stripped)
+
+  return sections.join('\n\n')
 }

--- a/packages/gateway/src/execute/prompt.ts
+++ b/packages/gateway/src/execute/prompt.ts
@@ -103,12 +103,14 @@ export function buildDiscordPrompt(params: DiscordPromptParams): string {
   const sections: string[] = []
 
   // 1. Persona (fail-soft: absent/null/empty/whitespace → omit)
+  // Scoped with a header so the persona defines VOICE/STYLE only and cannot
+  // override the Discord-mechanical guidance that follows.
   const trimmedPersona = persona?.trim() ?? ''
   if (trimmedPersona.length > 0) {
-    sections.push(trimmedPersona)
+    sections.push(`--- Persona (voice and style only) ---\n${trimmedPersona}\n--- End Persona ---`)
   }
 
-  // 2. Discord-mechanical guidance (always present)
+  // 2. Discord-mechanical guidance (always present; takes precedence over persona)
   sections.push(DISCORD_MECHANICAL_GUIDANCE)
 
   // 3. Repository context

--- a/packages/gateway/src/execute/run-core.test.ts
+++ b/packages/gateway/src/execute/run-core.test.ts
@@ -161,6 +161,36 @@ function sessionIdleEvent(sessionID: string): object {
   return {type: 'session.idle', properties: {sessionID}}
 }
 
+/**
+ * Factory: `message.part.updated` with a reasoning part carrying an `id`.
+ * Used to register a reasoning partID in the suppression set (Unit 2 / R5).
+ */
+function reasoningPartUpdatedEvent(partId: string, sessionID = 'sess-123'): object {
+  return {
+    type: 'message.part.updated',
+    properties: {
+      sessionID,
+      part: {
+        type: 'reasoning',
+        id: partId,
+        sessionID,
+        text: 'I am thinking about this...',
+      },
+    },
+  }
+}
+
+/**
+ * Factory: `message.part.delta` with a specific `partID` in properties.
+ * Used to simulate both reasoning deltas (suppressed) and text deltas (passed through).
+ */
+function partDeltaWithPartId(text: string, partId: string, sessionID = 'sess-123'): object {
+  return {
+    type: 'message.part.delta',
+    properties: {sessionID, partID: partId, delta: {type: 'text', text}, field: 'text'},
+  }
+}
+
 /** `session.error` event for a given session. */
 function sessionErrorEvent(sessionID: string, error = 'LLM error'): object {
   return {type: 'session.error', properties: {sessionID, error}}
@@ -420,10 +450,9 @@ describe('runOpenCodeCore', () => {
       // #when
       await runOpenCodeCore(params)
 
-      // #then
+      // #then — summarizer renders bash command inline (not raw 🔧 format)
       const combined = sink.buffered()
       expect(combined).toContain('pnpm test')
-      expect(combined).toContain('bash')
     })
 
     it('uses input.cmd as fallback for bash when command is absent', async () => {
@@ -446,8 +475,8 @@ describe('runOpenCodeCore', () => {
       expect(sink.buffered()).toContain('ls -la')
     })
 
-    it('uses structured.title when present (wins over input.command)', async () => {
-      // #given
+    it('bash tool: input.command is shown inline (summarizer uses command, not structured.title)', async () => {
+      // #given — bash summarizer renders the command inline; structured.title is not used for bash
       const sink = makeSink()
       const handle = makeHandle({
         subscribe: async () =>
@@ -462,14 +491,12 @@ describe('runOpenCodeCore', () => {
       // #when
       await runOpenCodeCore(params)
 
-      // #then
-      expect(sink.buffered()).toContain('Structured Title')
-      // Should NOT fall through to the raw command
-      expect(sink.buffered()).not.toContain('some command')
+      // #then — bash summarizer renders the command inline
+      expect(sink.buffered()).toContain('some command')
     })
 
-    it('uses tool name as title for non-bash tools', async () => {
-      // #given
+    it('non-bash MCP tool: summarizer renders input fields as fallback', async () => {
+      // #given — read_file is not in the hidden-tools list; MCP fallback renders input fields
       const sink = makeSink()
       const handle = makeHandle({
         subscribe: async () =>
@@ -484,8 +511,9 @@ describe('runOpenCodeCore', () => {
       // #when
       await runOpenCodeCore(params)
 
-      // #then
-      expect(sink.buffered()).toContain('read_file')
+      // #then — MCP fallback renders input fields (not raw 🔧 format)
+      expect(sink.buffered()).toContain('path')
+      expect(sink.buffered()).not.toContain('🔧')
     })
 
     it('uses input.title when present for non-bash tools', async () => {
@@ -530,8 +558,8 @@ describe('runOpenCodeCore', () => {
   })
 
   describe('tool call progress (message.part.updated — OpenCode 1.15.13 contract)', () => {
-    it('appends a progress line for a bash tool using state.title', async () => {
-      // #given
+    it('appends a progress line for a bash tool using input.command', async () => {
+      // #given — bash summarizer renders the command inline (not the tool name)
       const sink = makeSink()
       const handle = makeHandle({
         subscribe: async () =>
@@ -545,9 +573,8 @@ describe('runOpenCodeCore', () => {
       // #when
       await runOpenCodeCore(params)
 
-      // #then
+      // #then — summarizer renders command inline
       const combined = sink.buffered()
-      expect(combined).toContain('bash')
       expect(combined).toContain('echo hi')
     })
 
@@ -589,8 +616,8 @@ describe('runOpenCodeCore', () => {
       expect(sink.buffered()).toContain('ls -la')
     })
 
-    it('uses tool name as title for non-bash tools when state.title is absent', async () => {
-      // #given
+    it('non-bash MCP tool: summarizer renders input fields as fallback when state.title is absent', async () => {
+      // #given — read_file is not in the hidden-tools list; MCP fallback renders input fields
       const sink = makeSink()
       const handle = makeHandle({
         subscribe: async () =>
@@ -604,8 +631,9 @@ describe('runOpenCodeCore', () => {
       // #when
       await runOpenCodeCore(params)
 
-      // #then
-      expect(sink.buffered()).toContain('read_file')
+      // #then — MCP fallback renders input fields (not raw 🔧 format)
+      expect(sink.buffered()).toContain('path')
+      expect(sink.buffered()).not.toContain('🔧')
     })
 
     it('does NOT emit a tool line for partType text (no double-render)', async () => {
@@ -1208,6 +1236,269 @@ describe('runOpenCodeCore', () => {
 
       // #then — subscribe fires before prompt
       expect(callOrder).toEqual(['subscribe', 'promptAsync'])
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Unit 2: Reasoning suppression (R5 regression) + tool summarizer wiring
+  // ---------------------------------------------------------------------------
+
+  describe('reasoning suppression — R5 regression (partID correlation)', () => {
+    it('(R5 critical) reasoning part registers its id; subsequent deltas with that partID → sink receives nothing', async () => {
+      // #given — reasoning part arrives first, then its deltas
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            reasoningPartUpdatedEvent('part-reasoning-1'),
+            partDeltaWithPartId('I am thinking step 1', 'part-reasoning-1'),
+            partDeltaWithPartId('I am thinking step 2', 'part-reasoning-1'),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — reasoning deltas must be fully suppressed
+      expect(sink._appended).toHaveLength(0)
+      expect(sink.buffered()).toBe('')
+    })
+
+    it('text delta whose partID is NOT a reasoning part → passes through unchanged', async () => {
+      // #given — no reasoning part registered; text delta with any partID passes through
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([partDeltaWithPartId('Hello from the answer', 'part-text-1'), sessionIdleEvent('sess-123')]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — text delta passes through
+      expect(sink._appended).toEqual(['Hello from the answer'])
+    })
+
+    it('interleaved: reasoning deltas suppressed, text deltas from different partID pass through', async () => {
+      // #given — realistic ordering: reasoning part registered, then interleaved deltas
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            // Reasoning part arrives first (registers the ID)
+            reasoningPartUpdatedEvent('part-reasoning-1'),
+            // Reasoning delta — must be suppressed
+            partDeltaWithPartId('chain of thought A', 'part-reasoning-1'),
+            // Text delta from a different part — must pass through
+            partDeltaWithPartId('real answer part 1', 'part-text-2'),
+            // Another reasoning delta — suppressed
+            partDeltaWithPartId('chain of thought B', 'part-reasoning-1'),
+            // More real answer — passes through
+            partDeltaWithPartId(' real answer part 2', 'part-text-2'),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — only the text deltas reach the sink
+      expect(sink._appended).toEqual(['real answer part 1', ' real answer part 2'])
+      expect(sink.buffered()).toBe('real answer part 1 real answer part 2')
+    })
+
+    it('reasoning part from a different session does NOT register in the suppression set', async () => {
+      // #given — reasoning part from other-session; text delta with same partID from our session passes through
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            // Reasoning part from a DIFFERENT session — must not pollute our set
+            {
+              type: 'message.part.updated',
+              properties: {
+                sessionID: 'other-session',
+                part: {type: 'reasoning', id: 'part-r-1', sessionID: 'other-session', text: 'thinking'},
+              },
+            },
+            // Text delta from our session with the same partID — must NOT be suppressed
+            partDeltaWithPartId('our answer', 'part-r-1'),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — the text delta passes through (other-session reasoning didn't register)
+      expect(sink._appended).toEqual(['our answer'])
+    })
+  })
+
+  describe('tool summarizer wiring — Unit 2 (replaces raw 🔧 format)', () => {
+    it('edit tool via message.part.updated → sink receives summary line, NOT raw 🔧 format', async () => {
+      // #given — edit tool with filePath and newString/oldString
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partUpdatedToolEvent('edit', 'completed', {
+              input: {filePath: 'src/foo.ts', newString: 'line1\nline2\nline3', oldString: 'old1\nold2'},
+            }),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — summary format, not raw 🔧
+      const combined = sink.buffered()
+      expect(combined).toContain('foo.ts')
+      expect(combined).not.toContain('🔧')
+      // Summary contains the file name in italic markdown
+      expect(combined).toContain('*foo.ts*')
+    })
+
+    it('read tool via message.part.updated → sink receives nothing (hidden)', async () => {
+      // #given — read tool is non-essential
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partUpdatedToolEvent('read', 'completed', {input: {filePath: 'src/foo.ts'}}),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — nothing appended for hidden tool
+      expect(sink._appended).toHaveLength(0)
+    })
+
+    it('grep tool via message.part.updated → sink receives nothing (hidden)', async () => {
+      // #given — grep tool is non-essential
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partUpdatedToolEvent('grep', 'completed', {input: {pattern: 'foo', path: 'src/'}}),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then
+      expect(sink._appended).toHaveLength(0)
+    })
+
+    it('write tool via message.part.updated → sink receives summary line', async () => {
+      // #given — write tool with filePath and content
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partUpdatedToolEvent('write', 'completed', {
+              input: {filePath: 'src/bar.ts', content: 'line1\nline2\nline3\nline4\nline5'},
+            }),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — summary contains filename and line count
+      const combined = sink.buffered()
+      expect(combined).toContain('bar.ts')
+      expect(combined).not.toContain('🔧')
+    })
+
+    it('read tool via session.next.tool.success → sink receives nothing (hidden)', async () => {
+      // #given — read tool via legacy path
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            toolCalledEvent('call-r1', 'read', {filePath: 'src/foo.ts'}),
+            toolSuccessEvent('call-r1'),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — nothing appended for hidden tool
+      expect(sink._appended).toHaveLength(0)
+    })
+
+    it('integration: session.next.tool.success and message.part.updated produce identical output for same edit tool', async () => {
+      // #given — same edit tool input via both paths
+      const editInput = {filePath: 'src/utils.ts', newString: 'a\nb\nc', oldString: 'x\ny'}
+
+      const sinkA = makeSink()
+      const handleA = makeHandle({
+        subscribe: async () =>
+          subscribeOk([partUpdatedToolEvent('edit', 'completed', {input: editInput}), sessionIdleEvent('sess-123')]),
+      })
+      const paramsA = {...buildParams(handleA), sink: sinkA, coordinator: makeCoordinator()}
+
+      const sinkB = makeSink()
+      const handleB = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            toolCalledEvent('call-e1', 'edit', editInput),
+            toolSuccessEvent('call-e1'),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const paramsB = {...buildParams(handleB), sink: sinkB, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(paramsA)
+      await runOpenCodeCore(paramsB)
+
+      // #then — both paths produce identical output
+      expect(sinkA.buffered()).toBe(sinkB.buffered())
+      // And neither contains the raw 🔧 format
+      expect(sinkA.buffered()).not.toContain('🔧')
+      expect(sinkB.buffered()).not.toContain('🔧')
+    })
+
+    it('no raw 🔧 format in any tool output — bash tool uses summarizer', async () => {
+      // #given — bash tool via message.part.updated
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partUpdatedToolEvent('bash', 'completed', {input: {command: 'pnpm build'}}),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — summary format (backtick-wrapped command), not raw 🔧
+      const combined = sink.buffered()
+      expect(combined).toContain('pnpm build')
+      expect(combined).not.toContain('🔧')
     })
   })
 

--- a/packages/gateway/src/execute/run-core.test.ts
+++ b/packages/gateway/src/execute/run-core.test.ts
@@ -455,13 +455,13 @@ describe('runOpenCodeCore', () => {
       expect(combined).toContain('pnpm test')
     })
 
-    it('uses input.cmd as fallback for bash when command is absent', async () => {
-      // #given
+    it('uses input.cmd as fallback for bash when command is absent (side-effecting command)', async () => {
+      // #given — uses a side-effecting command so it is not hidden by read-only bash filtering
       const sink = makeSink()
       const handle = makeHandle({
         subscribe: async () =>
           subscribeOk([
-            toolCalledEvent('call-1', 'bash', {cmd: 'ls -la'}),
+            toolCalledEvent('call-1', 'bash', {cmd: 'pnpm install'}),
             toolSuccessEvent('call-1'),
             sessionIdleEvent('sess-123'),
           ]),
@@ -472,7 +472,7 @@ describe('runOpenCodeCore', () => {
       await runOpenCodeCore(params)
 
       // #then
-      expect(sink.buffered()).toContain('ls -la')
+      expect(sink.buffered()).toContain('pnpm install')
     })
 
     it('bash tool: input.command is shown inline (summarizer uses command, not structured.title)', async () => {
@@ -558,13 +558,18 @@ describe('runOpenCodeCore', () => {
   })
 
   describe('tool call progress (message.part.updated — OpenCode 1.15.13 contract)', () => {
-    it('appends a progress line for a bash tool using input.command', async () => {
+    it('appends a progress line for a bash tool using input.command (side-effecting command)', async () => {
       // #given — bash summarizer renders the command inline (not the tool name)
+      // Uses a side-effecting command (pnpm build) so it is not hidden by read-only bash filtering
       const sink = makeSink()
       const handle = makeHandle({
         subscribe: async () =>
           subscribeOk([
-            partUpdatedToolEvent('bash', 'completed', {title: 'echo hi', input: {command: 'echo hi'}, output: ''}),
+            partUpdatedToolEvent('bash', 'completed', {
+              title: 'pnpm build',
+              input: {command: 'pnpm build'},
+              output: '',
+            }),
             sessionIdleEvent('sess-123'),
           ]),
       })
@@ -575,7 +580,7 @@ describe('runOpenCodeCore', () => {
 
       // #then — summarizer renders command inline
       const combined = sink.buffered()
-      expect(combined).toContain('echo hi')
+      expect(combined).toContain('pnpm build')
     })
 
     it('falls back to input.command when state.title is absent', async () => {
@@ -597,13 +602,13 @@ describe('runOpenCodeCore', () => {
       expect(sink.buffered()).toContain('pnpm test')
     })
 
-    it('falls back to input.cmd when command is absent', async () => {
-      // #given
+    it('falls back to input.cmd when command is absent (side-effecting command)', async () => {
+      // #given — uses a side-effecting command so it is not hidden by read-only bash filtering
       const sink = makeSink()
       const handle = makeHandle({
         subscribe: async () =>
           subscribeOk([
-            partUpdatedToolEvent('bash', 'completed', {input: {cmd: 'ls -la'}, output: ''}),
+            partUpdatedToolEvent('bash', 'completed', {input: {cmd: 'pnpm install'}, output: ''}),
             sessionIdleEvent('sess-123'),
           ]),
       })
@@ -613,7 +618,7 @@ describe('runOpenCodeCore', () => {
       await runOpenCodeCore(params)
 
       // #then
-      expect(sink.buffered()).toContain('ls -la')
+      expect(sink.buffered()).toContain('pnpm install')
     })
 
     it('non-bash MCP tool: summarizer renders input fields as fallback when state.title is absent', async () => {
@@ -1554,6 +1559,232 @@ describe('runOpenCodeCore', () => {
 
       // #when / #then — must resolve cleanly
       await expect(runOpenCodeCore(params)).resolves.toBeUndefined()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // P1.2: Fail-soft tool rendering — malformed tool input must not abort stream
+  // ---------------------------------------------------------------------------
+
+  describe('fail-soft tool rendering (P1.2) — malformed tool input does not abort stream', () => {
+    it('message.part.updated: hostile/malformed tool input does not abort stream — subsequent text deltas still process', async () => {
+      // #given — a tool part with a deeply hostile input that would cause formatToolPart to throw
+      // We simulate this by passing a Proxy that throws on property access
+      const sink = makeSink()
+      const hostileInput = new Proxy(
+        {},
+        {
+          get() {
+            throw new Error('hostile property access')
+          },
+        },
+      )
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            // Hostile tool part — formatToolPart will throw when accessing input
+            {
+              type: 'message.part.updated',
+              properties: {
+                sessionID: 'sess-123',
+                part: {
+                  type: 'tool',
+                  tool: 'bash',
+                  sessionID: 'sess-123',
+                  state: {status: 'completed', input: hostileInput},
+                },
+              },
+            },
+            // Subsequent text delta — must still be processed
+            partDeltaObjectEvent('answer after hostile tool'),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when — must NOT throw; stream continues
+      await expect(runOpenCodeCore(params)).resolves.toBeUndefined()
+
+      // #then — text delta after the hostile tool still reached the sink
+      expect(sink._appended).toContain('answer after hostile tool')
+    })
+
+    it('session.next.tool.success: hostile/malformed tool input does not abort stream', async () => {
+      // #given — hostile input on the legacy tool success path
+      // The tool is called with a Proxy that throws on property access, simulating a malformed input
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () => {
+          // Build a hostile proxy that throws on any property access
+          const hostileInput = new Proxy(
+            {},
+            {
+              get() {
+                throw new Error('hostile property access')
+              },
+            },
+          )
+          return subscribeOk([
+            // Tool called with hostile input (stored in pendingToolCalls)
+            {
+              type: 'session.next.tool.called',
+              properties: {sessionID: 'sess-123', callID: 'call-hostile', tool: 'bash', input: hostileInput},
+            },
+            // Tool success — formatToolPart will throw when accessing the hostile input
+            {
+              type: 'session.next.tool.success',
+              properties: {sessionID: 'sess-123', callID: 'call-hostile'},
+            },
+            partDeltaObjectEvent('answer after hostile legacy tool'),
+            sessionIdleEvent('sess-123'),
+          ])
+        },
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when — must NOT throw
+      await expect(runOpenCodeCore(params)).resolves.toBeUndefined()
+
+      // #then — text delta still reached the sink
+      expect(sink._appended).toContain('answer after hostile legacy tool')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // P1.3: R5 ordering + cross-run isolation
+  // ---------------------------------------------------------------------------
+
+  describe('R5 ordering + cross-run isolation (P1.3)', () => {
+    it('out-of-order: reasoning delta AFTER its part.updated registration → suppressed', async () => {
+      // #given — normal OpenCode order: reasoning part.updated first, then its deltas
+      // This is the load-bearing ordering: part.updated registers the ID before deltas arrive
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            // 1. Reasoning part registers its ID
+            reasoningPartUpdatedEvent('part-r-order'),
+            // 2. Reasoning delta with that partID → must be suppressed
+            partDeltaWithPartId('chain of thought', 'part-r-order'),
+            // 3. Text delta with a different partID → must stream
+            partDeltaWithPartId('real answer', 'part-text-order'),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — reasoning delta suppressed; text delta passes through
+      expect(sink._appended).toEqual(['real answer'])
+      expect(sink.buffered()).toBe('real answer')
+    })
+
+    it('out-of-order: delta whose partID was never registered as reasoning → streams (answer never eaten)', async () => {
+      // #given — no reasoning part registered; text delta with any partID passes through
+      // This verifies the suppression set is not over-eager
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            // No reasoning part.updated — partID 'part-unknown' is not in the suppression set
+            partDeltaWithPartId('this is the answer', 'part-unknown'),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — unregistered partID passes through unchanged
+      expect(sink._appended).toEqual(['this is the answer'])
+    })
+
+    it('cross-run isolation: reasoningPartIds is per-run, not shared across runs', async () => {
+      // #given — run 1 registers reasoning partID 'part-shared'
+      const sink1 = makeSink()
+      const handle1 = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            reasoningPartUpdatedEvent('part-shared'),
+            partDeltaWithPartId('run1 reasoning — suppressed', 'part-shared'),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params1 = {...buildParams(handle1), sink: sink1, coordinator: makeCoordinator()}
+
+      // #when — run 1 completes
+      await runOpenCodeCore(params1)
+
+      // #then — run 1: reasoning suppressed
+      expect(sink1._appended).toHaveLength(0)
+
+      // #given — run 2: fresh run, same partID 'part-shared' used for a TEXT delta
+      const sink2 = makeSink()
+      const handle2 = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            // No reasoning part.updated in run 2 — 'part-shared' is NOT in the new run's set
+            partDeltaWithPartId('run2 answer — must stream', 'part-shared'),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params2 = {...buildParams(handle2), sink: sink2, coordinator: makeCoordinator()}
+
+      // #when — run 2 completes
+      await runOpenCodeCore(params2)
+
+      // #then — run 2: text delta with previously-seen partID STREAMS (per-run isolation)
+      expect(sink2._appended).toEqual(['run2 answer — must stream'])
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // P2.6: Both tool event paths route through appendToolSummary
+  // ---------------------------------------------------------------------------
+
+  describe('tool render helper routing (P2.6) — both event paths produce output', () => {
+    it('message.part.updated path produces tool summary line', async () => {
+      // #given
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partUpdatedToolEvent('edit', 'completed', {
+              input: {filePath: 'src/helper.ts', newString: 'a\nb', oldString: 'c'},
+            }),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — summary line appended via message.part.updated path
+      expect(sink.buffered()).toContain('helper.ts')
+    })
+
+    it('session.next.tool.success path produces tool summary line', async () => {
+      // #given
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            toolCalledEvent('call-p26', 'edit', {filePath: 'src/helper.ts', newString: 'a\nb', oldString: 'c'}),
+            toolSuccessEvent('call-p26'),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator()}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — summary line appended via session.next.tool.success path
+      expect(sink.buffered()).toContain('helper.ts')
     })
   })
 })

--- a/packages/gateway/src/execute/run-core.ts
+++ b/packages/gateway/src/execute/run-core.ts
@@ -27,6 +27,7 @@ import type {GatewayLogger} from '../discord/client.js'
 import type {DiscordStreamSink} from '../discord/streaming.js'
 
 import {parsePermissionReply, parsePermissionRequest} from '../approvals/coordinator.js'
+import {formatToolPart} from './format-part.js'
 
 // ---------------------------------------------------------------------------
 // Typed error
@@ -276,6 +277,13 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
   // V2 sync tool lifecycle: correlate called→success by callID.
   const pendingToolCalls = new Map<string, ToolCallInfo>()
 
+  // Reasoning suppression (R5): track part IDs of reasoning parts so their
+  // deltas can be suppressed at the message.part.delta site. Reasoning parts
+  // carry `id` on `message.part.updated` (type === 'reasoning'); their deltas
+  // carry `partID` on `message.part.delta` but no part kind — correlation is
+  // the only way to distinguish them from text deltas.
+  const reasoningPartIds = new Set<string>()
+
   // Wrap the raw event stream in an abort-aware iterator so we do not block
   // indefinitely waiting for the next event when the signal fires mid-stream.
   // The inner generator races each `next()` call against the abort signal so
@@ -293,19 +301,26 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
     if (eventType === 'message.part.delta') {
       // New SDK shape: streaming text delta events.
       // delta may be {type:'text', text:string} or a plain string when field === 'text'.
+      // Reasoning suppression: skip any delta whose partID is a known reasoning part.
       const eventSessionID = getEventSessionID(rawEvent)
       if (eventSessionID === sessionId) {
-        const delta = getObjectProperty(eventPayload, 'delta')
-        const deltaType = getStringProperty(delta, 'type')
-        const deltaText = getStringProperty(delta, 'text')
-        if (deltaType === 'text' && deltaText != null) {
-          sink.append(deltaText)
-        } else if (typeof delta === 'string' && getStringProperty(eventPayload, 'field') === 'text') {
-          sink.append(delta)
+        const deltaPartId = getStringProperty(eventPayload, 'partID')
+        if (deltaPartId !== null && reasoningPartIds.has(deltaPartId)) {
+          // This delta belongs to a reasoning part — suppress it entirely.
+        } else {
+          const delta = getObjectProperty(eventPayload, 'delta')
+          const deltaType = getStringProperty(delta, 'type')
+          const deltaText = getStringProperty(delta, 'text')
+          if (deltaType === 'text' && deltaText != null) {
+            sink.append(deltaText)
+          } else if (typeof delta === 'string' && getStringProperty(eventPayload, 'field') === 'text') {
+            sink.append(delta)
+          }
         }
       }
     } else if (eventType === 'session.next.text.delta') {
       // Sync/session.next shape: delta is a plain string or {type:'text', text:string}.
+      // No partID on this legacy path — reasoning suppression does not apply here.
       const eventSessionID = getEventSessionID(rawEvent)
       if (eventSessionID === sessionId) {
         const deltaRaw = getObjectProperty(eventPayload, 'delta')
@@ -320,22 +335,36 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
       const eventSessionID = getSessionID(eventPayload) ?? getSessionID(part)
       if (eventSessionID === sessionId) {
         const partType = getStringProperty(part, 'type')
-        if (partType === 'tool') {
+        if (partType === 'reasoning') {
+          // Reasoning suppression: register this part's ID so its deltas are suppressed
+          // at the message.part.delta site. Render nothing for reasoning parts.
+          const reasoningId = getStringProperty(part, 'id')
+          if (reasoningId !== null) {
+            reasoningPartIds.add(reasoningId)
+          }
+        } else if (partType === 'tool') {
           // ONLY handle tool parts — text parts are streamed via message.part.delta.
           const toolState = getObjectProperty(part, 'state')
-          if (getStringProperty(toolState, 'status') === 'completed') {
+          const status = getStringProperty(toolState, 'status')
+          if (status === 'completed' || status === 'error') {
             const tool = getStringProperty(part, 'tool') ?? ''
-            // Title resolution: state.title → input.title → bash command/cmd → tool name.
-            const stateTitle = getStringProperty(toolState, 'title')
             const stateInput = getObjectProperty(toolState, 'input')
-            const title =
-              stateTitle ??
-              getStringProperty(stateInput, 'title') ??
-              (tool.toLowerCase() === 'bash'
-                ? String(getObjectProperty(stateInput, 'command') ?? getObjectProperty(stateInput, 'cmd') ?? tool)
-                : tool)
-            logger.debug({tool, title}, 'run-core: tool completed (message.part.updated)')
-            sink.append(`\n🔧 ${tool}: ${title}\n`)
+            const stateTitle = getStringProperty(toolState, 'title')
+            logger.debug({tool, status}, 'run-core: tool completed (message.part.updated)')
+            const summary = formatToolPart({
+              tool,
+              state: {
+                input:
+                  stateInput != null && typeof stateInput === 'object'
+                    ? (stateInput as Record<string, unknown>)
+                    : undefined,
+                title: stateTitle ?? undefined,
+                status: status === 'error' ? 'error' : 'completed',
+              },
+            })
+            if (summary != null && summary.length > 0) {
+              sink.append(`\n${summary}\n`)
+            }
           }
         }
       }
@@ -363,14 +392,21 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
             const {tool, input} = callInfo
             // Title resolution: structured.title → input.title → bash command → tool name.
             const structured = getObjectProperty(eventPayload, 'structured')
-            const title =
-              getStringProperty(structured, 'title') ??
-              getStringProperty(input, 'title') ??
-              (tool.toLowerCase() === 'bash'
-                ? String(getObjectProperty(input, 'command') ?? getObjectProperty(input, 'cmd') ?? tool)
-                : tool)
-            logger.debug({callID, tool, title}, 'run-core: tool success')
-            sink.append(`\n🔧 ${tool}: ${title}\n`)
+            const structuredTitle = getStringProperty(structured, 'title')
+            const inputTitle = getStringProperty(input, 'title')
+            const title = structuredTitle ?? inputTitle ?? undefined
+            logger.debug({callID, tool}, 'run-core: tool success')
+            const summary = formatToolPart({
+              tool,
+              state: {
+                input: input != null && typeof input === 'object' ? (input as Record<string, unknown>) : undefined,
+                title,
+                status: 'completed',
+              },
+            })
+            if (summary != null && summary.length > 0) {
+              sink.append(`\n${summary}\n`)
+            }
           }
         }
       }

--- a/packages/gateway/src/execute/run-core.ts
+++ b/packages/gateway/src/execute/run-core.ts
@@ -160,6 +160,34 @@ interface ToolCallInfo {
 }
 
 // ---------------------------------------------------------------------------
+// Shared tool-render helper (P2.6 + P1.2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fail-soft tool-render helper shared by both tool event paths.
+ *
+ * Calls `formatToolPart`, catches any exception (malformed input, unexpected
+ * shape), logs `{tool, status}` only (no raw content), and appends nothing on
+ * error. A throwing `formatToolPart` must never abort the event stream.
+ */
+function appendToolSummary(
+  part: import('./format-part.js').ExtractedToolPart,
+  sink: DiscordStreamSink,
+  logger: GatewayLogger,
+): void {
+  let summary: string | null
+  try {
+    summary = formatToolPart(part)
+  } catch {
+    logger.warn({tool: part.tool, status: part.state.status}, 'run-core: formatToolPart threw — skipping tool line')
+    return
+  }
+  if (summary !== null && summary.length > 0) {
+    sink.append(`\n${summary}\n`)
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Core
 // ---------------------------------------------------------------------------
 
@@ -351,20 +379,21 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
             const stateInput = getObjectProperty(toolState, 'input')
             const stateTitle = getStringProperty(toolState, 'title')
             logger.debug({tool, status}, 'run-core: tool completed (message.part.updated)')
-            const summary = formatToolPart({
-              tool,
-              state: {
-                input:
-                  stateInput != null && typeof stateInput === 'object'
-                    ? (stateInput as Record<string, unknown>)
-                    : undefined,
-                title: stateTitle ?? undefined,
-                status: status === 'error' ? 'error' : 'completed',
+            appendToolSummary(
+              {
+                tool,
+                state: {
+                  input:
+                    stateInput != null && typeof stateInput === 'object'
+                      ? (stateInput as Record<string, unknown>)
+                      : undefined,
+                  title: stateTitle ?? undefined,
+                  status: status === 'error' ? 'error' : 'completed',
+                },
               },
-            })
-            if (summary != null && summary.length > 0) {
-              sink.append(`\n${summary}\n`)
-            }
+              sink,
+              logger,
+            )
           }
         }
       }
@@ -396,17 +425,18 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
             const inputTitle = getStringProperty(input, 'title')
             const title = structuredTitle ?? inputTitle ?? undefined
             logger.debug({callID, tool}, 'run-core: tool success')
-            const summary = formatToolPart({
-              tool,
-              state: {
-                input: input != null && typeof input === 'object' ? (input as Record<string, unknown>) : undefined,
-                title,
-                status: 'completed',
+            appendToolSummary(
+              {
+                tool,
+                state: {
+                  input: input != null && typeof input === 'object' ? (input as Record<string, unknown>) : undefined,
+                  title,
+                  status: 'completed',
+                },
               },
-            })
-            if (summary != null && summary.length > 0) {
-              sink.append(`\n${summary}\n`)
-            }
+              sink,
+              logger,
+            )
           }
         }
       }

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -311,6 +311,7 @@ function makeDeps(overrides: Partial<RunMentionDeps> = {}): RunMentionDeps {
     attachToken: 'secret-bearer-token',
     runTimeoutMs: overrides.runTimeoutMs ?? 600000,
     botUserId: overrides.botUserId ?? 'bot-123',
+    persona: overrides.persona ?? null,
     logger: overrides.logger ?? {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()},
     approvalRegistry: overrides.approvalRegistry ?? makeApprovalRegistry(),
     approvalMode: overrides.approvalMode ?? 'approval-required',

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -35,6 +35,12 @@ export interface RunMentionDeps {
    * does not silently dispatch a no-op run.
    */
   readonly botUserId: string
+  /**
+   * Optional canonical persona text (from `GatewayConfig.persona`).
+   * Prepended to every Discord mention prompt before the Discord-mechanical guidance.
+   * `null` → mechanical guidance only (R4 fail-soft).
+   */
+  readonly persona: string | null
   readonly logger: GatewayLogger
   /** Program-scoped approval registry shared with the button handler and shutdown drain. */
   readonly approvalRegistry: ApprovalRegistry
@@ -157,7 +163,8 @@ export function computeApprovalDeadlineMs(remainingBudgetMs: number): number | u
  * - Every Discord send uses `allowedMentions: {parse: []}`.
  */
 export async function runMention(message: Message, binding: RepoBinding, deps: RunMentionDeps): Promise<void> {
-  const {concurrency, coordinationConfig, identity, attachUrl, attachToken, runTimeoutMs, botUserId, logger} = deps
+  const {concurrency, coordinationConfig, identity, attachUrl, attachToken, runTimeoutMs, botUserId, persona, logger} =
+    deps
   const {approvalRegistry, approvalMode, ensureClone, readyz} = deps
   const channelId = message.channel.id
   const repo = `${binding.owner}/${binding.repo}`
@@ -328,6 +335,7 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
         owner: bindingWithEnsuredPath.owner,
         repo: bindingWithEnsuredPath.repo,
         botUserId,
+        persona,
       })
 
       // ── Remaining budget — single origin for hard abort AND approval deadline ──

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -157,6 +157,7 @@ function makeFakeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     maxConcurrentRuns: 3,
     runTimeoutMs: 600_000,
     approvalMode: 'approval-required',
+    persona: null,
     announce: {
       webhookSecret: 'test-webhook-secret',
       presenceChannelId: 'test-presence-channel-id',

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -274,6 +274,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           attachToken: config.workspaceOpencodeToken,
           runTimeoutMs: config.runTimeoutMs,
           botUserId: client.user.id,
+          persona: config.persona,
           logger,
           approvalRegistry,
           approvalMode: config.approvalMode,


### PR DESCRIPTION
Makes the `@Fro Bot` Discord mention loop read like a capable teammate instead of dumping raw agent internals.

## What changes

- **Reasoning is hidden.** Chain-of-thought ("I'm wondering if we really need…") no longer streams to Discord — reasoning parts are tracked by id and their deltas suppressed.
- **Tool calls collapse to one-liners.** Instead of raw `🔧 <tool>: <title>` noise, actions render as concise summaries (`edit *file.ts* (+12-3)`, `bash …`). Read-only tools (reads, greps, globs, lists, and read-only bash like `git ls-files`) are hidden; errored hidden tools still surface a terse `⨯ read: file` so failures stay visible.
- **Fro Bot speaks in its own voice.** The canonical persona is injected into the Discord prompt via `GATEWAY_PERSONA_FILE` (or `GATEWAY_PERSONA`), scoped to voice/style so it can't override the mechanical Discord guidance. The agent is now told to stay conversational, not narrate its process, and summarize or attach long enumerations rather than pasting walls of text.

All additive — the run lifecycle, locking, and sink flush behavior are untouched. Reasoning suppression fails safe (an unrecognized delta still streams, so the answer is never eaten), tool rendering catches malformed parts instead of aborting the run, and a missing/unreadable persona file degrades to no persona rather than crashing startup.

## Operator setup

`GATEWAY_PERSONA_FILE` is optional. Mount the persona markdown and point the gateway at it (see `deploy/README.md` / `deploy/compose.yaml`). Without it, Fro Bot falls back to the built-in conversational guidance.