### PR TITLE
fix(gateway): harden mention rendering edge cases

### DIFF
--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -415,7 +415,7 @@ export function loadGatewayConfig(): GatewayConfig {
     console.warn(
       JSON.stringify({
         level: 'warn',
-        msg: 'GATEWAY_PERSONA read failed — persona will be null; gateway startup continues. Check GATEWAY_PERSONA_FILE path and permissions.',
+        msg: 'GATEWAY_PERSONA read failed — persona will be null; gateway startup continues. Check GATEWAY_PERSONA_FILE path, permissions, or whether the file exceeds the 4096-byte secret size limit.',
       }),
     )
   }

--- a/packages/gateway/src/execute/format-part.test.ts
+++ b/packages/gateway/src/execute/format-part.test.ts
@@ -161,6 +161,56 @@ describe('summarizeTool', () => {
       expect(result).toBe('*app.ts* (+3-1)')
     })
 
+    it('renders *filename* (+N-0) from OpenCode *** Add File: envelope', () => {
+      // #given — OpenCode apply_patch Add File verb
+      const patchText = [
+        '*** Begin Patch',
+        '*** Add File: src/new-module.ts',
+        '+export function hello() {',
+        '+  return "world"',
+        '+}',
+        '*** End Patch',
+      ].join('\n')
+      const part = completedTool('apply_patch', {patchText})
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then — Add File parsed: 3 additions, 0 deletions
+      expect(result).toBe('*new-module.ts* (+3-0)')
+    })
+
+    it('renders *filename* (+0-N) from OpenCode *** Delete File: envelope', () => {
+      // #given — OpenCode apply_patch Delete File verb (body lines are removals)
+      const patchText = [
+        '*** Begin Patch',
+        '*** Delete File: src/old-module.ts',
+        '-export function goodbye() {',
+        '-  return "bye"',
+        '-}',
+        '*** End Patch',
+      ].join('\n')
+      const part = completedTool('apply_patch', {patchText})
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then — Delete File parsed: 0 additions, 3 deletions
+      expect(result).toBe('*old-module.ts* (+0-3)')
+    })
+
+    it('renders *filename* (+0-0) from OpenCode *** Delete File: envelope with no body lines', () => {
+      // #given — Delete File with no body (pure deletion marker, no diff lines)
+      const patchText = ['*** Begin Patch', '*** Delete File: src/empty.ts', '*** End Patch'].join('\n')
+      const part = completedTool('apply_patch', {patchText})
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then — Delete File with no body: counts are 0/0 but file is still rendered
+      expect(result).toBe('*empty.ts* (+0-0)')
+    })
+
     it('falls back to tool name when patchText is absent', () => {
       // #given / #when / #then
       const part = completedTool('apply_patch', {})
@@ -356,6 +406,37 @@ describe('summarizeTool', () => {
       // #given / #when / #then
       const part = completedTool('task', {})
       expect(summarizeTool(part)).toBe('task')
+    })
+
+    it('truncates a long task description at ~120 chars with an ellipsis', () => {
+      // #given — description longer than 120 chars
+      const longDescription = 'A'.repeat(150)
+      const part = completedTool('task', {description: longDescription})
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then — result must be truncated and end with ellipsis
+      expect(result).not.toBeNull()
+      expect(typeof result === 'string' && result.endsWith('…')).toBe(true)
+      // The full 150-char description must NOT appear verbatim
+      expect(result).not.toContain(longDescription)
+      // But the prefix should be present
+      expect(result).toContain('task: ')
+      // Total length should be well under 150
+      expect(typeof result === 'string' && result.length).toBeLessThan(140)
+    })
+
+    it('does NOT truncate a task description at or below the cap', () => {
+      // #given — description exactly at the cap (120 chars)
+      const exactDescription = 'B'.repeat(120)
+      const part = completedTool('task', {description: exactDescription})
+
+      // #when
+      const result = summarizeTool(part)
+
+      // #then — no truncation for descriptions at or below the cap
+      expect(result).toBe(`task: ${exactDescription}`)
     })
   })
 

--- a/packages/gateway/src/execute/format-part.ts
+++ b/packages/gateway/src/execute/format-part.ts
@@ -44,6 +44,7 @@ export interface ExtractedToolPart {
 // ---------------------------------------------------------------------------
 
 const MAX_BASH_COMMAND_INLINE_LENGTH = 100
+const MAX_TASK_DESCRIPTION_LENGTH = 120
 const MAX_MCP_ARG_LENGTH = 50
 const ERROR_GLYPH = '⨯'
 
@@ -151,12 +152,16 @@ function parsePatchCounts(patchText: string): {
   let deletions = 0
 
   for (const line of patchText.split('\n')) {
-    // OpenCode envelope: *** Update File: path/to/file
-    if (line.startsWith('*** Update File:')) {
+    // OpenCode envelope: *** Update File: / *** Add File: / *** Delete File: path/to/file
+    if (
+      line.startsWith('*** Update File:') ||
+      line.startsWith('*** Add File:') ||
+      line.startsWith('*** Delete File:')
+    ) {
       if (currentFile !== '') {
         results.push({fileName: basename(currentFile), additions, deletions})
       }
-      currentFile = line.replace(/^\*\*\* Update File:\s*/, '').trim()
+      currentFile = line.replace(/^\*\*\* (?:Update|Add|Delete) File:\s*/, '').trim()
       additions = 0
       deletions = 0
     } else if (line.startsWith('+++ b/') || line.startsWith('+++ ')) {
@@ -314,7 +319,13 @@ function computeSummary(tool: string, input: Record<string, unknown> | undefined
   // --- task (subagent) ---
   if (tool === 'task') {
     const description = str(input, 'description') || str(input, 'prompt')
-    if (description.length > 0) return `task: ${description}`
+    if (description.length > 0) {
+      const truncated =
+        description.length > MAX_TASK_DESCRIPTION_LENGTH
+          ? `${description.slice(0, MAX_TASK_DESCRIPTION_LENGTH)}…`
+          : description
+      return `task: ${truncated}`
+    }
     return title !== undefined && title.length > 0 ? title : tool
   }
 

--- a/packages/gateway/src/execute/prompt.test.ts
+++ b/packages/gateway/src/execute/prompt.test.ts
@@ -229,6 +229,36 @@ describe('buildDiscordPrompt', () => {
       expect(result).toContain('Fix the bug')
       expect(result).not.toContain('<@123>')
     })
+
+    it('handles botUserId containing a regex metachar (e.g. "123.456") literally — does not throw', () => {
+      // #given — botUserId with a dot (regex metachar); without escaping, "123.456" would
+      // match "123X456" etc. With escaping it matches only the literal string.
+      const result = buildDiscordPrompt({
+        messageText: '<@123.456> Fix the bug',
+        owner: 'org',
+        repo: 'repo',
+        botUserId: '123.456',
+      })
+
+      // #then — must not throw, and the mention is stripped correctly
+      expect(result).toContain('Fix the bug')
+      expect(result).not.toContain('<@123.456>')
+    })
+
+    it('botUserId with regex metachar does NOT match a different ID (literal match only)', () => {
+      // #given — botUserId "123.456" must NOT strip a mention like "<@123X456>"
+      // (the dot should be treated as a literal dot, not a wildcard)
+      const result = buildDiscordPrompt({
+        messageText: '<@123X456> Fix the bug',
+        owner: 'org',
+        repo: 'repo',
+        botUserId: '123.456',
+      })
+
+      // #then — the mention is NOT stripped (different ID), message still present
+      expect(result).toContain('<@123X456>')
+      expect(result).toContain('Fix the bug')
+    })
   })
 
   describe('empty / whitespace guard', () => {

--- a/packages/gateway/src/execute/prompt.ts
+++ b/packages/gateway/src/execute/prompt.ts
@@ -57,13 +57,27 @@ export class EmptyPromptError extends Error {
 }
 
 /**
+ * Escape all regex metacharacters in `s` so it can be safely interpolated
+ * into a `RegExp` pattern and matched literally.
+ *
+ * Discord snowflakes are digits-only in practice, but this guard removes the
+ * theoretical broken-regex path for any future ID format.
+ */
+function escapeRegExp(s: string): string {
+  return s.replaceAll(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`)
+}
+
+/**
  * Strip leading Discord mention token(s) (`<@ID>` or `<@!ID>`) that match
  * `botUserId` from the start of `text`. Removes as many consecutive leading
  * matches as are present, then trims the result.
  */
 function stripLeadingMentions(text: string, botUserId: string): string {
   // A single mention pattern: optional whitespace, then <@ID> or <@!ID>.
-  const mentionPattern = new RegExp(String.raw`^\s*<@!?${botUserId}>`, '')
+  // escapeRegExp ensures botUserId is matched literally even if it contains
+  // regex metacharacters (e.g. a dot in a non-snowflake ID).
+  const escapedId = escapeRegExp(botUserId)
+  const mentionPattern = new RegExp(String.raw`^\s*<@!?${escapedId}>`, '')
   let result = text
   let prev: string
   do {

--- a/packages/gateway/src/execute/run-core.test.ts
+++ b/packages/gateway/src/execute/run-core.test.ts
@@ -1787,4 +1787,131 @@ describe('runOpenCodeCore', () => {
       expect(sink.buffered()).toContain('helper.ts')
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // Item 5: stream-ended error kind
+  // ---------------------------------------------------------------------------
+
+  describe('stream-ended error kind', () => {
+    it('throws RunCoreError with kind "stream-ended" when event stream closes before session.idle', async () => {
+      // #given — stream ends immediately with no events (no session.idle, no abort)
+      const handle = makeHandle({
+        subscribe: async () =>
+          Promise.resolve({
+            stream: (async function* () {
+              // Yields nothing — stream closes immediately without session.idle
+            })(),
+          }),
+      })
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
+
+      // #when / #then — stream-ended kind thrown
+      const err = await runOpenCodeCore(params).catch((error: unknown) => error)
+      expect(err).toBeInstanceOf(RunCoreError)
+      expect((err as RunCoreError).kind).toBe('stream-ended')
+    })
+
+    it('throws RunCoreError with kind "stream-ended" when stream closes after some events but before session.idle', async () => {
+      // #given — stream yields some text deltas then closes without session.idle
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partDeltaObjectEvent('partial answer'),
+            // No sessionIdleEvent — stream ends prematurely
+          ]),
+      })
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
+
+      // #when / #then
+      const err = await runOpenCodeCore(params).catch((error: unknown) => error)
+      expect(err).toBeInstanceOf(RunCoreError)
+      expect((err as RunCoreError).kind).toBe('stream-ended')
+    })
+
+    it('stream-ended error is NOT thrown when signal is aborted (timeout takes precedence)', async () => {
+      // #given — signal aborts before stream ends; timeout kind should be thrown, not stream-ended
+      const controller = new AbortController()
+      const handle = makeHandle({
+        promptAsync: async () => {
+          controller.abort()
+          return promptAsyncOk()
+        },
+        subscribe: async () =>
+          Promise.resolve({
+            stream: (async function* () {
+              // Silent stream — never yields
+              await new Promise<void>(() => {
+                /* never resolves */
+              })
+            })(),
+          }),
+      })
+      const params = {...buildParams(handle), signal: controller.signal, coordinator: makeCoordinator()}
+
+      // #when / #then — timeout kind, not stream-ended
+      const err = await runOpenCodeCore(params).catch((error: unknown) => error)
+      expect(err).toBeInstanceOf(RunCoreError)
+      expect((err as RunCoreError).kind).toBe('timeout')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Item 7: session.error with eventSessionID === null (global error path)
+  // ---------------------------------------------------------------------------
+
+  describe('session.error with null sessionID (global error path)', () => {
+    it('throws RunCoreError with kind "session-error" when session.error has no sessionID (null)', async () => {
+      // #given — session.error event with no sessionID in properties
+      // The run-core code: `if (eventSessionID === null || eventSessionID === sessionId)`
+      // A null sessionID is treated as a global error that applies to any session.
+      const globalErrorEvent = {
+        type: 'session.error',
+        properties: {error: 'global LLM failure'},
+        // no sessionID field → getEventSessionID returns null
+      }
+      const handle = makeHandle({
+        subscribe: async () => subscribeOk([globalErrorEvent]),
+      })
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
+
+      // #when / #then — global session.error (null sessionID) surfaces as session-error
+      const err = await runOpenCodeCore(params).catch((error: unknown) => error)
+      expect(err).toBeInstanceOf(RunCoreError)
+      expect((err as RunCoreError).kind).toBe('session-error')
+    })
+
+    it('session.error with null sessionID carries the error detail in the message', async () => {
+      // #given — global session.error with a specific error message
+      const globalErrorEvent = {
+        type: 'session.error',
+        properties: {error: 'quota exceeded globally'},
+      }
+      const handle = makeHandle({
+        subscribe: async () => subscribeOk([globalErrorEvent]),
+      })
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
+
+      // #when
+      const err = await runOpenCodeCore(params).catch((error: unknown) => error)
+
+      // #then — error message contains the detail from the event
+      expect(err).toBeInstanceOf(RunCoreError)
+      expect((err as RunCoreError).message).toContain('quota exceeded globally')
+    })
+
+    it('session.error from a different (non-null) sessionID is ignored', async () => {
+      // #given — session.error for a different session; our session continues to idle
+      const otherSessionError = {
+        type: 'session.error',
+        properties: {sessionID: 'other-session', error: 'other session failed'},
+      }
+      const handle = makeHandle({
+        subscribe: async () => subscribeOk([otherSessionError, sessionIdleEvent('sess-123')]),
+      })
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
+
+      // #when / #then — other session's error is ignored; our session resolves normally
+      await expect(runOpenCodeCore(params)).resolves.toBeUndefined()
+    })
+  })
 })


### PR DESCRIPTION
Cleans up the non-blocking edge cases noted while reviewing the mention output rendering, plus the two error paths that lacked coverage.

- **apply_patch summaries** now recognize OpenCode's `*** Add File:` and `*** Delete File:` envelope verbs, not just `*** Update File:` — added and deleted files no longer render with an empty filename.
- **Subagent task descriptions** in tool summaries are capped so a long description can't flood the Discord message.
- **The leading-mention strip regex** escapes the bot user id before building the pattern, removing a theoretical broken-regex path.
- **The persona read-failure warning** names the 4096-byte secret size limit as a possible cause, so an oversized persona file isn't a silent mystery.
- **Added coverage** for the stream-ended error kind and the null-session error path.

All additive and low-risk; no behavior change on the happy path.