### PR TITLE
docs(plans): reconcile mention-loop plans with shipped state

### DIFF
--- a/docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
+++ b/docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
@@ -752,12 +752,11 @@ The Action and gateway both import from `@fro-bot/runtime` (the name is internal
 
 **Dependencies:** Unit 1 (runtime), Unit 2 (coordination), Unit 4 (gateway skeleton), Unit 5 (binding)
 
-**Unit 6 reconciliation (2026-06-01):**
+**Unit 6 reconciliation (updated 2026-06-09):**
 
-- **Shipped (MVP):** mention → thread creation → lock/run-state/heartbeat coordination → remote OpenCode attach (workspace container, bearer-token proxy, HTTP/SSE) → streamed Discord final output; trigger-role/ManageChannels authorization; failure-path partial-output flush.
-- **Not yet shipped (deferred from original Unit 6 scope):** tool-approval embeds/buttons + `permission.updated` handling (S5); reactions + working-message progress editor (R9); serial per-channel queue + `/clear-queue` (current behavior REJECTS concurrent same-channel runs rather than queueing, R11); `/review`, `/sessions`, `/resume`, `/approvals`, `/force-release-lock` commands (only `ping` + `add-project` are registered); reactions + working-message progress editor (R9).
+- **Shipped:** mention execution + remote-attach streaming (PR #705); native tool-approval embeds/buttons + `permission.asked`/`permission.replied` handling (S5, shipped earlier); working-state status UX — live status message + typing indicator (Phase 2, PR #843); clean rendering + Discord persona prompt (Phase 1, PR #831); serial per-channel queue + `/fro-bot clear-queue` (Phase 3, PR #850). Commands registered: `/fro-bot ping`, `/fro-bot add-project`, `/fro-bot clear-queue`.
+- **Remaining:** `/fro-bot sessions`, `/fro-bot resume`, `/fro-bot force-release-lock`, `/fro-bot review`, `/fro-bot approvals` command; reactions/R9 progress affordances; abort/self-test command-surface gaps.
 - **Dropped (won't-do):** `no-fro-bot` block role (R6) — redundant deny-list on top of the existing allow-list authorization model. The mention/approval gate already requires the trigger role or guild-level `ManageChannels`; excluding a user is done by not granting the trigger role, so a separate block role adds a second provisioning surface and a precedence question for no real gain.
-- **Shipped since:** tool-approval embeds/buttons + `permission.asked`/`permission.replied` handling (S5); gateway startup conditional-write self-test wiring (`validateProviderSemanticsEffect` now runs fail-fast at boot before `client.login`).
 
 **Files:**
 - Create: `packages/gateway/src/execute/local.ts` (orchestrates: acquire lock, create run-state, spawn OpenCode session in workspace, stream events → Discord)

--- a/docs/plans/2026-06-07-003-feat-mention-loop-rendering-persona-plan.md
+++ b/docs/plans/2026-06-07-003-feat-mention-loop-rendering-persona-plan.md
@@ -1,10 +1,11 @@
 ---
 title: "feat: Mention-loop clean rendering + Discord persona (Phase 1)"
 type: feat
-status: active
+status: completed
 date: 2026-06-07
 origin: docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md
 deepened: 2026-06-07
+completed: 2026-06-09
 ---
 
 # Mention-loop clean rendering + Discord persona (Phase 1)

--- a/docs/plans/2026-06-07-004-feat-mention-loop-working-state-ux-plan.md
+++ b/docs/plans/2026-06-07-004-feat-mention-loop-working-state-ux-plan.md
@@ -1,10 +1,11 @@
 ---
 title: "feat: Mention-loop working-state UX (live status + typing)"
 type: feat
-status: active
+status: completed
 date: 2026-06-07
 origin: docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md
 deepened: 2026-06-07
+completed: 2026-06-09
 ---
 
 # feat: Mention-loop working-state UX (live status + typing)

--- a/docs/plans/2026-06-07-005-fix-workspace-gateway-reliability-hardening-plan.md
+++ b/docs/plans/2026-06-07-005-fix-workspace-gateway-reliability-hardening-plan.md
@@ -1,9 +1,10 @@
 ---
 title: "fix: Workspace/gateway reliability hardening (#763)"
 type: fix
-status: active
+status: completed
 date: 2026-06-07
 deepened: 2026-06-07
+completed: 2026-06-09
 ---
 
 # fix: Workspace/gateway reliability hardening (#763)


### PR DESCRIPTION
Aligns the mention-loop planning docs with what has actually shipped, so the next phase plans from current state.

- Marks the rendering/persona, working-state UX, and workspace/gateway reliability plans as completed (shipped in #831, #843, and the reliability work).
- Rewrites the Gateway v1 Unit 6 reconciliation block into a single coherent shipped/remaining/dropped statement. The previous block contradicted itself — listing the tool-approval flow and serial queue as both "not yet shipped" and "shipped since."

Current shipped state for the mention loop: clean rendering + persona, working-state status UX, native tool-approval embeds/buttons, serial per-channel queue with `/fro-bot clear-queue`, and the `/fro-bot ping` / `add-project` / `clear-queue` command surface. Remaining: `/fro-bot sessions`, `resume`, `force-release-lock`, optionally `review` and `approvals`, plus reaction-based progress affordances.
