### PR TITLE
fix(deploy): reject egress-weakening compose keys in the topology guard

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -495,4 +495,10 @@ workspace → sandbox-net (internal:true) → mitmproxy → egress-net → inter
 - mitmproxy is dual-homed: it receives workspace traffic on `sandbox-net` and dials allowlisted upstream hosts via `egress-net` (a dedicated non-internal network). Only mitmproxy joins `egress-net`.
 - The gateway is dual-homed on `gateway-net` (non-internal) and `sandbox-net`. It reaches Discord, GitHub, and object storage directly via `gateway-net` — **not** through mitmproxy. This is a deliberate trusted first-party exception: the gateway is operator-controlled code, not the untrusted workspace. The containment guarantee is that **the workspace reaches the internet only via mitmproxy**; the gateway is explicitly outside that constraint.
 
+The compose topology guard (`deploy/validate-stack.sh`) enforces this model statically. In addition to the network-attachment allowlist and the blanket `network_mode` ban, the guard rejects the following egress-weakening keys on **any** service, because each can relay or tunnel workspace egress around mitmproxy:
+
+- `extra_hosts` with a `host-gateway` value — gives the container the Docker host's bridge IP, enabling relay via any host-bound proxy or tunnel.
+- `cap_add: NET_ADMIN` or `cap_add: NET_RAW` — enables raw-socket and routing-table manipulation used to build VPN tunnels.
+- `devices: /dev/net/tun` — the kernel TUN/TAP interface used by VPN clients to construct egress tunnels.
+
 **Forward constraint:** never give the workspace a gateway endpoint that performs caller-directed outbound requests. The only workspace-reachable HTTP ingress on the gateway is the HMAC/replay-gated `POST /v1/announce` endpoint, which posts a fixed embed — it does not perform arbitrary outbound requests on behalf of the caller. If a new workspace-reachable gateway endpoint is added that performs caller-directed outbound, the topology must be revisited. A CI pinning test enforces this: it asserts the gateway's HTTP ingress surface is exactly `{POST /v1/announce}` and fails if a new route is added without a deliberate review.

--- a/deploy/validate-stack.sh
+++ b/deploy/validate-stack.sh
@@ -25,6 +25,16 @@ PYTHON3_BIN="${PYTHON3_BIN:-python3}"
 # Invariants checked:
 #   1. sandbox-net is internal:true — no direct internet gateway for any
 #      container on this network.
+#   1b. NO service may declare network_mode — bypasses the network-attachment
+#      model entirely (host/shared networking).
+#   1c. NO service may declare extra_hosts with a host-gateway value — gives
+#      the container the Docker host's bridge IP, enabling egress relay around
+#      mitmproxy via any host-bound proxy/tunnel.
+#   1d. NO service may declare cap_add with NET_ADMIN or NET_RAW — enables
+#      raw-socket/routing manipulation used to build VPN tunnels that bypass
+#      mitmproxy.
+#   1e. NO service may map the /dev/net/tun device — the TUN/TAP interface
+#      used by VPN clients to construct egress tunnels around mitmproxy.
 #   2. workspace is attached to sandbox-net ONLY — it has zero direct egress.
 #   3. mitmproxy is attached to sandbox-net AND at least one non-internal
 #      network (its upstream leg to the internet).
@@ -249,6 +259,93 @@ for net in sorted(non_internal_nets - allowed_non_internal_nets):
         f"FAIL: unknown non-internal network '{net}' declared; "
         "only egress-net/gateway-net are permitted"
     )
+
+# ------------------------------------------------------------------
+# Invariant 1c: NO service may declare extra_hosts with a host-gateway mapping.
+#
+# extra_hosts: ["proxy.local:host-gateway"] gives the container the Docker
+# host's bridge IP.  If the host runs any forward proxy/SOCKS/tunnel bound
+# to 0.0.0.0, the workspace can relay egress around mitmproxy.  Reject any
+# extra_hosts entry whose value is "host-gateway" on ANY service.
+#
+# Normalized shape (docker compose config JSON): list of "name=value" strings.
+# Raw-YAML fallback shape: list of "name:value" strings OR a dict {name: value}.
+# ------------------------------------------------------------------
+for _svc in sorted(services.keys()):
+    _svc_cfg = services.get(_svc) or {}
+    _extra_hosts = _svc_cfg.get("extra_hosts") or []
+    if isinstance(_extra_hosts, dict):
+        # Raw-YAML dict form: {hostname: value}
+        _extra_hosts_items = list(_extra_hosts.values())
+    else:
+        # Normalized list form: ["name=value", ...] or raw-YAML ["name:value", ...]
+        _extra_hosts_items = []
+        for _entry in _extra_hosts:
+            if isinstance(_entry, dict):
+                # Possible future dict-list form
+                _extra_hosts_items.append(_entry.get("ip") or _entry.get("value") or "")
+            elif isinstance(_entry, str):
+                # Split on first '=' (normalized) or first ':' (raw YAML)
+                if "=" in _entry:
+                    _extra_hosts_items.append(_entry.split("=", 1)[1])
+                elif ":" in _entry:
+                    _extra_hosts_items.append(_entry.split(":", 1)[1])
+    for _val in _extra_hosts_items:
+        if str(_val).strip() == "host-gateway":
+            failures.append(
+                f"FAIL: service '{_svc}' declares extra_hosts with value 'host-gateway' — "
+                "host-gateway gives the container the Docker host's bridge IP and can relay "
+                "workspace egress around mitmproxy. Remove the host-gateway extra_hosts entry."
+            )
+            break
+
+# ------------------------------------------------------------------
+# Invariant 1d: NO service may declare cap_add with NET_ADMIN or NET_RAW.
+#
+# NET_ADMIN and NET_RAW enable raw-socket and routing-table manipulation.
+# Combined with a VPN client image and /dev/net/tun, they can build a tunnel
+# that bypasses mitmproxy.  Reject either capability on ANY service.
+# ------------------------------------------------------------------
+_BANNED_CAPS = {"NET_ADMIN", "NET_RAW"}
+for _svc in sorted(services.keys()):
+    _svc_cfg = services.get(_svc) or {}
+    _cap_add = _svc_cfg.get("cap_add") or []
+    for _cap in _cap_add:
+        if str(_cap).upper() in _BANNED_CAPS:
+            failures.append(
+                f"FAIL: service '{_svc}' declares cap_add '{_cap}' — "
+                "NET_ADMIN and NET_RAW enable raw-socket/routing manipulation that can "
+                "tunnel workspace egress around mitmproxy and are not permitted."
+            )
+
+# ------------------------------------------------------------------
+# Invariant 1e: NO service may map the /dev/net/tun device.
+#
+# /dev/net/tun is the kernel TUN/TAP interface used by VPN clients to build
+# tunnels.  Combined with NET_ADMIN/NET_RAW, it provides a complete egress
+# bypass path.  Reject any device mapping whose host path is /dev/net/tun
+# on ANY service.
+#
+# Normalized shape (docker compose config JSON): list of dicts {source, target, permissions}.
+# Raw-YAML fallback shape: list of "host:container[:perms]" strings.
+# ------------------------------------------------------------------
+for _svc in sorted(services.keys()):
+    _svc_cfg = services.get(_svc) or {}
+    _devices = _svc_cfg.get("devices") or []
+    for _dev in _devices:
+        if isinstance(_dev, dict):
+            _host_path = _dev.get("source") or ""
+        elif isinstance(_dev, str):
+            _host_path = _dev.split(":")[0]
+        else:
+            _host_path = ""
+        if str(_host_path).strip() == "/dev/net/tun":
+            failures.append(
+                f"FAIL: service '{_svc}' maps device '/dev/net/tun' — "
+                "the TUN/TAP interface enables VPN tunnel construction that can bypass "
+                "mitmproxy egress containment and is not permitted."
+            )
+            break
 
 # ------------------------------------------------------------------
 # Invariant 6: workspace must mount the named volume 'workspace-repos'

--- a/deploy/validate-stack.sh
+++ b/deploy/validate-stack.sh
@@ -32,9 +32,12 @@ PYTHON3_BIN="${PYTHON3_BIN:-python3}"
 #      mitmproxy via any host-bound proxy/tunnel.
 #   1d. NO service may declare cap_add with NET_ADMIN or NET_RAW — enables
 #      raw-socket/routing manipulation used to build VPN tunnels that bypass
-#      mitmproxy.
+#      mitmproxy.  CAP_ prefix and case variants are normalized before checking.
 #   1e. NO service may map the /dev/net/tun device — the TUN/TAP interface
 #      used by VPN clients to construct egress tunnels around mitmproxy.
+#      Path normalization catches //, /./ and similar variants.
+#   1f. NO service may declare privileged: true — grants ALL capabilities and
+#      ALL host devices, nullifying Invariants 1d and 1e entirely.
 #   2. workspace is attached to sandbox-net ONLY — it has zero direct egress.
 #   3. mitmproxy is attached to sandbox-net AND at least one non-internal
 #      network (its upstream leg to the internet).
@@ -278,6 +281,10 @@ for _svc in sorted(services.keys()):
         # Raw-YAML dict form: {hostname: value}
         _extra_hosts_items = list(_extra_hosts.values())
     else:
+        # Scalar-string guard: a bare string (e.g. extra_hosts: "proxy.local:host-gateway")
+        # would be iterated character-by-character without this wrap.
+        if isinstance(_extra_hosts, str):
+            _extra_hosts = [_extra_hosts]
         # Normalized list form: ["name=value", ...] or raw-YAML ["name:value", ...]
         _extra_hosts_items = []
         for _entry in _extra_hosts:
@@ -305,33 +312,66 @@ for _svc in sorted(services.keys()):
 # NET_ADMIN and NET_RAW enable raw-socket and routing-table manipulation.
 # Combined with a VPN client image and /dev/net/tun, they can build a tunnel
 # that bypasses mitmproxy.  Reject either capability on ANY service.
+#
+# Normalization: Docker Compose may preserve the CAP_ prefix (e.g.
+# CAP_NET_ADMIN) or lowercase variants (cap_net_admin) from raw YAML.
+# Strip a leading CAP_ prefix and uppercase before checking the banned set
+# so all forms are caught.
+#
+# Scalar-string guard: if cap_add is a bare string (not a list), wrap it
+# into a single-element list before iterating so scalar YAML values are
+# not silently missed by character-iteration.
 # ------------------------------------------------------------------
 _BANNED_CAPS = {"NET_ADMIN", "NET_RAW"}
 for _svc in sorted(services.keys()):
     _svc_cfg = services.get(_svc) or {}
     _cap_add = _svc_cfg.get("cap_add") or []
+    if isinstance(_cap_add, str):
+        _cap_add = [_cap_add]
     for _cap in _cap_add:
-        if str(_cap).upper() in _BANNED_CAPS:
+        _cap_norm = str(_cap).strip().upper()
+        if _cap_norm.startswith("CAP_"):
+            _cap_norm = _cap_norm[4:]
+        if _cap_norm in _BANNED_CAPS:
             failures.append(
                 f"FAIL: service '{_svc}' declares cap_add '{_cap}' — "
                 "NET_ADMIN and NET_RAW enable raw-socket/routing manipulation that can "
                 "tunnel workspace egress around mitmproxy and are not permitted."
             )
+            break
 
 # ------------------------------------------------------------------
 # Invariant 1e: NO service may map the /dev/net/tun device.
 #
 # /dev/net/tun is the kernel TUN/TAP interface used by VPN clients to build
 # tunnels.  Combined with NET_ADMIN/NET_RAW, it provides a complete egress
-# bypass path.  Reject any device mapping whose host path is /dev/net/tun
-# on ANY service.
+# bypass path.  Reject any device mapping whose host path resolves to
+# /dev/net/tun on ANY service.
 #
 # Normalized shape (docker compose config JSON): list of dicts {source, target, permissions}.
 # Raw-YAML fallback shape: list of "host:container[:perms]" strings.
+#
+# Path normalization: collapse multiple leading slashes to one (POSIX treats
+# // as implementation-defined, but Docker normalizes it to /), then apply
+# os.path.normpath to collapse /./ and similar segments.  This catches
+# //dev/net/tun, /dev/./net/tun, /dev/net/./tun, etc.
+#
+# Scalar-string guard: if devices is a bare string (not a list), wrap it
+# into a single-element list before iterating.
 # ------------------------------------------------------------------
+import re as _re
+
+def _norm_dev_path(p):
+    """Normalize a device host path: collapse leading // to /, then normpath."""
+    p = _re.sub(r'^/+', '/', str(p).strip())
+    return os.path.normpath(p)
+
+_TUN_PATH = _norm_dev_path("/dev/net/tun")
 for _svc in sorted(services.keys()):
     _svc_cfg = services.get(_svc) or {}
     _devices = _svc_cfg.get("devices") or []
+    if isinstance(_devices, str):
+        _devices = [_devices]
     for _dev in _devices:
         if isinstance(_dev, dict):
             _host_path = _dev.get("source") or ""
@@ -339,13 +379,32 @@ for _svc in sorted(services.keys()):
             _host_path = _dev.split(":")[0]
         else:
             _host_path = ""
-        if str(_host_path).strip() == "/dev/net/tun":
+        if _norm_dev_path(_host_path) == _TUN_PATH:
             failures.append(
                 f"FAIL: service '{_svc}' maps device '/dev/net/tun' — "
                 "the TUN/TAP interface enables VPN tunnel construction that can bypass "
                 "mitmproxy egress containment and is not permitted."
             )
             break
+
+# ------------------------------------------------------------------
+# Invariant 1f: NO service may declare privileged: true.
+#
+# privileged: true grants the container ALL Linux capabilities (including
+# NET_ADMIN and NET_RAW) plus access to ALL host devices (including
+# /dev/net/tun).  It nullifies Invariants 1d and 1e entirely.  Reject
+# any service that declares privileged as boolean True or the string "true".
+# ------------------------------------------------------------------
+for _svc in sorted(services.keys()):
+    _svc_cfg = services.get(_svc) or {}
+    _privileged = _svc_cfg.get("privileged")
+    if _privileged is True or str(_privileged).lower() == "true":
+        failures.append(
+            f"FAIL: service '{_svc}' declares privileged: true — "
+            "privileged mode grants all Linux capabilities (including NET_ADMIN and NET_RAW) "
+            "and access to all host devices (including /dev/net/tun), bypassing the egress "
+            "containment controls enforced by Invariants 1d and 1e. Remove privileged: true."
+        )
 
 # ------------------------------------------------------------------
 # Invariant 6: workspace must mount the named volume 'workspace-repos'

--- a/deploy/validate-stack.test.sh
+++ b/deploy/validate-stack.test.sh
@@ -1418,6 +1418,307 @@ echo "  gateway-egress-net-test output (stderr+stdout combined):"
 echo "${GW_EGRESS_OUTPUT}" | sed 's/^/    /'
 
 # ---------------------------------------------------------------------------
+# TEST 26 — Negative: extra_hosts with host-gateway must be rejected.
+#
+# extra_hosts: ["proxy.local:host-gateway"] gives the container the Docker
+# host's bridge IP.  If the host runs any forward proxy/SOCKS/tunnel bound
+# to 0.0.0.0, the workspace can relay egress around mitmproxy.
+# The failure message must name the service and mention 'host-gateway'.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 26: guard rejects extra_hosts with host-gateway mapping ---"
+
+EXTRA_HOSTS_HG_COMPOSE="${TMPDIR_TEST}/compose-extra-hosts-hg.yaml"
+cat > "${EXTRA_HOSTS_HG_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    extra_hosts:
+      - "proxy.local:host-gateway"
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+EXTRA_HOSTS_HG_OUTPUT=""
+EXTRA_HOSTS_HG_EXIT=0
+EXTRA_HOSTS_HG_OUTPUT="$(COMPOSE_FILE="${EXTRA_HOSTS_HG_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || EXTRA_HOSTS_HG_EXIT=$?
+
+if [[ "${EXTRA_HOSTS_HG_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${EXTRA_HOSTS_HG_EXIT}) for extra_hosts host-gateway"
+else
+  fail "validate-stack.sh exited ZERO for extra_hosts host-gateway — guard did NOT fire"
+fi
+
+if echo "${EXTRA_HOSTS_HG_OUTPUT}" | grep -q "workspace"; then
+  pass "extra_hosts host-gateway failure message names the service 'workspace'"
+else
+  fail "extra_hosts host-gateway failure message does not name 'workspace' — output: ${EXTRA_HOSTS_HG_OUTPUT}"
+fi
+
+if echo "${EXTRA_HOSTS_HG_OUTPUT}" | grep -q "host-gateway"; then
+  pass "extra_hosts host-gateway failure message mentions 'host-gateway'"
+else
+  fail "extra_hosts host-gateway failure message does not mention 'host-gateway' — output: ${EXTRA_HOSTS_HG_OUTPUT}"
+fi
+
+echo ""
+echo "  extra-hosts-hg-test output (stderr+stdout combined):"
+echo "${EXTRA_HOSTS_HG_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 27 — Negative: cap_add with NET_ADMIN must be rejected.
+#
+# NET_ADMIN enables routing-table and network-interface manipulation.
+# Combined with /dev/net/tun and a VPN client image, it can build a tunnel
+# that bypasses mitmproxy.  The failure message must name the service and
+# mention 'NET_ADMIN'.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 27: guard rejects cap_add NET_ADMIN ---"
+
+CAP_ADD_NET_ADMIN_COMPOSE="${TMPDIR_TEST}/compose-cap-add-net-admin.yaml"
+cat > "${CAP_ADD_NET_ADMIN_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    cap_add:
+      - NET_ADMIN
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+CAP_ADD_NET_ADMIN_OUTPUT=""
+CAP_ADD_NET_ADMIN_EXIT=0
+CAP_ADD_NET_ADMIN_OUTPUT="$(COMPOSE_FILE="${CAP_ADD_NET_ADMIN_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || CAP_ADD_NET_ADMIN_EXIT=$?
+
+if [[ "${CAP_ADD_NET_ADMIN_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${CAP_ADD_NET_ADMIN_EXIT}) for cap_add NET_ADMIN"
+else
+  fail "validate-stack.sh exited ZERO for cap_add NET_ADMIN — guard did NOT fire"
+fi
+
+if echo "${CAP_ADD_NET_ADMIN_OUTPUT}" | grep -q "workspace"; then
+  pass "cap_add NET_ADMIN failure message names the service 'workspace'"
+else
+  fail "cap_add NET_ADMIN failure message does not name 'workspace' — output: ${CAP_ADD_NET_ADMIN_OUTPUT}"
+fi
+
+if echo "${CAP_ADD_NET_ADMIN_OUTPUT}" | grep -q "NET_ADMIN"; then
+  pass "cap_add NET_ADMIN failure message mentions 'NET_ADMIN'"
+else
+  fail "cap_add NET_ADMIN failure message does not mention 'NET_ADMIN' — output: ${CAP_ADD_NET_ADMIN_OUTPUT}"
+fi
+
+echo ""
+echo "  cap-add-net-admin-test output (stderr+stdout combined):"
+echo "${CAP_ADD_NET_ADMIN_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 28 — Negative: cap_add with NET_RAW must be rejected.
+#
+# NET_RAW enables raw-socket access (ICMP, packet injection).  Covers the
+# second banned capability alongside NET_ADMIN.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 28: guard rejects cap_add NET_RAW ---"
+
+CAP_ADD_NET_RAW_COMPOSE="${TMPDIR_TEST}/compose-cap-add-net-raw.yaml"
+cat > "${CAP_ADD_NET_RAW_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    cap_add:
+      - NET_RAW
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+CAP_ADD_NET_RAW_OUTPUT=""
+CAP_ADD_NET_RAW_EXIT=0
+CAP_ADD_NET_RAW_OUTPUT="$(COMPOSE_FILE="${CAP_ADD_NET_RAW_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || CAP_ADD_NET_RAW_EXIT=$?
+
+if [[ "${CAP_ADD_NET_RAW_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${CAP_ADD_NET_RAW_EXIT}) for cap_add NET_RAW"
+else
+  fail "validate-stack.sh exited ZERO for cap_add NET_RAW — guard did NOT fire"
+fi
+
+if echo "${CAP_ADD_NET_RAW_OUTPUT}" | grep -q "workspace"; then
+  pass "cap_add NET_RAW failure message names the service 'workspace'"
+else
+  fail "cap_add NET_RAW failure message does not name 'workspace' — output: ${CAP_ADD_NET_RAW_OUTPUT}"
+fi
+
+if echo "${CAP_ADD_NET_RAW_OUTPUT}" | grep -q "NET_RAW"; then
+  pass "cap_add NET_RAW failure message mentions 'NET_RAW'"
+else
+  fail "cap_add NET_RAW failure message does not mention 'NET_RAW' — output: ${CAP_ADD_NET_RAW_OUTPUT}"
+fi
+
+echo ""
+echo "  cap-add-net-raw-test output (stderr+stdout combined):"
+echo "${CAP_ADD_NET_RAW_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 29 — Negative: devices mapping /dev/net/tun must be rejected.
+#
+# /dev/net/tun is the kernel TUN/TAP interface used by VPN clients.  Combined
+# with NET_ADMIN/NET_RAW, it provides a complete egress bypass path.
+# The failure message must name the service and mention '/dev/net/tun'.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 29: guard rejects devices mapping /dev/net/tun ---"
+
+DEVICES_TUN_COMPOSE="${TMPDIR_TEST}/compose-devices-tun.yaml"
+cat > "${DEVICES_TUN_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    devices:
+      - "/dev/net/tun:/dev/net/tun"
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+DEVICES_TUN_OUTPUT=""
+DEVICES_TUN_EXIT=0
+DEVICES_TUN_OUTPUT="$(COMPOSE_FILE="${DEVICES_TUN_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || DEVICES_TUN_EXIT=$?
+
+if [[ "${DEVICES_TUN_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${DEVICES_TUN_EXIT}) for devices /dev/net/tun"
+else
+  fail "validate-stack.sh exited ZERO for devices /dev/net/tun — guard did NOT fire"
+fi
+
+if echo "${DEVICES_TUN_OUTPUT}" | grep -q "workspace"; then
+  pass "devices /dev/net/tun failure message names the service 'workspace'"
+else
+  fail "devices /dev/net/tun failure message does not name 'workspace' — output: ${DEVICES_TUN_OUTPUT}"
+fi
+
+if echo "${DEVICES_TUN_OUTPUT}" | grep -q "/dev/net/tun"; then
+  pass "devices /dev/net/tun failure message mentions '/dev/net/tun'"
+else
+  fail "devices /dev/net/tun failure message does not mention '/dev/net/tun' — output: ${DEVICES_TUN_OUTPUT}"
+fi
+
+echo ""
+echo "  devices-tun-test output (stderr+stdout combined):"
+echo "${DEVICES_TUN_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 30 — Positive: benign extra_hosts (non-host-gateway) must NOT be rejected.
+#
+# extra_hosts: ["db:10.0.0.5"] is a legitimate static host entry that does not
+# grant host-network access.  The guard must not over-reject benign extra_hosts.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 30: guard accepts benign extra_hosts (non-host-gateway value) ---"
+
+EXTRA_HOSTS_BENIGN_COMPOSE="${TMPDIR_TEST}/compose-extra-hosts-benign.yaml"
+cat > "${EXTRA_HOSTS_BENIGN_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    extra_hosts:
+      - "db:10.0.0.5"
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+EXTRA_HOSTS_BENIGN_OUTPUT=""
+EXTRA_HOSTS_BENIGN_EXIT=0
+EXTRA_HOSTS_BENIGN_OUTPUT="$(COMPOSE_FILE="${EXTRA_HOSTS_BENIGN_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || EXTRA_HOSTS_BENIGN_EXIT=$?
+
+if [[ "${EXTRA_HOSTS_BENIGN_EXIT}" -eq 0 ]]; then
+  pass "validate-stack.sh exited zero for benign extra_hosts (db:10.0.0.5) — no over-rejection"
+else
+  fail "validate-stack.sh exited non-zero (${EXTRA_HOSTS_BENIGN_EXIT}) for benign extra_hosts — over-rejection: ${EXTRA_HOSTS_BENIGN_OUTPUT}"
+fi
+
+echo ""
+echo "  extra-hosts-benign-test output (stderr+stdout combined):"
+echo "${EXTRA_HOSTS_BENIGN_OUTPUT}" | sed 's/^/    /'
+
+# NOTE: TEST 2 (above) already asserts that the real deploy/compose.yaml passes
+# the topology guard (exit zero).  No duplicate test is added here.
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/deploy/validate-stack.test.sh
+++ b/deploy/validate-stack.test.sh
@@ -1719,6 +1719,459 @@ echo "${EXTRA_HOSTS_BENIGN_OUTPUT}" | sed 's/^/    /'
 # the topology guard (exit zero).  No duplicate test is added here.
 
 # ---------------------------------------------------------------------------
+# TEST 31 — Negative: privileged: true must be rejected (Invariant 1f).
+#
+# privileged: true grants ALL Linux capabilities (including NET_ADMIN and
+# NET_RAW) and access to ALL host devices (including /dev/net/tun), nullifying
+# Invariants 1d and 1e.  The failure message must name the service and mention
+# 'privileged'.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 31: guard rejects privileged: true (Invariant 1f) ---"
+
+PRIVILEGED_COMPOSE="${TMPDIR_TEST}/compose-privileged.yaml"
+cat > "${PRIVILEGED_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    privileged: true
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+PRIVILEGED_OUTPUT=""
+PRIVILEGED_EXIT=0
+PRIVILEGED_OUTPUT="$(COMPOSE_FILE="${PRIVILEGED_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || PRIVILEGED_EXIT=$?
+
+if [[ "${PRIVILEGED_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${PRIVILEGED_EXIT}) for privileged: true"
+else
+  fail "validate-stack.sh exited ZERO for privileged: true — Invariant 1f did NOT fire"
+fi
+
+if echo "${PRIVILEGED_OUTPUT}" | grep -q "workspace"; then
+  pass "privileged: true failure message names the service 'workspace'"
+else
+  fail "privileged: true failure message does not name 'workspace' — output: ${PRIVILEGED_OUTPUT}"
+fi
+
+if echo "${PRIVILEGED_OUTPUT}" | grep -qi "privileged"; then
+  pass "privileged: true failure message mentions 'privileged'"
+else
+  fail "privileged: true failure message does not mention 'privileged' — output: ${PRIVILEGED_OUTPUT}"
+fi
+
+echo ""
+echo "  privileged-true-test output (stderr+stdout combined):"
+echo "${PRIVILEGED_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 32 — Negative: cap_add: [CAP_NET_ADMIN] must be rejected (CAP_ prefix bypass).
+#
+# Docker Compose may preserve the CAP_ prefix from raw YAML or its own
+# normalization.  The old check `str(_cap).upper() in {"NET_ADMIN","NET_RAW"}`
+# would miss "CAP_NET_ADMIN" → "CAP_NET_ADMIN" not in set.  The fixed guard
+# strips the CAP_ prefix before checking.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 32: guard rejects cap_add: [CAP_NET_ADMIN] (CAP_ prefix bypass) ---"
+
+CAP_PREFIX_COMPOSE="${TMPDIR_TEST}/compose-cap-prefix.yaml"
+cat > "${CAP_PREFIX_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    cap_add:
+      - CAP_NET_ADMIN
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+CAP_PREFIX_OUTPUT=""
+CAP_PREFIX_EXIT=0
+CAP_PREFIX_OUTPUT="$(COMPOSE_FILE="${CAP_PREFIX_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || CAP_PREFIX_EXIT=$?
+
+if [[ "${CAP_PREFIX_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${CAP_PREFIX_EXIT}) for cap_add: [CAP_NET_ADMIN]"
+else
+  fail "validate-stack.sh exited ZERO for cap_add: [CAP_NET_ADMIN] — CAP_ prefix bypass NOT caught"
+fi
+
+if echo "${CAP_PREFIX_OUTPUT}" | grep -q "workspace"; then
+  pass "CAP_NET_ADMIN failure message names the service 'workspace'"
+else
+  fail "CAP_NET_ADMIN failure message does not name 'workspace' — output: ${CAP_PREFIX_OUTPUT}"
+fi
+
+if echo "${CAP_PREFIX_OUTPUT}" | grep -q "CAP_NET_ADMIN"; then
+  pass "CAP_NET_ADMIN failure message mentions 'CAP_NET_ADMIN'"
+else
+  fail "CAP_NET_ADMIN failure message does not mention 'CAP_NET_ADMIN' — output: ${CAP_PREFIX_OUTPUT}"
+fi
+
+echo ""
+echo "  cap-prefix-test output (stderr+stdout combined):"
+echo "${CAP_PREFIX_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 33 — Negative: cap_add: [cap_net_admin] must be rejected (lowercase bypass).
+#
+# Raw YAML may contain lowercase capability names.  The old check uppercased
+# but did not strip the CAP_ prefix, so "cap_net_admin" → "CAP_NET_ADMIN"
+# which is NOT in {"NET_ADMIN","NET_RAW"}.  The fixed guard normalizes both
+# case and prefix.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 33: guard rejects cap_add: [cap_net_admin] (lowercase bypass) ---"
+
+CAP_LOWER_COMPOSE="${TMPDIR_TEST}/compose-cap-lower.yaml"
+cat > "${CAP_LOWER_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    cap_add:
+      - cap_net_admin
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+CAP_LOWER_OUTPUT=""
+CAP_LOWER_EXIT=0
+CAP_LOWER_OUTPUT="$(COMPOSE_FILE="${CAP_LOWER_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || CAP_LOWER_EXIT=$?
+
+if [[ "${CAP_LOWER_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${CAP_LOWER_EXIT}) for cap_add: [cap_net_admin]"
+else
+  fail "validate-stack.sh exited ZERO for cap_add: [cap_net_admin] — lowercase bypass NOT caught"
+fi
+
+if echo "${CAP_LOWER_OUTPUT}" | grep -q "workspace"; then
+  pass "cap_net_admin failure message names the service 'workspace'"
+else
+  fail "cap_net_admin failure message does not name 'workspace' — output: ${CAP_LOWER_OUTPUT}"
+fi
+
+if echo "${CAP_LOWER_OUTPUT}" | grep -qi "cap_net_admin\|NET_ADMIN"; then
+  pass "cap_net_admin failure message mentions the capability"
+else
+  fail "cap_net_admin failure message does not mention the capability — output: ${CAP_LOWER_OUTPUT}"
+fi
+
+echo ""
+echo "  cap-lower-test output (stderr+stdout combined):"
+echo "${CAP_LOWER_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 34 — Negative: devices: ["//dev/net/tun:/dev/net/tun"] must be rejected
+#           (double-slash path normalization bypass).
+#
+# Docker normalizes device paths via filepath.Clean, so //dev/net/tun resolves
+# to /dev/net/tun at runtime.  The old literal == "/dev/net/tun" check missed
+# the double-slash form.  The fixed guard uses os.path.normpath.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 34: guard rejects devices: [\"//dev/net/tun:/dev/net/tun\"] (double-slash path) ---"
+
+DEVICES_DSLASH_COMPOSE="${TMPDIR_TEST}/compose-devices-dslash.yaml"
+cat > "${DEVICES_DSLASH_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    devices:
+      - "//dev/net/tun:/dev/net/tun"
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+DEVICES_DSLASH_OUTPUT=""
+DEVICES_DSLASH_EXIT=0
+DEVICES_DSLASH_OUTPUT="$(COMPOSE_FILE="${DEVICES_DSLASH_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || DEVICES_DSLASH_EXIT=$?
+
+if [[ "${DEVICES_DSLASH_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${DEVICES_DSLASH_EXIT}) for devices //dev/net/tun"
+else
+  fail "validate-stack.sh exited ZERO for devices //dev/net/tun — double-slash bypass NOT caught"
+fi
+
+if echo "${DEVICES_DSLASH_OUTPUT}" | grep -q "workspace"; then
+  pass "//dev/net/tun failure message names the service 'workspace'"
+else
+  fail "//dev/net/tun failure message does not name 'workspace' — output: ${DEVICES_DSLASH_OUTPUT}"
+fi
+
+if echo "${DEVICES_DSLASH_OUTPUT}" | grep -q "/dev/net/tun"; then
+  pass "//dev/net/tun failure message mentions '/dev/net/tun'"
+else
+  fail "//dev/net/tun failure message does not mention '/dev/net/tun' — output: ${DEVICES_DSLASH_OUTPUT}"
+fi
+
+echo ""
+echo "  devices-dslash-test output (stderr+stdout combined):"
+echo "${DEVICES_DSLASH_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 35 — Negative: devices: ["/dev/./net/tun:/dev/net/tun"] must be rejected
+#           (/./ segment path normalization bypass).
+#
+# /dev/./net/tun resolves to /dev/net/tun via filepath.Clean at runtime.
+# The old literal check missed this form.  The fixed guard uses os.path.normpath.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 35: guard rejects devices: [\"/dev/./net/tun:/dev/net/tun\"] (/./ segment path) ---"
+
+DEVICES_DOT_COMPOSE="${TMPDIR_TEST}/compose-devices-dot.yaml"
+cat > "${DEVICES_DOT_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    devices:
+      - "/dev/./net/tun:/dev/net/tun"
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+DEVICES_DOT_OUTPUT=""
+DEVICES_DOT_EXIT=0
+DEVICES_DOT_OUTPUT="$(COMPOSE_FILE="${DEVICES_DOT_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || DEVICES_DOT_EXIT=$?
+
+if [[ "${DEVICES_DOT_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${DEVICES_DOT_EXIT}) for devices /dev/./net/tun"
+else
+  fail "validate-stack.sh exited ZERO for devices /dev/./net/tun — /./ bypass NOT caught"
+fi
+
+if echo "${DEVICES_DOT_OUTPUT}" | grep -q "workspace"; then
+  pass "/dev/./net/tun failure message names the service 'workspace'"
+else
+  fail "/dev/./net/tun failure message does not name 'workspace' — output: ${DEVICES_DOT_OUTPUT}"
+fi
+
+if echo "${DEVICES_DOT_OUTPUT}" | grep -q "/dev/net/tun"; then
+  pass "/dev/./net/tun failure message mentions '/dev/net/tun'"
+else
+  fail "/dev/./net/tun failure message does not mention '/dev/net/tun' — output: ${DEVICES_DOT_OUTPUT}"
+fi
+
+echo ""
+echo "  devices-dot-test output (stderr+stdout combined):"
+echo "${DEVICES_DOT_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 36 — Negative: cap_add: NET_ADMIN (scalar string, not list) must be
+#           rejected (scalar bypass).
+#
+# YAML allows `cap_add: NET_ADMIN` (scalar) instead of `cap_add: [NET_ADMIN]`
+# (list).  The old `for _cap in _cap_add:` would iterate characters of the
+# string "NET_ADMIN" and silently miss the violation.  The fixed guard wraps
+# scalar strings into a single-element list before iterating.
+#
+# NOTE: docker compose config normalizes scalar cap_add to a list, so this
+# bypass only fires via the raw-YAML fallback path (no docker in PATH).
+# This test strips docker from PATH and requires PyYAML.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 36: guard rejects cap_add: NET_ADMIN (scalar string, not list) via raw-YAML path ---"
+
+CAP_SCALAR_COMPOSE="${TMPDIR_TEST}/compose-cap-scalar.yaml"
+cat > "${CAP_SCALAR_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    cap_add: NET_ADMIN
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+if "${PYTHON3_BIN}" -c "import yaml" 2>/dev/null; then
+  CAP_SCALAR_OUTPUT=""
+  CAP_SCALAR_EXIT=0
+  CAP_SCALAR_OUTPUT="$(PATH="${NO_DOCKER_PATH}" COMPOSE_FILE="${CAP_SCALAR_COMPOSE}" PYTHON3_BIN="${PYTHON3_BIN}" "${BASH_BIN}" deploy/validate-stack.sh --topology-only 2>&1)" || CAP_SCALAR_EXIT=$?
+
+  if [[ "${CAP_SCALAR_EXIT}" -ne 0 ]]; then
+    pass "validate-stack.sh exited non-zero (${CAP_SCALAR_EXIT}) for scalar cap_add: NET_ADMIN"
+  else
+    fail "validate-stack.sh exited ZERO for scalar cap_add: NET_ADMIN — scalar bypass NOT caught"
+  fi
+
+  if echo "${CAP_SCALAR_OUTPUT}" | grep -q "workspace"; then
+    pass "scalar cap_add failure message names the service 'workspace'"
+  else
+    fail "scalar cap_add failure message does not name 'workspace' — output: ${CAP_SCALAR_OUTPUT}"
+  fi
+
+  if echo "${CAP_SCALAR_OUTPUT}" | grep -qi "NET_ADMIN"; then
+    pass "scalar cap_add failure message mentions 'NET_ADMIN'"
+  else
+    fail "scalar cap_add failure message does not mention 'NET_ADMIN' — output: ${CAP_SCALAR_OUTPUT}"
+  fi
+
+  echo ""
+  echo "  cap-scalar-test output (stderr+stdout combined):"
+  echo "${CAP_SCALAR_OUTPUT}" | sed 's/^/    /'
+else
+  echo "  SKIP: scalar cap_add test: PyYAML not available — install python3-yaml/PyYAML to run this test."
+  echo "        (docker compose config normalizes scalar cap_add to a list; raw-YAML path required for this bypass)"
+fi
+
+# ---------------------------------------------------------------------------
+# TEST 37 — Negative: extra_hosts dict form {proxy.local: host-gateway} must
+#           be rejected (raw-YAML dict form).
+#
+# Raw YAML allows extra_hosts as a mapping: {proxy.local: host-gateway}.
+# The guard handles this via the dict branch.  This test exercises that path
+# via the raw-YAML fallback (no docker in PATH) and requires PyYAML.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 37: guard rejects extra_hosts dict form {proxy.local: host-gateway} via raw-YAML path ---"
+
+EXTRA_HOSTS_DICT_COMPOSE="${TMPDIR_TEST}/compose-extra-hosts-dict.yaml"
+cat > "${EXTRA_HOSTS_DICT_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    extra_hosts:
+      proxy.local: host-gateway
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+if "${PYTHON3_BIN}" -c "import yaml" 2>/dev/null; then
+  EXTRA_HOSTS_DICT_OUTPUT=""
+  EXTRA_HOSTS_DICT_EXIT=0
+  EXTRA_HOSTS_DICT_OUTPUT="$(PATH="${NO_DOCKER_PATH}" COMPOSE_FILE="${EXTRA_HOSTS_DICT_COMPOSE}" PYTHON3_BIN="${PYTHON3_BIN}" "${BASH_BIN}" deploy/validate-stack.sh --topology-only 2>&1)" || EXTRA_HOSTS_DICT_EXIT=$?
+
+  if [[ "${EXTRA_HOSTS_DICT_EXIT}" -ne 0 ]]; then
+    pass "validate-stack.sh exited non-zero (${EXTRA_HOSTS_DICT_EXIT}) for extra_hosts dict {proxy.local: host-gateway}"
+  else
+    fail "validate-stack.sh exited ZERO for extra_hosts dict form — dict bypass NOT caught"
+  fi
+
+  if echo "${EXTRA_HOSTS_DICT_OUTPUT}" | grep -q "workspace"; then
+    pass "extra_hosts dict failure message names the service 'workspace'"
+  else
+    fail "extra_hosts dict failure message does not name 'workspace' — output: ${EXTRA_HOSTS_DICT_OUTPUT}"
+  fi
+
+  if echo "${EXTRA_HOSTS_DICT_OUTPUT}" | grep -q "host-gateway"; then
+    pass "extra_hosts dict failure message mentions 'host-gateway'"
+  else
+    fail "extra_hosts dict failure message does not mention 'host-gateway' — output: ${EXTRA_HOSTS_DICT_OUTPUT}"
+  fi
+
+  echo ""
+  echo "  extra-hosts-dict-test output (stderr+stdout combined):"
+  echo "${EXTRA_HOSTS_DICT_OUTPUT}" | sed 's/^/    /'
+else
+  echo "  SKIP: extra_hosts dict test: PyYAML not available — install python3-yaml/PyYAML to run this test."
+  echo "        (docker compose config normalizes dict extra_hosts to list form; raw-YAML path required)"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/docs/plans/2026-06-14-003-fix-egress-weakening-compose-keys-plan.md
+++ b/docs/plans/2026-06-14-003-fix-egress-weakening-compose-keys-plan.md
@@ -1,0 +1,173 @@
+---
+title: "fix: Reject egress-weakening compose keys in the topology guard (#899)"
+type: fix
+status: active
+date: 2026-06-14
+---
+
+# Reject egress-weakening compose keys in the topology guard (#899)
+
+## Overview
+
+The compose topology guard (`deploy/validate-stack.sh`, `check_compose_topology`) enforces that workspace egress flows through mitmproxy by policing network attachments (only allowlisted `(service, network)` pairs on non-internal networks, plus a blanket `network_mode` ban). But it does not inspect other compose keys that can grant a sandbox-net-reachable container an egress path around mitmproxy. This plan adds defense-in-depth rejections for three such keys — `extra_hosts` using `host-gateway`, `cap_add` of `NET_ADMIN`/`NET_RAW`, and `/dev/net/tun` device mappings — on all services, mirroring the existing blanket `network_mode` rejection (Invariant 1b). Closes #899.
+
+## Problem Frame
+
+`network_mode` is already blanket-rejected (Invariant 1b, `deploy/validate-stack.sh`), but adjacent egress-weakening keys are blind spots. A compose override that passes the current guard can still:
+- **`extra_hosts: ["proxy.local:host-gateway"]`** — give the workspace the Docker host's bridge IP; if the host runs any forward proxy/SOCKS/tunnel bound to `0.0.0.0`, the workspace relays egress around mitmproxy (cleartext HTTP; HTTPS fails CA validation).
+- **`cap_add: [NET_ADMIN]` (or `NET_RAW`) + `devices: ["/dev/net/tun:/dev/net/tun"]`** — with a custom image carrying a VPN client, build a tunnel that bypasses mitmproxy.
+
+The inconsistency (the most obvious bypass banned, adjacent ones open) is the gap #899 tracks. Surfaced by the ce:review adversarial pass on the #814/#745 fix and intentionally deferred from that PR to keep it scoped to the network-attachment class.
+
+## Requirements Trace
+
+- R1. The guard fails any service declaring an `extra_hosts` entry that maps to `host-gateway`.
+- R2. The guard fails any service whose `cap_add` includes `NET_ADMIN` or `NET_RAW`.
+- R3. The guard fails any service declaring a device mapping for `/dev/net/tun`.
+- R4. Enforcement is blanket (all services), mirroring the `network_mode` ban — these keys have no legitimate use in this stack.
+- R5. The real shipped `deploy/compose.yaml` still passes (no current service uses these keys).
+- R6. Failure messages are actionable (name the service + the offending key/value) and fail closed, consistent with the existing invariants.
+
+## Scope Boundaries
+
+- Not changing the existing network-attachment / `network_mode` invariants (already shipped via #814).
+- Not adding proxy-agent config or touching mitmproxy/allowlist behavior.
+- Blanket all-services enforcement (not scoped to sandbox-net-reachable only) — confirmed scope decision.
+
+### Deferred to Separate Tasks
+
+- IPv6 egress-path check (issue #899 mentioned it): separate concern about mitmproxy's IPv4 listener scope / allowlist coverage, not a compose-key check. Out of scope here; track separately if IPv6 egress becomes a real path.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `deploy/validate-stack.sh` — `check_compose_topology` embeds Python in a bash heredoc. Invariant 1b (`network_mode_services` loop) is the exact template: iterate `sorted(services.keys())`, read a key via `svc_cfg.get(...)`, `failures.append(...)` with a clear message. The new checks slot in as sibling invariants.
+- `service_networks(svc)`, `non_internal_nets`, `network_mode_services`, `services`, `networks`, `failures` — existing locals available to reuse.
+- Compose key shapes (under `docker compose config` normalization — verify exact normalized forms during implementation):
+  - `extra_hosts`: normalized to a list of `"host:ip"` strings (or possibly a map) — check for a value of `host-gateway`.
+  - `cap_add`: list of capability strings.
+  - `devices`: list of `"host:container[:perms]"` strings (or normalized dicts) — check for `/dev/net/tun`.
+  Account for the raw-YAML fallback path too (when docker compose config is unavailable), as the existing invariants do.
+- `deploy/validate-stack.test.sh` — existing shell test harness; the #814 tests (TEST 20-26) are the style template (single-file fixtures docker-free via `--topology-only`; docker-gated / PyYAML-skip pattern where needed). Continue numbering from the current highest TEST.
+- `deploy/README.md` / `deploy/compose.yaml` comments — egress/topology section to note the additional rejected keys.
+
+### Institutional Learnings
+
+- The #814 fix family (network-attachment global invariant + drift check) and its ce:review established the blanket-ban-with-actionable-message pattern and the docker-gated-vs-raw-YAML test discipline.
+
+### External References
+
+- Issue #899 (the three egress-weakening keys + the `network_mode`-consistency argument).
+
+## Key Technical Decisions
+
+- **Blanket all-services enforcement**, mirroring Invariant 1b — simplest, fail-closed, and these keys have no legit use in this stack (workspace is sandbox-net-only; no service needs host-gateway/NET_ADMIN/tun).
+- **Include `NET_RAW` alongside `NET_ADMIN`** — both enable raw-socket/routing manipulation relevant to tunneling; cheap to cover both.
+- **Reuse the existing invariant structure** (Python-in-heredoc, `failures.append`, sorted-services loop) rather than a new mechanism.
+- **Defer IPv6** — distinct from compose-key inspection; would pull in mitmproxy listener/allowlist scope.
+
+## Open Questions
+
+### Resolved During Planning
+
+- All-services vs sandbox-net-reachable enforcement: resolved to blanket all-services (KTD).
+- IPv6: deferred (Scope Boundaries).
+
+### Deferred to Implementation
+
+- Exact normalized shapes of `extra_hosts` / `cap_add` / `devices` under `docker compose config` vs the raw-YAML fallback — verify both paths during implementation and handle each (the existing invariants already branch on the fallback). Determine whether `extra_hosts` normalizes to list-of-strings or a map in this compose/docker version.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add egress-weakening compose-key rejections to the guard**
+
+**Goal:** The guard fails closed on `extra_hosts` host-gateway, `cap_add` NET_ADMIN/NET_RAW, and `/dev/net/tun` device mappings, on any service.
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `deploy/validate-stack.sh` (add sibling invariants after the `network_mode` block / alongside the existing checks)
+
+**Approach:**
+- Add a loop over `sorted(services.keys())` (or fold into the existing service iteration) that, per service config, checks:
+  - `extra_hosts`: handle both list-of-`"name:value"` and map forms; fail if any entry's value is `host-gateway`.
+  - `cap_add`: fail if it contains `NET_ADMIN` or `NET_RAW`.
+  - `devices`: handle list-of-strings (`"/dev/net/tun:..."`) and normalized-dict forms; fail if any maps `/dev/net/tun`.
+- Each failure: `failures.append(f"FAIL: service '{svc}' ...")` naming the key + offending value, mirroring Invariant 1b's wording.
+- Ensure the raw-YAML fallback path (no docker compose config) also sees these keys, consistent with existing invariants.
+
+**Patterns to follow:** the `network_mode_services` block in `deploy/validate-stack.sh` (sorted iteration, `svc_cfg.get`, actionable failure message).
+
+**Test scenarios:** (covered by Unit 2)
+
+**Verification:** running the guard against current `deploy/compose.yaml` exits 0; against each malicious fixture exits non-zero naming the service + key.
+
+- [ ] **Unit 2: Guard tests for the new rejections**
+
+**Goal:** Lock the three rejections + the real-stack-passes behavior with regression tests.
+
+**Requirements:** R1, R2, R3, R5, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `deploy/validate-stack.test.sh` (continue TEST numbering from the current highest)
+
+**Approach:** Single-file fixtures, docker-free via `--topology-only`/raw-YAML where possible (follow the existing skip-with-notice pattern if PyYAML/docker is needed). One fixture per key plus a passing case.
+
+**Execution note:** Write the failing fixtures first (they encode #899), confirm they fail with the fix and would pass (guard exit 0) without it — i.e., the test actually guards the new behavior.
+
+**Test scenarios:**
+- Edge: service with `extra_hosts: ["proxy.local:host-gateway"]` → fails, message names the service + `host-gateway`.
+- Edge: service with `cap_add: [NET_ADMIN]` → fails, names the service + `NET_ADMIN`.
+- Edge: service with `cap_add: [NET_RAW]` → fails (covers the second capability).
+- Edge: service with `devices: ["/dev/net/tun:/dev/net/tun"]` → fails, names the service + `/dev/net/tun`.
+- Happy path: an `extra_hosts` entry that is NOT host-gateway (e.g. `"db:10.0.0.5"`) → passes (don't over-reject benign extra_hosts).
+- Happy path: the real `deploy/compose.yaml` passes (if not already covered by the existing real-compose test, add it; otherwise note the dup).
+
+**Verification:** the suite passes; removing the Unit 1 checks makes the malicious fixtures pass (proving the tests guard the bug); benign `extra_hosts` is not falsely rejected.
+
+- [ ] **Unit 3: Document the additional rejected keys**
+
+**Goal:** Operators understand which compose keys the guard forbids and why.
+
+**Requirements:** R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `deploy/README.md` (egress/topology section), `deploy/validate-stack.sh` header comment if it enumerates invariants
+
+**Approach:** Add a brief line to the egress containment docs: the guard rejects `network_mode`, plus `extra_hosts: host-gateway`, `cap_add: NET_ADMIN/NET_RAW`, and `/dev/net/tun` device mappings, because each can relay or tunnel workspace egress around mitmproxy.
+
+**Test scenarios:** Test expectation: none — documentation only.
+
+**Verification:** the docs list the newly rejected keys alongside `network_mode`.
+
+## System-Wide Impact
+
+- **Interaction graph:** guard runs in the `workspace-smoke` CI job (`bash deploy/validate-stack.sh --topology-only` + `bash deploy/validate-stack.test.sh`). Additive checks only.
+- **Error propagation:** fail-closed (any offending key → non-zero exit + named failure).
+- **API surface parity:** none — internal deploy tooling.
+- **Unchanged invariants:** the network-attachment allowlist, drift check, `network_mode` ban, and workspace/mitmproxy/volume invariants are untouched; the real compose stack continues to pass.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Over-rejecting benign `extra_hosts` (non-host-gateway) | Unit 2 includes a benign-extra_hosts passing test; only `host-gateway` value triggers failure |
+| Normalized key shape differs (docker compose config vs raw YAML) | Unit 1 handles both forms; deferred-to-implementation note flags verifying exact shapes |
+| New check accidentally fails the real stack | Unit 2 asserts real `deploy/compose.yaml` passes; run guard against it |
+
+## Documentation / Operational Notes
+
+- `deploy/README.md` egress section updated for the additional rejected keys. Closes #899.
+
+## Sources & References
+
+- Issue #899 (egress-weakening compose keys).
+- Code: `deploy/validate-stack.sh` (Invariant 1b `network_mode` block as template), `deploy/validate-stack.test.sh` (TEST 20-26 style), `deploy/compose.yaml`, `deploy/README.md`.
+- Related: #814/#745 (the network-attachment fix this extends), PR #901.


### PR DESCRIPTION
## What this does

Extends the compose egress-containment guard to reject compose keys that could give a sandbox-net container an egress path around mitmproxy, beyond the network-attachment and `network_mode` rules already enforced.

The guard now fails closed, on any service, for:
- `extra_hosts` mapped to `host-gateway` (host bridge IP → relay through any host-bound proxy)
- `cap_add` of `NET_ADMIN` or `NET_RAW` (raw-socket / routing manipulation for tunneling)
- `/dev/net/tun` device mappings (TUN/TAP tunnel device)
- `privileged: true` (grants all capabilities and device access, superseding the above)

## Verification

Guard tests cover each rejected key plus a benign `extra_hosts` case (no over-rejection) and the real compose stack passing. The checks handle the relevant shapes — `docker compose config` normalization (`name=value` for extra_hosts, dict devices), raw-YAML (`name:value`, string devices, dicts), and scalar-string forms — and normalize capability names (`CAP_` prefix and case) and device paths (`//dev/net/tun`, `/dev/./net/tun`) so equivalent forms can't slip through.

## Follow-up

Further escalation vectors (`pid_mode: host`, dangerous `sysctls`, confinement-disabling `security_opt`) are tracked in #908 for incremental hardening. The primary containment boundary remains `sandbox-net` `internal: true`.

Closes #899
