### PR TITLE
fix(deploy): close egress-relay bypass in the topology guard + add live egress smoke

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -655,6 +655,17 @@ jobs:
             echo "::warning::Checksum negative test: docker build failed for bogus version '${bogus_version}' but the failure signal is NOT in the expected download/checksum path (curl/SHA256SUMS/hash-mismatch). Fail-closed still holds — the build aborted — but the failure may be a stage-1 (network/apk) issue rather than the checksum path. Investigate if this recurs. Build output is printed above."
           fi
 
+      - name: Live egress containment smoke
+        run: |
+          # Proves the workspace's only internet path is mitmproxy:
+          #   (a) direct internet request (no proxy) → fails (sandbox-net is internal:true)
+          #   (b) non-allowlisted host through mitmproxy → 403
+          #   (c) allowlisted host through mitmproxy → 200, AND mitmproxy logs the flow
+          # The workspace image carries the mitmproxy CA trust + proxy env via its
+          # entrypoint; an arbitrary container would not and the HTTPS 200 case would
+          # fail for the wrong reason (TLS error, not a routing failure).
+          WORKSPACE_IMAGE=fro-bot-workspace:smoke bash deploy/egress-smoke.sh
+
   dependency-review:
     if: ${{ github.event_name == 'pull_request' }}
     name: Dependency Review

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -656,6 +656,7 @@ jobs:
           fi
 
       - name: Live egress containment smoke
+        timeout-minutes: 8
         run: |
           # Proves the workspace's only internet path is mitmproxy:
           #   (a) direct internet request (no proxy) → fails (sandbox-net is internal:true)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -484,7 +484,7 @@ If `WORKSPACE_EGRESS_HOSTS` is unset or empty, no extra hosts are added (fail-cl
 
 ### Egress topology
 
-The containment model is:
+The workspace containment model is:
 
 ```
 workspace → sandbox-net (internal:true) → mitmproxy → egress-net → internet
@@ -493,4 +493,6 @@ workspace → sandbox-net (internal:true) → mitmproxy → egress-net → inter
 - `sandbox-net` is `internal: true` — no container on this network has a host gateway or direct internet access.
 - The workspace is attached to `sandbox-net` only. It has zero direct egress.
 - mitmproxy is dual-homed: it receives workspace traffic on `sandbox-net` and dials allowlisted upstream hosts via `egress-net` (a dedicated non-internal network). Only mitmproxy joins `egress-net`.
-- The gateway is dual-homed on `gateway-net` (external) and `sandbox-net`. Its own egress also routes through mitmproxy (`HTTPS_PROXY=http://mitmproxy:8080`), which is why Discord and the GitHub/object-store hosts it needs are in the static allowlist. The topology guard intentionally does not constrain the gateway's networks — only the workspace is held to sandbox-net-only.
+- The gateway is dual-homed on `gateway-net` (non-internal) and `sandbox-net`. It reaches Discord, GitHub, and object storage directly via `gateway-net` — **not** through mitmproxy. This is a deliberate trusted first-party exception: the gateway is operator-controlled code, not the untrusted workspace. The containment guarantee is that **the workspace reaches the internet only via mitmproxy**; the gateway is explicitly outside that constraint.
+
+**Forward constraint:** never give the workspace a gateway endpoint that performs caller-directed outbound requests. The only workspace-reachable HTTP ingress on the gateway is the HMAC/replay-gated `POST /v1/announce` endpoint, which posts a fixed embed — it does not perform arbitrary outbound requests on behalf of the caller. If a new workspace-reachable gateway endpoint is added that performs caller-directed outbound, the topology must be revisited. A CI pinning test enforces this: it asserts the gateway's HTTP ingress surface is exactly `{POST /v1/announce}` and fails if a new route is added without a deliberate review.

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -337,7 +337,14 @@ volumes:
   workspace-repos:
 
 networks:
-  # External-facing network for gateway ↔ Discord/S3
+  # External-facing network for the gateway service.
+  # The gateway attaches here as a deliberate trusted first-party exception: it must
+  # reach Discord, GitHub, and object storage directly. This is an explicit TCB
+  # decision — the gateway is trusted code under operator control, not the untrusted
+  # workspace. The containment guarantee is that the WORKSPACE reaches the internet
+  # only via mitmproxy; the gateway is not subject to that constraint.
+  # Forward constraint: never give the workspace a gateway endpoint that performs
+  # caller-directed outbound requests. If that changes, revisit the topology.
   gateway-net:
     driver: bridge
   # Isolated sandbox: workspace + mitmproxy receive side only.
@@ -346,7 +353,8 @@ networks:
   sandbox-net:
     driver: bridge
     internal: true
-  # mitmproxy's upstream leg only. No other service joins this network.
-  # Containment invariant: workspace → sandbox-net → mitmproxy → egress-net → internet.
+  # mitmproxy's upstream leg. Only mitmproxy joins this network.
+  # Workspace containment invariant: workspace → sandbox-net → mitmproxy → egress-net → internet.
+  # (The gateway reaches the internet via gateway-net, not egress-net — see gateway-net comment above.)
   egress-net:
     driver: bridge

--- a/deploy/egress-smoke.sh
+++ b/deploy/egress-smoke.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Egress containment smoke — proves the workspace's only internet path is mitmproxy.
+#
+# Runs three probes from inside the workspace container (which carries the
+# mitmproxy CA trust and proxy env set up by its entrypoint):
+#
+#   (a) Direct internet request with proxy env unset → must fail (no route on
+#       sandbox-net, which is internal:true). Baseline containment check.
+#
+#   (b) Request to a non-allowlisted host through mitmproxy → expect 403.
+#       Proves the allowlist enforcement is active.
+#
+#   (c) Request to an allowlisted host through mitmproxy → expect 200, AND
+#       mitmproxy must have logged the allowed flow. This is the routing proof:
+#       the request succeeds ONLY because it went through mitmproxy.
+#
+# Negative-control teeth: if the allowlist is set to allow-all, probe (b)
+# returns non-403 and the smoke fails. If mitmproxy is removed from the stack,
+# probe (c) has no route and fails. Either mutation breaks the smoke.
+#
+# Allowlisted host (probe c): api.github.com — always in the static allowlist,
+#   reliable HTTPS endpoint, returns 200 on GET /zen.
+# Blocked host (probe b):     example.com — not in the allowlist, stable,
+#   no DNS surprises.
+#
+# Usage (from repo root):
+#   WORKSPACE_IMAGE=fro-bot-workspace:smoke bash deploy/egress-smoke.sh
+#
+# WORKSPACE_IMAGE must be a pre-built workspace image (the entrypoint installs
+# the mitmproxy CA; an arbitrary image won't have it and probe (c) would fail
+# for the wrong reason — TLS verification error, not a routing failure).
+set -euo pipefail
+
+WORKSPACE_IMAGE="${WORKSPACE_IMAGE:-fro-bot-workspace:smoke}"
+COMPOSE_PROJECT="egress-smoke-$$"
+SMOKE_DIR="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+cleanup() {
+  echo "--- cleaning up compose project ${COMPOSE_PROJECT} ---"
+  docker compose -p "${COMPOSE_PROJECT}" -f "${SMOKE_DIR}/compose.yaml" down -v --remove-orphans 2>/dev/null || true
+  rm -rf "${SMOKE_DIR}"
+}
+trap cleanup EXIT
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# Wait for a container's Docker healthcheck to reach "healthy".
+# Args: <container-id> <max-attempts> <sleep-seconds>
+wait_healthy() {
+  local cid="$1" max="$2" interval="$3"
+  for _ in $(seq 1 "${max}"); do
+    status="$(docker inspect "${cid}" --format '{{.State.Health.Status}}' 2>/dev/null || echo "")"
+    if [ "${status}" = "healthy" ]; then
+      return 0
+    fi
+    sleep "${interval}"
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Write a self-contained compose file for the smoke stack.
+# Only mitmproxy and workspace — no gateway, no secrets bind-mounts.
+# The workspace image is pre-built (passed via WORKSPACE_IMAGE).
+# ---------------------------------------------------------------------------
+cat > "${SMOKE_DIR}/compose.yaml" <<YAML
+name: ${COMPOSE_PROJECT}
+
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:11.1.3@sha256:e0deb0df7edf9f909053f274a067cd1cacb90f5c17d74459e1693179c0b98d8f
+    command: >
+      mitmdump
+      -s /scripts/allowlist.py
+      --listen-host 0.0.0.0
+      --listen-port 8080
+      --set confdir=/home/mitmproxy/.mitmproxy
+      --set ssl_insecure=false
+    volumes:
+      - ./allowlist.py:/scripts/allowlist.py:ro
+      - mitmproxy-certs:/home/mitmproxy/.mitmproxy
+    networks:
+      - sandbox-net
+      - egress-net
+    healthcheck:
+      test: [CMD-SHELL, test -f /home/mitmproxy/.mitmproxy/mitmproxy-ca-cert.pem]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 30s
+
+  workspace:
+    image: ${WORKSPACE_IMAGE}
+    depends_on:
+      mitmproxy:
+        condition: service_healthy
+    environment:
+      HTTPS_PROXY: http://mitmproxy:8080
+      HTTP_PROXY: http://mitmproxy:8080
+      NO_PROXY: localhost,127.0.0.1,workspace
+      # Dummy token keeps the workspace-agent supervisor alive (clone-only mode).
+      WORKSPACE_OPENCODE_TOKEN: dummy-egress-smoke-token
+      # The entrypoint waits for the CA at this path (named volume mount below).
+      MITMPROXY_CA_PATH: /run/mitmproxy-certs/mitmproxy-ca-cert.pem
+    volumes:
+      - mitmproxy-certs:/run/mitmproxy-certs:ro
+    networks:
+      - sandbox-net
+    healthcheck:
+      test: [CMD-SHELL, curl -fsS http://127.0.0.1:9100/healthz || exit 1]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 60s
+
+volumes:
+  mitmproxy-certs:
+
+networks:
+  sandbox-net:
+    driver: bridge
+    internal: true
+  egress-net:
+    driver: bridge
+YAML
+
+# Copy the allowlist script into the smoke dir so the compose volume mount works.
+cp "$(dirname "$0")/mitmproxy/allowlist.py" "${SMOKE_DIR}/allowlist.py"
+
+echo "--- starting egress smoke stack (project: ${COMPOSE_PROJECT}) ---"
+docker compose -p "${COMPOSE_PROJECT}" -f "${SMOKE_DIR}/compose.yaml" up -d
+
+# ---------------------------------------------------------------------------
+# Wait for mitmproxy healthy (CA written to shared volume).
+# ---------------------------------------------------------------------------
+echo "--- waiting for mitmproxy healthy (CA generation) ---"
+mitm_cid="$(docker compose -p "${COMPOSE_PROJECT}" -f "${SMOKE_DIR}/compose.yaml" ps -q mitmproxy 2>/dev/null)"
+if ! wait_healthy "${mitm_cid}" 24 5; then
+  echo "ERROR: mitmproxy did not become healthy within 120s"
+  docker compose -p "${COMPOSE_PROJECT}" -f "${SMOKE_DIR}/compose.yaml" logs mitmproxy
+  exit 1
+fi
+echo "mitmproxy is healthy (CA written)"
+
+# ---------------------------------------------------------------------------
+# Wait for workspace healthy (CA installed, agent up on :9100).
+# ---------------------------------------------------------------------------
+echo "--- waiting for workspace healthy (CA trust + agent boot) ---"
+ws_cid="$(docker compose -p "${COMPOSE_PROJECT}" -f "${SMOKE_DIR}/compose.yaml" ps -q workspace 2>/dev/null)"
+if ! wait_healthy "${ws_cid}" 18 5; then
+  echo "ERROR: workspace did not become healthy within 90s"
+  docker compose -p "${COMPOSE_PROJECT}" -f "${SMOKE_DIR}/compose.yaml" logs workspace
+  exit 1
+fi
+echo "workspace is healthy (CA installed, agent up)"
+
+# ---------------------------------------------------------------------------
+# Probe (a): direct internet request with proxy env unset → must fail.
+# sandbox-net is internal:true so there is no host gateway; the connection
+# attempt is refused at the network layer. This is the containment baseline.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- probe (a): direct internet request (no proxy) → must fail ---"
+probe_a_exit=0
+docker compose -p "${COMPOSE_PROJECT}" -f "${SMOKE_DIR}/compose.yaml" exec -T \
+  -e HTTPS_PROXY="" -e HTTP_PROXY="" -e https_proxy="" -e http_proxy="" \
+  workspace \
+  sh -c 'curl -fsS --max-time 10 --noproxy "*" https://api.github.com/zen' \
+  >/dev/null 2>&1 || probe_a_exit=$?
+
+if [ "${probe_a_exit}" -ne 0 ]; then
+  pass "probe (a): direct internet request failed as expected (exit ${probe_a_exit})"
+else
+  fail "probe (a): direct internet request SUCCEEDED — sandbox-net containment is broken"
+fi
+
+# ---------------------------------------------------------------------------
+# Probe (b): non-allowlisted host through mitmproxy → expect 403.
+# example.com is not in the allowlist; mitmproxy short-circuits with 403.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- probe (b): blocked host (example.com) through mitmproxy → expect 403 ---"
+probe_b_exit=0
+probe_b_output=""
+probe_b_output="$(docker compose -p "${COMPOSE_PROJECT}" -f "${SMOKE_DIR}/compose.yaml" exec -T \
+  workspace \
+  sh -c 'curl -sv --max-time 15 --proxy http://mitmproxy:8080 https://example.com/ 2>&1')" || probe_b_exit=$?
+
+if echo "${probe_b_output}" | grep -q "403"; then
+  pass "probe (b): mitmproxy returned 403 for non-allowlisted host example.com"
+else
+  fail "probe (b): expected 403 from mitmproxy for example.com, got: exit=${probe_b_exit} output=${probe_b_output}"
+fi
+
+# ---------------------------------------------------------------------------
+# Probe (c): allowlisted host through mitmproxy → expect 200 + log proof.
+# api.github.com is in the static allowlist. The request succeeds only because
+# it routes through mitmproxy (the workspace has no direct internet path).
+# We then assert mitmproxy logged the allowed flow — this is the routing proof.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- probe (c): allowlisted host (api.github.com) through mitmproxy → expect 200 + log ---"
+probe_c_exit=0
+probe_c_output=""
+probe_c_output="$(docker compose -p "${COMPOSE_PROJECT}" -f "${SMOKE_DIR}/compose.yaml" exec -T \
+  workspace \
+  sh -c 'curl -fsS --max-time 30 https://api.github.com/zen 2>&1')" || probe_c_exit=$?
+
+if [ "${probe_c_exit}" -eq 0 ] && [ -n "${probe_c_output}" ]; then
+  pass "probe (c): allowlisted host api.github.com returned 200 (body: ${probe_c_output})"
+else
+  fail "probe (c): expected 200 from api.github.com via mitmproxy, got: exit=${probe_c_exit} output=${probe_c_output}"
+fi
+
+# Assert mitmproxy logged the allowed flow — proves routing, not just isolation.
+echo "--- checking mitmproxy logs for routing proof ---"
+mitm_logs="$(docker compose -p "${COMPOSE_PROJECT}" -f "${SMOKE_DIR}/compose.yaml" logs mitmproxy 2>&1)"
+if echo "${mitm_logs}" | grep -q "\[allowlist\] ALLOWED.*api\.github\.com"; then
+  pass "routing proof: mitmproxy logged ALLOWED connect for api.github.com"
+else
+  fail "routing proof: mitmproxy did NOT log ALLOWED for api.github.com — request may not have routed through mitmproxy"
+  echo "--- mitmproxy logs (last 50 lines) ---"
+  echo "${mitm_logs}" | tail -50
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== egress smoke results: ${PASS} passed, ${FAIL} failed ==="
+if [ "${FAIL}" -gt 0 ]; then
+  exit 1
+fi

--- a/deploy/egress-smoke.sh
+++ b/deploy/egress-smoke.sh
@@ -85,6 +85,7 @@ services:
     networks:
       - sandbox-net
       - egress-net
+    restart: unless-stopped
     healthcheck:
       test: [CMD-SHELL, test -f /home/mitmproxy/.mitmproxy/mitmproxy-ca-cert.pem]
       interval: 5s
@@ -180,19 +181,43 @@ fi
 # ---------------------------------------------------------------------------
 # Probe (b): non-allowlisted host through mitmproxy → expect 403.
 # example.com is not in the allowlist; mitmproxy short-circuits with 403.
+#
+# Retry policy: retry ONLY on transport/connectivity failures (curl non-zero
+# exit) or transient server errors (5xx/429). A definitive but WRONG status
+# (any 2xx/3xx — meaning the block failed) is NEVER retried: that is a real
+# containment failure and must fail immediately to preserve the test's teeth.
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- probe (b): blocked host (example.com) through mitmproxy → expect 403 ---"
 probe_b_exit=0
 probe_b_output=""
-probe_b_output="$(docker compose -p "${COMPOSE_PROJECT}" -f "${SMOKE_DIR}/compose.yaml" exec -T \
-  workspace \
-  sh -c 'curl -sv --max-time 15 --proxy http://mitmproxy:8080 https://example.com/ 2>&1')" || probe_b_exit=$?
+probe_b_status=""
+for _attempt in 1 2 3; do
+  probe_b_exit=0
+  probe_b_output=""
+  probe_b_output="$(docker compose -p "${COMPOSE_PROJECT}" -f "${SMOKE_DIR}/compose.yaml" exec -T \
+    workspace \
+    sh -c 'curl -sv --max-time 15 --proxy http://mitmproxy:8080 https://example.com/ 2>&1')" || probe_b_exit=$?
+  # Extract the HTTP status code from curl verbose output (last "< HTTP/... NNN" line).
+  probe_b_status="$(echo "${probe_b_output}" | grep -oE '< HTTP/[0-9.]+ [0-9]+' | tail -1 | grep -oE '[0-9]+$' || true)"
+  if [ "${probe_b_status}" = "403" ]; then
+    break  # definitive correct result — stop retrying
+  elif [ -n "${probe_b_status}" ] && [ "${probe_b_status}" != "429" ] && \
+       ! echo "${probe_b_status}" | grep -qE '^5[0-9][0-9]$'; then
+    # Definitive WRONG status (2xx/3xx/4xx≠403): containment failure — fail immediately, no retry.
+    break
+  fi
+  # Transport error (curl exit non-zero, no status) or 5xx/429 — transient; retry with backoff.
+  if [ "${_attempt}" -lt 3 ]; then
+    echo "  probe (b) attempt ${_attempt} transient (exit=${probe_b_exit} status=${probe_b_status:-none}), retrying in 3s..."
+    sleep 3
+  fi
+done
 
-if echo "${probe_b_output}" | grep -q "403"; then
+if [ "${probe_b_status}" = "403" ]; then
   pass "probe (b): mitmproxy returned 403 for non-allowlisted host example.com"
 else
-  fail "probe (b): expected 403 from mitmproxy for example.com, got: exit=${probe_b_exit} output=${probe_b_output}"
+  fail "probe (b): expected 403 from mitmproxy for example.com, got: exit=${probe_b_exit} status=${probe_b_status:-none} output=${probe_b_output}"
 fi
 
 # ---------------------------------------------------------------------------
@@ -200,19 +225,43 @@ fi
 # api.github.com is in the static allowlist. The request succeeds only because
 # it routes through mitmproxy (the workspace has no direct internet path).
 # We then assert mitmproxy logged the allowed flow — this is the routing proof.
+#
+# Retry policy: retry ONLY on transport errors (curl non-zero exit) or
+# transient server errors (5xx/429). A definitive but WRONG status (anything
+# other than 200) is NEVER retried: that is a real routing/allowlist failure
+# and must fail immediately to preserve the test's teeth.
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- probe (c): allowlisted host (api.github.com) through mitmproxy → expect 200 + log ---"
 probe_c_exit=0
 probe_c_output=""
-probe_c_output="$(docker compose -p "${COMPOSE_PROJECT}" -f "${SMOKE_DIR}/compose.yaml" exec -T \
-  workspace \
-  sh -c 'curl -fsS --max-time 30 https://api.github.com/zen 2>&1')" || probe_c_exit=$?
+probe_c_status=""
+for _attempt in 1 2 3; do
+  probe_c_exit=0
+  probe_c_output=""
+  probe_c_output="$(docker compose -p "${COMPOSE_PROJECT}" -f "${SMOKE_DIR}/compose.yaml" exec -T \
+    workspace \
+    sh -c 'curl -sv --max-time 30 https://api.github.com/zen 2>&1')" || probe_c_exit=$?
+  # Extract the HTTP status code from curl verbose output (last "< HTTP/... NNN" line).
+  probe_c_status="$(echo "${probe_c_output}" | grep -oE '< HTTP/[0-9.]+ [0-9]+' | tail -1 | grep -oE '[0-9]+$' || true)"
+  if [ "${probe_c_status}" = "200" ]; then
+    break  # definitive correct result — stop retrying
+  elif [ -n "${probe_c_status}" ] && [ "${probe_c_status}" != "429" ] && \
+       ! echo "${probe_c_status}" | grep -qE '^5[0-9][0-9]$'; then
+    # Definitive WRONG status (3xx/4xx≠429): routing/allowlist failure — fail immediately, no retry.
+    break
+  fi
+  # Transport error (curl exit non-zero, no status) or 5xx/429 — transient; retry with backoff.
+  if [ "${_attempt}" -lt 3 ]; then
+    echo "  probe (c) attempt ${_attempt} transient (exit=${probe_c_exit} status=${probe_c_status:-none}), retrying in 3s..."
+    sleep 3
+  fi
+done
 
-if [ "${probe_c_exit}" -eq 0 ] && [ -n "${probe_c_output}" ]; then
-  pass "probe (c): allowlisted host api.github.com returned 200 (body: ${probe_c_output})"
+if [ "${probe_c_status}" = "200" ]; then
+  pass "probe (c): allowlisted host api.github.com returned 200"
 else
-  fail "probe (c): expected 200 from api.github.com via mitmproxy, got: exit=${probe_c_exit} output=${probe_c_output}"
+  fail "probe (c): expected 200 from api.github.com via mitmproxy, got: exit=${probe_c_exit} status=${probe_c_status:-none} output=${probe_c_output}"
 fi
 
 # Assert mitmproxy logged the allowed flow — proves routing, not just isolation.

--- a/deploy/validate-stack.sh
+++ b/deploy/validate-stack.sh
@@ -30,8 +30,10 @@ PYTHON3_BIN="${PYTHON3_BIN:-python3}"
 #      network (its upstream leg to the internet).
 #   4. workspace is attached to NO non-internal network — it cannot reach the
 #      internet directly, even if a new network is added to the compose file.
-#   5. egress-net has EXACTLY ONE attached service (mitmproxy) — no other
-#      service may join the internet-capable network.
+#   5. Only allowlisted (service, network) pairs may attach to any non-internal
+#      network: {mitmproxy→egress-net, gateway→gateway-net}. Any other service
+#      on any non-internal network fails closed. Unknown non-internal network
+#      declarations also fail (drift check).
 #   6. workspace mounts the named volume 'workspace-repos' at exactly
 #      '/workspace/repos' — repo checkouts must survive container recreation.
 #
@@ -220,23 +222,33 @@ if "workspace" not in network_mode_services and workspace_egress_nets:
     )
 
 # ------------------------------------------------------------------
-# Invariant 5: each non-internal network that mitmproxy uses must have
-# EXACTLY ONE attached service (mitmproxy itself).
-# (mitmproxy_egress_nets is empty when mitmproxy has network_mode, so
-# this loop is a no-op in that case — no explicit skip needed)
+# Invariant 5: only allowlisted (service, network) pairs may attach to
+# any non-internal network.  The allowlist is the minimal trusted set:
+#   mitmproxy → egress-net  (the workspace's only internet chokepoint)
+#   gateway   → gateway-net (trusted first-party TCB; see deploy/README.md)
+# Any other service on any non-internal network fails closed, including
+# services on non-internal networks that mitmproxy is not on.
+# Services that declare network_mode are already rejected by Invariant 1b.
 # ------------------------------------------------------------------
-for egress_net in mitmproxy_egress_nets:
-    attached = [
-        svc for svc, spec in services.items()
-        if egress_net in service_networks(svc)
-    ]
-    if attached != ["mitmproxy"] and set(attached) != {"mitmproxy"}:
-        others = [s for s in attached if s != "mitmproxy"]
-        failures.append(
-            f"FAIL: non-internal network '{egress_net}' has unexpected service(s) "
-            f"attached: {others!r}. Only mitmproxy may join the internet-capable "
-            "network — adding other services breaks the containment boundary."
-        )
+allowed_non_internal_attachments = {("mitmproxy", "egress-net"), ("gateway", "gateway-net")}
+for svc in sorted(services):
+    if svc in network_mode_services:
+        continue
+    for net in sorted(service_networks(svc) & non_internal_nets):
+        if (svc, net) not in allowed_non_internal_attachments:
+            failures.append(
+                f"FAIL: service '{svc}' attached to non-internal network '{net}'; "
+                f"only these (service, network) pairs are permitted: {sorted(allowed_non_internal_attachments)!r}"
+            )
+
+# Drift check: fail any declared non-internal network not in the known set,
+# so a shadow egress network cannot be introduced even before a service joins it.
+allowed_non_internal_nets = {"egress-net", "gateway-net"}
+for net in sorted(non_internal_nets - allowed_non_internal_nets):
+    failures.append(
+        f"FAIL: unknown non-internal network '{net}' declared; "
+        "only egress-net/gateway-net are permitted"
+    )
 
 # ------------------------------------------------------------------
 # Invariant 6: workspace must mount the named volume 'workspace-repos'
@@ -320,7 +332,7 @@ print(f"    workspace networks: {sorted(workspace_nets)!r}  ✓")
 print(f"    mitmproxy networks: {sorted(mitmproxy_nets)!r}  ✓")
 print(f"    mitmproxy egress leg(s): {sorted(mitmproxy_egress_nets)!r}  ✓")
 print("    workspace has no direct egress  ✓")
-print("    egress network(s) have exactly one attached service (mitmproxy)  ✓")
+print(f"    non-internal network attachments: only allowlisted pairs {sorted(allowed_non_internal_attachments)!r}  ✓")
 print(f"    workspace mounts {REQUIRED_SOURCE!r} at {REQUIRED_TARGET!r}  ✓")
 PYEOF
 

--- a/deploy/validate-stack.test.sh
+++ b/deploy/validate-stack.test.sh
@@ -1347,6 +1347,77 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# TEST 25 — Negative: gateway attached to [sandbox-net, egress-net] must be
+#           rejected — the allowlist binds the PAIR (service, network), not
+#           just the network.  gateway is only allowed on gateway-net; attaching
+#           it to egress-net is a violation even though egress-net itself is
+#           allowlisted for mitmproxy.
+#
+#           This proves the guard checks the (service, network) pair, not just
+#           the network name.  The failure message must name BOTH 'gateway' and
+#           'egress-net' to confirm the pair binding is enforced.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 25: guard rejects gateway attached to [sandbox-net, egress-net] (wrong pair) ---"
+
+GW_EGRESS_COMPOSE="${TMPDIR_TEST}/compose-gw-egress.yaml"
+cat > "${GW_EGRESS_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  gateway:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+GW_EGRESS_OUTPUT=""
+GW_EGRESS_EXIT=0
+GW_EGRESS_OUTPUT="$(COMPOSE_FILE="${GW_EGRESS_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || GW_EGRESS_EXIT=$?
+
+if [[ "${GW_EGRESS_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${GW_EGRESS_EXIT}) for gateway attached to egress-net"
+else
+  fail "validate-stack.sh exited ZERO for gateway on egress-net — pair-binding guard did NOT fire"
+fi
+
+# The failure message must name BOTH 'gateway' AND 'egress-net' to prove the
+# allowlist binds the pair, not just the network.
+if echo "${GW_EGRESS_OUTPUT}" | grep -q "gateway"; then
+  pass "failure message names 'gateway'"
+else
+  fail "failure message does not name 'gateway' — output: ${GW_EGRESS_OUTPUT}"
+fi
+
+if echo "${GW_EGRESS_OUTPUT}" | grep -q "egress-net"; then
+  pass "failure message names 'egress-net'"
+else
+  fail "failure message does not name 'egress-net' — output: ${GW_EGRESS_OUTPUT}"
+fi
+
+echo ""
+echo "  gateway-egress-net-test output (stderr+stdout combined):"
+echo "${GW_EGRESS_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/deploy/validate-stack.test.sh
+++ b/deploy/validate-stack.test.sh
@@ -995,6 +995,358 @@ echo "  single-file-no-docker-test output (stderr+stdout combined):"
 echo "${SINGLE_NODOCK_OUTPUT}" | sed 's/^/    /'
 
 # ---------------------------------------------------------------------------
+# TEST 20 — Negative: sidecar attached to [sandbox-net, shadow-egress]
+#           must be rejected by the global non-internal-attachment invariant.
+#
+# This is the core #814 bypass class: a service bridges sandbox-net to a
+# non-internal network that mitmproxy is NOT on.  The old per-mitmproxy-net
+# loop would miss this; the new global allowlist must catch it.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 20: global invariant rejects sidecar on [sandbox-net, shadow-egress] ---"
+
+SHADOW_EGRESS_COMPOSE="${TMPDIR_TEST}/compose-shadow-egress.yaml"
+cat > "${SHADOW_EGRESS_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+  leakproxy:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+      - shadow-egress
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+  shadow-egress: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+SHADOW_EGRESS_OUTPUT=""
+SHADOW_EGRESS_EXIT=0
+SHADOW_EGRESS_OUTPUT="$(COMPOSE_FILE="${SHADOW_EGRESS_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || SHADOW_EGRESS_EXIT=$?
+
+if [[ "${SHADOW_EGRESS_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${SHADOW_EGRESS_EXIT}) for sidecar on shadow-egress"
+else
+  fail "validate-stack.sh exited ZERO for sidecar on shadow-egress — global invariant did NOT fire"
+fi
+
+if echo "${SHADOW_EGRESS_OUTPUT}" | grep -q "leakproxy"; then
+  pass "failure message names the offending service 'leakproxy'"
+else
+  fail "failure message does not name 'leakproxy' — output: ${SHADOW_EGRESS_OUTPUT}"
+fi
+
+if echo "${SHADOW_EGRESS_OUTPUT}" | grep -q "shadow-egress"; then
+  pass "failure message names the offending network 'shadow-egress'"
+else
+  fail "failure message does not name 'shadow-egress' — output: ${SHADOW_EGRESS_OUTPUT}"
+fi
+
+echo ""
+echo "  shadow-egress-test output (stderr+stdout combined):"
+echo "${SHADOW_EGRESS_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 21 — Negative: sidecar attached to [sandbox-net, gateway-net]
+#           must be rejected — only gateway may join gateway-net.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 21: global invariant rejects sidecar on [sandbox-net, gateway-net] ---"
+
+GATEWAY_NET_SIDECAR_COMPOSE="${TMPDIR_TEST}/compose-gateway-net-sidecar.yaml"
+cat > "${GATEWAY_NET_SIDECAR_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  gateway:
+    image: ubuntu:22.04
+    networks:
+      - gateway-net
+      - sandbox-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+  sidecar:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+      - gateway-net
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+  gateway-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+GATEWAY_NET_SIDECAR_OUTPUT=""
+GATEWAY_NET_SIDECAR_EXIT=0
+GATEWAY_NET_SIDECAR_OUTPUT="$(COMPOSE_FILE="${GATEWAY_NET_SIDECAR_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || GATEWAY_NET_SIDECAR_EXIT=$?
+
+if [[ "${GATEWAY_NET_SIDECAR_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${GATEWAY_NET_SIDECAR_EXIT}) for sidecar on gateway-net"
+else
+  fail "validate-stack.sh exited ZERO for sidecar on gateway-net — global invariant did NOT fire"
+fi
+
+if echo "${GATEWAY_NET_SIDECAR_OUTPUT}" | grep -q "sidecar"; then
+  pass "failure message names the offending service 'sidecar'"
+else
+  fail "failure message does not name 'sidecar' — output: ${GATEWAY_NET_SIDECAR_OUTPUT}"
+fi
+
+if echo "${GATEWAY_NET_SIDECAR_OUTPUT}" | grep -q "gateway-net"; then
+  pass "failure message names the offending network 'gateway-net'"
+else
+  fail "failure message does not name 'gateway-net' — output: ${GATEWAY_NET_SIDECAR_OUTPUT}"
+fi
+
+echo ""
+echo "  gateway-net-sidecar-test output (stderr+stdout combined):"
+echo "${GATEWAY_NET_SIDECAR_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 22 — Negative: shadow-egress declared with no service attached
+#           must be rejected by the drift check (raw-YAML path).
+#
+# The drift check fails any declared non-internal network not in
+# {egress-net, gateway-net}, even if no service has joined it yet.
+# This prevents the hole from being introduced by declaration alone.
+#
+# NOTE: `docker compose config` drops unused networks from its normalized
+# output, so the drift check for declared-but-unused networks only fires
+# via the raw-YAML fallback (no docker in PATH).  This test strips docker
+# from PATH to exercise that path.  When a service IS attached to the
+# unknown network, docker compose config keeps it and the drift check fires
+# in both paths (see TEST 20 which also triggers the drift check message).
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 22: drift check rejects shadow-egress declared with no service (raw-YAML path, no docker) ---"
+
+DRIFT_COMPOSE="${TMPDIR_TEST}/compose-drift.yaml"
+cat > "${DRIFT_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+  shadow-egress: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+if "${PYTHON3_BIN}" -c "import yaml" 2>/dev/null; then
+  DRIFT_OUTPUT=""
+  DRIFT_EXIT=0
+  DRIFT_OUTPUT="$(PATH="${NO_DOCKER_PATH}" COMPOSE_FILE="${DRIFT_COMPOSE}" PYTHON3_BIN="${PYTHON3_BIN}" "${BASH_BIN}" deploy/validate-stack.sh --topology-only 2>&1)" || DRIFT_EXIT=$?
+
+  if [[ "${DRIFT_EXIT}" -ne 0 ]]; then
+    pass "drift check exited non-zero (${DRIFT_EXIT}) for shadow-egress declared with no service (raw-YAML path)"
+  else
+    fail "drift check exited ZERO for shadow-egress declared with no service (raw-YAML path) — drift check did NOT fire"
+  fi
+
+  if echo "${DRIFT_OUTPUT}" | grep -q "shadow-egress"; then
+    pass "drift-check failure message names 'shadow-egress'"
+  else
+    fail "drift-check failure message does not name 'shadow-egress' — output: ${DRIFT_OUTPUT}"
+  fi
+
+  if echo "${DRIFT_OUTPUT}" | grep -qi "unknown non-internal\|only egress-net"; then
+    pass "drift-check failure message indicates unknown non-internal network"
+  else
+    fail "drift-check failure message missing expected text — output: ${DRIFT_OUTPUT}"
+  fi
+
+  echo ""
+  echo "  drift-check-test output (stderr+stdout combined):"
+  echo "${DRIFT_OUTPUT}" | sed 's/^/    /'
+else
+  echo "  SKIP: drift check (raw-YAML path): PyYAML not available — install python3-yaml/PyYAML to run this test."
+  echo "        (docker compose config drops unused networks, so the raw-YAML path is required for this case)"
+fi
+
+# ---------------------------------------------------------------------------
+# TEST 23 — Positive: mitmproxy→egress-net + gateway→gateway-net only
+#           (the exact allowlisted pairs) must pass.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 23: global invariant accepts allowlisted pairs mitmproxy→egress-net + gateway→gateway-net ---"
+
+ALLOWLIST_COMPOSE="${TMPDIR_TEST}/compose-allowlist.yaml"
+cat > "${ALLOWLIST_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  gateway:
+    image: ubuntu:22.04
+    networks:
+      - gateway-net
+      - sandbox-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+  gateway-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+ALLOWLIST_OUTPUT=""
+ALLOWLIST_EXIT=0
+ALLOWLIST_OUTPUT="$(COMPOSE_FILE="${ALLOWLIST_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || ALLOWLIST_EXIT=$?
+
+if [[ "${ALLOWLIST_EXIT}" -eq 0 ]]; then
+  pass "validate-stack.sh exited zero for allowlisted pairs mitmproxy→egress-net + gateway→gateway-net"
+else
+  fail "validate-stack.sh exited non-zero (${ALLOWLIST_EXIT}) for allowlisted pairs — output: ${ALLOWLIST_OUTPUT}"
+fi
+
+if echo "${ALLOWLIST_OUTPUT}" | grep -q "allowlisted pairs"; then
+  pass "output confirms allowlisted pairs check passed"
+else
+  fail "output does not confirm allowlisted pairs check — output: ${ALLOWLIST_OUTPUT}"
+fi
+
+echo ""
+echo "  allowlist-pairs-test output (stderr+stdout combined):"
+echo "${ALLOWLIST_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 24 — Multi-file override (#814 literal repro): base compose + override
+#           that adds a leakproxy sidecar on [sandbox-net, shadow-egress].
+#
+# This is the exact bypass class from issue #814: the override introduces a
+# service on a non-internal network that mitmproxy is NOT on.  The old guard
+# would miss it; the new global allowlist must catch it via docker compose
+# merge semantics.
+#
+# REQUIRES docker compose for authoritative multi-file merge.  The raw-YAML
+# fallback fail-closes on multi-file input (see TEST 16), so this test MUST
+# run through real docker compose config.  Hard-skip with a visible notice
+# when docker is absent — do NOT let it silently pass via the raw-YAML path.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 24: multi-file override (#814 repro) — leakproxy sidecar on shadow-egress (docker-gated) ---"
+
+MULTI814_BASE_COMPOSE="${TMPDIR_TEST}/compose-814-base.yaml"
+cat > "${MULTI814_BASE_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+MULTI814_OVERRIDE_COMPOSE="${TMPDIR_TEST}/compose-814-override.yaml"
+cat > "${MULTI814_OVERRIDE_COMPOSE}" <<'YAML'
+services:
+  leakproxy:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+      - shadow-egress
+
+networks:
+  shadow-egress: {}
+YAML
+
+if command -v docker &>/dev/null; then
+  MULTI814_OUTPUT=""
+  MULTI814_EXIT=0
+  MULTI814_OUTPUT="$(COMPOSE_FILE="${MULTI814_BASE_COMPOSE}:${MULTI814_OVERRIDE_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || MULTI814_EXIT=$?
+
+  if [[ "${MULTI814_EXIT}" -ne 0 ]]; then
+    pass "multi-file #814 repro: validate-stack.sh exited non-zero (${MULTI814_EXIT}) — leakproxy/shadow-egress bypass caught"
+  else
+    fail "multi-file #814 repro: validate-stack.sh exited ZERO — override-merged topology violation was NOT caught"
+  fi
+
+  if echo "${MULTI814_OUTPUT}" | grep -q "leakproxy"; then
+    pass "multi-file #814 repro: failure message names 'leakproxy'"
+  else
+    fail "multi-file #814 repro: failure message does not name 'leakproxy' — output: ${MULTI814_OUTPUT}"
+  fi
+
+  if echo "${MULTI814_OUTPUT}" | grep -q "shadow-egress"; then
+    pass "multi-file #814 repro: failure message names 'shadow-egress'"
+  else
+    fail "multi-file #814 repro: failure message does not name 'shadow-egress' — output: ${MULTI814_OUTPUT}"
+  fi
+
+  echo ""
+  echo "  multi-file-814-repro output (stderr+stdout combined):"
+  echo "${MULTI814_OUTPUT}" | sed 's/^/    /'
+else
+  echo "  SKIP: multi-file #814 repro: docker not in PATH — this test requires docker compose for authoritative"
+  echo "        multi-file merge semantics; raw-YAML fallback fail-closes on multi-file input (see TEST 16)."
+  echo "        Install docker compose to run this test."
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/docs/plans/2026-06-14-002-fix-egress-topology-guard-relay-plan.md
+++ b/docs/plans/2026-06-14-002-fix-egress-topology-guard-relay-plan.md
@@ -1,0 +1,215 @@
+---
+title: "fix: Close egress-relay bypass in the compose topology guard (#814) + live egress smoke (#745)"
+type: fix
+status: active
+date: 2026-06-14
+deepened: 2026-06-14
+---
+
+# Close the egress-relay bypass in the topology guard (#814) + live egress smoke (#745)
+
+## Overview
+
+The compose topology guard (`deploy/validate-stack.sh`, `check_compose_topology`) is supposed to enforce that all workspace egress flows through mitmproxy. Its Invariant 5 only inspects the non-internal networks **mitmproxy itself** is attached to, so a service bridging `sandbox-net` to a *different* non-internal network (one mitmproxy is not on) is never inspected — an unguarded egress relay reachable from the workspace. This plan replaces Invariant 5 with a global invariant: no service may attach to any non-internal network except an explicit allowlist of trusted `(service, network)` pairs — `{mitmproxy→egress-net, gateway→gateway-net}`. It documents the gateway as a deliberate trusted-TCB exception, corrects the now-inaccurate topology comments, and adds a runtime egress smoke (#745) that proves the workspace's only internet path is mitmproxy.
+
+Decision basis: Option B from issue #814, chosen after threat-model analysis confirmed the untrusted workspace cannot induce the trusted first-party gateway to make caller-directed outbound requests (gateway↔sandbox-net traffic is gateway-initiated, plus one HMAC/replay-gated announce endpoint that posts a fixed embed). Option A (route all gateway egress through mitmproxy, enforce "only mitmproxy on any non-internal net") was rejected as over-engineering with real outage risk — the Discord/Octokit/S3 clients configure no proxy agent today, and persistent Discord WSS through a CONNECT proxy is unverified.
+
+## Problem Frame
+
+`deploy/validate-stack.sh:228-239` (Invariant 5) iterates only `mitmproxy_egress_nets` (the non-internal networks mitmproxy uses). A compose override adding `leakproxy: {networks: [sandbox-net, shadow-egress]}` where mitmproxy is not on `shadow-egress` passes the guard (exits 0): the workspace stays sandbox-net-only, mitmproxy keeps its egress leg, and the new non-internal network is never inspected. The workspace can reach `leakproxy` over `sandbox-net`, and `leakproxy` has direct internet egress — defeating the containment model. The current guard also lacks any runtime proof that egress containment actually holds; `workspace-smoke` runs only static allowlist unit tests (`deploy/mitmproxy/test_allowlist.py`).
+
+## Requirements Trace
+
+- R1. The topology guard fails any service (other than the allowlisted pairs) attached to any non-internal network — including a non-internal network mitmproxy is not on. (#814)
+- R2. The allowlist is explicit and minimal: `{mitmproxy→egress-net, gateway→gateway-net}`. Any other `(service, non-internal-net)` attachment fails closed.
+- R3. The guard also fails declaration of an unknown non-internal network (not in `{egress-net, gateway-net}`), so a `shadow-egress` network can't be introduced even before a service joins it (drift check).
+- R4. The shipped production stack (gateway on gateway-net + sandbox-net, mitmproxy on sandbox-net + egress-net, workspace sandbox-net-only) still passes.
+- R5. The gateway's non-internal attachment is documented as a deliberate trusted-TCB exception, with the constraint that the workspace must never be given a gateway endpoint that performs caller-directed outbound requests. Inaccurate "only mitmproxy touches the internet" comments are corrected. The constraint is backed by a pinning test (see R7), not prose alone.
+- R7. A regression/pinning test asserts the gateway's only sandbox-net-reachable HTTP ingress is the HMAC/replay-gated announce endpoint (gateway↔workspace is otherwise gateway-initiated), so a future workspace-reachable gateway endpoint that performs caller-directed outbound fails CI rather than silently reopening the trust boundary. (security-lens + adversarial finding)
+- R6. A live egress smoke (#745) proves, from the workspace's vantage, that direct internet egress fails, a blocked host through mitmproxy returns 403, and an allowlisted host through mitmproxy succeeds.
+
+## Scope Boundaries
+
+- Not removing the gateway from `gateway-net` (that is Option A; explicitly rejected for #814).
+- Not adding proxy-agent configuration to the Discord/Octokit/S3 clients (Option A plumbing).
+- The live egress smoke proves the **workspace** containment model only; it does not assert gateway traffic routes through mitmproxy (the gateway is an explicit exception).
+
+### Deferred to Separate Tasks
+
+- Revisiting strict single-chokepoint topology (Option A) only if a future gateway endpoint accepts workspace-directed outbound — tracked as the documented constraint, not active work.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `deploy/validate-stack.sh:228-239` — Invariant 5 (the flawed per-mitmproxy-net check) to replace; surrounding invariants 1/3/4 at lines ~190-220 show the established `failures.append(...)` pattern, `service_networks(svc)`, `non_internal_nets`, and `network_mode_services` helpers to reuse.
+- `deploy/compose.yaml` — topology: `workspace` networks `[sandbox-net]` (internal), `mitmproxy` `[sandbox-net, egress-net]`, `gateway` `[gateway-net, sandbox-net]`; `sandbox-net: {internal: true}`, `egress-net`/`gateway-net` non-internal. Topology comments (~lines 339-351) that say only mitmproxy is internet-capable need correction.
+- `deploy/mitmproxy/allowlist.py` — CONNECT + plain-HTTP allowlist enforcement; existing allowed hosts (Discord/GitHub/LLM) — the smoke's allowed/blocked host choices should align with this.
+- `deploy/mitmproxy/test_allowlist.py` — existing static allowlist unit tests run by `workspace-smoke`.
+- `.github/workflows/ci.yaml:341-360` — `workspace-smoke` job (runs allowlist tests + builds workspace image); `.github/workflows/ci.yaml:241+` — `gateway-smoke`. The live egress smoke is a new step/job here.
+- Guard test pattern: check how `deploy/validate-stack.sh` is currently tested (look for `deploy/scripts/*.test.mjs` or a validate-stack test harness) and follow it; `deploy/scripts/` uses Node's built-in `node --test` runner per AGENTS.md, not Vitest.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/cross-libc-build-and-release-safety-2026-06-14.md` and the egress-hardening history (#741/#746/#815) — prior topology-guard work; fail-closed multi-file validation and `network_mode` rejection already shipped.
+
+### External References
+
+- Issue #814 (the bypass + A/B decision), issue #745 (live egress smoke).
+
+## Key Technical Decisions
+
+- **Option B (allowlist exception), not A (strict chokepoint).** Threat-model-justified: workspace cannot use the gateway as a relay; A risks outages with no proxy-agent config present.
+- **Global invariant with an explicit `(service, network)` allowlist set.** Replaces the per-mitmproxy-net loop; closes the shadow-egress class entirely.
+- **Drift check on network declarations.** Fail any declared non-internal network not in `{egress-net, gateway-net}`, so the hole can't be reintroduced by declaration.
+- **Gateway documented as trusted TCB exception** with the explicit forward constraint (no workspace-directed-outbound gateway endpoint), so the weaker-than-strict posture is deliberate and auditable.
+- **Live smoke proves the workspace model only.** Gateway egress is an explicit exception, so the smoke does not assert proxy-only routing for gateway traffic.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Strict vs allowlist posture (#814 A/B): resolved to B (see KTD).
+- Does the workspace have a relay path via the gateway? No — verified gateway ingress from sandbox-net is gateway-initiated + HMAC-gated announce only.
+
+### Deferred to Implementation
+
+- Exact allowed/blocked host choices for the live smoke: pick from `deploy/mitmproxy/allowlist.py` at implementation (e.g., an allowlisted LLM/GitHub host for the 200 case, an arbitrary non-allowlisted host for the 403 case).
+- Whether the live smoke runs as a new step inside `workspace-smoke` or a dedicated job: decide when wiring, based on what infra the smoke needs (it must `docker compose up` the stack).
+
+## Implementation Units
+
+- [ ] **Unit 1: Replace Invariant 5 with a global non-internal-attachment allowlist + drift check**
+
+**Goal:** The guard fails any non-allowlisted service on any non-internal network, and any unknown non-internal network declaration.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `deploy/validate-stack.sh` (replace Invariant 5 block ~228-239; add the drift check)
+
+**Approach:**
+- Define `allowed_non_internal_attachments = {("mitmproxy","egress-net"), ("gateway","gateway-net")}` and `allowed_non_internal_nets = {"egress-net","gateway-net"}`.
+- Global loop over all services (skipping `network_mode_services`): for each non-internal network the service is attached to, fail if the `(svc, net)` pair is not in the allowlist — naming the offending pair and the allowed set.
+- Drift check: fail any declared network in `non_internal_nets` not in `allowed_non_internal_nets`.
+- Remove the old per-`mitmproxy_egress_nets` loop. Keep invariants 1/3/4 intact.
+
+**Technical design:** *(directional, not implementation spec)*
+```python
+allowed_non_internal_attachments = {("mitmproxy", "egress-net"), ("gateway", "gateway-net")}
+for svc in sorted(services):
+    if svc in network_mode_services: continue
+    for net in sorted(service_networks(svc) & non_internal_nets):
+        if (svc, net) not in allowed_non_internal_attachments:
+            failures.append(f"FAIL: service '{svc}' attached to non-internal network '{net}'; allowed: {sorted(allowed_non_internal_attachments)!r}")
+# drift check
+for net in sorted(non_internal_nets - {"egress-net", "gateway-net"}):
+    failures.append(f"FAIL: unknown non-internal network '{net}' declared; only egress-net/gateway-net are permitted")
+```
+
+**Patterns to follow:** existing `failures.append(...)` / `service_networks` / `non_internal_nets` usage in the same file.
+
+**Test scenarios:**
+- Happy path: real shipped topology (workspace sandbox-net; mitmproxy sandbox+egress; gateway gateway+sandbox) → passes.
+- Edge: `sidecar: [sandbox-net, shadow-egress]` (mitmproxy not on shadow-egress) → fails with the sidecar/shadow-egress pair named.
+- Edge: `sidecar: [sandbox-net, gateway-net]` (joining the gateway's allowed net) → fails (only gateway may join gateway-net).
+- Edge: declaring `shadow-egress` with no service attached → fails (drift check).
+- Edge: mitmproxy on egress-net + gateway on gateway-net → both pass (allowlisted pairs).
+- Error path: workspace on a non-internal net → still fails (invariant 4 unaffected).
+
+**Verification:** running the guard against current `deploy/compose.yaml` exits 0; against each malicious fixture exits non-zero with the precise failing pair/network.
+
+- [ ] **Unit 2: Guard tests for the global invariant**
+
+**Goal:** Lock the new invariant + drift check behavior with regression tests.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `deploy/validate-stack.test.sh` (the EXISTING shell test harness — not `deploy/scripts/*.test.mjs`, which was a misstatement; add fixture cases here)
+
+**Approach:** Drive the guard with minimal compose fixtures for each scenario in Unit 1's test list; assert exit code + the specific failure message substring. The guard supports `--topology-only` with a raw-YAML fallback, so **single-file** fixtures run docker-free. CAVEAT (feasibility/adversarial): the no-docker raw-YAML path fail-closes on **multi-file** input, and #814's bypass class depends on `docker compose config` **merge** semantics — so the override-merge regression (base compose + a malicious override file) MUST run through real `docker compose config`. If compose is unavailable in the harness environment, that specific case must **hard-skip with a visible notice or fail**, never silently downgrade to the raw-YAML path (which would give false confidence). Single-file fixtures (shadow-egress declared inline, gateway-net sidecar inline, drift) cover the rest docker-free.
+
+**Execution note:** Write the shadow-egress and gateway-net-sidecar failing fixtures first (they encode the #814 bug), then confirm they fail before/after to prove the fix.
+
+**Test scenarios:** mirror Unit 1's six scenarios as discrete test cases with exit-code + message assertions; include at least one **multi-file override** case (docker-gated) since that is the literal #814 reproduction.
+
+**Verification:** the test suite passes; removing the Unit 1 fix makes the shadow-egress test fail (the test actually guards the bug); the multi-file override case runs through `docker compose config` (or is explicitly skipped, not silently raw-YAML'd).
+
+- [ ] **Unit 3: Document the gateway TCB exception + correct topology comments + pin the gateway ingress surface**
+
+**Goal:** Make the deliberate weaker-than-strict posture explicit and auditable; remove false "only mitmproxy reaches the internet" statements; back the TCB assumption with a pinning test so it can't silently erode.
+
+**Requirements:** R5, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `deploy/compose.yaml` (topology comments ~339-351), `deploy/validate-stack.sh` (header comment ~33-34), `deploy/README.md` (egress/topology section)
+- Create/Modify: a gateway-ingress pinning test in `packages/gateway/` (follow existing gateway test conventions) asserting the sandbox-net-reachable HTTP ingress surface is exactly the HMAC/replay-gated announce endpoint
+
+**Approach:**
+- Docs: state that the gateway attaches to gateway-net as a trusted first-party TCB because it must reach Discord/GitHub/object storage; the containment guarantee is "the **workspace** reaches the internet only via mitmproxy." Add the forward constraint: never give the workspace a gateway endpoint that performs caller-directed outbound requests; if that changes, revisit strict topology (Option A). Correct any comment asserting only mitmproxy is internet-capable.
+- Pinning test (R7): assert the gateway's HTTP server (the `src/http/` ingress, currently only `POST /v1/announce`, HMAC/timestamp/replay/schema-gated, posting a fixed embed) is its only inbound HTTP surface reachable from sandbox-net, and that the gateway→workspace direction (clone/readyz/opencode-proxy) is gateway-initiated. The test should fail if a new route is added to the gateway HTTP ingress without updating the pin — forcing a deliberate security review of any new workspace-reachable endpoint. Right-size it: a route-inventory assertion against the registered HTTP handlers, not a heuristic "detects arbitrary-URL" analyzer.
+
+**Test scenarios:**
+- Happy path: the gateway HTTP ingress route inventory equals {announce} → pin passes.
+- Edge/guard: adding a hypothetical second ingress route → pin fails (forces review). (Express this as the assertion that locks the current route set.)
+
+**Verification:** no remaining comment claims "only mitmproxy" reaches the internet; the gateway exception + constraint is stated in compose, guard header, and README; the gateway ingress pin passes for the current surface and would fail on an unreviewed new route.
+
+- [ ] **Unit 4: Live workspace egress smoke (#745)**
+
+**Goal:** Prove at runtime that the workspace's only internet path is mitmproxy.
+
+**Requirements:** R6
+
+**Dependencies:** Unit 1 (topology must be guard-valid first)
+
+**Files:**
+- Modify: `.github/workflows/ci.yaml` (`workspace-smoke` job, or a new dedicated egress-smoke job) — bring the stack up and run the probes
+- Create (if a script is cleaner than inline): `deploy/egress-smoke.sh` (workspace-vantage probes)
+
+**Approach:** Bring up the relevant compose services (sandbox-net + mitmproxy + egress-net). Run probes from the **actual workspace container** (it carries the mitmproxy CA trust + proxy env via its entrypoint; an arbitrary throwaway container would not, and would make the HTTPS 200 case fail for the wrong reason). The smoke must **prove routing, not just absence of direct egress** — because `sandbox-net` is `internal: true`, a "direct request fails" check can pass trivially (no route at all) even if proxying is broken (security/adversarial finding). So assert: (a) direct internet request with proxy env unset → fails/refused (containment baseline); (b) request to a non-allowlisted host **through mitmproxy** → 403; (c) request to an allowlisted host **through mitmproxy** → 200 AND mitmproxy logged the allowed flow; (d) the 200 case proves mitmproxy is the path (it succeeds only via the proxy). Sequence the smoke AFTER mitmproxy is healthy and its CA is generated/installed (the 200 HTTPS case depends on the workspace trusting the mitmproxy CA). Keep it hermetic and bounded (timeouts). Do not require gateway traffic to route through mitmproxy.
+
+**Execution note:** This is integration/runtime — it must actually `docker compose up`; verify it fails if mitmproxy is removed or the allowlist is set to allow-all (the negative control must have teeth: an allow-all allowlist makes case (b) return non-403 and the smoke fails).
+
+**Test scenarios:**
+- Integration: workspace direct egress (no proxy) → connection fails (baseline, not the routing proof).
+- Integration: workspace → blocked host via mitmproxy → 403.
+- Integration: workspace → allowlisted host via mitmproxy → 200, succeeds only through the proxy, and mitmproxy logs the allowed flow (this is the routing proof).
+- Integration (negative control, teeth): allow-all allowlist → blocked-host case returns non-403 → smoke fails. mitmproxy removed → allowlisted-host 200 case fails (no path).
+
+**Verification:** the CI job passes on the real stack; allow-all allowlist OR removing mitmproxy makes it fail; the 200 case is observable in mitmproxy logs (proves routing, not just isolation).
+
+## System-Wide Impact
+
+- **Interaction graph:** guard runs in `workspace-smoke`/validate-stack CI path; the live smoke adds a `docker compose up` runtime surface in CI.
+- **Error propagation:** guard remains fail-closed (any violation → non-zero exit + named failure).
+- **API surface parity:** none — internal deploy tooling only.
+- **Integration coverage:** Unit 4 provides the runtime proof unit tests can't (the static guard checks declarations; the smoke checks actual packet flow).
+- **Unchanged invariants:** invariants 1 (workspace sandbox-only), 3 (mitmproxy upstream leg), 4 (workspace no direct egress), 6 (workspace-repos volume) are untouched; the gateway's existing gateway-net membership is preserved (now explicitly allowlisted).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Global invariant too strict → fails the real stack | Unit 1 test + run guard against current compose.yaml; allowlist includes the two real pairs |
+| Live smoke flaky in CI (network/timeouts) | Bounded timeouts, hermetic stack, allow retry on transport flake; assert on mitmproxy decision logs not just status |
+| Gateway TCB exception misread as "secure as strict" | Unit 3 documents the residual risk + forward constraint explicitly |
+| Future gateway endpoint enables workspace-directed outbound | Documented constraint; revisit Option A if it changes |
+
+## Documentation / Operational Notes
+
+- `deploy/README.md` egress section updated for the gateway exception + the workspace-only containment guarantee.
+- Closes #814 and #745.
+
+## Sources & References
+
+- Issue #814 (egress-relay bypass + A/B decision), Issue #745 (live egress smoke).
+- Oracle analysis (2026-06-14): Option B recommendation, gateway-ingress threat-model verification, exact guard rewrite.
+- Code: `deploy/validate-stack.sh:228-239`, `deploy/compose.yaml`, `deploy/mitmproxy/allowlist.py`, `.github/workflows/ci.yaml:341-360`.

--- a/packages/gateway/src/http/ingress-pin.test.ts
+++ b/packages/gateway/src/http/ingress-pin.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Gateway HTTP ingress surface pinning test.
+ *
+ * The gateway is reachable from the workspace over sandbox-net. Its only
+ * inbound HTTP surface must be the HMAC/replay-gated POST /v1/announce
+ * endpoint — a fixed-embed webhook that does not perform caller-directed
+ * outbound requests. Any new route added to the gateway's HTTP ingress
+ * could reopen the egress trust boundary (a workspace-reachable endpoint
+ * that performs arbitrary outbound requests would let the workspace bypass
+ * mitmproxy via the gateway). This test fails if the route inventory
+ * changes, forcing a deliberate security review before the change ships.
+ *
+ * If you are adding a new HTTP route and this test fails:
+ *   1. Confirm the new endpoint does NOT perform caller-directed outbound
+ *      requests on behalf of the workspace.
+ *   2. Update EXPECTED_ROUTES below with the new route after review.
+ *   3. Update deploy/README.md (Egress topology → Forward constraint) to
+ *      document the new endpoint and its trust properties.
+ */
+
+import type {Client} from 'discord.js'
+import type {AnnounceLogger} from './announce-handler.js'
+import {describe, expect, it, vi} from 'vitest'
+import {buildAnnounceApp} from './server.js'
+
+// ---------------------------------------------------------------------------
+// Pinned ingress surface — update only after deliberate security review.
+// ---------------------------------------------------------------------------
+
+/**
+ * The complete set of HTTP routes the gateway exposes over sandbox-net.
+ * Each entry is { method, path } matching Hono's app.routes shape.
+ *
+ * Current surface: exactly one endpoint — the HMAC/replay/timestamp/schema-gated
+ * announce webhook. It posts a fixed embed to a configured Discord channel and
+ * does not perform caller-directed outbound requests.
+ */
+const EXPECTED_ROUTES: readonly {method: string; path: string}[] = [{method: 'POST', path: '/v1/announce'}]
+
+// ---------------------------------------------------------------------------
+// Minimal stubs — we only need to build the app, not run requests.
+// ---------------------------------------------------------------------------
+
+function makeStubDeps(): Parameters<typeof buildAnnounceApp>[0] {
+  const logger: AnnounceLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+  // Structural stub — only the shape matters; no real Discord calls are made.
+  const client = {channels: {fetch: vi.fn()}} as unknown as Client
+  return {client, logger}
+}
+
+function makeStubConfig(): Parameters<typeof buildAnnounceApp>[1] {
+  return {
+    webhookSecret: 'stub-secret',
+    presenceChannelId: 'stub-channel',
+    httpPort: 0, // not used — we never call serve()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pin test
+// ---------------------------------------------------------------------------
+
+describe('gateway HTTP ingress surface', () => {
+  it('is exactly {POST /v1/announce} — no undeclared routes', () => {
+    // #given — build the Hono app without starting a server
+    const app = buildAnnounceApp(makeStubDeps(), makeStubConfig())
+
+    // #when — extract the registered user-defined routes as unique (method, path) pairs.
+    // Hono registers each middleware in a chain as a separate entry for the same route
+    // (e.g. bodyLimit + handler both appear as POST /v1/announce). Deduplicate by
+    // (method, path) so the pin reflects the logical route inventory, not the
+    // middleware-chain expansion. A new logical route still produces a new unique pair.
+    const seen = new Set<string>()
+    const actualRoutes = app.routes
+      .map(r => ({method: r.method, path: r.path}))
+      .filter(r => {
+        const key = `${r.method}:${r.path}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+
+    // #then — the inventory must match the pinned set exactly.
+    // Adding a route without updating this pin fails the test, requiring a
+    // security review of the new workspace-reachable endpoint.
+    expect(actualRoutes).toEqual(EXPECTED_ROUTES)
+  })
+})

--- a/packages/gateway/src/http/ingress-pin.test.ts
+++ b/packages/gateway/src/http/ingress-pin.test.ts
@@ -16,10 +16,27 @@
  *   2. Update EXPECTED_ROUTES below with the new route after review.
  *   3. Update deploy/README.md (Egress topology → Forward constraint) to
  *      document the new endpoint and its trust properties.
+ *
+ * SERVER ENTRY-POINT PIN (tamper-evident):
+ *   A second HTTP server added anywhere in packages/gateway/src/ would bypass
+ *   the route-inventory check above (it only inspects buildAnnounceApp's routes).
+ *   The static source-scan test below asserts there is exactly ONE serve() call
+ *   across the entire gateway source tree. Adding a second server entry point
+ *   fails this pin, requiring a deliberate security review.
+ *
+ *   We use a static source scan (readFileSync + regex) rather than routing the
+ *   existing pin through createAnnounceServer with serve() stubbed, because:
+ *   - The stub approach only catches routes wired through the factory chain;
+ *     a second server in a different file would still be invisible.
+ *   - A source scan is file-system-wide and catches any new serve() call
+ *     regardless of where it lives in the package.
+ *   - The scan is fast, deterministic, and requires no runtime setup.
  */
 
 import type {Client} from 'discord.js'
 import type {AnnounceLogger} from './announce-handler.js'
+import {readdirSync, readFileSync, statSync} from 'node:fs'
+import {join} from 'node:path'
 import {describe, expect, it, vi} from 'vitest'
 import {buildAnnounceApp} from './server.js'
 
@@ -88,5 +105,79 @@ describe('gateway HTTP ingress surface', () => {
     // Adding a route without updating this pin fails the test, requiring a
     // security review of the new workspace-reachable endpoint.
     expect(actualRoutes).toEqual(EXPECTED_ROUTES)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Server entry-point pin — tamper-evident single-server assertion.
+//
+// The route-inventory test above only inspects routes registered through
+// buildAnnounceApp(). A second HTTP server (serve() / http.createServer())
+// added ELSEWHERE in the gateway package would be completely invisible to it.
+//
+// This test statically scans every .ts source file under packages/gateway/src/
+// and asserts there is exactly ONE serve( call. Adding a second server entry
+// point fails this pin, requiring a deliberate security review before the
+// change ships.
+//
+// We use a static source scan rather than a runtime stub approach because:
+//   - Stubs only catch routes wired through the factory chain; a second server
+//     in a different file would still be invisible.
+//   - A source scan is file-system-wide and catches any new serve() call
+//     regardless of where it lives in the package.
+//   - The scan is fast, deterministic, and requires no runtime setup.
+// ---------------------------------------------------------------------------
+
+/** Recursively collect all .ts files under a directory. */
+function collectTsFiles(dir: string): string[] {
+  const entries = readdirSync(dir)
+  const files: string[] = []
+  for (const entry of entries) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      files.push(...collectTsFiles(full))
+    } else if (entry.endsWith('.ts')) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+describe('gateway server entry-point pin', () => {
+  it('has exactly one serve() call across packages/gateway/src/ — adding a second server requires security review', () => {
+    // #given — locate the gateway src directory relative to this test file.
+    // __dirname is packages/gateway/src/http; go up one level to src/.
+    const gatewaySrcDir = join(__dirname, '..')
+
+    // #when — scan all .ts source files (excluding test files) for serve( calls.
+    const tsFiles = collectTsFiles(gatewaySrcDir).filter(f => !f.endsWith('.test.ts'))
+    const serveCallPattern = /\bserve\s*\(/g
+
+    const serveCallSites: {file: string; line: number}[] = []
+    for (const file of tsFiles) {
+      const content = readFileSync(file, 'utf8')
+      const lines = content.split('\n')
+      lines.forEach((line, idx) => {
+        // Strip single-line comments (//) and JSDoc/block-comment lines (lines
+        // whose non-whitespace content starts with * or /*) before matching.
+        // This avoids false positives from doc-comment references like "serve()/handle".
+        const stripped = line.replace(/\/\/.*$/, '').trim()
+        const isCommentLine = stripped.startsWith('*') || stripped.startsWith('/*')
+        const codePart = isCommentLine ? '' : stripped
+        if (serveCallPattern.test(codePart)) {
+          serveCallSites.push({file, line: idx + 1})
+        }
+        serveCallPattern.lastIndex = 0 // reset stateful regex after each line
+      })
+    }
+
+    // #then — exactly one serve() call must exist (in createAnnounceServer in server.ts).
+    // If this assertion fails, a new HTTP server entry point was added to the gateway.
+    // Before updating this count:
+    //   1. Confirm the new server does NOT expose workspace-reachable endpoints that
+    //      perform caller-directed outbound requests (egress trust boundary).
+    //   2. Update deploy/README.md (Egress topology → Forward constraint).
+    expect(serveCallSites).toHaveLength(1)
+    expect(serveCallSites[0]?.file).toMatch(/server\.ts$/)
   })
 })

--- a/packages/gateway/src/http/server.ts
+++ b/packages/gateway/src/http/server.ts
@@ -58,11 +58,14 @@ export interface AnnounceServerConfig {
 // ---------------------------------------------------------------------------
 
 /**
- * Build and start the Hono server for POST /v1/announce.
+ * Build the Hono application for the announce server.
  *
- * Returns the @hono/node-server handle. Call `.close(cb)` during shutdown.
+ * Exported separately from createAnnounceServer so the route inventory can be
+ * inspected in tests without binding a port. This is the authoritative place
+ * where HTTP routes are registered — any new route added here is immediately
+ * visible to the ingress-pin test.
  */
-export function createAnnounceServer(deps: AnnounceServerDeps, config: AnnounceServerConfig): ServerType {
+export function buildAnnounceApp(deps: AnnounceServerDeps, config: AnnounceServerConfig): Hono {
   const replayCache = deps.replayCache ?? createReplayCache({clock: deps.clock})
   const rateLimiter = deps.rateLimiter ?? createRateLimiter({clock: deps.clock})
   const checkShuttingDown = deps.isShuttingDown ?? (() => false)
@@ -131,5 +134,15 @@ export function createAnnounceServer(deps: AnnounceServerDeps, config: AnnounceS
 
   app.notFound(c => c.json({error: 'not-found'}, 404))
 
+  return app
+}
+
+/**
+ * Build and start the Hono server for POST /v1/announce.
+ *
+ * Returns the @hono/node-server handle. Call `.close(cb)` during shutdown.
+ */
+export function createAnnounceServer(deps: AnnounceServerDeps, config: AnnounceServerConfig): ServerType {
+  const app = buildAnnounceApp(deps, config)
   return serve({fetch: app.fetch, port: config.httpPort})
 }


### PR DESCRIPTION
## What this does

Closes a bypass in the compose egress-containment guard and adds a runtime proof that the workspace's only internet path is mitmproxy.

The topology guard previously only inspected the non-internal networks mitmproxy itself was attached to, so a service bridging the sandbox network to a *different* non-internal network was never checked — an unguarded egress relay reachable from the workspace. The guard now enforces a global invariant: only the allowlisted `(service, network)` pairs (`mitmproxy → egress-net`, `gateway → gateway-net`) may attach to any non-internal network, plus a drift check rejecting unknown non-internal network declarations.

The gateway's `gateway-net` attachment is documented as a deliberate trusted first-party exception (it must reach Discord/GitHub/object storage); the containment guarantee is scoped precisely to the workspace. That exception is backed by a pinning test that locks the gateway's inbound HTTP surface to the announce endpoint and asserts a single HTTP server entry point, so a new workspace-reachable route fails CI and forces review.

## Verification

- Guard tests cover the relay class: a sidecar on a non-allowlisted non-internal network fails, a sidecar joining the gateway's network fails, an unknown non-internal network declaration fails, the gateway-on-the-wrong-net misconfig fails, and the real compose stack passes. The literal multi-file override reproduction runs through real `docker compose config` merge.
- A new CI egress smoke proves routing, not just isolation: a direct request fails, a non-allowlisted host through mitmproxy returns 403, and an allowlisted host succeeds only through mitmproxy with a matching proxy log line. Probes retry only on transport/transient-server errors so a flaky upstream can't fail the gate, while a wrong status fails immediately.

## Follow-up

Defense-in-depth for other egress-weakening compose keys (`extra_hosts` host-gateway, `cap_add: NET_ADMIN`, tun devices) is tracked separately in #899, intentionally kept out of this network-attachment-scoped fix.

Closes #814
Closes #745
