### PR TITLE
feat(harness): build and publish musl Linux release assets

### DIFF
--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -461,7 +461,7 @@ jobs:
             echo "short_sha=${SHORT_SHA}"
           } >> "$GITHUB_OUTPUT"
 
-      # Download all four platform binaries (mirrors publish job's download steps).
+      # Download all six platform binaries (4 glibc + 2 musl/baseline for workspace).
       - name: Download linux/x64 binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -486,7 +486,22 @@ jobs:
           name: harness-binary-darwin-arm64
           path: /tmp/harness-binaries/darwin-arm64
 
-      - name: Existence gate — assert all 4 binaries are present and non-empty
+      - name: Download linux/x64-baseline-musl binary
+        # R9: additive musl asset for workspace (Alpine). Distinct artifact name avoids
+        # collision with the glibc linux-x64 artifact.
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: harness-binary-linux-x64-baseline-musl
+          path: /tmp/harness-binaries/linux-x64-baseline-musl
+
+      - name: Download linux/arm64-musl binary
+        # R9: additive musl asset for workspace (Alpine/arm64).
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: harness-binary-linux-arm64-musl
+          path: /tmp/harness-binaries/linux-arm64-musl
+
+      - name: Existence gate — assert all 6 binaries are present and non-empty
         # R10: all-or-nothing. Fail immediately if any binary is missing or empty.
         # Covers transient artifact expiry and partial uploads.
         run: |
@@ -505,6 +520,18 @@ jobs:
                 echo "OK: ${BIN} ($(wc -c < "${BIN}") bytes)"
               fi
             done
+          done
+          for MUSL_TARGET in linux-x64-baseline-musl linux-arm64-musl; do
+            BIN="/tmp/harness-binaries/${MUSL_TARGET}/opencode"
+            if [ ! -f "${BIN}" ]; then
+              echo "ERROR: missing binary: ${BIN}" >&2
+              FAIL=1
+            elif [ ! -s "${BIN}" ]; then
+              echo "ERROR: binary is empty: ${BIN}" >&2
+              FAIL=1
+            else
+              echo "OK: ${BIN} ($(wc -c < "${BIN}") bytes)"
+            fi
           done
           if [ "${FAIL}" -ne 0 ]; then
             echo "FATAL: one or more platform binaries are missing or empty. Aborting release." >&2
@@ -545,10 +572,47 @@ jobs:
             echo "${TARGET}: pre-verified by build job on its native runner."
           done
 
+          # musl binaries: also pre-verified on their native runners by the build job.
+          for TARGET in linux-x64-baseline-musl linux-arm64-musl; do
+            echo "${TARGET}: pre-verified by build job on its native runner."
+          done
+
+      - name: Assert musl binaries are actually musl (R11 packaging-side libc check)
+        # R11: before packaging, verify each musl artifact is actually musl-linked.
+        # A silently-failed patch (LLM-merge non-determinism) could produce a glibc binary
+        # under a musl artifact name; this gate catches it before the asset is published.
+        # Uses `file` to inspect the ELF interpreter: musl binaries reference musl-libc,
+        # not the glibc ld-linux interpreter. Fails loud if glibc is detected.
+        run: |
+          set -euo pipefail
+          FAIL=0
+          for MUSL_TARGET in linux-x64-baseline-musl linux-arm64-musl; do
+            BIN="/tmp/harness-binaries/${MUSL_TARGET}/opencode"
+            chmod +x "${BIN}"
+            FILE_OUT=$(file "${BIN}")
+            echo "${MUSL_TARGET}: ${FILE_OUT}"
+            # glibc binaries reference the ld-linux interpreter (ld-linux-x86-64.so.2,
+            # ld-linux-aarch64.so.1, etc.). musl binaries reference musl-libc or are
+            # statically linked. Fail if the glibc interpreter is present.
+            if echo "${FILE_OUT}" | grep -qE 'ld-linux|ld\.so\.[0-9]'; then
+              echo "ERROR: ${MUSL_TARGET} binary appears to be glibc-linked (found glibc interpreter in 'file' output)." >&2
+              echo "  file output: ${FILE_OUT}" >&2
+              echo "  This indicates the build.ts musl patch did not take effect for this target." >&2
+              FAIL=1
+            else
+              echo "OK: ${MUSL_TARGET} does not reference glibc interpreter."
+            fi
+          done
+          if [ "${FAIL}" -ne 0 ]; then
+            echo "FATAL: one or more musl artifacts failed the libc assertion. Aborting release." >&2
+            exit 1
+          fi
+
       - name: Repackage binaries into stock-OpenCode-shaped release assets
-        # R1: linux → .tar.gz, darwin → .zip; binary at archive root named "opencode".
+        # R1/R9: linux → .tar.gz, darwin → .zip; binary at archive root named "opencode".
         # Mirrors stock anomalyco/opencode asset naming so action consumers can use
         # the same download path with only the repo/tag changed.
+        # Musl assets use the same tar layout as glibc linux assets (binary at archive root).
         run: |
           set -euo pipefail
           ASSETS_DIR="/tmp/harness-release-assets"
@@ -587,23 +651,48 @@ jobs:
             echo "Verified archive root: ${MEMBERS}"
           done
 
+          # Musl/baseline assets: same tar layout as glibc linux assets.
+          # Binary at archive root named "opencode" so workspace `tar -xz -C /usr/local/bin`
+          # extracts directly to /usr/local/bin/opencode.
+          for MUSL_TARGET in linux-x64-baseline-musl linux-arm64-musl; do
+            BIN="/tmp/harness-binaries/${MUSL_TARGET}/opencode"
+            chmod +x "${BIN}"
+            ASSET="opencode-${MUSL_TARGET}.tar.gz"
+            tar -czf "${ASSET}" -C "/tmp/harness-binaries/${MUSL_TARGET}" opencode
+            echo "Created: ${ASSET}"
+            MEMBERS=$(tar -tzf "${ASSET}")
+            if ! echo "${MEMBERS}" | grep -qx 'opencode'; then
+              echo "ERROR: ${ASSET} archive root does not contain 'opencode' at root (got: ${MEMBERS})" >&2
+              exit 1
+            fi
+            echo "Verified archive root: ${MEMBERS}"
+          done
+
           echo "All assets created:"
           ls -lh "${ASSETS_DIR}"
 
       - name: Generate SHA256SUMS
-        # Aggregated checksum file over all 4 assets (de-facto standard for mise/aqua/local consumers).
+        # Aggregated checksum file over all 6 assets (R2/R9: musl assets included).
         # The action verifies its single platform asset against the matching line.
+        # The workspace Dockerfile verifies the musl asset against the matching line.
         run: |
           set -euo pipefail
           cd /tmp/harness-release-assets
-          sha256sum opencode-linux-x64.tar.gz opencode-linux-arm64.tar.gz opencode-darwin-x64.zip opencode-darwin-arm64.zip > SHA256SUMS
+          sha256sum \
+            opencode-linux-x64.tar.gz \
+            opencode-linux-arm64.tar.gz \
+            opencode-darwin-x64.zip \
+            opencode-darwin-arm64.zip \
+            opencode-linux-x64-baseline-musl.tar.gz \
+            opencode-linux-arm64-musl.tar.gz \
+            > SHA256SUMS
           echo "SHA256SUMS:"
           cat SHA256SUMS
 
       - name: Create GitHub Release
         # Guard: skip actual release creation in dry-run mode.
-        # All prior steps (existence gate, version check, repackage, checksums) still run
-        # so dry-run validates everything except the publish.
+        # All prior steps (existence gate, libc assertion, version check, repackage, checksums)
+        # still run so dry-run validates everything except the publish.
         if: steps.params.outputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -627,6 +716,8 @@ jobs:
               opencode-linux-arm64.tar.gz \
               opencode-darwin-x64.zip \
               opencode-darwin-arm64.zip \
+              opencode-linux-x64-baseline-musl.tar.gz \
+              opencode-linux-arm64-musl.tar.gz \
               SHA256SUMS \
               --clobber
             echo "Assets re-uploaded (clobber) for: ${RELEASE_TAG}"
@@ -640,6 +731,8 @@ jobs:
               opencode-linux-arm64.tar.gz \
               opencode-darwin-x64.zip \
               opencode-darwin-arm64.zip \
+              opencode-linux-x64-baseline-musl.tar.gz \
+              opencode-linux-arm64-musl.tar.gz \
               SHA256SUMS
             echo "GitHub Release created: ${RELEASE_TAG}"
           fi

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -200,7 +200,7 @@ jobs:
   # Windows is out of scope (linux x64/arm64 + darwin x64/arm64 only).
   # ---------------------------------------------------------------------------
   build:
-    name: build (${{ matrix.platform }}/${{ matrix.arch }})
+    name: build (${{ matrix.platform }}/${{ matrix.arch }}${{ matrix.abi != '' && format('/{0}', matrix.abi) || '' }}${{ matrix.baseline && '/baseline' || '' }})
     needs: [prepare-integrate, integrate]
     # Run when prepare-integrate succeeded AND integrate did not fail.
     # integrate.result is 'skipped' for empty carry → build runs.
@@ -212,18 +212,41 @@ jobs:
       fail-fast: true # All-or-nothing: one failure blocks the whole publish.
       matrix:
         include:
+          # --- glibc Linux (unchanged; used by the action download path) ---
           - platform: linux
             arch: x64
             runner: ubuntu-24.04
+            abi: ''
+            baseline: false
           - platform: linux
             arch: arm64
             runner: ubuntu-24.04-arm
+            abi: ''
+            baseline: false
+          # --- musl Linux (additive; used by the workspace Dockerfile on Alpine) ---
+          # linux/x64 baseline-musl: avx2=false + musl — matches opencode-linux-x64-baseline-musl
+          - platform: linux
+            arch: x64
+            runner: ubuntu-24.04
+            abi: musl
+            baseline: true
+          # linux/arm64 musl: arm64 + musl — matches opencode-linux-arm64-musl
+          - platform: linux
+            arch: arm64
+            runner: ubuntu-24.04-arm
+            abi: musl
+            baseline: false
+          # --- Darwin (unchanged) ---
           - platform: darwin
             arch: x64
             runner: macos-15-intel
+            abi: ''
+            baseline: false
           - platform: darwin
             arch: arm64
             runner: macos-15
+            abi: ''
+            baseline: false
 
     runs-on: ${{ matrix.runner }}
 
@@ -301,41 +324,71 @@ jobs:
 
           echo "integration_commit=${INTEGRATION_COMMIT}" >> "$GITHUB_OUTPUT"
 
-      - name: Build native binary for ${{ matrix.platform }}/${{ matrix.arch }}
+      - name: Build native binary for ${{ matrix.platform }}/${{ matrix.arch }}${{ matrix.abi != '' && format('/{0}', matrix.abi) || '' }}${{ matrix.baseline && '/baseline' || '' }}
         env:
           INTEGRATION_COMMIT: ${{ steps.fetch-integrate.outputs.integration_commit }}
           BASE_VERSION: ${{ needs.prepare-integrate.outputs.base_version }}
           RUNNER_TEMP: ${{ runner.temp }}
           MATRIX_PLATFORM: ${{ matrix.platform }}
           MATRIX_ARCH: ${{ matrix.arch }}
+          MATRIX_ABI: ${{ matrix.abi }}
+          MATRIX_BASELINE: ${{ matrix.baseline }}
         run: |
-          bun run packages/harness/scripts/build-platform.ts \
-            --integration-commit "$INTEGRATION_COMMIT" \
-            --base-version "$BASE_VERSION" \
-            --platform "$MATRIX_PLATFORM" \
-            --arch "$MATRIX_ARCH" \
-            --source-tree "$RUNNER_TEMP/integration-src" \
-            --work-dir "$RUNNER_TEMP/harness-build-work" \
-            --out-dir "$RUNNER_TEMP/harness-build-out"
+          set -euo pipefail
+          # Build the command with optional --abi and --baseline flags for musl/baseline targets.
+          # For glibc entries (abi=''), these flags are omitted — preserving existing behavior.
+          # Use an array to avoid SC2086 word-splitting issues with unquoted flag variables.
+          CMD=(bun run packages/harness/scripts/build-platform.ts
+            --integration-commit "$INTEGRATION_COMMIT"
+            --base-version "$BASE_VERSION"
+            --platform "$MATRIX_PLATFORM"
+            --arch "$MATRIX_ARCH")
+          if [ -n "${MATRIX_ABI}" ]; then
+            CMD+=(--abi "${MATRIX_ABI}")
+          fi
+          if [ "${MATRIX_BASELINE}" = "true" ]; then
+            CMD+=(--baseline)
+          fi
+          CMD+=(--source-tree "$RUNNER_TEMP/integration-src"
+            --work-dir "$RUNNER_TEMP/harness-build-work"
+            --out-dir "$RUNNER_TEMP/harness-build-out")
+          "${CMD[@]}"
 
-      - name: Verify binary (${{ matrix.platform }}/${{ matrix.arch }})
+      - name: Verify binary (${{ matrix.platform }}/${{ matrix.arch }}${{ matrix.abi != '' && format('/{0}', matrix.abi) || '' }}${{ matrix.baseline && '/baseline' || '' }})
         env:
           INTEGRATION_COMMIT: ${{ steps.fetch-integrate.outputs.integration_commit }}
           BASE_VERSION: ${{ needs.prepare-integrate.outputs.base_version }}
           RUNNER_TEMP: ${{ runner.temp }}
           MATRIX_PLATFORM: ${{ matrix.platform }}
           MATRIX_ARCH: ${{ matrix.arch }}
+          MATRIX_ABI: ${{ matrix.abi }}
+          MATRIX_BASELINE: ${{ matrix.baseline }}
         run: |
+          set -euo pipefail
+          # Compute the binary dir suffix matching build.ts name computation:
+          #   [pkg.name, os, arch, avx2===false ? 'baseline' : undefined, abi ?? undefined].join('-')
+          # Order: baseline before abi (e.g. -baseline-musl, not -musl-baseline).
+          SUFFIX=""
+          if [ "${MATRIX_BASELINE}" = "true" ]; then
+            SUFFIX="${SUFFIX}-baseline"
+          fi
+          if [ -n "${MATRIX_ABI}" ]; then
+            SUFFIX="${SUFFIX}-${MATRIX_ABI}"
+          fi
           bun run packages/harness/scripts/verify-binary.ts \
-            --binary "$RUNNER_TEMP/harness-build-out/opencode-$MATRIX_PLATFORM-$MATRIX_ARCH/bin/opencode" \
+            --binary "$RUNNER_TEMP/harness-build-out/opencode-$MATRIX_PLATFORM-$MATRIX_ARCH${SUFFIX}/bin/opencode" \
             --base-version "$BASE_VERSION" \
             --integration-commit "$INTEGRATION_COMMIT"
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: harness-binary-${{ matrix.platform }}-${{ matrix.arch }}
-          path: ${{ runner.temp }}/harness-build-out/opencode-${{ matrix.platform }}-${{ matrix.arch }}/bin/opencode
+          # Artifact name encodes the full target identity (platform/arch/baseline/abi).
+          # Order matches upstream build.ts name computation: baseline before abi.
+          # Musl variants use a distinct name so they don't collide with glibc artifacts.
+          # e.g. harness-binary-linux-x64-baseline-musl, harness-binary-linux-arm64-musl
+          name: harness-binary-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.baseline && '-baseline' || '' }}${{ matrix.abi != '' && format('-{0}', matrix.abi) || '' }}
+          path: ${{ runner.temp }}/harness-build-out/opencode-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.baseline && '-baseline' || '' }}${{ matrix.abi != '' && format('-{0}', matrix.abi) || '' }}/bin/opencode
           if-no-files-found: error
           retention-days: 1
 

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -209,7 +209,7 @@ jobs:
     # !cancelled() prevents running if the workflow was manually cancelled.
     if: ${{ !cancelled() && needs.prepare-integrate.result == 'success' && (needs.integrate.result == 'success' || needs.integrate.result == 'skipped') }}
     strategy:
-      fail-fast: true # All-or-nothing: one failure blocks the whole publish.
+      fail-fast: false # Allow completed builds to survive a flaky musl failure; the existence gate enforces all-or-nothing after all builds finish.
       matrix:
         include:
           # --- glibc Linux (unchanged; used by the action download path) ---
@@ -492,7 +492,7 @@ jobs:
           path: /tmp/harness-binaries/darwin-arm64
 
       - name: Download linux/x64-baseline-musl binary
-        # R9: additive musl asset for workspace (Alpine). Distinct artifact name avoids
+        # Additive musl asset for workspace (Alpine). Distinct artifact name avoids
         # collision with the glibc linux-x64 artifact.
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -500,14 +500,14 @@ jobs:
           path: /tmp/harness-binaries/linux-x64-baseline-musl
 
       - name: Download linux/arm64-musl binary
-        # R9: additive musl asset for workspace (Alpine/arm64).
+        # Additive musl asset for workspace (Alpine/arm64).
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: harness-binary-linux-arm64-musl
           path: /tmp/harness-binaries/linux-arm64-musl
 
       - name: Existence gate — assert all 6 binaries are present and non-empty
-        # R10: all-or-nothing. Fail immediately if any binary is missing or empty.
+        # All-or-nothing: fail immediately if any binary is missing or empty.
         # Covers transient artifact expiry and partial uploads.
         run: |
           set -euo pipefail
@@ -544,7 +544,7 @@ jobs:
           fi
 
       - name: Operational integrity — verify the native binary reports the expected version
-        # R9: operational integrity. The binary must self-report "<base>+harness.<short8>";
+        # Operational integrity: the binary must self-report "<base>+harness.<short8>";
         # a stray stock binary reports bare "<base>" and fails this check.
         # Only the binary matching THIS runner's architecture (ubuntu-24.04 = linux-x64) can
         # be executed here — cross-arch (linux-arm64) and cross-OS (darwin) binaries cannot
@@ -582,12 +582,13 @@ jobs:
             echo "${TARGET}: pre-verified by build job on its native runner."
           done
 
-      - name: Assert musl binaries are actually musl (R11 packaging-side libc check)
-        # R11: before packaging, verify each musl artifact is actually musl-linked.
+      - name: libc linkage check — assert musl binaries are actually musl
+        # Before packaging, verify each musl artifact is actually musl-linked.
         # A silently-failed patch (LLM-merge non-determinism) could produce a glibc binary
         # under a musl artifact name; this gate catches it before the asset is published.
-        # Uses `file` to inspect the ELF interpreter: musl binaries reference musl-libc,
-        # not the glibc ld-linux interpreter. Fails loud if glibc is detected.
+        # Uses `file` to inspect the ELF interpreter with positive + negative assertions:
+        #   Positive: must be ELF, must match expected arch, must be statically linked or musl.
+        #   Negative: must NOT reference the glibc ld-linux interpreter.
         run: |
           set -euo pipefail
           FAIL=0
@@ -596,17 +597,45 @@ jobs:
             chmod +x "${BIN}"
             FILE_OUT=$(file "${BIN}")
             echo "${MUSL_TARGET}: ${FILE_OUT}"
-            # glibc binaries reference the ld-linux interpreter (ld-linux-x86-64.so.2,
-            # ld-linux-aarch64.so.1, etc.). musl binaries reference musl-libc or are
-            # statically linked. Fail if the glibc interpreter is present.
-            if echo "${FILE_OUT}" | grep -qE 'ld-linux|ld\.so\.[0-9]'; then
+
+            # Determine expected architecture string for this target.
+            case "${MUSL_TARGET}" in
+              linux-x64-baseline-musl) EXPECTED_ARCH="x86-64" ;;
+              linux-arm64-musl)        EXPECTED_ARCH="aarch64" ;;
+              *)                       EXPECTED_ARCH="" ;;
+            esac
+
+            # Positive assertion 1: must be an ELF binary.
+            if ! echo "${FILE_OUT}" | grep -q 'ELF'; then
+              echo "ERROR: ${MUSL_TARGET} is not an ELF binary (file output: ${FILE_OUT})" >&2
+              FAIL=1
+              continue
+            fi
+
+            # Positive assertion 2: must match expected architecture.
+            if [ -n "${EXPECTED_ARCH}" ] && ! echo "${FILE_OUT}" | grep -q "${EXPECTED_ARCH}"; then
+              echo "ERROR: ${MUSL_TARGET} does not match expected architecture '${EXPECTED_ARCH}' (file output: ${FILE_OUT})" >&2
+              FAIL=1
+              continue
+            fi
+
+            # Positive assertion 3: must be statically linked or reference musl.
+            if ! echo "${FILE_OUT}" | grep -qE 'statically linked|musl'; then
+              echo "ERROR: ${MUSL_TARGET} is neither statically linked nor musl-linked (file output: ${FILE_OUT})" >&2
+              FAIL=1
+              continue
+            fi
+
+            # Negative assertion: must NOT reference the glibc ld-linux interpreter.
+            if echo "${FILE_OUT}" | grep -qE 'ld-linux'; then
               echo "ERROR: ${MUSL_TARGET} binary appears to be glibc-linked (found glibc interpreter in 'file' output)." >&2
               echo "  file output: ${FILE_OUT}" >&2
               echo "  This indicates the build.ts musl patch did not take effect for this target." >&2
               FAIL=1
-            else
-              echo "OK: ${MUSL_TARGET} does not reference glibc interpreter."
+              continue
             fi
+
+            echo "OK: ${MUSL_TARGET} — ELF, ${EXPECTED_ARCH}, statically linked / musl, no glibc interpreter."
           done
           if [ "${FAIL}" -ne 0 ]; then
             echo "FATAL: one or more musl artifacts failed the libc assertion. Aborting release." >&2
@@ -614,7 +643,7 @@ jobs:
           fi
 
       - name: Repackage binaries into stock-OpenCode-shaped release assets
-        # R1/R9: linux → .tar.gz, darwin → .zip; binary at archive root named "opencode".
+        # linux → .tar.gz, darwin → .zip; binary at archive root named "opencode".
         # Mirrors stock anomalyco/opencode asset naming so action consumers can use
         # the same download path with only the repo/tag changed.
         # Musl assets use the same tar layout as glibc linux assets (binary at archive root).
@@ -677,7 +706,7 @@ jobs:
           ls -lh "${ASSETS_DIR}"
 
       - name: Generate SHA256SUMS
-        # Aggregated checksum file over all 6 assets (R2/R9: musl assets included).
+        # Aggregated checksum file over all 6 assets (musl assets included).
         # The action verifies its single platform asset against the matching line.
         # The workspace Dockerfile verifies the musl asset against the matching line.
         run: |

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -375,10 +375,15 @@ jobs:
           if [ -n "${MATRIX_ABI}" ]; then
             SUFFIX="${SUFFIX}-${MATRIX_ABI}"
           fi
-          bun run packages/harness/scripts/verify-binary.ts \
-            --binary "$RUNNER_TEMP/harness-build-out/opencode-$MATRIX_PLATFORM-$MATRIX_ARCH${SUFFIX}/bin/opencode" \
-            --base-version "$BASE_VERSION" \
-            --integration-commit "$INTEGRATION_COMMIT"
+          # Use an array to avoid SC2086 word-splitting issues with unquoted flag variables.
+          CMD=(bun run packages/harness/scripts/verify-binary.ts
+            --binary "$RUNNER_TEMP/harness-build-out/opencode-$MATRIX_PLATFORM-$MATRIX_ARCH${SUFFIX}/bin/opencode"
+            --base-version "$BASE_VERSION"
+            --integration-commit "$INTEGRATION_COMMIT")
+          if [ -n "${MATRIX_ABI}" ]; then
+            CMD+=(--abi "${MATRIX_ABI}")
+          fi
+          "${CMD[@]}"
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -1059,7 +1059,11 @@ jobs:
     needs: [prepare-integrate, build, publish]
     # Only run after a real successful publish. Never on dry-run.
     # The release is already done; this job failing does not affect it.
-    if: ${{ needs.publish.result == 'success' && inputs.dry_run != 'true' }}
+    # dry_run is a boolean input: compare against the boolean `true`, NOT the
+    # string 'true'. A boolean-vs-string `!=` coerces numerically ('true' → NaN),
+    # so `inputs.dry_run != 'true'` is always truthy and would run on dry-runs.
+    # For tag-triggered releases inputs.dry_run is null, which is also != true.
+    if: ${{ needs.publish.result == 'success' && inputs.dry_run != true }}
     runs-on: ubuntu-24.04
     continue-on-error: true # Best-effort: release already succeeded.
 

--- a/docs/plans/2026-06-13-001-feat-workspace-harness-cutover-plan.md
+++ b/docs/plans/2026-06-13-001-feat-workspace-harness-cutover-plan.md
@@ -1,0 +1,234 @@
+---
+title: "feat: Cut the workspace executor over to the harness OpenCode binary"
+type: feat
+status: active
+date: 2026-06-13
+deepened: 2026-06-13
+origin: docs/brainstorms/2026-06-13-workspace-harness-cutover-requirements.md
+---
+
+# feat: Cut the workspace executor over to the harness OpenCode binary
+
+## Overview
+
+The GitHub Action runs the patched harness OpenCode build by default (PR #884). The gateway's **workspace executor image** still bakes stock OpenCode from `anomalyco/opencode`. This plan extends the harness release to publish musl + x64-baseline Linux assets, then repoints `deploy/workspace.Dockerfile` at the harness release so the workspace runs the same patched binary — delivering the carried session/plugin/compaction fixes (#19961, #31859, #31638) into the mention-loop execution path. The gateway process is unchanged (it remote-attaches to the workspace OpenCode proxy and bakes no binary).
+
+## Problem Frame
+
+The workspace is Alpine-based and needs **musl** OpenCode binaries (`opencode-linux-x64-baseline-musl.tar.gz`, `opencode-linux-arm64-musl.tar.gz`). The harness release currently publishes only **generic glibc** assets, because `build-platform.ts` invokes upstream `build.ts --single`, which hard-skips musl targets (verified: `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/script/build.ts:116-135`). A glibc binary cannot run on Alpine, so this is not a simple repoint — the harness Linux build must additionally produce the musl/baseline variants. (see origin: docs/brainstorms/2026-06-13-workspace-harness-cutover-requirements.md)
+
+## Requirements Trace
+
+- R1. The harness release publishes `opencode-linux-x64-baseline-musl.tar.gz` and `opencode-linux-arm64-musl.tar.gz` from the same pinned integration commit, `--version` reporting `<base>+harness.<sha>`, alongside the existing generic glibc assets.
+- R2. The new musl/baseline assets are included in the release `SHA256SUMS`.
+- R3. `deploy/workspace.Dockerfile` downloads the binary from `fro-bot/agent` harness releases (not `anomalyco/opencode`), using the `+harness.<sha>` version (`+`→`%2B`), keeping the existing musl/baseline asset names.
+- R4. The workspace download verifies the asset against the release `SHA256SUMS` before use (fail-closed) — an upgrade from today's unchecked `curl | tar`.
+- R5. The workspace `OPENCODE_VERSION` pin stays independently controllable (not coupled to the action self-update); its Renovate manager retargets to the harness release channel, and the workspace can revert without touching the action's harness SHA.
+- R6. The existing action glibc download path (PR #884) is unchanged.
+- R7. The gateway image and process are unchanged.
+- R8. Verification goes beyond `--version`: the `Workspace Image Smoke Test` proves the musl harness binary boots on Alpine and exercises a real execution path.
+- R9. The release workflow's Linux asset handling — build matrix, download, existence gate, repackaging, `SHA256SUMS`, upload — expands from the current 4-asset world to include the new musl/baseline assets. The glibc `linux-x64`/`linux-arm64` assets remain published unchanged (musl is **additive**); x64 builds twice (glibc + baseline-musl).
+- R10. Workspace download fail-closed semantics are explicit: any download, checksum fetch, hash mismatch, partial download, or 404 aborts the build with no fallback (no cached-binary fallback, no stock fallback, no silent retry); smoke coverage includes a hash-mismatch / missing-checksum negative path.
+- R11. The build job asserts the patch took effect **in the real publish path** (not only the dry-run): after patching `build.ts`, verify the patch hunks landed (grep for the target-selector hook, fail fast if absent), and after building, verify each emitted Linux musl artifact is actually musl (`file`/`ldd`) before packaging — so a silently-failed patch produces a loud build failure, never a wrong-libc asset. This runs every release because the LLM-merge integration commit (and thus the build) differs each run, making a green dry-run non-authoritative for the published artifact.
+- R12. The build job's isolation is preserved: `contents: read`, no `id-token`, `persist-credentials: false`; the `build.ts` patch step is a local build-time mutation of the checked-out source tree only — no git push, no credentials, no OIDC, constrained to a narrow diff around the `singleFlag` filter.
+
+## Scope Boundaries
+
+- The `@opencode-ai/sdk` pin stays stock `1.17.3`.
+- The action glibc download path (#884) is unchanged (R6).
+- The gateway image/process is unchanged (R7).
+- Darwin assets are unchanged (the workspace is Linux-only).
+
+### Deferred to Separate Tasks
+
+- Migrating the action path to musl (would let the glibc assets drop): future, only if ever desired.
+- Coupling the workspace pin to the action self-update mechanism: explicitly rejected (R5 keeps it independent).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `deploy/workspace.Dockerfile:41-65` — workspace OpenCode bake (the consumption side to repoint).
+- `packages/harness/scripts/build-platform.ts:219-320` — `runUpstreamBuild` (hardcodes `build.ts --single`), `resolveBuiltBinaryPath`/`emitBinary` (assume generic `opencode-<os>-<arch>` dir).
+- `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/script/build.ts:53-199` — target matrix, `--single` filter (skips musl), per-target build loop (`name` = pkg+os+arch+baseline+abi, `FFF_LIBC`, Bun `--target`).
+- `.github/workflows/harness-release.yaml:213-228` (per-platform build matrix), `:334-339,495-547` (Release Binaries packaging/checksum/upload, hardcoded 4 assets).
+- `src/services/setup/opencode.ts` — the action's harness download + SHA256SUMS verification + `%2B` encoding pattern to mirror in the Dockerfile (R3/R4).
+- `.github/renovate.json5:84-92` — workspace `OPENCODE_VERSION` manager to retarget (R5).
+
+### Institutional Learnings
+
+- Memory 5392 (C2 gap: harness glibc-only, workspace needs musl), 5393 (cutover value confirmed 3/3), 5394 (build-invocation spike: `--single` can't emit musl).
+- Memory 5361 (published release `v1.17.3+harness.2c9cdbd2`).
+- `docs/solutions/` harness build/version docs (versioned-tool, harness-base-version-source-of-truth).
+
+## Key Technical Decisions
+
+- **Build-invocation strategy: ephemeral workflow-time patch to `build.ts`.** Since `build.ts --single` cannot emit musl and has no target-selection hook, the harness-release workflow applies a small patch to the integration-tree `build.ts` (after checkout, before build) **adding an explicit target selector** that the `singleFlag` path honors (not merely removing the musl skip); the per-`item` build loop is already target-parameterized, so the patch is local to the `singleFlag` filter (`build.ts:116-135`). `build-platform.ts` then requests the specific musl/baseline target per Linux runner, and its `resolveBuiltBinaryPath`/`emitBinary` become target-aware for the `-baseline-musl`/`-musl` dist dir names. The patch is applied to `${RUNNER_TEMP}/integration-src` (the `--source-tree` `build-platform.ts` actually builds from — verified, not a fresh clone). Chosen over a permanent carried integration patch (consumes a harness carry slot, permanently forks upstream — against the lean 1-3 ref carry policy) and over the full non-`--single` matrix (builds 10 unused Windows/macOS targets per Linux run — wasteful).
+- **Checksum is transport integrity, not provenance.** `SHA256SUMS` is same-release/same-origin — it proves integrity-in-transit, not that the binary came from a trusted build. Provenance comes from commit-pinning (the resolved integration commit threaded build→release) plus the build job's isolation (R12). The workspace consumes the exact `v<base>+harness.<sha>` tag/asset tuple.
+- **Both libc flavors published — compatibility constraint, not goal.** The generic glibc assets are kept solely so the action path (#884) is undisturbed; the workspace needs musl. Not core scope.
+- **Workspace pin independent (R5).** Preserves the lag/rollback safety valve the action/workspace split was designed for (the workspace deliberately lagged the action during the 1.15.13/1.17.3 cutovers).
+- **Fail-closed download with checksum (R4/R10).** Mirrors the action's harness-download posture; upgrades the workspace from unchecked `curl | tar`.
+
+## Open Questions
+
+### Resolved During Planning
+
+- How does the harness Linux build emit musl? — Ephemeral workflow-time `build.ts` patch + per-runner target selection (KTD).
+- musl-only or both libc flavors? — Both (compatibility constraint for the action).
+- Workspace pin coupling? — Independent (R5).
+- Is the cutover valuable? — Yes, 3/3 carried patches affect the workspace (origin doc, verified).
+
+### Deferred to Implementation
+
+- **Exact shape of the `build.ts` target-selector patch** (new `--target os/arch/abi/baseline` flag vs env vars) — settle against the real integration-tree `build.ts` during Unit 1; the loop body is already per-`item` parameterized, so the patch targets the `singleFlag` filter (`build.ts:116-135`).
+- **CI wall-clock cost** of the two extra Linux targets — measure via the Unit 4 dry-run before treating "incremental" as fact; if material, reconsider.
+- **Asset packaging dir-name resolution** — `resolveBuiltBinaryPath`/`emitBinary` must become target-aware for the `-baseline-musl`/`-musl` dist dirs; exact dir names confirmed against a real build in Unit 1.
+- **The functional smoke probe shape (R8)** — what "real execution path" the workspace smoke exercises (binary boot in server mode + one interaction) vs. just `--version`; settle against the existing `Workspace Image Smoke Test` job.
+
+## Implementation Units
+
+- [ ] **Unit 1: Harness build emits musl/baseline Linux targets**
+
+**Goal:** Make the harness Linux build produce `linux-x64-baseline-musl` and `linux-arm64-musl` binaries via an ephemeral `build.ts` target-selector patch + target-aware wrapper.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `.github/workflows/harness-release.yaml` (build job: add a step that patches the integration-tree `build.ts` after checkout; expand/parameterize the Linux build matrix for the musl/baseline targets)
+- Modify: `packages/harness/scripts/build-platform.ts` (`runUpstreamBuild` to pass the target selection; `resolveBuiltBinaryPath`/`emitBinary` to handle `-baseline-musl`/`-musl` dist dir names)
+- Test: `packages/harness/scripts/build-platform.test.ts` (target-name/dir resolution)
+
+- Add a CLI flag(s) to `build-platform.ts` (e.g. `--abi musl`, `--baseline`) selecting the Linux variant; thread it into `runUpstreamBuild` and make `resolveBuiltBinaryPath`/`emitBinary` target-aware for the `-baseline-musl`/`-musl` dist dir names.
+- In the workflow, after the integration-tree checkout (`fetch-integrate`), apply a minimal patch to `${RUNNER_TEMP}/integration-src/packages/opencode/script/build.ts` adding an explicit target selector the `singleFlag` path honors. Constrain the patch to a narrow diff around the `singleFlag` filter (R12).
+- **Guard (R11): assert the patch landed** (grep for the selector hook; fail fast if absent) immediately after patching, before building.
+- Expand the Linux matrix entries: keep `linux/x64` glibc unchanged (for the action), **add** `linux/x64` baseline-musl and `linux/arm64` musl (additive, for the workspace). x64 builds twice (glibc + baseline-musl). Each runs on its native runner.
+
+**Patterns to follow:** existing `build-platform.ts` arg parsing + `runUpstreamBuild`; the per-platform matrix in `harness-release.yaml:213-228`.
+
+**Test scenarios:**
+- Happy path: target-name resolution returns the `-baseline-musl` / `-musl` dist dir for the new variants and the plain dir for glibc.
+- Edge case: an unknown/unsupported abi/baseline combination is rejected with a clear error.
+- Integration (workflow, proven in Unit 4 dry-run, not unit-testable): the patched `build.ts` actually emits a musl binary (`file`/`ldd` shows musl, not glibc).
+
+**Verification:** a dry-run (Unit 4) produces musl/baseline binaries whose libc is verified musl and `--version` reports the harness version.
+
+- [ ] **Unit 2: Release workflow publishes + checksums the new assets**
+
+**Goal:** Expand Release Binaries asset handling from 4 to 6 so the musl/baseline assets are packaged, checksummed, and uploaded.
+
+**Requirements:** R2, R9
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `.github/workflows/harness-release.yaml` (Release Binaries job: download/existence-gate/repackage/`SHA256SUMS`/upload steps)
+
+- Add `opencode-linux-x64-baseline-musl.tar.gz` and `opencode-linux-arm64-musl.tar.gz` to every step currently hardcoded around the 4-asset set (existence gate, `sha256sum ... > SHA256SUMS`, `gh release upload`).
+- **Libc assertion (R11): before packaging, verify each Linux musl artifact is actually musl** (`file`/`ldd`) in the real build/publish path — not only the dry-run — so a non-deterministic LLM-merge run that silently built glibc fails loud rather than publishing a wrong-libc asset.
+- Keep the all-or-nothing publish semantics: a missing new asset fails the release.
+
+**Patterns to follow:** the existing 4-asset handling in `harness-release.yaml:334-339,495-547`; the `release-binaries` arch-verify pattern (only run native `--version` on the runner-matching artifact).
+
+**Test scenarios:** Test expectation: none — workflow change; validated via `actionlint` (Unit 5) and the Unit 4 dry-run (assets present in the release + in `SHA256SUMS`).
+
+**Verification:** dry-run release contains all 6 assets and `SHA256SUMS` lists the 2 new ones.
+
+- [ ] **Unit 3: Workspace Dockerfile repoint + checksum verification**
+
+**Goal:** Point the workspace OpenCode bake at the harness release with fail-closed checksum verification and the harness version.
+
+**Requirements:** R3, R4, R10, R5
+
+**Dependencies:** Units 1-2 **must publish the new musl assets first** — the existing `v1.17.3+harness.2c9cdbd2` release does NOT have musl assets, so it cannot be used as a consumption surrogate. Unit 3 repoint can only be tested/deployed after a real release carrying the musl assets exists.
+
+**Files:**
+- Modify: `deploy/workspace.Dockerfile` (download host → `fro-bot/agent`, `+`→`%2B` URL encoding, fetch `SHA256SUMS`, verify the selected asset before extract, fail-closed)
+- Modify: `.github/renovate.json5` (retarget the workspace `OPENCODE_VERSION` manager to the harness release channel; keep it independent of the action default)
+- Modify: `deploy/README.md` (operator note: workspace now runs the harness binary; independent pin)
+
+**Approach:**
+- Mirror the action's harness download pattern from `src/services/setup/opencode.ts`: construct the `fro-bot/agent` release URL with `%2B`-encoded `+`, download `SHA256SUMS`, verify the asset hash, abort with no fallback on any failure (R10).
+- Keep the existing `TARGETARCH`→asset-name mapping (`opencode-linux-x64-baseline-musl`, `opencode-linux-arm64-musl`) as a **fixed allowlist** (not free-form interpolation), and validate the version string before interpolation — mirroring the action's safe pattern — so the download URL/path has no traversal/injection surface.
+- `OPENCODE_VERSION` becomes the `<base>+harness.<sha>` form; Renovate manager retargets to track `fro-bot/agent` harness releases independently.
+
+**Patterns to follow:** `src/services/setup/opencode.ts` harness download + SHA256SUMS verification; existing Dockerfile `TARGETARCH` case.
+
+**Test scenarios:** Test expectation: none for the Dockerfile itself (no unit layer) — behavior is proven by the Unit 5 smoke test (R8) including the R10 negative path.
+
+**Verification:** the image builds, downloads the musl harness asset from `fro-bot/agent`, verifies the checksum, and boots; a tampered/missing checksum aborts the build.
+
+- [ ] **Unit 4: Dry-run validation (CI cost + asset correctness)**
+
+**Goal:** Prove end-to-end via a real harness-release dry-run before any publish, and measure the added CI cost.
+
+**Requirements:** R1, R2, R9
+
+**Dependencies:** Units 1-2
+
+**Files:**
+- None (operational: `gh workflow run harness-release.yaml -f base_version=1.17.3 -f dry_run=true`)
+
+- Dispatch a dry-run; confirm the 6 assets assemble, `SHA256SUMS` covers them, and the musl binaries are actually musl (`file`/`ldd`). Note: the dry-run is a **build-shape check**, not authoritative for the published artifact (the LLM-merge integration commit differs per run); the R11 build-job guard is what protects the real publish.
+- Record the Linux-runner wall-clock delta vs the prior 4-asset run. **Abort threshold:** if the added musl targets slow the harness release by more than ~50% or more than ~10 minutes wall-clock, stop and revisit the build strategy (full-matrix vs per-target, or whether x64-baseline is required) before proceeding to publish.
+
+**Test scenarios:** Test expectation: none — operational validation gate.
+
+**Verification:** dry-run succeeds, all 6 assets present + checksummed, musl confirmed via `file`/`ldd`, CI cost recorded against the abort threshold.
+
+- [ ] **Unit 5: Workspace smoke test (functional, beyond --version) + negative path**
+
+**Goal:** Prove the musl harness binary boots on Alpine and runs a real execution path, plus the fail-closed negative path.
+
+**Requirements:** R8, R10
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Modify: `.github/workflows/ci.yaml` (the `Workspace Image Smoke Test` job)
+- Modify: `deploy/` smoke assets as needed
+
+**Approach:**
+- Extend the smoke beyond `opencode --version`: launch the binary in the production server mode (`opencode serve` as the workspace does) and verify one real interaction / readiness, catching libc-loader or runtime issues `--version` misses.
+- Add a negative-path assertion: a tampered or missing `SHA256SUMS` / hash mismatch aborts the image build with no fallback (R10).
+
+**Patterns to follow:** the existing `Workspace Image Smoke Test`; the workspace `opencode serve` launch in `apps/workspace-agent/src/opencode-server.ts`.
+
+**Test scenarios:**
+- Happy path: musl harness binary boots on Alpine, `opencode serve` reaches readiness, `--version` reports the harness version.
+- Error path: checksum mismatch / missing `SHA256SUMS` aborts the build (no stale-binary fallback).
+
+**Verification:** the smoke job proves boot + a real execution path on the musl harness binary and the fail-closed negative path.
+
+## System-Wide Impact
+
+- **Interaction graph:** the workspace OpenCode binary runs the gateway mention loop (`packages/gateway/src/execute/run-core.ts` drives `session.promptAsync`); the harness patches (#19961/#31859/#31638) now apply there.
+- **Error propagation:** the workspace download becomes fail-closed (R4/R10) — a bad/missing asset aborts the image build rather than silently shipping stock.
+- **State lifecycle risks:** version skew between action (glibc harness) and workspace (musl harness) is intentional and independently pinned (R5); both track the same `+harness.<sha>` base but can advance/rollback separately.
+- **Unchanged invariants:** action glibc path (#884), gateway image/process, SDK pin, darwin assets — all explicitly unchanged (R6/R7 + Scope).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `build.ts` target-selector patch is more invasive than expected | Unit 1 settles the exact patch against real source; the loop is already per-`item` parameterized, only the `singleFlag` filter needs the hook |
+| musl build silently produces glibc (or vice versa) | Unit 4 dry-run verifies libc via `file`/`ldd`; Unit 5 smoke boots it on Alpine |
+| Extra Linux targets materially slow every harness release | Unit 4 measures the delta; revisit strategy if material |
+| Workspace gets a glibc binary by mistake (won't boot on Alpine) | Explicit musl asset name + checksum + R8 functional smoke |
+| Supply-chain trust shifts to our LLM-merge pipeline | Bounded by workspace sandbox-net + mitmproxy egress containment; checksum proves integrity-in-transit (note: not provenance) |
+| Ephemeral workflow patch drifts from upstream `build.ts` shape | Keep the patch minimal + local to the `singleFlag` filter; the dry-run catches breakage before publish |
+
+## Documentation / Operational Notes
+
+- `deploy/README.md`: workspace now runs the harness binary; independent version pin; how to bump/rollback the workspace OpenCode version separately from the action.
+- **Rollback matrix (R5 independence needs an explicit procedure):** if the musl workspace binary misbehaves in the mention loop while the action path is healthy, roll back **only** the workspace `OPENCODE_VERSION` pin to the prior harness release (or to a prior stock musl release as a last resort); leave the action's harness SHA untouched. Action and workspace may be temporarily out of phase — that is acceptable by design (R5). Document this as the "workspace smoke/mention-loop failure" runbook entry.
+- **Sequencing:** the first real (non-dry-run) harness release after Units 1-2 land must publish the new musl assets before the workspace repoint (Unit 3) can consume them in production.
+- **Smoke scope honesty (R8):** the `Workspace Image Smoke Test` proves boot + readiness + one real interaction on the musl harness binary — it catches libc-loader/boot failures `--version` misses, but is not full mention-loop load coverage. Real-traffic regressions are caught by the existing post-deploy behavior in the mention loop, not this smoke; treat the smoke as a boot/readiness gate, not a traffic canary.
+
+## Sources & References
+
+- **Origin document:** docs/brainstorms/2026-06-13-workspace-harness-cutover-requirements.md
+- Build-invocation analysis (this session, explorer): `build.ts:53-199`, `build-platform.ts:219-320`.
+- Memory 5392/5393/5394 (gap, value, spike).
+- Related: PR #884 (action harness cutover — download/checksum/`%2B` pattern).

--- a/packages/harness/scripts/build-platform.test.ts
+++ b/packages/harness/scripts/build-platform.test.ts
@@ -958,6 +958,16 @@ describe('assertMuslBinary: musl linkage guard', () => {
     expect(() => assertMuslBinary('/tmp/opencode', 'arm64')).not.toThrow()
   })
 
+  it('does not throw for a static-pie linked musl binary', () => {
+    // #given — some file(1) versions report static-PIE musl binaries as 'static-pie linked'
+    mockedExecFileSync.mockReturnValue(
+      '/tmp/opencode: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, stripped\n',
+    )
+
+    // #when / #then — must not throw (static-pie is a valid musl linkage form)
+    expect(() => assertMuslBinary('/tmp/opencode', 'x64')).not.toThrow()
+  })
+
   it('does not throw when file output shows musl linker (x64)', () => {
     // #given — binary references musl dynamic linker
     mockedExecFileSync.mockReturnValue(

--- a/packages/harness/scripts/build-platform.test.ts
+++ b/packages/harness/scripts/build-platform.test.ts
@@ -36,6 +36,7 @@ import {
   patchBuildTs,
   resolveTargetDirSuffix,
   runUpstreamBuild,
+  TARGET_ORIGINAL,
   verifyBuiltBinary,
 } from './build-platform.js'
 
@@ -711,6 +712,78 @@ describe('parseArgs: --abi and --baseline flags', () => {
     // #then
     expect(result).toBeNull()
   })
+
+  it('returns null when --abi is present but has no value (last arg)', () => {
+    // #given — --abi is the last arg with no following value
+    const argv = [...BASE_ARGV, '--abi']
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then — must fail with clear error, not silently treat as glibc
+    expect(result).toBeNull()
+  })
+
+  it('returns null when --abi is present but followed by another flag (no value)', () => {
+    // #given — --abi is followed by another flag token (no value)
+    const argv = [...BASE_ARGV, '--abi', '--baseline']
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then — must fail-closed
+    expect(result).toBeNull()
+  })
+
+  it('returns null when --baseline is used with non-linux platform', () => {
+    // #given — --baseline on darwin is not supported
+    const argv = [
+      'bun',
+      'build-platform.ts',
+      '--integration-commit',
+      'abc12345def67890',
+      '--base-version',
+      '1.15.13',
+      '--platform',
+      'darwin',
+      '--arch',
+      'x64',
+      '--abi',
+      'musl',
+      '--baseline',
+    ]
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then — cross-validation must reject
+    expect(result).toBeNull()
+  })
+
+  it('returns null when --baseline is used with arm64 arch', () => {
+    // #given — --baseline on arm64 is not supported (x64-only)
+    const argv = [
+      'bun',
+      'build-platform.ts',
+      '--integration-commit',
+      'abc12345def67890',
+      '--base-version',
+      '1.15.13',
+      '--platform',
+      'linux',
+      '--arch',
+      'arm64',
+      '--abi',
+      'musl',
+      '--baseline',
+    ]
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then — cross-validation must reject
+    expect(result).toBeNull()
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -725,21 +798,10 @@ describe('patchBuildTs: build.ts patch mechanism', () => {
   const mockedReadFileSync = vi.mocked(readFileSync)
   const mockedWriteFileSync = vi.mocked(writeFileSync)
 
-  // The exact baseline+abi+return-true block from upstream build.ts (lines 122-133).
-  // This is the NEW patch target — spans BOTH the baseline gate AND the abi gate.
-  // Must match what patchBuildTs looks for exactly (whitespace included).
-  const PATCH_TARGET = `      // When building for the current platform, prefer a single native binary by default.
-      // Baseline binaries require additional Bun artifacts and can be flaky to download.
-      if (item.avx2 === false) {
-        return baselineFlag
-      }
-
-      // also skip abi-specific builds for the same reason
-      if (item.abi !== undefined) {
-        return false
-      }
-
-      return true`
+  // Use the exported TARGET_ORIGINAL constant — single source of truth.
+  // Matches anomalyco/opencode v1.17.3's singleFlag filter block (lines 122-133).
+  // Must be re-diffed if clonedeps is bumped to a new upstream version.
+  const PATCH_TARGET = TARGET_ORIGINAL
 
   afterEach(() => {
     vi.restoreAllMocks()
@@ -833,10 +895,10 @@ describe('patchBuildTs: build.ts patch mechanism', () => {
 })
 
 // ---------------------------------------------------------------------------
-// assertMuslBinary — R11 musl linkage guard
+// assertMuslBinary — musl linkage guard (positive + negative assertions)
 // ---------------------------------------------------------------------------
 
-describe('assertMuslBinary: R11 musl linkage guard', () => {
+describe('assertMuslBinary: musl linkage guard', () => {
   const mockedExecFileSync = vi.mocked(execFileSync)
 
   beforeEach(() => {
@@ -848,25 +910,53 @@ describe('assertMuslBinary: R11 musl linkage guard', () => {
     vi.clearAllMocks()
   })
 
-  it('does not throw when file output shows statically linked (musl)', () => {
-    // #given — Bun musl compile produces a statically linked binary
+  // -------------------------------------------------------------------------
+  // Happy paths: valid musl binaries
+  // -------------------------------------------------------------------------
+
+  it('does not throw for statically linked x64 musl binary', () => {
+    // #given — Bun musl compile produces a statically linked x86-64 binary
     mockedExecFileSync.mockReturnValue(
       '/tmp/opencode: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped\n',
     )
 
     // #when / #then — must not throw
-    expect(() => assertMuslBinary('/tmp/opencode')).not.toThrow()
+    expect(() => assertMuslBinary('/tmp/opencode', 'x64')).not.toThrow()
   })
 
-  it('does not throw when file output shows musl linker', () => {
+  it('does not throw for statically linked arm64 musl binary', () => {
+    // #given — Bun musl compile produces a statically linked aarch64 binary
+    mockedExecFileSync.mockReturnValue(
+      '/tmp/opencode: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped\n',
+    )
+
+    // #when / #then — must not throw
+    expect(() => assertMuslBinary('/tmp/opencode', 'arm64')).not.toThrow()
+  })
+
+  it('does not throw when file output shows musl linker (x64)', () => {
     // #given — binary references musl dynamic linker
     mockedExecFileSync.mockReturnValue(
       '/tmp/opencode: ELF 64-bit LSB executable, x86-64, interpreter /lib/ld-musl-x86_64.so.1, stripped\n',
     )
 
     // #when / #then — must not throw
-    expect(() => assertMuslBinary('/tmp/opencode')).not.toThrow()
+    expect(() => assertMuslBinary('/tmp/opencode', 'x64')).not.toThrow()
   })
+
+  it('does not throw when file output shows musl linker (arm64)', () => {
+    // #given — binary references musl dynamic linker for aarch64
+    mockedExecFileSync.mockReturnValue(
+      '/tmp/opencode: ELF 64-bit LSB executable, ARM aarch64, interpreter /lib/ld-musl-aarch64.so.1, stripped\n',
+    )
+
+    // #when / #then — must not throw
+    expect(() => assertMuslBinary('/tmp/opencode', 'arm64')).not.toThrow()
+  })
+
+  // -------------------------------------------------------------------------
+  // Negative assertions: glibc binaries must throw
+  // -------------------------------------------------------------------------
 
   it('throws when file output shows glibc x86-64 interpreter', () => {
     // #given — glibc binary
@@ -875,7 +965,7 @@ describe('assertMuslBinary: R11 musl linkage guard', () => {
     )
 
     // #when / #then — must throw with clear message
-    expect(() => assertMuslBinary('/tmp/opencode')).toThrow('glibc-linked')
+    expect(() => assertMuslBinary('/tmp/opencode', 'x64')).toThrow('glibc-linked')
   })
 
   it('throws when file output shows glibc aarch64 interpreter', () => {
@@ -885,7 +975,39 @@ describe('assertMuslBinary: R11 musl linkage guard', () => {
     )
 
     // #when / #then — must throw
-    expect(() => assertMuslBinary('/tmp/opencode')).toThrow('glibc-linked')
+    expect(() => assertMuslBinary('/tmp/opencode', 'arm64')).toThrow('glibc-linked')
+  })
+
+  // -------------------------------------------------------------------------
+  // Positive assertions: non-ELF and wrong-arch must throw (FIX 1)
+  // -------------------------------------------------------------------------
+
+  it('throws when file output shows non-ELF ASCII text (stale text file)', () => {
+    // #given — stale text file, not a binary
+    mockedExecFileSync.mockReturnValue('/tmp/opencode: ASCII text\n')
+
+    // #when / #then — must throw (not an ELF binary)
+    expect(() => assertMuslBinary('/tmp/opencode', 'x64')).toThrow('not an ELF binary')
+  })
+
+  it('throws when file output shows wrong architecture (arm64 binary checked as x64)', () => {
+    // #given — arm64 binary but we expect x64
+    mockedExecFileSync.mockReturnValue(
+      '/tmp/opencode: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped\n',
+    )
+
+    // #when / #then — must throw (architecture mismatch)
+    expect(() => assertMuslBinary('/tmp/opencode', 'x64')).toThrow('Architecture mismatch')
+  })
+
+  it('throws when file output shows wrong architecture (x64 binary checked as arm64)', () => {
+    // #given — x64 binary but we expect arm64
+    mockedExecFileSync.mockReturnValue(
+      '/tmp/opencode: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped\n',
+    )
+
+    // #when / #then — must throw (architecture mismatch)
+    expect(() => assertMuslBinary('/tmp/opencode', 'arm64')).toThrow('Architecture mismatch')
   })
 
   it('throws when file command itself fails', () => {
@@ -895,7 +1017,7 @@ describe('assertMuslBinary: R11 musl linkage guard', () => {
     })
 
     // #when / #then — must throw
-    expect(() => assertMuslBinary('/tmp/opencode')).toThrow("'file' command failed")
+    expect(() => assertMuslBinary('/tmp/opencode', 'x64')).toThrow("'file' command failed")
   })
 })
 
@@ -943,23 +1065,10 @@ describe('runUpstreamBuild: musl/baseline target env vars', () => {
 
   it('sets OPENCODE_TARGET_ABI=musl when abi is musl', () => {
     // #given — musl build; simulate the patch read/write cycle via stateful mocks.
-    // patchBuildTs reads the file (gets PATCH_TARGET), writes the patched content.
+    // patchBuildTs reads the file (gets TARGET_ORIGINAL), writes the patched content.
     // assertPatchLanded reads the file again (must get the patched content with the hook).
-    // PATCH_TARGET must match the NEW TARGET_ORIGINAL (the full baseline+abi+return-true block).
-    const PATCH_TARGET = `      // When building for the current platform, prefer a single native binary by default.
-      // Baseline binaries require additional Bun artifacts and can be flaky to download.
-      if (item.avx2 === false) {
-        return baselineFlag
-      }
-
-      // also skip abi-specific builds for the same reason
-      if (item.abi !== undefined) {
-        return false
-      }
-
-      return true`
     // Stateful mock: tracks what was last written so assertPatchLanded sees the patched content.
-    let fileContent = PATCH_TARGET
+    let fileContent = TARGET_ORIGINAL
     mockedReadFileSync.mockImplementation(() => fileContent)
     mockedWriteFileSync.mockImplementation((_path, data) => {
       fileContent = data as string
@@ -983,20 +1092,7 @@ describe('runUpstreamBuild: musl/baseline target env vars', () => {
 
   it('sets OPENCODE_TARGET_ABI=musl and OPENCODE_TARGET_BASELINE=true when abi=musl and baseline=true', () => {
     // #given — musl baseline build; stateful mock simulates the patch read/write cycle.
-    // PATCH_TARGET must match the NEW TARGET_ORIGINAL (the full baseline+abi+return-true block).
-    const PATCH_TARGET = `      // When building for the current platform, prefer a single native binary by default.
-      // Baseline binaries require additional Bun artifacts and can be flaky to download.
-      if (item.avx2 === false) {
-        return baselineFlag
-      }
-
-      // also skip abi-specific builds for the same reason
-      if (item.abi !== undefined) {
-        return false
-      }
-
-      return true`
-    let fileContent = PATCH_TARGET
+    let fileContent = TARGET_ORIGINAL
     mockedReadFileSync.mockImplementation(() => fileContent)
     mockedWriteFileSync.mockImplementation((_path, data) => {
       fileContent = data as string

--- a/packages/harness/scripts/build-platform.test.ts
+++ b/packages/harness/scripts/build-platform.test.ts
@@ -19,28 +19,41 @@
 
 import type {BuildArgs} from './build-platform.js'
 import {execFileSync, spawnSync} from 'node:child_process'
-import {readdirSync, readFileSync, statSync} from 'node:fs'
+import {readdirSync, readFileSync, statSync, writeFileSync} from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import {fileURLToPath} from 'node:url'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {HARNESS_BUN_VERSION} from '../src/bun-version.js'
 import {buildHarnessVersion} from '../src/version.js'
-import {cloneAndCheckout, enforceBunVersion, main, parseArgs, runUpstreamBuild} from './build-platform.js'
+import {
+  assertMuslBinary,
+  assertPatchLanded,
+  cloneAndCheckout,
+  enforceBunVersion,
+  main,
+  parseArgs,
+  patchBuildTs,
+  resolveTargetDirSuffix,
+  runUpstreamBuild,
+} from './build-platform.js'
 
 // ---------------------------------------------------------------------------
 // Drift guard
 // ---------------------------------------------------------------------------
 
 describe('drift guard: harness-release.yaml bun-version literals', () => {
-  it('all bun-version occurrences in harness-release.yaml equal HARNESS_BUN_VERSION', () => {
+  it('all bun-version occurrences in harness-release.yaml equal HARNESS_BUN_VERSION', async () => {
     // #given — resolve the workflow file relative to this test file (scripts/ → repo root)
     const thisDir = path.dirname(fileURLToPath(import.meta.url))
     const repoRoot = path.resolve(thisDir, '..', '..', '..')
     const workflowPath = path.join(repoRoot, '.github', 'workflows', 'harness-release.yaml')
 
-    // #when
-    const content = readFileSync(workflowPath, 'utf8')
+    // #when — use the REAL readFileSync (not the vi.mock'd one) to read the workflow file.
+    // vi.mock('node:fs') is hoisted and intercepts the module-level import, so we use
+    // vi.importActual to get the real node:fs module and bypass the mock.
+    const realFs = await vi.importActual<typeof import('node:fs')>('node:fs')
+    const content = realFs.readFileSync(workflowPath, 'utf8')
     const matches = [...content.matchAll(/bun-version:\s*(\d+\.\d+\.\d+)/g)]
 
     // #then — there must be at least one occurrence (sanity check)
@@ -78,6 +91,7 @@ vi.mock('node:fs', async importOriginal => {
     readdirSync: vi.fn(),
     mkdirSync: vi.fn(),
     cpSync: vi.fn(),
+    readFileSync: vi.fn(),
     writeFileSync: vi.fn(),
   }
 })
@@ -572,8 +586,8 @@ describe('runUpstreamBuild: version derivation is pure-from-arg', () => {
     const integrationCommit = 'deadbeef12345678'
     const expectedVersion = buildHarnessVersion(baseVersion, integrationCommit)
 
-    // #when
-    runUpstreamBuild('/some/source-tree', baseVersion, integrationCommit)
+    // #when — glibc default (abi=null, baseline=false)
+    runUpstreamBuild('/some/source-tree', baseVersion, integrationCommit, null, false)
 
     // #then — no git rev-parse call
     const gitRevParseCalls = mockedSpawnSync.mock.calls.filter(
@@ -592,6 +606,348 @@ describe('runUpstreamBuild: version derivation is pure-from-arg', () => {
     const buildEnv = (bunBuildCalls[0]?.[2] as {env?: Record<string, string>} | undefined)?.env
     expect(buildEnv?.OPENCODE_VERSION).toBe(expectedVersion)
     expect(expectedVersion).toBe(`${baseVersion}+harness.${integrationCommit.slice(0, 8)}`)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveTargetDirSuffix — target-name/dir resolution
+// ---------------------------------------------------------------------------
+
+describe('resolveTargetDirSuffix: target dir suffix computation', () => {
+  it('returns empty string for glibc default (no abi, no baseline)', () => {
+    // #given / #when / #then
+    expect(resolveTargetDirSuffix(null, false)).toBe('')
+  })
+
+  it('returns -musl for arm64 musl (no baseline)', () => {
+    // #given / #when / #then — linux-arm64-musl
+    expect(resolveTargetDirSuffix('musl', false)).toBe('-musl')
+  })
+
+  it('returns -baseline-musl for x64 baseline musl', () => {
+    // #given / #when / #then — linux-x64-baseline-musl
+    expect(resolveTargetDirSuffix('musl', true)).toBe('-baseline-musl')
+  })
+
+  it('returns -baseline for baseline-only (no abi)', () => {
+    // #given / #when / #then — e.g. linux-x64-baseline (avx2=false, glibc)
+    expect(resolveTargetDirSuffix(null, true)).toBe('-baseline')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseArgs — abi and baseline flags
+// ---------------------------------------------------------------------------
+
+describe('parseArgs: --abi and --baseline flags', () => {
+  const BASE_ARGV = [
+    'bun',
+    'build-platform.ts',
+    '--integration-commit',
+    'abc12345def67890',
+    '--base-version',
+    '1.15.13',
+    '--platform',
+    'linux',
+    '--arch',
+    'x64',
+  ]
+
+  it('parses --abi musl into BuildArgs.abi', () => {
+    // #given
+    const argv = [...BASE_ARGV, '--abi', 'musl']
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then
+    expect(result).not.toBeNull()
+    expect((result as BuildArgs).abi).toBe('musl')
+    expect((result as BuildArgs).baseline).toBe(false)
+  })
+
+  it('parses --baseline into BuildArgs.baseline', () => {
+    // #given
+    const argv = [...BASE_ARGV, '--abi', 'musl', '--baseline']
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then
+    expect(result).not.toBeNull()
+    expect((result as BuildArgs).abi).toBe('musl')
+    expect((result as BuildArgs).baseline).toBe(true)
+  })
+
+  it('defaults abi to null and baseline to false when flags are absent', () => {
+    // #given — no --abi or --baseline
+    const result = parseArgs(BASE_ARGV)
+
+    // #then
+    expect(result).not.toBeNull()
+    expect((result as BuildArgs).abi).toBeNull()
+    expect((result as BuildArgs).baseline).toBe(false)
+  })
+
+  it('rejects unknown abi values', () => {
+    // #given — unsupported abi
+    const argv = [...BASE_ARGV, '--abi', 'glibc']
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then — must return null (unsupported abi)
+    expect(result).toBeNull()
+  })
+
+  it('rejects abi value of "gnu"', () => {
+    // #given — 'gnu' is not a valid --abi value (only 'musl' is accepted)
+    const argv = [...BASE_ARGV, '--abi', 'gnu']
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// patchBuildTs + assertPatchLanded — patch mechanism
+// ---------------------------------------------------------------------------
+
+describe('patchBuildTs: build.ts patch mechanism', () => {
+  // patchBuildTs and assertPatchLanded use readFileSync/writeFileSync from node:fs,
+  // which are mocked globally. We control the mock to simulate file reads/writes
+  // without touching the real filesystem.
+
+  const mockedReadFileSync = vi.mocked(readFileSync)
+  const mockedWriteFileSync = vi.mocked(writeFileSync)
+
+  // The exact singleFlag musl-skip block from upstream build.ts (lines ~128-131).
+  // This is the patch target — must match what patchBuildTs looks for.
+  const PATCH_TARGET = `      // also skip abi-specific builds for the same reason
+      if (item.abi !== undefined) {
+        return false
+      }`
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('patches the singleFlag musl-skip block and adds the OPENCODE_TARGET_ABI hook', () => {
+    // #given — readFileSync returns a fake build.ts with the patch target
+    const fakeContent = `// preamble\n${PATCH_TARGET}\n// postamble`
+    mockedReadFileSync.mockImplementation(() => fakeContent)
+    let writtenContent = ''
+    mockedWriteFileSync.mockImplementation((_path, data) => {
+      writtenContent = data as string
+    })
+
+    // #when
+    patchBuildTs('/fake/build.ts')
+
+    // #then — the hook marker is present in the written content
+    expect(writtenContent).toContain('OPENCODE_TARGET_ABI')
+    expect(writtenContent).toContain('process.env["OPENCODE_TARGET_ABI"]')
+    // The original unconditional return false is gone
+    expect(writtenContent).not.toContain(
+      '// also skip abi-specific builds for the same reason\n      if (item.abi !== undefined) {\n        return false\n      }',
+    )
+  })
+
+  it('throws when the patch target is not found in build.ts', () => {
+    // #given — readFileSync returns content WITHOUT the expected patch target
+    mockedReadFileSync.mockImplementation(() => '// no singleFlag filter here\nconsole.log("hello")')
+
+    // #when / #then — must throw
+    expect(() => patchBuildTs('/fake/build.ts')).toThrow('patch target not found')
+  })
+
+  it('assertPatchLanded passes when the hook marker is present', () => {
+    // #given — readFileSync returns content with the hook marker
+    mockedReadFileSync.mockImplementation(() => '// OPENCODE_TARGET_ABI hook is here\nconsole.log("patched")')
+
+    // #when / #then — must not throw
+    expect(() => assertPatchLanded('/fake/build.ts')).not.toThrow()
+  })
+
+  it('assertPatchLanded throws when the hook marker is absent', () => {
+    // #given — readFileSync returns content without the hook marker
+    mockedReadFileSync.mockImplementation(() => '// no hook here\nconsole.log("hello")')
+
+    // #when / #then — must throw
+    expect(() => assertPatchLanded('/fake/build.ts')).toThrow('patch hook')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// assertMuslBinary — R11 musl linkage guard
+// ---------------------------------------------------------------------------
+
+describe('assertMuslBinary: R11 musl linkage guard', () => {
+  const mockedExecFileSync = vi.mocked(execFileSync)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('does not throw when file output shows statically linked (musl)', () => {
+    // #given — Bun musl compile produces a statically linked binary
+    mockedExecFileSync.mockReturnValue(
+      '/tmp/opencode: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped\n',
+    )
+
+    // #when / #then — must not throw
+    expect(() => assertMuslBinary('/tmp/opencode')).not.toThrow()
+  })
+
+  it('does not throw when file output shows musl linker', () => {
+    // #given — binary references musl dynamic linker
+    mockedExecFileSync.mockReturnValue(
+      '/tmp/opencode: ELF 64-bit LSB executable, x86-64, interpreter /lib/ld-musl-x86_64.so.1, stripped\n',
+    )
+
+    // #when / #then — must not throw
+    expect(() => assertMuslBinary('/tmp/opencode')).not.toThrow()
+  })
+
+  it('throws when file output shows glibc x86-64 interpreter', () => {
+    // #given — glibc binary
+    mockedExecFileSync.mockReturnValue(
+      '/tmp/opencode: ELF 64-bit LSB executable, x86-64, interpreter /lib64/ld-linux-x86-64.so.2, stripped\n',
+    )
+
+    // #when / #then — must throw with clear message
+    expect(() => assertMuslBinary('/tmp/opencode')).toThrow('glibc-linked')
+  })
+
+  it('throws when file output shows glibc aarch64 interpreter', () => {
+    // #given — glibc arm64 binary
+    mockedExecFileSync.mockReturnValue(
+      '/tmp/opencode: ELF 64-bit LSB executable, ARM aarch64, interpreter /lib/ld-linux-aarch64.so.1, stripped\n',
+    )
+
+    // #when / #then — must throw
+    expect(() => assertMuslBinary('/tmp/opencode')).toThrow('glibc-linked')
+  })
+
+  it('throws when file command itself fails', () => {
+    // #given — file command throws
+    mockedExecFileSync.mockImplementation(() => {
+      throw new Error('file: command not found')
+    })
+
+    // #when / #then — must throw
+    expect(() => assertMuslBinary('/tmp/opencode')).toThrow("'file' command failed")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runUpstreamBuild — musl/baseline target selection
+// ---------------------------------------------------------------------------
+
+describe('runUpstreamBuild: musl/baseline target env vars', () => {
+  const mockedSpawnSync = vi.mocked(spawnSync)
+  const mockedReadFileSync = vi.mocked(readFileSync)
+  const mockedWriteFileSync = vi.mocked(writeFileSync)
+
+  beforeEach(() => {
+    mockedSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: '',
+      stderr: '',
+      pid: 1,
+      output: [],
+      signal: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('does NOT set OPENCODE_TARGET_ABI when abi is null (glibc default)', () => {
+    // #given — glibc build (no abi, no baseline)
+    runUpstreamBuild('/some/source-tree', '1.15.13', 'deadbeef12345678', null, false)
+
+    // #then — build.ts invoked without OPENCODE_TARGET_ABI
+    const bunBuildCalls = mockedSpawnSync.mock.calls.filter(
+      call =>
+        call[0] === 'bun' &&
+        Array.isArray(call[1]) &&
+        call[1].some((a: unknown) => typeof a === 'string' && a.includes('build.ts')),
+    )
+    expect(bunBuildCalls.length).toBeGreaterThan(0)
+    const buildEnv = (bunBuildCalls[0]?.[2] as {env?: Record<string, string>} | undefined)?.env
+    expect(buildEnv?.OPENCODE_TARGET_ABI).toBeUndefined()
+    expect(buildEnv?.OPENCODE_TARGET_BASELINE).toBeUndefined()
+  })
+
+  it('sets OPENCODE_TARGET_ABI=musl when abi is musl', () => {
+    // #given — musl build; simulate the patch read/write cycle via stateful mocks.
+    // patchBuildTs reads the file (gets PATCH_TARGET), writes the patched content.
+    // assertPatchLanded reads the file again (must get the patched content with the hook).
+    const PATCH_TARGET = `      // also skip abi-specific builds for the same reason
+      if (item.abi !== undefined) {
+        return false
+      }`
+    // Stateful mock: tracks what was last written so assertPatchLanded sees the patched content.
+    let fileContent = PATCH_TARGET
+    mockedReadFileSync.mockImplementation(() => fileContent)
+    mockedWriteFileSync.mockImplementation((_path, data) => {
+      fileContent = data as string
+    })
+
+    // #when
+    runUpstreamBuild('/some/source-tree', '1.15.13', 'deadbeef12345678', 'musl', false)
+
+    // #then — build.ts invoked with OPENCODE_TARGET_ABI=musl
+    const bunBuildCalls = mockedSpawnSync.mock.calls.filter(
+      call =>
+        call[0] === 'bun' &&
+        Array.isArray(call[1]) &&
+        call[1].some((a: unknown) => typeof a === 'string' && a.includes('build.ts')),
+    )
+    expect(bunBuildCalls.length).toBeGreaterThan(0)
+    const buildEnv = (bunBuildCalls[0]?.[2] as {env?: Record<string, string>} | undefined)?.env
+    expect(buildEnv?.OPENCODE_TARGET_ABI).toBe('musl')
+    expect(buildEnv?.OPENCODE_TARGET_BASELINE).toBeUndefined()
+  })
+
+  it('sets OPENCODE_TARGET_ABI=musl and OPENCODE_TARGET_BASELINE=true when abi=musl and baseline=true', () => {
+    // #given — musl baseline build; stateful mock simulates the patch read/write cycle.
+    const PATCH_TARGET = `      // also skip abi-specific builds for the same reason
+      if (item.abi !== undefined) {
+        return false
+      }`
+    let fileContent = PATCH_TARGET
+    mockedReadFileSync.mockImplementation(() => fileContent)
+    mockedWriteFileSync.mockImplementation((_path, data) => {
+      fileContent = data as string
+    })
+
+    // #when
+    runUpstreamBuild('/some/source-tree', '1.15.13', 'deadbeef12345678', 'musl', true)
+
+    // #then
+    const bunBuildCalls = mockedSpawnSync.mock.calls.filter(
+      call =>
+        call[0] === 'bun' &&
+        Array.isArray(call[1]) &&
+        call[1].some((a: unknown) => typeof a === 'string' && a.includes('build.ts')),
+    )
+    expect(bunBuildCalls.length).toBeGreaterThan(0)
+    const buildEnv = (bunBuildCalls[0]?.[2] as {env?: Record<string, string>} | undefined)?.env
+    expect(buildEnv?.OPENCODE_TARGET_ABI).toBe('musl')
+    expect(buildEnv?.OPENCODE_TARGET_BASELINE).toBe('true')
   })
 })
 

--- a/packages/harness/scripts/build-platform.test.ts
+++ b/packages/harness/scripts/build-platform.test.ts
@@ -784,6 +784,30 @@ describe('parseArgs: --abi and --baseline flags', () => {
     // #then — cross-validation must reject
     expect(result).toBeNull()
   })
+
+  it('returns null when --abi musl is used with --platform darwin', () => {
+    // #given — --abi musl on darwin is not supported (linux-only); exercises the abi !== null branch
+    const argv = [
+      'bun',
+      'build-platform.ts',
+      '--integration-commit',
+      'abc12345def67890',
+      '--base-version',
+      '1.15.13',
+      '--platform',
+      'darwin',
+      '--arch',
+      'x64',
+      '--abi',
+      'musl',
+    ]
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then — cross-validation must reject
+    expect(result).toBeNull()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/harness/scripts/build-platform.test.ts
+++ b/packages/harness/scripts/build-platform.test.ts
@@ -724,21 +724,30 @@ describe('patchBuildTs: build.ts patch mechanism', () => {
   const mockedReadFileSync = vi.mocked(readFileSync)
   const mockedWriteFileSync = vi.mocked(writeFileSync)
 
-  // The exact singleFlag musl-skip block from upstream build.ts (lines ~128-131).
-  // This is the patch target — must match what patchBuildTs looks for.
-  const PATCH_TARGET = `      // also skip abi-specific builds for the same reason
+  // The exact baseline+abi+return-true block from upstream build.ts (lines 122-133).
+  // This is the NEW patch target — spans BOTH the baseline gate AND the abi gate.
+  // Must match what patchBuildTs looks for exactly (whitespace included).
+  const PATCH_TARGET = `      // When building for the current platform, prefer a single native binary by default.
+      // Baseline binaries require additional Bun artifacts and can be flaky to download.
+      if (item.avx2 === false) {
+        return baselineFlag
+      }
+
+      // also skip abi-specific builds for the same reason
       if (item.abi !== undefined) {
         return false
-      }`
+      }
+
+      return true`
 
   afterEach(() => {
     vi.restoreAllMocks()
     vi.clearAllMocks()
   })
 
-  it('patches the singleFlag musl-skip block and adds the OPENCODE_TARGET_ABI hook', () => {
+  it('patches the singleFlag baseline+abi block and adds the OPENCODE_TARGET_ABI hook', () => {
     // #given — readFileSync returns a fake build.ts with the patch target
-    const fakeContent = `// preamble\n${PATCH_TARGET}\n// postamble`
+    const fakeContent = `// preamble\n${PATCH_TARGET}\n    })\n  : allTargets`
     mockedReadFileSync.mockImplementation(() => fakeContent)
     let writtenContent = ''
     mockedWriteFileSync.mockImplementation((_path, data) => {
@@ -751,10 +760,50 @@ describe('patchBuildTs: build.ts patch mechanism', () => {
     // #then — the hook marker is present in the written content
     expect(writtenContent).toContain('OPENCODE_TARGET_ABI')
     expect(writtenContent).toContain('process.env["OPENCODE_TARGET_ABI"]')
-    // The original unconditional return false is gone
-    expect(writtenContent).not.toContain(
-      '// also skip abi-specific builds for the same reason\n      if (item.abi !== undefined) {\n        return false\n      }',
-    )
+    // The original unconditional baseline gate is preserved in the fallback path
+    expect(writtenContent).toContain('return baselineFlag')
+    // The original unconditional abi skip is preserved in the fallback path
+    expect(writtenContent).toContain('if (item.abi !== undefined)')
+  })
+
+  it('patched filter rejects default glibc target when OPENCODE_TARGET_ABI is set', () => {
+    // #given — readFileSync returns a fake build.ts with the patch target
+    const fakeContent = `// preamble\n${PATCH_TARGET}\n    })\n  : allTargets`
+    mockedReadFileSync.mockImplementation(() => fakeContent)
+    let writtenContent = ''
+    mockedWriteFileSync.mockImplementation((_path, data) => {
+      writtenContent = data as string
+    })
+
+    // #when
+    patchBuildTs('/fake/build.ts')
+
+    // #then — the patched content contains the explicit-target-mode block that:
+    // 1. Checks item.abi !== _harnessTargetAbi (rejects glibc target with no abi)
+    expect(writtenContent).toContain('if (item.abi !== _harnessTargetAbi)')
+    // 2. Honors the baseline flag via avx2===false comparison
+    expect(writtenContent).toContain('(item.avx2 === false) !== _harnessTargetBaseline')
+    // 3. Returns true only when both abi and baseline match
+    expect(writtenContent).toContain('return true')
+    // 4. The original baseline gate is preserved in the fallback path (no env var set)
+    expect(writtenContent).toContain('return baselineFlag')
+  })
+
+  it('patched filter honors OPENCODE_TARGET_BASELINE at the avx2 gate', () => {
+    // #given — readFileSync returns a fake build.ts with the patch target
+    const fakeContent = `// preamble\n${PATCH_TARGET}\n    })\n  : allTargets`
+    mockedReadFileSync.mockImplementation(() => fakeContent)
+    let writtenContent = ''
+    mockedWriteFileSync.mockImplementation((_path, data) => {
+      writtenContent = data as string
+    })
+
+    // #when
+    patchBuildTs('/fake/build.ts')
+
+    // #then — the patched content reads OPENCODE_TARGET_BASELINE and compares avx2===false
+    expect(writtenContent).toContain('process.env["OPENCODE_TARGET_BASELINE"] === "true"')
+    expect(writtenContent).toContain('item.avx2 === false')
   })
 
   it('throws when the patch target is not found in build.ts', () => {
@@ -895,10 +944,19 @@ describe('runUpstreamBuild: musl/baseline target env vars', () => {
     // #given — musl build; simulate the patch read/write cycle via stateful mocks.
     // patchBuildTs reads the file (gets PATCH_TARGET), writes the patched content.
     // assertPatchLanded reads the file again (must get the patched content with the hook).
-    const PATCH_TARGET = `      // also skip abi-specific builds for the same reason
+    // PATCH_TARGET must match the NEW TARGET_ORIGINAL (the full baseline+abi+return-true block).
+    const PATCH_TARGET = `      // When building for the current platform, prefer a single native binary by default.
+      // Baseline binaries require additional Bun artifacts and can be flaky to download.
+      if (item.avx2 === false) {
+        return baselineFlag
+      }
+
+      // also skip abi-specific builds for the same reason
       if (item.abi !== undefined) {
         return false
-      }`
+      }
+
+      return true`
     // Stateful mock: tracks what was last written so assertPatchLanded sees the patched content.
     let fileContent = PATCH_TARGET
     mockedReadFileSync.mockImplementation(() => fileContent)
@@ -924,10 +982,19 @@ describe('runUpstreamBuild: musl/baseline target env vars', () => {
 
   it('sets OPENCODE_TARGET_ABI=musl and OPENCODE_TARGET_BASELINE=true when abi=musl and baseline=true', () => {
     // #given — musl baseline build; stateful mock simulates the patch read/write cycle.
-    const PATCH_TARGET = `      // also skip abi-specific builds for the same reason
+    // PATCH_TARGET must match the NEW TARGET_ORIGINAL (the full baseline+abi+return-true block).
+    const PATCH_TARGET = `      // When building for the current platform, prefer a single native binary by default.
+      // Baseline binaries require additional Bun artifacts and can be flaky to download.
+      if (item.avx2 === false) {
+        return baselineFlag
+      }
+
+      // also skip abi-specific builds for the same reason
       if (item.abi !== undefined) {
         return false
-      }`
+      }
+
+      return true`
     let fileContent = PATCH_TARGET
     mockedReadFileSync.mockImplementation(() => fileContent)
     mockedWriteFileSync.mockImplementation((_path, data) => {

--- a/packages/harness/scripts/build-platform.test.ts
+++ b/packages/harness/scripts/build-platform.test.ts
@@ -36,6 +36,7 @@ import {
   patchBuildTs,
   resolveTargetDirSuffix,
   runUpstreamBuild,
+  verifyBuiltBinary,
 } from './build-platform.js'
 
 // ---------------------------------------------------------------------------
@@ -1058,5 +1059,134 @@ describe('cloneAndCheckout: backward-compat', () => {
       call => call[0] === 'git' && Array.isArray(call[1]) && call[1].includes('clone'),
     )
     expect(gitCloneCalls.length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// verifyBuiltBinary — musl execution skip + glibc execution
+// ---------------------------------------------------------------------------
+
+describe('verifyBuiltBinary: musl skip vs glibc execution', () => {
+  const mockedExecFileSync = vi.mocked(execFileSync)
+  const mockedSpawnSync = vi.mocked(spawnSync)
+
+  const BINARY_PATH = '/tmp/dist/opencode-linux-x64-baseline-musl/bin/opencode'
+  const EXPECTED_VERSION = '1.15.13+harness.abc12345'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default: binary exists (test -f returns 0)
+    mockedSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: '',
+      stderr: '',
+      pid: 1,
+      output: [],
+      signal: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  // -------------------------------------------------------------------------
+  // musl target: existence checked, --version NOT executed
+  // -------------------------------------------------------------------------
+
+  it('musl target: does not call execFileSync (no --version execution)', () => {
+    // #given — musl target; binary exists (spawnSync test -f returns 0)
+
+    // #when
+    verifyBuiltBinary(BINARY_PATH, EXPECTED_VERSION, 'musl')
+
+    // #then — execFileSync was NOT called (no --version execution)
+    expect(mockedExecFileSync).not.toHaveBeenCalled()
+  })
+
+  it('musl target: does not throw when binary exists', () => {
+    // #given — musl target; binary exists
+
+    // #when / #then — must not throw
+    expect(() => verifyBuiltBinary(BINARY_PATH, EXPECTED_VERSION, 'musl')).not.toThrow()
+  })
+
+  it('musl target: throws when binary does not exist', () => {
+    // #given — musl target; binary missing (test -f returns non-zero)
+    mockedSpawnSync.mockReturnValue({
+      status: 1,
+      stdout: '',
+      stderr: '',
+      pid: 1,
+      output: [],
+      signal: null,
+    })
+
+    // #when / #then — must throw with "not found" message
+    expect(() => verifyBuiltBinary(BINARY_PATH, EXPECTED_VERSION, 'musl')).toThrow('Built binary not found at')
+  })
+
+  // -------------------------------------------------------------------------
+  // glibc target: existence checked + --version executed + version asserted
+  // -------------------------------------------------------------------------
+
+  it('glibc target: calls execFileSync with --version', () => {
+    // #given — glibc target (abi=null); binary exists; --version returns expected version
+    mockedExecFileSync.mockReturnValue(`${EXPECTED_VERSION}\n`)
+
+    // #when
+    verifyBuiltBinary(BINARY_PATH, EXPECTED_VERSION, null)
+
+    // #then — execFileSync was called with the binary and --version
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      BINARY_PATH,
+      ['--version'],
+      expect.objectContaining({encoding: 'utf8'}),
+    )
+  })
+
+  it('glibc target: does not throw when --version matches expected version', () => {
+    // #given — glibc target; --version returns exact expected version
+    mockedExecFileSync.mockReturnValue(`${EXPECTED_VERSION}\n`)
+
+    // #when / #then — must not throw
+    expect(() => verifyBuiltBinary(BINARY_PATH, EXPECTED_VERSION, null)).not.toThrow()
+  })
+
+  it('glibc target: throws on version mismatch', () => {
+    // #given — glibc target; --version returns wrong version
+    mockedExecFileSync.mockReturnValue('1.0.0-wrong\n')
+
+    // #when / #then — must throw with version mismatch message
+    expect(() => verifyBuiltBinary(BINARY_PATH, EXPECTED_VERSION, null)).toThrow('Version mismatch')
+  })
+
+  it('glibc target: throws when --version execution fails (ENOENT)', () => {
+    // #given — glibc target; execFileSync throws (binary not executable or missing loader)
+    mockedExecFileSync.mockImplementation(() => {
+      const err = new Error('ENOENT: no such file or directory, posix_spawn') as NodeJS.ErrnoException
+      err.code = 'ENOENT'
+      throw err
+    })
+
+    // #when / #then — must throw with "Binary --version failed" message
+    expect(() => verifyBuiltBinary(BINARY_PATH, EXPECTED_VERSION, null)).toThrow('Binary --version failed')
+  })
+
+  it('glibc target: throws when binary does not exist', () => {
+    // #given — glibc target; binary missing (test -f returns non-zero)
+    mockedSpawnSync.mockReturnValue({
+      status: 1,
+      stdout: '',
+      stderr: '',
+      pid: 1,
+      output: [],
+      signal: null,
+    })
+
+    // #when / #then — must throw before attempting --version
+    expect(() => verifyBuiltBinary(BINARY_PATH, EXPECTED_VERSION, null)).toThrow('Built binary not found at')
+    expect(mockedExecFileSync).not.toHaveBeenCalled()
   })
 })

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -17,7 +17,9 @@
  *     The version string embeds the integration commit short SHA so the binary
  *     self-reports it. The upstream build bakes OPENCODE_VERSION into the binary
  *     via the `define: { OPENCODE_VERSION: ... }` field in build.ts.
- *   - Built binary --version is verified == OPENCODE_VERSION before emitting.
+ *   - Built binary --version is verified == OPENCODE_VERSION before emitting (glibc targets only;
+ *     musl targets skip execution — cannot run musl binary on glibc runner — and rely on
+ *     assertMuslBinary() file-based linkage check instead).
  *   - provenance.json is written to packages/harness/ for the workflow assemble step.
  *
  * Integration commit embedding mechanism:
@@ -502,12 +504,27 @@ function resolveBuiltBinaryPath(
   return path.join(workDir, 'packages', 'opencode', 'dist', name, 'bin', binary)
 }
 
-function verifyBuiltBinary(binaryPath: string, expectedVersion: string): void {
+export function verifyBuiltBinary(binaryPath: string, expectedVersion: string, abi: 'musl' | null): void {
   console.log(`[build-platform] Verifying binary: ${binaryPath} --version`)
 
   const binaryExists = spawnSync('test', ['-f', binaryPath]).status === 0
   if (!binaryExists) {
     throw new Error(`Built binary not found at: ${binaryPath}`)
+  }
+
+  if (abi === 'musl') {
+    // musl binaries cannot execute on a glibc runner (posix_spawn ENOENT — no compatible loader).
+    // Upstream build.ts guards its own smoke test the same way (build.ts:201-202):
+    //   if (item.os === process.platform && item.arch === process.arch && !item.abi)
+    // Skip --version execution for musl targets; correctness is proven by:
+    //   (a) binary exists (checked above), and
+    //   (b) assertMuslBinary() (file-based libc check) which runs immediately after this call.
+    // The version string is baked at compile time via OPENCODE_VERSION define — we trust the build.
+    console.log(
+      `[build-platform] Skipping --version execution for musl target (cannot run musl binary on glibc runner). ` +
+        `Existence confirmed; musl linkage will be verified by assertMuslBinary().`,
+    )
+    return
   }
 
   let actual: string
@@ -684,7 +701,7 @@ export async function main(): Promise<void> {
   const binaryPath = resolveBuiltBinaryPath(buildSourceDir, platform, arch, abi, baseline)
   const expectedVersion = buildHarnessVersion(baseVersion, integrationCommit)
   try {
-    verifyBuiltBinary(binaryPath, expectedVersion)
+    verifyBuiltBinary(binaryPath, expectedVersion, abi)
   } catch (error) {
     console.error(`[build-platform] Verification failed: ${error instanceof Error ? error.message : String(error)}`)
     process.exit(1)

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -46,7 +46,7 @@
  */
 
 import {execFileSync, spawnSync} from 'node:child_process'
-import {cpSync, mkdirSync, readdirSync, statSync, writeFileSync} from 'node:fs'
+import {cpSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync} from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import {fileURLToPath} from 'node:url'
@@ -86,6 +86,10 @@ export interface BuildArgs {
   readonly workDir: string
   readonly outDir: string
   readonly sourceTree: string | null
+  /** musl ABI variant — when set to 'musl', selects the musl target in build.ts */
+  readonly abi: 'musl' | null
+  /** When true, selects the baseline (avx2=false) target variant */
+  readonly baseline: boolean
 }
 
 export function parseArgs(argv: string[]): BuildArgs | null {
@@ -122,6 +126,17 @@ export function parseArgs(argv: string[]): BuildArgs | null {
   }
   const sourceTree = sourceTreeValue
 
+  // --abi: optional, only 'musl' is accepted (additive; glibc is the default when absent).
+  const abiRaw = flag('--abi')
+  if (abiRaw !== null && abiRaw !== 'musl') {
+    console.error(`[build-platform] --abi '${abiRaw}' is not supported. Only 'musl' is accepted.`)
+    return null
+  }
+  const abi = abiRaw === 'musl' ? 'musl' : null
+
+  // --baseline: optional boolean flag (presence = true).
+  const baseline = args.includes('--baseline')
+
   if (integrationCommit === null || baseVersion === null || platform === null || arch === null) {
     console.error('[build-platform] Missing required arguments.')
     console.error('  Required: --integration-commit, --base-version, --platform, --arch')
@@ -129,7 +144,7 @@ export function parseArgs(argv: string[]): BuildArgs | null {
     return null
   }
 
-  return {integrationCommit, baseVersion, platform, arch, repoUrl, workDir, outDir, sourceTree}
+  return {integrationCommit, baseVersion, platform, arch, repoUrl, workDir, outDir, sourceTree, abi, baseline}
 }
 
 function printHelp(): void {
@@ -142,6 +157,8 @@ Usage:
     --base-version <version>            Base release version (e.g. 1.15.13)
     --platform <linux|darwin>           Target OS (linux or darwin; no windows)
     --arch <x64|arm64>                  Target CPU arch
+    [--abi musl]                        ABI variant (only 'musl' accepted; omit for glibc default)
+    [--baseline]                        Select the baseline (avx2=false) target variant
     [--repo-url <url>]                  Upstream repo URL (default: anomalyco/opencode)
     [--work-dir <path>]                 Working directory for the clone (default: .harness-build-work)
     [--out-dir <path>]                  Output directory for the native binary (default: .harness-build-out)
@@ -155,6 +172,13 @@ Build-environment contract:
   - Built binary --version verified == OPENCODE_VERSION before emitting.
   - provenance.json written to packages/harness/ for the workflow assemble step.
   - Exits non-zero on any failure.
+
+Musl/baseline variants:
+  - --abi musl --baseline: selects linux-x64-baseline-musl (avx2=false, musl)
+  - --abi musl (no --baseline): selects linux-arm64-musl (arm64, musl)
+  - No flags: selects the default glibc target for the current platform/arch (unchanged behavior).
+  - The build.ts singleFlag filter is patched in-place in the source tree to honor
+    OPENCODE_TARGET_ABI / OPENCODE_TARGET_BASELINE env vars before invoking build.ts.
 `)
 }
 
@@ -213,10 +237,159 @@ export function cloneAndCheckout(repoUrl: string, workDir: string, commit: strin
 }
 
 // ---------------------------------------------------------------------------
+// Target-name helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes the dist dir suffix that upstream build.ts appends for musl/baseline variants.
+ *
+ * Upstream build.ts `name` computation (lines 146-155):
+ *   [pkg.name, os, arch, avx2===false ? 'baseline' : undefined, abi ?? undefined].filter(Boolean).join('-')
+ *
+ * So for our targets:
+ *   linux/x64 + baseline + musl → opencode-linux-x64-baseline-musl
+ *   linux/arm64 + musl (no baseline) → opencode-linux-arm64-musl
+ *   linux/x64 (glibc, no baseline) → opencode-linux-x64  (unchanged)
+ *
+ * Returns the suffix string to append after `opencode-<os>-<arch>`, e.g. '-baseline-musl'.
+ * Returns '' for the default glibc target.
+ */
+export function resolveTargetDirSuffix(abi: 'musl' | null, baseline: boolean): string {
+  const parts: string[] = []
+  if (baseline) parts.push('baseline')
+  if (abi !== null) parts.push(abi)
+  return parts.length > 0 ? `-${parts.join('-')}` : ''
+}
+
+/**
+ * Patches the upstream build.ts singleFlag filter in-place to honor
+ * OPENCODE_TARGET_ABI and OPENCODE_TARGET_BASELINE env vars for explicit target selection.
+ *
+ * The patch is MINIMAL and LOCAL to the singleFlag filter block (R12).
+ * It replaces the unconditional `if (item.abi !== undefined) { return false }` guard
+ * with a conditional that allows the target through when the env vars match.
+ *
+ * The patch hook string is: `OPENCODE_TARGET_ABI` — used by the R11 guard to assert
+ * the patch landed before building.
+ *
+ * @param buildTsPath - Absolute path to the integration-tree build.ts to patch.
+ */
+export function patchBuildTs(buildTsPath: string): void {
+  console.log(`[build-platform] Patching build.ts for explicit target selection: ${buildTsPath}`)
+
+  const original = readFileSync(buildTsPath, 'utf8')
+
+  // The exact text we're replacing — the unconditional musl skip in the singleFlag filter.
+  // This matches build.ts lines ~128-131 (verified against .slim/clonedeps source).
+  const TARGET_ORIGINAL = `      // also skip abi-specific builds for the same reason
+      if (item.abi !== undefined) {
+        return false
+      }`
+
+  // The replacement: honor OPENCODE_TARGET_ABI / OPENCODE_TARGET_BASELINE env vars
+  // for explicit target selection. When these env vars are set, the filter selects
+  // the target that matches them instead of unconditionally skipping musl/baseline.
+  // The loop body already handles abi/baseline correctly — only the filter needs this hook.
+  const TARGET_REPLACEMENT = `      // also skip abi-specific builds for the same reason,
+      // UNLESS an explicit target is requested via OPENCODE_TARGET_ABI env var.
+      // This hook is injected by the harness build-platform.ts for musl/baseline targets.
+      // OPENCODE_TARGET_ABI
+      if (item.abi !== undefined) {
+        const targetAbi = process.env["OPENCODE_TARGET_ABI"]
+        const targetBaseline = process.env["OPENCODE_TARGET_BASELINE"] === "true"
+        if (targetAbi === undefined || item.abi !== targetAbi) {
+          return false
+        }
+        // When targeting musl, also match the baseline flag
+        if (item.avx2 === false && !targetBaseline) {
+          return false
+        }
+        if (item.avx2 !== false && targetBaseline) {
+          return false
+        }
+      }`
+
+  if (!original.includes(TARGET_ORIGINAL)) {
+    throw new Error(
+      `[build-platform] build.ts patch target not found — upstream build.ts shape may have changed. ` +
+        `Expected to find the singleFlag musl-skip block. Refusing to build with an unpatched build.ts.`,
+    )
+  }
+
+  const patched = original.replace(TARGET_ORIGINAL, TARGET_REPLACEMENT)
+  writeFileSync(buildTsPath, patched, 'utf8')
+  console.log(`[build-platform] build.ts patched successfully.`)
+}
+
+/**
+ * R11 guard: asserts the patch hook landed in the patched build.ts.
+ * Throws if the hook string is absent — meaning the patch silently failed.
+ */
+export function assertPatchLanded(buildTsPath: string): void {
+  const content = readFileSync(buildTsPath, 'utf8')
+  // The hook comment is the canonical marker — present iff the patch succeeded.
+  const HOOK_MARKER = 'OPENCODE_TARGET_ABI'
+  if (!content.includes(HOOK_MARKER)) {
+    throw new Error(
+      `[build-platform] R11 guard: patch hook '${HOOK_MARKER}' not found in ${buildTsPath} after patching. ` +
+        `The patch did not land. Refusing to build.`,
+    )
+  }
+  console.log(`[build-platform] R11 guard: patch hook confirmed in build.ts.`)
+}
+
+/**
+ * R11 guard: asserts the emitted binary is actually a musl binary (not glibc).
+ * Uses `file` to inspect the binary's ELF interpreter / linkage.
+ * Throws if the binary appears to be glibc-linked.
+ *
+ * musl statically-linked binaries show "statically linked" or reference "musl" in `file` output.
+ * glibc binaries reference "/lib64/ld-linux-x86-64.so.2" or similar glibc interpreter.
+ */
+export function assertMuslBinary(binaryPath: string): void {
+  console.log(`[build-platform] R11 guard: asserting musl linkage for ${binaryPath}`)
+
+  let fileOutput: string
+  try {
+    fileOutput = execFileSync('file', [binaryPath], {encoding: 'utf8', timeout: 10_000}).trim()
+  } catch (error) {
+    throw new Error(
+      `[build-platform] R11 guard: 'file' command failed on ${binaryPath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    )
+  }
+
+  console.log(`[build-platform] file output: ${fileOutput}`)
+
+  // glibc binaries reference the glibc dynamic linker (ld-linux-*.so or ld-linux-x86-64.so.2).
+  // musl binaries are either statically linked or reference the musl linker (ld-musl-*).
+  // Bun musl compile targets produce statically linked binaries.
+  const glibcPatterns = [/ld-linux-x86-64\.so/, /ld-linux-aarch64\.so/, /ld-linux\.so/, /interpreter \/lib.*ld-linux/]
+  for (const pattern of glibcPatterns) {
+    if (pattern.test(fileOutput)) {
+      throw new Error(
+        `[build-platform] R11 guard: binary at ${binaryPath} appears to be glibc-linked (file output: '${fileOutput}'). ` +
+          `A musl target was requested but the binary is not musl. ` +
+          `This means the build.ts patch did not correctly select the musl target.`,
+      )
+    }
+  }
+
+  console.log(`[build-platform] R11 guard: musl linkage confirmed (no glibc interpreter found).`)
+}
+
+// ---------------------------------------------------------------------------
 // Build invocation
 // ---------------------------------------------------------------------------
 
-export function runUpstreamBuild(workDir: string, baseVersion: string, integrationCommit: string): void {
+export function runUpstreamBuild(
+  workDir: string,
+  baseVersion: string,
+  integrationCommit: string,
+  abi: 'musl' | null,
+  baseline: boolean,
+): void {
   const opencodeVersion = buildHarnessVersion(baseVersion, integrationCommit)
   console.log(`[build-platform] Running upstream build in ${workDir}`)
   console.log(`[build-platform] Env: OPENCODE_CHANNEL=${OPENCODE_CHANNEL} OPENCODE_VERSION=${opencodeVersion}`)
@@ -242,14 +415,36 @@ export function runUpstreamBuild(workDir: string, baseVersion: string, integrati
     throw new Error(`Workspace install failed with exit code ${installResult.status ?? 'unknown'}`)
   }
 
+  // For musl/baseline targets, patch the upstream build.ts singleFlag filter to honor
+  // OPENCODE_TARGET_ABI / OPENCODE_TARGET_BASELINE env vars (R12: minimal, local patch).
+  // The patch is applied in-place to the source tree before invoking build.ts.
+  const buildTsPath = path.join(workDir, 'packages', 'opencode', 'script', 'build.ts')
+  const buildEnv: Record<string, string> = {
+    ...process.env,
+    OPENCODE_CHANNEL,
+    OPENCODE_VERSION: opencodeVersion,
+  }
+
+  if (abi !== null || baseline) {
+    // Apply the ephemeral patch to the integration-tree build.ts.
+    patchBuildTs(buildTsPath)
+    // R11 guard: assert the patch hook landed before building.
+    assertPatchLanded(buildTsPath)
+
+    // Set env vars that the patched singleFlag filter reads to select the target.
+    if (abi !== null) {
+      buildEnv.OPENCODE_TARGET_ABI = abi
+    }
+    if (baseline) {
+      buildEnv.OPENCODE_TARGET_BASELINE = 'true'
+    }
+    console.log(`[build-platform] Musl/baseline target selected: abi=${abi ?? 'none'} baseline=${String(baseline)}`)
+  }
+
   const result = spawnSync('bun', ['./packages/opencode/script/build.ts', '--single'], {
     cwd: workDir, // NOTE: workDir (repo root) — build.ts does its own process.chdir to packages/opencode
     stdio: 'inherit',
-    env: {
-      ...process.env,
-      OPENCODE_CHANNEL,
-      OPENCODE_VERSION: opencodeVersion,
-    },
+    env: buildEnv,
     timeout: 30 * 60 * 1000, // 30-minute hard timeout
   })
 
@@ -262,9 +457,18 @@ export function runUpstreamBuild(workDir: string, baseVersion: string, integrati
 // Binary resolution and version verification
 // ---------------------------------------------------------------------------
 
-function resolveBuiltBinaryPath(workDir: string, platform: string, arch: string): string {
-  // Upstream build.ts emits to: packages/opencode/dist/opencode-<os>-<arch>/bin/opencode
-  const name = `opencode-${platform}-${arch}`
+function resolveBuiltBinaryPath(
+  workDir: string,
+  platform: string,
+  arch: string,
+  abi: 'musl' | null,
+  baseline: boolean,
+): string {
+  // Upstream build.ts emits to: packages/opencode/dist/opencode-<os>-<arch>[suffix]/bin/opencode
+  // The suffix matches the `name` computation in build.ts (lines 146-155):
+  //   [pkg.name, os, arch, avx2===false ? 'baseline' : undefined, abi ?? undefined].filter(Boolean).join('-')
+  const suffix = resolveTargetDirSuffix(abi, baseline)
+  const name = `opencode-${platform}-${arch}${suffix}`
   const binary = 'opencode'
   return path.join(workDir, 'packages', 'opencode', 'dist', name, 'bin', binary)
 }
@@ -300,9 +504,19 @@ function verifyBuiltBinary(binaryPath: string, expectedVersion: string): void {
 // Output emission
 // ---------------------------------------------------------------------------
 
-function emitBinary(binaryPath: string, outDir: string, platform: string, arch: string): string {
+function emitBinary(
+  binaryPath: string,
+  outDir: string,
+  platform: string,
+  arch: string,
+  abi: 'musl' | null,
+  baseline: boolean,
+): string {
   mkdirSync(outDir, {recursive: true})
-  const destName = `opencode-${platform}-${arch}`
+  // The emitted out-dir name matches the upstream dist dir name so the release workflow
+  // and workspace Dockerfile can find the asset by its canonical name.
+  const suffix = resolveTargetDirSuffix(abi, baseline)
+  const destName = `opencode-${platform}-${arch}${suffix}`
   const destBinDir = path.join(outDir, destName, 'bin')
   mkdirSync(destBinDir, {recursive: true})
   const destPath = path.join(destBinDir, 'opencode')
@@ -357,7 +571,7 @@ export async function main(): Promise<void> {
     process.exit(1)
   }
 
-  const {integrationCommit, baseVersion, platform, arch, repoUrl, workDir, outDir, sourceTree} = args
+  const {integrationCommit, baseVersion, platform, arch, repoUrl, workDir, outDir, sourceTree, abi, baseline} = args
 
   // Derive the harness package directory (two levels up from this script).
   const harnessPackageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
@@ -366,6 +580,8 @@ export async function main(): Promise<void> {
   console.log(`  integration commit: ${integrationCommit}`)
   console.log(`  base version:       ${baseVersion}`)
   console.log(`  platform:           ${platform}/${arch}`)
+  console.log(`  abi:                ${abi ?? 'glibc (default)'}`)
+  console.log(`  baseline:           ${String(baseline)}`)
   if (sourceTree === null) {
     console.log(`  repo:               ${repoUrl}`)
     console.log(`  work dir:           ${workDir}`)
@@ -426,15 +642,17 @@ export async function main(): Promise<void> {
   //    OPENCODE_VERSION embeds the integration commit short SHA for binary self-reporting.
   //    Version derivation is pure-from-arg (buildHarnessVersion uses --integration-commit
   //    directly; no git rev-parse is invoked — works with no .git present).
+  //    For musl/baseline targets, runUpstreamBuild patches build.ts in-place and sets
+  //    OPENCODE_TARGET_ABI / OPENCODE_TARGET_BASELINE env vars before invoking build.ts.
   try {
-    runUpstreamBuild(buildSourceDir, baseVersion, integrationCommit)
+    runUpstreamBuild(buildSourceDir, baseVersion, integrationCommit, abi, baseline)
   } catch (error) {
     console.error(`[build-platform] Build failed: ${error instanceof Error ? error.message : String(error)}`)
     process.exit(1)
   }
 
   // 4. Verify the built binary --version == OPENCODE_VERSION (build-environment contract).
-  const binaryPath = resolveBuiltBinaryPath(buildSourceDir, platform, arch)
+  const binaryPath = resolveBuiltBinaryPath(buildSourceDir, platform, arch, abi, baseline)
   const expectedVersion = buildHarnessVersion(baseVersion, integrationCommit)
   try {
     verifyBuiltBinary(binaryPath, expectedVersion)
@@ -443,9 +661,22 @@ export async function main(): Promise<void> {
     process.exit(1)
   }
 
+  // 4a. R11 guard: for musl targets, assert the emitted binary is actually musl (not glibc).
+  //     This runs in the real publish path (not only dry-run) because the LLM-merge
+  //     integration commit differs per run, making a green dry-run non-authoritative.
+  if (abi === 'musl') {
+    try {
+      assertMuslBinary(binaryPath)
+    } catch (error) {
+      console.error(`[build-platform] R11 musl guard failed: ${error instanceof Error ? error.message : String(error)}`)
+      process.exit(1)
+    }
+  }
+
   // 5. Emit the binary to the output directory.
+  const suffix = resolveTargetDirSuffix(abi, baseline)
   try {
-    emitBinary(binaryPath, outDir, platform, arch)
+    emitBinary(binaryPath, outDir, platform, arch, abi, baseline)
   } catch (error) {
     console.error(`[build-platform] Emit failed: ${error instanceof Error ? error.message : String(error)}`)
     process.exit(1)
@@ -460,7 +691,7 @@ export async function main(): Promise<void> {
     process.exit(1)
   }
 
-  console.log(`[build-platform] Done. Binary ready at: ${outDir}/opencode-${platform}-${arch}/bin/opencode`)
+  console.log(`[build-platform] Done. Binary ready at: ${outDir}/opencode-${platform}-${arch}${suffix}/bin/opencode`)
 }
 
 // Only run when executed directly (not when imported by tests or other modules).

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -265,9 +265,17 @@ export function resolveTargetDirSuffix(abi: 'musl' | null, baseline: boolean): s
  * Patches the upstream build.ts singleFlag filter in-place to honor
  * OPENCODE_TARGET_ABI and OPENCODE_TARGET_BASELINE env vars for explicit target selection.
  *
- * The patch is MINIMAL and LOCAL to the singleFlag filter block (R12).
- * It replaces the unconditional `if (item.abi !== undefined) { return false }` guard
- * with a conditional that allows the target through when the env vars match.
+ * The patch replaces the ENTIRE baseline+abi+return-true block (lines 122-133 in upstream
+ * build.ts) with a single coherent block that:
+ *   - When OPENCODE_TARGET_ABI is set: selects ONLY the target matching {abi, baseline},
+ *     rejecting the default glibc target (no abi) AND wrong baseline variants.
+ *   - When OPENCODE_TARGET_ABI is NOT set: preserves original behavior exactly.
+ *
+ * This fixes two bugs in the prior patch:
+ *   1. The baseline gate (avx2===false → return baselineFlag) was hit BEFORE the abi gate,
+ *      so a baseline-musl target was rejected at line 124 before reaching the patched abi block.
+ *   2. The default glibc target (no abi, no avx2) was not suppressed when an explicit musl
+ *      target was requested, causing the glibc linux-x64 binary to build instead.
  *
  * The patch hook string is: `OPENCODE_TARGET_ABI` — used by the R11 guard to assert
  * the patch landed before building.
@@ -279,40 +287,62 @@ export function patchBuildTs(buildTsPath: string): void {
 
   const original = readFileSync(buildTsPath, 'utf8')
 
-  // The exact text we're replacing — the unconditional musl skip in the singleFlag filter.
-  // This matches build.ts lines ~128-131 (verified against .slim/clonedeps source).
-  const TARGET_ORIGINAL = `      // also skip abi-specific builds for the same reason
+  // The exact text we're replacing — the ENTIRE baseline+abi+return-true block in the
+  // singleFlag filter. Spans lines 122-133 in upstream build.ts (verified against
+  // .slim/clonedeps/repos/anomalyco__opencode/packages/opencode/script/build.ts).
+  const TARGET_ORIGINAL = `      // When building for the current platform, prefer a single native binary by default.
+      // Baseline binaries require additional Bun artifacts and can be flaky to download.
+      if (item.avx2 === false) {
+        return baselineFlag
+      }
+
+      // also skip abi-specific builds for the same reason
       if (item.abi !== undefined) {
         return false
-      }`
+      }
 
-  // The replacement: honor OPENCODE_TARGET_ABI / OPENCODE_TARGET_BASELINE env vars
-  // for explicit target selection. When these env vars are set, the filter selects
-  // the target that matches them instead of unconditionally skipping musl/baseline.
-  // The loop body already handles abi/baseline correctly — only the filter needs this hook.
-  const TARGET_REPLACEMENT = `      // also skip abi-specific builds for the same reason,
-      // UNLESS an explicit target is requested via OPENCODE_TARGET_ABI env var.
+      return true`
+
+  // The replacement: when OPENCODE_TARGET_ABI is set, drive the ENTIRE selection from the
+  // explicit target spec — honoring both the baseline gate (avx2===false) and the abi gate,
+  // AND suppressing the default glibc target (no abi) so only the requested {abi, baseline}
+  // target survives. When OPENCODE_TARGET_ABI is NOT set, original behavior is preserved.
+  // OPENCODE_TARGET_ABI
+  const TARGET_REPLACEMENT = `      // When building for the current platform, prefer a single native binary by default.
+      // Baseline binaries require additional Bun artifacts and can be flaky to download.
+      // OPENCODE_TARGET_ABI: when set, the harness selects the explicit {abi, baseline} target.
       // This hook is injected by the harness build-platform.ts for musl/baseline targets.
-      // OPENCODE_TARGET_ABI
+      const _harnessTargetAbi = process.env["OPENCODE_TARGET_ABI"]
+      const _harnessTargetBaseline = process.env["OPENCODE_TARGET_BASELINE"] === "true"
+      if (_harnessTargetAbi !== undefined) {
+        // Explicit target mode: select ONLY the target matching {abi, baseline}.
+        // Reject the default glibc target (no abi) — it would otherwise build instead of musl.
+        if (item.abi !== _harnessTargetAbi) {
+          return false
+        }
+        // Honor the baseline flag: avx2===false means baseline; must match OPENCODE_TARGET_BASELINE.
+        if ((item.avx2 === false) !== _harnessTargetBaseline) {
+          return false
+        }
+        return true
+      }
+
+      // Original behavior (no explicit target): prefer a single native binary by default.
+      if (item.avx2 === false) {
+        return baselineFlag
+      }
+
+      // also skip abi-specific builds for the same reason
       if (item.abi !== undefined) {
-        const targetAbi = process.env["OPENCODE_TARGET_ABI"]
-        const targetBaseline = process.env["OPENCODE_TARGET_BASELINE"] === "true"
-        if (targetAbi === undefined || item.abi !== targetAbi) {
-          return false
-        }
-        // When targeting musl, also match the baseline flag
-        if (item.avx2 === false && !targetBaseline) {
-          return false
-        }
-        if (item.avx2 !== false && targetBaseline) {
-          return false
-        }
-      }`
+        return false
+      }
+
+      return true`
 
   if (!original.includes(TARGET_ORIGINAL)) {
     throw new Error(
       `[build-platform] build.ts patch target not found — upstream build.ts shape may have changed. ` +
-        `Expected to find the singleFlag musl-skip block. Refusing to build with an unpatched build.ts.`,
+        `Expected to find the singleFlag baseline+abi+return-true block. Refusing to build with an unpatched build.ts.`,
     )
   }
 
@@ -320,7 +350,6 @@ export function patchBuildTs(buildTsPath: string): void {
   writeFileSync(buildTsPath, patched, 'utf8')
   console.log(`[build-platform] build.ts patched successfully.`)
 }
-
 /**
  * R11 guard: asserts the patch hook landed in the patched build.ts.
  * Throws if the hook string is absent — meaning the patch silently failed.

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -129,7 +129,14 @@ export function parseArgs(argv: string[]): BuildArgs | null {
   const sourceTree = sourceTreeValue
 
   // --abi: optional, only 'musl' is accepted (additive; glibc is the default when absent).
+  // Presence-without-value check: if --abi is in args but flag() returned null, the value is missing.
+  const abiPresent = args.includes('--abi')
   const abiRaw = flag('--abi')
+  if (abiPresent && (abiRaw === null || abiRaw === '')) {
+    console.error('[build-platform] --abi requires a value: --abi musl')
+    console.error('Run with --help for usage.')
+    return null
+  }
   if (abiRaw !== null && abiRaw !== 'musl') {
     console.error(`[build-platform] --abi '${abiRaw}' is not supported. Only 'musl' is accepted.`)
     return null
@@ -143,6 +150,18 @@ export function parseArgs(argv: string[]): BuildArgs | null {
     console.error('[build-platform] Missing required arguments.')
     console.error('  Required: --integration-commit, --base-version, --platform, --arch')
     printHelp()
+    return null
+  }
+
+  // Cross-validation: --baseline and --abi musl are linux-only; --baseline is x64-only.
+  if ((baseline || abi !== null) && platform !== 'linux') {
+    console.error(
+      `[build-platform] --baseline and --abi musl are only supported for --platform linux (got: ${platform}).`,
+    )
+    return null
+  }
+  if (baseline && arch !== 'x64') {
+    console.error(`[build-platform] --baseline is only supported for --arch x64 (got: ${arch}).`)
     return null
   }
 
@@ -279,20 +298,23 @@ export function resolveTargetDirSuffix(abi: 'musl' | null, baseline: boolean): s
  *   2. The default glibc target (no abi, no avx2) was not suppressed when an explicit musl
  *      target was requested, causing the glibc linux-x64 binary to build instead.
  *
- * The patch hook string is: `OPENCODE_TARGET_ABI` — used by the R11 guard to assert
+ * The patch hook string is: `OPENCODE_TARGET_ABI` — used by the patch-landed guard to assert
  * the patch landed before building.
  *
  * @param buildTsPath - Absolute path to the integration-tree build.ts to patch.
  */
-export function patchBuildTs(buildTsPath: string): void {
-  console.log(`[build-platform] Patching build.ts for explicit target selection: ${buildTsPath}`)
+// ---------------------------------------------------------------------------
+// Patch constants — exported for test deduplication
+// ---------------------------------------------------------------------------
 
-  const original = readFileSync(buildTsPath, 'utf8')
-
-  // The exact text we're replacing — the ENTIRE baseline+abi+return-true block in the
-  // singleFlag filter. Spans lines 122-133 in upstream build.ts (verified against
-  // .slim/clonedeps/repos/anomalyco__opencode/packages/opencode/script/build.ts).
-  const TARGET_ORIGINAL = `      // When building for the current platform, prefer a single native binary by default.
+/**
+ * The exact baseline+abi+return-true block from upstream build.ts (lines 122-133).
+ * Verified against anomalyco/opencode v1.17.3's singleFlag filter block.
+ * Must be re-diffed if clonedeps is bumped to a new upstream version.
+ *
+ * @see .slim/clonedeps/repos/anomalyco__opencode/packages/opencode/script/build.ts
+ */
+export const TARGET_ORIGINAL = `      // When building for the current platform, prefer a single native binary by default.
       // Baseline binaries require additional Bun artifacts and can be flaky to download.
       if (item.avx2 === false) {
         return baselineFlag
@@ -305,12 +327,14 @@ export function patchBuildTs(buildTsPath: string): void {
 
       return true`
 
-  // The replacement: when OPENCODE_TARGET_ABI is set, drive the ENTIRE selection from the
-  // explicit target spec — honoring both the baseline gate (avx2===false) and the abi gate,
-  // AND suppressing the default glibc target (no abi) so only the requested {abi, baseline}
-  // target survives. When OPENCODE_TARGET_ABI is NOT set, original behavior is preserved.
-  // OPENCODE_TARGET_ABI
-  const TARGET_REPLACEMENT = `      // When building for the current platform, prefer a single native binary by default.
+/**
+ * The replacement block: when OPENCODE_TARGET_ABI is set, drives the ENTIRE selection from the
+ * explicit target spec — honoring both the baseline gate (avx2===false) and the abi gate,
+ * AND suppressing the default glibc target (no abi) so only the requested {abi, baseline}
+ * target survives. When OPENCODE_TARGET_ABI is NOT set, original behavior is preserved.
+ * OPENCODE_TARGET_ABI
+ */
+export const TARGET_REPLACEMENT = `      // When building for the current platform, prefer a single native binary by default.
       // Baseline binaries require additional Bun artifacts and can be flaky to download.
       // OPENCODE_TARGET_ABI: when set, the harness selects the explicit {abi, baseline} target.
       // This hook is injected by the harness build-platform.ts for musl/baseline targets.
@@ -341,6 +365,11 @@ export function patchBuildTs(buildTsPath: string): void {
 
       return true`
 
+export function patchBuildTs(buildTsPath: string): void {
+  console.log(`[build-platform] Patching build.ts for explicit target selection: ${buildTsPath}`)
+
+  const original = readFileSync(buildTsPath, 'utf8')
+
   if (!original.includes(TARGET_ORIGINAL)) {
     throw new Error(
       `[build-platform] build.ts patch target not found — upstream build.ts shape may have changed. ` +
@@ -353,7 +382,7 @@ export function patchBuildTs(buildTsPath: string): void {
   console.log(`[build-platform] build.ts patched successfully.`)
 }
 /**
- * R11 guard: asserts the patch hook landed in the patched build.ts.
+ * Guard: asserts the patch hook landed in the patched build.ts.
  * Throws if the hook string is absent — meaning the patch silently failed.
  */
 export function assertPatchLanded(buildTsPath: string): void {
@@ -362,30 +391,38 @@ export function assertPatchLanded(buildTsPath: string): void {
   const HOOK_MARKER = 'OPENCODE_TARGET_ABI'
   if (!content.includes(HOOK_MARKER)) {
     throw new Error(
-      `[build-platform] R11 guard: patch hook '${HOOK_MARKER}' not found in ${buildTsPath} after patching. ` +
+      `[build-platform] Guard: patch hook '${HOOK_MARKER}' not found in ${buildTsPath} after patching. ` +
         `The patch did not land. Refusing to build.`,
     )
   }
-  console.log(`[build-platform] R11 guard: patch hook confirmed in build.ts.`)
+  console.log(`[build-platform] Guard: patch hook confirmed in build.ts.`)
 }
 
 /**
- * R11 guard: asserts the emitted binary is actually a musl binary (not glibc).
+ * Guard: asserts the emitted binary is actually a musl binary (not glibc).
  * Uses `file` to inspect the binary's ELF interpreter / linkage.
- * Throws if the binary appears to be glibc-linked.
  *
- * musl statically-linked binaries show "statically linked" or reference "musl" in `file` output.
- * glibc binaries reference "/lib64/ld-linux-x86-64.so.2" or similar glibc interpreter.
+ * Positive assertions (all must pass):
+ *   - Output contains 'ELF' (not a text file, wrong format, or corrupt binary).
+ *   - Output contains the expected architecture string:
+ *       x64   → 'x86-64'
+ *       arm64 → 'aarch64'
+ *   - Output contains 'statically linked' OR 'musl' (Bun musl builds are statically linked).
+ *
+ * Negative assertion (must NOT be present):
+ *   - glibc dynamic linker patterns (ld-linux-*.so) → throws if found.
+ *
+ * Throws on any assertion failure.
  */
-export function assertMuslBinary(binaryPath: string): void {
-  console.log(`[build-platform] R11 guard: asserting musl linkage for ${binaryPath}`)
+export function assertMuslBinary(binaryPath: string, arch: 'x64' | 'arm64'): void {
+  console.log(`[build-platform] Asserting musl linkage for ${binaryPath} (arch: ${arch})`)
 
   let fileOutput: string
   try {
     fileOutput = execFileSync('file', [binaryPath], {encoding: 'utf8', timeout: 10_000}).trim()
   } catch (error) {
     throw new Error(
-      `[build-platform] R11 guard: 'file' command failed on ${binaryPath}: ${
+      `[build-platform] 'file' command failed on ${binaryPath}: ${
         error instanceof Error ? error.message : String(error)
       }`,
     )
@@ -393,21 +430,49 @@ export function assertMuslBinary(binaryPath: string): void {
 
   console.log(`[build-platform] file output: ${fileOutput}`)
 
-  // glibc binaries reference the glibc dynamic linker (ld-linux-*.so or ld-linux-x86-64.so.2).
-  // musl binaries are either statically linked or reference the musl linker (ld-musl-*).
-  // Bun musl compile targets produce statically linked binaries.
+  // Positive assertion 1: must be an ELF binary.
+  if (!fileOutput.includes('ELF')) {
+    throw new Error(
+      `[build-platform] Binary at ${binaryPath} is not an ELF binary (file output: '${fileOutput}'). ` +
+        `Expected an ELF executable for a musl target.`,
+    )
+  }
+
+  // Positive assertion 2: must match the expected architecture.
+  const archString = arch === 'x64' ? 'x86-64' : 'aarch64'
+  if (!fileOutput.includes(archString)) {
+    throw new Error(
+      `[build-platform] Binary at ${binaryPath} does not match expected architecture '${archString}' ` +
+        `(arch: ${arch}, file output: '${fileOutput}'). Architecture mismatch.`,
+    )
+  }
+
+  // Negative assertion: glibc binaries reference the glibc dynamic linker (ld-linux-*.so).
+  // Check this before the "statically linked or musl" positive check so glibc binaries
+  // get a clear, specific error message rather than the generic "not musl-linked" message.
   const glibcPatterns = [/ld-linux-x86-64\.so/, /ld-linux-aarch64\.so/, /ld-linux\.so/, /interpreter \/lib.*ld-linux/]
   for (const pattern of glibcPatterns) {
     if (pattern.test(fileOutput)) {
       throw new Error(
-        `[build-platform] R11 guard: binary at ${binaryPath} appears to be glibc-linked (file output: '${fileOutput}'). ` +
+        `[build-platform] Binary at ${binaryPath} appears to be glibc-linked (file output: '${fileOutput}'). ` +
           `A musl target was requested but the binary is not musl. ` +
           `This means the build.ts patch did not correctly select the musl target.`,
       )
     }
   }
 
-  console.log(`[build-platform] R11 guard: musl linkage confirmed (no glibc interpreter found).`)
+  // Positive assertion 3: must be statically linked or reference musl.
+  // Bun musl compile targets produce statically linked binaries.
+  if (!fileOutput.includes('statically linked') && !fileOutput.includes('musl')) {
+    throw new Error(
+      `[build-platform] Binary at ${binaryPath} is neither statically linked nor musl-linked ` +
+        `(file output: '${fileOutput}'). A musl target was requested but the binary does not show musl linkage.`,
+    )
+  }
+
+  console.log(
+    `[build-platform] Musl linkage verified (ELF, ${archString}, statically linked / musl, no glibc interpreter).`,
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -447,7 +512,8 @@ export function runUpstreamBuild(
   }
 
   // For musl/baseline targets, patch the upstream build.ts singleFlag filter to honor
-  // OPENCODE_TARGET_ABI / OPENCODE_TARGET_BASELINE env vars (R12: minimal, local patch).
+  // OPENCODE_TARGET_ABI / OPENCODE_TARGET_BASELINE env vars.
+  // Build-time mutation of the checked-out source tree only — no credentials/push/OIDC.
   // The patch is applied in-place to the source tree before invoking build.ts.
   const buildTsPath = path.join(workDir, 'packages', 'opencode', 'script', 'build.ts')
   const buildEnv: Record<string, string> = {
@@ -459,7 +525,7 @@ export function runUpstreamBuild(
   if (abi !== null || baseline) {
     // Apply the ephemeral patch to the integration-tree build.ts.
     patchBuildTs(buildTsPath)
-    // R11 guard: assert the patch hook landed before building.
+    // Guard: assert the patch hook landed before building.
     assertPatchLanded(buildTsPath)
 
     // Set env vars that the patched singleFlag filter reads to select the target.
@@ -707,14 +773,21 @@ export async function main(): Promise<void> {
     process.exit(1)
   }
 
-  // 4a. R11 guard: for musl targets, assert the emitted binary is actually musl (not glibc).
+  // 4a. Musl linkage guard: for musl targets, assert the emitted binary is actually musl (not glibc).
   //     This runs in the real publish path (not only dry-run) because the LLM-merge
   //     integration commit differs per run, making a green dry-run non-authoritative.
   if (abi === 'musl') {
+    const typedArch = arch === 'x64' || arch === 'arm64' ? arch : null
+    if (typedArch === null) {
+      console.error(`[build-platform] Musl linkage guard: unsupported arch '${arch}' for musl assertion.`)
+      process.exit(1)
+    }
     try {
-      assertMuslBinary(binaryPath)
+      assertMuslBinary(binaryPath, typedArch)
     } catch (error) {
-      console.error(`[build-platform] R11 musl guard failed: ${error instanceof Error ? error.message : String(error)}`)
+      console.error(
+        `[build-platform] Musl linkage guard failed: ${error instanceof Error ? error.message : String(error)}`,
+      )
       process.exit(1)
     }
   }

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -461,9 +461,14 @@ export function assertMuslBinary(binaryPath: string, arch: 'x64' | 'arm64'): voi
     }
   }
 
-  // Positive assertion 3: must be statically linked or reference musl.
-  // Bun musl compile targets produce statically linked binaries.
-  if (!fileOutput.includes('statically linked') && !fileOutput.includes('musl')) {
+  // Positive assertion 3: must be statically linked, static-pie linked, or reference musl.
+  // Bun musl compile targets produce statically linked binaries. Some `file` versions report
+  // static-PIE musl binaries as "static-pie linked" rather than "statically linked".
+  if (
+    !fileOutput.includes('statically linked') &&
+    !fileOutput.includes('static-pie linked') &&
+    !fileOutput.includes('musl')
+  ) {
     throw new Error(
       `[build-platform] Binary at ${binaryPath} is neither statically linked nor musl-linked ` +
         `(file output: '${fileOutput}'). A musl target was requested but the binary does not show musl linkage.`,

--- a/packages/harness/scripts/verify-binary.test.ts
+++ b/packages/harness/scripts/verify-binary.test.ts
@@ -110,6 +110,28 @@ describe('parseArgs: --abi flag', () => {
     expect(result).toBeNull()
   })
 
+  it('returns null when --abi is present but has no value (last arg)', () => {
+    // #given — --abi is the last arg with no following value
+    const argv = [...BASE_ARGV, '--abi']
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then — must fail with clear error, not silently treat as glibc
+    expect(result).toBeNull()
+  })
+
+  it('returns null when --abi is present but followed by another flag (no value)', () => {
+    // #given — --abi is followed by another flag token (no value)
+    const argv = [...BASE_ARGV, '--abi', '--binary']
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then — must fail-closed
+    expect(result).toBeNull()
+  })
+
   it('parses all fields correctly with --abi musl', () => {
     // #given
     const argv = [...BASE_ARGV, '--abi', 'musl']
@@ -150,7 +172,6 @@ describe('main(): musl path', () => {
 
   it('exits 0 without calling execFileSync when --abi musl and binary exists', () => {
     // #given — musl binary exists (12 MB)
-    vi.stubEnv('', '')
     process.argv = [
       'bun',
       'verify-binary.ts',

--- a/packages/harness/scripts/verify-binary.test.ts
+++ b/packages/harness/scripts/verify-binary.test.ts
@@ -1,0 +1,288 @@
+/**
+ * verify-binary.test.ts — unit tests for the verify-binary.ts script layer.
+ *
+ * Tests:
+ *   1. parseArgs: --abi musl parsed correctly; absent → null; invalid → null.
+ *   2. main() musl path: skips --version execution, checks file existence only.
+ *   3. main() glibc path: runs --version + marker assertions (existing behavior).
+ *   4. main() musl path: exits non-zero when binary file is missing.
+ *   5. main() musl path: exits non-zero when binary file is empty.
+ */
+
+import {execFileSync} from 'node:child_process'
+import {statSync} from 'node:fs'
+import process from 'node:process'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {main, parseArgs} from './verify-binary.js'
+
+// ---------------------------------------------------------------------------
+// Module-level mocks (hoisted by Vitest)
+// ---------------------------------------------------------------------------
+
+vi.mock('node:child_process', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  return {
+    ...actual,
+    execFileSync: vi.fn(),
+  }
+})
+
+vi.mock('node:fs', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    statSync: vi.fn(),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// parseArgs — --abi flag
+// ---------------------------------------------------------------------------
+
+describe('parseArgs: --abi flag', () => {
+  const BASE_ARGV = [
+    'bun',
+    'verify-binary.ts',
+    '--binary',
+    '/tmp/opencode',
+    '--base-version',
+    '1.17.3',
+    '--integration-commit',
+    'cafebabe1234abcd',
+  ]
+
+  let exitSpy: {mock: {calls: unknown[][]}}
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number | string | null | undefined) => {
+      throw new Error(`process.exit called with code ${_code}`)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('parses --abi musl into VerifyArgs.abi === "musl"', () => {
+    // #given
+    const argv = [...BASE_ARGV, '--abi', 'musl']
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then
+    expect(result).not.toBeNull()
+    expect(result?.abi).toBe('musl')
+    expect(exitSpy.mock.calls).toHaveLength(0)
+  })
+
+  it('sets abi to null when --abi is absent', () => {
+    // #given — no --abi flag
+    const result = parseArgs(BASE_ARGV)
+
+    // #then
+    expect(result).not.toBeNull()
+    expect(result?.abi).toBeNull()
+  })
+
+  it('returns null and does not exit(0) for unsupported --abi value', () => {
+    // #given — unsupported ABI
+    const argv = [...BASE_ARGV, '--abi', 'glibc']
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then — returns null (caller will exit(1))
+    expect(result).toBeNull()
+    // process.exit was NOT called by parseArgs itself for invalid abi (returns null, main exits)
+    expect(exitSpy.mock.calls).toHaveLength(0)
+  })
+
+  it('returns null when --binary is missing', () => {
+    // #given
+    const argv = ['bun', 'verify-binary.ts', '--base-version', '1.17.3']
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then
+    expect(result).toBeNull()
+  })
+
+  it('parses all fields correctly with --abi musl', () => {
+    // #given
+    const argv = [...BASE_ARGV, '--abi', 'musl']
+
+    // #when
+    const result = parseArgs(argv)
+
+    // #then
+    expect(result).not.toBeNull()
+    expect(result?.binaryPath).toBe('/tmp/opencode')
+    expect(result?.baseVersion).toBe('1.17.3')
+    expect(result?.integrationCommit).toBe('cafebabe1234abcd')
+    expect(result?.abi).toBe('musl')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// main() — musl path: skips --version, checks file existence
+// ---------------------------------------------------------------------------
+
+describe('main(): musl path', () => {
+  const mockedExecFileSync = vi.mocked(execFileSync)
+  const mockedStatSync = vi.mocked(statSync)
+  let exitSpy: {mock: {calls: unknown[][]}}
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number | string | null | undefined) => {
+      throw new Error(`process.exit called with code ${_code}`)
+    })
+    // Default: binary exists and is non-empty
+    mockedStatSync.mockReturnValue({size: 12_345_678} as ReturnType<typeof statSync>)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('exits 0 without calling execFileSync when --abi musl and binary exists', () => {
+    // #given — musl binary exists (12 MB)
+    vi.stubEnv('', '')
+    process.argv = [
+      'bun',
+      'verify-binary.ts',
+      '--binary',
+      '/tmp/opencode-linux-x64-baseline-musl/bin/opencode',
+      '--base-version',
+      '1.17.3',
+      '--integration-commit',
+      'cafebabe1234abcd',
+      '--abi',
+      'musl',
+    ]
+
+    // #when
+    expect(() => main()).toThrow('process.exit called with code 0')
+
+    // #then — execFileSync must NOT have been called (no --version probe)
+    expect(mockedExecFileSync).not.toHaveBeenCalled()
+    // statSync must have been called to check existence
+    expect(mockedStatSync).toHaveBeenCalledWith('/tmp/opencode-linux-x64-baseline-musl/bin/opencode')
+    expect(exitSpy.mock.calls[0]?.[0]).toBe(0)
+  })
+
+  it('exits 1 when --abi musl but binary file is missing', () => {
+    // #given — statSync throws ENOENT
+    mockedStatSync.mockImplementation(() => {
+      const err = new Error('ENOENT: no such file or directory')
+      ;(err as NodeJS.ErrnoException).code = 'ENOENT'
+      throw err
+    })
+    process.argv = [
+      'bun',
+      'verify-binary.ts',
+      '--binary',
+      '/tmp/missing-binary',
+      '--base-version',
+      '1.17.3',
+      '--abi',
+      'musl',
+    ]
+
+    // #when / #then
+    expect(() => main()).toThrow('process.exit called with code 1')
+    expect(exitSpy.mock.calls[0]?.[0]).toBe(1)
+    // execFileSync must NOT have been called
+    expect(mockedExecFileSync).not.toHaveBeenCalled()
+  })
+
+  it('exits 1 when --abi musl but binary file is empty (size === 0)', () => {
+    // #given — statSync returns size 0
+    mockedStatSync.mockReturnValue({size: 0} as ReturnType<typeof statSync>)
+    process.argv = [
+      'bun',
+      'verify-binary.ts',
+      '--binary',
+      '/tmp/empty-binary',
+      '--base-version',
+      '1.17.3',
+      '--abi',
+      'musl',
+    ]
+
+    // #when / #then
+    expect(() => main()).toThrow('process.exit called with code 1')
+    expect(exitSpy.mock.calls[0]?.[0]).toBe(1)
+    expect(mockedExecFileSync).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// main() — glibc / native path: runs --version + marker assertions
+// ---------------------------------------------------------------------------
+
+describe('main(): glibc / native path', () => {
+  const mockedExecFileSync = vi.mocked(execFileSync)
+  let exitSpy: {mock: {calls: unknown[][]}}
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: number | string | null | undefined) => {
+      throw new Error(`process.exit called with code ${_code}`)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('exits 0 when --version matches expected harness version (no --abi)', () => {
+    // #given — glibc binary self-reports the correct harness version
+    const commit = 'cafebabe1234abcd'
+    const expectedVersion = `1.17.3+harness.${commit.slice(0, 8)}`
+    mockedExecFileSync.mockReturnValue(`${expectedVersion}\n`)
+    process.argv = [
+      'bun',
+      'verify-binary.ts',
+      '--binary',
+      '/tmp/opencode-linux-x64/bin/opencode',
+      '--base-version',
+      '1.17.3',
+      '--integration-commit',
+      commit,
+    ]
+
+    // #when
+    expect(() => main()).toThrow('process.exit called with code 0')
+
+    // #then — execFileSync was called for --version
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      '/tmp/opencode-linux-x64/bin/opencode',
+      ['--version'],
+      expect.objectContaining({encoding: 'utf8'}),
+    )
+    expect(exitSpy.mock.calls[0]?.[0]).toBe(0)
+  })
+
+  it('exits 1 when --version output does not match expected version (no --abi)', () => {
+    // #given — binary reports wrong version (stock upstream, no harness marker)
+    mockedExecFileSync.mockReturnValue('1.17.3\n')
+    process.argv = [
+      'bun',
+      'verify-binary.ts',
+      '--binary',
+      '/tmp/opencode-linux-x64/bin/opencode',
+      '--base-version',
+      '1.17.3',
+      '--integration-commit',
+      'cafebabe1234abcd',
+    ]
+
+    // #when / #then
+    expect(() => main()).toThrow('process.exit called with code 1')
+    expect(exitSpy.mock.calls[0]?.[0]).toBe(1)
+  })
+})

--- a/packages/harness/scripts/verify-binary.ts
+++ b/packages/harness/scripts/verify-binary.ts
@@ -77,7 +77,15 @@ export function parseArgs(argv: string[]): VerifyArgs | null {
   const binaryPath = flag('--binary')
   const baseVersion = flag('--base-version')
   const integrationCommit = flag('--integration-commit')
+
+  // Presence-without-value check: if --abi is in args but flag() returned null, the value is missing.
+  const abiPresent = args.includes('--abi')
   const abiRaw = flag('--abi')
+  if (abiPresent && (abiRaw === null || abiRaw === '')) {
+    console.error('[verify-binary] --abi requires a value: --abi musl')
+    console.error('Run with --help for usage.')
+    return null
+  }
 
   if (binaryPath === null || baseVersion === null) {
     console.error('[verify-binary] Missing required arguments.')

--- a/packages/harness/scripts/verify-binary.ts
+++ b/packages/harness/scripts/verify-binary.ts
@@ -18,19 +18,32 @@
  * The assertion LOGIC is extracted into src/verify.ts (unit-testable with stubs).
  * This script wires the real binary exec to those assertions.
  *
+ * musl targets: when --abi musl is passed, --version execution is SKIPPED because a
+ * musl binary cannot execute on a glibc GitHub Actions runner (posix_spawn ENOENT —
+ * no compatible dynamic linker). Upstream build.ts guards its own smoke test the same
+ * way (only runs --version when os===platform && arch===arch && !abi). For musl, this
+ * script only verifies that the binary FILE EXISTS (and is non-empty). The musl linkage
+ * assertion (that it is actually musl, not glibc) is handled separately by the
+ * release-binaries job's `file`-based assertion.
+ *
  * Usage:
  *   bun run packages/harness/scripts/verify-binary.ts \
  *     --binary <path> \
  *     --base-version <version> \
- *     [--integration-commit <sha>]
+ *     [--integration-commit <sha>] \
+ *     [--abi musl]
  *
  * The --integration-commit is optional: when absent (dev scaffold), the marker
  * check is skipped. When present, the binary's --version must contain
  * "+harness.<short8>" where short8 is the first 8 chars of the commit.
+ *
+ * The --abi is optional: when 'musl', execution-based verification is skipped.
  */
 
 import {execFileSync} from 'node:child_process'
+import {statSync} from 'node:fs'
 import process from 'node:process'
+import {fileURLToPath} from 'node:url'
 import {runVerifications} from '../src/verify.js'
 import {buildHarnessVersion} from '../src/version.js'
 
@@ -38,13 +51,15 @@ import {buildHarnessVersion} from '../src/version.js'
 // CLI argument parsing
 // ---------------------------------------------------------------------------
 
-interface VerifyArgs {
+export interface VerifyArgs {
   readonly binaryPath: string
   readonly baseVersion: string
   readonly integrationCommit: string | null
+  /** musl ABI variant — when set to 'musl', execution-based verification is skipped */
+  readonly abi: 'musl' | null
 }
 
-function parseArgs(argv: string[]): VerifyArgs | null {
+export function parseArgs(argv: string[]): VerifyArgs | null {
   const args = argv.slice(2)
 
   if (args.includes('--help') || args.includes('-h')) {
@@ -62,6 +77,7 @@ function parseArgs(argv: string[]): VerifyArgs | null {
   const binaryPath = flag('--binary')
   const baseVersion = flag('--base-version')
   const integrationCommit = flag('--integration-commit')
+  const abiRaw = flag('--abi')
 
   if (binaryPath === null || baseVersion === null) {
     console.error('[verify-binary] Missing required arguments.')
@@ -70,7 +86,14 @@ function parseArgs(argv: string[]): VerifyArgs | null {
     return null
   }
 
-  return {binaryPath, baseVersion, integrationCommit}
+  if (abiRaw !== null && abiRaw !== 'musl') {
+    console.error(`[verify-binary] --abi '${abiRaw}' is not supported. Only 'musl' is accepted.`)
+    return null
+  }
+
+  const abi: 'musl' | null = abiRaw === 'musl' ? 'musl' : null
+
+  return {binaryPath, baseVersion, integrationCommit, abi}
 }
 
 function printHelp(): void {
@@ -84,15 +107,23 @@ Usage:
     [--integration-commit <sha>]        Frozen integration commit SHA; when supplied,
                                         the binary's --version must contain
                                         "+harness.<short8>" (first 8 chars of the SHA)
+    [--abi musl]                        ABI variant; when 'musl', execution-based
+                                        verification is skipped (musl binary cannot run
+                                        on a glibc runner). Only file existence is checked.
     [--help]                            Print this help
 
-Assertions:
+Assertions (glibc / darwin-native):
   1. Binary exits 0 on --version.
   2. --version output == expected version (exact match, trimmed).
      For a harness build: "<base>+harness.<short8>". A stock binary reports bare
      "<base>" and fails — proving this is a harness build for the expected commit.
   3. Integration marker "+harness.<short8>" present in --version (when --integration-commit
      supplied). Defense-in-depth on top of the exact version match.
+
+Assertions (musl — execution skipped):
+  1. Binary file exists and is non-empty.
+  (--version cannot run on a glibc host; musl linkage is verified separately by the
+   release-binaries job's file-based assertion.)
 
 Exits non-zero on any assertion failure.
 `)
@@ -134,13 +165,46 @@ function probeBinary(binaryPath: string): ProbeResult {
 // Main
 // ---------------------------------------------------------------------------
 
-function main(): void {
+export function main(): void {
   const args = parseArgs(process.argv)
   if (args === null) {
     process.exit(1)
   }
 
-  const {binaryPath, baseVersion, integrationCommit} = args
+  const {binaryPath, baseVersion, integrationCommit, abi} = args
+
+  console.log(`[verify-binary] Verifying binary: ${binaryPath}`)
+  console.log(`  abi:                ${abi ?? '(glibc / native)'}`)
+
+  if (abi === 'musl') {
+    // musl binaries cannot execute on a glibc runner (posix_spawn ENOENT — no compatible
+    // dynamic linker). Upstream build.ts guards its own smoke test the same way:
+    //   if (item.os === process.platform && item.arch === process.arch && !item.abi)
+    // Skip --version execution for musl; only verify the binary file exists and is non-empty.
+    // The musl linkage assertion (that it is actually musl, not glibc) is handled separately
+    // by the release-binaries job's `file`-based assertion.
+    console.log(
+      `[verify-binary] Skipping --version execution for musl target ` +
+        `(cannot run musl binary on glibc runner). Checking file existence only.`,
+    )
+
+    let fileSize: number
+    try {
+      const st = statSync(binaryPath)
+      fileSize = st.size
+    } catch {
+      console.error(`[verify-binary] Binary file not found or inaccessible: ${binaryPath}`)
+      process.exit(1)
+    }
+
+    if (fileSize === 0) {
+      console.error(`[verify-binary] Binary file is empty: ${binaryPath}`)
+      process.exit(1)
+    }
+
+    console.log(`[verify-binary] musl binary exists (${fileSize} bytes). Execution-based verification skipped.`)
+    process.exit(0)
+  }
 
   // Compute the full expected version string.
   // For a harness build, the binary self-reports "<base>+harness.<short8>".
@@ -150,7 +214,6 @@ function main(): void {
       ? buildHarnessVersion(baseVersion, integrationCommit)
       : baseVersion
 
-  console.log(`[verify-binary] Verifying binary: ${binaryPath}`)
   console.log(`  expected version:   ${expectedVersion}`)
   console.log(`  integration commit: ${integrationCommit ?? '(none — dev scaffold)'}`)
 
@@ -178,4 +241,7 @@ function main(): void {
   process.exit(1)
 }
 
-main()
+// Only run when executed directly (not when imported by tests or other modules).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main()
+}

--- a/src/services/setup/opencode.test.ts
+++ b/src/services/setup/opencode.test.ts
@@ -617,8 +617,12 @@ describe('opencode', () => {
   })
 
   describe('DEFAULT_OPENCODE_VERSION', () => {
-    it('equals the pinned harness build', () => {
-      expect(DEFAULT_OPENCODE_VERSION).toBe('1.17.3+harness.2c9cdbd2')
+    it('is a harness build pinned to a base version plus an integration commit', () => {
+      // Assert the SHAPE, not a specific commit: the self-update release workflow
+      // bumps the integration SHA on every harness release, so pinning an exact
+      // value here would break every legitimate bump. The invariant is the form
+      // `<major.minor.patch>+harness.<short-sha>`.
+      expect(DEFAULT_OPENCODE_VERSION).toMatch(/^\d+\.\d+\.\d+\+harness\.[0-9a-f]{7,}$/)
     })
 
     it('is a harness version', () => {


### PR DESCRIPTION
## What this does

Teaches the harness release to build and publish **musl** Linux binaries so the gateway's Alpine-based workspace executor can run the patched harness OpenCode build, not just stock upstream. The harness build previously emitted glibc only (`build.ts --single` skips musl), which can't run on Alpine.

This is the first of two PRs. It only adds the build/publish side — the workspace repoint follows in a second PR once a release carrying the musl assets exists.

## Changes

- The Linux build matrix gains additive `linux-x64-baseline-musl` and `linux-arm64-musl` targets. The existing generic glibc assets are unchanged, so the action download path is untouched.
- `build-platform.ts` selects the requested variant: it applies a minimal, fail-loud patch to the integration-tree `build.ts` enabling explicit target selection via env vars, then builds that one target. New `--abi`/`--baseline` flags are validated against the platform/arch.
- A musl binary can't execute on the glibc CI runner, so the post-build `--version` smoke check is skipped for musl targets (mirroring upstream's own guard). Instead, the binary is verified by inspection: it must be ELF, the expected architecture, and statically linked / musl — never glibc.
- The release-binaries job packages, checksums, and uploads all six assets (two new musl variants in `SHA256SUMS`), with a packaging-side libc assertion that fails the release if a musl artifact is actually glibc.
- Fixes a release-safety bug: a dry-run could open a spurious version-bump PR because the gate compared a boolean input against the string `'true'` (which coerces to always-truthy). It now compares against the boolean.
- The default-version test asserts the `<base>+harness.<sha>` shape instead of a hardcoded commit, so it survives the automatic version bump on each release.

## Validation

Validated end-to-end with a dry-run release: all six assets build and assemble, `SHA256SUMS` covers them, both musl binaries are confirmed musl by inspection, and no spurious bump PR is opened. The two musl targets add no critical-path time (they build in parallel, ~1m46s / 2m12s, comparable to the glibc builds).
