### PR TITLE
docs(solutions): Effect failure-channel discipline + refresh stale references

### DIFF
--- a/docs/solutions/best-practices/discord-slash-command-orchestration-patterns-2026-05-27.md
+++ b/docs/solutions/best-practices/discord-slash-command-orchestration-patterns-2026-05-27.md
@@ -1,6 +1,7 @@
 ---
 title: Discord slash command orchestration — permission checks, bootstrap wiring, and token safety
 date: 2026-05-27
+last_updated: 2026-06-10
 category: best-practices
 module: gateway
 problem_type: best_practice
@@ -59,11 +60,12 @@ function botHasRequiredPermissions(appPermissions: PermissionsBitField | null): 
   )
 }
 
-// Call site:
+// Call site — all Discord content sends go through discord/io.ts helpers
+// (mention-safe by default; enforced by io.boundary.test.ts):
 if (botHasRequiredPermissions(interaction.appPermissions) === false) {
-  await interaction.editReply({
+  await editInteractionAsync(interaction, {
     content: `fro-bot needs **Manage Channels** and **Send Messages**. Re-invite at: ${installUrl}`,
-  })
+  }, log)
   return
 }
 ```
@@ -75,22 +77,34 @@ The command was refactored to receive its dependencies through a factory (`creat
 The fix is an integration-level test that builds the **real** registry and dispatches a **real** interaction:
 
 ```ts
-export function createFroBotCommand(deps: AddProjectDeps): SlashCommand {
-  const execute = (interaction: ChatInputCommandInteraction): Effect.Effect<void, Error> => {
-    const subcommand = interaction.options.getSubcommand(true)
-    if (subcommand === 'add-project') return executeAddProject(interaction, deps)
-    return Effect.fail(new Error(`Unknown subcommand: ${subcommand}`))
-  }
-  return {data, execute}
-}
-
 // Test the dispatch seam, not just executeAddProject:
 const registry = getCommandRegistry(makeMockDeps())
 await Effect.runPromise(dispatchCommand(mockInteraction, registry))
 expect(mockDeps.workspaceClient.clone).toHaveBeenCalled()
 ```
 
-`getCommandRegistry` and `dispatchCommand` live in `packages/gateway/src/discord/commands/index.ts`; the factory and bootstrap wiring are in `commands/fro-bot.ts` and `program.ts` respectively.
+`getCommandRegistry` and `dispatchCommand` live in `packages/gateway/src/discord/commands/index.ts`; the parent-command factory is in `commands/fro-bot.ts` and bootstrap wiring is in `program.ts`.
+
+### 2a. The orchestration skeleton is now owned by `makeGuildCommand`
+
+The per-command hand-rolled sequence (`deferReply → guild-null guard → auth → editReply`) is now owned by the shared `makeGuildCommand` pipeline (`packages/gateway/src/discord/commands/guild-command.ts`). New guild commands supply a `GuildCommandSpec` with `{authorize, work, preDefer?}` instead of hand-rolling the skeleton:
+
+```ts
+// packages/gateway/src/discord/commands/add-project.ts
+export function buildAddProjectSpec(deps: AddProjectDeps): {
+  readonly preDefer: (ctx: PreDeferCtx) => Effect.Effect<PreDeferSignal, never>
+  readonly authorize: (ctx: GuildCommandCtx) => Effect.Effect<AuthDecision, never>
+  readonly work: (ctx: GuildCommandCtx) => Effect.Effect<void, Error>
+} { /* ... */ }
+
+// Wired in executeAddProject:
+const executor = makeGuildCommand(
+  {name: 'add-project', preDefer, authorize, work, serverOnlyCopy: '...'},
+  deps,
+)
+```
+
+The underlying WHY is unchanged: `deferReply` must fire before any REST calls to beat the 3-second interaction-token window. That sequencing is now guaranteed by the pipeline rather than each command author. A structural test in `guild-command.test.ts` scans every `commands/*.ts` file (excluding `guild-command.ts`) and fails the suite if any hand-rolled `.deferReply(` call is found.
 
 ### 3. Installation access token (IAT) handling across an HTTP boundary
 
@@ -143,21 +157,23 @@ Accepted v1 fallout and boundaries:
 - **Shutdown gating**: new invocations are refused during drain (after `deferReply` so Discord gets its mandatory ack). In-flight runs that are hard-cut during a process restart are healed by the next retry via the resume path.
 
 ```ts
-// Resume only on CONFIRMED absent binding — store errors do NOT resume:
+// Resume only on CONFIRMED absent binding — store errors do NOT resume.
+// All Discord content sends go through discord/io.ts helpers (editInteractionAsync
+// / editInteraction) — mention-safe by default; enforced by io.boundary.test.ts.
 let existing: Awaited<ReturnType<typeof bindingsStore.getBindingByRepo>>
 try {
   existing = await bindingsStore.getBindingByRepo(owner, repo)
 } catch {
-  await interaction.editReply({content: 'Internal error checking existing bindings. Please retry in a moment.'})
+  await editInteractionAsync(interaction, {content: 'Internal error checking existing bindings. Please retry in a moment.'}, log)
   return
 }
 if (existing.success === false) {
-  await interaction.editReply({content: 'Internal error checking existing bindings. Please retry in a moment.'})
+  await editInteractionAsync(interaction, {content: 'Internal error checking existing bindings. Please retry in a moment.'}, log)
   return
 }
 if (existing.data !== null) {
   // Already bound — redirect.
-  await interaction.editReply({content: `\`${owner}/${repo}\` is already set up in <#${existing.data.channelId}>.`})
+  await editInteractionAsync(interaction, {content: `\`${owner}/${repo}\` is already set up in <#${existing.data.channelId}>.`}, log)
   return
 }
 // Confirmed absent binding — resume from CREATING_CHANNEL.
@@ -166,9 +182,9 @@ workspacePath = workspaceRepoPath(owner, repo)
 
 // Partial-write recovery names both keys for manual cleanup:
 if (error.code === 'BINDING_PARTIAL_WRITE_ERROR') {
-  await interaction.editReply({
+  await editInteractionAsync(interaction, {
     content: `Partial write: primary written, index failed. Manual S3 cleanup:\n- Primary: \`${error.primaryKey}\`\n- Index: \`${error.indexKey}\``,
-  })
+  }, log)
 }
 ```
 

--- a/docs/solutions/best-practices/effect-failure-channel-discipline-2026-06-10.md
+++ b/docs/solutions/best-practices/effect-failure-channel-discipline-2026-06-10.md
@@ -1,4 +1,6 @@
 ---
+title: Effect failure-channel discipline for fail-soft boundaries
+category: best-practices
 module: gateway
 date: 2026-06-10
 problem_type: best_practice

--- a/docs/solutions/best-practices/effect-failure-channel-discipline-2026-06-10.md
+++ b/docs/solutions/best-practices/effect-failure-channel-discipline-2026-06-10.md
@@ -1,0 +1,124 @@
+---
+module: gateway
+date: 2026-06-10
+problem_type: best_practice
+component: service_object
+severity: medium
+applies_when:
+  - "An Effect recovery boundary must guarantee a user-facing or cleanup side effect on every failure"
+  - "A hook surface is deliberately typed with a never error channel (fail-soft contract)"
+  - "Fiber interruption (shutdown) can reach a boundary that edits user-visible state"
+  - "A package mixes Result-in-success-channel and error-channel Effect adapters"
+tags:
+  - effect
+  - catchallcause
+  - fail-soft
+  - interruption
+  - defect
+  - discord
+  - gateway
+---
+
+# Effect Failure-Channel Discipline for Fail-Soft Boundaries
+
+## Context
+
+The gateway's Discord command pipeline (`packages/gateway/src/discord/commands/guild-command.ts`) owns a guarantee: any failure after `deferReply` must edit the deferred reply before re-failing, so a user is never left at "thinking…" until the interaction token expires. Its hooks are deliberately fail-soft — `authorize` is typed `Effect<AuthDecision, never>` and the Discord I/O helpers (`discord/io.ts`) are typed `Effect<Result<unknown, Error>, never>`.
+
+The first implementation guarded that guarantee with `Effect.catchAll`. Review proved this defect-blind: `Effect.catchAll` catches only **typed** failures, and a `never`-typed channel means any escaped error (a rejection inside `Effect.promise` in a future non-fail-closed `authorize`) surfaces as a **defect** (Die cause) — which skips `catchAll` entirely and reproduces the exact failure the boundary exists to eliminate. A second round caught the complement: naively squashing all causes converts fiber **interrupts** (shutdown) into misleading user-facing "internal error" replies carrying a useless FiberId string.
+
+## Guidance
+
+1. **Recovery boundaries that must be total use `catchAllCause`, not `catchAll`.** `catchAll` sees only the typed error channel; defects sail past it.
+2. **Guard interrupts first.** `Cause.isInterruptedOnly(cause)` → `Effect.failCause(cause)` so interruption propagates cleanly (it also skips the user-facing edit — an interrupted command should not claim "internal error").
+3. **One normalization boundary at the scope edge, not per step.** A per-step `catchAllCause` on `work` plus an outer `catchAll` is redundant and still leaves the other steps defect-blind. Normalize once, where the guarantee lives.
+4. **`never` error channels are contracts the type system cannot enforce.** `Effect.promise(async () => …)` claims `never` but a thrown rejection becomes a defect. Keep the fail-closed convention (hooks return denials, not errors) for precise user messages — but make the boundary defect-proof *by construction* so a contract violation degrades to a generic reply instead of a hang.
+5. **Opposite error-channel conventions are a composition hazard — document the boundary, don't mix blindly.** `io.ts` returns errors inside the `Result` on the success channel (callers always proceed); `runtime-effect.ts` unwraps `Result` and fails the Effect channel (callers `catchAll`). Composing both in one `Effect.gen` means a single `catchAll` cannot see io.ts failures. Both conventions are valid; the rule is to know which one each adapter uses and handle accordingly.
+
+Before (defect-blind):
+
+```ts
+yield* Effect.gen(function* () {
+  // defer → authorize → work
+}).pipe(
+  Effect.catchAll(error =>
+    Effect.gen(function* () {
+      yield* editInteraction(interaction, {content: INTERNAL_ERROR_COPY}, log)
+      return yield* Effect.fail(error)
+    }),
+  ),
+)
+```
+
+After (defect-proof, interrupt-aware — `guild-command.ts`):
+
+```ts
+yield* Effect.gen(function* () {
+  // defer → authorize → work (work inside Effect.suspend so sync throws become defects)
+  yield* Effect.suspend(() => spec.work(ctx))
+}).pipe(
+  Effect.catchAllCause(cause => {
+    if (Cause.isInterruptedOnly(cause)) {
+      return Effect.failCause(cause) // shutdown propagates; no user-facing edit
+    }
+    const squashed = Cause.squash(cause)
+    const error = squashed instanceof Error ? squashed : new Error(String(squashed))
+    return Effect.gen(function* () {
+      const editResult = yield* editInteraction(interaction, {content: INTERNAL_ERROR_COPY}, log)
+      if (editResult.success === false) {
+        log.error({err: editResult.error.message}, 'guild-command: failed to deliver internal-error reply')
+      }
+      return yield* Effect.fail(error)
+    })
+  }),
+)
+```
+
+## Why This Matters
+
+A defect-blind boundary fails exactly when its contract is violated — silently, in the path that was designed to be the safety net. The type checker is satisfied, every test with well-behaved hooks passes, and the hole only opens when a future implementation breaks the unenforced `never` promise. Interrupt squashing is the mirror image: clean shutdowns become user-visible errors and garbage log entries, training operators to ignore the exact signal that matters.
+
+## When to Apply
+
+- Any Effect recovery boundary guaranteeing a side effect on failure (user reply, lock release, resource cleanup).
+- Any surface where hooks/plugins are typed `Effect<T, never>` as a convention rather than a provable property.
+- Shutdown-capable systems where fibers running these boundaries can be interrupted.
+- Code that composes adapters with different error-channel conventions in one `Effect.gen`.
+
+## Examples
+
+Pinning the defect path — an `authorize` that violates its `never` contract still produces the user-facing reply and re-fails with the real error:
+
+```ts
+const authorize = vi.fn().mockReturnValue(
+  Effect.promise(async () => {
+    throw authError // escapes as a defect, not a typed failure
+  }),
+)
+const result = await Effect.runPromise(Effect.either(executor(interaction)))
+expect(editReply).toHaveBeenCalledOnce() // user saw the internal-error reply
+expect(result._tag).toBe('Left') // original error re-failed
+expect(work).not.toHaveBeenCalled()
+```
+
+Pinning interrupt propagation — interruption never claims "internal error":
+
+```ts
+const work = vi.fn().mockReturnValue(Effect.never)
+const exit = await Effect.runPromise(
+  Effect.gen(function* () {
+    const fiber = yield* Effect.fork(executor(interaction))
+    yield* Fiber.interrupt(fiber)
+    return yield* Fiber.await(fiber)
+  }),
+)
+expect(Exit.isFailure(exit) && Cause.isInterrupted(exit.cause)).toBe(true)
+expect(internalErrorCalls).toHaveLength(0)
+```
+
+## Related
+
+- [Centralize S3 key/identity construction](centralize-s3-key-identity-construction-2026-06-09.md) — the sibling "one owner per boundary" lesson (resource keys instead of failure channels)
+- [Discord slash-command orchestration patterns](discord-slash-command-orchestration-patterns-2026-05-27.md) — the command entry sequencing this pipeline now owns
+- [Gateway OpenCode mention-loop best practices](gateway-opencode-mention-loop-best-practices-2026-05-30.md) — failure-path flush and lock-ownership discipline in the adjacent run loop
+- [Atomic serial channel queue handoff](atomic-serial-channel-queue-handoff-2026-06-09.md) — defer-before-REST and honest shutdown for the same command surface

--- a/docs/solutions/best-practices/gateway-opencode-mention-loop-best-practices-2026-05-30.md
+++ b/docs/solutions/best-practices/gateway-opencode-mention-loop-best-practices-2026-05-30.md
@@ -1,6 +1,7 @@
 ---
 title: Gateway OpenCode mention-loop best practices
 date: 2026-05-30
+last_updated: 2026-06-10
 category: best-practices
 module: gateway
 problem_type: best_practice
@@ -104,20 +105,38 @@ stale run before releasing**. A stale run-state whose lease already expired may 
 lock re-acquired by a newer, live run; releasing blindly deletes the newer run's lock and
 permits concurrent execution against the same repo. This was a P0.
 
+The canonical recovery entry point is `recoverStaleRuns` (`packages/gateway/src/execute/recovery.ts`),
+which calls the internal `recoverOneRun` helper per stale run. Both `getLockKey` and `getRunKey`
+are the exported key builders from `packages/runtime/src/coordination/lock.ts` and
+`packages/runtime/src/coordination/run-state.ts` respectively — never construct these keys
+ad-hoc. See also: `docs/solutions/best-practices/centralize-s3-key-identity-construction-2026-06-09.md`.
+
 ```ts
-// packages/gateway/src/execute/recovery.ts
+// packages/gateway/src/execute/recovery.ts (inside recoverOneRun)
+// Key builders from @fro-bot/runtime — single source of truth for key shape:
+const runKeyResult = getRunKey(coordinationConfig, identity, repo, run.run_id)
+const lockKeyResult = getLockKey(coordinationConfig, repo)
+
+// Only release the lock when it belongs to this stale run:
 const lockFetch = await fetchLockRecord(coordinationConfig, lockKeyResult.data, logger)
 if (lockFetch !== null) {
   if (lockFetch.runId === run.run_id) {
     await releaseLock(coordinationConfig, repo, lockFetch.etag, coordLogger)
   } else {
-    logger.warn({runId: run.run_id, repo, lockRunId: lockFetch.runId}, 'recovery: lock owned by another run — skip release')
+    logger.warn(
+      {runId: run.run_id, repo, lockRunId: lockFetch.runId},
+      'recovery: lock.run_id does not match stale run — skipping release (lock belongs to a different run)',
+    )
   }
 }
 ```
 
 An unparseable/missing `run_id` resolves to `null` → skip the release (fail safe: never delete
 a lock you cannot prove belongs to the stale run).
+
+`forceReleaseStaleLock` (`packages/runtime/src/coordination/lock.ts`) is the dual-signal
+(lease-expired + heartbeat-stale) variant used outside the startup sweep; it also calls
+`getLockKey` internally and guards the read→delete race with an `IfMatch` conditional delete.
 
 ### 4. Flush partial output on failure paths
 
@@ -126,13 +145,18 @@ timeout/error — so the most expensive failure (a 600s timeout) yields the leas
 Flush buffered output best-effort **in the catch path, before the coarse error reply**, in its
 own try/catch so a flush failure cannot mask the original error. Guard against double-post.
 
+The coarse user message is sent via `sendMessage` from `discord/io.ts` (the old `safeSend`/
+`safeReply` local helpers in `run.ts` have been deleted; all Discord content sends now go
+through `discord/io.ts`).
+
 ```ts
 // packages/gateway/src/execute/run.ts (catch path)
 if (sink !== null) {
   await sink.flush().catch((flushError: unknown) =>
     logger.warn({repo, runId, err: String(flushError)}, 'run: sink.flush failed in error path'))
 }
-// ...then send the coarse, detail-free user message
+// ...then send the coarse, detail-free user message via sendMessage (discord/io.ts):
+await sendMessage(thread, {content: userMessage}, logger)
 ```
 
 ### 5. Bounded execution + guaranteed resource release


### PR DESCRIPTION
Captures the Effect failure-channel lesson from the recent gateway refactors and refreshes two solution docs whose examples drifted behind the shipped code.

- **New:** `effect-failure-channel-discipline-2026-06-10.md` — recovery boundaries that must guarantee a side effect use `catchAllCause` (not the defect-blind `catchAll`), guard `Cause.isInterruptedOnly` first so shutdown interrupts propagate instead of becoming user-facing "internal error" replies, normalize once at the scope edge, treat `never`-typed channels as unenforced contracts, and don't mix opposite error-channel adapter conventions under a single `catchAll`. Snippets verified against the shipped pipeline and Effect 3.21 semantics.
- **Refreshed:** the slash-command orchestration doc now reflects that the entry skeleton is owned by `makeGuildCommand` (with the structural no-hand-rolled-`deferReply` test) and that sends go through `discord/io.ts`; the mention-loop doc's lock-ownership section now names the canonical `recoverStaleRuns`/`forceReleaseStaleLock` primitives and exported key builders.
