### PR TITLE
feat(gateway): live status message + typing for mention runs

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -343,6 +343,23 @@ Each approval prompt has a deadline that is a sub-deadline of the overall run ti
 
 A pending approval prompt is held in memory by the per-run coordinator. If the gateway or workspace container restarts while a prompt is open, the approval is abandoned. The run surfaces as interrupted in the thread. Re-mention to retry.
 
+## Working-state UX
+
+`GATEWAY_STATUS_MODE` controls what the gateway posts in the run thread while the agent is working:
+
+| Value | Behaviour |
+| --- | --- |
+| `live-status` (default) | Posts a single live status message that updates as the agent progresses, plus a typing indicator. |
+| `typing-only` | Shows only the typing indicator — no status message. Quieter; useful when status noise is unwanted. |
+
+Set it as a plain environment variable on the `gateway` service (in `deploy/.env` or `compose.override.yaml`):
+
+```env
+GATEWAY_STATUS_MODE=typing-only
+```
+
+Absent or empty → `live-status` applies.
+
 ## Persistent Volumes
 
 The stack uses two named Docker volumes that survive container recreation and daemon upgrades:

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -47,6 +47,10 @@ services:
       # Absent → the loop falls back to built-in Discord guidance (fail-soft).
       # Provision the file from fro-bot/.github persona/fro-bot-persona.md.
       # GATEWAY_PERSONA_FILE: /run/secrets/gateway_persona
+      # Optional — working-state UX for the @-mention loop.
+      # live-status (default): posts a single live status message + typing indicator while the agent works.
+      # typing-only: shows only the typing indicator (quieter; no status message).
+      # GATEWAY_STATUS_MODE: live-status
       HTTPS_PROXY: http://mitmproxy:8080
       HTTP_PROXY: http://mitmproxy:8080
       NO_PROXY: workspace,localhost,127.0.0.1

--- a/docs/plans/2026-06-07-004-feat-mention-loop-working-state-ux-plan.md
+++ b/docs/plans/2026-06-07-004-feat-mention-loop-working-state-ux-plan.md
@@ -1,0 +1,241 @@
+---
+title: "feat: Mention-loop working-state UX (live status + typing)"
+type: feat
+status: active
+date: 2026-06-07
+origin: docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md
+deepened: 2026-06-07
+---
+
+# feat: Mention-loop working-state UX (live status + typing)
+
+## Overview
+
+Phase 2 of the production-ready `@Fro Bot` Discord mention loop. Phase 1 (clean rendering + persona, shipped in #831) made the *final* output read well; this phase makes the *waiting* read well. Today a mention runs silently until the final answer lands — on a long task the user has no signal the agent is alive. This adds a single live status message that updates on a rate-limit-safe cadence with Phase-1 action summaries, plus a Discord typing indicator pulsed while the session is busy. A deploy-wide setting can drop the status message for a quieter typing-only experience. The status message is replaced by the clean final answer when the run completes, or edited into a terse persona-voice failure note when it fails.
+
+## Problem Frame
+
+`packages/gateway/src/execute/run.ts` creates the thread, feeds a `DiscordStreamSink`, and flushes one final message at the end (`sink.flush()` at COMPLETED, coarse `safeSend` on failure). Between thread creation and that final flush, nothing is posted: the sink only appends + flushes (confirmed — no edit surface), `session.status` (busy/idle) is never observed, and no typing indicator is ever sent. For a multi-step coding task that can run minutes, the thread looks dead. The brainstorm (origin: working-state UX section) specifies a single editable status message + typing as the fix, with a typing-only mode for deployments that want minimal chatter.
+
+## Requirements Trace
+
+- R1. During a longer run, the user sees a single status message that updates as the agent works (default mode), never a wall of progress posts (origin SC4).
+- R2. The status message is **replaced by** the clean final answer on completion — one clean thread message for short answers (origin: final-answer transition).
+- R3. A typing indicator is shown only while the session is actually working and is cleared on idle/abort and **paused during an approval wait** so it never sticks or falsely implies active work (origin working-state UX).
+- R4. A deploy-wide setting (`GATEWAY_STATUS_MODE`) selects `live-status` (default) or `typing-only`; typing-only suppresses the status message entirely (origin OQ1, configurability).
+- R5. A failed/timed-out/aborted run reads as a terse failure note in Fro Bot's voice, not a raw error/tool dump; the status message transitions into that note (origin: failure presentation interaction state).
+- R6. Status updates are debounced to stay within Discord edit rate limits — one edited message, not per-token (origin OQ2).
+
+## Scope Boundaries
+
+- Not changing the rendering/summary layer (`format-part.ts`) — it is the content source, consumed as-is.
+- Not changing the `DiscordStreamSink` into an edit surface — the status controller is a separate component; the sink stays append-only.
+- Not adding per-channel status configuration — deploy-wide only (origin OQ1 lean).
+- Not adding the optional Kimaki-style footer (duration · model · context%) — deferred (origin OQ6).
+- Not adding an expandable full action trace — collapsed essential summaries are the v1 surface (origin OQ7).
+
+### Deferred to Separate Tasks
+
+- **Serial per-channel queue + `/clear-queue`** (origin Phase 3): the queued-task acknowledgement interaction state is owned there, not here.
+- **`/sessions` / `/resume` / `/force-release-lock` commands** (origin Phase 4).
+- **Native approval-button UX polish** (origin Phase 4): showing the permission prompt *in* the status message, and richer approval-state thread UX. v1 here does the minimum correctness step — **pause typing while an approval is pending** (`setBusy(false)`) so the indicator doesn't falsely imply active work — but does not build any approval-state status UX.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/gateway/src/discord/streaming.ts` — `createDiscordStreamSink()`: `append()`/`flush()`/`buffered()` + the `pendingVisibleOutput`/`markVisibleOutputPending`/`hasVisibleOutput` visible-output-race machinery. Append-only; no `.edit()`. The status controller must coordinate with `hasVisibleOutput()` so a status message counts (or is excluded) correctly for the no-output fallback.
+- `packages/gateway/src/execute/run.ts` — thread creation (`message.startThread` → `SinkThread`), sink construction, the run lifecycle (acquire lock → run-core → COMPLETED `sink.flush()` → failure `safeSend`), and the inner `finally` that disposes the coordinator. The status controller is created here (per-run, after thread creation) and torn down in the same `finally`. **Prior art for editing a posted message:** the approval embed settlement already does `message.edit(...)` (~run.ts:461) — mirror that handle-retention + edit pattern.
+- `packages/gateway/src/execute/run-core.ts` — the OpenCode event loop: `message.part.delta`/tool-summary append sites, and the terminal `session.idle` return / `RunCoreError` throw paths. `session.status` is **not** observed here today — the busy/idle signal that drives typing must be added. This file already routes events; the status/typing hooks live alongside the existing handlers, fed by a callback/handle passed from `run.ts`.
+- `packages/gateway/src/config.ts` — optional enum config pattern: `GATEWAY_APPROVAL_MODE` validates against a `VALID_APPROVAL_MODES` const tuple and rejects unsupported values (~config.ts:291-302). `GATEWAY_STATUS_MODE` mirrors this exactly.
+- `packages/gateway/src/execute/format-part.ts` — `summarizeTool`/essential-tool filter (Phase 1): the status line content is derived from the same essential-action summaries, not re-invented.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/gateway-opencode-mention-loop-best-practices-2026-05-30.md` — bounded executions with guaranteed cleanup (dual `finally`), preserve user-visible output even on failure-path flush. The status controller teardown must follow the same guaranteed-cleanup discipline so typing never leaks past a run.
+
+### External References
+
+- discord.js 14.26.4: `TextBasedChannel#sendTyping()` → `Promise<void>`, server-side typing indicator auto-expires ~10s, so it must be re-pulsed (~7s interval) while busy. `Message#edit()` for the status message. Discord edit rate limits favor a debounced single edited message over frequent edits.
+
+## Key Technical Decisions
+
+- **Separate status controller, not a sink change.** A new `packages/gateway/src/discord/status-message.ts` owns one message ID and edits it on a debounced cadence. The sink stays append-only. Rationale: the sink's buffer/flush/visible-output contract is load-bearing and recently hardened; bolting an edit surface onto it would entangle two concerns (origin: "real new component, not a formatting tweak").
+- **Status content = running count of essential actions**, derived from the Phase-1 summaries (e.g. `⏳ Working… edited 2 files · ran 1 command`). Not the full per-action log (that would re-introduce noise). Debounced at ~1.5–2s.
+- **Final-answer transition = edit-in-place when it fits, else delete-then-post.** When the final answer fits one ≤2000-char message, edit the status message into the answer (one clean thread message). When the answer needs the >2000-char summary+attachment path (or otherwise can't be an in-place edit), delete the status message and let the sink post the answer normally. Rationale: short answers stay tidy; long answers reuse the existing tested flush path without contortion.
+- **Typing driven by busy/idle**, pulsed ~7s, cleared on idle/abort/terminal **and paused during an approval wait** (`setBusy(false)` when the run blocks on a permission approval, so typing never falsely implies active work while waiting on a human). Rationale: ties the indicator to real work, satisfies R3's "never sticks."
+- **`GATEWAY_STATUS_MODE` deploy-wide enum** (`live-status` default | `typing-only`), validated like `GATEWAY_APPROVAL_MODE`. In `typing-only`, the status controller is created in a no-status mode: typing still pulses, but no status message is posted/edited; `resolveToAnswer`/`resolveToFailure` always return `transition: 'delegated'` so the caller posts the final answer/failure via the sink/`safeSend`.
+- **Single explicit transition contract (no scattered mode branching).** `resolveToAnswer(text)` and `resolveToFailure(note)` always return a discriminated result: `{ transition: 'handled' }` (the controller put the answer/note into the status message — caller does NOT post) or `{ transition: 'delegated' }` (caller must post via the sink/`safeSend`). The caller branches on this single result, not on `mode`. In `live-status`: short answer → `handled` (edited in place); long/attachment answer or empty → `delegated` (status deleted, sink posts). In `typing-only`: always `delegated`. This makes the success and failure call sites identical across modes.
+- **Single owner for failure output (no double message).** On failure, the caller calls `resolveToFailure(note)` exactly once and posts the failure via `safeSend` **only when** the result is `delegated`. `resolveToFailure` never both edits the status AND lets `safeSend` fire — `handled` means the controller owns the failure message (status edited into the note), `delegated` means the caller owns it (status had nothing to edit, or typing-only). This removes the "instead of (or feeding) safeSend" ambiguity.
+- **Settle before resolve (no late-edit race).** `resolveToAnswer`/`resolveToFailure`/`dispose` first enter a settle phase: cancel any pending debounce timer and **await any in-flight edit promise** before performing the final edit/delete. This prevents a debounced status edit that fired just before teardown from landing *after* the final answer and corrupting the thread — structurally the same hazard as the already-fixed visible-output race. The controller tracks the in-flight edit promise so settle can await it.
+- **Coordinate with `hasVisibleOutput()`:** a posted status message must not cause the sink to think real answer output already exists (it would suppress the `_(no output)_` fallback wrongly) — the status controller's message is tracked separately from the sink's visible-output accounting. The status message is always resolved (handled or deleted) **before** the sink's flush decision, so the two never double-post. The no-output case (`handled`/`delegated` both apply): if the final answer is empty, the controller deletes the status message and returns `delegated`, and the sink owns the `_(no output)_` fallback — the status message never becomes the no-output placeholder.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Config granularity** (origin OQ1): deploy-wide `GATEWAY_STATUS_MODE`, not per-channel — confirmed.
+- **Cadence + content** (origin OQ2): ~1.5–2s debounce, running count of essential actions — confirmed.
+- **Final-answer transition mechanics** (origin interaction state): edit-in-place when it fits one message, delete-then-post for long/attachment answers — confirmed.
+- **Failure presentation** (origin interaction state): status edited into a terse persona-voice failure note — confirmed.
+- **Reasoning marker** (origin OQ3): fully suppressed — already settled and shipped in Phase 1.
+
+### Deferred to Implementation
+
+- **Exact debounce constant** (1500ms vs 2000ms) and the exact status-line wording/emoji: pick during implementation against the real edit-rate-limit behavior; keep the constant named and easily tunable.
+- **`session.status` event shape:** confirm the exact SDK event field for busy/idle against the installed `@opencode-ai/sdk` (1.15.13) during implementation — `run-core.ts` already consumes the event stream; the busy/idle discriminant is read from the same events. If no distinct `session.status` busy event is emitted, fall back to "busy = between prompt-send and `session.idle`" as the typing window.
+- **Exact approval-wait detection point:** v1 pauses typing during an approval wait via `setBusy(false)`; the exact call site (which permission-coordinator event marks "now waiting on a human") is an implementation detail to wire against the existing approval path. The *richer* approval-state status UX (prompt-in-status-message) remains Phase-4 work.
+
+## Implementation Units
+
+- [ ] **Unit 1: `GATEWAY_STATUS_MODE` config**
+
+**Goal:** Add the deploy-wide working-state mode setting.
+
+**Requirements:** R4
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `packages/gateway/src/config.ts`
+- Modify: `packages/gateway/src/config.test.ts`
+
+**Approach:**
+- Add `VALID_STATUS_MODES = ['live-status', 'typing-only'] as const` and a `statusMode` field on the gateway config, read via the optional-env pattern with default `live-status`, validated against the tuple (reject unsupported values with a clear error). Mirror `GATEWAY_APPROVAL_MODE` exactly.
+
+**Patterns to follow:**
+- `GATEWAY_APPROVAL_MODE` / `VALID_APPROVAL_MODES` validation in `config.ts`.
+
+**Test scenarios:**
+- Happy path: unset → defaults to `live-status`; `GATEWAY_STATUS_MODE=typing-only` → `typing-only`.
+- Edge case: surrounding whitespace / empty string → default.
+- Error path: an unsupported value (e.g. `silent`) → config load fails with a clear error naming the valid values.
+
+**Verification:** config exposes a validated `statusMode`; invalid values are rejected at load.
+
+- [ ] **Unit 2: Status-message manager + typing pulse**
+
+**Goal:** A per-run component that owns one status message (post/edit/resolve) on a debounced cadence and pulses the typing indicator while busy.
+
+**Requirements:** R1, R2, R3, R5, R6
+
+**Dependencies:** Unit 1 (reads `statusMode`).
+
+**Files:**
+- Create: `packages/gateway/src/discord/status-message.ts`
+- Create: `packages/gateway/src/discord/status-message.test.ts`
+
+- Factory `createStatusController({ thread, mode, logger })` returning a closure-based controller (functions-only) with: `noteActivity(summary)` — record an essential-action summary and schedule a debounced status edit; `setBusy(boolean)` — start/stop the ~7s typing re-pulse (callers also call `setBusy(false)` when the run blocks on an approval wait so typing pauses); `resolveToAnswer(text)` and `resolveToFailure(note)` — settle, then put the answer/note into the status message and return `{ transition: 'handled' }`, OR delete the status message and return `{ transition: 'delegated' }` (caller posts via sink/`safeSend`); `dispose()` — settle then clear all timers, stop typing, guaranteed-cleanup.
+- **Transition contract (identical across modes at the call site):** `handled` = controller owns the final message (caller does nothing more); `delegated` = caller posts the answer/failure via the sink/`safeSend`. In `live-status`: a short answer that fits one ≤2000-char message → `handled` (edited in place); a long/attachment answer or an empty answer → `delegated` (status deleted). `resolveToFailure`: status message exists → edit into the note → `handled`; no status message yet → `delegated`. In `typing-only` mode: `noteActivity` posts nothing; `setBusy` still pulses typing; `resolveToAnswer`/`resolveToFailure` always return `delegated` (no status to edit).
+- **Settle phase (before every resolve/dispose):** cancel the pending debounce timer and `await` any in-flight edit promise before performing the final edit/delete. The controller retains the in-flight edit promise so a debounced edit can never land after the final answer.
+- Debounce: coalesce rapid `noteActivity` calls into one edit on a named interval constant; never edit per-token. First activity posts the initial status message; subsequent activity edits it.
+- Typing: `setBusy(true)` immediately `thread.sendTyping()` and schedules re-pulse every ~7s; `setBusy(false)`/`dispose()` clears the interval. Typing failures are non-fatal (log + continue) — typing is cosmetic.
+- All Discord calls are fail-soft (a failed edit/typing/delete logs and does not abort the run), consistent with the sink's `safeSend` discipline.
+
+**Patterns to follow:**
+- `message.edit(...)` handle retention from the approval-embed settlement in `run.ts` (~461).
+- Closure-based controller with `dispose()` like `createHeartbeatController` (runtime) / the sink's settle-handle style.
+- Fail-soft Discord I/O like `safeSend` in `streaming.ts`.
+
+**Test scenarios:**
+- Happy path (live-status): first `noteActivity` posts a status message; subsequent `noteActivity` within the debounce window coalesces into a single edit; the rendered status reflects the accumulated essential-action counts.
+- Happy path (transition): `resolveToAnswer(short)` edits the status message into the answer and returns `transition: 'handled'`; `resolveToAnswer(long/needs-attachment)` deletes the status and returns `transition: 'delegated'`.
+- Edge case (empty answer): `resolveToAnswer('')`/whitespace deletes the status and returns `transition: 'delegated'` (the sink owns the no-output fallback; the status never becomes the placeholder).
+- Edge case (2000-char boundary): an answer exactly at the one-message limit resolves consistently (`handled`), and one char over → `delegated` — pin the boundary explicitly.
+- Settle/race: a debounced edit is scheduled, then `resolveToAnswer` is called before the timer fires AND while a prior edit promise is in flight → assert the final answer is the last write, no late status edit lands after it.
+- Happy path (typing): `setBusy(true)` sends typing and re-pulses on the interval; `setBusy(false)`/`dispose()` stops further pulses.
+- Approval-wait: `setBusy(false)` during a simulated multi-pulse wait → no typing pulses fire while paused; `setBusy(true)` resumes.
+- Failure path: `resolveToFailure(note)` with a status message present edits the status into the note and returns `transition: 'handled'`; with no status message yet returns `transition: 'delegated'` (caller posts) rather than throwing. Assert never both.
+- Edge case (typing-only mode): `noteActivity` posts nothing, `setBusy` still pulses typing, `resolveToAnswer`/`resolveToFailure` always return `transition: 'delegated'`.
+- Edge case (fail-soft): a rejected `thread.sendTyping()` / `message.edit()` / `message.delete()` is caught, logged, and does not throw.
+- Edge case (dispose): `dispose()` settles then clears the typing interval and the pending debounce timer; no edits/pulses fire after dispose.
+
+**Verification:** the controller posts/edits exactly one status message on cadence, pulses typing only while genuinely busy (paused during approval waits), resolves to a single `handled`/`delegated` outcome with no late-edit race, and never throws on Discord I/O failure.
+
+- [ ] **Unit 3: Wire the status controller into the run lifecycle**
+
+**Goal:** Drive the controller from the run-core event stream and own its lifecycle in `run.ts`, coordinating with the sink's final flush and failure paths.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** Unit 2.
+
+**Files:**
+- Modify: `packages/gateway/src/execute/run.ts`
+- Modify: `packages/gateway/src/execute/run-core.ts`
+- Modify: `packages/gateway/src/execute/run.test.ts`
+- Modify: `packages/gateway/src/execute/run-core.test.ts`
+
+- `run.ts`: create the status controller right after thread/sink creation (passing `config.statusMode`); dispose it in the same inner `finally` that disposes the coordinator (guaranteed cleanup). The completion and failure call sites use the **single transition contract** and do NOT branch on mode:
+  - On COMPLETED, before `sink.flush()`: `const r = await resolveToAnswer(finalText)`; if `r.transition === 'handled'` skip the sink flush (answer is in the status message); if `'delegated'` flush via the sink as today.
+  - On failure (`RunCoreError`/timeout/abort): `const r = await resolveToFailure(coarseNote)` using the existing failure-copy mapping; post the coarse note via `safeSend` **only when** `r.transition === 'delegated'`. Never both.
+- `run-core.ts`: thread a lightweight hook/handle (e.g. an `onActivity(summary)` and `onBusy(boolean)` pair) into the event loop. Call `onActivity` at each essential tool-summary append site (reusing `appendToolSummary`'s computed summary); `onBusy(true)` when work starts; `onBusy(false)` on `session.idle`/terminal **and when the run enters an approval wait** (the permission-coordinator path already knows this moment — pause typing there). If no distinct `session.status` busy event exists, treat the window between prompt-send and `session.idle` as busy.
+- No-output fallback: because `resolveToAnswer('')` returns `delegated` and deletes the status message, the sink owns the `_(no output)_` fallback exactly as today — the status message never becomes the placeholder.
+- Typing-only mode: the same call sites run unchanged (the controller always returns `delegated`), so typing pulses but the sink/`safeSend` own the final answer/failure — no mode-specific branching at the call site.
+
+**Execution note:** integration-test the COMPLETED edit-in-place path and the failure-note path through `run.ts`, since mocks alone won't prove the status↔sink hand-off.
+
+**Patterns to follow:**
+- Per-run component creation + dual-`finally` teardown already used for the heartbeat/coordinator in `run.ts`.
+- The existing `appendToolSummary` site in `run-core.ts` as the activity source.
+
+**Test scenarios:**
+- Integration (live-status, short answer): a run that produces tool activity then a short final answer → a status message is posted during the run and edited into the final answer; the sink does not post a second message.
+- Integration (live-status, long answer): a run whose final answer needs the attachment path → the status message is deleted and the answer posts via the sink's summary+attachment path.
+- Integration (failure): a run that throws `RunCoreError` → the status message is edited into a terse failure note (`handled`); exactly one failure message in the thread, no second `safeSend`, no raw error dump.
+- Integration (failure before activity): a run that fails before any tool activity (no status message posted) → `resolveToFailure` returns `delegated` and `safeSend` posts the note; still exactly one failure message.
+- Integration (typing-only mode): tool activity posts no status message; the final answer/failure posts via the sink/`safeSend`; typing was pulsed during the run.
+- Integration (approval-wait): a run that enters an approval wait → typing pauses (no pulses) during the wait and resumes after.
+- Edge case (no output): an empty-answer run still yields the `_(no output)_` (or persona equivalent) without a leftover status message.
+- Edge case (cleanup): the controller is disposed in `finally` on both success and failure (no leaked typing interval).
+
+**Verification:** during a live-status run the thread shows one updating status message that becomes the answer (or is replaced for long answers); failures read as a persona note; typing-only shows only typing + answer; no timers leak.
+
+- [ ] **Unit 4: Deploy wiring + docs**
+
+**Goal:** Surface `GATEWAY_STATUS_MODE` for operators.
+
+**Requirements:** R4
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `deploy/compose.yaml`
+- Modify: `deploy/README.md`
+- Modify: `packages/gateway/AGENTS.md`
+
+**Approach:**
+- Add a commented optional `GATEWAY_STATUS_MODE` env entry in `deploy/compose.yaml` (default behavior documented as `live-status`), and a short operator note in `deploy/README.md` describing `live-status` vs `typing-only`. Add a one-line behavior note to `packages/gateway/AGENTS.md`. No plan-speak / phase taxonomy in any shipped file.
+
+**Test expectation:** none — config/docs only (behavior covered by Units 1–3).
+
+**Verification:** compose validates; docs describe the two modes without internal taxonomy.
+
+## System-Wide Impact
+
+- **Interaction graph:** the status controller sits between `run-core.ts` (activity/busy events) and Discord (`thread.send`/`message.edit`/`sendTyping`), and coordinates with the sink's final flush in `run.ts`. It does not touch lock/run-state/heartbeat.
+- **Error propagation:** all Discord I/O in the controller is fail-soft (log + continue); a status/typing failure must never abort or fail a run.
+- **State lifecycle risks:** the typing re-pulse interval and the debounce timer must be cleared on dispose in the run's `finally` — a leaked interval would pulse typing forever. The status message must always be resolved (edited/deleted) so it isn't orphaned.
+- **API surface parity:** none — internal gateway component; no exported contract changes. `GATEWAY_STATUS_MODE` is the only new external (operator) surface.
+- **Integration coverage:** the status↔sink hand-off (edit-in-place vs delete-then-post, and the no-output fallback) is the cross-layer behavior unit mocks won't prove — covered by Unit 3 integration tests.
+- **Unchanged invariants:** the `DiscordStreamSink` contract, the lock/run-state/heartbeat coordination, and the approval embed flow are unchanged; the final-answer content and the `_(no output)_` fallback semantics are preserved.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Status edits hit Discord rate limits and throttle the run | Debounced single edited message (~1.5–2s), fail-soft on edit failure; one message edited, never per-token. |
+| Status message + sink both post → double message (success or failure) | Single transition contract: the caller posts via sink/`safeSend` ONLY on `delegated`; `handled` means the controller owns the message. Settle phase cancels pending debounce + awaits in-flight edit before resolve, so no late edit lands after the answer. Unit 2/3 tests assert exactly one final/failure message and the race case. |
+| Leaked typing interval keeps the thread "typing" forever, or typing lies during an approval wait | `dispose()` settles + clears all timers in the run's inner `finally`; `setBusy(false)` pauses typing on approval wait. Unit 2/3 cleanup + approval-wait tests assert no pulses after dispose / during a wait. |
+| `session.status` busy/idle event shape differs in the SDK | Deferred-to-implementation: confirm against `@opencode-ai/sdk` 1.15.13; fall back to prompt-send→`session.idle` as the busy window. |
+| Posted status message confuses the sink's `hasVisibleOutput` no-output accounting | Status message tracked separately from sink visible-output; resolved before the flush decision (KTD). |
+
+## Documentation / Operational Notes
+
+- `deploy/README.md` + `deploy/compose.yaml`: document `GATEWAY_STATUS_MODE` (`live-status` default | `typing-only`). Operators wanting the quietest experience set `typing-only`.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md](docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md) — Phase 2 (working-state UX), OQ1/OQ2, interaction states.
+- Related code: `packages/gateway/src/discord/streaming.ts`, `packages/gateway/src/execute/run.ts`, `packages/gateway/src/execute/run-core.ts`, `packages/gateway/src/config.ts`, `packages/gateway/src/execute/format-part.ts`.
+- Phase 1 (shipped): #831 (rendering + persona), #837 (NBC follow-ups), #833 (lock-leak fix).

--- a/docs/plans/2026-06-07-004-feat-mention-loop-working-state-ux-plan.md
+++ b/docs/plans/2026-06-07-004-feat-mention-loop-working-state-ux-plan.md
@@ -88,7 +88,7 @@ Phase 2 of the production-ready `@Fro Bot` Discord mention loop. Phase 1 (clean 
 
 ## Implementation Units
 
-- [ ] **Unit 1: `GATEWAY_STATUS_MODE` config**
+- [x] **Unit 1: `GATEWAY_STATUS_MODE` config**
 
 **Goal:** Add the deploy-wide working-state mode setting.
 
@@ -113,7 +113,7 @@ Phase 2 of the production-ready `@Fro Bot` Discord mention loop. Phase 1 (clean 
 
 **Verification:** config exposes a validated `statusMode`; invalid values are rejected at load.
 
-- [ ] **Unit 2: Status-message manager + typing pulse**
+- [x] **Unit 2: Status-message manager + typing pulse**
 
 **Goal:** A per-run component that owns one status message (post/edit/resolve) on a debounced cadence and pulses the typing indicator while busy.
 
@@ -152,7 +152,7 @@ Phase 2 of the production-ready `@Fro Bot` Discord mention loop. Phase 1 (clean 
 
 **Verification:** the controller posts/edits exactly one status message on cadence, pulses typing only while genuinely busy (paused during approval waits), resolves to a single `handled`/`delegated` outcome with no late-edit race, and never throws on Discord I/O failure.
 
-- [ ] **Unit 3: Wire the status controller into the run lifecycle**
+- [x] **Unit 3: Wire the status controller into the run lifecycle**
 
 **Goal:** Drive the controller from the run-core event stream and own its lifecycle in `run.ts`, coordinating with the sink's final flush and failure paths.
 
@@ -191,7 +191,7 @@ Phase 2 of the production-ready `@Fro Bot` Discord mention loop. Phase 1 (clean 
 
 **Verification:** during a live-status run the thread shows one updating status message that becomes the answer (or is replaced for long answers); failures read as a persona note; typing-only shows only typing + answer; no timers leak.
 
-- [ ] **Unit 4: Deploy wiring + docs**
+- [x] **Unit 4: Deploy wiring + docs**
 
 **Goal:** Surface `GATEWAY_STATUS_MODE` for operators.
 

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -76,6 +76,10 @@ Existing deployments that need the privileged set must set this on the next
 deploy. The allowlist is intentionally narrow — operators cannot enable
 arbitrary Discord intents via this knob.
 
+### `GATEWAY_STATUS_MODE`
+
+Controls the working-state UX posted to the run thread while the agent is executing. `live-status` (default) posts a single live status message plus a typing indicator; `typing-only` shows only the typing indicator (no status message). Absent or empty → `live-status`.
+
 ## Mention-triggered execution loop
 
 When a guild member `@fro-bot`s in a channel, `discord/mentions.ts` handles the event:

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -66,6 +66,8 @@ beforeEach(() => {
     'GATEWAY_MAX_CONCURRENT_RUNS',
     'GATEWAY_APPROVAL_MODE',
     'GATEWAY_APPROVAL_MODE_FILE',
+    'GATEWAY_STATUS_MODE',
+    'GATEWAY_STATUS_MODE_FILE',
     'GATEWAY_PERSONA',
     'GATEWAY_PERSONA_FILE',
   ]) {
@@ -1552,5 +1554,122 @@ describe('loadGatewayConfig — GATEWAY_PERSONA_FILE (persona)', () => {
       config = loadGatewayConfig()
     }).not.toThrow()
     expect(config?.persona).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GATEWAY_STATUS_MODE
+// ---------------------------------------------------------------------------
+
+describe('loadGatewayConfig — GATEWAY_STATUS_MODE', () => {
+  it('happy path: unset GATEWAY_STATUS_MODE → statusMode defaults to "live-status"', () => {
+    // #given — GATEWAY_STATUS_MODE not set
+    setRequiredEnv()
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.statusMode).toBe('live-status')
+  })
+
+  it('happy path: GATEWAY_STATUS_MODE=live-status → statusMode is "live-status"', () => {
+    // #given
+    setRequiredEnv()
+    process.env.GATEWAY_STATUS_MODE = 'live-status'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.statusMode).toBe('live-status')
+  })
+
+  it('happy path: GATEWAY_STATUS_MODE=typing-only → statusMode is "typing-only"', () => {
+    // #given
+    setRequiredEnv()
+    process.env.GATEWAY_STATUS_MODE = 'typing-only'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.statusMode).toBe('typing-only')
+  })
+
+  it('edge case: empty GATEWAY_STATUS_MODE → treated as unset, defaults to "live-status"', () => {
+    // #given — empty string is treated as absent by readOptionalSecret
+    setRequiredEnv()
+    process.env.GATEWAY_STATUS_MODE = ''
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.statusMode).toBe('live-status')
+  })
+
+  it('edge case: whitespace-only GATEWAY_STATUS_MODE → treated as unset, defaults to "live-status"', () => {
+    // #given — whitespace-only is treated as absent by readOptionalSecret
+    setRequiredEnv()
+    process.env.GATEWAY_STATUS_MODE = '   '
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.statusMode).toBe('live-status')
+  })
+
+  it('error path: unknown GATEWAY_STATUS_MODE value → throws with clear config error naming valid values', () => {
+    // #given
+    setRequiredEnv()
+    process.env.GATEWAY_STATUS_MODE = 'silent'
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(
+      'Invalid GATEWAY_STATUS_MODE value: "silent" (valid values: live-status, typing-only)',
+    )
+  })
+
+  it('error path: GATEWAY_STATUS_MODE_FILE with unknown value → throws with clear config error', () => {
+    // #given
+    setRequiredEnv()
+    const modeFile = join(tmpDir, 'status-mode-bad.txt')
+    writeFileSync(modeFile, 'verbose\n', {mode: 0o600})
+    process.env.GATEWAY_STATUS_MODE_FILE = modeFile
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(
+      'Invalid GATEWAY_STATUS_MODE value: "verbose" (valid values: live-status, typing-only)',
+    )
+  })
+
+  it('edge case: GATEWAY_STATUS_MODE_FILE with typing-only value → reads from file', () => {
+    // #given — value provided via _FILE (the compose bind-mount pattern)
+    setRequiredEnv()
+    const modeFile = join(tmpDir, 'status-mode.txt')
+    writeFileSync(modeFile, 'typing-only\n', {mode: 0o600})
+    process.env.GATEWAY_STATUS_MODE_FILE = modeFile
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then — trailing newline stripped; value parsed correctly
+    expect(config.statusMode).toBe('typing-only')
+  })
+
+  it('edge case: GATEWAY_STATUS_MODE_FILE with empty file → defaults to "live-status"', () => {
+    // #given — empty file is treated as absent by readOptionalSecret
+    setRequiredEnv()
+    const modeFile = join(tmpDir, 'status-mode-empty.txt')
+    writeFileSync(modeFile, '', {mode: 0o600})
+    process.env.GATEWAY_STATUS_MODE_FILE = modeFile
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.statusMode).toBe('live-status')
   })
 })

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -18,6 +18,9 @@ const DEFAULT_APPROVAL_MODE = 'approval-required' as const
 const VALID_APPROVAL_MODES = ['approval-required'] as const
 const DEFERRED_APPROVAL_MODES = ['autonomous-low-risk'] as const
 
+const DEFAULT_STATUS_MODE = 'live-status' as const
+const VALID_STATUS_MODES = ['live-status', 'typing-only'] as const
+
 const ALLOWED_PRIVILEGED_INTENTS = {
   MessageContent: GatewayIntentBits.MessageContent,
   GuildMembers: GatewayIntentBits.GuildMembers,
@@ -56,6 +59,13 @@ export interface GatewayConfig {
    * the rationale (OpenCode last-match-wins evaluation makes session-scoped denies unsafe).
    */
   readonly approvalMode: 'approval-required'
+  /**
+   * Deploy-wide working-state UX mode for mention runs.
+   * - `live-status` (default): posts a single editable status message that updates on a
+   *   debounced cadence while the agent works, then transitions into the final answer.
+   * - `typing-only`: suppresses the status message entirely; only the typing indicator is shown.
+   */
+  readonly statusMode: 'live-status' | 'typing-only'
   /**
    * Canonical Fro Bot persona text, read from `GATEWAY_PERSONA_FILE` (or `GATEWAY_PERSONA` env var).
    * Prepended to every Discord mention prompt before the Discord-mechanical guidance.
@@ -301,6 +311,14 @@ export function loadGatewayConfig(): GatewayConfig {
   }
   const approvalMode = rawApprovalMode as GatewayConfig['approvalMode']
 
+  const rawStatusMode = readOptionalSecret('GATEWAY_STATUS_MODE') ?? DEFAULT_STATUS_MODE
+  if (!(VALID_STATUS_MODES as readonly string[]).includes(rawStatusMode)) {
+    throw new Error(
+      `Invalid GATEWAY_STATUS_MODE value: "${rawStatusMode}" (valid values: ${VALID_STATUS_MODES.join(', ')})`,
+    )
+  }
+  const statusMode = rawStatusMode as GatewayConfig['statusMode']
+
   const rawIntents = readOptionalSecret('DISCORD_PRIVILEGED_INTENTS')
   const privilegedIntents: GatewayIntentBits[] = []
   if (rawIntents !== null) {
@@ -464,6 +482,7 @@ export function loadGatewayConfig(): GatewayConfig {
     logLevel,
     privilegedIntents,
     approvalMode,
+    statusMode,
     persona,
     githubAppId,
     githubAppPrivateKey,

--- a/packages/gateway/src/discord/constants.ts
+++ b/packages/gateway/src/discord/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Shared Discord constants for the gateway package.
+ */
+
+/** Discord's hard content-length limit for a single message. */
+export const MAX_DISCORD_MESSAGE_LENGTH = 2000

--- a/packages/gateway/src/discord/mentions.test.ts
+++ b/packages/gateway/src/discord/mentions.test.ts
@@ -148,6 +148,7 @@ function makeRunMentionDeps(): MentionDeps['run'] {
       disposeAll: vi.fn(),
     },
     approvalMode: 'approval-required' as const,
+    statusMode: 'live-status' as const,
     persona: null,
     ensureClone: vi.fn().mockResolvedValue({success: true as const, data: '/workspace/repos/acme/widget'}),
     readyz: vi.fn().mockResolvedValue({success: true as const, data: {ready: true, opencode: 'ready'}}),

--- a/packages/gateway/src/discord/status-message.test.ts
+++ b/packages/gateway/src/discord/status-message.test.ts
@@ -147,23 +147,315 @@ describe('createStatusController', () => {
       expect(thread._send).toHaveBeenCalledOnce()
     })
 
-    it('status content reflects accumulated essential-action counts', async () => {
+    it('status content reflects accumulated essential-action counts with working prefix', async () => {
       // #given
       const mockMsg = makeMockMessage()
       const thread = makeThread(async () => mockMsg)
       const logger = makeLogger()
       const ctrl = createStatusController({thread, mode: 'live-status', logger})
 
-      // #when — multiple activities
+      // #when — multiple activities: 2x "edited", 1x "ran"
       ctrl.noteActivity('edited 1 file')
       ctrl.noteActivity('ran 1 command')
       ctrl.noteActivity('edited 1 file')
       await flushDebounce()
 
-      // #then — the posted content should mention the activities
+      // #then — the posted content starts with the working prefix and includes counted summaries
       const [sendArg] = thread._send.mock.calls[0] as [{content: string}]
-      expect(typeof sendArg.content).toBe('string')
-      expect(sendArg.content.length).toBeGreaterThan(0)
+      expect(sendArg.content).toMatch(/^⏳ Working…/)
+      // "edited" appears 2 times, "ran" appears 1 time
+      expect(sendArg.content).toMatch(/edited 2 times/)
+      expect(sendArg.content).toMatch(/ran 1 time/)
+    })
+
+    it('status content with no activities is just the working prefix', async () => {
+      // #given — noteActivity called but with empty-ish content that still triggers a post
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // #when — trigger a post with a single activity
+      ctrl.noteActivity('worked')
+      await flushDebounce()
+
+      // #then — content starts with working prefix
+      const [sendArg] = thread._send.mock.calls[0] as [{content: string}]
+      expect(sendArg.content).toMatch(/^⏳ Working…/)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // P1-C — allowedMentions on status sends and edits
+  // -------------------------------------------------------------------------
+
+  describe('P1-C — allowedMentions suppression', () => {
+    it('initial status post includes allowedMentions: {parse: []}', async () => {
+      // #given
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // #when
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #then — send called with allowedMentions
+      expect(thread._send).toHaveBeenCalledOnce()
+      const [sendArg] = thread._send.mock.calls[0] as [{content: string; allowedMentions: unknown}]
+      expect(sendArg.allowedMentions).toEqual({parse: []})
+    })
+
+    it('progress edit includes allowedMentions: {parse: []}', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // Post initial status
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when — trigger a progress edit
+      ctrl.noteActivity('ran 1 command')
+      await flushDebounce()
+
+      // #then — edit called with allowedMentions
+      expect(mockMsg.edit).toHaveBeenCalledOnce()
+      const [editArg] = mockMsg.edit.mock.calls[0] as [{content: string; allowedMentions: unknown}]
+      expect(editArg.allowedMentions).toEqual({parse: []})
+    })
+
+    it('terminal edit (resolveToAnswer) includes allowedMentions: {parse: []}', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when
+      await ctrl.resolveToAnswer('Final answer')
+
+      // #then — terminal edit includes allowedMentions
+      const lastEditArg = mockMsg.edit.mock.calls.at(-1)?.[0] as {content: string; allowedMentions: unknown}
+      expect(lastEditArg.allowedMentions).toEqual({parse: []})
+    })
+
+    it('terminal edit (resolveToFailure) includes allowedMentions: {parse: []}', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when
+      await ctrl.resolveToFailure('Something went wrong')
+
+      // #then — terminal edit includes allowedMentions
+      const lastEditArg = mockMsg.edit.mock.calls.at(-1)?.[0] as {content: string; allowedMentions: unknown}
+      expect(lastEditArg.allowedMentions).toEqual({parse: []})
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // P1-A — Terminal edit failure returns 'delegated'
+  // -------------------------------------------------------------------------
+
+  describe('P1-A — terminal edit failure returns delegated', () => {
+    it('resolveToAnswer: terminal msg.edit() rejects → returns delegated', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      // All edits fail (progress edits are fail-soft; terminal edit must return delegated)
+      mockMsg.edit.mockRejectedValue(new Error('Unknown Message'))
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when — terminal edit will fail
+      const result = await ctrl.resolveToAnswer('Final answer')
+
+      // #then — delegated because the edit failed
+      expect(result.transition).toBe('delegated')
+      // edit was attempted
+      expect(mockMsg.edit).toHaveBeenCalled()
+      // warn was logged
+      expect(logger.warn).toHaveBeenCalled()
+    })
+
+    it('resolveToFailure: terminal msg.edit() rejects → returns delegated', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      mockMsg.edit.mockRejectedValue(new Error('Unknown Message'))
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when — terminal edit will fail
+      const result = await ctrl.resolveToFailure('Failure note')
+
+      // #then — delegated because the edit failed
+      expect(result.transition).toBe('delegated')
+      expect(mockMsg.edit).toHaveBeenCalled()
+      expect(logger.warn).toHaveBeenCalled()
+    })
+
+    it('resolveToAnswer: terminal edit succeeds → returns handled', async () => {
+      // #given — edit succeeds (default mock)
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when
+      const result = await ctrl.resolveToAnswer('Final answer')
+
+      // #then — handled because the edit succeeded
+      expect(result.transition).toBe('handled')
+    })
+
+    it('resolveToFailure: terminal edit succeeds → returns handled', async () => {
+      // #given — edit succeeds (default mock)
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when
+      const result = await ctrl.resolveToFailure('Failure note')
+
+      // #then — handled because the edit succeeded
+      expect(result.transition).toBe('handled')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // P1-B — Settle must await the in-flight INITIAL post
+  // -------------------------------------------------------------------------
+
+  describe('P1-B — settle awaits in-flight initial post', () => {
+    it('resolveToAnswer while initial thread.send is pending: no stale "Working…" after resolve', async () => {
+      // #given — controllable initial post promise
+      let resolvePost!: (msg: MockMessage) => void
+      const postPromise = new Promise<MockMessage>(resolve => {
+        resolvePost = resolve
+      })
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => postPromise)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // Trigger the initial post (debounce fires, safePost starts but doesn't resolve yet)
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+      // The send was called but not yet resolved
+      expect(thread._send).toHaveBeenCalledOnce()
+
+      // #when — resolveToAnswer starts while the initial post is still in flight
+      const resolvePromise = ctrl.resolveToAnswer('Final answer')
+
+      // Now resolve the initial post
+      resolvePost(mockMsg)
+      const result = await resolvePromise
+
+      // #then — the controller awaited the post, so statusMessage is now known
+      // Since the post resolved with mockMsg, the terminal edit should have been attempted
+      expect(result.transition).toBe('handled')
+      // The terminal edit was called on the now-known message (not a stale "Working…")
+      expect(mockMsg.edit).toHaveBeenCalledOnce()
+      const [editArg] = mockMsg.edit.mock.calls[0] as [{content: string}]
+      expect(editArg.content).toBe('Final answer')
+    })
+
+    it('dispose while initial thread.send is pending: no stale "Working…" message left', async () => {
+      // #given — controllable initial post promise
+      let resolvePost!: (msg: MockMessage) => void
+      const postPromise = new Promise<MockMessage>(resolve => {
+        resolvePost = resolve
+      })
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => postPromise)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // Trigger the initial post
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+      expect(thread._send).toHaveBeenCalledOnce()
+
+      // #when — dispose starts while the initial post is still in flight
+      const disposePromise = ctrl.dispose()
+
+      // Resolve the initial post
+      resolvePost(mockMsg)
+      await disposePromise
+
+      // #then — dispose completed; no further edits or sends
+      // The controller is disposed; no stale "Working…" message was left untracked
+      expect(mockMsg.edit).not.toHaveBeenCalled()
+      expect(mockMsg.delete).not.toHaveBeenCalled()
+    })
+
+    it('combined: debounce timer pending AND in-flight edit when resolveToAnswer runs → final answer is last write', async () => {
+      // #given — controllable in-flight edit promise
+      let resolveEdit!: () => void
+      const editPromise = new Promise<void>(resolve => {
+        resolveEdit = resolve
+      })
+      const mockMsg = {
+        edit: vi.fn().mockReturnValueOnce(editPromise).mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+      }
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // Post initial status
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // Trigger a second debounced edit — this starts the in-flight edit
+      ctrl.noteActivity('ran 1 command')
+      await flushDebounce()
+      // The in-flight edit is now pending (not yet resolved)
+      expect(mockMsg.edit).toHaveBeenCalledOnce()
+
+      // Schedule another debounce (timer NOT yet fired)
+      ctrl.noteActivity('read 1 file')
+
+      // #when — resolveToAnswer is called while edit is in flight AND debounce is pending
+      const resolvePromise = ctrl.resolveToAnswer('Final answer')
+
+      // Resolve the in-flight edit
+      resolveEdit()
+      const result = await resolvePromise
+
+      // Advance timers — the debounce should have been cancelled
+      await flushDebounce()
+
+      // #then — final answer edit happened; no late edit from the cancelled debounce
+      expect(result.transition).toBe('handled')
+      // edit called twice: once for the in-flight debounce, once for the final answer
+      expect(mockMsg.edit).toHaveBeenCalledTimes(2)
+      const lastEditArg = mockMsg.edit.mock.calls[1]?.[0] as {content: string}
+      expect(lastEditArg.content).toBe('Final answer')
     })
   })
 
@@ -372,6 +664,83 @@ describe('createStatusController', () => {
       expect(mockMsg.edit).toHaveBeenCalledTimes(2)
       const lastEditArg = mockMsg.edit.mock.calls[1]?.[0] as {content: string}
       expect(lastEditArg.content).toBe('Final answer')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // P2 — Settling flag stops late activity
+  // -------------------------------------------------------------------------
+
+  describe('P2 — terminal flag stops late activity', () => {
+    it('noteActivity after resolveToAnswer has begun does nothing (no new debounce)', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+      const editCallsBeforeResolve = mockMsg.edit.mock.calls.length
+
+      // #when — start resolving (sets terminal=true)
+      const resolvePromise = ctrl.resolveToAnswer('Final answer')
+      // Immediately try to schedule more activity
+      ctrl.noteActivity('ran 1 command')
+      ctrl.noteActivity('read 1 file')
+      await resolvePromise
+
+      // Advance timers — any debounce that was scheduled should NOT fire
+      await flushDebounce()
+
+      // #then — only the terminal edit happened; no extra edits from late activity
+      // editCallsBeforeResolve is 0 (no progress edits yet), terminal edit is 1
+      expect(mockMsg.edit.mock.calls.length).toBe(editCallsBeforeResolve + 1)
+      const lastEditArg = mockMsg.edit.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastEditArg.content).toBe('Final answer')
+    })
+
+    it('noteActivity after resolveToFailure has begun does nothing', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+      const editCallsBeforeResolve = mockMsg.edit.mock.calls.length
+
+      // #when — start resolving failure
+      const resolvePromise = ctrl.resolveToFailure('Failure note')
+      ctrl.noteActivity('ran 1 command')
+      await resolvePromise
+
+      await flushDebounce()
+
+      // #then — only the terminal edit happened
+      expect(mockMsg.edit.mock.calls.length).toBe(editCallsBeforeResolve + 1)
+      const lastEditArg = mockMsg.edit.mock.calls.at(-1)?.[0] as {content: string}
+      expect(lastEditArg.content).toBe('Failure note')
+    })
+
+    it('noteActivity after dispose does nothing', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when
+      await ctrl.dispose()
+      ctrl.noteActivity('ran 1 command')
+      await flushDebounce()
+
+      // #then — no extra edits after dispose
+      expect(mockMsg.edit).not.toHaveBeenCalled()
     })
   })
 
@@ -618,7 +987,7 @@ describe('createStatusController', () => {
       expect(logger.warn).toHaveBeenCalled()
     })
 
-    it('rejected message.edit is caught and logged, does not throw', async () => {
+    it('rejected message.edit (progress) is caught and logged, does not throw', async () => {
       // #given
       const mockMsg = makeMockMessage()
       mockMsg.edit.mockRejectedValue(new Error('Unknown Message'))
@@ -629,7 +998,7 @@ describe('createStatusController', () => {
       ctrl.noteActivity('edited 1 file')
       await flushDebounce()
 
-      // #when — second activity triggers an edit
+      // #when — second activity triggers a progress edit
       ctrl.noteActivity('ran 1 command')
 
       // #then — must not throw when debounce fires

--- a/packages/gateway/src/discord/status-message.test.ts
+++ b/packages/gateway/src/discord/status-message.test.ts
@@ -1,0 +1,758 @@
+/**
+ * Tests for createStatusController — per-run status message + typing pulse manager.
+ *
+ * Uses vi.useFakeTimers() throughout to control debounce and pulse intervals.
+ */
+
+import type {GatewayLogger} from './client.js'
+import type {StatusThread} from './status-message.js'
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createStatusController, STATUS_DEBOUNCE_MS, STATUS_TYPING_PULSE_MS} from './status-message.js'
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+/** A mock Discord message with edit and delete vi.fns. */
+function makeMockMessage() {
+  return {
+    edit: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+type MockMessage = ReturnType<typeof makeMockMessage>
+
+/**
+ * Build a StatusThread mock. By default send() resolves with a fresh mock message.
+ * Pass `sendImpl` to override the send behaviour (e.g. to return a controllable promise).
+ */
+function makeThread(sendImpl?: () => Promise<MockMessage>): StatusThread & {
+  readonly _send: ReturnType<typeof vi.fn>
+  readonly _sendTyping: ReturnType<typeof vi.fn>
+} {
+  const defaultImpl = async (): Promise<MockMessage> => makeMockMessage()
+  const sendFn = vi.fn().mockImplementation(sendImpl ?? defaultImpl)
+  const sendTypingFn = vi.fn().mockResolvedValue(undefined)
+  const result: StatusThread & {
+    readonly _send: ReturnType<typeof vi.fn>
+    readonly _sendTyping: ReturnType<typeof vi.fn>
+  } = {
+    send: sendFn,
+    sendTyping: sendTypingFn,
+    _send: sendFn,
+    _sendTyping: sendTypingFn,
+  }
+  return result
+}
+
+function makeLogger(): GatewayLogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Advance fake timers by the debounce interval so the pending edit fires. */
+async function flushDebounce(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(STATUS_DEBOUNCE_MS)
+}
+
+/** Advance fake timers by the typing pulse interval. */
+async function flushTypingPulse(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(STATUS_TYPING_PULSE_MS)
+}
+
+/** Flush pending microtasks (Promise.resolve() tick). */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createStatusController', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // -------------------------------------------------------------------------
+  // Happy path — live-status mode
+  // -------------------------------------------------------------------------
+
+  describe('happy path — live-status mode', () => {
+    it('first noteActivity posts a status message', async () => {
+      // #given
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // #when
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #then
+      expect(thread._send).toHaveBeenCalledOnce()
+    })
+
+    it('subsequent noteActivity within the debounce window coalesces into a single edit', async () => {
+      // #given
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // #when — three rapid calls before the debounce fires
+      ctrl.noteActivity('edited 1 file')
+      ctrl.noteActivity('ran 1 command')
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #then — only one send (initial post), no extra sends
+      expect(thread._send).toHaveBeenCalledOnce()
+    })
+
+    it('subsequent noteActivity after debounce fires edits the existing message', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // #when — first batch posts
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+      expect(thread._send).toHaveBeenCalledOnce()
+
+      // second batch edits
+      ctrl.noteActivity('ran 1 command')
+      await flushDebounce()
+
+      // #then — edit called on the posted message
+      expect(mockMsg.edit).toHaveBeenCalledOnce()
+      // send still only called once (the initial post)
+      expect(thread._send).toHaveBeenCalledOnce()
+    })
+
+    it('status content reflects accumulated essential-action counts', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // #when — multiple activities
+      ctrl.noteActivity('edited 1 file')
+      ctrl.noteActivity('ran 1 command')
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #then — the posted content should mention the activities
+      const [sendArg] = thread._send.mock.calls[0] as [{content: string}]
+      expect(typeof sendArg.content).toBe('string')
+      expect(sendArg.content.length).toBeGreaterThan(0)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Transition — resolveToAnswer
+  // -------------------------------------------------------------------------
+
+  describe('resolveToAnswer', () => {
+    it('short answer (≤2000 chars) edits the status message and returns handled', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when
+      const result = await ctrl.resolveToAnswer('Short answer text')
+
+      // #then
+      expect(result.transition).toBe('handled')
+      expect(mockMsg.edit).toHaveBeenCalledOnce()
+      expect(mockMsg.delete).not.toHaveBeenCalled()
+    })
+
+    it('long answer (>2000 chars) deletes the status message and returns delegated', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when
+      const longAnswer = 'x'.repeat(2001)
+      const result = await ctrl.resolveToAnswer(longAnswer)
+
+      // #then
+      expect(result.transition).toBe('delegated')
+      expect(mockMsg.delete).toHaveBeenCalledOnce()
+      expect(mockMsg.edit).not.toHaveBeenCalled()
+    })
+
+    it('exactly 2000 chars → handled (boundary inclusive)', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when
+      const exactAnswer = 'x'.repeat(2000)
+      const result = await ctrl.resolveToAnswer(exactAnswer)
+
+      // #then
+      expect(result.transition).toBe('handled')
+      expect(mockMsg.edit).toHaveBeenCalledOnce()
+    })
+
+    it('2001 chars → delegated (one over boundary)', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when
+      const overAnswer = 'x'.repeat(2001)
+      const result = await ctrl.resolveToAnswer(overAnswer)
+
+      // #then
+      expect(result.transition).toBe('delegated')
+      expect(mockMsg.delete).toHaveBeenCalledOnce()
+    })
+
+    it('empty answer deletes the status message and returns delegated', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when
+      const result = await ctrl.resolveToAnswer('')
+
+      // #then
+      expect(result.transition).toBe('delegated')
+      expect(mockMsg.delete).toHaveBeenCalledOnce()
+      expect(mockMsg.edit).not.toHaveBeenCalled()
+    })
+
+    it('whitespace-only answer deletes the status message and returns delegated', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when
+      const result = await ctrl.resolveToAnswer('   \n\t  ')
+
+      // #then
+      expect(result.transition).toBe('delegated')
+      expect(mockMsg.delete).toHaveBeenCalledOnce()
+    })
+
+    it('no status message yet → resolveToAnswer returns delegated without deleting', async () => {
+      // #given — no noteActivity called, so no status message posted
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // #when
+      const result = await ctrl.resolveToAnswer('Short answer')
+
+      // #then
+      expect(result.transition).toBe('delegated')
+      expect(thread._send).not.toHaveBeenCalled()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Settle / race condition
+  // -------------------------------------------------------------------------
+
+  describe('settle / race condition', () => {
+    it('cancels pending debounce timer before resolving — no late edit after answer', async () => {
+      // #given — schedule a debounced edit but do NOT advance timers yet
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // Post the initial status message
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+      expect(thread._send).toHaveBeenCalledOnce()
+
+      // Schedule another debounced edit (timer NOT yet fired)
+      ctrl.noteActivity('ran 1 command')
+
+      // #when — resolve before the debounce fires
+      const result = await ctrl.resolveToAnswer('Final answer')
+
+      // Advance timers — the debounce should have been cancelled
+      await flushDebounce()
+
+      // #then — the answer edit happened, but no extra edit from the cancelled debounce
+      expect(result.transition).toBe('handled')
+      // edit called exactly once (for the answer), not twice (answer + late debounce)
+      expect(mockMsg.edit).toHaveBeenCalledOnce()
+      const [editArg] = mockMsg.edit.mock.calls[0] as [{content: string}]
+      expect(editArg.content).toBe('Final answer')
+    })
+
+    it('awaits in-flight edit promise before performing final edit', async () => {
+      // #given — controllable in-flight edit promise
+      let resolveEdit!: () => void
+      const editPromise = new Promise<void>(resolve => {
+        resolveEdit = resolve
+      })
+      const mockMsg = {
+        edit: vi.fn().mockReturnValueOnce(editPromise).mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+      }
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // Post initial status
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // Trigger a second debounced edit — this starts the in-flight edit
+      ctrl.noteActivity('ran 1 command')
+      await flushDebounce()
+      // The in-flight edit is now pending (not yet resolved)
+      expect(mockMsg.edit).toHaveBeenCalledOnce()
+
+      // #when — resolveToAnswer is called while edit is still in flight
+      const resolvePromise = ctrl.resolveToAnswer('Final answer')
+
+      // Resolve the in-flight edit
+      resolveEdit()
+      const result = await resolvePromise
+
+      // #then — final answer edit happened after the in-flight edit settled
+      expect(result.transition).toBe('handled')
+      // edit called twice: once for the in-flight debounce, once for the final answer
+      expect(mockMsg.edit).toHaveBeenCalledTimes(2)
+      const lastEditArg = mockMsg.edit.mock.calls[1]?.[0] as {content: string}
+      expect(lastEditArg.content).toBe('Final answer')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Typing pulse — setBusy
+  // -------------------------------------------------------------------------
+
+  describe('setBusy — typing pulse', () => {
+    it('setBusy(true) immediately sends typing', async () => {
+      // #given
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // #when
+      ctrl.setBusy(true)
+      await flushMicrotasks()
+
+      // #then
+      expect(thread._sendTyping).toHaveBeenCalledOnce()
+    })
+
+    it('setBusy(true) re-pulses typing on the interval', async () => {
+      // #given
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // #when
+      ctrl.setBusy(true)
+      await flushMicrotasks()
+      await flushTypingPulse()
+      await flushMicrotasks()
+
+      // #then — at least 2 typing calls (initial + 1 pulse)
+      expect(thread._sendTyping.mock.calls.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('setBusy(false) stops further typing pulses', async () => {
+      // #given
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.setBusy(true)
+      await flushMicrotasks()
+      const callsAfterStart = thread._sendTyping.mock.calls.length
+
+      // #when
+      ctrl.setBusy(false)
+      await flushTypingPulse()
+      await flushMicrotasks()
+
+      // #then — no additional pulses after setBusy(false)
+      expect(thread._sendTyping.mock.calls.length).toBe(callsAfterStart)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Approval-wait: setBusy(false) pauses, setBusy(true) resumes
+  // -------------------------------------------------------------------------
+
+  describe('approval-wait — typing paused during wait', () => {
+    it('no pulses fire while paused; setBusy(true) resumes', async () => {
+      // #given
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.setBusy(true)
+      await flushMicrotasks()
+      const callsBeforePause = thread._sendTyping.mock.calls.length
+
+      // #when — pause (approval wait)
+      ctrl.setBusy(false)
+      await flushTypingPulse()
+      await flushTypingPulse()
+      await flushMicrotasks()
+
+      // #then — no new pulses during pause
+      expect(thread._sendTyping.mock.calls.length).toBe(callsBeforePause)
+
+      // #when — resume
+      ctrl.setBusy(true)
+      await flushMicrotasks()
+      const callsAfterResume = thread._sendTyping.mock.calls.length
+
+      // #then — typing resumed
+      expect(callsAfterResume).toBeGreaterThan(callsBeforePause)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Failure path — resolveToFailure
+  // -------------------------------------------------------------------------
+
+  describe('resolveToFailure', () => {
+    it('with status message present: edits into the note and returns handled', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when
+      const result = await ctrl.resolveToFailure('Something went wrong')
+
+      // #then
+      expect(result.transition).toBe('handled')
+      expect(mockMsg.edit).toHaveBeenCalledOnce()
+      expect(mockMsg.delete).not.toHaveBeenCalled()
+    })
+
+    it('with no status message yet: returns delegated without throwing', async () => {
+      // #given — no noteActivity, no status message
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // #when
+      const result = await ctrl.resolveToFailure('Something went wrong')
+
+      // #then
+      expect(result.transition).toBe('delegated')
+      expect(thread._send).not.toHaveBeenCalled()
+    })
+
+    it('handled: edits status message and does NOT delete it', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when
+      const result = await ctrl.resolveToFailure('Failure note')
+
+      // #then — handled: edit called, delete NOT called (never both)
+      expect(result.transition).toBe('handled')
+      expect(mockMsg.edit).toHaveBeenCalledOnce()
+      expect(mockMsg.delete).not.toHaveBeenCalled()
+    })
+
+    it('delegated: does NOT edit the status message', async () => {
+      // #given — no status message posted
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // #when
+      const result = await ctrl.resolveToFailure('Failure note')
+
+      // #then — delegated: no edit, no delete
+      expect(result.transition).toBe('delegated')
+      expect(thread._send).not.toHaveBeenCalled()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // typing-only mode
+  // -------------------------------------------------------------------------
+
+  describe('typing-only mode', () => {
+    it('noteActivity posts nothing', async () => {
+      // #given
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'typing-only', logger})
+
+      // #when
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #then
+      expect(thread._send).not.toHaveBeenCalled()
+    })
+
+    it('setBusy(true) still pulses typing in typing-only mode', async () => {
+      // #given
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'typing-only', logger})
+
+      // #when
+      ctrl.setBusy(true)
+      await flushMicrotasks()
+
+      // #then
+      expect(thread._sendTyping).toHaveBeenCalledOnce()
+    })
+
+    it('resolveToAnswer always returns delegated in typing-only mode', async () => {
+      // #given
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'typing-only', logger})
+
+      // #when
+      const result = await ctrl.resolveToAnswer('Short answer')
+
+      // #then
+      expect(result.transition).toBe('delegated')
+      expect(thread._send).not.toHaveBeenCalled()
+    })
+
+    it('resolveToFailure always returns delegated in typing-only mode', async () => {
+      // #given
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'typing-only', logger})
+
+      // #when
+      const result = await ctrl.resolveToFailure('Failure note')
+
+      // #then
+      expect(result.transition).toBe('delegated')
+      expect(thread._send).not.toHaveBeenCalled()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Fail-soft — Discord I/O errors are caught and logged
+  // -------------------------------------------------------------------------
+
+  describe('fail-soft — Discord I/O errors', () => {
+    it('rejected sendTyping is caught and logged, does not throw', async () => {
+      // #given
+      const thread = makeThread()
+      thread._sendTyping.mockRejectedValue(new Error('Rate limited'))
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // #when
+      ctrl.setBusy(true)
+      await flushMicrotasks()
+
+      // #then — no throw, warn was called
+      expect(logger.warn).toHaveBeenCalled()
+    })
+
+    it('rejected message.edit is caught and logged, does not throw', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      mockMsg.edit.mockRejectedValue(new Error('Unknown Message'))
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when — second activity triggers an edit
+      ctrl.noteActivity('ran 1 command')
+
+      // #then — must not throw when debounce fires
+      await expect(flushDebounce()).resolves.not.toThrow()
+      expect(logger.warn).toHaveBeenCalled()
+    })
+
+    it('rejected message.delete is caught and logged, does not throw', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      mockMsg.delete.mockRejectedValue(new Error('Unknown Message'))
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when — long answer triggers delete
+      const result = await ctrl.resolveToAnswer('x'.repeat(2001))
+
+      // #then — delegated, no throw
+      expect(result.transition).toBe('delegated')
+      expect(logger.warn).toHaveBeenCalled()
+    })
+
+    it('rejected thread.send is caught and logged, does not throw', async () => {
+      // #given
+      const thread = makeThread()
+      thread._send.mockRejectedValue(new Error('Missing Permissions'))
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // #when
+      ctrl.noteActivity('edited 1 file')
+
+      // #then — must not throw when debounce fires
+      await expect(flushDebounce()).resolves.not.toThrow()
+      expect(logger.warn).toHaveBeenCalled()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // dispose
+  // -------------------------------------------------------------------------
+
+  describe('dispose', () => {
+    it('clears the typing interval — no pulses after dispose', async () => {
+      // #given
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.setBusy(true)
+      await flushMicrotasks()
+      const callsBeforeDispose = thread._sendTyping.mock.calls.length
+
+      // #when
+      await ctrl.dispose()
+      await flushTypingPulse()
+      await flushMicrotasks()
+
+      // #then — no new pulses after dispose
+      expect(thread._sendTyping.mock.calls.length).toBe(callsBeforeDispose)
+    })
+
+    it('cancels the pending debounce timer — no edit fires after dispose', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // Post initial status
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // Schedule another debounced edit
+      ctrl.noteActivity('ran 1 command')
+
+      // #when — dispose before debounce fires
+      await ctrl.dispose()
+      await flushDebounce()
+
+      // #then — no extra edit after dispose
+      expect(mockMsg.edit).not.toHaveBeenCalled()
+    })
+
+    it('is idempotent — calling dispose twice does not throw', async () => {
+      // #given
+      const thread = makeThread()
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      // #when / #then
+      await expect(ctrl.dispose()).resolves.not.toThrow()
+      await expect(ctrl.dispose()).resolves.not.toThrow()
+    })
+
+    it('no edits or pulses fire after dispose', async () => {
+      // #given
+      const mockMsg = makeMockMessage()
+      const thread = makeThread(async () => mockMsg)
+      const logger = makeLogger()
+      const ctrl = createStatusController({thread, mode: 'live-status', logger})
+
+      ctrl.setBusy(true)
+      ctrl.noteActivity('edited 1 file')
+      await flushDebounce()
+
+      // #when
+      await ctrl.dispose()
+      const editCallsAtDispose = mockMsg.edit.mock.calls.length
+      const typingCallsAtDispose = thread._sendTyping.mock.calls.length
+
+      ctrl.noteActivity('ran 1 command')
+      await flushDebounce()
+      await flushTypingPulse()
+      await flushMicrotasks()
+
+      // #then — nothing new after dispose
+      expect(mockMsg.edit.mock.calls.length).toBe(editCallsAtDispose)
+      expect(thread._sendTyping.mock.calls.length).toBe(typingCallsAtDispose)
+    })
+  })
+})

--- a/packages/gateway/src/discord/status-message.ts
+++ b/packages/gateway/src/discord/status-message.ts
@@ -10,9 +10,13 @@
  * - `typing-only`: suppresses the status message entirely; only the typing indicator is shown.
  *
  * All Discord I/O is fail-soft: rejections are caught + logged and never abort the run.
+ * Exception: terminal edits (resolveToAnswer / resolveToFailure) return `delegated` on
+ * failure so the caller can fall back to posting via the sink / safeSend.
  */
 
 import type {GatewayLogger} from './client.js'
+
+import {MAX_DISCORD_MESSAGE_LENGTH} from './constants.js'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -24,9 +28,6 @@ export const STATUS_DEBOUNCE_MS = 1500
 /** Typing indicator re-pulse interval (ms). Discord typing auto-expires ~10s; pulse at ~7s. */
 export const STATUS_TYPING_PULSE_MS = 7000
 
-/** Discord's hard content-length limit for a single message. */
-const DISCORD_MESSAGE_CHAR_LIMIT = 2000
-
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -36,7 +37,10 @@ const DISCORD_MESSAGE_CHAR_LIMIT = 2000
  * Typed narrowly so test doubles don't need the full `ThreadChannel` API.
  */
 export interface StatusThread {
-  readonly send: (options: {readonly content: string}) => Promise<StatusMessage>
+  readonly send: (options: {
+    readonly content: string
+    readonly allowedMentions: {readonly parse: readonly []}
+  }) => Promise<StatusMessage>
   readonly sendTyping: () => Promise<void>
 }
 
@@ -45,7 +49,10 @@ export interface StatusThread {
  * Typed narrowly for testability.
  */
 export interface StatusMessage {
-  readonly edit: (options: {readonly content: string}) => Promise<unknown>
+  readonly edit: (options: {
+    readonly content: string
+    readonly allowedMentions: {readonly parse: readonly []}
+  }) => Promise<unknown>
   readonly delete: () => Promise<unknown>
 }
 
@@ -58,6 +65,7 @@ export interface StatusController {
    * Record an essential-action summary and schedule a debounced status edit.
    * First call posts the initial status message; subsequent calls edit it.
    * In `typing-only` mode, this is a no-op (no message posted).
+   * No-ops once a terminal transition (resolveToAnswer/resolveToFailure/dispose) has begun.
    */
   readonly noteActivity: (summary: string) => void
   /**
@@ -70,23 +78,26 @@ export interface StatusController {
   /**
    * Settle, then resolve the status message into the final answer.
    * - `handled`: controller edited the status message into the answer (caller does nothing more).
-   * - `delegated`: caller must post the answer via the sink (status deleted or never existed).
+   * - `delegated`: caller must post the answer via the sink (status deleted, never existed, or
+   *   the terminal edit failed).
    *
    * Conditions for `handled`: live-status mode AND a status message exists AND
-   * the answer is non-empty, non-whitespace, and fits one Discord message (≤2000 chars).
+   * the answer is non-empty, non-whitespace, and fits one Discord message (≤2000 chars)
+   * AND the terminal edit succeeds.
    * All other cases → `delegated`.
    */
   readonly resolveToAnswer: (text: string) => Promise<TransitionResult>
   /**
    * Settle, then resolve the status message into a failure note.
    * - `handled`: controller edited the status message into the note (caller does nothing more).
-   * - `delegated`: caller must post the failure note via safeSend (no status to edit, or typing-only).
+   * - `delegated`: caller must post the failure note via safeSend (no status to edit, typing-only,
+   *   or the terminal edit failed).
    *
    * Never both edits and delegates.
    */
   readonly resolveToFailure: (note: string) => Promise<TransitionResult>
   /**
-   * Settle (cancel debounce, await in-flight edit), then clear all timers.
+   * Settle (cancel debounce, await in-flight update), then clear all timers.
    * Idempotent. No edits or pulses fire after dispose.
    */
   readonly dispose: () => Promise<void>
@@ -106,7 +117,7 @@ export interface StatusControllerDeps {
 /**
  * Aggregate activity summaries into a human-readable status line.
  * Counts occurrences of key action verbs and formats them as a compact summary.
- * e.g. `⏳ Working… edited 2 files · ran 1 command`
+ * e.g. `⏳ Working… edited 2 times · ran 1 time`
  */
 function buildStatusContent(summaries: readonly string[]): string {
   if (summaries.length === 0) {
@@ -161,8 +172,11 @@ export function createStatusController(deps: StatusControllerDeps): StatusContro
   /** Pending debounce timer ID. */
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
-  /** In-flight edit promise (awaited during settle). */
-  let inFlightEdit: Promise<unknown> | null = null
+  /**
+   * In-flight update promise — tracks BOTH the initial safePost AND subsequent safeEdits.
+   * Awaited during settle() so no late update can land after the terminal transition.
+   */
+  let inFlightUpdate: Promise<unknown> | null = null
 
   /** Typing pulse interval ID. */
   let typingInterval: ReturnType<typeof setInterval> | null = null
@@ -170,13 +184,21 @@ export function createStatusController(deps: StatusControllerDeps): StatusContro
   /** Whether the controller has been disposed. */
   let disposed = false
 
+  /**
+   * Set to true at the start of resolveToAnswer / resolveToFailure / dispose.
+   * Once set, noteActivity (and its debounce scheduling) no-ops so a late event
+   * during settle can't schedule a new edit that overwrites the final answer.
+   */
+  let terminal = false
+
   // -------------------------------------------------------------------------
   // Fail-soft Discord I/O wrappers
   // -------------------------------------------------------------------------
 
+  /** Post the initial status message. Fail-soft: returns null on error. */
   async function safePost(content: string): Promise<StatusMessage | null> {
     try {
-      const msg = await thread.send({content})
+      const msg = await thread.send({content, allowedMentions: {parse: []}})
       return msg
     } catch (error) {
       logger.warn({err: String(error)}, 'status-message: failed to post status message')
@@ -184,11 +206,30 @@ export function createStatusController(deps: StatusControllerDeps): StatusContro
     }
   }
 
+  /**
+   * Edit the status message. Fail-soft: catches and logs errors.
+   * Used for ORDINARY progress edits (debounce path) — errors are swallowed.
+   */
   async function safeEdit(msg: StatusMessage, content: string): Promise<void> {
     try {
-      await msg.edit({content})
+      await msg.edit({content, allowedMentions: {parse: []}})
     } catch (error) {
       logger.warn({err: String(error)}, 'status-message: failed to edit status message')
+    }
+  }
+
+  /**
+   * Edit the status message for a TERMINAL transition.
+   * Returns true if the edit succeeded, false if it failed.
+   * The caller uses this to decide between 'handled' and 'delegated'.
+   */
+  async function terminalEdit(msg: StatusMessage, content: string): Promise<boolean> {
+    try {
+      await msg.edit({content, allowedMentions: {parse: []}})
+      return true
+    } catch (error) {
+      logger.warn({err: String(error)}, 'status-message: failed to perform terminal edit')
+      return false
     }
   }
 
@@ -218,7 +259,7 @@ export function createStatusController(deps: StatusControllerDeps): StatusContro
     }
     debounceTimer = setTimeout(() => {
       debounceTimer = null
-      if (disposed === true) {
+      if (disposed === true || terminal === true) {
         return
       }
       // eslint-disable-next-line no-void
@@ -230,23 +271,31 @@ export function createStatusController(deps: StatusControllerDeps): StatusContro
     const content = buildStatusContent(activitySummaries)
 
     if (statusMessage === null) {
-      // First update — post the initial status message
-      const posted = await safePost(content)
-      statusMessage = posted
+      // First update — post the initial status message.
+      // Track the post as inFlightUpdate so settle() can await it.
+      const postPromise = safePost(content)
+      inFlightUpdate = postPromise
+      try {
+        const posted = await postPromise
+        statusMessage = posted
+      } finally {
+        inFlightUpdate = null
+      }
     } else {
       // Subsequent update — edit the existing message
       const msg = statusMessage
-      inFlightEdit = safeEdit(msg, content)
+      const editPromise = safeEdit(msg, content)
+      inFlightUpdate = editPromise
       try {
-        await inFlightEdit
+        await editPromise
       } finally {
-        inFlightEdit = null
+        inFlightUpdate = null
       }
     }
   }
 
   // -------------------------------------------------------------------------
-  // Settle phase — cancel debounce + await in-flight edit
+  // Settle phase — cancel debounce + await in-flight update (post OR edit)
   // -------------------------------------------------------------------------
 
   async function settle(): Promise<void> {
@@ -255,10 +304,12 @@ export function createStatusController(deps: StatusControllerDeps): StatusContro
       clearTimeout(debounceTimer)
       debounceTimer = null
     }
-    // Await any in-flight edit so it can't land after the final message
-    if (inFlightEdit !== null) {
-      await inFlightEdit
-      inFlightEdit = null
+    // Await any in-flight update (initial post OR progress edit) so it can't
+    // land after the final message. After this, statusMessage reflects the
+    // actual posted state.
+    if (inFlightUpdate !== null) {
+      await inFlightUpdate
+      inFlightUpdate = null
     }
   }
 
@@ -267,7 +318,8 @@ export function createStatusController(deps: StatusControllerDeps): StatusContro
   // -------------------------------------------------------------------------
 
   const noteActivity = (summary: string): void => {
-    if (disposed === true) {
+    if (disposed === true || terminal === true) {
+      // P2: once a terminal transition has begun, no new activity is scheduled
       return
     }
     if (mode === 'typing-only') {
@@ -308,6 +360,9 @@ export function createStatusController(deps: StatusControllerDeps): StatusContro
   }
 
   const resolveToAnswer = async (text: string): Promise<TransitionResult> => {
+    // P2: mark terminal before settle so noteActivity no-ops during the await
+    terminal = true
+
     await settle()
 
     if (disposed === true) {
@@ -334,18 +389,25 @@ export function createStatusController(deps: StatusControllerDeps): StatusContro
     }
 
     // Long answer (>2000 chars): delete status and delegate
-    if (text.length > DISCORD_MESSAGE_CHAR_LIMIT) {
+    if (text.length > MAX_DISCORD_MESSAGE_LENGTH) {
       await safeDelete(statusMessage)
       statusMessage = null
       return {transition: 'delegated'}
     }
 
-    // Short answer that fits: edit in place
-    await safeEdit(statusMessage, text)
+    // P1-A: Short answer that fits — use terminalEdit so failure is observable.
+    // If the edit fails, return 'delegated' so the caller falls back to sink.flush().
+    const editSucceeded = await terminalEdit(statusMessage, text)
+    if (editSucceeded === false) {
+      return {transition: 'delegated'}
+    }
     return {transition: 'handled'}
   }
 
   const resolveToFailure = async (note: string): Promise<TransitionResult> => {
+    // P2: mark terminal before settle so noteActivity no-ops during the await
+    terminal = true
+
     await settle()
 
     if (disposed === true) {
@@ -362,8 +424,12 @@ export function createStatusController(deps: StatusControllerDeps): StatusContro
       return {transition: 'delegated'}
     }
 
-    // Status message exists: edit into the failure note
-    await safeEdit(statusMessage, note)
+    // P1-A: Status message exists — use terminalEdit so failure is observable.
+    // If the edit fails, return 'delegated' so the caller falls back to safeSend.
+    const editSucceeded = await terminalEdit(statusMessage, note)
+    if (editSucceeded === false) {
+      return {transition: 'delegated'}
+    }
     return {transition: 'handled'}
   }
 
@@ -371,9 +437,11 @@ export function createStatusController(deps: StatusControllerDeps): StatusContro
     if (disposed === true) {
       return
     }
+    // P2: mark terminal before settle so noteActivity no-ops during the await
+    terminal = true
     disposed = true
 
-    // Settle: cancel debounce + await in-flight edit
+    // Settle: cancel debounce + await in-flight update
     await settle()
 
     // Clear typing interval

--- a/packages/gateway/src/discord/status-message.ts
+++ b/packages/gateway/src/discord/status-message.ts
@@ -1,0 +1,387 @@
+/**
+ * Per-run status message + typing pulse controller.
+ *
+ * Owns one editable Discord status message and a typing indicator pulse.
+ * Created once per mention run; disposed in the run's `finally` block.
+ *
+ * Modes:
+ * - `live-status` (default): posts a single editable status message that updates on a
+ *   debounced cadence while the agent works, then transitions into the final answer.
+ * - `typing-only`: suppresses the status message entirely; only the typing indicator is shown.
+ *
+ * All Discord I/O is fail-soft: rejections are caught + logged and never abort the run.
+ */
+
+import type {GatewayLogger} from './client.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Debounce interval for status message edits (ms). Keeps edits within Discord rate limits. */
+export const STATUS_DEBOUNCE_MS = 1500
+
+/** Typing indicator re-pulse interval (ms). Discord typing auto-expires ~10s; pulse at ~7s. */
+export const STATUS_TYPING_PULSE_MS = 7000
+
+/** Discord's hard content-length limit for a single message. */
+const DISCORD_MESSAGE_CHAR_LIMIT = 2000
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal thread interface required by the status controller.
+ * Typed narrowly so test doubles don't need the full `ThreadChannel` API.
+ */
+export interface StatusThread {
+  readonly send: (options: {readonly content: string}) => Promise<StatusMessage>
+  readonly sendTyping: () => Promise<void>
+}
+
+/**
+ * Minimal message interface for the posted status message.
+ * Typed narrowly for testability.
+ */
+export interface StatusMessage {
+  readonly edit: (options: {readonly content: string}) => Promise<unknown>
+  readonly delete: () => Promise<unknown>
+}
+
+/** Discriminated result of a resolve call. */
+export type TransitionResult = {readonly transition: 'handled'} | {readonly transition: 'delegated'}
+
+/** The controller returned by `createStatusController`. */
+export interface StatusController {
+  /**
+   * Record an essential-action summary and schedule a debounced status edit.
+   * First call posts the initial status message; subsequent calls edit it.
+   * In `typing-only` mode, this is a no-op (no message posted).
+   */
+  readonly noteActivity: (summary: string) => void
+  /**
+   * Start or stop the typing indicator pulse.
+   * - `true`: immediately sends typing and schedules re-pulse every ~7s.
+   * - `false`: clears the pulse interval (e.g. during an approval wait).
+   * Runs in BOTH modes (typing pulses even in typing-only).
+   */
+  readonly setBusy: (busy: boolean) => void
+  /**
+   * Settle, then resolve the status message into the final answer.
+   * - `handled`: controller edited the status message into the answer (caller does nothing more).
+   * - `delegated`: caller must post the answer via the sink (status deleted or never existed).
+   *
+   * Conditions for `handled`: live-status mode AND a status message exists AND
+   * the answer is non-empty, non-whitespace, and fits one Discord message (≤2000 chars).
+   * All other cases → `delegated`.
+   */
+  readonly resolveToAnswer: (text: string) => Promise<TransitionResult>
+  /**
+   * Settle, then resolve the status message into a failure note.
+   * - `handled`: controller edited the status message into the note (caller does nothing more).
+   * - `delegated`: caller must post the failure note via safeSend (no status to edit, or typing-only).
+   *
+   * Never both edits and delegates.
+   */
+  readonly resolveToFailure: (note: string) => Promise<TransitionResult>
+  /**
+   * Settle (cancel debounce, await in-flight edit), then clear all timers.
+   * Idempotent. No edits or pulses fire after dispose.
+   */
+  readonly dispose: () => Promise<void>
+}
+
+/** Dependencies injected into the factory. */
+export interface StatusControllerDeps {
+  readonly thread: StatusThread
+  readonly mode: 'live-status' | 'typing-only'
+  readonly logger: GatewayLogger
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregate activity summaries into a human-readable status line.
+ * Counts occurrences of key action verbs and formats them as a compact summary.
+ * e.g. `⏳ Working… edited 2 files · ran 1 command`
+ */
+function buildStatusContent(summaries: readonly string[]): string {
+  if (summaries.length === 0) {
+    return '⏳ Working…'
+  }
+
+  // Count by action verb (first word of each summary)
+  const counts = new Map<string, number>()
+  for (const summary of summaries) {
+    const verb = summary.trim().split(/\s+/)[0] ?? 'worked'
+    counts.set(verb, (counts.get(verb) ?? 0) + 1)
+  }
+
+  const parts: string[] = []
+  for (const [verb, count] of counts) {
+    parts.push(`${verb} ${count} ${count === 1 ? 'time' : 'times'}`)
+  }
+
+  return `⏳ Working… ${parts.join(' · ')}`
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a per-run status message + typing pulse controller.
+ *
+ * Usage:
+ * ```ts
+ * const ctrl = createStatusController({ thread, mode: config.statusMode, logger })
+ * ctrl.setBusy(true)
+ * ctrl.noteActivity('edited 1 file')
+ * const result = await ctrl.resolveToAnswer(finalText)
+ * // if result.transition === 'delegated': post via sink
+ * await ctrl.dispose() // in finally
+ * ```
+ */
+export function createStatusController(deps: StatusControllerDeps): StatusController {
+  const {thread, mode, logger} = deps
+
+  // -------------------------------------------------------------------------
+  // State
+  // -------------------------------------------------------------------------
+
+  /** The posted status message, if any. */
+  let statusMessage: StatusMessage | null = null
+
+  /** Accumulated activity summaries since last edit. */
+  const activitySummaries: string[] = []
+
+  /** Pending debounce timer ID. */
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+  /** In-flight edit promise (awaited during settle). */
+  let inFlightEdit: Promise<unknown> | null = null
+
+  /** Typing pulse interval ID. */
+  let typingInterval: ReturnType<typeof setInterval> | null = null
+
+  /** Whether the controller has been disposed. */
+  let disposed = false
+
+  // -------------------------------------------------------------------------
+  // Fail-soft Discord I/O wrappers
+  // -------------------------------------------------------------------------
+
+  async function safePost(content: string): Promise<StatusMessage | null> {
+    try {
+      const msg = await thread.send({content})
+      return msg
+    } catch (error) {
+      logger.warn({err: String(error)}, 'status-message: failed to post status message')
+      return null
+    }
+  }
+
+  async function safeEdit(msg: StatusMessage, content: string): Promise<void> {
+    try {
+      await msg.edit({content})
+    } catch (error) {
+      logger.warn({err: String(error)}, 'status-message: failed to edit status message')
+    }
+  }
+
+  async function safeDelete(msg: StatusMessage): Promise<void> {
+    try {
+      await msg.delete()
+    } catch (error) {
+      logger.warn({err: String(error)}, 'status-message: failed to delete status message')
+    }
+  }
+
+  async function safeSendTyping(): Promise<void> {
+    try {
+      await thread.sendTyping()
+    } catch (error) {
+      logger.warn({err: String(error)}, 'status-message: failed to send typing indicator')
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Debounced status update
+  // -------------------------------------------------------------------------
+
+  function scheduleDebounce(): void {
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer)
+    }
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null
+      if (disposed === true) {
+        return
+      }
+      // eslint-disable-next-line no-void
+      void performStatusUpdate()
+    }, STATUS_DEBOUNCE_MS)
+  }
+
+  async function performStatusUpdate(): Promise<void> {
+    const content = buildStatusContent(activitySummaries)
+
+    if (statusMessage === null) {
+      // First update — post the initial status message
+      const posted = await safePost(content)
+      statusMessage = posted
+    } else {
+      // Subsequent update — edit the existing message
+      const msg = statusMessage
+      inFlightEdit = safeEdit(msg, content)
+      try {
+        await inFlightEdit
+      } finally {
+        inFlightEdit = null
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Settle phase — cancel debounce + await in-flight edit
+  // -------------------------------------------------------------------------
+
+  async function settle(): Promise<void> {
+    // Cancel any pending debounce timer
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer)
+      debounceTimer = null
+    }
+    // Await any in-flight edit so it can't land after the final message
+    if (inFlightEdit !== null) {
+      await inFlightEdit
+      inFlightEdit = null
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  const noteActivity = (summary: string): void => {
+    if (disposed === true) {
+      return
+    }
+    if (mode === 'typing-only') {
+      // typing-only: no status message posted
+      return
+    }
+    activitySummaries.push(summary)
+    scheduleDebounce()
+  }
+
+  const setBusy = (busy: boolean): void => {
+    if (busy === true) {
+      // Clear any existing interval first (idempotent start)
+      if (typingInterval !== null) {
+        clearInterval(typingInterval)
+        typingInterval = null
+      }
+      // Immediately send typing
+      // eslint-disable-next-line no-void
+      void safeSendTyping()
+      // Schedule re-pulse
+      typingInterval = setInterval(() => {
+        if (disposed === true) {
+          if (typingInterval !== null) {
+            clearInterval(typingInterval)
+            typingInterval = null
+          }
+          return
+        }
+        // eslint-disable-next-line no-void
+        void safeSendTyping()
+      }, STATUS_TYPING_PULSE_MS)
+    } else if (typingInterval !== null) {
+      // Stop pulsing
+      clearInterval(typingInterval)
+      typingInterval = null
+    }
+  }
+
+  const resolveToAnswer = async (text: string): Promise<TransitionResult> => {
+    await settle()
+
+    if (disposed === true) {
+      return {transition: 'delegated'}
+    }
+
+    // typing-only mode: always delegate
+    if (mode === 'typing-only') {
+      return {transition: 'delegated'}
+    }
+
+    // No status message posted yet: delegate
+    if (statusMessage === null) {
+      return {transition: 'delegated'}
+    }
+
+    const trimmed = text.trim()
+
+    // Empty/whitespace answer: delete status and delegate
+    if (trimmed.length === 0) {
+      await safeDelete(statusMessage)
+      statusMessage = null
+      return {transition: 'delegated'}
+    }
+
+    // Long answer (>2000 chars): delete status and delegate
+    if (text.length > DISCORD_MESSAGE_CHAR_LIMIT) {
+      await safeDelete(statusMessage)
+      statusMessage = null
+      return {transition: 'delegated'}
+    }
+
+    // Short answer that fits: edit in place
+    await safeEdit(statusMessage, text)
+    return {transition: 'handled'}
+  }
+
+  const resolveToFailure = async (note: string): Promise<TransitionResult> => {
+    await settle()
+
+    if (disposed === true) {
+      return {transition: 'delegated'}
+    }
+
+    // typing-only mode: always delegate
+    if (mode === 'typing-only') {
+      return {transition: 'delegated'}
+    }
+
+    // No status message: delegate (caller posts via safeSend)
+    if (statusMessage === null) {
+      return {transition: 'delegated'}
+    }
+
+    // Status message exists: edit into the failure note
+    await safeEdit(statusMessage, note)
+    return {transition: 'handled'}
+  }
+
+  const dispose = async (): Promise<void> => {
+    if (disposed === true) {
+      return
+    }
+    disposed = true
+
+    // Settle: cancel debounce + await in-flight edit
+    await settle()
+
+    // Clear typing interval
+    if (typingInterval !== null) {
+      clearInterval(typingInterval)
+      typingInterval = null
+    }
+  }
+
+  return {noteActivity, setBusy, resolveToAnswer, resolveToFailure, dispose}
+}

--- a/packages/gateway/src/discord/streaming.ts
+++ b/packages/gateway/src/discord/streaming.ts
@@ -16,12 +16,14 @@ import type {GatewayLogger} from './client.js'
 import {Buffer} from 'node:buffer'
 import {AttachmentBuilder} from 'discord.js'
 
+import {MAX_DISCORD_MESSAGE_LENGTH} from './constants.js'
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 /** Discord's hard content-length limit for a single message. */
-const DISCORD_MESSAGE_CHAR_LIMIT = 2000
+const DISCORD_MESSAGE_CHAR_LIMIT = MAX_DISCORD_MESSAGE_LENGTH
 
 /** Fallback message shown when a flush yields nothing. */
 const EMPTY_OUTPUT_MESSAGE = '_(no output)_'

--- a/packages/gateway/src/execute/run-core.test.ts
+++ b/packages/gateway/src/execute/run-core.test.ts
@@ -1914,4 +1914,208 @@ describe('runOpenCodeCore', () => {
       await expect(runOpenCodeCore(params)).resolves.toBeUndefined()
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // Unit 3: onActivity and onBusy hooks
+  // ---------------------------------------------------------------------------
+
+  describe('onActivity and onBusy hooks (Unit 3)', () => {
+    it('onBusy(true) called after prompt is sent successfully', async () => {
+      // #given
+      const onBusy = vi.fn()
+      const handle = makeHandle()
+      const params = {...buildParams(handle), coordinator: makeCoordinator(), onBusy}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — onBusy(true) called after prompt send
+      expect(onBusy).toHaveBeenCalledWith(true)
+    })
+
+    it('onBusy(false) called when session.idle is received', async () => {
+      // #given
+      const onBusy = vi.fn()
+      const handle = makeHandle()
+      const params = {...buildParams(handle), coordinator: makeCoordinator(), onBusy}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — onBusy(false) called on session.idle
+      expect(onBusy).toHaveBeenCalledWith(false)
+    })
+
+    it('onBusy call order: true (prompt sent) then false (session.idle)', async () => {
+      // #given
+      const callOrder: boolean[] = []
+      const onBusy = vi.fn().mockImplementation((busy: boolean) => {
+        callOrder.push(busy)
+      })
+      const handle = makeHandle()
+      const params = {...buildParams(handle), coordinator: makeCoordinator(), onBusy}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — true before false
+      expect(callOrder[0]).toBe(true)
+      expect(callOrder.at(-1)).toBe(false)
+    })
+
+    it('onActivity called with tool summary when message.part.updated tool completes', async () => {
+      // #given — edit tool via message.part.updated
+      const onActivity = vi.fn()
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partUpdatedToolEvent('edit', 'completed', {
+              input: {filePath: 'src/foo.ts', newString: 'new\ncontent', oldString: 'old'},
+            }),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator(), onActivity}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — onActivity called with the same summary appended to the sink
+      expect(onActivity).toHaveBeenCalledOnce()
+      const activitySummary = (onActivity as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string
+      expect(typeof activitySummary).toBe('string')
+      expect(activitySummary.length).toBeGreaterThan(0)
+      // The summary should contain the filename (same as what the sink received)
+      expect(activitySummary).toContain('foo.ts')
+    })
+
+    it('onActivity called with tool summary when session.next.tool.success fires', async () => {
+      // #given — bash tool via legacy path
+      const onActivity = vi.fn()
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            toolCalledEvent('call-act-1', 'bash', {command: 'pnpm build'}),
+            toolSuccessEvent('call-act-1'),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator(), onActivity}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — onActivity called with the bash summary
+      expect(onActivity).toHaveBeenCalledOnce()
+      const activitySummary = (onActivity as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string
+      expect(activitySummary).toContain('pnpm build')
+    })
+
+    it('onActivity NOT called for hidden tools (read, grep)', async () => {
+      // #given — read tool is non-essential; formatToolPart returns null → no append, no onActivity
+      const onActivity = vi.fn()
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partUpdatedToolEvent('read', 'completed', {input: {filePath: 'src/foo.ts'}}),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator(), onActivity}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — onActivity NOT called (hidden tool produces no summary)
+      expect(onActivity).not.toHaveBeenCalled()
+    })
+
+    it('onActivity called once per essential tool, not per text delta', async () => {
+      // #given — two essential tools + text deltas
+      const onActivity = vi.fn()
+      const sink = makeSink()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partDeltaObjectEvent('text delta 1'),
+            partUpdatedToolEvent('edit', 'completed', {input: {filePath: 'a.ts', newString: 'x', oldString: 'y'}}),
+            partDeltaObjectEvent('text delta 2'),
+            partUpdatedToolEvent('write', 'completed', {input: {filePath: 'b.ts', content: 'content'}}),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), sink, coordinator: makeCoordinator(), onActivity}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — onActivity called exactly twice (once per essential tool)
+      expect(onActivity).toHaveBeenCalledTimes(2)
+    })
+
+    it('onBusy(false) called on permission.asked (approval wait pauses typing)', async () => {
+      // #given — permission.asked event arrives
+      const onBusy = vi.fn()
+      const coordinator = makeCoordinator()
+      const handle = makeHandle({
+        subscribe: async () => subscribeOk([permissionAskedEvent('req-busy-1'), sessionIdleEvent('sess-123')]),
+      })
+      const params = {...buildParams(handle), coordinator, onBusy}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — onBusy(false) called when approval wait starts
+      const calls = (onBusy as ReturnType<typeof vi.fn>).mock.calls.map(c => c[0] as boolean)
+      expect(calls).toContain(false)
+      // The false call should come after the initial true (prompt sent)
+      const trueIdx = calls.indexOf(true)
+      const falseIdx = calls.indexOf(false)
+      expect(trueIdx).toBeGreaterThanOrEqual(0)
+      expect(falseIdx).toBeGreaterThan(trueIdx)
+    })
+
+    it('onBusy(true) called on permission.replied (typing resumes after approval)', async () => {
+      // #given — permission.asked then permission.replied
+      const onBusy = vi.fn()
+      const coordinator = makeCoordinator()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            permissionAskedEvent('req-resume-1'),
+            permissionRepliedEvent('req-resume-1', 'once'),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), coordinator, onBusy}
+
+      // #when
+      await runOpenCodeCore(params)
+
+      // #then — onBusy(true) called after permission.replied (resume after approval)
+      const calls = (onBusy as ReturnType<typeof vi.fn>).mock.calls.map(c => c[0] as boolean)
+      // Sequence: true (prompt), false (asked), true (replied), false (idle)
+      expect(calls.filter(v => v === true).length).toBeGreaterThanOrEqual(2)
+      expect(calls.filter(v => v === false).length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('onActivity and onBusy are optional — omitting them does not throw', async () => {
+      // #given — no onActivity or onBusy provided (backward compatibility)
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            partUpdatedToolEvent('edit', 'completed', {input: {filePath: 'x.ts', newString: 'a', oldString: 'b'}}),
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {...buildParams(handle), coordinator: makeCoordinator()}
+      // No onActivity or onBusy in params
+
+      // #when / #then — must not throw
+      await expect(runOpenCodeCore(params)).resolves.toBeUndefined()
+    })
+  })
 })

--- a/packages/gateway/src/execute/run-core.ts
+++ b/packages/gateway/src/execute/run-core.ts
@@ -99,6 +99,21 @@ export interface RunCoreParams {
    * supported mode). Fail-closed: if absent, `runOpenCodeCore` throws before session creation.
    */
   readonly coordinator?: PermissionCoordinator
+  /**
+   * Optional hook called with each essential tool-action summary string as it is appended.
+   * Receives the same summary string that `appendToolSummary` computes — no recomputation.
+   * Used by `run.ts` to drive the status controller's `noteActivity`.
+   * No-op when absent.
+   */
+  readonly onActivity?: (summary: string) => void
+  /**
+   * Optional hook called when the busy state changes.
+   * - `true`: work has started (prompt sent to session).
+   * - `false`: work has stopped (session.idle received, or run is blocked on an approval wait).
+   * Used by `run.ts` to drive the status controller's `setBusy`.
+   * No-op when absent.
+   */
+  readonly onBusy?: (busy: boolean) => void
 }
 
 // ---------------------------------------------------------------------------
@@ -169,11 +184,15 @@ interface ToolCallInfo {
  * Calls `formatToolPart`, catches any exception (malformed input, unexpected
  * shape), logs `{tool, status}` only (no raw content), and appends nothing on
  * error. A throwing `formatToolPart` must never abort the event stream.
+ *
+ * When `onActivity` is provided, it is called with the same summary string
+ * that is appended to the sink — no recomputation.
  */
 function appendToolSummary(
   part: import('./format-part.js').ExtractedToolPart,
   sink: DiscordStreamSink,
   logger: GatewayLogger,
+  onActivity?: (summary: string) => void,
 ): void {
   let summary: string | null
   try {
@@ -184,6 +203,7 @@ function appendToolSummary(
   }
   if (summary !== null && summary.length > 0) {
     sink.append(`\n${summary}\n`)
+    onActivity?.(summary)
   }
 }
 
@@ -192,7 +212,7 @@ function appendToolSummary(
 // ---------------------------------------------------------------------------
 
 export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
-  const {handle, directory, promptText, sink, signal, logger, coordinator, approvalMode} = params
+  const {handle, directory, promptText, sink, signal, logger, coordinator, approvalMode, onActivity, onBusy} = params
   const {client} = handle
 
   // ── 0. Mode/coordinator pre-flight ────────────────────────────────────────
@@ -288,6 +308,8 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
       throw new RunCoreError('prompt-error', `PromptAsync error: ${errMsg}`)
     }
     logger.info({sessionId, directory}, 'run-core: prompt sent')
+    // Signal busy: work has started — drive typing indicator in the status controller.
+    onBusy?.(true)
   } catch (error) {
     if (error instanceof RunCoreError) throw error
     const message = error instanceof Error ? error.message : String(error)
@@ -393,6 +415,7 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
               },
               sink,
               logger,
+              onActivity,
             )
           }
         }
@@ -436,6 +459,7 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
               },
               sink,
               logger,
+              onActivity,
             )
           }
         }
@@ -449,6 +473,9 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
         if (req === null) {
           logger.warn({eventType}, 'run-core: permission.asked payload malformed — skipping')
         } else {
+          // Pause typing while waiting on a human approval — the run is blocked,
+          // not actively working. Typing would falsely imply active work.
+          onBusy?.(false)
           // Fire-and-continue: do NOT await — awaiting would starve the SSE drain.
           // eslint-disable-next-line no-void
           void coordinator.onPermissionAsked(req)
@@ -464,6 +491,8 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
         if (ev === null) {
           logger.warn({eventType}, 'run-core: permission.replied payload malformed — skipping')
         } else {
+          // Approval resolved — resume typing if the run continues.
+          onBusy?.(true)
           coordinator.onPermissionReplied(ev)
           logger.info(
             {requestID: ev.requestID, reply: ev.reply},
@@ -475,6 +504,8 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
       const eventSessionID = getEventSessionID(rawEvent)
       if (eventSessionID === sessionId) {
         logger.info({sessionId}, 'run-core: session.idle received — stream complete')
+        // Signal not-busy: work is done.
+        onBusy?.(false)
         return
       }
     } else if (eventType === 'session.error') {

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -2870,6 +2870,126 @@ describe('runMention', () => {
       // #and — sink.flush called (delegated → sink owns the no-output fallback)
       expect(flushMock).toHaveBeenCalledOnce()
     })
+
+    // ── P1-A integration: terminal edit failure falls back to sink/safeSend ──
+
+    it('p1-A: resolveToAnswer returns delegated (terminal edit failed) → answer delivered via sink.flush with exact content', async () => {
+      // #given — status controller returns 'delegated' (simulating a failed terminal edit)
+      // This is the P1-A regression guard: when the final edit fails, the answer must still
+      // reach the user via sink.flush(), not be silently dropped.
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const ctrl = makeStatusControllerMock({resolveToAnswerResult: {transition: 'delegated'}})
+      const ANSWER_TEXT = 'Here is the answer from the agent.'
+      const flushMock = vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: ANSWER_TEXT.length})
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: flushMock,
+        buffered: vi.fn().mockReturnValue(ANSWER_TEXT),
+        markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
+      })
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({statusMode: 'live-status'})
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — resolveToAnswer was called with the buffered answer text
+      expect(ctrl.resolveToAnswer).toHaveBeenCalledWith(ANSWER_TEXT)
+      // #and — exactly ONE flush call (answer delivered via sink, not dropped)
+      expect(flushMock).toHaveBeenCalledOnce()
+      // #and — no extra thread.send for the answer (sink.flush owns it)
+      // (thread.send may be called for other reasons but not for the answer content)
+    })
+
+    it('p1-A: resolveToFailure returns delegated (terminal edit failed) → failure note delivered via safeSend with exact content', async () => {
+      // #given — run-core throws; status controller returns 'delegated' (simulating a failed terminal edit)
+      // P1-A regression guard: when the final failure edit fails, the note must still reach
+      // the user via safeSend(), not be silently dropped.
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      const ctrl = makeStatusControllerMock({resolveToFailureResult: {transition: 'delegated'}})
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('unreachable', 'connect failed'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({statusMode: 'live-status'})
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — resolveToFailure was called
+      expect(ctrl.resolveToFailure).toHaveBeenCalledOnce()
+      const failureNote = (ctrl.resolveToFailure as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string
+      expect(typeof failureNote).toBe('string')
+      expect(failureNote.length).toBeGreaterThan(0)
+      // #and — thread.send was called with the exact failure note content (safeSend path)
+      const sendContents = thread.send.mock.calls.map(c => (c[0] as {content?: string}).content ?? '')
+      expect(sendContents.includes(failureNote)).toBe(true)
+      // #and — the send includes allowedMentions: {parse: []} (mention-safe)
+      const failureSend = thread.send.mock.calls.find(c => (c[0] as {content?: string}).content === failureNote)
+      expect((failureSend?.[0] as {allowedMentions?: unknown}).allowedMentions).toEqual({parse: []})
+    })
+
+    it('p1-A: resolveToAnswer returns handled → sink.flush NOT called (exactly one message path)', async () => {
+      // #given — status controller returns 'handled' (terminal edit succeeded)
+      // Verifies the single-owner invariant: when handled, the answer is in the status message
+      // and sink.flush must NOT be called (would double-post).
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const ctrl = makeStatusControllerMock({resolveToAnswerResult: {transition: 'handled'}})
+      const flushMock = vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 10})
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: flushMock,
+        buffered: vi.fn().mockReturnValue('Short answer'),
+        markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
+      })
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({statusMode: 'live-status'})
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — resolveToAnswer called
+      expect(ctrl.resolveToAnswer).toHaveBeenCalledOnce()
+      // #and — sink.flush NOT called (answer is in the status message — no double-post)
+      expect(flushMock).not.toHaveBeenCalled()
+    })
+
+    it('p1-A: resolveToFailure returns handled → safeSend NOT called (exactly one message path)', async () => {
+      // #given — run-core throws; status controller returns 'handled' (terminal edit succeeded)
+      // Verifies the single-owner invariant: when handled, the failure note is in the status
+      // message and safeSend must NOT be called (would double-post).
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      const ctrl = makeStatusControllerMock({resolveToFailureResult: {transition: 'handled'}})
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('session-error', 'LLM error'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({statusMode: 'live-status'})
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — resolveToFailure called
+      expect(ctrl.resolveToFailure).toHaveBeenCalledOnce()
+      const failureNote = (ctrl.resolveToFailure as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string
+      // #and — thread.send NOT called with the failure note (controller owns it)
+      const sendContents = thread.send.mock.calls.map(c => (c[0] as {content?: string}).content ?? '')
+      expect(sendContents.includes(failureNote)).toBe(false)
+    })
   })
 })
 

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -8,6 +8,7 @@ import * as runtimeModule from '@fro-bot/runtime'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import * as coordinatorModule from '../approvals/coordinator.js'
 import * as discordApprovalsModule from '../discord/approvals.js'
+import * as statusMessageModule from '../discord/status-message.js'
 import * as streamingModule from '../discord/streaming.js'
 import * as attachModule from './opencode-attach.js'
 import * as promptModule from './prompt.js'
@@ -89,6 +90,16 @@ vi.mock('./run-core.js', () => ({
   },
 }))
 
+vi.mock('../discord/status-message.js', () => ({
+  createStatusController: vi.fn().mockReturnValue({
+    noteActivity: vi.fn(),
+    setBusy: vi.fn(),
+    resolveToAnswer: vi.fn().mockResolvedValue({transition: 'delegated'}),
+    resolveToFailure: vi.fn().mockResolvedValue({transition: 'delegated'}),
+    dispose: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
 // ---------------------------------------------------------------------------
 // Typed mocks
 // ---------------------------------------------------------------------------
@@ -97,6 +108,7 @@ const mockRuntime = vi.mocked(runtimeModule)
 const mockRunOpenCodeCore = vi.mocked(runCoreModule.runOpenCodeCore)
 const mockCreateDiscordStreamSink = vi.mocked(streamingModule.createDiscordStreamSink)
 const mockCreatePermissionCoordinator = vi.mocked(coordinatorModule.createPermissionCoordinator)
+const mockCreateStatusController = vi.mocked(statusMessageModule.createStatusController)
 vi.mocked(discordApprovalsModule) // ensure module mock is applied
 
 // ---------------------------------------------------------------------------
@@ -284,6 +296,27 @@ function makeStatefulPendingSinkMock() {
   }
 }
 
+/**
+ * Build a status controller mock with configurable transition results.
+ * Returns the mock controller and wires it into `mockCreateStatusController`.
+ */
+function makeStatusControllerMock(
+  opts: {
+    resolveToAnswerResult?: {transition: 'handled' | 'delegated'}
+    resolveToFailureResult?: {transition: 'handled' | 'delegated'}
+  } = {},
+) {
+  const ctrl = {
+    noteActivity: vi.fn(),
+    setBusy: vi.fn(),
+    resolveToAnswer: vi.fn().mockResolvedValue(opts.resolveToAnswerResult ?? {transition: 'delegated'}),
+    resolveToFailure: vi.fn().mockResolvedValue(opts.resolveToFailureResult ?? {transition: 'delegated'}),
+    dispose: vi.fn().mockResolvedValue(undefined),
+  }
+  mockCreateStatusController.mockReturnValue(ctrl)
+  return ctrl
+}
+
 function makeEnsureCloneFn(result: 'success' | 'failure' = 'success') {
   return result === 'success'
     ? vi.fn().mockResolvedValue({success: true as const, data: '/workspace/acme/widget'})
@@ -315,6 +348,7 @@ function makeDeps(overrides: Partial<RunMentionDeps> = {}): RunMentionDeps {
     logger: overrides.logger ?? {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()},
     approvalRegistry: overrides.approvalRegistry ?? makeApprovalRegistry(),
     approvalMode: overrides.approvalMode ?? 'approval-required',
+    statusMode: overrides.statusMode ?? 'live-status',
     ensureClone: overrides.ensureClone ?? makeEnsureCloneFn('success'),
     readyz: overrides.readyz ?? makeReadyzFn('ready'),
     ...overrides,
@@ -2552,6 +2586,289 @@ describe('runMention', () => {
       // Must be approximately runTimeoutMs − SIMULATED_ELAPSED_MS
       expect(signalBudgetMs).toBeLessThanOrEqual(runTimeoutMs - SIMULATED_ELAPSED_MS + 100) // +100ms tolerance
       expect(signalBudgetMs).toBeGreaterThan(0)
+    })
+  })
+
+  // ── Unit 3: Status controller wiring ────────────────────────────────────
+
+  describe('status controller wiring (Unit 3)', () => {
+    it('integration (live-status, short answer): resolveToAnswer(handled) → sink.flush NOT called', async () => {
+      // #given — status controller returns 'handled' (edited in place)
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const ctrl = makeStatusControllerMock({resolveToAnswerResult: {transition: 'handled'}})
+      const flushMock = vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 10})
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: flushMock,
+        buffered: vi.fn().mockReturnValue('Short answer text'),
+        markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
+      })
+
+      const deps = makeDeps({statusMode: 'live-status'})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — resolveToAnswer called with buffered text
+      expect(ctrl.resolveToAnswer).toHaveBeenCalledWith('Short answer text')
+      // #and — sink.flush NOT called (answer is in the status message)
+      expect(flushMock).not.toHaveBeenCalled()
+    })
+
+    it('integration (live-status, long answer): resolveToAnswer(delegated) → sink.flush IS called', async () => {
+      // #given — status controller returns 'delegated' (status deleted, sink posts)
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const ctrl = makeStatusControllerMock({resolveToAnswerResult: {transition: 'delegated'}})
+      const flushMock = vi.fn().mockResolvedValue({kind: 'attachment' as const, charCount: 3000})
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: flushMock,
+        buffered: vi.fn().mockReturnValue('x'.repeat(2001)),
+        markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
+      })
+
+      const deps = makeDeps({statusMode: 'live-status'})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — resolveToAnswer called
+      expect(ctrl.resolveToAnswer).toHaveBeenCalled()
+      // #and — sink.flush IS called (delegated → sink owns the answer)
+      expect(flushMock).toHaveBeenCalledOnce()
+    })
+
+    it('integration (failure, status present): resolveToFailure(handled) → safeSend NOT called', async () => {
+      // #given — run-core throws; status controller returns 'handled' for failure
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      const ctrl = makeStatusControllerMock({resolveToFailureResult: {transition: 'handled'}})
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('session-error', 'LLM error'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({statusMode: 'live-status'})
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — resolveToFailure called with the coarse failure note
+      expect(ctrl.resolveToFailure).toHaveBeenCalledOnce()
+      const failureNote = (ctrl.resolveToFailure as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string
+      expect(typeof failureNote).toBe('string')
+      expect(failureNote.length).toBeGreaterThan(0)
+      // #and — thread.send NOT called for the failure message (controller owns it)
+      // The only sends should be from the sink flush (partial output), not the error message
+      const sendContents = thread.send.mock.calls.map(c => (c[0] as {content?: string}).content ?? '')
+      // None of the sends should be the coarse failure note (controller handled it)
+      expect(sendContents.includes(failureNote)).toBe(false)
+    })
+
+    it('integration (failure before activity, no status): resolveToFailure(delegated) → safeSend IS called', async () => {
+      // #given — run-core throws; no status message posted; controller returns 'delegated'
+      const {runMention} = await import('./run.js')
+      const {RunCoreError} = runCoreModule
+      setupHappyPath()
+      const ctrl = makeStatusControllerMock({resolveToFailureResult: {transition: 'delegated'}})
+      mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('unreachable', 'connect failed'))
+
+      const thread = makeThread()
+      const message = makeMessage(thread)
+      const deps = makeDeps({statusMode: 'live-status'})
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — resolveToFailure called
+      expect(ctrl.resolveToFailure).toHaveBeenCalledOnce()
+      // #and — thread.send called for the failure message (delegated → safeSend posts it)
+      const sendContents = thread.send.mock.calls.map(c => (c[0] as {content?: string}).content ?? '')
+      expect(sendContents.some(c => c.includes('not reachable'))).toBe(true)
+    })
+
+    it('integration (typing-only mode): resolveToAnswer always delegated → sink.flush called', async () => {
+      // #given — typing-only mode; controller always returns 'delegated'
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const ctrl = makeStatusControllerMock({resolveToAnswerResult: {transition: 'delegated'}})
+      const flushMock = vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 10})
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: flushMock,
+        buffered: vi.fn().mockReturnValue('answer text'),
+        markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
+      })
+
+      const deps = makeDeps({statusMode: 'typing-only'})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — createStatusController called with typing-only mode
+      expect(mockCreateStatusController).toHaveBeenCalledWith(expect.objectContaining({mode: 'typing-only'}))
+      // #and — sink.flush called (delegated)
+      expect(flushMock).toHaveBeenCalledOnce()
+      // #and — resolveToAnswer called (same call site regardless of mode)
+      expect(ctrl.resolveToAnswer).toHaveBeenCalledOnce()
+    })
+
+    it('edge (cleanup): controller.dispose called in finally on success', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const ctrl = makeStatusControllerMock()
+
+      const deps = makeDeps()
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — dispose called exactly once
+      expect(ctrl.dispose).toHaveBeenCalledOnce()
+    })
+
+    it('edge (cleanup): controller.dispose called in finally on failure', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const ctrl = makeStatusControllerMock()
+      mockRunOpenCodeCore.mockRejectedValue(new Error('boom'))
+
+      const deps = makeDeps()
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — dispose called even when run-core throws
+      expect(ctrl.dispose).toHaveBeenCalledOnce()
+    })
+
+    it('createStatusController receives statusMode from deps', async () => {
+      // #given — live-status mode
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      makeStatusControllerMock()
+
+      const deps = makeDeps({statusMode: 'live-status'})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — createStatusController called with mode: 'live-status'
+      expect(mockCreateStatusController).toHaveBeenCalledWith(expect.objectContaining({mode: 'live-status'}))
+    })
+
+    it('runOpenCodeCore receives onActivity and onBusy callbacks', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      makeStatusControllerMock()
+
+      const deps = makeDeps()
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — runOpenCodeCore called with onActivity and onBusy
+      expect(mockRunOpenCodeCore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onActivity: expect.any(Function) as unknown,
+          onBusy: expect.any(Function) as unknown,
+        }),
+      )
+    })
+
+    it('onActivity callback calls controller.noteActivity', async () => {
+      // #given — capture the onActivity callback from runOpenCodeCore
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const ctrl = makeStatusControllerMock()
+
+      let capturedOnActivity: ((summary: string) => void) | undefined
+      mockRunOpenCodeCore.mockImplementation(async params => {
+        capturedOnActivity = (params as {onActivity?: (s: string) => void}).onActivity
+      })
+
+      const deps = makeDeps()
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      expect(capturedOnActivity).toBeDefined()
+      capturedOnActivity?.('edited 1 file')
+
+      // #then — noteActivity called with the summary
+      expect(ctrl.noteActivity).toHaveBeenCalledWith('edited 1 file')
+    })
+
+    it('onBusy callback calls controller.setBusy', async () => {
+      // #given — capture the onBusy callback from runOpenCodeCore
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const ctrl = makeStatusControllerMock()
+
+      let capturedOnBusy: ((busy: boolean) => void) | undefined
+      mockRunOpenCodeCore.mockImplementation(async params => {
+        capturedOnBusy = (params as {onBusy?: (b: boolean) => void}).onBusy
+      })
+
+      const deps = makeDeps()
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      expect(capturedOnBusy).toBeDefined()
+      capturedOnBusy?.(true)
+      capturedOnBusy?.(false)
+
+      // #then — setBusy called with the correct values
+      expect(ctrl.setBusy).toHaveBeenCalledWith(true)
+      expect(ctrl.setBusy).toHaveBeenCalledWith(false)
+    })
+
+    it('edge (no output): empty answer → resolveToAnswer called with empty string → delegated → sink.flush called', async () => {
+      // #given — empty buffer; controller returns 'delegated' for empty answer
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const ctrl = makeStatusControllerMock({resolveToAnswerResult: {transition: 'delegated'}})
+      const flushMock = vi.fn().mockResolvedValue({kind: 'empty' as const})
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: flushMock,
+        buffered: vi.fn().mockReturnValue(''),
+        markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
+      })
+
+      const deps = makeDeps()
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — resolveToAnswer called with empty string
+      expect(ctrl.resolveToAnswer).toHaveBeenCalledWith('')
+      // #and — sink.flush called (delegated → sink owns the no-output fallback)
+      expect(flushMock).toHaveBeenCalledOnce()
     })
   })
 })

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -12,6 +12,7 @@ import {acquireLock, createHeartbeatController, createRun, releaseLock, transiti
 
 import {createPermissionCoordinator} from '../approvals/coordinator.js'
 import {buildApprovalButtons, buildApprovalEmbed, buildSettledEmbed} from '../discord/approvals.js'
+import {createStatusController} from '../discord/status-message.js'
 import {createDiscordStreamSink} from '../discord/streaming.js'
 import {attachOpencode} from './opencode-attach.js'
 import {buildDiscordPrompt, EmptyPromptError} from './prompt.js'
@@ -50,6 +51,12 @@ export interface RunMentionDeps {
    * `autonomous-low-risk` is deferred (unsafe due to OpenCode last-match-wins evaluation).
    */
   readonly approvalMode: 'approval-required'
+  /**
+   * Working-state UX mode. Propagated from `GatewayConfig.statusMode`.
+   * - `live-status` (default): posts a single editable status message that updates as the agent works.
+   * - `typing-only`: suppresses the status message; only the typing indicator is shown.
+   */
+  readonly statusMode: 'live-status' | 'typing-only'
   /**
    * Ensure the workspace checkout exists for the given owner/repo.
    * Called after the concurrency gate acquires a slot, before readyz/execution.
@@ -165,7 +172,7 @@ export function computeApprovalDeadlineMs(remainingBudgetMs: number): number | u
 export async function runMention(message: Message, binding: RepoBinding, deps: RunMentionDeps): Promise<void> {
   const {concurrency, coordinationConfig, identity, attachUrl, attachToken, runTimeoutMs, botUserId, persona, logger} =
     deps
-  const {approvalRegistry, approvalMode, ensureClone, readyz} = deps
+  const {approvalRegistry, approvalMode, statusMode, ensureClone, readyz} = deps
   const channelId = message.channel.id
   const repo = `${binding.owner}/${binding.repo}`
 
@@ -310,6 +317,16 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
 
     let heartbeatStopped = false
     let sink: ReturnType<typeof createDiscordStreamSink> | null = null
+
+    // ── Status controller — per-run, created after thread is available ────────────────────────
+    // Adapts rawThread to StatusThread: discord.js ThreadChannel has .send() and .sendTyping()
+    // which structurally satisfy the StatusThread interface. Messages returned by .send() have
+    // .edit() and .delete() which satisfy StatusMessage.
+    const statusController = createStatusController({
+      thread: rawThread,
+      mode: statusMode,
+      logger,
+    })
 
     try {
       const execResult = await transitionRun(
@@ -495,6 +512,12 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
           logger,
           coordinator,
           approvalMode,
+          onActivity: (summary: string) => {
+            statusController.noteActivity(summary)
+          },
+          onBusy: (busy: boolean) => {
+            statusController.setBusy(busy)
+          },
         })
       } finally {
         // Fail-closed: dispose any still-open coordinator entries so pending approvals
@@ -528,7 +551,17 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
         // Non-fatal: continue to flush sink and release resources
       }
 
-      await sink.flush()
+      // ── Status controller final-answer transition ─────────────────────────────────────────────
+      // Get the buffered text BEFORE flush so the controller can decide whether to edit in place.
+      // resolveToAnswer returns:
+      //   'handled'   → controller edited the status message into the answer; skip sink flush.
+      //   'delegated' → controller deleted the status (or typing-only); flush via sink as normal.
+      const finalText = sink.buffered()
+      const answerResult = await statusController.resolveToAnswer(finalText)
+      if (answerResult.transition === 'delegated') {
+        await sink.flush()
+      }
+      // 'handled': answer is already in the status message — do not flush (would double-post).
     } catch (execError: unknown) {
       // ── Error classification ───────────────────────────────────────────────
 
@@ -602,9 +635,20 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
                 ? 'The task stream closed unexpectedly. Please try again.'
                 : 'The task failed. Please try again.'
 
-      await safeSend(thread, userMessage).catch((error: unknown) => {
-        logger.warn({repo, runId, err: String(error)}, 'run: failed to send error reply to thread')
+      // ── Status controller failure transition ──────────────────────────────────────────────────
+      // resolveToFailure returns:
+      //   'handled'   → controller edited the status message into the failure note; skip safeSend.
+      //   'delegated' → no status to edit (or typing-only); post via safeSend as normal.
+      // Never both — single owner for the failure message.
+      const failureResult = await statusController.resolveToFailure(userMessage).catch((error: unknown) => {
+        logger.warn({repo, runId, err: String(error)}, 'run: statusController.resolveToFailure failed — delegating')
+        return {transition: 'delegated' as const}
       })
+      if (failureResult.transition === 'delegated') {
+        await safeSend(thread, userMessage).catch((error: unknown) => {
+          logger.warn({repo, runId, err: String(error)}, 'run: failed to send error reply to thread')
+        })
+      }
     } finally {
       // Stop heartbeat if not yet stopped (defensive — should not normally happen)
       if (heartbeatStopped === false) {
@@ -612,6 +656,12 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
           /* best-effort */
         })
       }
+
+      // Dispose status controller — guaranteed cleanup of typing interval and debounce timer.
+      // Must run in finally so timers never leak regardless of success or failure.
+      await statusController.dispose().catch((error: unknown) => {
+        logger.warn({repo, runId, err: String(error)}, 'run: statusController.dispose failed')
+      })
 
       // Release lock (best-effort)
       const releaseResult = await releaseLock(coordinationConfig, repo, lockEtag, coordLogger)

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -157,6 +157,7 @@ function makeFakeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     maxConcurrentRuns: 3,
     runTimeoutMs: 600_000,
     approvalMode: 'approval-required',
+    statusMode: 'live-status',
     persona: null,
     announce: {
       webhookSecret: 'test-webhook-secret',

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -278,6 +278,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           logger,
           approvalRegistry,
           approvalMode: config.approvalMode,
+          statusMode: config.statusMode,
           // Workspace readiness gate — uses the same :9100 base as the clone endpoint.
           // Placed inside run so it is called after the concurrency gate, not before.
           readyz: async () => workspaceClient.readyz(),


### PR DESCRIPTION
Makes a running `@Fro Bot` mention feel alive. Today a mention runs silently until the final answer lands — on a multi-step task the thread looks dead. This adds a single live status message that updates as the agent works and becomes the final answer, plus a typing indicator while it's busy.

## What changes

- **A live status message.** During a run, one status message (`⏳ Working… edited 2 files · ran 1 command`) updates on a rate-limit-safe cadence with the agent's essential actions, then is **replaced by the clean final answer** — one tidy thread message for short replies; longer/attachment answers post normally.
- **A typing indicator** pulses while the session is actually working and **pauses during an approval wait**, so it never sticks or implies work that isn't happening.
- **Failures read in Fro Bot's voice** — a terse failure note, not a raw error dump.
- **`GATEWAY_STATUS_MODE`** (default `live-status`) — set `typing-only` for the quietest experience (typing + answer only, no status message). See `deploy/README.md`.

## Safety & correctness

The status controller is a separate component; the stream sink stays append-only. All Discord I/O is fail-soft, but the **terminal** message is observable: if the final status edit fails, the controller falls back to the normal send so the answer is never dropped. A settle phase awaits any in-flight status write before resolving, so a late edit can't land after the answer. Status sends suppress mentions. Typing and debounce timers are cleared on every exit path.