### PR TITLE
docs: harness rollout + release-pipeline incident learnings

### DIFF
--- a/.agents/skills/versioned-tool/SKILL.md
+++ b/.agents/skills/versioned-tool/SKILL.md
@@ -13,11 +13,15 @@ This project manages external CLI tools through a **single-source-of-truth versi
 
 | Tool | Constant | User-facing input | Renovate datasource |
 | --- | --- | --- | --- |
-| OpenCode | `DEFAULT_OPENCODE_VERSION` | `opencode-version` | `github-releases` (`anomalyco/opencode`) |
+| OpenCode (action default) | `DEFAULT_OPENCODE_VERSION` | `opencode-version` | _Release-job coupled — NOT Renovate (see below)_ |
+| OpenCode (action fallback) | `FALLBACK_VERSION` in `src/services/setup/opencode.ts` | _(internal only)_ | `github-releases` (`anomalyco/opencode`) |
+| OpenCode (workspace image) | `ARG OPENCODE_VERSION` in `deploy/workspace.Dockerfile` | _(internal only)_ | _Release-job coupled — NOT Renovate (see below)_ |
 | oMo | `DEFAULT_OMO_VERSION` | `omo-version` | `npm` (`oh-my-openagent`) |
 | Bun | `DEFAULT_BUN_VERSION` | _(internal only)_ | `github-releases` (`oven-sh/bun`, extract `bun-v` prefix) |
 | Systematic | `DEFAULT_SYSTEMATIC_VERSION` | `systematic-version` | `npm` (`@fro.bot/systematic`) |
 | OpenCode (harness base) | `base_version` in `packages/harness/harness.config.json` | _(internal only — config-JSON, not a TS constant)_ | `github-releases` (`anomalyco/opencode`) |
+
+**Release-job coupled sites (not Renovate-tracked):** `DEFAULT_OPENCODE_VERSION` and the workspace `ARG OPENCODE_VERSION` hold the harness build version (`<base>+harness.<sha>`). Renovate cannot order SemVer build-metadata tags, so both are bumped together by `harness-release.yaml`'s `sync-default-version` job at publish time (one auto-PR, dual-source idempotency guard). Do not add Renovate `customManager` entries for these — they would be dropped. See `docs/solutions/best-practices/cross-libc-build-and-release-safety-2026-06-14.md` §4 and `docs/solutions/workflow-issues/harness-base-version-source-of-truth-2026-06-12.md`.
 
 ## Quick Start
 

--- a/docs/solutions/best-practices/cross-libc-build-and-release-safety-2026-06-14.md
+++ b/docs/solutions/best-practices/cross-libc-build-and-release-safety-2026-06-14.md
@@ -1,0 +1,118 @@
+---
+module: "harness/release pipeline"
+date: 2026-06-14
+problem_type: best_practice
+component: tooling
+severity: medium
+tags:
+  - github-actions
+  - musl
+  - cross-compilation
+  - release-pipeline
+  - harness
+  - boolean-inputs
+  - opencode
+applies_when:
+  - Building cross-libc binaries (musl vs glibc) that must be verified in CI
+  - "Comparing GitHub Actions `if:` conditions against `type: boolean` inputs"
+  - A release job auto-bumps the same version into more than one file
+  - Downloading a binary from a release into a Dockerfile or CI step
+---
+
+# Cross-libc builds and release-pipeline safety
+
+Reusable build/release/CI lessons from teaching the `@fro.bot/harness` pipeline to produce musl OpenCode binaries for the Alpine workspace executor (the action consumes glibc; the workspace needs musl). Most of these traps are not OpenCode-specific — they recur anywhere a pipeline cross-builds, cross-libcs, guards on workflow inputs, or auto-bumps a version into multiple files.
+
+## Context
+
+The harness build emitted glibc only. Adding musl/baseline Linux targets and repointing the Alpine workspace at them surfaced four distinct, reusable failure modes — three caught loud by guards during dry-runs before any PR, one a pre-existing release-safety bug the dry-runs exposed. Each is documented below as standalone guidance.
+
+## 1. Compare boolean `workflow_dispatch` inputs to boolean literals, not strings
+
+**Guidance.** A `workflow_dispatch`/`workflow_call` input declared `type: boolean` is a real boolean inside expressions. A boolean-vs-string `!=` coerces **numerically**: boolean `true` → `1`, string `'true'` → `NaN`, and `1 != NaN` is `true` **always**. So a guard like `if: inputs.dry_run != 'true'` never blocks anything — it is a silent no-op. Compare boolean inputs against the boolean literal: `inputs.dry_run != true`. Step/job **outputs** are always strings (emitted via `echo >> $GITHUB_OUTPUT`) — compare *those* to `'true'`/`'false'`. The rule: read the producer's type before writing the consumer's comparison.
+
+**Why it matters.** A wrong-type guard misfires in exactly the wrong direction with no log, warning, or review prompt. Here it let a `dry_run: true` release open a real version-bump PR pinning a release that was never published.
+
+**When to apply.** Every `if:` on a job/step that depends on a `type: boolean` input. Review-checklist item: any `inputs.<name> != 'true'` where `<name>` is declared `type: boolean` is a bug.
+
+```yaml
+# Before — silently always-truthy (dry_run is type: boolean)
+if: ${{ needs.publish.result == 'success' && inputs.dry_run != 'true' }}
+
+# After — boolean literal. Tag-triggered runs have inputs.dry_run == null,
+# which is also != true, so real releases still pass.
+if: ${{ needs.publish.result == 'success' && inputs.dry_run != true }}
+```
+
+## 2. A cross-libc binary can be built on the wrong runner — but not executed
+
+**Guidance.** A musl-target binary builds fine on a glibc Ubuntu runner, but **running** it (e.g. `opencode --version`) fails with `posix_spawn ENOENT` — there is no musl loader on a glibc host. Every post-build verification that *executes* the binary must split into two cases: same-libc targets execute and assert the version; cross-libc targets **skip execution** and verify by **inspection** — `file <binary>` must show `ELF`, the expected arch, and `statically linked` / `static-pie linked` / `musl`, and must **not** show a glibc dynamic linker (`ld-linux-*.so`). The negative assertion is the load-bearing one: a glibc binary published under a musl asset name runs on every CI runner (all glibc) and only explodes at the Alpine consumer — CI is structurally blind to it without the `file` check.
+
+This trap recurs at **every** verification layer independently — in this work it hit the build wrapper's `--version` probe, a separate workflow verify step, and a regression smoke test. A guard in one place does not protect the others. Mirror upstream's own predicate (OpenCode's `build.ts` only smoke-tests `os === process.platform && arch === process.arch && !item.abi`).
+
+**Why it matters.** `posix_spawn ENOENT` reads as a toolchain error and sends investigators the wrong way; the real cause is the ELF interpreter, visible only by inspection.
+
+```typescript
+// Negative assertion FIRST → specific, actionable error for a glibc binary.
+for (const pattern of [/ld-linux-x86-64\.so/, /ld-linux-aarch64\.so/, /ld-linux\.so/, /interpreter \/lib.*ld-linux/]) {
+  if (pattern.test(fileOutput)) {
+    throw new Error(`Binary appears glibc-linked (${fileOutput}); a musl target was requested — the build did not select musl.`)
+  }
+}
+if (!fileOutput.includes('statically linked') && !fileOutput.includes('static-pie linked') && !fileOutput.includes('musl')) {
+  throw new Error(`Binary does not show musl linkage (${fileOutput}).`)
+}
+
+// And, at the execution layer, skip exec for cross-libc targets:
+if (abi === 'musl') {
+  // musl binaries cannot execute on a glibc runner (posix_spawn ENOENT).
+  // Verify by existence + file-inspection instead; do not run --version.
+  return
+}
+```
+
+## 3. Patch an upstream build script at workflow time instead of carrying a fork
+
+**Guidance.** Upstream OpenCode's `build.ts --single` filters to the current-platform glibc target and unconditionally skips `abi: musl` with no override flag. The bad workarounds: drop `--single` (builds the whole 12-target matrix), or carry a permanent fork (burns a carry slot, drifts every bump). Instead, apply an **ephemeral in-place patch** to the freshly-checked-out integration-tree `build.ts` before invoking it: (1) assert the exact pre-patch block is present and **abort loud** if not (upstream shape drifted); (2) replace it with an env-var-driven selector that preserves original behavior verbatim when the env var is unset and, when set, drives the *entire* selection (so a request for one target cannot also build the default glibc target); (3) after writing, assert a hook marker is present — a `String.replace` that matches nothing is a silent no-op, and the marker is what makes it loud. The patch lives in the source tree, reapplies on every clone, and fails closed when upstream changes.
+
+**Why it matters.** "Patch and proceed regardless" is worse than no patch: it produces a glibc binary under a musl asset name, which only the §2 file-inspection catches. Fail-loud assertions on both sides (patch landed, binary is musl) are what keep the ephemeral patch trustworthy.
+
+## 4. Coupled multi-file version bumps need a dual-source idempotency guard
+
+**Guidance.** When a release job auto-bumps the same version into N>1 files (here: the action's `DEFAULT_OPENCODE_VERSION` and the workspace Dockerfile `ARG OPENCODE_VERSION`), the idempotency `skip` must check **all N** files — skip only when *every* coupled file already equals the new value. A one-file check is a one-way data-loss ratchet: the first time file A bumps but file B's step fails (with `continue-on-error: true`), every later run sees A current → skips → B is frozen at the old version forever, with no signal. Also give each file-update step an `id:` and gate PR-open on **all** their outcomes, so a half-bumped diff is never opened. Keep each replacement a precise literal match that fails loud on a no-op match.
+
+**Why it matters.** `continue-on-error: true` (correct for "the release already shipped") removes the safety net that would otherwise stop partial state — the dual-source idempotency *is* the replacement net. Retrying the job does not help: retries hit the same skip branch.
+
+```yaml
+# Skip only if BOTH files already equal NEW_VERSION.
+if [ "${CURRENT_CONSTANTS}" = "${NEW_VERSION}" ] && [ "${CURRENT_DOCKERFILE}" = "${NEW_VERSION}" ]; then
+  echo "skip=true" >> "$GITHUB_OUTPUT"
+fi
+# ...each update step gets `id:`; PR-open gates on all of them:
+# if: steps.version.outputs.skip != 'true' && steps.build.outcome == 'success' && steps.dockerfile.outcome == 'success'
+```
+
+## 5. Fail-closed binary download in a Dockerfile (supporting)
+
+**Guidance.** Downloading a binary from a release into a Dockerfile is a small set of deliberate choices in service of one rule — **on any anomaly, abort with no fallback**: validate the version against a strict allowlist before interpolating it into a URL; use a fixed asset-name allowlist (branch on `${TARGETARCH}`, never interpolate the version into the name); URL-encode SemVer build metadata (`${VAR//+/%2B}` — GitHub reads a raw `+` as a space); `curl --retry` for transient blips while `-f` keeps a persistent 404 fatal; verify the checksum by **exact field match** (`awk '$2 == f {print $1}'`, not a regex that a substring can satisfy); `set -euo pipefail`; and prove the binary runs (`opencode --version`) so a corrupt-but-extracted binary fails at build, not in production. No "fall back to cached", no "fall back to stock", no "warn and continue".
+
+**Why it matters.** A supply-chain gate with a fallback is not a gate — the fallback becomes the gate and the fallback does not verify. Every layer above (§2, §4) assumes the asset at the URL *is* the asset.
+
+## When to apply
+
+- Any build matrix mixing glibc and musl targets, or a static binary built to run on a different libc than the builder.
+- Any GitHub Actions guard on a `type: boolean` input.
+- Any release job that writes the same version to more than one file.
+- Any Dockerfile/CI step that downloads a binary from a release.
+
+## Why this matters (cross-cutting)
+
+The four layers reinforce each other: the fail-closed download (§5) assumes the asset is the asset; the dual-source bump (§4) assumes the bumped file matches the asset; the musl verification (§2) assumes the asset is the expected libc; the patch guard (§3) assumes the asset was built against the requested target. Drop any one and the others work in the dark. Note also that `fail-fast: false` on the matrix is required so the all-or-nothing existence/libc/dual-source gates can evaluate against *all* artifacts.
+
+## Related
+
+- `docs/solutions/workflow-issues/harness-base-version-source-of-truth-2026-06-12.md` — direct predecessor on version-source drift. Its "Renovate tracks the consumed source" rule still holds generally, but the workspace `OPENCODE_VERSION` pin specifically moved *off* Renovate (build-metadata `+harness.<sha>` tags can't be ordered) onto the release-job coupled bump described in §4.
+- `docs/solutions/build-errors/gateway-docker-runtime-resolution-crash-loop-2026-05-31.md` — sibling image-only packaging gap; same "verify by inspection, not host-checkout execution" pattern.
+- `docs/solutions/best-practices/workspace-executor-opencode-provisioning-best-practices-2026-06-01.md` — the workspace Dockerfile surface these changes modify.
+- `docs/solutions/build-errors/tool-binary-caching-ephemeral-runners.md` — verify the tools cache key includes the full `+harness.<sha>` literal so two harness builds of the same base don't collide.
+- PRs #887 (musl build/publish), #889 (workspace repoint + coupled bump), #874 (harness GitHub Release + boolean-gate fix).

--- a/docs/solutions/workflow-issues/harness-base-version-source-of-truth-2026-06-12.md
+++ b/docs/solutions/workflow-issues/harness-base-version-source-of-truth-2026-06-12.md
@@ -1,6 +1,7 @@
 ---
 title: "Duplicate Version Sources Cause Silently-Missed Bumps"
 date: 2026-06-12
+last_updated: 2026-06-14
 problem_type: workflow_issue
 component: tooling
 severity: medium
@@ -46,6 +47,8 @@ Three structural rules:
 1. **Eliminate the duplicate.** A vestigial constant nothing imports is not a convenience; it is a second source that will drift. Delete it.
 2. **Point automation at the consumed source.** A Renovate `customManager` must match the exact file the build reads. Renovate custom managers fail **silently** — a non-matching `managerFilePatterns` or `matchStrings` produces no PR, no error, no log. A wrongly-targeted manager looks healthy while tracking nothing.
 3. **Inventory every version site.** If a tool maintains a "managed versions" list, an un-inventoried site is a blind spot that drifts unnoticed. The inventory must be complete, including config-JSON sites that aren't TypeScript constants.
+
+> **Exception (added 2026-06-14): when the consumed source can't be Renovate-tracked.** "Point automation at the consumed source" assumes Renovate *can* order that source. It can't order SemVer **build-metadata** versions like `1.17.3+harness.<sha>` (build metadata has no defined ordering; the SHA suffix is non-monotonic). For the OpenCode harness build the action default (`DEFAULT_OPENCODE_VERSION`) and the workspace `OPENCODE_VERSION` ARG are those un-orderable versions, so they were deliberately moved *off* Renovate onto a release-job coupled bump that writes both files at publish time — guarded by a dual-source idempotency check so a partial failure can't freeze one file. The single-source thesis still holds (one writer owns the value); the *writer* is the release job rather than Renovate. See `docs/solutions/best-practices/cross-libc-build-and-release-safety-2026-06-14.md` §4.
 
 When a fallback is genuinely needed (e.g. config unreadable), use an honest sentinel like `"unknown"` — never a hardcoded version literal, which is just another copy waiting to drift.
 

--- a/docs/solutions/workflow-issues/semantic-release-tag-namespace-collision-2026-06-14.md
+++ b/docs/solutions/workflow-issues/semantic-release-tag-namespace-collision-2026-06-14.md
@@ -1,0 +1,113 @@
+---
+title: "Auxiliary v-Prefixed Tags Poison semantic-release Version Computation"
+module: "release-pipeline"
+date: 2026-06-14
+problem_type: workflow_issue
+component: tooling
+severity: high
+tags:
+  - semantic-release
+  - tag-namespace
+  - release-pipeline
+  - github-release
+  - git-tag
+  - harness
+  - recovery
+applies_when:
+  - A repo runs semantic-release with the default `tagFormat: 'v${version}'` AND also publishes other GitHub Releases (sub-package binaries, etc.)
+  - You discover the next product version computed wrong (a major/minor jump) after a release
+  - You need to migrate a GitHub Release to a different tag name
+  - You're tempted to reach for semantic-release config to "exclude tags by pattern" — there is none
+  - You reset the `release` branch during release-pipeline recovery
+---
+
+# Auxiliary v-prefixed tags poison semantic-release version computation
+
+semantic-release published the wrong product version (`v1.18.0` instead of `v0.63.0`) because the `@fro.bot/harness` sub-package published its GitHub Releases under **`v`-prefixed** tags (`v1.17.3+harness.<sha>`) in the same repo. Those tags matched semantic-release's product tag pattern, parsed as `1.17.3`, outranked the real `v0.62.0`, and jumped the release off a cliff. Fixed forward (PRs #889/#890) and recovered by tag cleanup + a `release`-branch reset.
+
+## Root cause (verified)
+
+semantic-release v25 discovers releases by building a regex from `tagFormat` (`lib/branches/get-tags.js:14`):
+
+```js
+const tagRegexp = `^${escapeRegExp(template(tagFormat)({ version: " " })).replace(" ", "(.+)")}`
+```
+
+For the default `tagFormat: 'v${version}'` (this repo's `.releaserc.yaml` has no override) that is `^v(.+)`. It then validates the capture with `semver.valid(semver.clean(version))` — and **`semver.clean()` strips SemVer build metadata**. So `v1.17.3+harness.94c10df9` matches `^v(.+)`, cleans to `1.17.3`, and sorts above the product `0.62.0` by core-version precedence. There is **no semantic-release config to exclude tags** — `tagFormat` is a single fixed `${version}` template, not a regex or allowlist.
+
+## Rules
+
+### 1. Keep auxiliary release tags out of the product's tag namespace
+
+If a repo runs semantic-release with `v${version}` and also publishes other releases, those other tags must not be `v`-prefixed-semver-valid, or they contaminate the product version computation. The fix is a **non-`v`** tag form. Build metadata (`+...`) is *not* protection — semantic-release strips it and sorts by core version, so any non-zero core version in the auxiliary namespace wins silently.
+
+```diff
+- v1.17.3+harness.94c10df9   # matches /^v(.+)/, cleans to 1.17.3, outranks v0.62.0
++ 1.17.3+harness.94c10df9    # invisible to /^v(.+)/, isolated namespace
+```
+
+Verified anchors: `.github/workflows/harness-release.yaml` (`RELEASE_TAG="${BASE_VERSION}+harness.${SHORT_SHA}"`, no `v`); `src/services/setup/opencode.ts` `encodeHarnessTag()` strips a leading `v` for the harness download URL while `buildDownloadUrl()` keeps the `v` for stock `anomalyco/opencode` downloads (separate path, regression-tested).
+
+### 2. semantic-release has no tag-exclusion knob — don't try to fix this in config
+
+`tagFormat` is a single `${version}` template. Removing the `v` from `tagFormat` changes the *captured group*, not the *matched set* — `^(.+)` would still match `v1.17.3+harness.<sha>`. The only durable lever is the **names of the tags you create**. The workflow-side `git tag --list 'v*' | grep -vF '+harness'` filter in this repo guards the pipeline's *own* before/after detection, but it does **not** reach semantic-release's internal scan — only non-`v` tag names do.
+
+```text
+default tagFormat 'v${version}':
+  matched   = tags matching /^v(.+)/
+  effective = semver.clean(capture)   ← strips +metadata
+  precedence= semver.compare on effective
+  → v1.17.3+harness.x competes as 1.17.3 and beats v0.62.0
+```
+
+### 3. Deleting a git tag orphans its GitHub Release — migrate, don't delete-in-place
+
+`git push --delete origin <tag>` does **not** delete the GitHub Release, but it orphans it: the release flips to `draft`, its asset `browser_download_url` rewrites to `releases/download/untagged-<id>/...`, and the canonical `/releases/download/<tag>/...` URL returns **404**. (Empirically observed and confirmed this incident — an assumption that the tag delete keeps asset URLs alive was directly disproved.)
+
+To move a release to a new tag namespace, **create the new release on the new tag with the same assets first** (so the new URL resolves), then delete the old — never rely on tag-delete preserving URLs.
+
+```bash
+# Mirror (safe relocation): download existing assets, then
+gh release create "<new-tag>" --target "<sha>" --latest=false <assets...> SHA256SUMS
+# Only after the new URL is verified 200, retire the old:
+gh release delete "<old-tag>" --cleanup-tag --yes
+```
+
+Recovery if a tag was already deleted and the release orphaned:
+
+```bash
+git tag "<tag>" "<sha>" && git push origin "refs/tags/<tag>"
+gh api -X PATCH "repos/<owner>/<repo>/releases/<id>" -f tag_name="<tag>" -F draft=false -F make_latest=false
+# allow ~12s CDN propagation before re-checking the canonical download URL
+```
+
+### 4. Reset the `release` branch to the last release TAG, not the last merge commit
+
+The `next → release` pipeline requires `release` to sit at the **last released tag** (e.g. `v0.62.0`); merging `next` is what advances it. Resetting `release` to a merge commit that is *ahead* of the last tag makes the next `next → release` PR conflict (DIRTY — typically rename/rename on `dist/artifact-*.js`, whose bundle hash changes every commit). The release branch is a projection of `main` at the last *released* version, not the last *merged* commit.
+
+Verified anchor: `prepare-release-pr.yaml` "Reset to last release tag and merge main" does `git reset --hard "$last_tag"` where `last_tag=$(git tag --list 'v*' --sort=-version:refname | grep -vF '+harness' | head -1)`.
+
+### 5. Know your release trigger's side effects
+
+`prepare-release-pr.yaml -f force-release=true` does **not** just create the release PR — its merge-policy step **auto-merges** it (`gh pr merge --merge`), which fires Auto Release. And Auto Release only triggers on `pull_request: closed` with `merged==true && head=='next' && base=='release'` — **not** on a plain push to `release`. So resetting the `release` branch alone will not re-fire a release; regenerate via `prepare-release-pr.yaml` (which produces the qualifying `next → release` PR merge).
+
+## Recovery sequence used (verified, worked)
+
+1. Forward fix merged (#889/#890): harness tags + URLs drop the `v`; stock keeps it; `buildHarnessReleaseTag` helper aligned to non-`v`.
+2. Created non-`v` mirror releases for the two existing harness builds (assets re-uploaded, `--latest=false`). Required `gh auth refresh -s workflow` because the target commits touch `.github/workflows/`.
+3. Deleted both `v`-harness releases+tags (`gh release delete <tag> --cleanup-tag`) and the bad `v1.18.0` tag → `scripts/release/preview-next-release.ts` then predicted `next_version=0.63.0`.
+4. Reset `release` to the last release tag (`v0.62.0` commit), then `gh workflow run prepare-release-pr.yaml -f force-release=true` → regenerated and auto-merged the `next → release` PR → Auto Release published **v0.63.0** (correct), `v0` major channel updated, release-notes narration ran.
+
+## When to apply
+
+- Adding any auxiliary GitHub Release stream to a repo that runs semantic-release with the default `v${version}`.
+- Diagnosing a surprise major/minor version jump after a release.
+- Relocating or retiring a GitHub Release whose download URLs may have consumers.
+- Recovering a release branch — reset to the last *tag*, regenerate via the prepare-release workflow.
+
+## Related
+
+- `docs/solutions/workflow-issues/harness-base-version-source-of-truth-2026-06-12.md` — same domain (harness version management), different failure mode (duplicate version *source* drift vs. tag-*namespace* collision).
+- `docs/solutions/best-practices/cross-libc-build-and-release-safety-2026-06-14.md` — sibling harness release-pipeline lessons (musl builds, coupled version bumps, fail-closed download). Both came out of the same harness rollout.
+- `docs/solutions/best-practices/release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md` — adjacent semantic-release ops lesson (post-publish narration).
+- PRs #889 (workspace repoint), #890 (forward fix: non-`v` harness tags).


### PR DESCRIPTION
## What this adds

Two solutions docs (plus two targeted refreshes) capturing the learnings from the harness OpenCode rollout and the release-pipeline incident.

**`semantic-release-tag-namespace-collision-2026-06-14.md`** — why `v`-prefixed harness release tags poisoned semantic-release's product version computation (it computed `v1.18.0` instead of `v0.63.0`), and the recovery: keep auxiliary tags out of the product `v*` namespace, no semantic-release config can exclude tags, deleting a git tag orphans its GitHub Release (canonical download URL 404s — mirror before delete), reset the `release` branch to the last release tag, and `prepare-release --force-release` auto-merges the release PR.

**`cross-libc-build-and-release-safety-2026-06-14.md`** — reusable build/release lessons from teaching the harness pipeline to produce musl assets: GitHub Actions boolean inputs compared to strings are always-truthy, cross-libc binaries can't be verified by execution on the wrong runner (inspect, don't run), ephemeral build-script patching over a carried fork, dual-source idempotency for coupled version bumps, and fail-closed binary downloads.

**Refreshes:** the harness base-version doc gains an exception note (the harness pins moved off Renovate onto the release-job coupled bump), and the `versioned-tool` skill table reflects the same.

Source-verified examples, cross-linked across the release-pipeline doc family.
