### PR TITLE
fix(harness): set GH_REPO for the release step (no checkout in job)

### DIFF
--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -554,6 +554,9 @@ jobs:
         if: steps.params.outputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          # This job has no repo checkout, so gh cannot infer the repo from a .git
+          # directory. GH_REPO points all gh release subcommands at the right repo.
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.params.outputs.release_tag }}
           BASE_VERSION: ${{ steps.params.outputs.base_version }}
           SHORT_SHA: ${{ steps.params.outputs.short_sha }}


### PR DESCRIPTION
The `Release Binaries` job got past the build, version check, repackage, and checksum steps, then failed at **Create GitHub Release**:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The job downloads only the build artifacts into `/tmp` and has no repo checkout, so `gh release view`/`create`/`upload` could not infer the repository from a `.git` directory.

Setting `GH_REPO: ${{ github.repository }}` in the step env points all `gh release` subcommands at the repo explicitly, with no git context required. No checkout is needed — the job only uploads pre-built assets.

I audited the rest of the job: every other step operates on `/tmp` paths with standard tools (`tar`/`zip`/`sha256sum`) and has no repo/git dependency. This is the only `gh`/git-context gap.

No partial release or tag was left behind by the failed run (the error fired at `gh release view`, before any create).
