### PR TITLE
fix(deploy): reject egress-escalation compose keys in the topology guard

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -502,7 +502,7 @@ The compose topology guard (`deploy/validate-stack.sh`) enforces this model stat
 - `devices: /dev/net/tun` — the kernel TUN/TAP interface used by VPN clients to construct egress tunnels.
 - `privileged: true` — grants all Linux capabilities and all host devices, nullifying the `cap_add` and `devices` controls entirely.
 - `device_cgroup_rules` with any device-grant rule — a cgroup allow rule (e.g. `c 10:200 rwm`) grants device access by major:minor number independent of the `devices:` mapping; combined with `mknod` inside the container, it can restore tunnel capability.
-- `pid_mode: host` — shares the host PID namespace; with sufficient capability a container process can `nsenter` into host namespaces and escape `internal: true` network isolation entirely.
+- `pid: host` — shares the host PID namespace; with sufficient capability a container process can `nsenter` into host namespaces and escape `internal: true` network isolation entirely.
 - `sysctls` enabling IP forwarding (`net.ipv4.ip_forward=1` or `net.ipv6.conf.<iface>.forwarding=1`) — turns the container into a router that can relay traffic between network interfaces, bypassing the mitmproxy chokepoint.
 - `security_opt: seccomp:unconfined` or `security_opt: apparmor:unconfined` — disables kernel confinement profiles (seccomp syscall filter or AppArmor MAC), unblocking operations that aid egress bypass.
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -498,7 +498,12 @@ workspace → sandbox-net (internal:true) → mitmproxy → egress-net → inter
 The compose topology guard (`deploy/validate-stack.sh`) enforces this model statically. In addition to the network-attachment allowlist and the blanket `network_mode` ban, the guard rejects the following egress-weakening keys on **any** service, because each can relay or tunnel workspace egress around mitmproxy:
 
 - `extra_hosts` with a `host-gateway` value — gives the container the Docker host's bridge IP, enabling relay via any host-bound proxy or tunnel.
-- `cap_add: NET_ADMIN` or `cap_add: NET_RAW` — enables raw-socket and routing-table manipulation used to build VPN tunnels.
+- `cap_add: NET_ADMIN`, `cap_add: NET_RAW`, or `cap_add: ALL` — enables raw-socket and routing-table manipulation used to build VPN tunnels. `ALL` grants every capability including `NET_ADMIN` and `NET_RAW`.
 - `devices: /dev/net/tun` — the kernel TUN/TAP interface used by VPN clients to construct egress tunnels.
+- `privileged: true` — grants all Linux capabilities and all host devices, nullifying the `cap_add` and `devices` controls entirely.
+- `device_cgroup_rules` with any device-grant rule — a cgroup allow rule (e.g. `c 10:200 rwm`) grants device access by major:minor number independent of the `devices:` mapping; combined with `mknod` inside the container, it can restore tunnel capability.
+- `pid_mode: host` — shares the host PID namespace; with sufficient capability a container process can `nsenter` into host namespaces and escape `internal: true` network isolation entirely.
+- `sysctls` enabling IP forwarding (`net.ipv4.ip_forward=1` or `net.ipv6.conf.<iface>.forwarding=1`) — turns the container into a router that can relay traffic between network interfaces, bypassing the mitmproxy chokepoint.
+- `security_opt: seccomp:unconfined` or `security_opt: apparmor:unconfined` — disables kernel confinement profiles (seccomp syscall filter or AppArmor MAC), unblocking operations that aid egress bypass.
 
 **Forward constraint:** never give the workspace a gateway endpoint that performs caller-directed outbound requests. The only workspace-reachable HTTP ingress on the gateway is the HMAC/replay-gated `POST /v1/announce` endpoint, which posts a fixed embed — it does not perform arbitrary outbound requests on behalf of the caller. If a new workspace-reachable gateway endpoint is added that performs caller-directed outbound, the topology must be revisited. A CI pinning test enforces this: it asserts the gateway's HTTP ingress surface is exactly `{POST /v1/announce}` and fails if a new route is added without a deliberate review.

--- a/deploy/validate-stack.sh
+++ b/deploy/validate-stack.sh
@@ -30,14 +30,28 @@ PYTHON3_BIN="${PYTHON3_BIN:-python3}"
 #   1c. NO service may declare extra_hosts with a host-gateway value — gives
 #      the container the Docker host's bridge IP, enabling egress relay around
 #      mitmproxy via any host-bound proxy/tunnel.
-#   1d. NO service may declare cap_add with NET_ADMIN or NET_RAW — enables
-#      raw-socket/routing manipulation used to build VPN tunnels that bypass
-#      mitmproxy.  CAP_ prefix and case variants are normalized before checking.
+#   1d. NO service may declare cap_add with NET_ADMIN, NET_RAW, or ALL —
+#      enables raw-socket/routing manipulation used to build VPN tunnels that
+#      bypass mitmproxy.  ALL grants every capability including NET_ADMIN and
+#      NET_RAW.  CAP_ prefix and case variants are normalized before checking.
 #   1e. NO service may map the /dev/net/tun device — the TUN/TAP interface
 #      used by VPN clients to construct egress tunnels around mitmproxy.
 #      Path normalization catches //, /./ and similar variants.
 #   1f. NO service may declare privileged: true — grants ALL capabilities and
 #      ALL host devices, nullifying Invariants 1d and 1e entirely.
+#   1g. NO service may declare device_cgroup_rules with any device-grant rule —
+#      a cgroup allow rule (e.g. "c 10:200 rwm") grants device access by
+#      major:minor independent of a devices: mapping; combined with mknod it
+#      restores tunnel capability that Invariant 1e blocks.
+#   1h. NO service may declare pid: host — with sufficient capability a
+#      container can nsenter into host namespaces, escaping internal:true
+#      entirely.  pid: service:<x>/container:<x> is not rejected.
+#   1i. NO service may declare an IP-forwarding sysctl (net.ipv4.ip_forward or
+#      net.ipv6.conf.<iface>.forwarding) set to an enabling value — enables
+#      container-as-router behavior for relaying traffic.
+#   1j. NO service may declare a confinement-disabling security_opt
+#      (seccomp:unconfined or apparmor:unconfined) — relaxes kernel confinement
+#      and unblocks operations that aid egress bypass.
 #   2. workspace is attached to sandbox-net ONLY — it has zero direct egress.
 #   3. mitmproxy is attached to sandbox-net AND at least one non-internal
 #      network (its upstream leg to the internet).
@@ -316,13 +330,14 @@ for _svc in sorted(services.keys()):
 # Normalization: Docker Compose may preserve the CAP_ prefix (e.g.
 # CAP_NET_ADMIN) or lowercase variants (cap_net_admin) from raw YAML.
 # Strip a leading CAP_ prefix and uppercase before checking the banned set
-# so all forms are caught.
+# so all forms are caught.  ALL is included because it grants every capability
+# including NET_ADMIN and NET_RAW — same supersetting threat as privileged:true.
 #
 # Scalar-string guard: if cap_add is a bare string (not a list), wrap it
 # into a single-element list before iterating so scalar YAML values are
 # not silently missed by character-iteration.
 # ------------------------------------------------------------------
-_BANNED_CAPS = {"NET_ADMIN", "NET_RAW"}
+_BANNED_CAPS = {"NET_ADMIN", "NET_RAW", "ALL"}
 for _svc in sorted(services.keys()):
     _svc_cfg = services.get(_svc) or {}
     _cap_add = _svc_cfg.get("cap_add") or []
@@ -335,8 +350,9 @@ for _svc in sorted(services.keys()):
         if _cap_norm in _BANNED_CAPS:
             failures.append(
                 f"FAIL: service '{_svc}' declares cap_add '{_cap}' — "
-                "NET_ADMIN and NET_RAW enable raw-socket/routing manipulation that can "
-                "tunnel workspace egress around mitmproxy and are not permitted."
+                "NET_ADMIN, NET_RAW, and ALL enable raw-socket/routing manipulation that can "
+                "tunnel workspace egress around mitmproxy and are not permitted. "
+                "(ALL grants every capability including NET_ADMIN and NET_RAW.)"
             )
             break
 
@@ -405,6 +421,149 @@ for _svc in sorted(services.keys()):
             "and access to all host devices (including /dev/net/tun), bypassing the egress "
             "containment controls enforced by Invariants 1d and 1e. Remove privileged: true."
         )
+
+# ------------------------------------------------------------------
+# Invariant 1g: NO service may declare device_cgroup_rules with any
+# device-grant (allow) rule.
+#
+# A cgroup device-allow rule (e.g. "c 10:200 rwm") grants the container
+# access to a device by major:minor number, independent of any devices:
+# mapping.  Combined with an in-container mknod, this restores tunnel
+# capability that Invariant 1e blocks (e.g. recreating /dev/net/tun via
+# major 10, minor 200).  The workspace stack has no legitimate device-grant
+# need, so any non-empty allow rule is rejected (broad/fail-closed).
+#
+# Normalized shape (docker compose config JSON): list of strings like
+# "c 10:200 rwm" or "a *:* rwm".
+# Raw-YAML fallback shape: same list of strings, or a bare scalar string.
+#
+# Scalar-string guard: wrap a bare string into a single-element list.
+# ------------------------------------------------------------------
+for _svc in sorted(services.keys()):
+    _svc_cfg = services.get(_svc) or {}
+    _dcgr = _svc_cfg.get("device_cgroup_rules") or []
+    if isinstance(_dcgr, str):
+        _dcgr = [_dcgr]
+    for _rule in _dcgr:
+        _rule_s = str(_rule).strip()
+        if _rule_s:
+            failures.append(
+                f"FAIL: service '{_svc}' declares device_cgroup_rules '{_rule_s}' — "
+                "device cgroup allow rules grant device access by major:minor number "
+                "independent of the devices: mapping; combined with mknod this can "
+                "restore tunnel capability bypassing the /dev/net/tun control "
+                "(Invariant 1e). Remove all device_cgroup_rules entries."
+            )
+            break
+
+# ------------------------------------------------------------------
+# Invariant 1h: NO service may declare pid: host.
+#
+# pid: host shares the host's PID namespace with the container.
+# With sufficient capability or privilege, a process inside the container
+# can nsenter into host namespaces, escaping the internal:true network
+# isolation entirely.  This is the most dangerous escalation when combined
+# with the (now-blocked) privileged: true.
+#
+# pid: service:<x> and pid: container:<x> share another container's PID
+# namespace (not the host's) and are not rejected here.
+#
+# Normalized shape (docker compose config JSON): scalar string "host" or
+# "service:<x>".  Raw-YAML fallback shape: same scalar string.
+# ------------------------------------------------------------------
+for _svc in sorted(services.keys()):
+    _svc_cfg = services.get(_svc) or {}
+    _pid = _svc_cfg.get("pid")
+    if _pid is not None and str(_pid).strip().lower() == "host":
+        failures.append(
+            f"FAIL: service '{_svc}' declares pid: host — "
+            "pid: host shares the host PID namespace; with sufficient capability "
+            "a container process can nsenter into host namespaces and escape the "
+            "internal:true network isolation. Remove pid: host."
+        )
+
+# ------------------------------------------------------------------
+# Invariant 1i: NO service may declare an IP-forwarding sysctl set to an
+# enabling value.
+#
+# net.ipv4.ip_forward=1 and net.ipv6.conf.<iface>.forwarding=1 enable
+# container-as-router behavior, allowing the container to relay traffic
+# between network interfaces and bypass the mitmproxy chokepoint.
+#
+# Normalized shape (docker compose config JSON): dict {name: value}.
+# Raw-YAML fallback shape: dict {name: value} OR list of "name=value" strings.
+# Compose normalizes list form to dict; we handle both defensively.
+#
+# Enabling values: integer 1, string "1", boolean True/"true".
+# Forwarding=0 and all other sysctls are not rejected.
+# ------------------------------------------------------------------
+import re as _re_sysctl
+
+_IPV6_FWD_RE = _re_sysctl.compile(r'^net\.ipv6\.conf\.[^.]+\.forwarding$')
+
+def _is_enabling_sysctl_value(v):
+    """Return True if the sysctl value enables forwarding."""
+    if v is True:
+        return True
+    s = str(v).strip().lower()
+    return s in ("1", "true")
+
+for _svc in sorted(services.keys()):
+    _svc_cfg = services.get(_svc) or {}
+    _sysctls = _svc_cfg.get("sysctls") or {}
+    # Handle list-of-"name=value" strings (raw-YAML form)
+    if isinstance(_sysctls, list):
+        _sysctls_dict = {}
+        for _entry in _sysctls:
+            if isinstance(_entry, str) and "=" in _entry:
+                _k, _v = _entry.split("=", 1)
+                _sysctls_dict[_k.strip()] = _v.strip()
+        _sysctls = _sysctls_dict
+    for _sysctl_key, _sysctl_val in (_sysctls or {}).items():
+        _k = str(_sysctl_key).strip()
+        if (_k == "net.ipv4.ip_forward" or _IPV6_FWD_RE.match(_k)) and _is_enabling_sysctl_value(_sysctl_val):
+            failures.append(
+                f"FAIL: service '{_svc}' declares sysctl '{_k}={_sysctl_val}' — "
+                "enabling IP forwarding turns the container into a router that can "
+                "relay traffic between network interfaces, bypassing the mitmproxy "
+                "egress chokepoint. Remove or disable the IP-forwarding sysctl."
+            )
+            break
+
+# ------------------------------------------------------------------
+# Invariant 1j: NO service may declare a confinement-disabling security_opt.
+#
+# seccomp:unconfined disables the seccomp syscall filter, unblocking
+# operations otherwise restricted that aid egress bypass.
+# apparmor:unconfined disables the AppArmor MAC profile, similarly
+# relaxing kernel confinement.
+# label:* and no-new-privileges:* are allowed (the latter strengthens
+# confinement).
+#
+# Normalized shape: list of strings like "seccomp:unconfined",
+# "apparmor:unconfined", "label:disable", "no-new-privileges:true".
+# Raw-YAML fallback shape: same list, or a bare scalar string.
+#
+# Scalar-string guard: wrap a bare string into a single-element list.
+# Normalization: strip whitespace, lowercase, tolerate = separator.
+# ------------------------------------------------------------------
+_BANNED_SECURITY_OPTS = {"seccomp:unconfined", "apparmor:unconfined",
+                         "seccomp=unconfined", "apparmor=unconfined"}
+for _svc in sorted(services.keys()):
+    _svc_cfg = services.get(_svc) or {}
+    _sec_opts = _svc_cfg.get("security_opt") or []
+    if isinstance(_sec_opts, str):
+        _sec_opts = [_sec_opts]
+    for _opt in _sec_opts:
+        _opt_norm = str(_opt).strip().lower()
+        if _opt_norm in _BANNED_SECURITY_OPTS:
+            failures.append(
+                f"FAIL: service '{_svc}' declares security_opt '{_opt}' — "
+                "seccomp:unconfined and apparmor:unconfined disable kernel confinement "
+                "profiles, unblocking syscalls and operations that aid egress bypass. "
+                "Remove the unconfined security_opt entry."
+            )
+            break
 
 # ------------------------------------------------------------------
 # Invariant 6: workspace must mount the named volume 'workspace-repos'

--- a/deploy/validate-stack.sh
+++ b/deploy/validate-stack.sh
@@ -321,23 +321,33 @@ for _svc in sorted(services.keys()):
             break
 
 # ------------------------------------------------------------------
-# Invariant 1d: NO service may declare cap_add with NET_ADMIN or NET_RAW.
+# Invariant 1d: NO service may declare cap_add with NET_ADMIN, NET_RAW,
+# SYS_MODULE, SYS_ADMIN, or ALL.
 #
 # NET_ADMIN and NET_RAW enable raw-socket and routing-table manipulation.
 # Combined with a VPN client image and /dev/net/tun, they can build a tunnel
-# that bypasses mitmproxy.  Reject either capability on ANY service.
+# that bypasses mitmproxy.
+#
+# SYS_MODULE allows loading kernel modules (init_module/finit_module syscalls
+# are permitted by Docker's default seccomp profile when CAP_SYS_MODULE is
+# present) — an attacker can load a tunnel kernel module to bypass mitmproxy.
+#
+# SYS_ADMIN enables the nsenter namespace-escape chain (ioctl NS_GET_PARENT +
+# setns into the host network namespace), escaping sandbox-net isolation.
+#
+# ALL grants every Linux capability including all of the above — same
+# supersetting threat as privileged:true.
 #
 # Normalization: Docker Compose may preserve the CAP_ prefix (e.g.
 # CAP_NET_ADMIN) or lowercase variants (cap_net_admin) from raw YAML.
 # Strip a leading CAP_ prefix and uppercase before checking the banned set
-# so all forms are caught.  ALL is included because it grants every capability
-# including NET_ADMIN and NET_RAW — same supersetting threat as privileged:true.
+# so all forms are caught.
 #
 # Scalar-string guard: if cap_add is a bare string (not a list), wrap it
 # into a single-element list before iterating so scalar YAML values are
 # not silently missed by character-iteration.
 # ------------------------------------------------------------------
-_BANNED_CAPS = {"NET_ADMIN", "NET_RAW", "ALL"}
+_BANNED_CAPS = {"NET_ADMIN", "NET_RAW", "SYS_MODULE", "SYS_ADMIN", "ALL"}
 for _svc in sorted(services.keys()):
     _svc_cfg = services.get(_svc) or {}
     _cap_add = _svc_cfg.get("cap_add") or []
@@ -350,9 +360,10 @@ for _svc in sorted(services.keys()):
         if _cap_norm in _BANNED_CAPS:
             failures.append(
                 f"FAIL: service '{_svc}' declares cap_add '{_cap}' — "
-                "NET_ADMIN, NET_RAW, and ALL enable raw-socket/routing manipulation that can "
-                "tunnel workspace egress around mitmproxy and are not permitted. "
-                "(ALL grants every capability including NET_ADMIN and NET_RAW.)"
+                "NET_ADMIN, NET_RAW, SYS_MODULE, SYS_ADMIN, and ALL enable raw-socket/routing "
+                "manipulation, kernel module loading, or namespace escape that can tunnel "
+                "workspace egress around mitmproxy and are not permitted. "
+                "(ALL grants every capability including NET_ADMIN, NET_RAW, SYS_MODULE, and SYS_ADMIN.)"
             )
             break
 
@@ -486,9 +497,14 @@ for _svc in sorted(services.keys()):
 # Invariant 1i: NO service may declare an IP-forwarding sysctl set to an
 # enabling value.
 #
-# net.ipv4.ip_forward=1 and net.ipv6.conf.<iface>.forwarding=1 enable
-# container-as-router behavior, allowing the container to relay traffic
-# between network interfaces and bypass the mitmproxy chokepoint.
+# net.ipv4.ip_forward=1, net.ipv4.conf.all.forwarding=1,
+# net.ipv4.conf.<iface>.forwarding=1, and net.ipv6.conf.<iface>.forwarding=1
+# all enable container-as-router behavior, allowing the container to relay
+# traffic between network interfaces and bypass the mitmproxy chokepoint.
+#
+# The Linux kernel aliases net.ipv4.conf.all.forwarding and
+# net.ipv4.conf.<iface>.forwarding to the same forwarding behavior as
+# net.ipv4.ip_forward — all three forms must be rejected.
 #
 # Normalized shape (docker compose config JSON): dict {name: value}.
 # Raw-YAML fallback shape: dict {name: value} OR list of "name=value" strings.
@@ -500,6 +516,7 @@ for _svc in sorted(services.keys()):
 import re as _re_sysctl
 
 _IPV6_FWD_RE = _re_sysctl.compile(r'^net\.ipv6\.conf\.[^.]+\.forwarding$')
+_IPV4_CONF_FWD_RE = _re_sysctl.compile(r'^net\.ipv4\.conf\.[^.]+\.forwarding$')
 
 def _is_enabling_sysctl_value(v):
     """Return True if the sysctl value enables forwarding."""
@@ -521,7 +538,7 @@ for _svc in sorted(services.keys()):
         _sysctls = _sysctls_dict
     for _sysctl_key, _sysctl_val in (_sysctls or {}).items():
         _k = str(_sysctl_key).strip()
-        if (_k == "net.ipv4.ip_forward" or _IPV6_FWD_RE.match(_k)) and _is_enabling_sysctl_value(_sysctl_val):
+        if (_k == "net.ipv4.ip_forward" or _IPV4_CONF_FWD_RE.match(_k) or _IPV6_FWD_RE.match(_k)) and _is_enabling_sysctl_value(_sysctl_val):
             failures.append(
                 f"FAIL: service '{_svc}' declares sysctl '{_k}={_sysctl_val}' — "
                 "enabling IP forwarding turns the container into a router that can "
@@ -531,37 +548,47 @@ for _svc in sorted(services.keys()):
             break
 
 # ------------------------------------------------------------------
-# Invariant 1j: NO service may declare a confinement-disabling security_opt.
+# Invariant 1j: NO service may declare a confinement-weakening security_opt
+# for seccomp or apparmor.
 #
-# seccomp:unconfined disables the seccomp syscall filter, unblocking
-# operations otherwise restricted that aid egress bypass.
-# apparmor:unconfined disables the AppArmor MAC profile, similarly
-# relaxing kernel confinement.
-# label:* and no-new-privileges:* are allowed (the latter strengthens
-# confinement).
+# seccomp:unconfined disables the seccomp syscall filter entirely.
+# apparmor:unconfined disables the AppArmor MAC profile entirely.
+# A custom profile path (e.g. seccomp=/path/to/profile.json or
+# seccomp:/path/to/profile.json) replaces the default Docker seccomp profile
+# with an operator-supplied one that may be permissive — this is equally
+# dangerous because the workspace has no legitimate need for a custom profile.
+#
+# Rule: reject any security_opt entry matching
+#   ^(seccomp|apparmor)[:=](?!default$).+
+# i.e. any seccomp/apparmor value that is NOT the literal "default".
+# The implicit default (no seccomp/apparmor key at all) and the explicit
+# ":default" form are both allowed.  label:* and no-new-privileges:* are
+# always allowed (the latter strengthens confinement).
 #
 # Normalized shape: list of strings like "seccomp:unconfined",
-# "apparmor:unconfined", "label:disable", "no-new-privileges:true".
+# "apparmor:unconfined", "seccomp=/path/to/profile.json",
+# "label:disable", "no-new-privileges:true".
 # Raw-YAML fallback shape: same list, or a bare scalar string.
 #
 # Scalar-string guard: wrap a bare string into a single-element list.
-# Normalization: strip whitespace, lowercase, tolerate = separator.
+# Normalization: strip whitespace; check is case-insensitive on the prefix.
 # ------------------------------------------------------------------
-_BANNED_SECURITY_OPTS = {"seccomp:unconfined", "apparmor:unconfined",
-                         "seccomp=unconfined", "apparmor=unconfined"}
+_SECOPT_CUSTOM_RE = _re_sysctl.compile(r'^(seccomp|apparmor)[:=](?!default$).+', _re_sysctl.IGNORECASE)
 for _svc in sorted(services.keys()):
     _svc_cfg = services.get(_svc) or {}
     _sec_opts = _svc_cfg.get("security_opt") or []
     if isinstance(_sec_opts, str):
         _sec_opts = [_sec_opts]
     for _opt in _sec_opts:
-        _opt_norm = str(_opt).strip().lower()
-        if _opt_norm in _BANNED_SECURITY_OPTS:
+        _opt_s = str(_opt).strip()
+        if _SECOPT_CUSTOM_RE.match(_opt_s):
             failures.append(
                 f"FAIL: service '{_svc}' declares security_opt '{_opt}' — "
-                "seccomp:unconfined and apparmor:unconfined disable kernel confinement "
-                "profiles, unblocking syscalls and operations that aid egress bypass. "
-                "Remove the unconfined security_opt entry."
+                "custom or unconfined seccomp/apparmor profiles weaken kernel confinement: "
+                "seccomp:unconfined/apparmor:unconfined disable the filter entirely, and "
+                "a custom profile path replaces the default Docker profile with one that "
+                "may permit dangerous syscalls. Only the implicit default profile is allowed. "
+                "Remove the seccomp/apparmor security_opt entry."
             )
             break
 

--- a/deploy/validate-stack.test.sh
+++ b/deploy/validate-stack.test.sh
@@ -2172,6 +2172,666 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# TEST 38 — Negative: cap_add: [ALL] must be rejected (Invariant 1d, ALL cap).
+#
+# ALL grants every Linux capability including the banned NET_ADMIN and NET_RAW.
+# The failure message must name the service and mention 'ALL'.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 38: guard rejects cap_add: [ALL] ---"
+
+CAP_ALL_COMPOSE="${TMPDIR_TEST}/compose-cap-all.yaml"
+cat > "${CAP_ALL_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    cap_add:
+      - ALL
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+CAP_ALL_OUTPUT=""
+CAP_ALL_EXIT=0
+CAP_ALL_OUTPUT="$(COMPOSE_FILE="${CAP_ALL_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || CAP_ALL_EXIT=$?
+
+if [[ "${CAP_ALL_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${CAP_ALL_EXIT}) for cap_add: [ALL]"
+else
+  fail "validate-stack.sh exited ZERO for cap_add: [ALL] — guard did NOT fire"
+fi
+
+if echo "${CAP_ALL_OUTPUT}" | grep -q "workspace"; then
+  pass "cap_add ALL failure message names the service 'workspace'"
+else
+  fail "cap_add ALL failure message does not name 'workspace' — output: ${CAP_ALL_OUTPUT}"
+fi
+
+if echo "${CAP_ALL_OUTPUT}" | grep -q "ALL"; then
+  pass "cap_add ALL failure message mentions 'ALL'"
+else
+  fail "cap_add ALL failure message does not mention 'ALL' — output: ${CAP_ALL_OUTPUT}"
+fi
+
+echo ""
+echo "  cap-add-all-test output (stderr+stdout combined):"
+echo "${CAP_ALL_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 39 — Negative: cap_add: [CAP_ALL] must be rejected (CAP_ prefix norm).
+#
+# Docker Compose or raw YAML may preserve the CAP_ prefix.  The guard strips
+# CAP_ before checking the banned set, so CAP_ALL → ALL is caught.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 39: guard rejects cap_add: [CAP_ALL] (CAP_ prefix normalization) ---"
+
+CAP_CAP_ALL_COMPOSE="${TMPDIR_TEST}/compose-cap-cap-all.yaml"
+cat > "${CAP_CAP_ALL_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    cap_add:
+      - CAP_ALL
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+CAP_CAP_ALL_OUTPUT=""
+CAP_CAP_ALL_EXIT=0
+CAP_CAP_ALL_OUTPUT="$(COMPOSE_FILE="${CAP_CAP_ALL_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || CAP_CAP_ALL_EXIT=$?
+
+if [[ "${CAP_CAP_ALL_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${CAP_CAP_ALL_EXIT}) for cap_add: [CAP_ALL]"
+else
+  fail "validate-stack.sh exited ZERO for cap_add: [CAP_ALL] — CAP_ prefix bypass NOT caught"
+fi
+
+if echo "${CAP_CAP_ALL_OUTPUT}" | grep -q "workspace"; then
+  pass "cap_add CAP_ALL failure message names the service 'workspace'"
+else
+  fail "cap_add CAP_ALL failure message does not name 'workspace' — output: ${CAP_CAP_ALL_OUTPUT}"
+fi
+
+if echo "${CAP_CAP_ALL_OUTPUT}" | grep -qi "CAP_ALL\|ALL"; then
+  pass "cap_add CAP_ALL failure message mentions the capability"
+else
+  fail "cap_add CAP_ALL failure message does not mention the capability — output: ${CAP_CAP_ALL_OUTPUT}"
+fi
+
+echo ""
+echo "  cap-cap-all-test output (stderr+stdout combined):"
+echo "${CAP_CAP_ALL_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 40 — Negative: device_cgroup_rules: ["c 10:200 rwm"] must be rejected
+#           (Invariant 1g).
+#
+# A cgroup device-allow rule grants device access by major:minor number
+# independent of the devices: mapping.  Combined with mknod, it can restore
+# tunnel capability that Invariant 1e blocks.  The failure message must name
+# the service and the offending rule.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 40: guard rejects device_cgroup_rules: [\"c 10:200 rwm\"] (Invariant 1g) ---"
+
+DCR_COMPOSE="${TMPDIR_TEST}/compose-dcr.yaml"
+cat > "${DCR_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    device_cgroup_rules:
+      - "c 10:200 rwm"
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+DCR_OUTPUT=""
+DCR_EXIT=0
+DCR_OUTPUT="$(COMPOSE_FILE="${DCR_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || DCR_EXIT=$?
+
+if [[ "${DCR_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${DCR_EXIT}) for device_cgroup_rules: [\"c 10:200 rwm\"]"
+else
+  fail "validate-stack.sh exited ZERO for device_cgroup_rules — Invariant 1g did NOT fire"
+fi
+
+if echo "${DCR_OUTPUT}" | grep -q "workspace"; then
+  pass "device_cgroup_rules failure message names the service 'workspace'"
+else
+  fail "device_cgroup_rules failure message does not name 'workspace' — output: ${DCR_OUTPUT}"
+fi
+
+if echo "${DCR_OUTPUT}" | grep -q "c 10:200 rwm"; then
+  pass "device_cgroup_rules failure message mentions the offending rule 'c 10:200 rwm'"
+else
+  fail "device_cgroup_rules failure message does not mention the rule — output: ${DCR_OUTPUT}"
+fi
+
+echo ""
+echo "  device-cgroup-rules-test output (stderr+stdout combined):"
+echo "${DCR_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 41 — Negative: pid: host must be rejected (Invariant 1h).
+#
+# pid: host shares the host PID namespace; with sufficient capability
+# a container can nsenter into host namespaces and escape internal:true.
+# The failure message must name the service and mention 'pid'.
+# (Docker Compose uses the key 'pid', not 'pid_mode'.)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 41: guard rejects pid: host (Invariant 1h) ---"
+
+PID_HOST_COMPOSE="${TMPDIR_TEST}/compose-pid-host.yaml"
+cat > "${PID_HOST_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    pid: host
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+PID_HOST_OUTPUT=""
+PID_HOST_EXIT=0
+PID_HOST_OUTPUT="$(COMPOSE_FILE="${PID_HOST_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || PID_HOST_EXIT=$?
+
+if [[ "${PID_HOST_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${PID_HOST_EXIT}) for pid: host"
+else
+  fail "validate-stack.sh exited ZERO for pid: host — Invariant 1h did NOT fire"
+fi
+
+if echo "${PID_HOST_OUTPUT}" | grep -q "workspace"; then
+  pass "pid: host failure message names the service 'workspace'"
+else
+  fail "pid: host failure message does not name 'workspace' — output: ${PID_HOST_OUTPUT}"
+fi
+
+if echo "${PID_HOST_OUTPUT}" | grep -qi "pid"; then
+  pass "pid: host failure message mentions 'pid'"
+else
+  fail "pid: host failure message does not mention 'pid' — output: ${PID_HOST_OUTPUT}"
+fi
+
+echo ""
+echo "  pid-host-test output (stderr+stdout combined):"
+echo "${PID_HOST_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 42 — Positive: pid: "service:mitmproxy" must NOT be rejected.
+#
+# pid: service:<x> shares another container's PID namespace, not the
+# host's.  It is not a host-namespace escape and must not be over-rejected.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 42: guard accepts pid: \"service:mitmproxy\" (not host-ns escape) ---"
+
+PID_SVC_COMPOSE="${TMPDIR_TEST}/compose-pid-svc.yaml"
+cat > "${PID_SVC_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    pid: "service:mitmproxy"
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+PID_SVC_OUTPUT=""
+PID_SVC_EXIT=0
+PID_SVC_OUTPUT="$(COMPOSE_FILE="${PID_SVC_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || PID_SVC_EXIT=$?
+
+if [[ "${PID_SVC_EXIT}" -eq 0 ]]; then
+  pass "validate-stack.sh exited zero for pid: \"service:mitmproxy\" — no over-rejection"
+else
+  fail "validate-stack.sh exited non-zero (${PID_SVC_EXIT}) for pid: \"service:mitmproxy\" — over-rejection: ${PID_SVC_OUTPUT}"
+fi
+
+echo ""
+echo "  pid-svc-test output (stderr+stdout combined):"
+echo "${PID_SVC_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 43 — Negative: sysctls: {net.ipv4.ip_forward: 1} must be rejected
+#           (Invariant 1i, map form).
+#
+# Enabling IP forwarding turns the container into a router that can relay
+# traffic between network interfaces, bypassing the mitmproxy chokepoint.
+# The failure message must name the service and the sysctl.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 43: guard rejects sysctls: {net.ipv4.ip_forward: 1} (Invariant 1i) ---"
+
+SYSCTL_IPV4_COMPOSE="${TMPDIR_TEST}/compose-sysctl-ipv4.yaml"
+cat > "${SYSCTL_IPV4_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    sysctls:
+      net.ipv4.ip_forward: 1
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+SYSCTL_IPV4_OUTPUT=""
+SYSCTL_IPV4_EXIT=0
+SYSCTL_IPV4_OUTPUT="$(COMPOSE_FILE="${SYSCTL_IPV4_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || SYSCTL_IPV4_EXIT=$?
+
+if [[ "${SYSCTL_IPV4_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${SYSCTL_IPV4_EXIT}) for sysctls net.ipv4.ip_forward=1"
+else
+  fail "validate-stack.sh exited ZERO for sysctls net.ipv4.ip_forward=1 — Invariant 1i did NOT fire"
+fi
+
+if echo "${SYSCTL_IPV4_OUTPUT}" | grep -q "workspace"; then
+  pass "sysctls ipv4 failure message names the service 'workspace'"
+else
+  fail "sysctls ipv4 failure message does not name 'workspace' — output: ${SYSCTL_IPV4_OUTPUT}"
+fi
+
+if echo "${SYSCTL_IPV4_OUTPUT}" | grep -q "net.ipv4.ip_forward"; then
+  pass "sysctls ipv4 failure message mentions 'net.ipv4.ip_forward'"
+else
+  fail "sysctls ipv4 failure message does not mention 'net.ipv4.ip_forward' — output: ${SYSCTL_IPV4_OUTPUT}"
+fi
+
+echo ""
+echo "  sysctl-ipv4-test output (stderr+stdout combined):"
+echo "${SYSCTL_IPV4_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 44 — Negative: sysctls list form ["net.ipv6.conf.all.forwarding=1"]
+#           must be rejected (Invariant 1i, list form + IPv6).
+#
+# Raw YAML may express sysctls as a list of "name=value" strings.  The guard
+# handles both map and list forms.  IPv6 forwarding is also an IP-forwarding
+# sysctl that enables container-as-router behavior.
+#
+# NOTE: docker compose config normalizes list-form sysctls to a map, so this
+# bypass only fires via the raw-YAML fallback path (no docker in PATH).
+# This test strips docker from PATH and requires PyYAML.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 44: guard rejects sysctls list form [\"net.ipv6.conf.all.forwarding=1\"] via raw-YAML path ---"
+
+SYSCTL_IPV6_COMPOSE="${TMPDIR_TEST}/compose-sysctl-ipv6.yaml"
+cat > "${SYSCTL_IPV6_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    sysctls:
+      - "net.ipv6.conf.all.forwarding=1"
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+if "${PYTHON3_BIN}" -c "import yaml" 2>/dev/null; then
+  SYSCTL_IPV6_OUTPUT=""
+  SYSCTL_IPV6_EXIT=0
+  SYSCTL_IPV6_OUTPUT="$(PATH="${NO_DOCKER_PATH}" COMPOSE_FILE="${SYSCTL_IPV6_COMPOSE}" PYTHON3_BIN="${PYTHON3_BIN}" "${BASH_BIN}" deploy/validate-stack.sh --topology-only 2>&1)" || SYSCTL_IPV6_EXIT=$?
+
+  if [[ "${SYSCTL_IPV6_EXIT}" -ne 0 ]]; then
+    pass "validate-stack.sh exited non-zero (${SYSCTL_IPV6_EXIT}) for sysctls list net.ipv6.conf.all.forwarding=1"
+  else
+    fail "validate-stack.sh exited ZERO for sysctls list net.ipv6.conf.all.forwarding=1 — Invariant 1i did NOT fire"
+  fi
+
+  if echo "${SYSCTL_IPV6_OUTPUT}" | grep -q "workspace"; then
+    pass "sysctls ipv6 list failure message names the service 'workspace'"
+  else
+    fail "sysctls ipv6 list failure message does not name 'workspace' — output: ${SYSCTL_IPV6_OUTPUT}"
+  fi
+
+  if echo "${SYSCTL_IPV6_OUTPUT}" | grep -q "net.ipv6.conf.all.forwarding"; then
+    pass "sysctls ipv6 list failure message mentions 'net.ipv6.conf.all.forwarding'"
+  else
+    fail "sysctls ipv6 list failure message does not mention the sysctl — output: ${SYSCTL_IPV6_OUTPUT}"
+  fi
+
+  echo ""
+  echo "  sysctl-ipv6-list-test output (stderr+stdout combined):"
+  echo "${SYSCTL_IPV6_OUTPUT}" | sed 's/^/    /'
+else
+  echo "  SKIP: sysctls list form test: PyYAML not available — install python3-yaml/PyYAML to run this test."
+  echo "        (docker compose config normalizes list-form sysctls to a map; raw-YAML path required for this form)"
+fi
+
+# ---------------------------------------------------------------------------
+# TEST 45 — Positive: sysctls: {net.ipv4.ip_forward: 0} must NOT be rejected.
+#
+# Forwarding disabled (value=0) is not an egress-enabling sysctl.  The guard
+# must not over-reject forwarding=0 or other benign sysctls.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 45: guard accepts sysctls: {net.ipv4.ip_forward: 0} (forwarding disabled) ---"
+
+SYSCTL_DISABLED_COMPOSE="${TMPDIR_TEST}/compose-sysctl-disabled.yaml"
+cat > "${SYSCTL_DISABLED_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    sysctls:
+      net.ipv4.ip_forward: 0
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+SYSCTL_DISABLED_OUTPUT=""
+SYSCTL_DISABLED_EXIT=0
+SYSCTL_DISABLED_OUTPUT="$(COMPOSE_FILE="${SYSCTL_DISABLED_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || SYSCTL_DISABLED_EXIT=$?
+
+if [[ "${SYSCTL_DISABLED_EXIT}" -eq 0 ]]; then
+  pass "validate-stack.sh exited zero for sysctls net.ipv4.ip_forward=0 — no over-rejection"
+else
+  fail "validate-stack.sh exited non-zero (${SYSCTL_DISABLED_EXIT}) for sysctls forwarding=0 — over-rejection: ${SYSCTL_DISABLED_OUTPUT}"
+fi
+
+echo ""
+echo "  sysctl-disabled-test output (stderr+stdout combined):"
+echo "${SYSCTL_DISABLED_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 46 — Negative: security_opt: ["seccomp:unconfined"] must be rejected
+#           (Invariant 1j).
+#
+# seccomp:unconfined disables the seccomp syscall filter, unblocking
+# operations otherwise restricted that aid egress bypass.
+# The failure message must name the service and the offending option.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 46: guard rejects security_opt: [\"seccomp:unconfined\"] (Invariant 1j) ---"
+
+SECOPT_SECCOMP_COMPOSE="${TMPDIR_TEST}/compose-secopt-seccomp.yaml"
+cat > "${SECOPT_SECCOMP_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    security_opt:
+      - "seccomp:unconfined"
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+SECOPT_SECCOMP_OUTPUT=""
+SECOPT_SECCOMP_EXIT=0
+SECOPT_SECCOMP_OUTPUT="$(COMPOSE_FILE="${SECOPT_SECCOMP_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || SECOPT_SECCOMP_EXIT=$?
+
+if [[ "${SECOPT_SECCOMP_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${SECOPT_SECCOMP_EXIT}) for security_opt: [\"seccomp:unconfined\"]"
+else
+  fail "validate-stack.sh exited ZERO for security_opt seccomp:unconfined — Invariant 1j did NOT fire"
+fi
+
+if echo "${SECOPT_SECCOMP_OUTPUT}" | grep -q "workspace"; then
+  pass "security_opt seccomp:unconfined failure message names the service 'workspace'"
+else
+  fail "security_opt seccomp:unconfined failure message does not name 'workspace' — output: ${SECOPT_SECCOMP_OUTPUT}"
+fi
+
+if echo "${SECOPT_SECCOMP_OUTPUT}" | grep -qi "seccomp"; then
+  pass "security_opt seccomp:unconfined failure message mentions 'seccomp'"
+else
+  fail "security_opt seccomp:unconfined failure message does not mention 'seccomp' — output: ${SECOPT_SECCOMP_OUTPUT}"
+fi
+
+echo ""
+echo "  secopt-seccomp-test output (stderr+stdout combined):"
+echo "${SECOPT_SECCOMP_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 47 — Negative: security_opt: ["apparmor:unconfined"] must be rejected
+#           (Invariant 1j).
+#
+# apparmor:unconfined disables the AppArmor MAC profile, relaxing kernel
+# confinement and unblocking operations that aid egress bypass.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 47: guard rejects security_opt: [\"apparmor:unconfined\"] (Invariant 1j) ---"
+
+SECOPT_APPARMOR_COMPOSE="${TMPDIR_TEST}/compose-secopt-apparmor.yaml"
+cat > "${SECOPT_APPARMOR_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    security_opt:
+      - "apparmor:unconfined"
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+SECOPT_APPARMOR_OUTPUT=""
+SECOPT_APPARMOR_EXIT=0
+SECOPT_APPARMOR_OUTPUT="$(COMPOSE_FILE="${SECOPT_APPARMOR_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || SECOPT_APPARMOR_EXIT=$?
+
+if [[ "${SECOPT_APPARMOR_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${SECOPT_APPARMOR_EXIT}) for security_opt: [\"apparmor:unconfined\"]"
+else
+  fail "validate-stack.sh exited ZERO for security_opt apparmor:unconfined — Invariant 1j did NOT fire"
+fi
+
+if echo "${SECOPT_APPARMOR_OUTPUT}" | grep -q "workspace"; then
+  pass "security_opt apparmor:unconfined failure message names the service 'workspace'"
+else
+  fail "security_opt apparmor:unconfined failure message does not name 'workspace' — output: ${SECOPT_APPARMOR_OUTPUT}"
+fi
+
+if echo "${SECOPT_APPARMOR_OUTPUT}" | grep -qi "apparmor"; then
+  pass "security_opt apparmor:unconfined failure message mentions 'apparmor'"
+else
+  fail "security_opt apparmor:unconfined failure message does not mention 'apparmor' — output: ${SECOPT_APPARMOR_OUTPUT}"
+fi
+
+echo ""
+echo "  secopt-apparmor-test output (stderr+stdout combined):"
+echo "${SECOPT_APPARMOR_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 48 — Positive: security_opt: ["no-new-privileges:true"] must NOT be
+#           rejected (Invariant 1j positive control).
+#
+# no-new-privileges:true strengthens confinement (prevents privilege
+# escalation via setuid/setgid).  The guard must not over-reject it.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 48: guard accepts security_opt: [\"no-new-privileges:true\"] (strengthens confinement) ---"
+
+SECOPT_NNP_COMPOSE="${TMPDIR_TEST}/compose-secopt-nnp.yaml"
+cat > "${SECOPT_NNP_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    security_opt:
+      - "no-new-privileges:true"
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+SECOPT_NNP_OUTPUT=""
+SECOPT_NNP_EXIT=0
+SECOPT_NNP_OUTPUT="$(COMPOSE_FILE="${SECOPT_NNP_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || SECOPT_NNP_EXIT=$?
+
+if [[ "${SECOPT_NNP_EXIT}" -eq 0 ]]; then
+  pass "validate-stack.sh exited zero for security_opt: [\"no-new-privileges:true\"] — no over-rejection"
+else
+  fail "validate-stack.sh exited non-zero (${SECOPT_NNP_EXIT}) for no-new-privileges:true — over-rejection: ${SECOPT_NNP_OUTPUT}"
+fi
+
+echo ""
+echo "  secopt-nnp-test output (stderr+stdout combined):"
+echo "${SECOPT_NNP_OUTPUT}" | sed 's/^/    /'
+
+# NOTE: TEST 2 (above) already asserts that the real deploy/compose.yaml passes
+# the topology guard (exit zero) — no duplicate test is added here for the new
+# invariants.  The real compose.yaml uses none of the newly-rejected keys, so
+# TEST 2 serves as the positive control for all of Invariants 1g-1j as well.
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/deploy/validate-stack.test.sh
+++ b/deploy/validate-stack.test.sh
@@ -2832,6 +2832,531 @@ echo "${SECOPT_NNP_OUTPUT}" | sed 's/^/    /'
 # TEST 2 serves as the positive control for all of Invariants 1g-1j as well.
 
 # ---------------------------------------------------------------------------
+# TEST 49 — Negative: cap_add: [SYS_MODULE] must be rejected (Invariant 1d).
+#
+# SYS_MODULE allows loading kernel modules.  Docker's default seccomp profile
+# permits init_module/finit_module when CAP_SYS_MODULE is present, enabling
+# an attacker to load a tunnel kernel module and bypass mitmproxy.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 49: guard rejects cap_add: [SYS_MODULE] (module-load bypass) ---"
+
+CAP_SYS_MODULE_COMPOSE="${TMPDIR_TEST}/compose-cap-sys-module.yaml"
+cat > "${CAP_SYS_MODULE_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    cap_add:
+      - SYS_MODULE
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+CAP_SYS_MODULE_OUTPUT=""
+CAP_SYS_MODULE_EXIT=0
+CAP_SYS_MODULE_OUTPUT="$(COMPOSE_FILE="${CAP_SYS_MODULE_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || CAP_SYS_MODULE_EXIT=$?
+
+if [[ "${CAP_SYS_MODULE_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${CAP_SYS_MODULE_EXIT}) for cap_add: [SYS_MODULE]"
+else
+  fail "validate-stack.sh exited ZERO for cap_add: [SYS_MODULE] — module-load bypass NOT caught"
+fi
+
+if echo "${CAP_SYS_MODULE_OUTPUT}" | grep -q "workspace"; then
+  pass "cap_add SYS_MODULE failure message names the service 'workspace'"
+else
+  fail "cap_add SYS_MODULE failure message does not name 'workspace' — output: ${CAP_SYS_MODULE_OUTPUT}"
+fi
+
+if echo "${CAP_SYS_MODULE_OUTPUT}" | grep -qi "SYS_MODULE"; then
+  pass "cap_add SYS_MODULE failure message mentions 'SYS_MODULE'"
+else
+  fail "cap_add SYS_MODULE failure message does not mention 'SYS_MODULE' — output: ${CAP_SYS_MODULE_OUTPUT}"
+fi
+
+echo ""
+echo "  cap-sys-module-test output (stderr+stdout combined):"
+echo "${CAP_SYS_MODULE_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 50 — Negative: cap_add: [SYS_ADMIN] must be rejected (Invariant 1d).
+#
+# SYS_ADMIN enables the nsenter namespace-escape chain (ioctl NS_GET_PARENT +
+# setns into the host network namespace), escaping sandbox-net isolation.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 50: guard rejects cap_add: [SYS_ADMIN] (namespace-escape bypass) ---"
+
+CAP_SYS_ADMIN_COMPOSE="${TMPDIR_TEST}/compose-cap-sys-admin.yaml"
+cat > "${CAP_SYS_ADMIN_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    cap_add:
+      - SYS_ADMIN
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+CAP_SYS_ADMIN_OUTPUT=""
+CAP_SYS_ADMIN_EXIT=0
+CAP_SYS_ADMIN_OUTPUT="$(COMPOSE_FILE="${CAP_SYS_ADMIN_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || CAP_SYS_ADMIN_EXIT=$?
+
+if [[ "${CAP_SYS_ADMIN_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${CAP_SYS_ADMIN_EXIT}) for cap_add: [SYS_ADMIN]"
+else
+  fail "validate-stack.sh exited ZERO for cap_add: [SYS_ADMIN] — namespace-escape bypass NOT caught"
+fi
+
+if echo "${CAP_SYS_ADMIN_OUTPUT}" | grep -q "workspace"; then
+  pass "cap_add SYS_ADMIN failure message names the service 'workspace'"
+else
+  fail "cap_add SYS_ADMIN failure message does not name 'workspace' — output: ${CAP_SYS_ADMIN_OUTPUT}"
+fi
+
+if echo "${CAP_SYS_ADMIN_OUTPUT}" | grep -qi "SYS_ADMIN"; then
+  pass "cap_add SYS_ADMIN failure message mentions 'SYS_ADMIN'"
+else
+  fail "cap_add SYS_ADMIN failure message does not mention 'SYS_ADMIN' — output: ${CAP_SYS_ADMIN_OUTPUT}"
+fi
+
+echo ""
+echo "  cap-sys-admin-test output (stderr+stdout combined):"
+echo "${CAP_SYS_ADMIN_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 51 — Negative: cap_add: [CAP_SYS_ADMIN] must be rejected (CAP_ prefix
+#           normalization, Invariant 1d).
+#
+# Docker Compose or raw YAML may preserve the CAP_ prefix.  The guard strips
+# CAP_ before checking the banned set, so CAP_SYS_ADMIN → SYS_ADMIN is caught.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 51: guard rejects cap_add: [CAP_SYS_ADMIN] (CAP_ prefix normalization) ---"
+
+CAP_CAP_SYS_ADMIN_COMPOSE="${TMPDIR_TEST}/compose-cap-cap-sys-admin.yaml"
+cat > "${CAP_CAP_SYS_ADMIN_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    cap_add:
+      - CAP_SYS_ADMIN
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+CAP_CAP_SYS_ADMIN_OUTPUT=""
+CAP_CAP_SYS_ADMIN_EXIT=0
+CAP_CAP_SYS_ADMIN_OUTPUT="$(COMPOSE_FILE="${CAP_CAP_SYS_ADMIN_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || CAP_CAP_SYS_ADMIN_EXIT=$?
+
+if [[ "${CAP_CAP_SYS_ADMIN_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${CAP_CAP_SYS_ADMIN_EXIT}) for cap_add: [CAP_SYS_ADMIN]"
+else
+  fail "validate-stack.sh exited ZERO for cap_add: [CAP_SYS_ADMIN] — CAP_ prefix bypass NOT caught"
+fi
+
+if echo "${CAP_CAP_SYS_ADMIN_OUTPUT}" | grep -q "workspace"; then
+  pass "cap_add CAP_SYS_ADMIN failure message names the service 'workspace'"
+else
+  fail "cap_add CAP_SYS_ADMIN failure message does not name 'workspace' — output: ${CAP_CAP_SYS_ADMIN_OUTPUT}"
+fi
+
+if echo "${CAP_CAP_SYS_ADMIN_OUTPUT}" | grep -qi "CAP_SYS_ADMIN\|SYS_ADMIN"; then
+  pass "cap_add CAP_SYS_ADMIN failure message mentions the capability"
+else
+  fail "cap_add CAP_SYS_ADMIN failure message does not mention the capability — output: ${CAP_CAP_SYS_ADMIN_OUTPUT}"
+fi
+
+echo ""
+echo "  cap-cap-sys-admin-test output (stderr+stdout combined):"
+echo "${CAP_CAP_SYS_ADMIN_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 52 — Negative: sysctls: {net.ipv4.conf.all.forwarding: 1} must be
+#           rejected (Invariant 1i, IPv4 per-interface alias).
+#
+# The Linux kernel aliases net.ipv4.conf.all.forwarding to the same forwarding
+# behavior as net.ipv4.ip_forward.  The guard must catch this form.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 52: guard rejects sysctls: {net.ipv4.conf.all.forwarding: 1} (IPv4 conf.all alias) ---"
+
+SYSCTL_IPV4_CONF_ALL_COMPOSE="${TMPDIR_TEST}/compose-sysctl-ipv4-conf-all.yaml"
+cat > "${SYSCTL_IPV4_CONF_ALL_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    sysctls:
+      net.ipv4.conf.all.forwarding: 1
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+SYSCTL_IPV4_CONF_ALL_OUTPUT=""
+SYSCTL_IPV4_CONF_ALL_EXIT=0
+SYSCTL_IPV4_CONF_ALL_OUTPUT="$(COMPOSE_FILE="${SYSCTL_IPV4_CONF_ALL_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || SYSCTL_IPV4_CONF_ALL_EXIT=$?
+
+if [[ "${SYSCTL_IPV4_CONF_ALL_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${SYSCTL_IPV4_CONF_ALL_EXIT}) for sysctls net.ipv4.conf.all.forwarding=1"
+else
+  fail "validate-stack.sh exited ZERO for sysctls net.ipv4.conf.all.forwarding=1 — IPv4 conf.all alias NOT caught"
+fi
+
+if echo "${SYSCTL_IPV4_CONF_ALL_OUTPUT}" | grep -q "workspace"; then
+  pass "sysctls ipv4.conf.all failure message names the service 'workspace'"
+else
+  fail "sysctls ipv4.conf.all failure message does not name 'workspace' — output: ${SYSCTL_IPV4_CONF_ALL_OUTPUT}"
+fi
+
+if echo "${SYSCTL_IPV4_CONF_ALL_OUTPUT}" | grep -q "net.ipv4.conf.all.forwarding"; then
+  pass "sysctls ipv4.conf.all failure message mentions 'net.ipv4.conf.all.forwarding'"
+else
+  fail "sysctls ipv4.conf.all failure message does not mention the sysctl — output: ${SYSCTL_IPV4_CONF_ALL_OUTPUT}"
+fi
+
+echo ""
+echo "  sysctl-ipv4-conf-all-test output (stderr+stdout combined):"
+echo "${SYSCTL_IPV4_CONF_ALL_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 53 — Negative: sysctls: {net.ipv4.conf.eth0.forwarding: 1} must be
+#           rejected (Invariant 1i, IPv4 per-interface form).
+#
+# net.ipv4.conf.<iface>.forwarding enables forwarding on a specific interface.
+# The guard must catch any single-segment interface name (e.g. eth0, ens3).
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 53: guard rejects sysctls: {net.ipv4.conf.eth0.forwarding: 1} (IPv4 per-iface) ---"
+
+SYSCTL_IPV4_CONF_IFACE_COMPOSE="${TMPDIR_TEST}/compose-sysctl-ipv4-conf-iface.yaml"
+cat > "${SYSCTL_IPV4_CONF_IFACE_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    sysctls:
+      net.ipv4.conf.eth0.forwarding: 1
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+SYSCTL_IPV4_CONF_IFACE_OUTPUT=""
+SYSCTL_IPV4_CONF_IFACE_EXIT=0
+SYSCTL_IPV4_CONF_IFACE_OUTPUT="$(COMPOSE_FILE="${SYSCTL_IPV4_CONF_IFACE_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || SYSCTL_IPV4_CONF_IFACE_EXIT=$?
+
+if [[ "${SYSCTL_IPV4_CONF_IFACE_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${SYSCTL_IPV4_CONF_IFACE_EXIT}) for sysctls net.ipv4.conf.eth0.forwarding=1"
+else
+  fail "validate-stack.sh exited ZERO for sysctls net.ipv4.conf.eth0.forwarding=1 — IPv4 per-iface NOT caught"
+fi
+
+if echo "${SYSCTL_IPV4_CONF_IFACE_OUTPUT}" | grep -q "workspace"; then
+  pass "sysctls ipv4.conf.eth0 failure message names the service 'workspace'"
+else
+  fail "sysctls ipv4.conf.eth0 failure message does not name 'workspace' — output: ${SYSCTL_IPV4_CONF_IFACE_OUTPUT}"
+fi
+
+if echo "${SYSCTL_IPV4_CONF_IFACE_OUTPUT}" | grep -q "net.ipv4.conf.eth0.forwarding"; then
+  pass "sysctls ipv4.conf.eth0 failure message mentions 'net.ipv4.conf.eth0.forwarding'"
+else
+  fail "sysctls ipv4.conf.eth0 failure message does not mention the sysctl — output: ${SYSCTL_IPV4_CONF_IFACE_OUTPUT}"
+fi
+
+echo ""
+echo "  sysctl-ipv4-conf-iface-test output (stderr+stdout combined):"
+echo "${SYSCTL_IPV4_CONF_IFACE_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 54 — Negative: security_opt: ["seccomp=/path/to/profile.json"] must be
+#           rejected (Invariant 1j, custom seccomp profile path).
+#
+# A custom seccomp profile path replaces Docker's default seccomp profile with
+# an operator-supplied one that may be permissive, bypassing the default
+# profile's protections.  The guard must reject any seccomp/apparmor value
+# that is not the literal "default".
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 54: guard rejects security_opt: [\"seccomp=/path/to/profile.json\"] (custom profile path) ---"
+
+SECOPT_CUSTOM_PATH_COMPOSE="${TMPDIR_TEST}/compose-secopt-custom-path.yaml"
+cat > "${SECOPT_CUSTOM_PATH_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    security_opt:
+      - "seccomp=/path/to/profile.json"
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+SECOPT_CUSTOM_PATH_OUTPUT=""
+SECOPT_CUSTOM_PATH_EXIT=0
+SECOPT_CUSTOM_PATH_OUTPUT="$(COMPOSE_FILE="${SECOPT_CUSTOM_PATH_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || SECOPT_CUSTOM_PATH_EXIT=$?
+
+if [[ "${SECOPT_CUSTOM_PATH_EXIT}" -ne 0 ]]; then
+  pass "validate-stack.sh exited non-zero (${SECOPT_CUSTOM_PATH_EXIT}) for security_opt: [\"seccomp=/path/to/profile.json\"]"
+else
+  fail "validate-stack.sh exited ZERO for security_opt seccomp=/path — custom profile bypass NOT caught"
+fi
+
+if echo "${SECOPT_CUSTOM_PATH_OUTPUT}" | grep -q "workspace"; then
+  pass "security_opt custom-path failure message names the service 'workspace'"
+else
+  fail "security_opt custom-path failure message does not name 'workspace' — output: ${SECOPT_CUSTOM_PATH_OUTPUT}"
+fi
+
+if echo "${SECOPT_CUSTOM_PATH_OUTPUT}" | grep -qi "seccomp"; then
+  pass "security_opt custom-path failure message mentions 'seccomp'"
+else
+  fail "security_opt custom-path failure message does not mention 'seccomp' — output: ${SECOPT_CUSTOM_PATH_OUTPUT}"
+fi
+
+echo ""
+echo "  secopt-custom-path-test output (stderr+stdout combined):"
+echo "${SECOPT_CUSTOM_PATH_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 55 — Positive: security_opt: ["seccomp:default"] must NOT be rejected
+#           (Invariant 1j positive control — explicit default allowed).
+#
+# seccomp:default explicitly requests Docker's default seccomp profile, which
+# is the same as not specifying seccomp at all.  The guard allows the literal
+# value "default" for both seccomp and apparmor.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 55: guard accepts security_opt: [\"seccomp:default\"] (explicit default allowed) ---"
+
+SECOPT_DEFAULT_COMPOSE="${TMPDIR_TEST}/compose-secopt-default.yaml"
+cat > "${SECOPT_DEFAULT_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    security_opt:
+      - "seccomp:default"
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+SECOPT_DEFAULT_OUTPUT=""
+SECOPT_DEFAULT_EXIT=0
+SECOPT_DEFAULT_OUTPUT="$(COMPOSE_FILE="${SECOPT_DEFAULT_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || SECOPT_DEFAULT_EXIT=$?
+
+if [[ "${SECOPT_DEFAULT_EXIT}" -eq 0 ]]; then
+  pass "validate-stack.sh exited zero for security_opt: [\"seccomp:default\"] — no over-rejection"
+else
+  fail "validate-stack.sh exited non-zero (${SECOPT_DEFAULT_EXIT}) for seccomp:default — over-rejection: ${SECOPT_DEFAULT_OUTPUT}"
+fi
+
+echo ""
+echo "  secopt-default-test output (stderr+stdout combined):"
+echo "${SECOPT_DEFAULT_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 56 — Positive: security_opt: ["label:disable"] must NOT be rejected
+#           (Invariant 1j positive control — label:* always allowed).
+#
+# label:* entries control SELinux label assignment and are not seccomp/apparmor
+# confinement controls.  The guard must not over-reject them.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 56: guard accepts security_opt: [\"label:disable\"] (label:* always allowed) ---"
+
+SECOPT_LABEL_COMPOSE="${TMPDIR_TEST}/compose-secopt-label.yaml"
+cat > "${SECOPT_LABEL_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    security_opt:
+      - "label:disable"
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+SECOPT_LABEL_OUTPUT=""
+SECOPT_LABEL_EXIT=0
+SECOPT_LABEL_OUTPUT="$(COMPOSE_FILE="${SECOPT_LABEL_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || SECOPT_LABEL_EXIT=$?
+
+if [[ "${SECOPT_LABEL_EXIT}" -eq 0 ]]; then
+  pass "validate-stack.sh exited zero for security_opt: [\"label:disable\"] — no over-rejection"
+else
+  fail "validate-stack.sh exited non-zero (${SECOPT_LABEL_EXIT}) for label:disable — over-rejection: ${SECOPT_LABEL_OUTPUT}"
+fi
+
+echo ""
+echo "  secopt-label-test output (stderr+stdout combined):"
+echo "${SECOPT_LABEL_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# TEST 57 — Positive: cap_add: [SYS_TIME] must NOT be rejected
+#           (Invariant 1d positive control — benign capability allowed).
+#
+# SYS_TIME allows setting the system clock.  It is not in the banned set and
+# must not be over-rejected.  This confirms the guard is not a blanket cap_add
+# ban but targets only the specific dangerous capabilities.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 57: guard accepts cap_add: [SYS_TIME] (benign capability, not banned) ---"
+
+CAP_SYS_TIME_COMPOSE="${TMPDIR_TEST}/compose-cap-sys-time.yaml"
+cat > "${CAP_SYS_TIME_COMPOSE}" <<'YAML'
+services:
+  mitmproxy:
+    image: mitmproxy/mitmproxy:latest
+    networks:
+      - sandbox-net
+      - egress-net
+  workspace:
+    image: ubuntu:22.04
+    networks:
+      - sandbox-net
+    volumes:
+      - workspace-repos:/workspace/repos
+    cap_add:
+      - SYS_TIME
+
+networks:
+  sandbox-net:
+    internal: true
+  egress-net: {}
+
+volumes:
+  workspace-repos:
+YAML
+
+CAP_SYS_TIME_OUTPUT=""
+CAP_SYS_TIME_EXIT=0
+CAP_SYS_TIME_OUTPUT="$(COMPOSE_FILE="${CAP_SYS_TIME_COMPOSE}" bash deploy/validate-stack.sh --topology-only 2>&1)" || CAP_SYS_TIME_EXIT=$?
+
+if [[ "${CAP_SYS_TIME_EXIT}" -eq 0 ]]; then
+  pass "validate-stack.sh exited zero for cap_add: [SYS_TIME] — no over-rejection"
+else
+  fail "validate-stack.sh exited non-zero (${CAP_SYS_TIME_EXIT}) for cap_add: [SYS_TIME] — over-rejection: ${CAP_SYS_TIME_OUTPUT}"
+fi
+
+echo ""
+echo "  cap-sys-time-test output (stderr+stdout combined):"
+echo "${CAP_SYS_TIME_OUTPUT}" | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""

--- a/docs/plans/2026-06-14-004-fix-egress-escalation-vectors-plan.md
+++ b/docs/plans/2026-06-14-004-fix-egress-escalation-vectors-plan.md
@@ -1,0 +1,261 @@
+---
+title: "fix: Reject remaining egress-escalation compose keys in the topology guard (#908)"
+type: fix
+status: active
+date: 2026-06-14
+---
+
+# Reject remaining egress-escalation compose keys in the topology guard (#908)
+
+## Overview
+
+#899 added topology-guard rejections for the primary egress-weakening compose keys (`extra_hosts: host-gateway`, `cap_add: NET_ADMIN/NET_RAW`, `/dev/net/tun` devices, `privileged: true` — Invariants 1c-1f). Review of that work surfaced five further escalation vectors that bypass or amplify those controls. This plan closes the class: reject `cap_add: ALL`, `device_cgroup_rules` granting any device, `pid_mode: host`, the IP-forwarding `sysctls` family, and confinement-disabling `security_opt`, all blanket all-services, mirroring the established invariant pattern. Closes #908.
+
+## Problem Frame
+
+Each remaining vector lets a sandbox-net container relay or tunnel egress around mitmproxy, or amplifies the already-blocked keys:
+- **`cap_add: ALL` / `CAP_ALL`** — grants every capability including the banned `NET_ADMIN`/`NET_RAW`; same supersetting threat as `privileged: true`, but `_BANNED_CAPS = {"NET_ADMIN","NET_RAW"}` does not include `ALL`.
+- **`device_cgroup_rules`** — a cgroup device-allow rule (e.g. `c 10:200 rwm`) grants the TUN device by major:minor independent of a `devices:` mapping; combined with an in-container `mknod`, restores tunnel capability that Invariant 1e blocks.
+- **`pid_mode: host`** — with sufficient capability/privilege, a container can `nsenter` into the host namespaces, escaping `internal: true` entirely; the most dangerous escalation when combined with the (now-blocked) `privileged: true`.
+- **`sysctls` IP-forwarding** (`net.ipv4.ip_forward=1`, `net.ipv6.conf.*.forwarding=1`) — enables container-as-router behavior for relaying traffic.
+- **`security_opt` unconfined** (`seccomp:unconfined`, `apparmor:unconfined`) — relaxes kernel confinement, unblocking operations otherwise restricted that aid bypass.
+
+These are not regressions introduced by #899; they are pre-existing vectors deferred from that PR's scope and tracked in #908 for incremental, deliberate hardening.
+
+## Requirements Trace
+
+- R1. The guard fails any service whose `cap_add` includes `ALL` (normalized for `CAP_` prefix/case, like the existing `NET_ADMIN`/`NET_RAW` check).
+- R2. The guard fails any service declaring a `device_cgroup_rules` entry that grants a device (any allow rule; the workspace has no legitimate device-grant need).
+- R3. The guard fails any service declaring `pid_mode: host`.
+- R4. The guard fails any service declaring an egress-relevant `sysctls` entry: `net.ipv4.ip_forward` or `net.ipv6.conf.<iface>.forwarding` set to an enabling value.
+- R5. The guard fails any service declaring a confinement-disabling `security_opt`: `seccomp:unconfined` or `apparmor:unconfined` (case/spacing-tolerant).
+- R6. Enforcement is blanket (all services), mirroring Invariants 1c-1f.
+- R7. The real shipped `deploy/compose.yaml` still passes (no current service uses these keys); benign uses of these keys (if any exist) are not over-rejected.
+- R8. Failure messages name the service + offending key/value and fail closed, consistent with existing invariants.
+
+## Scope Boundaries
+
+- Not changing Invariants 1b-1f or the network-attachment / allowlist logic shipped in #814/#899.
+- Not adding proxy-agent or mitmproxy/allowlist behavior.
+- Blanket all-services enforcement (not scoped to sandbox-net-reachable only), consistent with the existing invariants.
+- `sysctls`: denylist of the IP-forwarding family (not a full allowlist) — the stack may legitimately set other benign sysctls.
+- `device_cgroup_rules`: reject any device-granting allow rule (not only the TUN major:minor) — broad/fail-closed, consistent with the blanket posture.
+
+### Deferred to Separate Tasks
+
+- IPv6 `extra_hosts` normalized-split edge (Fro Bot NBC on #909): harmless today (only the `host-gateway` value is checked); revisit only if a future docker version emits IPv6 raw-YAML extra_hosts entries.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `deploy/validate-stack.sh` — `check_compose_topology` embeds Python in a bash heredoc. Invariants 1c-1f (added in #899) are the template: each iterates `sorted(services.keys())`, reads a key via `_svc_cfg.get(...)`, handles compose-config + raw-YAML + scalar-string + dict shapes, and `failures.append(...)` with an actionable message. New invariants slot in after Invariant 1f (~line 408), before Invariant 6.
+  - `cap_add: ALL` is the exception — not a new invariant; add `"ALL"` to `_BANNED_CAPS` (line 325). Invariant 1d already normalizes `CAP_` prefix + case, so `CAP_ALL` → `ALL` is caught.
+- Shape normalization patterns established in #899: `isinstance(_val, str)` → wrap to single-element list (scalar guard); `os.path.normpath` + leading-slash collapse for device paths; `.upper()` + `CAP_` strip for caps. Reuse the same defensive parsing for the new keys.
+- Compose key shapes (verify exact normalized forms during implementation, both `docker compose config` and raw-YAML fallback):
+  - `device_cgroup_rules`: list of strings like `"c 10:200 rwm"` / `"a *:* rwm"`. An allow rule grants; the first token is the device type (`a`/`b`/`c`), then `major:minor`, then perms.
+  - `pid_mode`: scalar string (`"host"`, `"service:x"`, `"container:x"`). Reject `host` (the netns-escape vector); `service:`/`container:` share another container's PID ns, not the host's — reject only `host` per R3.
+  - `sysctls`: map `{name: value}` OR list of `"name=value"` strings (compose normalizes to map). Check `net.ipv4.ip_forward` and `net.ipv6.conf.*.forwarding` for enabling values (`1`/`true`).
+  - `security_opt`: list of strings (`"seccomp:unconfined"`, `"apparmor:unconfined"`, `"label:..."`, `"no-new-privileges:true"`). Reject the two unconfined forms; allow label/no-new-privileges.
+- `deploy/validate-stack.test.sh` — shell test harness; #899 TESTs 26-37 are the style template (single-file fixtures docker-free via `--topology-only`; skip-with-notice when PyYAML/docker needed). Continue numbering from TEST 37 → TEST 38.
+- `deploy/README.md` / `deploy/validate-stack.sh` header comment — egress/topology invariant enumeration to extend.
+
+### Institutional Learnings
+
+- #899 + its ce:review established: blanket-ban-with-actionable-message; defensive shape handling (scalar/dict/list, normalization for case/prefix/path); the `docker compose config` normalization-vs-raw-YAML duality; and the discipline of verifying actual normalized shapes during implementation rather than assuming.
+
+### External References
+
+- Issue #908 (the five vectors + the cap_add:ALL / device_cgroup_rules additions from Fro Bot's #909 review).
+- TUN device is canonically major 10, minor 200 (informational; device_cgroup_rules rejection is broad, not TUN-specific).
+
+## Key Technical Decisions
+
+- **`cap_add: ALL` via `_BANNED_CAPS`**, not a new invariant — the existing 1d normalization already covers `CAP_ALL`/case; one-line set addition is the minimal correct fix.
+- **`device_cgroup_rules`: reject any device-granting (allow) rule** — broad/fail-closed; the workspace stack has no legitimate device-grant need, consistent with the blanket posture. Avoids brittle major:minor matching.
+- **`pid_mode`: reject only `host`** — `host` is the netns-escape vector; `service:`/`container:` forms don't reach the host namespace and aren't egress-relevant.
+- **`sysctls`: denylist the IP-forwarding family** — targeted (`net.ipv4.ip_forward`, `net.ipv6.conf.*.forwarding`); a full allowlist risks false-positives on benign sysctls the stack may set.
+- **`security_opt`: reject `seccomp:unconfined` / `apparmor:unconfined`** only — allow `label:*` and `no-new-privileges` (the latter strengthens confinement).
+- **Reuse #899's defensive shape handling** (scalar/dict/list normalization) rather than assuming a single shape per key.
+
+## Open Questions
+
+### Resolved During Planning
+
+- sysctls denylist vs allowlist → denylist (forwarding family) (KTD).
+- device_cgroup_rules TUN-specific vs any → any device-grant rule (KTD).
+- pid_mode host-only vs all forms → host only (KTD).
+
+### Deferred to Implementation
+
+- Exact normalized shapes of `device_cgroup_rules` / `sysctls` / `security_opt` / `pid_mode` under `docker compose config` vs raw-YAML — verify both paths during implementation and handle each, as #899 did.
+- Exact enabling-value matching for sysctls forwarding (`1`, `"1"`, `true`) — determine during implementation.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add cap_add: ALL to the banned capability set**
+
+**Goal:** `cap_add: ALL` / `CAP_ALL` is rejected by the existing capability invariant.
+
+**Requirements:** R1, R6, R8
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `deploy/validate-stack.sh` (`_BANNED_CAPS`, line 325; update Invariant 1d comment to mention ALL)
+
+**Approach:** Add `"ALL"` to `_BANNED_CAPS`. Invariant 1d already uppercases + strips `CAP_`, so `CAP_ALL`/`all` normalize to `ALL` and match. Confirm the failure message reads sensibly when the offending cap is `ALL` (it grants all caps including NET_ADMIN/NET_RAW).
+
+**Patterns to follow:** existing Invariant 1d.
+
+**Test scenarios:** (covered by Unit 6)
+
+**Verification:** a service with `cap_add: [ALL]` or `[CAP_ALL]` fails; real compose passes.
+
+- [ ] **Unit 2: Reject device_cgroup_rules that grant devices**
+
+**Goal:** The guard fails any service declaring a `device_cgroup_rules` allow rule.
+
+**Requirements:** R2, R6, R8
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `deploy/validate-stack.sh` (new Invariant after 1f)
+
+**Approach:** Iterate `sorted(services.keys())`; for each, read `device_cgroup_rules` (handle scalar-string → list, list-of-strings). Each rule is like `"c 10:200 rwm"` / `"a *:* rwm"`. Reject any non-empty rule that grants access (any allow rule — there's no legitimate device-grant in this stack). Message names the service + the rule + why (grants device access bypassing the /dev/net/tun control). Fail closed.
+
+**Patterns to follow:** Invariant 1e (devices) — scalar guard, list iteration, actionable message.
+
+**Test scenarios:** (covered by Unit 6)
+
+**Verification:** a service with `device_cgroup_rules: ["c 10:200 rwm"]` fails; real compose passes.
+
+- [ ] **Unit 3: Reject pid_mode: host**
+
+**Goal:** The guard fails any service declaring `pid_mode: host`.
+
+**Requirements:** R3, R6, R8
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `deploy/validate-stack.sh` (new Invariant after 1f)
+
+**Approach:** Iterate services; read `pid_mode` (scalar string). Reject when it equals `host` (case/strip-tolerant). Do not reject `service:`/`container:` forms (not host-namespace escape). Message names the service + pid_mode:host + the nsenter/netns-escape rationale.
+
+**Patterns to follow:** Invariant 1f (privileged) — scalar value check.
+
+**Test scenarios:** (covered by Unit 6)
+
+**Verification:** `pid_mode: host` fails; `pid_mode: "service:foo"` passes; real compose passes.
+
+- [ ] **Unit 4: Reject IP-forwarding sysctls**
+
+**Goal:** The guard fails any service enabling IP forwarding via `sysctls`.
+
+**Requirements:** R4, R6, R8
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `deploy/validate-stack.sh` (new Invariant after 1f)
+
+**Approach:** Iterate services; read `sysctls` (handle map `{name: value}` AND list-of-`"name=value"` strings — compose normalizes to map). For each entry, if the key is `net.ipv4.ip_forward` or matches `net.ipv6.conf.<iface>.forwarding`, and the value is enabling (`1`/`"1"`/`true`), fail. Message names the service + the sysctl + the container-as-router rationale. Don't reject benign sysctls or forwarding set to `0`.
+
+**Patterns to follow:** Invariant 1c (extra_hosts) — handles both dict and list-of-strings shapes.
+
+**Test scenarios:** (covered by Unit 6)
+
+**Verification:** `sysctls: {net.ipv4.ip_forward: 1}` fails; a benign sysctl (or forwarding=0) passes; real compose passes.
+
+- [ ] **Unit 5: Reject confinement-disabling security_opt**
+
+**Goal:** The guard fails any service that disables seccomp or AppArmor confinement.
+
+**Requirements:** R5, R6, R8
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `deploy/validate-stack.sh` (new Invariant after 1f; update header comment to enumerate all new invariants)
+
+**Approach:** Iterate services; read `security_opt` (scalar guard → list of strings). Normalize each entry (strip/lower), reject `seccomp:unconfined` and `apparmor:unconfined` (tolerate spacing like `seccomp=unconfined`). Allow `label:*` and `no-new-privileges:*`. Message names the service + the offending option + the confinement-relaxation rationale.
+
+**Patterns to follow:** Invariant 1d (cap_add) — normalize then membership/pattern check; scalar guard.
+
+**Test scenarios:** (covered by Unit 6)
+
+**Verification:** `security_opt: ["seccomp:unconfined"]` fails; `["no-new-privileges:true"]` passes; real compose passes.
+
+- [ ] **Unit 6: Guard tests for all five vectors**
+
+**Goal:** Lock each rejection + benign/positive controls with regression tests.
+
+**Requirements:** R1-R5, R7, R8
+
+**Dependencies:** Units 1-5
+
+**Files:**
+- Modify: `deploy/validate-stack.test.sh` (continue from TEST 37)
+
+**Approach:** Single-file fixtures, docker-free via `--topology-only`/raw-YAML where possible; skip-with-notice if a form needs PyYAML/docker (per #899 TESTs 36/37). Write failing fixtures first; confirm each fails WITH the fix and would pass WITHOUT the corresponding invariant (teeth).
+
+**Test scenarios:**
+- Edge: `cap_add: [ALL]` → fails (names service + ALL).
+- Edge: `cap_add: [CAP_ALL]` → fails (prefix normalization).
+- Edge: `device_cgroup_rules: ["c 10:200 rwm"]` → fails (names service + rule).
+- Edge: `pid_mode: host` → fails.
+- Happy path: `pid_mode: "service:foo"` → passes (not host-ns escape).
+- Edge: `sysctls: {net.ipv4.ip_forward: 1}` → fails.
+- Edge: `sysctls` list form `["net.ipv6.conf.all.forwarding=1"]` → fails (shape + ipv6).
+- Happy path: `sysctls: {net.ipv4.ip_forward: 0}` (or a benign sysctl) → passes (no over-rejection).
+- Edge: `security_opt: ["seccomp:unconfined"]` → fails.
+- Edge: `security_opt: ["apparmor:unconfined"]` → fails.
+- Happy path: `security_opt: ["no-new-privileges:true"]` → passes.
+- Happy path: real `deploy/compose.yaml` passes (if not already covered by TEST 2/17, note the dup rather than re-adding).
+
+**Verification:** suite passes; removing each Unit 1-5 check makes its fixture pass (teeth); benign/positive controls pass; pre-existing PyYAML-absent failures unchanged.
+
+- [ ] **Unit 7: Document the additional rejected keys**
+
+**Goal:** Operators understand the full set of forbidden egress-weakening keys.
+
+**Requirements:** R8
+
+**Dependencies:** Units 1-5
+
+**Files:**
+- Modify: `deploy/README.md` (egress/topology section), `deploy/validate-stack.sh` header comment
+
+**Approach:** Extend the rejected-keys list: the guard rejects `network_mode`, `extra_hosts:host-gateway`, `cap_add:NET_ADMIN/NET_RAW/ALL`, `/dev/net/tun` devices, `privileged:true`, plus `device_cgroup_rules` device grants, `pid_mode:host`, IP-forwarding `sysctls`, and `seccomp/apparmor:unconfined` `security_opt`. Operator-facing prose, no plan taxonomy.
+
+**Test scenarios:** Test expectation: none — documentation only.
+
+**Verification:** docs enumerate all rejected keys; guard header comment matches the invariants.
+
+## System-Wide Impact
+
+- **Interaction graph:** guard runs in the `workspace-smoke` CI job (`validate-stack.sh --topology-only` + `validate-stack.test.sh`). Additive checks only.
+- **Error propagation:** fail-closed (any offending key → non-zero exit + named failure).
+- **API surface parity:** none — internal deploy tooling.
+- **Unchanged invariants:** network-attachment allowlist, drift check, Invariants 1b-1f, workspace/mitmproxy/volume invariants untouched; real compose stack continues to pass.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Over-rejecting a benign sysctl/security_opt | Denylist is narrow (forwarding family; only the two unconfined security_opt); Unit 6 includes benign positive-control tests |
+| Normalized shape differs (compose-config vs raw-YAML) | Reuse #899 defensive shape handling; deferred-to-implementation note to verify exact shapes |
+| New check fails the real stack | Unit 6 asserts real `deploy/compose.yaml` passes; run guard against it |
+| device_cgroup_rules broad reject blocks a future legit device | Acceptable: no current device need; a future need would be a deliberate, reviewed change |
+
+## Documentation / Operational Notes
+
+- `deploy/README.md` egress section updated for the additional rejected keys. Closes #908.
+
+## Sources & References
+
+- Issue #908 (egress-escalation compose keys); Fro Bot review of #909 (cap_add:ALL, device_cgroup_rules).
+- Code: `deploy/validate-stack.sh` (Invariants 1c-1f as template, `_BANNED_CAPS` line 325), `deploy/validate-stack.test.sh` (TESTs 26-37 style), `deploy/compose.yaml`, `deploy/README.md`.
+- Related: #899/#909 (the egress-key rejections this completes), #814/#745.


### PR DESCRIPTION
## What this does

Completes the compose egress-containment guard by rejecting the remaining keys that let a sandbox container escalate privileges, share host namespaces, or route traffic around mitmproxy. Follows #909, which closed the primary egress-weakening keys.

The guard now fails closed, on any service, for:
- `cap_add` of `ALL`, `SYS_MODULE` (load a tunnel kernel module via the default seccomp profile), or `SYS_ADMIN` (nsenter host-namespace escape) — alongside the existing `NET_ADMIN`/`NET_RAW`
- `device_cgroup_rules` that grant a device (an alternate `/dev/net/tun` path)
- `pid: host` (host PID/network namespace escape)
- IP-forwarding `sysctls`: `net.ipv4.ip_forward`, `net.ipv4.conf.*.forwarding`, and `net.ipv6.conf.*.forwarding` (container-as-router)
- `security_opt` with any non-default `seccomp`/`apparmor` value — `unconfined` or a custom permissive profile path

## Verification

Guard tests cover each rejected key plus positive controls that must not be over-rejected (a benign capability, non-host `pid` modes, `forwarding=0`, `seccomp:default`, `label:*`, `no-new-privileges`). The checks handle the `docker compose config` normalized forms and the raw-YAML fallback shapes, and normalize capability names (`CAP_` prefix, case). The real compose stack continues to pass.

The compose key for PID namespace mode is `pid` (Docker rejects `pid_mode` as an invalid property), so the guard checks `pid` and the docs reference it accordingly.

## Follow-up

A separate cross-container / namespace-sharing class (`ipc: host`, `SYS_PTRACE`) is tracked in #910. The primary containment boundary remains `sandbox-net` `internal: true`.

Closes #908
