### PR TITLE
feat(gateway): serial per-channel queue for mentions

### DIFF
--- a/docs/plans/2026-06-09-002-feat-mention-loop-serial-queue-plan.md
+++ b/docs/plans/2026-06-09-002-feat-mention-loop-serial-queue-plan.md
@@ -1,0 +1,233 @@
+---
+title: "feat: Serial per-channel queue for mention loop"
+type: feat
+status: active
+date: 2026-06-09
+origin: docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md
+deepened: 2026-06-09
+---
+
+# feat: Serial per-channel queue for mention loop
+
+## Overview
+
+Replace the gateway mention loop's current "reject a second mention while a same-channel run is in flight" behavior with a **serial per-channel queue**: a mention that arrives while the channel is busy is acknowledged and queued, then runs automatically when the in-flight run finishes. Add a `/fro-bot clear-queue` subcommand to drop pending queued tasks (the in-flight task always runs to completion). This is Phase 3 of the mention-loop production-readiness effort (Phases 1–2 — rendering/persona and working-state UX — already shipped) and resolves success criterion SC5 (see origin).
+
+## Problem Frame
+
+Today, `runMention` acquires a per-channel concurrency slot via `concurrency.tryAcquire(channelId)`; when the channel already has an active run it returns `'busy'`, and `run.ts` replies "There is already a task running in this channel — please wait for it to finish." and stops (a terminal reject). For a busy channel this feels broken — the user must manually retry. The brainstorm's SC5 requires the second mention to be **queued and run**, not rejected.
+
+The current control flow is the key constraint: `handleMention` (`packages/gateway/src/discord/mentions.ts`) `await`s `runMention` (`packages/gateway/src/execute/run.ts`), and the per-channel slot is acquired *inside* `runMention`. A queue changes this — an enqueued mention must be acknowledged and return without blocking the interaction, then start when the in-flight run's slot release fires.
+
+Two serialization layers exist and only one changes: the **per-channel concurrency slot** (`'busy'` path — this becomes a queue) and the **per-repo S3 lock** (`acquireLock`, unchanged). The **global concurrency cap** (`'cap'` path) also stays terminal — a global-capacity rejection is not queued in v1. The queue is keyed by **Discord channel ID** (`message.channel.id`); thread messages are already ignored by `handleMention`.
+
+## Requirements Trace
+
+- R1. A mention arriving while its channel has an in-flight run is **queued**, not rejected, and the user gets a brief "queued" acknowledgement (SC5).
+- R2. When the in-flight run completes (success or failure), the next queued task for that channel **starts automatically** (SC5).
+- R3. `/fro-bot clear-queue` drops all pending queued tasks for the invoking channel; the in-flight task is unaffected and runs to completion (SC5).
+- R4. The queue is **in-memory** per channel; tasks pending at gateway restart are lost (documented, not solved — per the Unit 6 R11 boundary, see origin).
+- R5. The per-repo lock, the global concurrency cap (`'cap'` reject), and all existing run lifecycle behavior (thread/lock/run-state/heartbeat/execution/release ordering) are unchanged.
+- R6. The `'cap'` global-capacity path remains a terminal reject (not queued) in v1.
+
+## Scope Boundaries
+
+- Non-goal: persistent/cross-restart queue (in-memory only, R4).
+- Non-goal: queuing on global-cap rejection (`'cap'` stays terminal, R6).
+- Non-goal: changing the per-repo lock or the run lifecycle internals.
+- Non-goal: per-queue prioritization, reordering, or per-user fairness — strict FIFO per channel.
+- Non-goal: a queue-position/status display beyond the initial "queued" ack (no live "you are 2nd in line" updates in v1).
+
+### Deferred to Separate Tasks
+
+- Phase 4 — core commands (`/fro-bot sessions`, `/fro-bot resume`, `/fro-bot force-release-lock`) + native approval UX: separate phase per the origin's build order. **Note for Phase 4:** all commands must be `/fro-bot` subcommands (matching the existing `ping`/`add-project`/`clear-queue` convention), never top-level slash commands.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/gateway/src/execute/concurrency.ts` — `ConcurrencyRegistry`: `tryAcquire(channelId) -> 'ok'|'cap'|'busy'`, `release(channelId)`, global cap + `activeChannels` set, in-memory by design. The `'busy'` branch is what the queue replaces.
+- `packages/gateway/src/execute/run.ts` — `runMention(message, binding, deps)`: the slot dispatch (`tryAcquire` at ~189), the `'cap'`/`'busy'` terminal replies (~191–199), the happy path (ensureClone → readyz → startThread → acquireLock → run-state → heartbeat → execute), the inner finally `releaseLock`, and the **outer finally `concurrency.release(channelId)`** (~672–675) — the natural handoff point (replaced by the atomic handoff in Unit 2).
+- `packages/gateway/src/discord/mentions.ts` — `handleMention`: ignores thread messages, auth + binding lookup, then `await runMention(...)`. `safeReply` with mentions disabled is the ack pattern.
+- `packages/gateway/src/discord/commands/fro-bot.ts` — the `/fro-bot` command builder + subcommand dispatch (`interaction.options.getSubcommand(true)`); where `clear-queue` is added alongside `ping`/`add-project`.
+- `packages/gateway/src/discord/commands/index.ts` — command registry + `dispatchCommand` + REST registration.
+- `packages/gateway/src/program.ts` — builds the registry, registers slash commands, wires `interactionCreate` → `dispatchCommand`; also where the queue component is constructed and injected (like `concurrency`).
+
+### Institutional Learnings
+
+- The gateway mention-loop best-practices doc (`docs/solutions/best-practices/gateway-opencode-mention-loop-best-practices-*.md`) — bounded execution with guaranteed resource release (dual-finally), and the in-memory module-scoped registry pattern (breaks under multi-replica — acceptable for single-replica v1, same as `concurrency.ts` and the approval registry).
+- The approval registry / coordination work established the register-before-act and ownership-gated patterns; the queue should follow the same fail-soft, single-owner discipline.
+
+## Key Technical Decisions
+
+- **Dedicated in-memory queue component** (`packages/gateway/src/execute/queue.ts`): a `ChannelQueue` keyed by Discord channel ID, holding pending tasks (FIFO). Mirrors `concurrency.ts` shape (factory returning an interface, module-injected via deps), in-memory by design. Chosen over making the `'busy'` path block/await — blocking would tie up the interaction and give no ack.
+
+- **Explicit task descriptor (decided now, not deferred):** a queued task is `{message, binding, deps}` — exactly the three arguments `runMention` takes today. This is the stable contract the queue stores. No smaller capture is possible because `runMention` closes over nothing separate; the descriptor IS its argument tuple.
+
+- **Extract `startRun(task)` from `runMention` (the re-entry seam):** today `runMention` both (a) makes the acquire/busy decision AND (b) runs the post-acquire pipeline (clone → readyz → thread → lock → run-state → heartbeat → execute → release). Split these: `startRun(task)` owns the post-acquire pipeline and assumes the channel slot is already held; `runMention` becomes the thin **front door** that decides acquire-now vs enqueue and either calls `startRun` or enqueues. Both the immediate path and the drain call the *same* `startRun` — so a queued task is replayed through the execution path only, not the acquire decision again. (Resolves the "re-enter runMention re-runs the whole pipeline" feasibility gap.)
+
+- **Queue presence gates immediate-start (the FIFO fix):** a new mention must enqueue when the channel already has pending queued work, **even if a slot is free**. The decision is: if `pendingCount(channelId) > 0`, enqueue (never take an immediate `'ok'`); only the handoff path may start the next task. Without this, a fresh mention arriving in the gap after slot-release-before-drain would leapfrog older queued work (FIFO violation / starvation). So the front-door order is: if pending work exists → enqueue; else `tryAcquire` → `'ok'` runs now, `'busy'` enqueues, `'cap'` terminal-rejects.
+
+- **Atomic handoff, not release-then-drain (the serial-safety fix):** the in-flight run must NOT fully release the channel slot and then separately drain — that opens a window where a new mention sees `'ok'` and starts concurrently with the drained task (two runs, same channel). Instead, on run completion the run path performs an **atomic handoff**: while the channel is still reserved, `queue.takeNext(channelId)`; if it returns a task, start it *holding the same slot* (no release/re-acquire gap); only when the queue is empty does `concurrency.release(channelId)` fire. The completing run triggers this in `startRun`'s outer finally — no timers/polling. (The queue exposes the atomic `takeNext`; the run path owns the take-or-release decision.)
+
+- **`/fro-bot clear-queue` subcommand:** drops *pending* tasks for the invoking channel (not the in-flight run). Registered as a subcommand on the existing `/fro-bot` builder; the queue is plumbed into the command deps (the current command dep type carries no queue — it must be added and threaded `program.ts → getCommandRegistry → createFroBotCommand`).
+
+- **Required per-channel depth cap (not optional):** a public Discord channel lets one user spam mentions while busy → unbounded queued tasks + acks (a real spam/memory/delayed-flood vector). v1 **requires** a per-channel depth cap with a deterministic overflow response: reject the newest mention with a terse "queue is full for this channel" reply. Default cap chosen at implementation (small, e.g. 5–10); surface as config only if needed.
+
+- **Race-safe queue ops:** `enqueue`, the atomic `releaseOrHandoff`, `clear`, and `pendingCount` are all single-owner synchronous operations on the in-memory map (Node's single-threaded event loop makes each op atomic). `clear` racing a handoff is safe: handoff dequeues-and-commits atomically, so a task is either already handed off (runs) or still pending (cleared) — never both.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Queue keyed by channel or thread? Channel ID (`message.channel.id`) — matches `tryAcquire`; thread messages are ignored by `handleMention`.
+- Does `/clear-queue` abort the in-flight run? No — in-flight runs to completion; only pending tasks are dropped (R3).
+- Is the global `'cap'` path queued? No — stays terminal in v1 (R6).
+- Top-level `/clear-queue` or subcommand? `/fro-bot clear-queue` subcommand (matches existing convention).
+
+### Deferred to Implementation
+
+- Exact `maxDepth` default value (small — 5–10) and whether it needs a config knob vs. a constant. The cap itself is required (resolved); only the number/config surface is deferred.
+- Whether `startRun` is a standalone exported function or a closure inside `runMention`'s module — an internal structuring choice; the contract (`startRun(task)` owns the post-acquire pipeline, assumes slot held) is fixed.
+- The exact queued-ack copy and the overflow ("queue is full") copy — wording, not behavior.
+
+## Implementation Units
+
+- [ ] **Unit 1: In-memory channel queue component**
+
+**Goal:** A `ChannelQueue` that holds pending per-channel tasks FIFO with an atomic `takeNext` pop, plus clear-by-channel and a required depth cap.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/gateway/src/execute/queue.ts`
+- Test: `packages/gateway/src/execute/queue.test.ts`
+
+**Approach:**
+- Factory `createChannelQueue(maxDepth)` returning a readonly interface:
+  - `enqueue(channelId, task) -> 'queued' | 'full'` — append FIFO; return `'full'` (reject newest) when the channel is at `maxDepth`.
+  - `pendingCount(channelId) -> number` — pending depth for the channel (used by the front-door gate).
+  - `clear(channelId) -> number` — drop all pending for the channel, return count dropped.
+  - `takeNext(channelId) -> task | undefined` — atomic FIFO pop (the handoff primitive; single-owner, never returns the same task twice).
+- In-memory `Map<channelId, task[]>`. Mirror `concurrency.ts` style (readonly interface, functions-only, strict booleans, in-memory by design). Each op is synchronous → atomic under Node's event loop.
+- `task` is a typed descriptor `{message, binding, deps}` (the `runMention` argument tuple) — but the queue stays structurally agnostic; it stores and returns the descriptor opaquely.
+- **Depth cap is required** (`maxDepth`, small default e.g. 5–10): `enqueue` returns `'full'` at the cap so the caller can reply "queue is full".
+
+**Patterns to follow:**
+- `packages/gateway/src/execute/concurrency.ts` (factory + readonly interface + in-memory Map/Set, module-injected).
+
+**Test scenarios:**
+- Happy path: enqueue two tasks for a channel → `takeNext` returns them FIFO; `pendingCount` reflects depth and decrements on take.
+- Edge case: `takeNext` on empty channel → `undefined`; `clear` on empty → 0.
+- Edge case: tasks for different channels are isolated (enqueue A doesn't affect B's take/count).
+- R3: `clear(channelId)` drops only that channel's pending tasks and returns the count; other channels untouched.
+- Required depth cap: enqueue at `maxDepth` returns `'full'`; pending tasks and other channels unaffected; after a `takeNext` frees a slot, enqueue succeeds again.
+- Atomicity: two sequential `takeNext` calls never return the same task; interleaved enqueue + takeNext preserve FIFO and lose no task; `clear` after a `takeNext` drops only what remains.
+
+**Verification:** Queue holds/returns tasks FIFO, isolates channels, enforces the depth cap, clears pending by channel, and `takeNext` never double-returns a task.
+
+- [ ] **Unit 2: `startRun` seam + front-door enqueue + atomic handoff**
+
+**Goal:** Split `runMention` into an acquire-or-enqueue front door and a slot-holding `startRun` pipeline; replace the `'busy'` reject with enqueue+ack; hand the slot to the next queued task atomically on completion (no release-then-drain gap).
+
+**Requirements:** R1, R2, R5, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/gateway/src/execute/run.ts` (extract `startRun(task)`; front-door gate; atomic handoff in the outer finally)
+- Modify: `packages/gateway/src/program.ts` (construct `ChannelQueue`, inject into run deps alongside `concurrency`)
+- Test: `packages/gateway/src/execute/run.test.ts` (extend)
+
+**Approach:**
+- **Extract `startRun(task: {message, binding, deps})`**: the post-acquire pipeline currently inside `runMention` (clone → readyz → thread → lock → run-state → heartbeat → execute → cleanup). It assumes the channel slot is already held. This is the single entry both the immediate path and the handoff call.
+- **Front-door `runMention(message, binding, deps)`** becomes the gate, in this order:
+  1. If `queue.pendingCount(channelId) > 0` → `enqueue` + queued ack (queued work has priority; never take an immediate slot ahead of it — the FIFO fix).
+  2. Else `concurrency.tryAcquire(channelId)`:
+     - `'ok'` → `startRun(task)` (slot held).
+     - `'busy'` → `enqueue` + queued ack (or "queue is full" if `enqueue` returns `'full'`). Return without blocking. (Replaces the old terminal reject.)
+     - `'cap'` → terminal capacity reply, no enqueue (R6).
+- **Atomic handoff in `startRun`'s outer finally** (replaces `concurrency.release` + separate drain): call `queue.takeNext(channelId)` *while the slot is still held*. If it returns a task → start it on the held slot (`void startRun(next).catch(log)` — error-isolated, the slot stays owned by the chain). If it returns `undefined` → `concurrency.release(channelId)` (only now is the slot freed). This closes the release-before-drain window: a new mention can never see `'ok'` between a completion and the next task starting, because the slot is never free while pending work exists.
+- The handoff `startRun` is fire-and-forget from the completing run's perspective (so cleanup completes), but the slot ownership transfers without a gap. A handoff-start failure logs and must still release the slot (its own finally runs the same handoff/release logic).
+- `'ok'` happy path otherwise unchanged (R5); per-repo lock path unchanged.
+
+**Execution note:** Add a failing integration-style test first for the front-door gate + atomic handoff contract (busy mention enqueues+acks; completion hands off to the next without freeing the slot; a new mention with pending work present enqueues rather than running), then implement.
+
+**Patterns to follow:**
+- The existing `tryAcquire`/`release` dual-finally ordering in `run.ts`; fire-and-forget `.catch` logging used elsewhere in the gateway (status/approval sends).
+
+**Test scenarios:**
+- R1: mention while channel busy → `enqueue` + queued ack (not the old reject reply); `startRun` not invoked synchronously for it.
+- FIFO gate: a new mention arriving while `pendingCount > 0` is enqueued even though it could otherwise get `'ok'` — it does not leapfrog queued work.
+- Serial safety (the core fix): when a run completes with a queued task present, the slot is handed off (next `startRun` runs) WITHOUT `concurrency.release` being called in between — assert no window where `tryAcquire` would return `'ok'` for that channel; two runs never overlap for one channel.
+- R2: completion with a pending task → `takeNext` + next `startRun` starts; completion with empty queue → `concurrency.release` called, slot freed.
+- R5/R6: `'ok'` path runs normally; `'cap'` replies terminally and does NOT enqueue; per-repo lock unchanged.
+- Error path: a handed-off `startRun` that throws still releases/hands off the slot (its own finally), does not strand the queue, and logs.
+- Overflow: enqueue returning `'full'` → terse "queue is full" reply; channel state unaffected.
+- Integration: three mentions on a busy channel run strictly FIFO, each starting only after the prior completes, with no concurrent overlap.
+
+**Verification:** A busy-channel mention is queued+acked and runs after the current finishes in FIFO order; the slot is handed off without a free-slot gap (no double-start); a new mention with pending work enqueues rather than leapfrogging; `'cap'`/lock behavior unchanged.
+
+- [ ] **Unit 3: `/fro-bot clear-queue` subcommand**
+
+**Goal:** Operators/users can drop pending queued tasks for their channel; the in-flight run is unaffected.
+
+**Requirements:** R3
+
+**Dependencies:** Unit 1 (queue `clear`), Unit 2 (queue injected/available to commands)
+
+**Files:**
+- Modify: `packages/gateway/src/discord/commands/fro-bot.ts` (add `clear-queue` subcommand to the builder + dispatch)
+- Modify: `packages/gateway/src/discord/commands/index.ts` (only if registry/deps wiring needs the queue)
+- Modify: `packages/gateway/src/program.ts` (pass the `ChannelQueue` into command deps if not already)
+- Test: `packages/gateway/src/discord/commands/index.test.ts` and/or a `fro-bot.test.ts` (extend)
+
+**Approach:**
+- Add a `clear-queue` subcommand to the existing `/fro-bot` builder (alongside `ping`/`add-project`). On invoke: `queue.clear(channelId)` for the interaction's channel, reply ephemerally with the number of pending tasks dropped (e.g. "Cleared N queued task(s). The running task will finish.").
+- **Wire the queue into command deps:** the current command dep type (`AddProjectDeps`, passed via `program.ts → getCommandRegistry → createFroBotCommand`) carries no queue field. Add the `ChannelQueue` to the command deps type and thread it through those three sites so the subcommand handler can reach it. (Feasibility-flagged: the injection seam exists but must be explicitly extended.)
+- The in-flight run is not touched (R3) — only pending tasks are dropped. `clear` racing a completion handoff is safe (Unit 1's `takeNext`/`clear` are atomic single-owner ops): a task is either already handed off or still pending, never both.
+- Keyed by the interaction's channel ID, consistent with the queue/concurrency key.
+
+**Patterns to follow:**
+- The existing `/fro-bot` subcommand dispatch (`interaction.options.getSubcommand(true)`) and ephemeral reply style of `ping`/`add-project`.
+
+**Test scenarios:**
+- Happy path: `clear-queue` with N pending → queue `clear` called for the channel, ephemeral reply states N dropped.
+- Edge case: `clear-queue` with empty queue → replies 0 dropped (no error).
+- R3: `clear-queue` does not affect the in-flight run (only pending dropped) — assert the in-flight/active slot is untouched.
+- Dispatch: `/fro-bot clear-queue` routes to the handler (subcommand dispatch wired correctly).
+
+**Verification:** `/fro-bot clear-queue` drops pending tasks for the channel and reports the count; running task unaffected; registered/dispatched as a `/fro-bot` subcommand.
+
+## System-Wide Impact
+
+- **Interaction graph:** the handoff starts the next task from the completing run's outer finally via `void startRun(next).catch(log)` — each completion starts at most one successor (that successor's completion triggers the next handoff), so the chain is iterative, not unbounded recursion, and the stack does not grow (fire-and-forget detaches each link). The Discord interaction for a queued mention is acked immediately and not held open.
+- **State lifecycle risks:** in-memory queue lost on restart (R4, documented). The handoff is in `startRun`'s outer `finally`, so it runs on success and failure paths — a task is never stranded by a normal throw. The only genuine stranding case is a hard crash between completion and handoff (process death) — acceptable under the in-memory v1 boundary (same as `concurrency.ts`'s active-set loss). Note: because queued work has priority (front-door gate), a stranded queue does NOT silently get leapfrogged by new mentions — new mentions enqueue behind it; the next *completion* handoff or a restart is what resolves it.
+- **API surface parity:** `/fro-bot clear-queue` is the only new command surface; it follows the `/fro-bot` subcommand convention (and sets the precedent that ALL Phase 4 commands must be `/fro-bot` subcommands).
+- **Unchanged invariants:** per-repo S3 lock, global concurrency cap (`'cap'` terminal), run-state/heartbeat/thread lifecycle, and the `'ok'` immediate-run path (when no pending work) are unchanged. The per-channel `'busy'` path changes from reject to queue, and a new front-door gate enqueues even on a free slot when pending work exists.
+- **Integration coverage:** strict-FIFO across three queued mentions + the no-free-slot-gap handoff are the cross-layer scenarios unit-level mocks won't fully prove — covered by Unit 2's integration tests.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Free-slot gap double-starts a channel (new mention gets `'ok'` while a queued task also starts) | **Atomic handoff** — the slot is handed to the next task while still held; `concurrency.release` is called only when the queue is empty. No window where `tryAcquire` returns `'ok'` with pending work. Serial-safety test in Unit 2. |
+| New mention leapfrogs older queued work (FIFO violation/starvation) | **Front-door gate** — `pendingCount(channelId) > 0` forces enqueue even on a free slot; only the handoff starts the next task. FIFO-gate test in Unit 2. |
+| `takeNext` double-returns / loses a task | Atomic single-owner `takeNext` (Unit 1); atomicity tests. |
+| Hard crash between completion and handoff strands a queued task | Accepted under the in-memory v1 boundary (R4); front-door priority means new mentions queue behind it (not leapfrog); resolved on next completion handoff or restart. |
+| Unbounded enqueue from a spamming channel | **Required** per-channel depth cap (`maxDepth`) with a "queue is full" reply; FIFO bound. |
+| `clear-queue` races a completion handoff | Atomic `takeNext`/`clear` — a task is either already handed off (runs) or still pending (cleared), never both. |
+| Fire-and-forget handoff swallows errors silently | `.catch` logs; the handed-off `startRun`'s own finally still releases/hands off, so the queue never strands on a start failure. |
+
+## Documentation / Operational Notes
+
+- Update `packages/gateway/AGENTS.md` to document the serial per-channel queue (replaces reject-concurrent), the in-memory/restart-loss boundary, and the `/fro-bot clear-queue` subcommand.
+- Note the single-replica assumption (module-scoped in-memory queue, same as `concurrency.ts`).
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md](docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md) (Phase 3 / SC5)
+- Related code: `packages/gateway/src/execute/concurrency.ts`, `packages/gateway/src/execute/run.ts`, `packages/gateway/src/discord/mentions.ts`, `packages/gateway/src/discord/commands/fro-bot.ts`, `packages/gateway/src/program.ts`
+- Related learnings: `docs/solutions/best-practices/gateway-opencode-mention-loop-best-practices-*.md`

--- a/docs/plans/2026-06-09-002-feat-mention-loop-serial-queue-plan.md
+++ b/docs/plans/2026-06-09-002-feat-mention-loop-serial-queue-plan.md
@@ -1,10 +1,11 @@
 ---
 title: "feat: Serial per-channel queue for mention loop"
 type: feat
-status: active
+status: completed
 date: 2026-06-09
 origin: docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md
 deepened: 2026-06-09
+completed: 2026-06-09
 ---
 
 # feat: Serial per-channel queue for mention loop
@@ -93,7 +94,7 @@ Two serialization layers exist and only one changes: the **per-channel concurren
 
 ## Implementation Units
 
-- [ ] **Unit 1: In-memory channel queue component**
+- [x] **Unit 1: In-memory channel queue component**
 
 **Goal:** A `ChannelQueue` that holds pending per-channel tasks FIFO with an atomic `takeNext` pop, plus clear-by-channel and a required depth cap.
 
@@ -128,7 +129,7 @@ Two serialization layers exist and only one changes: the **per-channel concurren
 
 **Verification:** Queue holds/returns tasks FIFO, isolates channels, enforces the depth cap, clears pending by channel, and `takeNext` never double-returns a task.
 
-- [ ] **Unit 2: `startRun` seam + front-door enqueue + atomic handoff**
+- [x] **Unit 2: `startRun` seam + front-door enqueue + atomic handoff**
 
 **Goal:** Split `runMention` into an acquire-or-enqueue front door and a slot-holding `startRun` pipeline; replace the `'busy'` reject with enqueue+ack; hand the slot to the next queued task atomically on completion (no release-then-drain gap).
 
@@ -170,7 +171,7 @@ Two serialization layers exist and only one changes: the **per-channel concurren
 
 **Verification:** A busy-channel mention is queued+acked and runs after the current finishes in FIFO order; the slot is handed off without a free-slot gap (no double-start); a new mention with pending work enqueues rather than leapfrogging; `'cap'`/lock behavior unchanged.
 
-- [ ] **Unit 3: `/fro-bot clear-queue` subcommand**
+- [x] **Unit 3: `/fro-bot clear-queue` subcommand**
 
 **Goal:** Operators/users can drop pending queued tasks for their channel; the in-flight run is unaffected.
 

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -130,6 +130,8 @@ Each channel runs tasks serially via a per-channel FIFO queue. When a mention ar
 
 On completion, the finishing run atomically hands the channel slot to the next queued task (if any) without releasing and re-acquiring it. This closes the window where a concurrent mention could slip in ahead of queued work. The queue is in-memory only — a gateway restart drops any pending tasks.
 
+On graceful shutdown (SIGTERM), pending queued tasks are dropped: the handoff is suppressed and the channel slot is released immediately. The in-flight run finishes its own cleanup (lock release, run-state transition, heartbeat stop) but does not start any new runs. This is consistent with the `messageCreate` guard that refuses new mentions once shutdown is requested. The in-memory queue is lossy by design; dropping pending tasks on shutdown matches that contract.
+
 The `/fro-bot clear-queue` subcommand drops all pending queued tasks for the invoking channel. It is authorization-gated with the same authority check as the mention path (trigger role or guild-level ManageChannels). The in-flight run (if any) is unaffected.
 
 Releasing is always done in a `finally` block so crashes leave the system in a recoverable state.

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -121,11 +121,16 @@ Both ports are loopback-bound inside the sandbox network. The egress proxy (`mit
 
 ### Concurrent-run semantics
 
-There is no run queue. When capacity is exhausted or a channel already has an active run, the response is terminal:
+Each channel runs tasks serially via a per-channel FIFO queue. When a mention arrives:
 
-- **cap** — global `GATEWAY_MAX_CONCURRENT_RUNS` limit reached → "at capacity, try again shortly".
-- **busy** — this channel already has an active run → "task already running, wait for it to finish".
+- **cap** — global `GATEWAY_MAX_CONCURRENT_RUNS` limit reached → terminal "at capacity, try again shortly" reply. No queue entry is created.
+- **busy** — this channel already has an active run → the new task is enqueued (up to the per-channel queue depth). The user receives a "Queued" ack and the task starts automatically when the current run finishes.
+- **pending work present** — even if a slot appears free, a new mention is enqueued rather than starting immediately, so older queued work is never leapfrogged.
 - **waiting** — the repo lock is held by another run → "another task in progress for this repo, try again when it completes".
+
+On completion, the finishing run atomically hands the channel slot to the next queued task (if any) without releasing and re-acquiring it. This closes the window where a concurrent mention could slip in ahead of queued work. The queue is in-memory only — a gateway restart drops any pending tasks.
+
+The `/fro-bot clear-queue` subcommand drops all pending queued tasks for the invoking channel. It is authorization-gated with the same authority check as the mention path (trigger role or guild-level ManageChannels). The in-flight run (if any) is unaffected.
 
 Releasing is always done in a `finally` block so crashes leave the system in a recoverable state.
 
@@ -171,7 +176,7 @@ When the workspace OpenCode config sets any tool to `ask` (rather than the defau
   Discord-independent execution primitive and caller surface is deferred until a
   non-Discord caller exists.
 
-- **No run queue.** Mentions that arrive while the concurrency cap or repo lock is held are rejected immediately. There is no persistent queue, no back-pressure mechanism, and no retry. Users must manually re-send their message when the system is free.
+- **In-memory queue only.** The per-channel FIFO queue is in-memory and does not survive a gateway restart. Any pending queued tasks are silently dropped on restart; users must re-mention to retry. The global concurrency cap (`cap` path) is still terminal — no queue entry is created when the cap is reached.
 
 - **Tool approval does not survive a restart.** A pending approval is held in memory by the per-run coordinator. If the gateway or workspace restarts while a permission prompt is in flight, the pending approval is abandoned: the coordinator's deadline fires (or the process exits fail-closed), the Discord embed is settled with `rejected`, and the run surfaces as interrupted. Re-mention to retry.
 

--- a/packages/gateway/src/discord/commands/fro-bot.test.ts
+++ b/packages/gateway/src/discord/commands/fro-bot.test.ts
@@ -6,10 +6,11 @@
  * - Dispatch routing for each subcommand
  * - `/fro-bot clear-queue` handler: calls queue.clear(channelId), replies ephemerally with count
  * - Zero-pending edge case
- * - R3: clear-queue does not touch the in-flight run (only queue.clear is called)
+ * - clear-queue does not touch the in-flight run (only queue.clear is called)
+ * - Authorization gate: only authorized users may clear the queue
  */
 
-import type {ChatInputCommandInteraction} from 'discord.js'
+import type {ChatInputCommandInteraction, Guild} from 'discord.js'
 import type {ChannelQueue} from '../../execute/queue.js'
 import type {RunTask} from '../../execute/run.js'
 import type {FroBotDeps} from './fro-bot.js'
@@ -30,6 +31,29 @@ function makeQueue(clearReturnValue = 0): ChannelQueue<RunTask> {
     takeNext: vi.fn().mockReturnValue(undefined),
     clear: vi.fn().mockReturnValue(clearReturnValue),
   }
+}
+
+/**
+ * Build a mock Guild where members.fetch() resolves to a member with the given
+ * role set and ManageChannels permission.
+ */
+function makeGuild(opts: {hasRole?: boolean; hasManageChannels?: boolean} = {}): Guild {
+  const {hasRole = true, hasManageChannels = true} = opts
+  const member = {
+    roles: {
+      cache: {
+        has: vi.fn().mockReturnValue(hasRole),
+      },
+    },
+    permissions: {
+      has: vi.fn().mockReturnValue(hasManageChannels),
+    },
+  }
+  return {
+    members: {
+      fetch: vi.fn().mockResolvedValue(member),
+    },
+  } as unknown as Guild
 }
 
 function makeDeps(overrides?: Partial<FroBotDeps>): FroBotDeps {
@@ -55,6 +79,13 @@ function makeDeps(overrides?: Partial<FroBotDeps>): FroBotDeps {
       error: vi.fn(),
     },
     queue: makeQueue(),
+    triggerRoleId: null,
+    gatewayLogger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
     ...overrides,
   }
 }
@@ -62,6 +93,8 @@ function makeDeps(overrides?: Partial<FroBotDeps>): FroBotDeps {
 function makeInteraction(
   subcommand: string,
   channelId = 'ch-test-123',
+  guild: Guild | null = makeGuild(),
+  userId = 'user-authorized-123',
 ): {
   interaction: ChatInputCommandInteraction
   reply: ReturnType<typeof vi.fn>
@@ -70,6 +103,8 @@ function makeInteraction(
   const interaction = {
     commandName: 'fro-bot',
     channelId,
+    guild,
+    user: {id: userId},
     reply,
     options: {
       getSubcommand: vi.fn().mockReturnValue(subcommand),
@@ -225,5 +260,106 @@ describe('/fro-bot clear-queue', () => {
     expect(replyArg.content).toMatch(/Cleared 1 queued task/)
     expect(replyArg.content).toMatch(/running task will finish/)
     expect(replyArg.ephemeral).toBe(true)
+  })
+
+  it('queue.clear was called with interaction.channelId exactly', async () => {
+    // #given
+    const queue = makeQueue(2)
+    const deps = makeDeps({queue})
+    const cmd = createFroBotCommand(deps)
+    const channelId = 'ch-exact-id-check'
+    const {interaction} = makeInteraction('clear-queue', channelId)
+
+    // #when
+    await Effect.runPromise(cmd.execute(interaction))
+
+    // #then — clear called with the exact channelId from the interaction
+    expect(queue.clear).toHaveBeenCalledExactlyOnceWith(channelId)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// /fro-bot clear-queue — authorization gate (F2)
+// ---------------------------------------------------------------------------
+
+describe('/fro-bot clear-queue — authorization gate', () => {
+  it('authorized user (has trigger role) → queue.clear called + count reply', async () => {
+    // #given — user has the trigger role
+    const queue = makeQueue(3)
+    const guild = makeGuild({hasRole: true})
+    const deps = makeDeps({queue, triggerRoleId: 'role-trigger-123'})
+    const cmd = createFroBotCommand(deps)
+    const {interaction, reply} = makeInteraction('clear-queue', 'ch-auth', guild)
+
+    // #when
+    await Effect.runPromise(cmd.execute(interaction))
+
+    // #then — queue.clear was called
+    expect(queue.clear).toHaveBeenCalledOnce()
+    // #and — reply mentions the count
+    expect(reply).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        ephemeral: true,
+        content: expect.stringContaining('3') as unknown as string,
+      }),
+    )
+  })
+
+  it('unauthorized user (no role, no ManageChannels) → queue.clear NOT called + permission-denied reply', async () => {
+    // #given — user has neither the trigger role nor ManageChannels
+    const queue = makeQueue(2)
+    const guild = makeGuild({hasRole: false, hasManageChannels: false})
+    const deps = makeDeps({queue, triggerRoleId: 'role-trigger-123'})
+    const cmd = createFroBotCommand(deps)
+    const {interaction, reply} = makeInteraction('clear-queue', 'ch-unauth', guild)
+
+    // #when
+    await Effect.runPromise(cmd.execute(interaction))
+
+    // #then — queue.clear NOT called
+    expect(queue.clear).not.toHaveBeenCalled()
+    // #and — ephemeral permission-denied reply
+    expect(reply).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        ephemeral: true,
+        content: expect.stringMatching(/permission|not authorized/i) as unknown as string,
+      }),
+    )
+  })
+
+  it('null guild → queue.clear NOT called + server-only reply', async () => {
+    // #given — interaction has no guild (DM context)
+    const queue = makeQueue(1)
+    const deps = makeDeps({queue})
+    const cmd = createFroBotCommand(deps)
+    const {interaction, reply} = makeInteraction('clear-queue', 'ch-dm', null)
+
+    // #when
+    await Effect.runPromise(cmd.execute(interaction))
+
+    // #then — queue.clear NOT called
+    expect(queue.clear).not.toHaveBeenCalled()
+    // #and — ephemeral server-only reply
+    expect(reply).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        ephemeral: true,
+        content: expect.stringMatching(/server/i) as unknown as string,
+      }),
+    )
+  })
+
+  it('authorized user with ManageChannels (no trigger role configured) → queue.clear called', async () => {
+    // #given — no trigger role configured; user has ManageChannels
+    const queue = makeQueue(1)
+    const guild = makeGuild({hasRole: false, hasManageChannels: true})
+    const deps = makeDeps({queue, triggerRoleId: null})
+    const cmd = createFroBotCommand(deps)
+    const {interaction} = makeInteraction('clear-queue', 'ch-manage', guild)
+
+    // #when
+    await Effect.runPromise(cmd.execute(interaction))
+
+    // #then — queue.clear was called (ManageChannels fallback authorized)
+    expect(queue.clear).toHaveBeenCalledOnce()
   })
 })

--- a/packages/gateway/src/discord/commands/fro-bot.test.ts
+++ b/packages/gateway/src/discord/commands/fro-bot.test.ts
@@ -98,19 +98,25 @@ function makeInteraction(
 ): {
   interaction: ChatInputCommandInteraction
   reply: ReturnType<typeof vi.fn>
+  deferReply: ReturnType<typeof vi.fn>
+  editReply: ReturnType<typeof vi.fn>
 } {
   const reply = vi.fn().mockResolvedValue(undefined)
+  const deferReply = vi.fn().mockResolvedValue(undefined)
+  const editReply = vi.fn().mockResolvedValue(undefined)
   const interaction = {
     commandName: 'fro-bot',
     channelId,
     guild,
     user: {id: userId},
     reply,
+    deferReply,
+    editReply,
     options: {
       getSubcommand: vi.fn().mockReturnValue(subcommand),
     },
   } as unknown as ChatInputCommandInteraction
-  return {interaction, reply}
+  return {interaction, reply, deferReply, editReply}
 }
 
 // ---------------------------------------------------------------------------
@@ -183,46 +189,50 @@ describe('createFroBotCommand — dispatch', () => {
 // ---------------------------------------------------------------------------
 
 describe('/fro-bot clear-queue', () => {
-  it('happy path: calls queue.clear with the interaction channelId and replies ephemerally with count', async () => {
+  it('happy path: calls queue.clear with the interaction channelId and editReplies ephemerally with count', async () => {
     // #given — 3 pending tasks in the queue
     const queue = makeQueue(3)
     const deps = makeDeps({queue})
     const cmd = createFroBotCommand(deps)
     const channelId = 'ch-pending-123'
-    const {interaction, reply} = makeInteraction('clear-queue', channelId)
+    const {interaction, deferReply, editReply} = makeInteraction('clear-queue', channelId)
 
     // #when
     await Effect.runPromise(cmd.execute(interaction))
 
-    // #then — queue.clear was called with the channel ID
+    // #then — deferReply was called first (ephemeral)
+    expect(deferReply).toHaveBeenCalledExactlyOnceWith({ephemeral: true})
+
+    // #and — queue.clear was called with the channel ID
     expect(queue.clear).toHaveBeenCalledExactlyOnceWith(channelId)
 
-    // #and — reply was ephemeral and mentions the count
-    expect(reply).toHaveBeenCalledExactlyOnceWith(
+    // #and — editReply mentions the count (no ephemeral flag needed — deferred reply inherits it)
+    expect(editReply).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({
-        ephemeral: true,
         content: expect.stringContaining('3') as unknown as string,
       }),
     )
   })
 
-  it('zero pending: clear returns 0 → reply still sent with count 0', async () => {
+  it('zero pending: clear returns 0 → editReply still sent with count 0', async () => {
     // #given — empty queue
     const queue = makeQueue(0)
     const deps = makeDeps({queue})
     const cmd = createFroBotCommand(deps)
-    const {interaction, reply} = makeInteraction('clear-queue', 'ch-empty')
+    const {interaction, deferReply, editReply} = makeInteraction('clear-queue', 'ch-empty')
 
     // #when
     await Effect.runPromise(cmd.execute(interaction))
 
-    // #then — queue.clear was still called
+    // #then — deferReply called
+    expect(deferReply).toHaveBeenCalledExactlyOnceWith({ephemeral: true})
+
+    // #and — queue.clear was still called
     expect(queue.clear).toHaveBeenCalledExactlyOnceWith('ch-empty')
 
-    // #and — reply mentions 0
-    expect(reply).toHaveBeenCalledExactlyOnceWith(
+    // #and — editReply mentions 0
+    expect(editReply).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({
-        ephemeral: true,
         content: expect.stringContaining('0') as unknown as string,
       }),
     )
@@ -250,16 +260,15 @@ describe('/fro-bot clear-queue', () => {
     const queue = makeQueue(1)
     const deps = makeDeps({queue})
     const cmd = createFroBotCommand(deps)
-    const {interaction, reply} = makeInteraction('clear-queue', 'ch-wording')
+    const {interaction, editReply} = makeInteraction('clear-queue', 'ch-wording')
 
     // #when
     await Effect.runPromise(cmd.execute(interaction))
 
-    // #then — reply content matches expected format
-    const replyArg = reply.mock.calls[0]?.[0] as {content: string; ephemeral: boolean}
+    // #then — editReply content matches expected format
+    const replyArg = editReply.mock.calls[0]?.[0] as {content: string}
     expect(replyArg.content).toMatch(/Cleared 1 queued task/)
     expect(replyArg.content).toMatch(/running task will finish/)
-    expect(replyArg.ephemeral).toBe(true)
   })
 
   it('queue.clear was called with interaction.channelId exactly', async () => {
@@ -276,6 +285,27 @@ describe('/fro-bot clear-queue', () => {
     // #then — clear called with the exact channelId from the interaction
     expect(queue.clear).toHaveBeenCalledExactlyOnceWith(channelId)
   })
+
+  it('deferReply is called on the happy path (before auth and queue.clear)', async () => {
+    // #given — authorized user; verify deferReply is called as part of the happy path
+    // The code structure guarantees deferReply fires before userIsAuthorized (which awaits
+    // guild.members.fetch). This test proves deferReply is wired in at all.
+    const queue = makeQueue(2)
+    const guild = makeGuild({hasRole: true})
+    const deps = makeDeps({queue, triggerRoleId: 'role-123'})
+    const cmd = createFroBotCommand(deps)
+    const {interaction, deferReply, editReply} = makeInteraction('clear-queue', 'ch-defer-check', guild)
+
+    // #when
+    await Effect.runPromise(cmd.execute(interaction))
+
+    // #then — deferReply was called (ephemeral)
+    expect(deferReply).toHaveBeenCalledExactlyOnceWith({ephemeral: true})
+    // #and — editReply was used for the outcome (not reply)
+    expect(editReply).toHaveBeenCalledOnce()
+    // #and — queue.clear was called (auth passed)
+    expect(queue.clear).toHaveBeenCalledOnce()
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -283,69 +313,74 @@ describe('/fro-bot clear-queue', () => {
 // ---------------------------------------------------------------------------
 
 describe('/fro-bot clear-queue — authorization gate', () => {
-  it('authorized user (has trigger role) → queue.clear called + count reply', async () => {
+  it('authorized user (has trigger role) → queue.clear called + count editReply', async () => {
     // #given — user has the trigger role
     const queue = makeQueue(3)
     const guild = makeGuild({hasRole: true})
     const deps = makeDeps({queue, triggerRoleId: 'role-trigger-123'})
     const cmd = createFroBotCommand(deps)
-    const {interaction, reply} = makeInteraction('clear-queue', 'ch-auth', guild)
+    const {interaction, deferReply, editReply} = makeInteraction('clear-queue', 'ch-auth', guild)
 
     // #when
     await Effect.runPromise(cmd.execute(interaction))
 
-    // #then — queue.clear was called
+    // #then — deferReply called first
+    expect(deferReply).toHaveBeenCalledExactlyOnceWith({ephemeral: true})
+    // #and — queue.clear was called
     expect(queue.clear).toHaveBeenCalledOnce()
-    // #and — reply mentions the count
-    expect(reply).toHaveBeenCalledExactlyOnceWith(
+    // #and — editReply mentions the count
+    expect(editReply).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({
-        ephemeral: true,
         content: expect.stringContaining('3') as unknown as string,
       }),
     )
   })
 
-  it('unauthorized user (no role, no ManageChannels) → queue.clear NOT called + permission-denied reply', async () => {
+  it('unauthorized user (no role, no ManageChannels) → queue.clear NOT called + permission-denied editReply', async () => {
     // #given — user has neither the trigger role nor ManageChannels
     const queue = makeQueue(2)
     const guild = makeGuild({hasRole: false, hasManageChannels: false})
     const deps = makeDeps({queue, triggerRoleId: 'role-trigger-123'})
     const cmd = createFroBotCommand(deps)
-    const {interaction, reply} = makeInteraction('clear-queue', 'ch-unauth', guild)
+    const {interaction, deferReply, editReply} = makeInteraction('clear-queue', 'ch-unauth', guild)
 
     // #when
     await Effect.runPromise(cmd.execute(interaction))
 
-    // #then — queue.clear NOT called
+    // #then — deferReply called (interaction acked before auth)
+    expect(deferReply).toHaveBeenCalledExactlyOnceWith({ephemeral: true})
+    // #and — queue.clear NOT called
     expect(queue.clear).not.toHaveBeenCalled()
-    // #and — ephemeral permission-denied reply
-    expect(reply).toHaveBeenCalledExactlyOnceWith(
+    // #and — ephemeral permission-denied editReply
+    expect(editReply).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({
-        ephemeral: true,
         content: expect.stringMatching(/permission|not authorized/i) as unknown as string,
       }),
     )
   })
 
-  it('null guild → queue.clear NOT called + server-only reply', async () => {
+  it('null guild → queue.clear NOT called + server-only reply (synchronous guard, no defer)', async () => {
     // #given — interaction has no guild (DM context)
+    // The null-guild guard fires before deferReply because it is synchronous.
     const queue = makeQueue(1)
     const deps = makeDeps({queue})
     const cmd = createFroBotCommand(deps)
-    const {interaction, reply} = makeInteraction('clear-queue', 'ch-dm', null)
+    const {interaction, reply, deferReply} = makeInteraction('clear-queue', 'ch-dm', null)
 
     // #when
     await Effect.runPromise(cmd.execute(interaction))
 
     // #then — queue.clear NOT called
     expect(queue.clear).not.toHaveBeenCalled()
-    // #and — ephemeral server-only reply
+    // #and — plain reply (not deferred) with server-only message
     expect(reply).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({
         ephemeral: true,
         content: expect.stringMatching(/server/i) as unknown as string,
       }),
     )
+    // #and — deferReply NOT called (guard fires before defer)
+    expect(deferReply).not.toHaveBeenCalled()
   })
 
   it('authorized user with ManageChannels (no trigger role configured) → queue.clear called', async () => {

--- a/packages/gateway/src/discord/commands/fro-bot.test.ts
+++ b/packages/gateway/src/discord/commands/fro-bot.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for the `/fro-bot` parent command factory.
+ *
+ * Covers:
+ * - Subcommand registration (ping, add-project, clear-queue all present on the builder)
+ * - Dispatch routing for each subcommand
+ * - `/fro-bot clear-queue` handler: calls queue.clear(channelId), replies ephemerally with count
+ * - Zero-pending edge case
+ * - R3: clear-queue does not touch the in-flight run (only queue.clear is called)
+ */
+
+import type {ChatInputCommandInteraction} from 'discord.js'
+import type {ChannelQueue} from '../../execute/queue.js'
+import type {RunTask} from '../../execute/run.js'
+import type {FroBotDeps} from './fro-bot.js'
+
+import {Effect} from 'effect'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createFroBotCommand} from './fro-bot.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeQueue(clearReturnValue = 0): ChannelQueue<RunTask> {
+  return {
+    enqueue: vi.fn().mockReturnValue('queued'),
+    pendingCount: vi.fn().mockReturnValue(0),
+    takeNext: vi.fn().mockReturnValue(undefined),
+    clear: vi.fn().mockReturnValue(clearReturnValue),
+  }
+}
+
+function makeDeps(overrides?: Partial<FroBotDeps>): FroBotDeps {
+  return {
+    bindingsStore: {
+      createBinding: vi.fn(),
+      getBindingByRepo: vi.fn(),
+      getBindingByChannelId: vi.fn(),
+      listBindings: vi.fn(),
+    },
+    appClient: {
+      authForRepo: vi.fn(),
+      invalidateCache: vi.fn(),
+    },
+    workspaceClient: {
+      clone: vi.fn(),
+      readyz: vi.fn().mockResolvedValue({success: true, data: {ready: true, opencode: 'ready'}}),
+    },
+    installUrl: 'https://github.com/apps/fro-bot-agent/installations/new',
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    queue: makeQueue(),
+    ...overrides,
+  }
+}
+
+function makeInteraction(
+  subcommand: string,
+  channelId = 'ch-test-123',
+): {
+  interaction: ChatInputCommandInteraction
+  reply: ReturnType<typeof vi.fn>
+} {
+  const reply = vi.fn().mockResolvedValue(undefined)
+  const interaction = {
+    commandName: 'fro-bot',
+    channelId,
+    reply,
+    options: {
+      getSubcommand: vi.fn().mockReturnValue(subcommand),
+    },
+  } as unknown as ChatInputCommandInteraction
+  return {interaction, reply}
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand registration
+// ---------------------------------------------------------------------------
+
+describe('createFroBotCommand — builder registration', () => {
+  it('registers ping, add-project, and clear-queue subcommands on the builder', () => {
+    // #given
+    const cmd = createFroBotCommand(makeDeps())
+
+    // #when — inspect the builder's JSON representation
+    const json = cmd.data.toJSON()
+
+    // #then — all three subcommands are present
+    const subNames = (json.options ?? []).map((o: {name: string}) => o.name)
+    expect(subNames).toContain('ping')
+    expect(subNames).toContain('add-project')
+    expect(subNames).toContain('clear-queue')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Dispatch routing
+// ---------------------------------------------------------------------------
+
+describe('createFroBotCommand — dispatch', () => {
+  it('routes clear-queue to the handler (does not fall through to unknown)', async () => {
+    // #given
+    const queue = makeQueue(3)
+    const deps = makeDeps({queue})
+    const cmd = createFroBotCommand(deps)
+    const {interaction} = makeInteraction('clear-queue', 'ch-abc')
+
+    // #when
+    const result = await Effect.runPromise(Effect.either(cmd.execute(interaction)))
+
+    // #then — Effect succeeds (not an unknown-subcommand failure)
+    expect(result._tag).toBe('Right')
+  })
+
+  it('routes ping to executePing (existing behavior preserved)', async () => {
+    // #given
+    const cmd = createFroBotCommand(makeDeps())
+    const {interaction, reply} = makeInteraction('ping')
+
+    // #when
+    await Effect.runPromise(cmd.execute(interaction))
+
+    // #then — reply was called with pong
+    expect(reply).toHaveBeenCalledWith({content: 'pong', ephemeral: true})
+  })
+
+  it('returns Effect.fail for an unknown subcommand', async () => {
+    // #given
+    const cmd = createFroBotCommand(makeDeps())
+    const {interaction} = makeInteraction('nonexistent-sub')
+
+    // #when
+    const result = await Effect.runPromise(Effect.either(cmd.execute(interaction)))
+
+    // #then
+    expect(result._tag).toBe('Left')
+    expect(((result as {_tag: 'Left'; left: unknown}).left as Error).message).toContain('nonexistent-sub')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// /fro-bot clear-queue handler
+// ---------------------------------------------------------------------------
+
+describe('/fro-bot clear-queue', () => {
+  it('happy path: calls queue.clear with the interaction channelId and replies ephemerally with count', async () => {
+    // #given — 3 pending tasks in the queue
+    const queue = makeQueue(3)
+    const deps = makeDeps({queue})
+    const cmd = createFroBotCommand(deps)
+    const channelId = 'ch-pending-123'
+    const {interaction, reply} = makeInteraction('clear-queue', channelId)
+
+    // #when
+    await Effect.runPromise(cmd.execute(interaction))
+
+    // #then — queue.clear was called with the channel ID
+    expect(queue.clear).toHaveBeenCalledExactlyOnceWith(channelId)
+
+    // #and — reply was ephemeral and mentions the count
+    expect(reply).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        ephemeral: true,
+        content: expect.stringContaining('3') as unknown as string,
+      }),
+    )
+  })
+
+  it('zero pending: clear returns 0 → reply still sent with count 0', async () => {
+    // #given — empty queue
+    const queue = makeQueue(0)
+    const deps = makeDeps({queue})
+    const cmd = createFroBotCommand(deps)
+    const {interaction, reply} = makeInteraction('clear-queue', 'ch-empty')
+
+    // #when
+    await Effect.runPromise(cmd.execute(interaction))
+
+    // #then — queue.clear was still called
+    expect(queue.clear).toHaveBeenCalledExactlyOnceWith('ch-empty')
+
+    // #and — reply mentions 0
+    expect(reply).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        ephemeral: true,
+        content: expect.stringContaining('0') as unknown as string,
+      }),
+    )
+  })
+
+  it('clear-queue does not call enqueue/takeNext/pendingCount (only pending tasks dropped, not in-flight)', async () => {
+    // #given
+    const queue = makeQueue(2)
+    const deps = makeDeps({queue})
+    const cmd = createFroBotCommand(deps)
+    const {interaction} = makeInteraction('clear-queue', 'ch-r3')
+
+    // #when
+    await Effect.runPromise(cmd.execute(interaction))
+
+    // #then — only clear was called; no other queue methods touched
+    expect(queue.clear).toHaveBeenCalledOnce()
+    expect(queue.enqueue).not.toHaveBeenCalled()
+    expect(queue.takeNext).not.toHaveBeenCalled()
+    expect(queue.pendingCount).not.toHaveBeenCalled()
+  })
+
+  it('reply content includes the task(s) wording and running task note', async () => {
+    // #given — 1 pending task
+    const queue = makeQueue(1)
+    const deps = makeDeps({queue})
+    const cmd = createFroBotCommand(deps)
+    const {interaction, reply} = makeInteraction('clear-queue', 'ch-wording')
+
+    // #when
+    await Effect.runPromise(cmd.execute(interaction))
+
+    // #then — reply content matches expected format
+    const replyArg = reply.mock.calls[0]?.[0] as {content: string; ephemeral: boolean}
+    expect(replyArg.content).toMatch(/Cleared 1 queued task/)
+    expect(replyArg.content).toMatch(/running task will finish/)
+    expect(replyArg.ephemeral).toBe(true)
+  })
+})

--- a/packages/gateway/src/discord/commands/fro-bot.ts
+++ b/packages/gateway/src/discord/commands/fro-bot.ts
@@ -13,12 +13,14 @@
 import type {ChatInputCommandInteraction} from 'discord.js'
 import type {ChannelQueue} from '../../execute/queue.js'
 import type {RunTask} from '../../execute/run.js'
+import type {GatewayLogger} from '../client.js'
 import type {AddProjectDeps} from './add-project.js'
 import type {SlashCommand} from './index.js'
 
 import {SlashCommandBuilder} from 'discord.js'
 import {Effect} from 'effect'
 
+import {userIsAuthorized} from '../mentions.js'
 import {executeAddProject} from './add-project.js'
 import {executePing} from './ping.js'
 
@@ -35,6 +37,15 @@ import {executePing} from './ping.js'
 export interface FroBotDeps extends AddProjectDeps {
   /** Per-channel FIFO queue — the same instance used by the run path. */
   readonly queue: ChannelQueue<RunTask>
+  /**
+   * Discord role ID that confers trigger authorization.
+   * Mirrors the same field in `MentionDeps` — used by `clear-queue` to apply
+   * the same auth gate as the mention path (trigger role OR guild ManageChannels).
+   * `null` → fall back to guild-level ManageChannels.
+   */
+  readonly triggerRoleId: string | null
+  /** Gateway-scoped logger (context-first) for auth-gate resolution errors. */
+  readonly gatewayLogger: GatewayLogger
 }
 
 // ---------------------------------------------------------------------------
@@ -84,7 +95,7 @@ export function createFroBotCommand(deps: FroBotDeps): SlashCommand {
     }
 
     if (subcommand === 'clear-queue') {
-      return executeClearQueue(interaction, deps.queue)
+      return executeClearQueue(interaction, deps)
     }
 
     return Effect.fail(new Error(`Unknown subcommand: ${subcommand}`))
@@ -100,18 +111,38 @@ export function createFroBotCommand(deps: FroBotDeps): SlashCommand {
 /**
  * Handler for the `/fro-bot clear-queue` subcommand.
  *
+ * Authorization-gated: only users who pass the same authority check as the
+ * mention path (trigger role OR guild-level ManageChannels) may clear the queue.
+ * Fail closed: null guild or auth resolution failure → deny.
+ *
  * Drops all pending queued tasks for the invoking channel and replies
  * ephemerally with the count dropped. The in-flight run (if any) is
  * unaffected — it holds the concurrency slot, not the queue.
  */
-function executeClearQueue(
-  interaction: ChatInputCommandInteraction,
-  queue: ChannelQueue<RunTask>,
-): Effect.Effect<void, Error> {
+function executeClearQueue(interaction: ChatInputCommandInteraction, deps: FroBotDeps): Effect.Effect<void, Error> {
   return Effect.tryPromise({
     try: async () => {
+      // Fail closed: command must be used inside a server (guild).
+      const guild = interaction.guild
+      if (guild === null) {
+        await interaction.reply({
+          content: 'This command must be used in a server.',
+          ephemeral: true,
+        })
+        return
+      }
+
+      const authorized = await userIsAuthorized(guild, interaction.user.id, deps.triggerRoleId, deps.gatewayLogger)
+      if (authorized === false) {
+        await interaction.reply({
+          content: 'You do not have permission to clear the queue.',
+          ephemeral: true,
+        })
+        return
+      }
+
       const channelId = interaction.channelId
-      const dropped = queue.clear(channelId)
+      const dropped = deps.queue.clear(channelId)
       await interaction.reply({
         content: `Cleared ${dropped} queued task(s). The running task will finish.`,
         ephemeral: true,

--- a/packages/gateway/src/discord/commands/fro-bot.ts
+++ b/packages/gateway/src/discord/commands/fro-bot.ts
@@ -123,6 +123,8 @@ function executeClearQueue(interaction: ChatInputCommandInteraction, deps: FroBo
   return Effect.tryPromise({
     try: async () => {
       // Fail closed: command must be used inside a server (guild).
+      // Guard is synchronous (no await before it) so a plain reply is safe here
+      // — we haven't consumed the 3 s interaction window yet.
       const guild = interaction.guild
       if (guild === null) {
         await interaction.reply({
@@ -132,20 +134,23 @@ function executeClearQueue(interaction: ChatInputCommandInteraction, deps: FroBo
         return
       }
 
+      // Defer immediately — userIsAuthorized calls guild.members.fetch() (REST) which
+      // can exceed Discord's 3 s interaction-token window under latency. Deferring here
+      // acks the interaction before any await, matching the add-project pattern.
+      await interaction.deferReply({ephemeral: true})
+
       const authorized = await userIsAuthorized(guild, interaction.user.id, deps.triggerRoleId, deps.gatewayLogger)
       if (authorized === false) {
-        await interaction.reply({
+        await interaction.editReply({
           content: 'You do not have permission to clear the queue.',
-          ephemeral: true,
         })
         return
       }
 
       const channelId = interaction.channelId
       const dropped = deps.queue.clear(channelId)
-      await interaction.reply({
+      await interaction.editReply({
         content: `Cleared ${dropped} queued task(s). The running task will finish.`,
-        ephemeral: true,
       })
     },
     catch: error => (error instanceof Error ? error : new Error(String(error))),

--- a/packages/gateway/src/discord/commands/fro-bot.ts
+++ b/packages/gateway/src/discord/commands/fro-bot.ts
@@ -7,9 +7,12 @@
  * Subcommands:
  * - `ping` — smoke-test; responds with ephemeral "pong"
  * - `add-project` — bind a GitHub repo to a Discord channel
+ * - `clear-queue` — drop pending queued tasks for the invoking channel
  */
 
 import type {ChatInputCommandInteraction} from 'discord.js'
+import type {ChannelQueue} from '../../execute/queue.js'
+import type {RunTask} from '../../execute/run.js'
 import type {AddProjectDeps} from './add-project.js'
 import type {SlashCommand} from './index.js'
 
@@ -19,13 +22,32 @@ import {Effect} from 'effect'
 import {executeAddProject} from './add-project.js'
 import {executePing} from './ping.js'
 
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Dependencies for the `/fro-bot` parent command.
+ *
+ * Extends `AddProjectDeps` with the per-channel queue so the `clear-queue`
+ * subcommand can drop pending tasks for the invoking channel.
+ */
+export interface FroBotDeps extends AddProjectDeps {
+  /** Per-channel FIFO queue — the same instance used by the run path. */
+  readonly queue: ChannelQueue<RunTask>
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
 /**
  * Create the `/fro-bot` parent command with injected dependencies.
  *
  * The `deps` parameter is captured in the execute closure and passed directly
- * to `executeAddProject`. No module-global state is used.
+ * to `executeAddProject` and `executeClearQueue`. No module-global state is used.
  */
-export function createFroBotCommand(deps: AddProjectDeps): SlashCommand {
+export function createFroBotCommand(deps: FroBotDeps): SlashCommand {
   const data = new SlashCommandBuilder()
     .setName('fro-bot')
     .setDescription('fro-bot commands')
@@ -43,6 +65,11 @@ export function createFroBotCommand(deps: AddProjectDeps): SlashCommand {
             .setDescription('Optional Discord channel name (auto-derived from repo if omitted)')
             .setRequired(false),
         ),
+    )
+    .addSubcommand(sub =>
+      sub
+        .setName('clear-queue')
+        .setDescription('Drop pending queued tasks for this channel (in-flight run unaffected)'),
     ) as SlashCommandBuilder
 
   const execute = (interaction: ChatInputCommandInteraction): Effect.Effect<void, Error> => {
@@ -56,8 +83,40 @@ export function createFroBotCommand(deps: AddProjectDeps): SlashCommand {
       return executeAddProject(interaction, deps)
     }
 
+    if (subcommand === 'clear-queue') {
+      return executeClearQueue(interaction, deps.queue)
+    }
+
     return Effect.fail(new Error(`Unknown subcommand: ${subcommand}`))
   }
 
   return {data, execute}
+}
+
+// ---------------------------------------------------------------------------
+// clear-queue handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler for the `/fro-bot clear-queue` subcommand.
+ *
+ * Drops all pending queued tasks for the invoking channel and replies
+ * ephemerally with the count dropped. The in-flight run (if any) is
+ * unaffected — it holds the concurrency slot, not the queue.
+ */
+function executeClearQueue(
+  interaction: ChatInputCommandInteraction,
+  queue: ChannelQueue<RunTask>,
+): Effect.Effect<void, Error> {
+  return Effect.tryPromise({
+    try: async () => {
+      const channelId = interaction.channelId
+      const dropped = queue.clear(channelId)
+      await interaction.reply({
+        content: `Cleared ${dropped} queued task(s). The running task will finish.`,
+        ephemeral: true,
+      })
+    },
+    catch: error => (error instanceof Error ? error : new Error(String(error))),
+  })
 }

--- a/packages/gateway/src/discord/commands/index.test.ts
+++ b/packages/gateway/src/discord/commands/index.test.ts
@@ -39,6 +39,13 @@ function makeMockDeps(): FroBotDeps {
       takeNext: vi.fn().mockReturnValue(undefined),
       clear: vi.fn().mockReturnValue(0),
     },
+    triggerRoleId: null,
+    gatewayLogger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
   }
 }
 

--- a/packages/gateway/src/discord/commands/index.test.ts
+++ b/packages/gateway/src/discord/commands/index.test.ts
@@ -1,5 +1,5 @@
 import type {ChatInputCommandInteraction} from 'discord.js'
-import type {AddProjectDeps} from './add-project.js'
+import type {FroBotDeps} from './fro-bot.js'
 
 import {Routes} from 'discord.js'
 import {Effect} from 'effect'
@@ -11,7 +11,7 @@ import {dispatchCommand, getCommandRegistry, registerSlashCommands, type SlashCo
 // Minimal mock deps for getCommandRegistry
 // ---------------------------------------------------------------------------
 
-function makeMockDeps(): AddProjectDeps {
+function makeMockDeps(): FroBotDeps {
   return {
     bindingsStore: {
       createBinding: vi.fn(),
@@ -32,6 +32,12 @@ function makeMockDeps(): AddProjectDeps {
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
+    },
+    queue: {
+      enqueue: vi.fn().mockReturnValue('queued'),
+      pendingCount: vi.fn().mockReturnValue(0),
+      takeNext: vi.fn().mockReturnValue(undefined),
+      clear: vi.fn().mockReturnValue(0),
     },
   }
 }

--- a/packages/gateway/src/discord/commands/index.ts
+++ b/packages/gateway/src/discord/commands/index.ts
@@ -1,5 +1,5 @@
 import type {ChatInputCommandInteraction, SlashCommandBuilder} from 'discord.js'
-import type {AddProjectDeps} from './add-project.js'
+import type {FroBotDeps} from './fro-bot.js'
 
 import {REST, Routes} from 'discord.js'
 import {Effect} from 'effect'
@@ -16,7 +16,7 @@ export interface SlashCommand {
  *
  * @param deps - Runtime dependencies injected into command handlers.
  */
-export function getCommandRegistry(deps: AddProjectDeps): SlashCommand[] {
+export function getCommandRegistry(deps: FroBotDeps): SlashCommand[] {
   return [createFroBotCommand(deps)]
 }
 

--- a/packages/gateway/src/discord/mentions.test.ts
+++ b/packages/gateway/src/discord/mentions.test.ts
@@ -125,6 +125,12 @@ function makeRunMentionDeps(): MentionDeps['run'] {
       activeCount: vi.fn().mockReturnValue(0),
       max: 3,
     },
+    queue: {
+      enqueue: vi.fn().mockReturnValue('queued'),
+      pendingCount: vi.fn().mockReturnValue(0),
+      takeNext: vi.fn().mockReturnValue(undefined),
+      clear: vi.fn().mockReturnValue(0),
+    },
     attachUrl: 'http://workspace:9200',
     attachToken: 'secret-token',
     runTimeoutMs: 600_000,

--- a/packages/gateway/src/execute/queue.test.ts
+++ b/packages/gateway/src/execute/queue.test.ts
@@ -1,0 +1,291 @@
+import {describe, expect, it} from 'vitest'
+
+import {createChannelQueue, DEFAULT_MAX_QUEUE_DEPTH} from './queue.js'
+
+describe('createChannelQueue', () => {
+  it('exports DEFAULT_MAX_QUEUE_DEPTH', () => {
+    expect(DEFAULT_MAX_QUEUE_DEPTH).toBeGreaterThan(0)
+  })
+
+  describe('happy path — FIFO enqueue and takeNext', () => {
+    it('enqueues two tasks and returns them in FIFO order', () => {
+      // #given
+      const queue = createChannelQueue(5)
+      const task1 = {id: 'task-1'}
+      const task2 = {id: 'task-2'}
+
+      // #when
+      const r1 = queue.enqueue('ch-a', task1)
+      const r2 = queue.enqueue('ch-a', task2)
+
+      // #then
+      expect(r1).toBe('queued')
+      expect(r2).toBe('queued')
+      expect(queue.takeNext('ch-a')).toBe(task1)
+      expect(queue.takeNext('ch-a')).toBe(task2)
+    })
+
+    it('pendingCount reflects depth and decrements on each takeNext', () => {
+      // #given
+      const queue = createChannelQueue(5)
+      const task1 = {id: 'task-1'}
+      const task2 = {id: 'task-2'}
+
+      // #when — enqueue two
+      queue.enqueue('ch-a', task1)
+      queue.enqueue('ch-a', task2)
+
+      // #then — count is 2
+      expect(queue.pendingCount('ch-a')).toBe(2)
+
+      // #when — take one
+      queue.takeNext('ch-a')
+
+      // #then — count decrements
+      expect(queue.pendingCount('ch-a')).toBe(1)
+
+      // #when — take the last
+      queue.takeNext('ch-a')
+
+      // #then — count is 0
+      expect(queue.pendingCount('ch-a')).toBe(0)
+    })
+  })
+
+  describe('edge cases — empty / unknown channel', () => {
+    it('takeNext on an empty channel returns undefined', () => {
+      // #given
+      const queue = createChannelQueue(5)
+
+      // #when / #then
+      expect(queue.takeNext('ch-unknown')).toBeUndefined()
+    })
+
+    it('takeNext on a channel that was drained returns undefined', () => {
+      // #given
+      const queue = createChannelQueue(5)
+      queue.enqueue('ch-a', {id: 'task-1'})
+      queue.takeNext('ch-a')
+
+      // #when / #then
+      expect(queue.takeNext('ch-a')).toBeUndefined()
+    })
+
+    it('pendingCount on an unknown channel returns 0', () => {
+      // #given
+      const queue = createChannelQueue(5)
+
+      // #when / #then
+      expect(queue.pendingCount('ch-unknown')).toBe(0)
+    })
+
+    it('clear on an empty / unknown channel returns 0', () => {
+      // #given
+      const queue = createChannelQueue(5)
+
+      // #when / #then
+      expect(queue.clear('ch-unknown')).toBe(0)
+    })
+
+    it('clear on a drained channel returns 0', () => {
+      // #given
+      const queue = createChannelQueue(5)
+      queue.enqueue('ch-a', {id: 'task-1'})
+      queue.takeNext('ch-a')
+
+      // #when / #then
+      expect(queue.clear('ch-a')).toBe(0)
+    })
+  })
+
+  describe('channel isolation', () => {
+    it('enqueue on channel A does not affect pendingCount for channel B', () => {
+      // #given
+      const queue = createChannelQueue(5)
+
+      // #when
+      queue.enqueue('ch-a', {id: 'task-1'})
+      queue.enqueue('ch-a', {id: 'task-2'})
+
+      // #then — B is unaffected
+      expect(queue.pendingCount('ch-b')).toBe(0)
+    })
+
+    it('takeNext on channel A does not affect channel B', () => {
+      // #given
+      const queue = createChannelQueue(5)
+      const taskA = {id: 'task-a'}
+      const taskB = {id: 'task-b'}
+      queue.enqueue('ch-a', taskA)
+      queue.enqueue('ch-b', taskB)
+
+      // #when — drain A
+      queue.takeNext('ch-a')
+
+      // #then — B still has its task
+      expect(queue.pendingCount('ch-b')).toBe(1)
+      expect(queue.takeNext('ch-b')).toBe(taskB)
+    })
+
+    it('clear on channel A does not affect channel B', () => {
+      // #given
+      const queue = createChannelQueue(5)
+      const taskA = {id: 'task-a'}
+      const taskB = {id: 'task-b'}
+      queue.enqueue('ch-a', taskA)
+      queue.enqueue('ch-b', taskB)
+
+      // #when
+      queue.clear('ch-a')
+
+      // #then — B is untouched
+      expect(queue.pendingCount('ch-b')).toBe(1)
+      expect(queue.takeNext('ch-b')).toBe(taskB)
+    })
+  })
+
+  describe('required depth cap', () => {
+    it('enqueue at maxDepth returns full', () => {
+      // #given
+      const queue = createChannelQueue(2)
+      queue.enqueue('ch-a', {id: 'task-1'})
+      queue.enqueue('ch-a', {id: 'task-2'})
+
+      // #when — channel is at cap
+      const result = queue.enqueue('ch-a', {id: 'task-3'})
+
+      // #then
+      expect(result).toBe('full')
+    })
+
+    it('pending count is unchanged by a rejected enqueue', () => {
+      // #given
+      const queue = createChannelQueue(2)
+      queue.enqueue('ch-a', {id: 'task-1'})
+      queue.enqueue('ch-a', {id: 'task-2'})
+
+      // #when — rejected
+      queue.enqueue('ch-a', {id: 'task-3'})
+
+      // #then — still 2, not 3
+      expect(queue.pendingCount('ch-a')).toBe(2)
+    })
+
+    it('other channels are unaffected by a full channel', () => {
+      // #given
+      const queue = createChannelQueue(1)
+      queue.enqueue('ch-a', {id: 'task-a'})
+
+      // #when — ch-a is full; ch-b is independent
+      const result = queue.enqueue('ch-b', {id: 'task-b'})
+
+      // #then
+      expect(result).toBe('queued')
+      expect(queue.pendingCount('ch-b')).toBe(1)
+    })
+
+    it('after a takeNext frees a slot, enqueue succeeds again', () => {
+      // #given
+      const queue = createChannelQueue(2)
+      queue.enqueue('ch-a', {id: 'task-1'})
+      queue.enqueue('ch-a', {id: 'task-2'})
+      expect(queue.enqueue('ch-a', {id: 'task-3'})).toBe('full')
+
+      // #when — free a slot
+      queue.takeNext('ch-a')
+
+      // #then — enqueue succeeds
+      const result = queue.enqueue('ch-a', {id: 'task-3'})
+      expect(result).toBe('queued')
+      expect(queue.pendingCount('ch-a')).toBe(2)
+    })
+  })
+
+  describe('atomicity and FIFO correctness', () => {
+    it('two sequential takeNext calls never return the same task object', () => {
+      // #given
+      const queue = createChannelQueue(5)
+      const task1 = {id: 'task-1'}
+      const task2 = {id: 'task-2'}
+      queue.enqueue('ch-a', task1)
+      queue.enqueue('ch-a', task2)
+
+      // #when
+      const first = queue.takeNext('ch-a')
+      const second = queue.takeNext('ch-a')
+
+      // #then — distinct objects, correct order
+      expect(first).toBe(task1)
+      expect(second).toBe(task2)
+      expect(first).not.toBe(second)
+    })
+
+    it('interleaved enqueue + takeNext preserves FIFO and loses no task', () => {
+      // #given
+      const queue = createChannelQueue(5)
+      const task1 = {id: 'task-1'}
+      const task2 = {id: 'task-2'}
+      const task3 = {id: 'task-3'}
+
+      // #when — enqueue, take, enqueue two more, take all
+      queue.enqueue('ch-a', task1)
+      const first = queue.takeNext('ch-a')
+      queue.enqueue('ch-a', task2)
+      queue.enqueue('ch-a', task3)
+      const second = queue.takeNext('ch-a')
+      const third = queue.takeNext('ch-a')
+      const fourth = queue.takeNext('ch-a')
+
+      // #then — FIFO order, no loss, no phantom
+      expect(first).toBe(task1)
+      expect(second).toBe(task2)
+      expect(third).toBe(task3)
+      expect(fourth).toBeUndefined()
+    })
+
+    it('clear after a takeNext drops only the remaining tasks', () => {
+      // #given
+      const queue = createChannelQueue(5)
+      const task1 = {id: 'task-1'}
+      const task2 = {id: 'task-2'}
+      const task3 = {id: 'task-3'}
+      queue.enqueue('ch-a', task1)
+      queue.enqueue('ch-a', task2)
+      queue.enqueue('ch-a', task3)
+
+      // #when — take one, then clear
+      queue.takeNext('ch-a')
+      const dropped = queue.clear('ch-a')
+
+      // #then — only the 2 remaining were dropped
+      expect(dropped).toBe(2)
+      expect(queue.pendingCount('ch-a')).toBe(0)
+    })
+
+    it('clear returns the exact count of dropped tasks', () => {
+      // #given
+      const queue = createChannelQueue(5)
+      queue.enqueue('ch-a', {id: 'task-1'})
+      queue.enqueue('ch-a', {id: 'task-2'})
+      queue.enqueue('ch-a', {id: 'task-3'})
+
+      // #when
+      const dropped = queue.clear('ch-a')
+
+      // #then
+      expect(dropped).toBe(3)
+      expect(queue.pendingCount('ch-a')).toBe(0)
+    })
+
+    it('takeNext after clear returns undefined — no stale empty array', () => {
+      // #given
+      const queue = createChannelQueue(5)
+      queue.enqueue('ch-a', {id: 'task-1'})
+      queue.clear('ch-a')
+
+      // #when / #then
+      expect(queue.takeNext('ch-a')).toBeUndefined()
+      expect(queue.pendingCount('ch-a')).toBe(0)
+    })
+  })
+})

--- a/packages/gateway/src/execute/queue.test.ts
+++ b/packages/gateway/src/execute/queue.test.ts
@@ -145,6 +145,18 @@ describe('createChannelQueue', () => {
   })
 
   describe('required depth cap', () => {
+    it('createChannelQueue(0) rejects the very first enqueue (cap is zero)', () => {
+      // #given — maxDepth=0 means no tasks are ever accepted
+      const queue = createChannelQueue(0)
+
+      // #when
+      const result = queue.enqueue('ch-a', {id: 'task-1'})
+
+      // #then — first enqueue is rejected even though the channel is unknown
+      expect(result).toBe('full')
+      expect(queue.pendingCount('ch-a')).toBe(0)
+    })
+
     it('enqueue at maxDepth returns full', () => {
       // #given
       const queue = createChannelQueue(2)

--- a/packages/gateway/src/execute/queue.ts
+++ b/packages/gateway/src/execute/queue.ts
@@ -63,6 +63,7 @@ export function createChannelQueue<T>(maxDepth: number = DEFAULT_MAX_QUEUE_DEPTH
     enqueue: (channelId: string, task: T): 'queued' | 'full' => {
       const existing = queues.get(channelId)
       if (existing === undefined) {
+        if (maxDepth <= 0) return 'full'
         queues.set(channelId, [task])
       } else {
         if (existing.length >= maxDepth) return 'full'

--- a/packages/gateway/src/execute/queue.ts
+++ b/packages/gateway/src/execute/queue.ts
@@ -1,0 +1,98 @@
+/**
+ * In-memory per-channel FIFO task queue for the gateway mention loop.
+ *
+ * Holds pending tasks keyed by Discord channel ID. When a channel already has
+ * an in-flight run, arriving tasks are enqueued here and drained serially as
+ * each run completes (atomic handoff — see run.ts).
+ *
+ * In-memory state is intentional — gateway restart resets it.
+ * Each operation is synchronous and atomic under Node's single-threaded event loop.
+ */
+
+/** Default maximum pending tasks per channel before new arrivals are rejected. */
+export const DEFAULT_MAX_QUEUE_DEPTH = 5
+
+/**
+ * A per-channel FIFO queue holding pending tasks of type `T`.
+ *
+ * Channels are fully isolated: operations on one `channelId` never affect another.
+ */
+export interface ChannelQueue<T> {
+  /**
+   * Append a task to the tail of the channel's queue (FIFO).
+   *
+   * - `'queued'` — task accepted; caller should send a "queued" acknowledgement.
+   * - `'full'`   — channel is at `maxDepth`; task rejected (newest dropped);
+   *                caller should send a "queue is full" reply.
+   */
+  readonly enqueue: (channelId: string, task: T) => 'queued' | 'full'
+  /**
+   * Number of pending (not yet started) tasks for the channel.
+   * Returns `0` for unknown channels.
+   */
+  readonly pendingCount: (channelId: string) => number
+  /**
+   * Atomic FIFO pop — removes and returns the oldest pending task for the channel.
+   *
+   * Returns `undefined` when the channel has no pending tasks.
+   * Never returns the same task twice. Removing the last task leaves no stale
+   * empty array that would misreport `pendingCount`.
+   *
+   * This is the handoff primitive: the run path calls it while the channel slot
+   * is still held to start the next task without a free-slot gap.
+   */
+  readonly takeNext: (channelId: string) => T | undefined
+  /**
+   * Drop ALL pending tasks for the channel and return the count dropped.
+   * Returns `0` for unknown or already-empty channels.
+   * Does not affect the in-flight run (which holds the concurrency slot, not the queue).
+   */
+  readonly clear: (channelId: string) => number
+}
+
+/**
+ * Create a new `ChannelQueue` with the given per-channel depth cap.
+ *
+ * @param maxDepth - Maximum number of pending tasks per channel before `enqueue`
+ *   returns `'full'`. Defaults to `DEFAULT_MAX_QUEUE_DEPTH`.
+ */
+export function createChannelQueue<T>(maxDepth: number = DEFAULT_MAX_QUEUE_DEPTH): ChannelQueue<T> {
+  const queues = new Map<string, T[]>()
+
+  return {
+    enqueue: (channelId: string, task: T): 'queued' | 'full' => {
+      const existing = queues.get(channelId)
+      if (existing === undefined) {
+        queues.set(channelId, [task])
+      } else {
+        if (existing.length >= maxDepth) return 'full'
+        existing.push(task)
+      }
+      return 'queued'
+    },
+
+    pendingCount: (channelId: string): number => {
+      return queues.get(channelId)?.length ?? 0
+    },
+
+    takeNext: (channelId: string): T | undefined => {
+      const existing = queues.get(channelId)
+      if (existing === undefined || existing.length === 0) return undefined
+      const task = existing.shift()
+      // Clean up the entry when the array is drained so pendingCount stays accurate
+      // and we don't accumulate stale empty arrays.
+      if (existing.length === 0) {
+        queues.delete(channelId)
+      }
+      return task
+    },
+
+    clear: (channelId: string): number => {
+      const existing = queues.get(channelId)
+      if (existing === undefined) return 0
+      const count = existing.length
+      queues.delete(channelId)
+      return count
+    },
+  }
+}

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -2,7 +2,8 @@ import type {CoordinationConfig, HeartbeatController} from '@fro-bot/runtime'
 import type {Message, ThreadChannel} from 'discord.js'
 import type {ApprovalRegistry} from '../approvals/registry.js'
 import type {RepoBinding} from '../bindings/types.js'
-import type {RunMentionDeps} from './run.js'
+import type {ChannelQueue} from './queue.js'
+import type {RunMentionDeps, RunTask} from './run.js'
 
 import * as runtimeModule from '@fro-bot/runtime'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
@@ -184,6 +185,15 @@ function makeDefaultConcurrency() {
   }
 }
 
+function makeDefaultQueue(): ChannelQueue<RunTask> {
+  return {
+    enqueue: vi.fn().mockReturnValue('queued'),
+    pendingCount: vi.fn().mockReturnValue(0),
+    takeNext: vi.fn().mockReturnValue(undefined),
+    clear: vi.fn().mockReturnValue(0),
+  }
+}
+
 /**
  * Build a stream-sink mock with sensible defaults. Pass overrides to customise
  * individual methods without repeating the full literal in every test.
@@ -340,6 +350,7 @@ function makeDeps(overrides: Partial<RunMentionDeps> = {}): RunMentionDeps {
     coordinationConfig: {} as CoordinationConfig,
     identity: 'discord-gateway',
     concurrency: overrides.concurrency ?? makeDefaultConcurrency(),
+    queue: overrides.queue ?? makeDefaultQueue(),
     attachUrl: 'http://workspace:9200',
     attachToken: 'secret-bearer-token',
     runTimeoutMs: overrides.runTimeoutMs ?? 600000,
@@ -458,9 +469,12 @@ describe('runMention', () => {
   // ── Per-channel in-flight guard ─────────────────────────────────────────
 
   describe('per-channel in-flight guard', () => {
-    it('replies "busy" when channel already has an active run', async () => {
-      // #given
+    it('enqueues and sends queued ack when channel already has an active run (busy → queue)', async () => {
+      // #given — channel is busy; queue has capacity
       const {runMention} = await import('./run.js')
+      const enqueueFn = vi.fn().mockReturnValue('queued')
+      const queue = makeDefaultQueue()
+      ;(queue.enqueue as ReturnType<typeof vi.fn>).mockImplementation(enqueueFn)
       const deps = makeDeps({
         concurrency: {
           tryAcquire: vi.fn().mockReturnValue('busy'),
@@ -468,20 +482,25 @@ describe('runMention', () => {
           activeCount: vi.fn().mockReturnValue(1),
           max: 3,
         },
+        queue,
       })
       const message = makeMessage()
 
       // #when
       await runMention(message, makeBinding(), deps)
 
-      // #then
+      // #then — task enqueued
+      expect(queue.enqueue).toHaveBeenCalledOnce()
+      // #and — queued ack sent (not the old "already a task" reject)
       expect(message.reply).toHaveBeenCalledOnce()
       const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
         content: string
         allowedMentions: unknown
       }
-      expect(call.content).toContain('already a task')
+      expect(call.content).not.toContain('already a task')
+      expect(call.content).toMatch(/queue/i)
       expect(call.allowedMentions).toEqual({parse: []})
+      // #and — no thread created (not running immediately)
       expect(message.startThread).not.toHaveBeenCalled()
     })
   })
@@ -583,8 +602,8 @@ describe('runMention', () => {
       expect(ensureClone).not.toHaveBeenCalled()
     })
 
-    it('ensure-clone is NOT called when channel is busy (storm guard)', async () => {
-      // #given — busy fires before ensure-clone
+    it('ensure-clone is NOT called when channel is busy (enqueued — storm guard)', async () => {
+      // #given — busy enqueues; ensure-clone must not be called before the slot is held
       const {runMention} = await import('./run.js')
       const ensureClone = makeEnsureCloneFn('success')
       const deps = makeDeps({
@@ -601,10 +620,10 @@ describe('runMention', () => {
       // #when
       await runMention(message, makeBinding(), deps)
 
-      // #then — busy reply sent; ensureClone never called
+      // #then — queued ack sent; ensureClone never called
       expect(message.reply).toHaveBeenCalledOnce()
       const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {content: string}
-      expect(call.content).toContain('already a task')
+      expect(call.content).toMatch(/queue/i)
       expect(ensureClone).not.toHaveBeenCalled()
     })
 
@@ -2989,6 +3008,424 @@ describe('runMention', () => {
       // #and — thread.send NOT called with the failure note (controller owns it)
       const sendContents = thread.send.mock.calls.map(c => (c[0] as {content?: string}).content ?? '')
       expect(sendContents.includes(failureNote)).toBe(false)
+    })
+  })
+
+  // ── Unit 2: Serial per-channel queue — front door + atomic handoff ───────
+
+  describe('serial per-channel queue (Unit 2)', () => {
+    // ── R1: busy → enqueue + queued ack ─────────────────────────────────────
+
+    it('r1: mention while channel busy → queue.enqueue called + queued ack sent (not old reject)', async () => {
+      // #given — channel is busy; queue has capacity
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const queue = makeDefaultQueue()
+      const deps = makeDeps({
+        concurrency: {
+          tryAcquire: vi.fn().mockReturnValue('busy'),
+          release: vi.fn(),
+          activeCount: vi.fn().mockReturnValue(1),
+          max: 3,
+        },
+        queue,
+      })
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — task enqueued
+      expect(queue.enqueue).toHaveBeenCalledOnce()
+      // #and — queued ack sent (not the old terminal reject)
+      expect(message.reply).toHaveBeenCalledOnce()
+      const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+        content: string
+        allowedMentions: unknown
+      }
+      expect(call.content).toMatch(/queue/i)
+      expect(call.content).not.toContain('already a task')
+      expect(call.allowedMentions).toEqual({parse: []})
+      // #and — startRun pipeline NOT invoked synchronously
+      expect(message.startThread).not.toHaveBeenCalled()
+      expect(mockRunOpenCodeCore).not.toHaveBeenCalled()
+    })
+
+    it('r1: busy + queue.enqueue returns "full" → terse "queue is full" reply (not queued ack)', async () => {
+      // #given — channel is busy; queue is at capacity
+      const {runMention} = await import('./run.js')
+      const queue = makeDefaultQueue()
+      ;(queue.enqueue as ReturnType<typeof vi.fn>).mockReturnValue('full')
+      const deps = makeDeps({
+        concurrency: {
+          tryAcquire: vi.fn().mockReturnValue('busy'),
+          release: vi.fn(),
+          activeCount: vi.fn().mockReturnValue(1),
+          max: 3,
+        },
+        queue,
+      })
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — "queue is full" reply (not the queued ack)
+      expect(message.reply).toHaveBeenCalledOnce()
+      const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+        content: string
+        allowedMentions: unknown
+      }
+      expect(call.content).toMatch(/full/i)
+      expect(call.allowedMentions).toEqual({parse: []})
+      // #and — no thread created
+      expect(message.startThread).not.toHaveBeenCalled()
+    })
+
+    // ── FIFO gate: pending work present → enqueue even if slot is free ───────
+
+    it('fIFO gate: new mention with pendingCount > 0 is enqueued even though tryAcquire would return ok', async () => {
+      // #given — no in-flight run (tryAcquire would return 'ok') but pending work exists
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const queue = makeDefaultQueue()
+      // pendingCount returns 1 → front-door must enqueue without consulting tryAcquire
+      ;(queue.pendingCount as ReturnType<typeof vi.fn>).mockReturnValue(1)
+      const tryAcquireFn = vi.fn().mockReturnValue('ok')
+      const deps = makeDeps({
+        concurrency: {
+          tryAcquire: tryAcquireFn,
+          release: vi.fn(),
+          activeCount: vi.fn().mockReturnValue(0),
+          max: 3,
+        },
+        queue,
+      })
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — task enqueued (not started immediately)
+      expect(queue.enqueue).toHaveBeenCalledOnce()
+      // #and — tryAcquire NOT consulted (pending work has priority)
+      expect(tryAcquireFn).not.toHaveBeenCalled()
+      // #and — startRun pipeline NOT invoked
+      expect(message.startThread).not.toHaveBeenCalled()
+      expect(mockRunOpenCodeCore).not.toHaveBeenCalled()
+      // #and — queued ack sent
+      expect(message.reply).toHaveBeenCalledOnce()
+      const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {content: string}
+      expect(call.content).toMatch(/queue/i)
+    })
+
+    // ── R2: completion with pending task → takeNext + next startRun ──────────
+
+    it('r2: completion with pending task → takeNext called + next startRun begins', async () => {
+      // #given — first run completes; queue has one pending task
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const releaseFn = vi.fn()
+      const sharedConcurrency = {
+        tryAcquire: vi.fn().mockReturnValue('ok'),
+        release: releaseFn,
+        activeCount: vi.fn().mockReturnValue(1),
+        max: 3,
+      }
+      const queue = makeDefaultQueue()
+
+      // The pending task must share the same concurrency + queue so the handoff
+      // uses the same release fn and the same takeNext chain.
+      const pendingMessage = makeMessage()
+      const pendingBinding = makeBinding()
+      const pendingDeps = makeDeps({concurrency: sharedConcurrency, queue})
+      const pendingTask: RunTask = {message: pendingMessage, binding: pendingBinding, deps: pendingDeps}
+
+      ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValueOnce(pendingTask).mockReturnValue(undefined)
+
+      const deps = makeDeps({concurrency: sharedConcurrency, queue})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // Allow the fire-and-forget handoff to settle
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      // #then — takeNext was called (handoff attempted)
+      expect(queue.takeNext).toHaveBeenCalledWith(CHANNEL_ID)
+      // #and — runOpenCodeCore called twice (once for original, once for queued task)
+      expect(mockRunOpenCodeCore).toHaveBeenCalledTimes(2)
+      // #and — concurrency.release called exactly once (after the second run completes with empty queue)
+      // The slot was handed off (not freed) between the two runs; release fires only after the last run.
+      expect(releaseFn).toHaveBeenCalledExactlyOnceWith(CHANNEL_ID)
+    })
+
+    it('r2: completion with empty queue → concurrency.release IS called (slot freed)', async () => {
+      // #given — first run completes; queue is empty
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const queue = makeDefaultQueue()
+      // takeNext returns undefined → queue is empty
+      ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValue(undefined)
+
+      const releaseFn = vi.fn()
+      const deps = makeDeps({
+        concurrency: {
+          tryAcquire: vi.fn().mockReturnValue('ok'),
+          release: releaseFn,
+          activeCount: vi.fn().mockReturnValue(1),
+          max: 3,
+        },
+        queue,
+      })
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — takeNext was called
+      expect(queue.takeNext).toHaveBeenCalledWith(CHANNEL_ID)
+      // #and — concurrency.release IS called (queue was empty)
+      expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
+    })
+
+    // ── Serial safety: no free-slot gap ──────────────────────────────────────
+
+    it('serial safety: slot handed off without concurrency.release between runs (no free-slot gap)', async () => {
+      // #given — first run completes; queue has one pending task
+      // Assert: concurrency.release is NOT called between the two startRun invocations.
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const releaseFn = vi.fn()
+      const callOrder: string[] = []
+
+      // Track when release is called vs when runOpenCodeCore is called
+      releaseFn.mockImplementation(() => {
+        callOrder.push('release')
+      })
+      mockRunOpenCodeCore.mockImplementation(async () => {
+        callOrder.push('runOpenCodeCore')
+      })
+
+      const sharedConcurrency = {
+        tryAcquire: vi.fn().mockReturnValue('ok'),
+        release: releaseFn,
+        activeCount: vi.fn().mockReturnValue(1),
+        max: 3,
+      }
+      const queue = makeDefaultQueue()
+
+      // The pending task must share the same concurrency + queue so the handoff
+      // uses the same release fn and the same takeNext chain.
+      const pendingMessage = makeMessage()
+      const pendingDeps = makeDeps({concurrency: sharedConcurrency, queue})
+      const pendingTask: RunTask = {message: pendingMessage, binding: makeBinding(), deps: pendingDeps}
+
+      ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValueOnce(pendingTask).mockReturnValue(undefined)
+
+      const deps = makeDeps({concurrency: sharedConcurrency, queue})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      // #then — runOpenCodeCore called twice (two runs)
+      expect(callOrder.filter(e => e === 'runOpenCodeCore')).toHaveLength(2)
+      // #and — release NOT called between the two runs (no free-slot gap)
+      // release should only be called AFTER the second run completes
+      const firstRunIdx = callOrder.indexOf('runOpenCodeCore')
+      const secondRunIdx = callOrder.lastIndexOf('runOpenCodeCore')
+      const releaseIdx = callOrder.indexOf('release')
+      // release must come AFTER the second run, not between them
+      expect(releaseIdx).toBeGreaterThan(secondRunIdx)
+      // release must NOT appear between first and second run
+      expect(callOrder.slice(firstRunIdx + 1, secondRunIdx)).not.toContain('release')
+    })
+
+    // ── R5/R6: ok path and cap path unchanged ────────────────────────────────
+
+    it('r5: ok path (no pending work) runs normally — startRun pipeline invoked', async () => {
+      // #given — no pending work; tryAcquire returns ok
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      const queue = makeDefaultQueue()
+      // pendingCount returns 0 → ok path
+      ;(queue.pendingCount as ReturnType<typeof vi.fn>).mockReturnValue(0)
+      const deps = makeDeps({queue})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — full pipeline ran
+      expect(mockRunOpenCodeCore).toHaveBeenCalledOnce()
+      expect(message.startThread).toHaveBeenCalledOnce()
+    })
+
+    it('r6: cap path replies terminally and does NOT enqueue', async () => {
+      // #given — global cap reached
+      const {runMention} = await import('./run.js')
+      const queue = makeDefaultQueue()
+      const deps = makeDeps({
+        concurrency: {
+          tryAcquire: vi.fn().mockReturnValue('cap'),
+          release: vi.fn(),
+          activeCount: vi.fn().mockReturnValue(3),
+          max: 3,
+        },
+        queue,
+      })
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — terminal capacity reply
+      expect(message.reply).toHaveBeenCalledOnce()
+      const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {content: string}
+      expect(call.content).toContain('capacity')
+      // #and — NOT enqueued (R6: cap stays terminal)
+      expect(queue.enqueue).not.toHaveBeenCalled()
+      // #and — no thread created
+      expect(message.startThread).not.toHaveBeenCalled()
+    })
+
+    // ── Error path: handed-off startRun that throws still releases ───────────
+
+    it('error path: handed-off startRun that throws still releases/hands off (its own finally)', async () => {
+      // #given — first run completes; queue has one pending task that will throw
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const releaseFn = vi.fn()
+      const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+      const sharedConcurrency = {
+        tryAcquire: vi.fn().mockReturnValue('ok'),
+        release: releaseFn,
+        activeCount: vi.fn().mockReturnValue(1),
+        max: 3,
+      }
+      const queue = makeDefaultQueue()
+
+      // The pending task must share the same concurrency + queue so the handoff
+      // uses the same release fn and the same takeNext chain.
+      const pendingMessage = makeMessage()
+      const pendingDeps = makeDeps({concurrency: sharedConcurrency, queue, logger})
+      const pendingTask: RunTask = {message: pendingMessage, binding: makeBinding(), deps: pendingDeps}
+
+      ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValueOnce(pendingTask).mockReturnValue(undefined)
+
+      // Second run (the handed-off one) throws
+      mockRunOpenCodeCore
+        .mockResolvedValueOnce(undefined) // first run succeeds
+        .mockRejectedValueOnce(new Error('handoff run failed')) // second run throws
+
+      const deps = makeDeps({concurrency: sharedConcurrency, queue, logger})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+      // Allow the fire-and-forget handoff to settle (including its error path)
+      await new Promise(resolve => setTimeout(resolve, 20))
+
+      // #then — slot eventually released (handoff's own finally ran)
+      expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
+      // #and — queue not stranded (takeNext called for the handoff too)
+      expect(queue.takeNext).toHaveBeenCalledTimes(2)
+    })
+
+    // ── Integration: three mentions run strictly FIFO ─────────────────────────
+
+    it('integration: three mentions on a busy channel run strictly FIFO with no concurrent overlap', async () => {
+      // #given — simulate three sequential mentions on the same channel
+      // First mention: acquires slot immediately (ok) and runs
+      // Second + third: arrive while first is still running (busy → enqueue)
+      // After first completes: second starts via handoff; after second: third starts
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const runOrder: string[] = []
+      const releaseOrder: string[] = []
+
+      // Use a real queue to test FIFO ordering
+      const {createChannelQueue} = await import('./queue.js')
+      const realQueue = createChannelQueue<RunTask>()
+
+      // Control when the first run completes — it must pause so msg2/msg3 can be enqueued
+      let resolveFirstRun!: () => void
+      const firstRunPaused = new Promise<void>(resolve => {
+        resolveFirstRun = resolve
+      })
+
+      let runCount = 0
+      mockRunOpenCodeCore.mockImplementation(async () => {
+        runCount++
+        const thisRun = runCount
+        runOrder.push(`run-${thisRun}`)
+        // First run pauses until we explicitly release it
+        if (thisRun === 1) {
+          await firstRunPaused
+        }
+      })
+
+      const releaseFn = vi.fn().mockImplementation(() => {
+        releaseOrder.push('release')
+      })
+
+      // Concurrency: first tryAcquire returns 'ok', subsequent return 'busy'
+      let acquireCount = 0
+      const tryAcquireFn = vi.fn().mockImplementation(() => {
+        acquireCount++
+        return acquireCount === 1 ? 'ok' : 'busy'
+      })
+
+      const sharedConcurrency = {
+        tryAcquire: tryAcquireFn,
+        release: releaseFn,
+        activeCount: vi.fn().mockReturnValue(1),
+        max: 3,
+      }
+
+      // All three mentions share the same concurrency + queue so handoffs chain correctly.
+      const deps1 = makeDeps({concurrency: sharedConcurrency, queue: realQueue})
+      const deps2 = makeDeps({concurrency: sharedConcurrency, queue: realQueue})
+      const deps3 = makeDeps({concurrency: sharedConcurrency, queue: realQueue})
+
+      const msg1 = makeMessage()
+      const msg2 = makeMessage()
+      const msg3 = makeMessage()
+
+      // #when — start first mention (it will pause inside runOpenCodeCore)
+      const run1Promise = runMention(msg1, makeBinding(), deps1)
+
+      // Yield to let run1 start and reach the pause point
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      // Second and third arrive while first is still running (busy)
+      await runMention(msg2, makeBinding(), deps2)
+      await runMention(msg3, makeBinding(), deps3)
+
+      // Verify second and third were enqueued (not started yet)
+      expect(realQueue.pendingCount(CHANNEL_ID)).toBe(2)
+
+      // Release the first run to complete
+      resolveFirstRun()
+      await run1Promise
+
+      // Allow all handoffs to settle
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      // #then — all three runs completed in order
+      expect(runOrder).toEqual(['run-1', 'run-2', 'run-3'])
+      // #and — slot released exactly once (after the last run)
+      expect(releaseOrder).toHaveLength(1)
+      // #and — queue fully drained
+      expect(realQueue.pendingCount(CHANNEL_ID)).toBe(0)
     })
   })
 })

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -1016,7 +1016,7 @@ describe('runMention', () => {
       expect(lastCall.content).toMatch(/time.?limit|timed? ?out/i)
     })
 
-    // ── Timeout copy branching (Unit 2) ─────────────────────────────────────
+    // ── Timeout copy branching ───────────────────────────────────────────────
 
     it('timeout with no visible output: message includes configured duration and generic retry guidance', async () => {
       // #given — no visible output; runTimeoutMs = 600_000 (10 min)
@@ -1479,7 +1479,7 @@ describe('runMention', () => {
     })
   })
 
-  // ── Approval pending-visibility race (Unit 2) ───────────────────────────
+  // ── Approval pending-visibility race ────────────────────────────────────
 
   describe('approval pending-visibility race', () => {
     it('approval send STARTED but UNRESOLVED when timeout fires → visible-output timeout copy chosen', async () => {
@@ -1956,7 +1956,7 @@ describe('runMention', () => {
     })
   })
 
-  // ── Approval mode propagation (Unit 2) ──────────────────────────────────
+  // ── Approval mode propagation ────────────────────────────────────────────
 
   describe('approval mode propagation', () => {
     it('approval-required: runOpenCodeCore is called with approvalMode === "approval-required"', async () => {
@@ -2284,9 +2284,9 @@ describe('runMention', () => {
     })
   })
 
-  // ── Unit 4: Approval wait and timeout UX ────────────────────────────────
+  // ── Approval wait and timeout UX ────────────────────────────────────────
 
-  describe('approval wait and timeout UX (Unit 4)', () => {
+  describe('approval wait and timeout UX', () => {
     it('computeApprovalDeadlineMs: uses remainingBudgetMs (not raw runTimeoutMs) — shorter budget yields shorter deadline', async () => {
       // #given — the function should accept remainingBudgetMs
       const {computeApprovalDeadlineMs} = await import('./run.js')
@@ -2608,9 +2608,9 @@ describe('runMention', () => {
     })
   })
 
-  // ── Unit 3: Status controller wiring ────────────────────────────────────
+  // ── Status controller wiring ─────────────────────────────────────────────
 
-  describe('status controller wiring (Unit 3)', () => {
+  describe('status controller wiring', () => {
     it('integration (live-status, short answer): resolveToAnswer(handled) → sink.flush NOT called', async () => {
       // #given — status controller returns 'handled' (edited in place)
       const {runMention} = await import('./run.js')
@@ -3011,10 +3011,10 @@ describe('runMention', () => {
     })
   })
 
-  // ── Unit 2: Serial per-channel queue — front door + atomic handoff ───────
+  // ── Serial per-channel queue — front door + atomic handoff ─────────────
 
-  describe('serial per-channel queue (Unit 2)', () => {
-    // ── R1: busy → enqueue + queued ack ─────────────────────────────────────
+  describe('serial per-channel queue', () => {
+    // ── busy → enqueue + queued ack ──────────────────────────────────────────
 
     it('r1: mention while channel busy → queue.enqueue called + queued ack sent (not old reject)', async () => {
       // #given — channel is busy; queue has capacity
@@ -3119,7 +3119,7 @@ describe('runMention', () => {
       expect(call.content).toMatch(/queue/i)
     })
 
-    // ── R2: completion with pending task → takeNext + next startRun ──────────
+    // ── completion with pending task → takeNext + next startRun ─────────────
 
     it('r2: completion with pending task → takeNext called + next startRun begins', async () => {
       // #given — first run completes; queue has one pending task
@@ -3247,7 +3247,7 @@ describe('runMention', () => {
       expect(callOrder.slice(firstRunIdx + 1, secondRunIdx)).not.toContain('release')
     })
 
-    // ── R5/R6: ok path and cap path unchanged ────────────────────────────────
+    // ── ok path and cap path ─────────────────────────────────────────────────
 
     it('r5: ok path (no pending work) runs normally — startRun pipeline invoked', async () => {
       // #given — no pending work; tryAcquire returns ok
@@ -3289,7 +3289,7 @@ describe('runMention', () => {
       expect(message.reply).toHaveBeenCalledOnce()
       const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {content: string}
       expect(call.content).toContain('capacity')
-      // #and — NOT enqueued (R6: cap stays terminal)
+      // #and — NOT enqueued (cap stays terminal)
       expect(queue.enqueue).not.toHaveBeenCalled()
       // #and — no thread created
       expect(message.startThread).not.toHaveBeenCalled()
@@ -3427,6 +3427,279 @@ describe('runMention', () => {
       // #and — queue fully drained
       expect(realQueue.pendingCount(CHANNEL_ID)).toBe(0)
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F1: trackRun — shutdown-drain hook for handoff promises
+// ---------------------------------------------------------------------------
+
+describe('trackRun — shutdown-drain hook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('trackRun is called with the handoff promise when a queued task is handed off', async () => {
+    // #given — first run completes; queue has one pending task
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    const trackRun = vi.fn()
+    const sharedConcurrency = {
+      tryAcquire: vi.fn().mockReturnValue('ok'),
+      release: vi.fn(),
+      activeCount: vi.fn().mockReturnValue(1),
+      max: 3,
+    }
+    const queue = makeDefaultQueue()
+
+    const pendingMessage = makeMessage()
+    const pendingDeps = makeDeps({concurrency: sharedConcurrency, queue, trackRun})
+    const pendingTask: RunTask = {message: pendingMessage, binding: makeBinding(), deps: pendingDeps}
+
+    ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValueOnce(pendingTask).mockReturnValue(undefined)
+
+    const deps = makeDeps({concurrency: sharedConcurrency, queue, trackRun})
+    const message = makeMessage()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+    // Allow the fire-and-forget handoff to settle
+    await new Promise(resolve => setTimeout(resolve, 10))
+
+    // #then — trackRun was called with a Promise (the handoff promise)
+    expect(trackRun).toHaveBeenCalledOnce()
+    const arg: unknown = trackRun.mock.calls[0]?.[0]
+    expect(arg).toBeInstanceOf(Promise)
+  })
+
+  it('the completing run does NOT await the handoff (returns before handoff settles)', async () => {
+    // #given — first run completes; queue has one pending task that is slow
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    const handoffSettled: string[] = []
+    const trackRun = vi.fn()
+
+    const sharedConcurrency = {
+      tryAcquire: vi.fn().mockReturnValue('ok'),
+      release: vi.fn(),
+      activeCount: vi.fn().mockReturnValue(1),
+      max: 3,
+    }
+    const queue = makeDefaultQueue()
+
+    // Handoff run is slow — resolves after a delay
+    let resolveHandoff!: () => void
+    const handoffPaused = new Promise<void>(resolve => {
+      resolveHandoff = resolve
+    })
+
+    const pendingMessage = makeMessage()
+    const pendingDeps = makeDeps({concurrency: sharedConcurrency, queue, trackRun})
+    const pendingTask: RunTask = {message: pendingMessage, binding: makeBinding(), deps: pendingDeps}
+
+    ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValueOnce(pendingTask).mockReturnValue(undefined)
+
+    // First run resolves immediately; second (handoff) waits
+    mockRunOpenCodeCore
+      .mockResolvedValueOnce(undefined) // first run
+      .mockImplementationOnce(async () => {
+        await handoffPaused
+        handoffSettled.push('handoff-done')
+      })
+
+    const deps = makeDeps({concurrency: sharedConcurrency, queue, trackRun})
+    const message = makeMessage()
+
+    // #when — await the first run (should return before handoff settles)
+    await runMention(message, makeBinding(), deps)
+
+    // #then — handoff has NOT settled yet (completing run did not await it)
+    expect(handoffSettled).toHaveLength(0)
+
+    // Cleanup: resolve the handoff so the test doesn't leak
+    resolveHandoff()
+    await new Promise(resolve => setTimeout(resolve, 10))
+    expect(handoffSettled).toHaveLength(1)
+  })
+
+  it('trackRun is NOT called when the queue is empty (no handoff)', async () => {
+    // #given — first run completes; queue is empty
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    const trackRun = vi.fn()
+    const queue = makeDefaultQueue()
+    ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValue(undefined)
+
+    const deps = makeDeps({queue, trackRun})
+    const message = makeMessage()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — no handoff → trackRun not called
+    expect(trackRun).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F3: startThread throws → failure reply sent to message
+// ---------------------------------------------------------------------------
+
+describe('startThread throws — failure reply sent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('startThread rejection → safeReply sent to message, no thread-level send', async () => {
+    // #given — startThread rejects (e.g. Discord API error)
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    const message = makeMessage()
+    ;(message.startThread as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Discord API error'))
+
+    const deps = makeDeps()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — a failure reply was sent to the original message
+    expect(message.reply).toHaveBeenCalledOnce()
+    const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {content: string}
+    expect(call.content).toMatch(/could not start|please try again/i)
+
+    // #and — no thread-level sends (thread was never created)
+    expect(message._thread.send).not.toHaveBeenCalled()
+  })
+
+  it('startThread rejection → concurrency slot is released in outer finally', async () => {
+    // #given — startThread rejects
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    const releaseFn = vi.fn()
+    const message = makeMessage()
+    ;(message.startThread as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('thread creation failed'))
+
+    const deps = makeDeps({
+      concurrency: {
+        tryAcquire: vi.fn().mockReturnValue('ok'),
+        release: releaseFn,
+        activeCount: vi.fn().mockReturnValue(1),
+        max: 3,
+      },
+    })
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — slot released (outer finally ran)
+    expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F8: Additional handoff unit tests
+// ---------------------------------------------------------------------------
+
+describe('handoff unit tests (F8)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('mocked handoff: startRun runs for the next task; release NOT called during handoff; release IS called when takeNext returns undefined', async () => {
+    // #given — first run completes; queue has one pending task
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    const releaseFn = vi.fn()
+    const callOrder: string[] = []
+
+    releaseFn.mockImplementation(() => {
+      callOrder.push('release')
+    })
+    mockRunOpenCodeCore.mockImplementation(async () => {
+      callOrder.push('runOpenCodeCore')
+    })
+
+    const sharedConcurrency = {
+      tryAcquire: vi.fn().mockReturnValue('ok'),
+      release: releaseFn,
+      activeCount: vi.fn().mockReturnValue(1),
+      max: 3,
+    }
+    const queue = makeDefaultQueue()
+
+    const pendingMessage = makeMessage()
+    const pendingDeps = makeDeps({concurrency: sharedConcurrency, queue})
+    const pendingTask: RunTask = {message: pendingMessage, binding: makeBinding(), deps: pendingDeps}
+
+    // First takeNext returns the pending task; second returns undefined (queue empty)
+    ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValueOnce(pendingTask).mockReturnValue(undefined)
+
+    const deps = makeDeps({concurrency: sharedConcurrency, queue})
+    const message = makeMessage()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+    await new Promise(resolve => setTimeout(resolve, 10))
+
+    // #then — (1) startRun ran for the next task (runOpenCodeCore called twice)
+    expect(callOrder.filter(e => e === 'runOpenCodeCore')).toHaveLength(2)
+    // #and — (2) release NOT called during handoff (only after second run)
+    const firstRunIdx = callOrder.indexOf('runOpenCodeCore')
+    const secondRunIdx = callOrder.lastIndexOf('runOpenCodeCore')
+    const releaseIdx = callOrder.indexOf('release')
+    expect(callOrder.slice(firstRunIdx + 1, secondRunIdx)).not.toContain('release')
+    // #and — (3) release IS called after takeNext returns undefined
+    expect(releaseIdx).toBeGreaterThan(secondRunIdx)
+    expect(releaseFn).toHaveBeenCalledExactlyOnceWith(CHANNEL_ID)
+  })
+
+  it('fIFO-gate full branch: pendingCount > 0 and enqueue returns "full" → "queue is full" reply', async () => {
+    // #given — pending work exists; queue is at capacity
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    const queue = makeDefaultQueue()
+    ;(queue.pendingCount as ReturnType<typeof vi.fn>).mockReturnValue(1)
+    ;(queue.enqueue as ReturnType<typeof vi.fn>).mockReturnValue('full')
+
+    const deps = makeDeps({queue})
+    const message = makeMessage()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — "queue is full" reply via the FIFO-gate path
+    expect(message.reply).toHaveBeenCalledOnce()
+    const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {content: string}
+    expect(call.content).toMatch(/full/i)
+    // #and — ensureClone NOT called (rejected before pipeline)
+    expect(message.startThread).not.toHaveBeenCalled()
+  })
+
+  it('fIFO-gate: ensureClone not called when pendingCount > 0', async () => {
+    // #given — pending work exists; slot would be free
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    const ensureClone = makeEnsureCloneFn('success')
+    const queue = makeDefaultQueue()
+    ;(queue.pendingCount as ReturnType<typeof vi.fn>).mockReturnValue(1)
+    ;(queue.enqueue as ReturnType<typeof vi.fn>).mockReturnValue('queued')
+
+    const deps = makeDeps({queue, ensureClone})
+    const message = makeMessage()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — ensureClone NOT called (FIFO gate short-circuits before pipeline)
+    expect(ensureClone).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -3431,35 +3431,63 @@ describe('runMention', () => {
 })
 
 // ---------------------------------------------------------------------------
-// F1: trackRun — shutdown-drain hook for handoff promises
+// isShuttingDown — shutdown gate for handoff
 // ---------------------------------------------------------------------------
 
-describe('trackRun — shutdown-drain hook', () => {
+describe('isShuttingDown — handoff shutdown gate', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('trackRun is called with the handoff promise when a queued task is handed off', async () => {
-    // #given — first run completes; queue has one pending task
+  it('when isShuttingDown() returns true, handoff does NOT call queue.takeNext and DOES release the slot', async () => {
+    // #given — first run completes; shutdown is in progress
     const {runMention} = await import('./run.js')
     setupHappyPath()
 
-    const trackRun = vi.fn()
+    const releaseFn = vi.fn()
     const sharedConcurrency = {
       tryAcquire: vi.fn().mockReturnValue('ok'),
-      release: vi.fn(),
+      release: releaseFn,
       activeCount: vi.fn().mockReturnValue(1),
       max: 3,
     }
     const queue = makeDefaultQueue()
+    const isShuttingDown = vi.fn().mockReturnValue(true)
+
+    const deps = makeDeps({concurrency: sharedConcurrency, queue, isShuttingDown})
+    const message = makeMessage()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — shutdown gate fired: takeNext NOT called (no handoff started)
+    expect(queue.takeNext).not.toHaveBeenCalled()
+    // #and — slot released immediately (not transferred to a next run)
+    expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
+  })
+
+  it('when isShuttingDown() returns false, normal handoff proceeds (takeNext called, startRun fires)', async () => {
+    // #given — first run completes; NOT shutting down; queue has one pending task
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    const releaseFn = vi.fn()
+    const sharedConcurrency = {
+      tryAcquire: vi.fn().mockReturnValue('ok'),
+      release: releaseFn,
+      activeCount: vi.fn().mockReturnValue(1),
+      max: 3,
+    }
+    const queue = makeDefaultQueue()
+    const isShuttingDown = vi.fn().mockReturnValue(false)
 
     const pendingMessage = makeMessage()
-    const pendingDeps = makeDeps({concurrency: sharedConcurrency, queue, trackRun})
+    const pendingDeps = makeDeps({concurrency: sharedConcurrency, queue, isShuttingDown})
     const pendingTask: RunTask = {message: pendingMessage, binding: makeBinding(), deps: pendingDeps}
 
     ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValueOnce(pendingTask).mockReturnValue(undefined)
 
-    const deps = makeDeps({concurrency: sharedConcurrency, queue, trackRun})
+    const deps = makeDeps({concurrency: sharedConcurrency, queue, isShuttingDown})
     const message = makeMessage()
 
     // #when
@@ -3467,80 +3495,35 @@ describe('trackRun — shutdown-drain hook', () => {
     // Allow the fire-and-forget handoff to settle
     await new Promise(resolve => setTimeout(resolve, 10))
 
-    // #then — trackRun was called with a Promise (the handoff promise)
-    expect(trackRun).toHaveBeenCalledOnce()
-    const arg: unknown = trackRun.mock.calls[0]?.[0]
-    expect(arg).toBeInstanceOf(Promise)
+    // #then — not shutting down: takeNext WAS called (handoff attempted)
+    expect(queue.takeNext).toHaveBeenCalledWith(CHANNEL_ID)
+    // #and — slot NOT released by the first run (transferred to the handoff)
+    // (it will be released by the handoff run's own outer finally after it completes)
+    // We verify release was called exactly once — by the handoff run after it drains
+    expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
   })
 
-  it('the completing run does NOT await the handoff (returns before handoff settles)', async () => {
-    // #given — first run completes; queue has one pending task that is slow
+  it('when isShuttingDown is absent (undefined), normal handoff proceeds', async () => {
+    // #given — no isShuttingDown injected; queue has one pending task
     const {runMention} = await import('./run.js')
     setupHappyPath()
 
-    const handoffSettled: string[] = []
-    const trackRun = vi.fn()
-
-    const sharedConcurrency = {
-      tryAcquire: vi.fn().mockReturnValue('ok'),
-      release: vi.fn(),
-      activeCount: vi.fn().mockReturnValue(1),
-      max: 3,
-    }
     const queue = makeDefaultQueue()
-
-    // Handoff run is slow — resolves after a delay
-    let resolveHandoff!: () => void
-    const handoffPaused = new Promise<void>(resolve => {
-      resolveHandoff = resolve
-    })
-
     const pendingMessage = makeMessage()
-    const pendingDeps = makeDeps({concurrency: sharedConcurrency, queue, trackRun})
+    const pendingDeps = makeDeps({queue})
     const pendingTask: RunTask = {message: pendingMessage, binding: makeBinding(), deps: pendingDeps}
 
     ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValueOnce(pendingTask).mockReturnValue(undefined)
 
-    // First run resolves immediately; second (handoff) waits
-    mockRunOpenCodeCore
-      .mockResolvedValueOnce(undefined) // first run
-      .mockImplementationOnce(async () => {
-        await handoffPaused
-        handoffSettled.push('handoff-done')
-      })
-
-    const deps = makeDeps({concurrency: sharedConcurrency, queue, trackRun})
-    const message = makeMessage()
-
-    // #when — await the first run (should return before handoff settles)
-    await runMention(message, makeBinding(), deps)
-
-    // #then — handoff has NOT settled yet (completing run did not await it)
-    expect(handoffSettled).toHaveLength(0)
-
-    // Cleanup: resolve the handoff so the test doesn't leak
-    resolveHandoff()
-    await new Promise(resolve => setTimeout(resolve, 10))
-    expect(handoffSettled).toHaveLength(1)
-  })
-
-  it('trackRun is NOT called when the queue is empty (no handoff)', async () => {
-    // #given — first run completes; queue is empty
-    const {runMention} = await import('./run.js')
-    setupHappyPath()
-
-    const trackRun = vi.fn()
-    const queue = makeDefaultQueue()
-    ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValue(undefined)
-
-    const deps = makeDeps({queue, trackRun})
+    const deps = makeDeps({queue})
     const message = makeMessage()
 
     // #when
     await runMention(message, makeBinding(), deps)
+    await new Promise(resolve => setTimeout(resolve, 10))
 
-    // #then — no handoff → trackRun not called
-    expect(trackRun).not.toHaveBeenCalled()
+    // #then — takeNext was called (handoff proceeded normally)
+    expect(queue.takeNext).toHaveBeenCalledWith(CHANNEL_ID)
   })
 })
 

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -7,6 +7,7 @@ import type {SinkThread} from '../discord/streaming.js'
 import type {EnsureCloneFailure} from '../workspace-api/ensure-clone.js'
 import type {ReadyzResponse, WorkspaceError} from '../workspace-api/types.js'
 import type {ConcurrencyRegistry} from './concurrency.js'
+import type {ChannelQueue} from './queue.js'
 
 import {acquireLock, createHeartbeatController, createRun, releaseLock, transitionRun} from '@fro-bot/runtime'
 
@@ -26,6 +27,8 @@ export interface RunMentionDeps {
   readonly coordinationConfig: CoordinationConfig
   readonly identity: string
   readonly concurrency: ConcurrencyRegistry
+  /** Per-channel FIFO queue for pending tasks. */
+  readonly queue: ChannelQueue<RunTask>
   readonly attachUrl: string
   readonly attachToken: string
   /** Wall-clock milliseconds before an in-progress run is timed out. */
@@ -74,6 +77,17 @@ export interface RunMentionDeps {
    */
   readonly readyz: () => Promise<Result<ReadyzResponse, WorkspaceError>>
 }
+
+/**
+ * The task descriptor stored in the per-channel queue.
+ * Exactly the three arguments `runMention` takes — the stable contract the queue stores.
+ */
+export interface RunTask {
+  readonly message: Message
+  readonly binding: RepoBinding
+  readonly deps: RunMentionDeps
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -153,25 +167,38 @@ export function computeApprovalDeadlineMs(remainingBudgetMs: number): number | u
 }
 
 // ---------------------------------------------------------------------------
-// runMention — the lifecycle wrapper
+// startRun — the slot-holding execution pipeline
 // ---------------------------------------------------------------------------
 
 /**
- * Execute a mention-triggered OpenCode run with full lifecycle management.
+ * Execute the post-acquire pipeline for a task.
  *
- * Called by `mentions.ts` after authorization and binding lookup succeed.
- * Owns: concurrency registry, thread creation, lock, run-state, heartbeat,
- * execution, and release of all resources in a `finally` block.
+ * ASSUMES the channel concurrency slot is already held by the caller.
+ * Owns: clone → readyz → thread → lock → run-state → heartbeat → execute → cleanup.
  *
- * Hard invariants:
- * - "busy", "cap", "waiting" are TERMINAL — no queue, no retry. * - Internal identifiers (lock etags, holder IDs, workspace URLs, run IDs,
- *   raw errors) are logged but NEVER posted to Discord.
- * - Bearer token (`attachToken`) is never logged.
- * - Every Discord send uses `allowedMentions: {parse: []}`.
+ * On completion (success or failure), performs an **atomic handoff**:
+ * - Calls `queue.takeNext(channelId)` while the slot is still held.
+ * - If a next task exists → starts it on the held slot (no release/re-acquire gap).
+ * - If the queue is empty → calls `concurrency.release(channelId)` (only then is the slot freed).
+ *
+ * The handoff `startRun` is fire-and-forget from the completing run's perspective.
+ * Its own outer finally runs the same handoff/release logic, so the chain continues
+ * and a thrown handoff still releases.
  */
-export async function runMention(message: Message, binding: RepoBinding, deps: RunMentionDeps): Promise<void> {
-  const {concurrency, coordinationConfig, identity, attachUrl, attachToken, runTimeoutMs, botUserId, persona, logger} =
-    deps
+async function startRun(task: RunTask): Promise<void> {
+  const {message, binding, deps} = task
+  const {
+    concurrency,
+    queue,
+    coordinationConfig,
+    identity,
+    attachUrl,
+    attachToken,
+    runTimeoutMs,
+    botUserId,
+    persona,
+    logger,
+  } = deps
   const {approvalRegistry, approvalMode, statusMode, ensureClone, readyz} = deps
   const channelId = message.channel.id
   const repo = `${binding.owner}/${binding.repo}`
@@ -181,24 +208,6 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
   // deadline clearance are computed from the same wall-clock reference.
   const runStartMs = Date.now()
 
-  // ── Concurrency cap + per-channel in-flight guard ──────────
-  // IMPORTANT: ensureClone and readyz are called AFTER this gate so that
-  // same-channel mention storms do not each mint GitHub App tokens or call
-  // workspace clone before the busy/cap rejection fires.
-
-  const slotResult = concurrency.tryAcquire(channelId)
-
-  if (slotResult === 'cap') {
-    await safeReply(message, 'fro-bot is at capacity right now — please try again shortly.')
-    return
-  }
-
-  if (slotResult === 'busy') {
-    await safeReply(message, 'There is already a task running in this channel — please wait for it to finish.')
-    return
-  }
-
-  // Slot acquired — MUST release in outer finally
   try {
     // ── Ensure workspace checkout exists ──────────────────────────────────────────────────────
     // Rehydrates a missing checkout (e.g. after container recreation) before OpenCode can start.
@@ -670,7 +679,94 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
       }
     }
   } finally {
-    // ALWAYS release the concurrency slot
-    concurrency.release(channelId)
+    // ── Atomic handoff — replaces bare concurrency.release ──────────────────
+    //
+    // While the channel slot is still held, attempt to drain the next queued task.
+    // If a task is waiting → start it on the held slot (no release/re-acquire gap).
+    // If the queue is empty → release the slot now.
+    //
+    // This closes the free-slot window: there is NO moment where tryAcquire could
+    // return 'ok' for a channel that still has pending/handing-off work.
+    //
+    // The handed-off startRun is fire-and-forget from this run's perspective so
+    // cleanup completes, but its own outer finally runs the same handoff/release
+    // logic — so the chain continues and a thrown handoff still releases.
+    const nextTask = queue.takeNext(channelId)
+    if (nextTask === undefined) {
+      // Queue is empty — release the slot now.
+      concurrency.release(channelId)
+    } else {
+      // Slot ownership transfers to the next run — do NOT call concurrency.release.
+      // eslint-disable-next-line no-void
+      void startRun(nextTask).catch((error: unknown) => {
+        logger.error(
+          {channelId, err: error instanceof Error ? error.message : String(error)},
+          'run: handoff startRun failed',
+        )
+      })
+    }
   }
+}
+
+// ---------------------------------------------------------------------------
+// runMention — the thin front door
+// ---------------------------------------------------------------------------
+
+/**
+ * Front door for a mention-triggered run.
+ *
+ * Decides whether to run immediately or enqueue, in this order:
+ * 1. If `queue.pendingCount(channelId) > 0` → enqueue + queued ack (FIFO fix: pending work
+ *    has priority; never take an immediate slot ahead of it).
+ * 2. Else `concurrency.tryAcquire(channelId)`:
+ *    - `'ok'`   → `startRun(task)` (slot held).
+ *    - `'busy'` → enqueue + queued ack (or "queue is full" if at capacity). Return without blocking.
+ *    - `'cap'`  → terminal capacity reply, no enqueue (R6: global cap stays terminal).
+ *
+ * Hard invariants:
+ * - `'cap'` is TERMINAL — no queue, no retry.
+ * - Internal identifiers (lock etags, holder IDs, workspace URLs, run IDs,
+ *   raw errors) are logged but NEVER posted to Discord.
+ * - Bearer token (`attachToken`) is never logged.
+ * - Every Discord send uses `allowedMentions: {parse: []}`.
+ */
+export async function runMention(message: Message, binding: RepoBinding, deps: RunMentionDeps): Promise<void> {
+  const {concurrency, queue} = deps
+  const channelId = message.channel.id
+  const task: RunTask = {message, binding, deps}
+
+  // ── FIFO gate: if pending work exists, enqueue without consulting tryAcquire ──
+  // A new mention must never leapfrog older queued work, even if a slot is free.
+  // Only the handoff path (startRun's outer finally) may start the next task.
+  if (queue.pendingCount(channelId) > 0) {
+    const result = queue.enqueue(channelId, task)
+    if (result === 'queued') {
+      await safeReply(message, "Queued — I'll start this when the current task finishes.")
+    } else {
+      await safeReply(message, 'The queue is full for this channel — please wait for pending tasks to complete.')
+    }
+    return
+  }
+
+  // ── Concurrency cap + per-channel in-flight guard ──────────────────────────
+  const slotResult = concurrency.tryAcquire(channelId)
+
+  if (slotResult === 'cap') {
+    await safeReply(message, 'fro-bot is at capacity right now — please try again shortly.')
+    return
+  }
+
+  if (slotResult === 'busy') {
+    // Channel has an in-flight run — enqueue instead of rejecting (R1).
+    const enqueueResult = queue.enqueue(channelId, task)
+    if (enqueueResult === 'queued') {
+      await safeReply(message, "Queued — I'll start this when the current task finishes.")
+    } else {
+      await safeReply(message, 'The queue is full for this channel — please wait for pending tasks to complete.')
+    }
+    return
+  }
+
+  // Slot acquired — startRun owns the release (via atomic handoff in its outer finally).
+  await startRun(task)
 }

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -42,7 +42,7 @@ export interface RunMentionDeps {
   /**
    * Optional canonical persona text (from `GatewayConfig.persona`).
    * Prepended to every Discord mention prompt before the Discord-mechanical guidance.
-   * `null` → mechanical guidance only (R4 fail-soft).
+   * `null` → mechanical guidance only (fail-soft: omit persona rather than failing).
    */
   readonly persona: string | null
   readonly logger: GatewayLogger
@@ -60,6 +60,15 @@ export interface RunMentionDeps {
    * - `typing-only`: suppresses the status message; only the typing indicator is shown.
    */
   readonly statusMode: 'live-status' | 'typing-only'
+  /**
+   * Optional shutdown-drain hook. When present, called with the handoff promise so the
+   * program-level drain set can await it on SIGTERM. The completing run does NOT await
+   * the handoff — it remains fire-and-forget from the completing run's perspective.
+   *
+   * When absent (e.g. in tests that don't exercise shutdown drain), the handoff behaves
+   * exactly as before: fire-and-forget with no external tracking.
+   */
+  readonly trackRun?: (p: Promise<void>) => void
   /**
    * Ensure the workspace checkout exists for the given owner/repo.
    * Called after the concurrency gate acquires a slot, before readyz/execution.
@@ -200,6 +209,12 @@ async function startRun(task: RunTask): Promise<void> {
     logger,
   } = deps
   const {approvalRegistry, approvalMode, statusMode, ensureClone, readyz} = deps
+
+  // ── All mutable state that the outer finally needs is declared here so the
+  // finally block can always reference channelId regardless of where execution
+  // stopped. Async functions never throw synchronously, so the outer try/finally
+  // always runs — but keeping these declarations before the try makes the
+  // dependency explicit and avoids any ambiguity.
   const channelId = message.channel.id
   const repo = `${binding.owner}/${binding.repo}`
 
@@ -254,7 +269,14 @@ async function startRun(task: RunTask): Promise<void> {
     // ── Create response thread ─────────────────────────────────────────────────────────────────
 
     const runId = crypto.randomUUID()
-    const rawThread = await message.startThread({name: `fro-bot: ${binding.repo}`})
+    let rawThread: Awaited<ReturnType<typeof message.startThread>>
+    try {
+      rawThread = await message.startThread({name: `fro-bot: ${binding.repo}`})
+    } catch (threadError) {
+      logger.error({channelId, repo, err: String(threadError)}, 'run: startThread threw — aborting')
+      await safeReply(message, 'Could not start the task — please try again.')
+      return
+    }
     const threadId = rawThread.id
     const thread: SinkThread = rawThread
 
@@ -697,13 +719,17 @@ async function startRun(task: RunTask): Promise<void> {
       concurrency.release(channelId)
     } else {
       // Slot ownership transfers to the next run — do NOT call concurrency.release.
-      // eslint-disable-next-line no-void
-      void startRun(nextTask).catch((error: unknown) => {
+      const handoffPromise = startRun(nextTask).catch((error: unknown) => {
         logger.error(
           {channelId, err: error instanceof Error ? error.message : String(error)},
           'run: handoff startRun failed',
         )
       })
+      // Register the handoff promise with the shutdown drain if a tracker is provided,
+      // so SIGTERM can await it before tearing down. The completing run does not await it.
+      deps.trackRun?.(handoffPromise)
+      // eslint-disable-next-line no-void
+      void handoffPromise
     }
   }
 }
@@ -716,12 +742,12 @@ async function startRun(task: RunTask): Promise<void> {
  * Front door for a mention-triggered run.
  *
  * Decides whether to run immediately or enqueue, in this order:
- * 1. If `queue.pendingCount(channelId) > 0` → enqueue + queued ack (FIFO fix: pending work
- *    has priority; never take an immediate slot ahead of it).
+ * 1. If `queue.pendingCount(channelId) > 0` → enqueue + queued ack (pending work has
+ *    priority; never take an immediate slot ahead of it).
  * 2. Else `concurrency.tryAcquire(channelId)`:
  *    - `'ok'`   → `startRun(task)` (slot held).
  *    - `'busy'` → enqueue + queued ack (or "queue is full" if at capacity). Return without blocking.
- *    - `'cap'`  → terminal capacity reply, no enqueue (R6: global cap stays terminal).
+ *    - `'cap'`  → terminal capacity reply, no enqueue (global cap stays terminal).
  *
  * Hard invariants:
  * - `'cap'` is TERMINAL — no queue, no retry.
@@ -730,6 +756,18 @@ async function startRun(task: RunTask): Promise<void> {
  * - Bearer token (`attachToken`) is never logged.
  * - Every Discord send uses `allowedMentions: {parse: []}`.
  */
+/**
+ * Send the appropriate ephemeral ack for an enqueue result.
+ * Centralises the two reply strings so they live in exactly one place.
+ */
+async function ackEnqueueResult(message: Message, result: 'queued' | 'full'): Promise<void> {
+  if (result === 'queued') {
+    await safeReply(message, "Queued — I'll start this when the current task finishes.")
+  } else {
+    await safeReply(message, 'The queue is full for this channel — please wait for pending tasks to complete.')
+  }
+}
+
 export async function runMention(message: Message, binding: RepoBinding, deps: RunMentionDeps): Promise<void> {
   const {concurrency, queue} = deps
   const channelId = message.channel.id
@@ -739,12 +777,7 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
   // A new mention must never leapfrog older queued work, even if a slot is free.
   // Only the handoff path (startRun's outer finally) may start the next task.
   if (queue.pendingCount(channelId) > 0) {
-    const result = queue.enqueue(channelId, task)
-    if (result === 'queued') {
-      await safeReply(message, "Queued — I'll start this when the current task finishes.")
-    } else {
-      await safeReply(message, 'The queue is full for this channel — please wait for pending tasks to complete.')
-    }
+    await ackEnqueueResult(message, queue.enqueue(channelId, task))
     return
   }
 
@@ -757,13 +790,8 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
   }
 
   if (slotResult === 'busy') {
-    // Channel has an in-flight run — enqueue instead of rejecting (R1).
-    const enqueueResult = queue.enqueue(channelId, task)
-    if (enqueueResult === 'queued') {
-      await safeReply(message, "Queued — I'll start this when the current task finishes.")
-    } else {
-      await safeReply(message, 'The queue is full for this channel — please wait for pending tasks to complete.')
-    }
+    // Channel has an in-flight run — enqueue instead of rejecting.
+    await ackEnqueueResult(message, queue.enqueue(channelId, task))
     return
   }
 

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -61,14 +61,15 @@ export interface RunMentionDeps {
    */
   readonly statusMode: 'live-status' | 'typing-only'
   /**
-   * Optional shutdown-drain hook. When present, called with the handoff promise so the
-   * program-level drain set can await it on SIGTERM. The completing run does NOT await
-   * the handoff — it remains fire-and-forget from the completing run's perspective.
+   * Optional shutdown predicate. When present and returns `true`, the outer-finally
+   * handoff is suppressed: the channel slot is released immediately instead of
+   * starting the next queued task. Matches the `messageCreate` guard in program.ts
+   * that refuses new mentions during shutdown.
    *
-   * When absent (e.g. in tests that don't exercise shutdown drain), the handoff behaves
-   * exactly as before: fire-and-forget with no external tracking.
+   * When absent (e.g. in tests that don't exercise shutdown), the handoff always
+   * proceeds as normal.
    */
-  readonly trackRun?: (p: Promise<void>) => void
+  readonly isShuttingDown?: () => boolean
   /**
    * Ensure the workspace checkout exists for the given owner/repo.
    * Called after the concurrency gate acquires a slot, before readyz/execution.
@@ -710,26 +711,33 @@ async function startRun(task: RunTask): Promise<void> {
     // This closes the free-slot window: there is NO moment where tryAcquire could
     // return 'ok' for a channel that still has pending/handing-off work.
     //
+    // Shutdown gate: if shutdown has been requested, skip the handoff and release
+    // the slot immediately. The in-memory queue is lossy by design (documented in
+    // AGENTS.md); dropping pending tasks on graceful shutdown matches that contract.
+    // This is consistent with the messageCreate guard in program.ts that refuses
+    // new mentions once isShuttingDown() returns true.
+    //
     // The handed-off startRun is fire-and-forget from this run's perspective so
     // cleanup completes, but its own outer finally runs the same handoff/release
     // logic — so the chain continues and a thrown handoff still releases.
-    const nextTask = queue.takeNext(channelId)
-    if (nextTask === undefined) {
-      // Queue is empty — release the slot now.
+    if (deps.isShuttingDown?.() === true) {
+      // Shutdown in progress — drop pending queued tasks; release the slot.
       concurrency.release(channelId)
     } else {
-      // Slot ownership transfers to the next run — do NOT call concurrency.release.
-      const handoffPromise = startRun(nextTask).catch((error: unknown) => {
-        logger.error(
-          {channelId, err: error instanceof Error ? error.message : String(error)},
-          'run: handoff startRun failed',
-        )
-      })
-      // Register the handoff promise with the shutdown drain if a tracker is provided,
-      // so SIGTERM can await it before tearing down. The completing run does not await it.
-      deps.trackRun?.(handoffPromise)
-      // eslint-disable-next-line no-void
-      void handoffPromise
+      const nextTask = queue.takeNext(channelId)
+      if (nextTask === undefined) {
+        // Queue is empty — release the slot now.
+        concurrency.release(channelId)
+      } else {
+        // Slot ownership transfers to the next run — do NOT call concurrency.release.
+        // eslint-disable-next-line no-void
+        void startRun(nextTask).catch((error: unknown) => {
+          logger.error(
+            {channelId, err: error instanceof Error ? error.message : String(error)},
+            'run: handoff startRun failed',
+          )
+        })
+      }
     }
   }
 }

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -176,6 +176,8 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
       logger: addProjectLogger,
       isShuttingDown,
       queue: channelQueue,
+      triggerRoleId: config.triggerRoleId,
+      gatewayLogger: logger,
     }
 
     const registry = getCommandRegistry(commandDeps)
@@ -303,6 +305,18 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
                 error: (msg, meta) => logger.error(meta ?? {}, msg),
               },
             }),
+          // Shutdown-drain hook: register handoff promises in the same inFlightRuns
+          // set so SIGTERM can await them before tearing down. Mirrors the
+          // add-at-inFlightRuns / delete-in-finally pattern used for the initial
+          // handleMention promise above.
+          trackRun: (p: Promise<void>) => {
+            inFlightRuns.add(p)
+            p.finally(() => {
+              inFlightRuns.delete(p)
+            }).catch(() => {
+              // Errors are already handled inside the handoff promise; finally() cannot throw here.
+            })
+          },
         },
         logger,
       }

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -175,6 +175,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
       installUrl: config.gatewayGitHubAppInstallUrl,
       logger: addProjectLogger,
       isShuttingDown,
+      queue: channelQueue,
     }
 
     const registry = getCommandRegistry(commandDeps)

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -305,18 +305,11 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
                 error: (msg, meta) => logger.error(meta ?? {}, msg),
               },
             }),
-          // Shutdown-drain hook: register handoff promises in the same inFlightRuns
-          // set so SIGTERM can await them before tearing down. Mirrors the
-          // add-at-inFlightRuns / delete-in-finally pattern used for the initial
-          // handleMention promise above.
-          trackRun: (p: Promise<void>) => {
-            inFlightRuns.add(p)
-            p.finally(() => {
-              inFlightRuns.delete(p)
-            }).catch(() => {
-              // Errors are already handled inside the handoff promise; finally() cannot throw here.
-            })
-          },
+          // Shutdown gate: suppress handoff to next queued task once SIGTERM fires.
+          // The in-memory queue is lossy by design; dropping pending tasks on graceful
+          // shutdown matches that contract and is consistent with the messageCreate
+          // guard above that refuses new mentions once isShuttingDown() returns true.
+          isShuttingDown,
         },
         logger,
       }

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -3,6 +3,7 @@ import type {Client, GatewayIntentBits, Message} from 'discord.js'
 import type {GatewayConfig} from './config.js'
 import type {GatewayLogger} from './discord/client.js'
 import type {SinkThread} from './discord/streaming.js'
+import type {RunTask} from './execute/run.js'
 import type {AnnounceServerConfig, AnnounceServerDeps} from './http/server.js'
 import type {CoordinationLogger} from './runtime-effect.js'
 import type {CloseableServer} from './shutdown.js'
@@ -20,6 +21,7 @@ import {createDiscordClient} from './discord/client.js'
 import {dispatchCommand, getCommandRegistry, registerSlashCommands} from './discord/commands/index.js'
 import {handleMention, userIsAuthorized} from './discord/mentions.js'
 import {createConcurrencyRegistry} from './execute/concurrency.js'
+import {createChannelQueue, DEFAULT_MAX_QUEUE_DEPTH} from './execute/queue.js'
 import {recoverStaleRuns} from './execute/recovery.js'
 import {createAppClient} from './github/app-client.js'
 import {installShutdownHandlers, isShuttingDown} from './shutdown.js'
@@ -152,6 +154,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
     })
 
     const concurrencyRegistry = createConcurrencyRegistry(config.maxConcurrentRuns)
+    const channelQueue = createChannelQueue<RunTask>(DEFAULT_MAX_QUEUE_DEPTH)
     const bindingsStore = createBindingsStore({
       adapter: s3Adapter,
       storeConfig: config.objectStore,
@@ -270,6 +273,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           coordinationConfig: makeCoordinationConfig(s3Adapter, config),
           identity: config.identity,
           concurrency: concurrencyRegistry,
+          queue: channelQueue,
           attachUrl: config.workspaceOpencodeUrl,
           attachToken: config.workspaceOpencodeToken,
           runTimeoutMs: config.runTimeoutMs,


### PR DESCRIPTION
When the bot is mentioned in a channel that already has a run in progress, the new mention is now queued instead of rejected. Each channel processes its mentions serially in FIFO order, and the queued user gets an immediate acknowledgement.

## Behavior

- A mention in a busy channel is enqueued and acknowledged ("Queued — I'll get to this once the current task finishes") rather than dropped.
- Tasks run one at a time per channel, in arrival order. The slot is handed directly from the finishing run to the next queued task with no gap, so two runs can never overlap in the same channel.
- If a fresh mention arrives while tasks are already waiting, it joins the back of the queue even if the slot momentarily looks free — preserving fair ordering.
- A per-channel depth cap (default 5) bounds the queue; over the cap the newest mention is rejected with a "queue is full" reply.
- The per-repo lock and the global concurrency cap are unchanged — only the previous "channel busy → reject" path becomes a queue.

## Commands

- `/fro-bot clear-queue` drops the channel's pending (not-yet-started) tasks and reports how many were cleared. The in-progress run is untouched. Restricted to the same users who can trigger a run (trigger role, or Manage Channels), and fails closed.

## Notes

- The queue is in-memory: pending tasks are lost if the gateway restarts. The in-flight run and its repo lock are unaffected.
- On graceful shutdown, pending queued tasks are dropped (the queue is in-memory); the in-flight run finishes its own cleanup but no new queued task is started.

Closes part of the production-readiness work for the mention loop (output rendering and working-state UX shipped previously).

