### PR TITLE
fix(harness): publish prerelease packages with explicit --tag latest

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -72,10 +72,10 @@ jobs:
         id: semantic-release
         name: Semantic Release
         run: |
-          before_tag=$(git tag --list 'v*' --sort=-version:refname | head -1)
+          before_tag=$(git tag --list 'v*' --sort=-version:refname | grep -vF '+harness' | head -1)
           export GITHUB_REF=refs/heads/release GITHUB_SHA=$(git rev-parse HEAD) GITHUB_EVENT_NAME=push
           pnpm semantic-release --ci false
-          after_tag=$(git tag --list 'v*' --sort=-version:refname | head -1)
+          after_tag=$(git tag --list 'v*' --sort=-version:refname | grep -vF '+harness' | head -1)
           if [ -n "$after_tag" ] && [ "$after_tag" != "$before_tag" ]; then
             echo "new-release-version=${after_tag#v}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -72,10 +72,10 @@ jobs:
         id: semantic-release
         name: Semantic Release
         run: |
-          before_tag=$(git tag --list 'v*' --sort=-version:refname | grep -vF '+harness' | head -1)
+          before_tag=$(git tag --list 'v*' --sort=-version:refname | { grep -vF '+harness' || true; } | head -1)
           export GITHUB_REF=refs/heads/release GITHUB_SHA=$(git rev-parse HEAD) GITHUB_EVENT_NAME=push
           pnpm semantic-release --ci false
-          after_tag=$(git tag --list 'v*' --sort=-version:refname | grep -vF '+harness' | head -1)
+          after_tag=$(git tag --list 'v*' --sort=-version:refname | { grep -vF '+harness' || true; } | head -1)
           if [ -n "$after_tag" ] && [ "$after_tag" != "$before_tag" ]; then
             echo "new-release-version=${after_tag#v}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -674,7 +674,7 @@ jobs:
       # cause rename/rename conflicts that -Xtheirs cannot resolve.
       - name: Reset `${{ env.RELEASE_BRANCH }}` to last release tag
         run: |
-          last_tag=$(git tag --list 'v*' --sort=-version:refname | grep -vF '+harness' | head -1)
+          last_tag=$(git tag --list 'v*' --sort=-version:refname | { grep -vF '+harness' || true; } | head -1)
           echo "Resetting ${{ env.RELEASE_BRANCH }} to ${last_tag}"
           git reset --hard "${last_tag}"
       - if: ${{ github.event_name == 'pull_request' }}
@@ -699,7 +699,7 @@ jobs:
         name: Generate PR Body
         run: |
           VERSION="${{ steps.release-preview.outputs.next_version }}"
-          last_tag=$(git tag --list 'v*' --sort=-version:refname | grep -vF '+harness' | head -1)
+          last_tag=$(git tag --list 'v*' --sort=-version:refname | { grep -vF '+harness' || true; } | head -1)
           COMMIT_LIST=$(git log "${last_tag}..HEAD" --format='* %s (%h)' --no-merges --max-count=50)
           TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M UTC")
           TITLE_SUFFIX=": v${VERSION}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -674,7 +674,7 @@ jobs:
       # cause rename/rename conflicts that -Xtheirs cannot resolve.
       - name: Reset `${{ env.RELEASE_BRANCH }}` to last release tag
         run: |
-          last_tag=$(git tag --list 'v*' --sort=-version:refname | head -1)
+          last_tag=$(git tag --list 'v*' --sort=-version:refname | grep -vF '+harness' | head -1)
           echo "Resetting ${{ env.RELEASE_BRANCH }} to ${last_tag}"
           git reset --hard "${last_tag}"
       - if: ${{ github.event_name == 'pull_request' }}
@@ -699,7 +699,7 @@ jobs:
         name: Generate PR Body
         run: |
           VERSION="${{ steps.release-preview.outputs.next_version }}"
-          last_tag=$(git tag --list 'v*' --sort=-version:refname | head -1)
+          last_tag=$(git tag --list 'v*' --sort=-version:refname | grep -vF '+harness' | head -1)
           COMMIT_LIST=$(git log "${last_tag}..HEAD" --format='* %s (%h)' --no-merges --max-count=50)
           TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M UTC")
           TITLE_SUFFIX=": v${VERSION}"

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -834,7 +834,9 @@ jobs:
               fi
               echo "Publishing ${PKG_NAME}@${NPM_VERSION}..."
               # OIDC trusted publishing: no token, provenance is automatic.
-              npm publish "${PKG_DIR}"
+              # --tag latest is required: npm refuses to publish a prerelease version
+              # without an explicit tag, and harness IS the latest line.
+              npm publish "${PKG_DIR}" --tag latest
             done
           done
 
@@ -871,23 +873,10 @@ jobs:
             # OIDC trusted publishing: no token, provenance is automatic.
             # Use a directory-anchored publish so npm does not parse the path as a
             # github: package spec (npm publish <path> needs ./ or cd into the dir).
-            (cd packages/harness && npm publish .)
+            # --tag latest is required: npm refuses to publish a prerelease version
+            # without an explicit tag, and it sets the latest line directly.
+            (cd packages/harness && npm publish . --tag latest)
           fi
-
-      - name: Tag @fro.bot/harness as latest on npm
-        # Prereleases are NOT tagged latest by default — npm only auto-tags latest
-        # for non-prerelease versions. We must set it explicitly after publish.
-        # Platform packages (@fro.bot/harness-{linux,darwin}-{x64,arm64}) are
-        # optional dependencies resolved by npm automatically; only the main package
-        # needs the latest dist-tag for `bunx @fro.bot/harness` to resolve correctly.
-        if: steps.params.outputs.dry_run != 'true'
-        env:
-          NPM_VERSION: ${{ steps.params.outputs.npm_version }}
-        run: |
-          set -euo pipefail
-          echo "Tagging @fro.bot/harness@${NPM_VERSION} as latest..."
-          npm dist-tag add "@fro.bot/harness@${NPM_VERSION}" latest
-          echo "dist-tag latest → ${NPM_VERSION}"
 
       - name: Dry run summary
         if: steps.params.outputs.dry_run == 'true'

--- a/.github/workflows/prepare-release-pr.yaml
+++ b/.github/workflows/prepare-release-pr.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Reset to last release tag and merge `main`
         run: |
           set -euo pipefail
-          last_tag=$(git tag --list 'v*' --sort=-version:refname | head -1)
+          last_tag=$(git tag --list 'v*' --sort=-version:refname | { grep -vF '+harness' || true; } | head -1)
           echo "Resetting to ${last_tag}"
           git reset --hard "${last_tag}"
           git fetch origin main
@@ -102,7 +102,7 @@ jobs:
         name: Generate PR body
         run: |
           VERSION="${{ steps.release-preview.outputs.next_version }}"
-          last_tag=$(git tag --list 'v*' --sort=-version:refname | head -1)
+          last_tag=$(git tag --list 'v*' --sort=-version:refname | grep -vF '+harness' | head -1)
           COMMIT_LIST=$(git log "${last_tag}..HEAD" --format='* %s (%h)' --no-merges --max-count=50)
           TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M UTC")
           cat > /tmp/pr-body.md <<EOF

--- a/.github/workflows/prepare-release-pr.yaml
+++ b/.github/workflows/prepare-release-pr.yaml
@@ -102,7 +102,7 @@ jobs:
         name: Generate PR body
         run: |
           VERSION="${{ steps.release-preview.outputs.next_version }}"
-          last_tag=$(git tag --list 'v*' --sort=-version:refname | grep -vF '+harness' | head -1)
+          last_tag=$(git tag --list 'v*' --sort=-version:refname | { grep -vF '+harness' || true; } | head -1)
           COMMIT_LIST=$(git log "${last_tag}..HEAD" --format='* %s (%h)' --no-merges --max-count=50)
           TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M UTC")
           cat > /tmp/pr-body.md <<EOF

--- a/scripts/release/preview-next-release.ts
+++ b/scripts/release/preview-next-release.ts
@@ -8,7 +8,7 @@ import process from 'node:process'
 // --experimental-strip-types / --experimental-transform-types.
 // The test file (preview.test.ts) uses .js because it runs under
 // Vitest with bundler module resolution. Both are correct for their runtime.
-import {analyzeReleaseType, computeNextVersion} from './preview.ts'
+import {analyzeReleaseType, computeNextVersion, filterHarnessTags} from './preview.ts'
 
 const COMMIT_SEPARATOR = '---COMMIT_SEPARATOR---'
 
@@ -65,10 +65,12 @@ function resolveFromTag(overrideTag: string | null): string {
   }
 
   const tagsOutput = runGit('tag', '--list', 'v*', '--sort=-version:refname')
-  const latestTag = tagsOutput
-    .split('\n')
-    .map(tag => tag.trim())
-    .find(tag => tag.length > 0)
+  const latestTag = filterHarnessTags(
+    tagsOutput
+      .split('\n')
+      .map(tag => tag.trim())
+      .filter(tag => tag.length > 0),
+  )[0]
   if (latestTag === undefined) {
     throw new Error("No git tag matching pattern 'v*' was found")
   }

--- a/scripts/release/preview.test.ts
+++ b/scripts/release/preview.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {analyzeReleaseType, computeNextVersion} from './preview.js'
+import {analyzeReleaseType, computeNextVersion, filterHarnessTags} from './preview.js'
 
 describe('analyzeReleaseType', () => {
   it('returns patch for fix commit', () => {
@@ -166,5 +166,62 @@ describe('computeNextVersion', () => {
 
     // #then
     expect(result).toBeNull()
+  })
+})
+
+describe('filterHarnessTags', () => {
+  it('removes tags containing +harness', () => {
+    // #given
+    const tags = ['v1.17.3+harness.87250603', 'v0.62.0', 'v0.61.0']
+
+    // #when
+    const result = filterHarnessTags(tags)
+
+    // #then
+    expect(result).toEqual(['v0.62.0', 'v0.61.0'])
+  })
+
+  it('returns the latest clean SemVer tag first when harness tags sort highest', () => {
+    // #given — simulates git tag --sort=-version:refname output where +harness sorts above clean tags
+    const tags = ['v1.17.3+harness.87250603', 'v0.62.0', 'v0.61.0']
+
+    // #when
+    const result = filterHarnessTags(tags)
+
+    // #then — first element is the latest clean tag, not the harness tag
+    expect(result[0]).toBe('v0.62.0')
+  })
+
+  it('keeps all tags when none contain +harness', () => {
+    // #given
+    const tags = ['v0.62.0', 'v0.61.0', 'v0.60.0']
+
+    // #when
+    const result = filterHarnessTags(tags)
+
+    // #then
+    expect(result).toEqual(['v0.62.0', 'v0.61.0', 'v0.60.0'])
+  })
+
+  it('returns empty array when all tags are harness tags', () => {
+    // #given
+    const tags = ['v1.17.3+harness.87250603', 'v1.16.0+harness.aabbccdd']
+
+    // #when
+    const result = filterHarnessTags(tags)
+
+    // #then
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array for empty input', () => {
+    // #given
+    const tags: readonly string[] = []
+
+    // #when
+    const result = filterHarnessTags(tags)
+
+    // #then
+    expect(result).toEqual([])
   })
 })

--- a/scripts/release/preview.ts
+++ b/scripts/release/preview.ts
@@ -79,6 +79,10 @@ function resolveReleaseTypeForParsedCommit(parsed: ParsedCommit): ReleaseType {
   return 'none'
 }
 
+export function filterHarnessTags(tags: readonly string[]): readonly string[] {
+  return tags.filter(tag => !tag.includes('+harness'))
+}
+
 export function analyzeReleaseType(messages: readonly string[]): ReleaseType {
   let highest: ReleaseType = 'none'
 


### PR DESCRIPTION
Two release-tooling fixes exposed by the first harness GitHub Release.

## 1. npm prerelease publish needs an explicit tag

The harness release reached npm publish and failed immediately:

```
npm error You must specify a tag using --tag when publishing a prerelease version.
```

Harness packages publish as the prerelease `<base>-harness.<short8>`, and npm refuses to publish a prerelease without an explicit dist-tag. Both publishes now pass `--tag latest` (harness is the latest line), and the now-redundant separate `npm dist-tag add ... latest` step is removed.

## 2. Harness tags must be excluded from product version detection

The harness pipeline creates `v<base>+harness.<short8>` tags. These sort highest under `--sort=-version:refname` and were being picked up by the product release tooling, breaking version detection (`Invalid semantic version: 1.17.3+harness.<sha>`). All seven tag-selection sites now exclude any tag containing `+harness`:

- `.github/workflows/ci.yaml` (release preview, x2)
- `.github/workflows/prepare-release-pr.yaml` (x2)
- `.github/workflows/auto-release.yaml` (`before_tag`/`after_tag`)
- `scripts/release/preview-next-release.ts` (via a shared `filterHarnessTags` helper)

The one `set -euo pipefail` block guards the filter with `{ grep -vF '+harness' || true; }` so an all-harness-tags edge can't kill the step.

## Verification

92 script tests pass (5 new for `filterHarnessTags`), `tsc` clean for scripts, actionlint clean on the changed lines. The orphaned `v1.17.3+harness.87250603` tag from the prior partial run has been deleted, so product tag selection is clean again.
