### PR TITLE
feat(gateway): transport-agnostic execution and approval seam

### DIFF
--- a/docs/plans/2026-06-15-001-feat-gateway-control-surface-spine-phase-a-plan.md
+++ b/docs/plans/2026-06-15-001-feat-gateway-control-surface-spine-phase-a-plan.md
@@ -3,6 +3,7 @@ title: 'feat: Gateway control surface spine — Phase A (transport-agnostic exec
 type: feat
 status: active
 date: 2026-06-15
+deepened: 2026-06-15
 origin: docs/brainstorms/2026-06-15-gateway-control-surface-spine-requirements.md
 ---
 
@@ -78,7 +79,12 @@ The consequence: the dashboard cannot launch work, the operator cannot approve a
 
 ## Key Technical Decisions
 
+> **Plan vetted against current source (Oracle, main `0fa4ed32`).** The seam direction is sound, but the original anchors predated recent gateway churn (Discord `io.ts` refactor #858, serial queue #850, status controller #843, operator commands #854/#859). The decisions and units below incorporate that vetting. Line numbers are indicative, not authoritative — implementers verify against current source.
+
+- **`launchWork` is the public, queue-and-cap-preserving front door (decision).** `launchWork(request, deps)` acquires the per-channel slot / enqueues / respects the global concurrency cap exactly as `runMention` does today, then drives the long post-acquire pipeline via a **private inner primitive** (e.g. `executeWorkOnHeldSlot(task)`). A future web caller goes through the front door and **cannot bypass** the per-channel FIFO, global cap, or shutdown handoff. The inner primitive is internal-only and is never exported as a "core" that dodges the queue. This is the load-bearing correction: `startRun` today assumes the channel slot is already held and owns atomic handoff/release in its outer `finally` (`run.ts:726-764`), draining via `queue.takeNext(channelId)` — exposing that inner body directly would be a concurrency footgun.
 - **`LaunchWorkRequest` carries sinks, not a `Message`.** The engine receives `StatusSink` and `ReplySink` interfaces rather than a raw Discord `Message`. The Discord adapter constructs concrete implementations of these interfaces from the `Message` and passes them in. This is the minimal seam: the engine's logic is unchanged, only its input contract changes.
+- **Empty-prompt behavior IS changing in Phase A (deliberate, accepted).** Today a bare `@fro-bot` mention proceeds through thread creation, lock acquisition, and run-state setup before `buildDiscordPrompt` throws `EmptyPromptError` late in the engine (`prompt.ts:110-114`), so the "nothing to do" failure surfaces *in-thread* after churn. The Discord adapter will strip the mention and detect an empty prompt **before** calling `launchWork`, failing fast with no thread/lock/run-state churn. This is a small, intentional UX improvement and a documented exception to "zero Discord behavior change" — characterize the current behavior first, then assert the new fail-fast behavior. (This is the only accepted Discord behavior delta in Phase A.)
+- **Generalize the approval registry/coordinator names now, for Phase B readiness (decision).** Rename Discord-shaped registry terms to transport-neutral ones in Phase A: `channelID` → `approvalScopeId`, `handleButtonDecision` → `handleDecision`, `decidedBy: string` → a typed actor/operator identity. Extract the Discord approval transport from the `run.ts` `onPending` closure (`run.ts:396-536`) and the `program.ts` button handler (`program.ts:205-260`). This makes Phase B a clean plug-in rather than inheriting Discord-shaped names to rename later. No web auth/listener in Phase A.
 - **`runMention` stays as the Discord entry point, becomes a thin adapter.** It does not disappear — it maps `Message` → `LaunchWorkRequest` and calls `launchWork`. The `ChannelQueue<RunTask>` continues to work; `RunTask` carries a `LaunchWorkRequest` (or the sinks) rather than a raw `Message` where feasible, keeping the change minimal.
 - **Approval coordinator: the transport seam is the `onPending` + `onReplied` + `onDispose` deps callbacks, not a single render hook.** `PermissionCoordinatorDeps.onPending` (`coordinator.ts:94`) is the render-and-register hook — its doc states it "renders the Discord approval embed here **AND registers the entry in the approval registry** (including deadlineMs)." Render and registry-registration are coupled in this one callback, so the transport-neutral generalization must preserve that coupling (a transport renders its UI *and* registers the entry together), not split them. The decision-intake path is `onPermissionReplied`/`onReplied` → `registry.confirmReply`; teardown is `onDispose` → `registry.disposeRun` (fail-close). The public coordinator surface (`onPermissionAsked`/`onPermissionReplied`, `coordinator.ts:72`/`:78`) and the pure parsers (`parsePermissionRequest`/`parsePermissionReply`) are unchanged. Generalizing means a Discord transport supplies `onPending`/`onReplied`/`onDispose` implementations (embed + button wiring), and a future web transport supplies its own (notification + HTTP callback) — both reusing the same registry and fail-closed settlement.
 - **One gate, no parallel path (R5).** The registry owns pending state and settlement. Any new transport plugs into the same registry via the `onPending`/`onReplied`/`onDispose` callbacks — it cannot create a parallel registry or bypass the fail-closed timeout/restart semantics.
@@ -144,6 +150,26 @@ A future web caller (Phase B) will call `launchWork` directly with its own `Stat
 
 ## Implementation Units
 
+- [ ] **Unit 0: Characterization tests pinning current Discord behavior (mandatory)**
+
+  **Goal:** Lock the current `runMention → startRun` and approval behaviors with tests that pass before AND after the refactor — the zero-regression gate. This is not optional; the engine has many edge behaviors (queue/cap, thread creation, live-status vs typing-only, reactions, approval waiting/timeout, empty-prompt) that a seam extraction can silently break.
+
+  **Requirements:** R2, R3, R6 (guards the zero-change contract)
+
+  **Dependencies:** None
+
+  **Files:**
+  - Test: `packages/gateway/src/execute/run.test.ts` (extend), `packages/gateway/src/approvals/coordinator.test.ts` (extend)
+
+  **Approach:**
+  - Pin, via the existing Discord `Message`-based entry points, the observable behaviors that must not change: per-channel queue scope + global concurrency cap + FIFO handoff; thread creation (`message.startThread`); reactions lifecycle (working/awaiting/succeeded/failed); `statusMode: 'live-status'` (status message posted+edited) vs `'typing-only'` (typing pulse, no status message); approval waiting → button decision → settle; approval timeout → fail-closed reject; shutdown handoff.
+  - **Capture current empty-prompt behavior explicitly** (bare mention → late `EmptyPromptError` surfaced in-thread) so the deliberate Phase-A change (fail-fast in adapter) is a visible, reviewed diff, not a silent regression.
+
+  **Test scenarios:**
+  - Characterization: each behavior above asserted against the current code path; all green on unmodified `main`.
+
+  **Verification:** the new characterization tests pass on current `main` before any refactor; they remain the regression gate through Units 2–4.
+
 - [ ] **Unit 1: Define transport-neutral types — `LaunchWorkRequest`, `StatusSink`, `ReplySink`**
 
   **Goal:** Establish the typed interface contract that the engine will accept and the Discord adapter will implement. No runtime behavior changes in this unit.
@@ -156,7 +182,7 @@ A future web caller (Phase B) will call `launchWork` directly with its own `Stat
   - Create: `packages/gateway/src/execute/launch-types.ts` (or `packages/gateway/src/execute/types.ts` if a types file already exists — check first)
 
   **Approach:**
-  - Read `packages/gateway/src/execute/run.ts` lines 1–100 to inventory exactly what `startRun` reads from `RunTask.message` (prompt text extraction, `botUserId` mention-strip, status-reply calls, typing indicator). These reads define the `StatusSink`/`ReplySink` interface surface.
+  - Inventory **every** `message` read across the full `startRun` body (`run.ts:184-765`) and `runMention` (`run.ts:805-834`) — NOT just lines 1–100. Oracle's verified coupling list (current `main`): `message.channel.id` for queue/concurrency scope (`run.ts:205`, `:807`); pre-thread failure/queue/cap reply acks via `sendMessage(message, …)` (`:229`, `:252`, `:264`, `:793-803`, `:822`); thread creation `message.startThread(...)` (`:259-268`); source-message reactions `setRunReaction(message, …)` (`:370`, `:465`, `:574`, `:635`); prompt text `message.content` (`:376-382`); status/typing via `createStatusController({thread, mode})` (`:347-351`) and `createDiscordStreamSink(thread)` (`:375`). These reads define the sink/request interface surface. Note: lock + run-state are written with `surface: 'discord'` (`:273`, `:300`) — Phase A introduces a transport-neutral surface/source identifier so a future web run is not a fake Discord thread.
   - Define `LaunchWorkRequest` with: prompt text (string), source metadata (channel/guild IDs for logging), `RepoBinding`, requester identity (Discord user ID or future operator identity as a discriminated union), `StatusSink`, `ReplySink`.
   - Define `StatusSink` interface: the methods the engine calls to post/update status progress (e.g., `update(text: string): Promise<void>`, `setTyping(): Promise<void>`).
   - Define `ReplySink` interface: the method the engine calls to deliver final output (e.g., `send(content: string, options?: ReplyOptions): Promise<void>`).
@@ -165,10 +191,10 @@ A future web caller (Phase B) will call `launchWork` directly with its own `Stat
   **Patterns to follow:** existing `RunMentionDeps` and `RunTask` type shapes in `run.ts`; `Result<T, E>` from `@bfra.me/es`; discriminated union patterns used elsewhere in the gateway.
 
   **Test scenarios:**
-  - Types-only unit: no runtime behavior. Verification is `pnpm check-types` clean and the type shapes satisfy the constraints (e.g., a Discord `Message`-based implementation satisfies `StatusSink`/`ReplySink` structurally).
+  - Types-only unit: no runtime behavior. Verification is `pnpm --filter @fro-bot/gateway check-types` clean and the type shapes satisfy the constraints (e.g., a Discord `Message`-based implementation satisfies `StatusSink`/`ReplySink` structurally).
   - Structural: a mock object implementing `StatusSink` compiles without cast; a mock `LaunchWorkRequest` with a Discord requester identity compiles; a future web requester identity shape also compiles (discriminated union covers both).
 
-  **Verification:** `pnpm check-types` clean; the new types file exports `LaunchWorkRequest`, `StatusSink`, `ReplySink`; no `any` or `@ts-ignore`; the Discord `Message`-derived implementations in Unit 3 satisfy the interfaces structurally.
+  **Verification:** `pnpm --filter @fro-bot/gateway check-types` clean; the new types file exports `LaunchWorkRequest`, `StatusSink`, `ReplySink`; no `any` or `@ts-ignore`; the Discord `Message`-derived implementations in Unit 3 satisfy the interfaces structurally.
 
 - [ ] **Unit 2: Extract `launchWork` core from `startRun`**
 
@@ -176,7 +202,7 @@ A future web caller (Phase B) will call `launchWork` directly with its own `Stat
 
   **Requirements:** R1, R6
 
-  **Dependencies:** Unit 1
+  **Dependencies:** Unit 0 (characterization gate), Unit 1
 
   **Files:**
   - Modify: `packages/gateway/src/execute/run.ts` (extract `launchWork`, update `startRun`/`RunTask`)
@@ -198,7 +224,7 @@ A future web caller (Phase B) will call `launchWork` directly with its own `Stat
   - Queue/concurrency: `runMention` still enqueues via `ChannelQueue<RunTask>`; a second concurrent mention for the same channel is queued, not dropped.
   - Characterization regression: the existing Discord-path tests (via `runMention`) still pass unchanged after the refactor.
 
-  **Verification:** `pnpm check-types` clean; `pnpm test` passes (existing `run.test.ts` + new `launchWork` tests); `launchWork` is exported and accepts `LaunchWorkRequest` + in-memory sinks; no Discord import in `launchWork`'s own logic.
+  **Verification:** `pnpm --filter @fro-bot/gateway check-types` clean; `pnpm --filter @fro-bot/gateway test` passes (existing `run.test.ts` + new `launchWork` tests); `launchWork` is exported and accepts `LaunchWorkRequest` + in-memory sinks; no Discord import in `launchWork`'s own logic.
 
 - [ ] **Unit 3: Make `runMention` a thin Discord adapter**
 
@@ -206,19 +232,19 @@ A future web caller (Phase B) will call `launchWork` directly with its own `Stat
 
   **Requirements:** R2, R3
 
-  **Dependencies:** Units 1, 2
+  **Dependencies:** Unit 0 (characterization gate), Units 1, 2
 
   **Files:**
   - Modify: `packages/gateway/src/execute/run.ts` (the `runMention` function and the Discord sink implementations)
   - Test: `packages/gateway/src/execute/run.test.ts` (Discord adapter behavior tests)
 
   **Approach:**
-  - **Characterization-first:** verify the characterization tests from Unit 2 cover the Discord-path behavior (status message posted/edited, mention stripped via `botUserId`, queue/concurrency, reactions). These must pass before and after this unit.
-  - Implement `DiscordStatusSink` and `DiscordReplySink` (or inline implementations) that wrap the existing live-status/typing message flow. The `statusMode: 'live-status' | 'typing-only'` logic moves into `DiscordStatusSink`.
-  - `runMention` extracts prompt text from `message.content` (stripping the bot mention via `botUserId`), constructs the `LaunchWorkRequest` with the Discord sinks, and calls `launchWork` (or enqueues a `RunTask` carrying the `LaunchWorkRequest`).
-  - The `Message` object is no longer passed into `launchWork` or `startRun` — it is consumed entirely in the adapter.
+  - **Characterization-first:** the Unit 0 characterization tests cover the Discord-path behavior (status message posted/edited, mention stripped via `botUserId`, queue/concurrency, reactions). These must pass before and after this unit (except the deliberate empty-prompt delta below).
+  - **Adapt the existing `StatusController` and `DiscordStreamSink` — do NOT reimplement `statusMode`.** The status controller (`packages/gateway/src/discord/status-message.ts`, `createStatusController`) already owns `live-status` vs `typing-only` (typing pulse in both modes, status-message suppression in `typing-only`, final-answer/failure delegation). The `DiscordStatusSink` wraps/adapts `createStatusController` over the new interface; it does not re-derive the mode logic. The `DiscordReplySink` delegates to the `io.ts` safe-send boundary (`sendMessage`/`editMessage`) and the existing `createDiscordStreamSink` — never raw `message.reply`/`thread.send` (preserves the `allowedMentions:{parse:[]}` + fail-soft invariants the `io.ts`/boundary tests enforce).
+  - `runMention` extracts prompt text from `message.content`, strips the bot mention via `botUserId`, and **fails fast on an empty prompt before calling `launchWork`** (the accepted behavior change — see KTD; no thread/lock/run-state churn). On a non-empty prompt it constructs the `LaunchWorkRequest` with the Discord sinks and enqueues via `launchWork`'s front door.
+  - The `Message` object is consumed entirely in the adapter — it is not passed into the inner execution primitive. Reactions and thread creation are driven through adapter-provided sink/lifecycle hooks, not by handing the engine a raw `Message`.
 
-  **Patterns to follow:** existing `runMention` mention-strip logic; `statusMode` branching in `run.ts`; `discord/io.ts` `StatusSink`/`ReplySink` Discord implementations (if applicable from the io.ts refactor).
+  **Patterns to follow:** existing `runMention` mention-strip logic; the `createStatusController` mode handling in `status-message.ts` (adapt, don't reimplement); the `discord/io.ts` safe-send boundary (`sendMessage`/`editMessage`, `SendCapable`/`ReplyCapable`) — note `io.ts` does NOT already define `StatusSink`/`ReplySink`, so those are net-new in Unit 1; the Discord sink implementations delegate to `io.ts` for safety invariants.
 
   **Test scenarios:**
   - Happy path: `runMention` with a real Discord `Message` mock calls `launchWork` with a `LaunchWorkRequest` whose prompt text has the bot mention stripped; the `StatusSink` posts a status message; the `ReplySink` sends the final output.
@@ -229,7 +255,7 @@ A future web caller (Phase B) will call `launchWork` directly with its own `Stat
   - Reactions: existing reaction behavior (if any) is preserved.
   - Regression: the Discord user experience is identical to pre-refactor (status message content, timing, error messages unchanged).
 
-  **Verification:** `pnpm check-types` clean; `pnpm test` passes; `runMention` no longer passes a `Message` into `launchWork`/`startRun`; the Discord sink implementations satisfy `StatusSink`/`ReplySink` structurally; characterization tests pass.
+  **Verification:** `pnpm --filter @fro-bot/gateway check-types` clean; `pnpm --filter @fro-bot/gateway test` passes; `runMention` no longer passes a `Message` into `launchWork`/`startRun`; the Discord sink implementations satisfy `StatusSink`/`ReplySink` structurally; characterization tests pass.
 
 - [ ] **Unit 4: Generalize the approval coordinator seam**
 
@@ -240,12 +266,15 @@ A future web caller (Phase B) will call `launchWork` directly with its own `Stat
   **Dependencies:** Units 1, 2, 3 (the `LaunchWorkRequest` + sinks pattern is established; the coordinator is wired via `approvalRegistry` in `RunMentionDeps`)
 
   **Files:**
-  - Modify: `packages/gateway/src/approvals/coordinator.ts` (generalize the `onPending`/`onReplied`/`onDispose` deps callbacks; the public `onPermissionAsked`/`onPermissionReplied` surface stays)
-  - Modify (if needed): `packages/gateway/src/approvals/registry.ts` (verify fail-closed settlement is unchanged)
-  - Test: `packages/gateway/src/approvals/coordinator.test.ts` (new tests for non-Discord render+register and decision intake)
+  - Modify: `packages/gateway/src/approvals/registry.ts` (generalize Discord-shaped names — `channelID` → `approvalScopeId`, `handleButtonDecision` → `handleDecision`, `decidedBy: string` → typed actor identity; fail-closed settlement logic unchanged)
+  - Modify: `packages/gateway/src/execute/run.ts` (extract the Discord approval transport from the `onPending` closure at `:396-536`)
+  - Modify: `packages/gateway/src/approvals/coordinator.ts` (the coordinator is already mostly generic; confirm the `onPending`/`onReplied`/`onDispose` deps contract and the deprecated `onSettled` at `:109-114` — preserve or deliberately remove with its tests, don't leave it dangling)
+  - Modify: `packages/gateway/src/program.ts` (the Discord button decision handler at `:205-260` — point it at the renamed `handleDecision`)
+  - Test: `packages/gateway/src/approvals/coordinator.test.ts` + `registry.test.ts` (non-Discord render+register and decision intake; renamed-API tests; preserve `onSettled` coverage or update it)
 
   **Approach:**
-  - Read `coordinator.ts` in full to confirm the current callback contract. Verified seam (do not look for `onRequest` — it does not exist):
+  - The real Discord coupling for approvals is NOT in `coordinator.ts` (already mostly generic) — it lives in the `run.ts` `onPending` closure (`:396-536`, renders the embed + registers), the `program.ts` button handler (`:205-260`, intakes the decision), and the Discord-shaped registry names. Extract a Discord approval *transport* from the `run.ts` closure so a future web transport can supply its own render+register/decision/teardown without a parallel registry. Generalize the registry names (KTD) so the decision path is `handleDecision({approvalScopeId, actor, ...})`, not `handleButtonDecision({channelID})`.
+  - Read `coordinator.ts` in full to confirm the current callback contract. Verified seam (do not look for `onRequest` — it does not exist; note the deprecated `onSettled` at `:109-114`):
     - `PermissionCoordinatorDeps.onPending` (`coordinator.ts:94`) — renders the approval UI **and registers the entry in the approval registry** (including `deadlineMs`); render and registration are coupled in this one hook.
     - `PermissionCoordinatorDeps.onReplied` — forwards the decision to `registry.confirmReply`.
     - `PermissionCoordinatorDeps.onDispose` — calls `registry.disposeRun(sessionID, reason)` to fail-close on teardown.
@@ -265,7 +294,7 @@ A future web caller (Phase B) will call `launchWork` directly with its own `Stat
   - One gate: two concurrent requests from different transports both settle via the same registry; neither bypasses fail-closed semantics or creates a parallel registry.
   - `parsePermissionRequest`/`parsePermissionReply` unchanged: existing parse tests still pass.
 
-  **Verification:** `pnpm check-types` clean; `pnpm test` passes; a non-Discord transport renders+registers and settles via the same registry; fail-closed timeout/dispose behavior preserved and tested; `parsePermissionRequest`/`parsePermissionReply` tests unchanged; no reference to a nonexistent `onRequest`.
+  **Verification:** `pnpm --filter @fro-bot/gateway check-types` clean; `pnpm --filter @fro-bot/gateway test` passes; a non-Discord transport renders+registers and settles via the same registry; fail-closed timeout/dispose behavior preserved and tested; `parsePermissionRequest`/`parsePermissionReply` tests unchanged; no reference to a nonexistent `onRequest`.
 
 ## System-Wide Impact
 
@@ -273,7 +302,7 @@ A future web caller (Phase B) will call `launchWork` directly with its own `Stat
 - **Error propagation:** unchanged — the engine's error handling (timeout, shutdown, run failure) is preserved; errors are surfaced via `StatusSink`/`ReplySink` to the transport, not thrown into the queue.
 - **State lifecycle:** no persistence changes. The registry's in-memory pending state and fail-closed settlement are unchanged.
 - **API surface parity:** `runMention` signature is unchanged (it is the Discord entry point); `launchWork` is a new export. The approval coordinator's `onPending`/`onReplied`/`onDispose` deps-callback contracts change shape (generalized), but the Discord implementations are updated in the same PR.
-- **Sequencing:** Unit 1 (types) → Unit 2 (engine extraction) → Unit 3 (Discord adapter) → Unit 4 (approval seam). Units 2 and 3 both modify `run.ts` and are serial. Unit 4 modifies `coordinator.ts` and can run in parallel with Units 2–3 after Unit 1, but is logically cleaner after Unit 3 (the full `LaunchWorkRequest` pattern is established).
+- **Sequencing:** Unit 0 (characterization gate) → Unit 1 (types) → Unit 2 (engine extraction + front-door/inner split) → Unit 3 (Discord adapter, empty-prompt fail-fast) → Unit 4 (approval transport extraction + registry rename). Units 2, 3, and 4 all modify `run.ts` (Unit 4 extracts the `onPending` closure from it), so they are serial, not parallel. Unit 0 must be green on unmodified `main` before any refactor begins.
 - **Unchanged invariants:** Discord user experience (status message, typing indicator, queue behavior, reactions, approval button flow), ingress-pin constraint (`server.ts` has exactly one `serve()`), `parsePermissionRequest`/`parsePermissionReply` pure parsing, registry fail-closed settlement, `ChannelQueue<RunTask>` concurrency model.
 
 ## Risks & Dependencies
@@ -332,7 +361,7 @@ This section exists because the origin brainstorm (`docs/brainstorms/2026-06-15-
 - After Phase A merges: update `packages/gateway/AGENTS.md` to reflect that the transport-agnostic execution primitive now exists (`launchWork`) and that the approval coordinator's `onPending`/`onReplied`/`onDispose` callbacks are the approved extension points for new transports. Remove or update the "deferred until a non-Discord caller exists" note.
 - The `launchWork` function and the `StatusSink`/`ReplySink` interfaces should be documented with JSDoc comments explaining the transport-neutral contract and the Discord adapter pattern, so future implementers (Phase B) know exactly what to implement.
 - No infra changes in Phase A. Phase B requires coordination with `marcusrbrown/infra` on the deploy topology before any new listener lands.
-- Verification commands (pnpm repo): `pnpm bootstrap`, `pnpm check-types`, `pnpm lint`, `pnpm test`. All must pass before merge.
+- Verification commands — **gateway-scoped** (the root `pnpm check-types`/`lint`/`test` scripts filter runtime/action/harness only and do NOT cover the gateway package): `pnpm --filter @fro-bot/gateway check-types`, `pnpm --filter @fro-bot/gateway lint`, `pnpm --filter @fro-bot/gateway test`, `pnpm --filter @fro-bot/gateway build`. All must pass before merge. (`pnpm bootstrap` first if deps changed.)
 
 ## Sources & References
 

--- a/packages/gateway/src/approvals/approval-flow.integration.test.ts
+++ b/packages/gateway/src/approvals/approval-flow.integration.test.ts
@@ -14,13 +14,13 @@
  *
  * Fake effects:
  *   postReply    — records { requestID, directory, decision } per call
- *   renderFn     — records { request, decision, decidedBy, reason } per call
+ *   renderFn     — records { request, decision, actor, reason } per call
  *
  * All timer-sensitive tests use `vi.useFakeTimers()` to control deadline firing.
  */
 
 import type {PermissionReply, PermissionReplyEvent, PermissionRequest} from './coordinator.js'
-import type {ApprovalSideEffects, RegisterParams} from './registry.js'
+import type {ApprovalActor, ApprovalSideEffects, RegisterParams, RenderFn} from './registry.js'
 
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {createPermissionCoordinator} from './coordinator.js'
@@ -43,7 +43,7 @@ interface PostReplyCall {
 interface RenderCall {
   request: PermissionRequest
   decision: string
-  decidedBy: string | null
+  actor: ApprovalActor | null
   reason: string
 }
 
@@ -58,7 +58,7 @@ function makeFakeEffects() {
 
   function makeEffectsFor(_requestID: string): {
     effects: ApprovalSideEffects
-    renderFn: (request: PermissionRequest, decision: string, decidedBy: string | null, reason: string) => Promise<void>
+    renderFn: RenderFn
   } {
     const effects: ApprovalSideEffects = {
       postReply: vi.fn(async (requestID: string, directory: string, decision: PermissionReply) => {
@@ -66,9 +66,9 @@ function makeFakeEffects() {
         return {ok: true}
       }),
     }
-    const renderFn = vi.fn(
-      async (request: PermissionRequest, decision: string, decidedBy: string | null, reason: string) => {
-        renderCalls.push({request, decision, decidedBy, reason})
+    const renderFn: RenderFn = vi.fn(
+      async (request: PermissionRequest, decision: PermissionReply, actor: ApprovalActor | null, reason: string) => {
+        renderCalls.push({request, decision, actor, reason})
       },
     )
     return {effects, renderFn}
@@ -107,7 +107,7 @@ function setup(deadlineMs?: number) {
     const params: RegisterParams = {
       requestID: request.requestID,
       sessionID: request.sessionID,
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       directory: DIRECTORY,
       request,
       effects,
@@ -163,11 +163,11 @@ describe('approval flow — cross-seam integration', () => {
     expect(postReplyCalls).toHaveLength(0)
 
     // Authorized button click (approve)
-    const clickResult = await registry.handleButtonDecision({
+    const clickResult = await registry.handleDecision({
       requestID: 'req-1',
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       decision: 'once',
-      decidedBy: 'user-approved',
+      actor: {kind: 'discord-user', userId: 'user-approved'},
     })
     expect(clickResult).toBe('ok')
 
@@ -204,11 +204,11 @@ describe('approval flow — cross-seam integration', () => {
     const replyPromise = coordinator.onPermissionAsked(req)
 
     // Authorized deny click
-    const clickResult = await registry.handleButtonDecision({
+    const clickResult = await registry.handleDecision({
       requestID: 'req-2',
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       decision: 'reject',
-      decidedBy: 'user-deny',
+      actor: {kind: 'discord-user', userId: 'user-deny'},
     })
     expect(clickResult).toBe('ok')
     expect(postReplyCalls).toHaveLength(1)
@@ -244,11 +244,11 @@ describe('approval flow — cross-seam integration', () => {
     expect(registry.pending()).not.toContain('req-3')
 
     // Late button click
-    const lateResult = await registry.handleButtonDecision({
+    const lateResult = await registry.handleDecision({
       requestID: 'req-3',
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       decision: 'once',
-      decidedBy: 'user-late',
+      actor: {kind: 'discord-user', userId: 'user-late'},
     })
 
     // #then — late click does nothing; no postReply emitted
@@ -280,11 +280,11 @@ describe('approval flow — cross-seam integration', () => {
     const postRepliesAfterDeadline = postReplyCalls.length
 
     // Late button click after deadline
-    const lateResult = await registry.handleButtonDecision({
+    const lateResult = await registry.handleDecision({
       requestID: 'req-4',
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       decision: 'once',
-      decidedBy: 'user-late',
+      actor: {kind: 'discord-user', userId: 'user-late'},
     })
     expect(lateResult).toBe('not-found')
 
@@ -302,12 +302,12 @@ describe('approval flow — cross-seam integration', () => {
     const p5 = coordinator.onPermissionAsked(req)
     expect(registry.pending()).toContain('req-5')
 
-    // #when — button click from a different channel
-    const result = await registry.handleButtonDecision({
+    // #when — decision from a different scope
+    const result = await registry.handleDecision({
       requestID: 'req-5',
-      channelID: 'ch-WRONG',
+      approvalScopeId: 'ch-WRONG',
       decision: 'once',
-      decidedBy: 'attacker',
+      actor: {kind: 'discord-user', userId: 'attacker'},
     })
 
     // #then
@@ -407,7 +407,7 @@ describe('approval flow — cross-seam integration', () => {
     reg.register({
       requestID: 'req-8a',
       sessionID: SESSION_A,
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       directory: DIRECTORY,
       request: req8a,
       effects: e8a.effects,
@@ -417,7 +417,7 @@ describe('approval flow — cross-seam integration', () => {
     reg.register({
       requestID: 'req-8b',
       sessionID: SESSION_B,
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       directory: DIRECTORY,
       request: req8b,
       effects: e8b.effects,
@@ -478,7 +478,7 @@ describe('approval flow — cross-seam integration', () => {
     registry.register({
       requestID: req.requestID,
       sessionID: req.sessionID,
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       directory: DIRECTORY,
       request: req,
       effects: heldEffects,
@@ -487,11 +487,11 @@ describe('approval flow — cross-seam integration', () => {
     registry.attachMessage(req.requestID, renderFn)
 
     // #when — button approve claims the entry (postReply is in-flight, not yet resolved)
-    const buttonPromise = registry.handleButtonDecision({
+    const buttonPromise = registry.handleDecision({
       requestID: req.requestID,
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       decision: 'once',
-      decidedBy: 'user-approved',
+      actor: {kind: 'discord-user', userId: 'user-approved'},
     })
 
     // Advance past the deadline while button POST is still in-flight
@@ -539,7 +539,7 @@ describe('approval flow — cross-seam integration', () => {
     registry.register({
       requestID: req.requestID,
       sessionID: req.sessionID,
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       directory: DIRECTORY,
       request: req,
       effects,
@@ -574,7 +574,7 @@ describe('approval flow — cross-seam integration', () => {
     registry.register({
       requestID: req.requestID,
       sessionID: req.sessionID,
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       directory: DIRECTORY,
       request: req,
       effects: {postReply: vi.fn().mockReturnValue(heldPost)},
@@ -582,11 +582,11 @@ describe('approval flow — cross-seam integration', () => {
     })
     registry.attachMessage(req.requestID, renderFn)
 
-    const buttonPromise = registry.handleButtonDecision({
+    const buttonPromise = registry.handleDecision({
       requestID: req.requestID,
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       decision: 'once',
-      decidedBy: 'user-approved',
+      actor: {kind: 'discord-user', userId: 'user-approved'},
     })
 
     // Deadline fires while in-flight
@@ -624,7 +624,7 @@ describe('approval flow — cross-seam integration', () => {
     registry.register({
       requestID: 'req-ds-1',
       sessionID: SESSION_A,
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       directory: DIRECTORY,
       request: makeRequest('req-ds-1'),
       effects,
@@ -655,7 +655,7 @@ describe('approval flow — cross-seam integration', () => {
     registry.register({
       requestID: 'req-ds-2',
       sessionID: SESSION_A,
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       directory: DIRECTORY,
       request: makeRequest('req-ds-2'),
       effects,
@@ -665,11 +665,11 @@ describe('approval flow — cross-seam integration', () => {
     registry.attachMessage('req-ds-2', renderFn)
 
     // #when — button wins before deadline
-    await registry.handleButtonDecision({
+    await registry.handleDecision({
       requestID: 'req-ds-2',
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       decision: 'once',
-      decidedBy: 'user-approved',
+      actor: {kind: 'discord-user', userId: 'user-approved'},
     })
     registry.confirmReply({requestID: 'req-ds-2', sessionID: SESSION_A, reply: 'once'})
     await vi.runAllTimersAsync()
@@ -699,7 +699,7 @@ describe('approval flow — cross-seam integration', () => {
         reg.register({
           requestID: request.requestID,
           sessionID: request.sessionID,
-          channelID: 'ch-test',
+          approvalScopeId: 'ch-test',
           directory: DIRECTORY,
           request,
           effects,
@@ -738,5 +738,186 @@ describe('approval flow — cross-seam integration', () => {
     coordinator.onPermissionReplied(makeReplyEvent('req-9', 'once'))
     await vi.runAllTimersAsync()
     await replyPromise
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unit 4: Non-Discord transport test
+// Proves the seam works for a second transport: a plain function-call
+// (simulating a web transport) renders+registers and settles via the same
+// registry. One gate, no parallel path.
+// ---------------------------------------------------------------------------
+
+describe('Unit 4: non-Discord transport — same registry, same fail-closed gate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('web-operator decision settles via the same registry as a Discord decision would', async () => {
+    // #given a registry + coordinator wired with a "web transport" onPending
+    // (plain function calls, no Discord embeds, no Discord.js)
+    const logger = makeLogger()
+    const {postReplyCalls, renderCalls, makeEffectsFor} = makeFakeEffects()
+    const registry = createApprovalRegistry({logger})
+
+    // Simulate a web transport's onPending: register + attach render (no embed)
+    function webOnPending(request: PermissionRequest) {
+      const {effects, renderFn} = makeEffectsFor(request.requestID)
+      // Web transport uses a correlation ID as the approvalScopeId
+      registry.register({
+        requestID: request.requestID,
+        sessionID: request.sessionID,
+        approvalScopeId: 'web-session-abc123',
+        directory: DIRECTORY,
+        request,
+        effects,
+      })
+      // Web transport attaches its own render function (e.g. update a DB record)
+      registry.attachMessage(request.requestID, renderFn)
+    }
+
+    const coordinator = createPermissionCoordinator({
+      logger,
+      onPending: webOnPending,
+      onReplied: event => {
+        registry.confirmReply(event)
+      },
+      onDispose: sessionIDs => {
+        // eslint-disable-next-line no-void
+        void Promise.all(sessionIDs.map(async sid => registry.disposeRun(sid, 'run ended')))
+      },
+    })
+
+    const req = makeRequest('req-web-1', SESSION_A)
+
+    // #when permission.asked arrives
+    const replyPromise = coordinator.onPermissionAsked(req)
+    expect(registry.pending()).toContain('req-web-1')
+
+    // #when a web operator submits a decision (plain function call, not a Discord button)
+    // The actor is a web-operator identity — NOT a discord-user
+    const outcome = await registry.handleDecision({
+      requestID: 'req-web-1',
+      approvalScopeId: 'web-session-abc123',
+      decision: 'once',
+      actor: {kind: 'web-operator', operatorId: 'operator-42'},
+    })
+
+    // #then the decision was accepted (same registry, same gate)
+    expect(outcome).toBe('ok')
+    expect(postReplyCalls).toHaveLength(1)
+    expect(postReplyCalls[0]).toMatchObject({requestID: 'req-web-1', directory: DIRECTORY, decision: 'once'})
+
+    // #when permission.replied arrives (authoritative settlement)
+    coordinator.onPermissionReplied(makeReplyEvent('req-web-1', 'once'))
+    await vi.runAllTimersAsync()
+    await replyPromise
+
+    // #then the entry is settled and the render function was called
+    expect(registry.has('req-web-1')).toBe(false)
+    expect(renderCalls).toHaveLength(1)
+    expect(renderCalls[0]).toMatchObject({decision: 'once', reason: 'replied'})
+    // The actor is the web-operator identity
+    expect(renderCalls[0]?.actor).toEqual({kind: 'web-operator', operatorId: 'operator-42'})
+  })
+
+  it('web-operator scope mismatch is rejected (same fail-closed gate)', async () => {
+    // #given a registry entry registered with a web scope
+    const logger = makeLogger()
+    const registry = createApprovalRegistry({logger})
+    const {effects} = makeFakeEffects().makeEffectsFor('req-web-2')
+    const req = makeRequest('req-web-2', SESSION_A)
+    registry.register({
+      requestID: 'req-web-2',
+      sessionID: SESSION_A,
+      approvalScopeId: 'web-session-correct',
+      directory: DIRECTORY,
+      request: req,
+      effects,
+    })
+
+    // #when a decision arrives with the wrong scope (simulating a CSRF-like attack)
+    const outcome = await registry.handleDecision({
+      requestID: 'req-web-2',
+      approvalScopeId: 'web-session-WRONG',
+      decision: 'once',
+      actor: {kind: 'web-operator', operatorId: 'attacker'},
+    })
+
+    // #then scope mismatch — same fail-closed gate as Discord channel mismatch
+    expect(outcome).toBe('channel-mismatch')
+    expect(registry.has('req-web-2')).toBe(true)
+  })
+
+  it('two concurrent requests from different transports both settle via the same registry', async () => {
+    // #given a shared registry with one Discord entry and one web entry
+    const logger = makeLogger()
+    const {postReplyCalls, renderCalls, makeEffectsFor} = makeFakeEffects()
+    const registry = createApprovalRegistry({logger})
+
+    const reqDiscord = makeRequest('req-discord', SESSION_A)
+    const reqWeb = makeRequest('req-web', SESSION_B)
+
+    const {effects: effectsDiscord, renderFn: renderFnDiscord} = makeEffectsFor('req-discord')
+    const {effects: effectsWeb, renderFn: renderFnWeb} = makeEffectsFor('req-web')
+
+    // Discord transport registers with a thread ID as scope
+    registry.register({
+      requestID: 'req-discord',
+      sessionID: SESSION_A,
+      approvalScopeId: 'discord-thread-123',
+      directory: DIRECTORY,
+      request: reqDiscord,
+      effects: effectsDiscord,
+    })
+    registry.attachMessage('req-discord', renderFnDiscord)
+
+    // Web transport registers with a correlation ID as scope
+    registry.register({
+      requestID: 'req-web',
+      sessionID: SESSION_B,
+      approvalScopeId: 'web-session-xyz',
+      directory: DIRECTORY,
+      request: reqWeb,
+      effects: effectsWeb,
+    })
+    registry.attachMessage('req-web', renderFnWeb)
+
+    expect(registry.pending()).toHaveLength(2)
+
+    // #when Discord button click settles the Discord entry
+    const discordOutcome = await registry.handleDecision({
+      requestID: 'req-discord',
+      approvalScopeId: 'discord-thread-123',
+      decision: 'once',
+      actor: {kind: 'discord-user', userId: 'discord-user-1'},
+    })
+    expect(discordOutcome).toBe('ok')
+
+    // #when web operator settles the web entry
+    const webOutcome = await registry.handleDecision({
+      requestID: 'req-web',
+      approvalScopeId: 'web-session-xyz',
+      decision: 'reject',
+      actor: {kind: 'web-operator', operatorId: 'operator-99'},
+    })
+    expect(webOutcome).toBe('ok')
+
+    // #then both entries are claimed; confirmReply settles them
+    registry.confirmReply({requestID: 'req-discord', sessionID: SESSION_A, reply: 'once'})
+    registry.confirmReply({requestID: 'req-web', sessionID: SESSION_B, reply: 'reject'})
+    await vi.runAllTimersAsync()
+
+    // #then both entries are settled via the SAME registry
+    expect(registry.has('req-discord')).toBe(false)
+    expect(registry.has('req-web')).toBe(false)
+    expect(postReplyCalls).toHaveLength(2)
+    expect(renderCalls).toHaveLength(2)
+
+    // No parallel registry was created — both settled via the same registry instance
+    expect(registry.pending()).toHaveLength(0)
   })
 })

--- a/packages/gateway/src/approvals/approval-flow.integration.test.ts
+++ b/packages/gateway/src/approvals/approval-flow.integration.test.ts
@@ -742,13 +742,13 @@ describe('approval flow — cross-seam integration', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Unit 4: Non-Discord transport test
+// Non-Discord transport test
 // Proves the seam works for a second transport: a plain function-call
 // (simulating a web transport) renders+registers and settles via the same
 // registry. One gate, no parallel path.
 // ---------------------------------------------------------------------------
 
-describe('Unit 4: non-Discord transport — same registry, same fail-closed gate', () => {
+describe('non-Discord transport — same registry, same fail-closed gate', () => {
   beforeEach(() => {
     vi.useFakeTimers()
   })

--- a/packages/gateway/src/approvals/coordinator.test.ts
+++ b/packages/gateway/src/approvals/coordinator.test.ts
@@ -275,7 +275,7 @@ describe('createPermissionCoordinator', () => {
     sharedRegistry.register({
       requestID: 'per_A',
       sessionID: 'ses_A',
-      channelID: 'chan_1',
+      approvalScopeId: 'chan_1',
       directory: '/ws/a',
       request: reqA,
       effects: {postReply: vi.fn().mockResolvedValue({ok: true})},
@@ -285,7 +285,7 @@ describe('createPermissionCoordinator', () => {
     sharedRegistry.register({
       requestID: 'per_B',
       sessionID: 'ses_B',
-      channelID: 'chan_2',
+      approvalScopeId: 'chan_2',
       directory: '/ws/b',
       request: reqB,
       effects: {postReply: vi.fn().mockResolvedValue({ok: true})},

--- a/packages/gateway/src/approvals/discord-transport.ts
+++ b/packages/gateway/src/approvals/discord-transport.ts
@@ -7,8 +7,8 @@
  * - Attaches the settled-embed render function once the message is posted.
  * - Creates the per-request `postReply` closure that captures `sessionID`
  *   (the one documented Discord-specific cast in the approval path — the
- *   `result as Message` cast for `attachMessage`; Phase B will widen
- *   `ReplySink.send` to return a typed result when needed).
+ *   `result as Message` cast for `attachMessage`; widen `ReplySink.send` to
+ *   return a typed result when a web transport needs it).
  *
  * Returns a `PermissionCoordinatorDeps`-compatible `onPending` callback that
  * the engine wires into `createPermissionCoordinator`. A future web transport
@@ -185,8 +185,8 @@ export function createDiscordApprovalOnPending(
     // for attachMessage (Discord impl returns Result<Message, ...>).
     // This is the one documented Discord-specific cast in the approval transport —
     // the `result as Message` cast is resolved here (inside the transport where
-    // it's a clean Discord concern). Phase B will widen ReplySink.send to return
-    // a typed result when needed.
+    // it's a clean Discord concern). Widen ReplySink.send to return a typed
+    // result when a web transport needs the posted message reference.
     const settleEmbed = replySink.markVisibleOutputPending()
     // eslint-disable-next-line no-void
     void replySink

--- a/packages/gateway/src/approvals/discord-transport.ts
+++ b/packages/gateway/src/approvals/discord-transport.ts
@@ -1,0 +1,244 @@
+/**
+ * Discord approval transport.
+ *
+ * Owns the Discord-specific side of the approval flow:
+ * - Renders the approval embed + buttons and posts them via `replySink.send`.
+ * - Registers the entry in the approval registry (register-before-send pattern).
+ * - Attaches the settled-embed render function once the message is posted.
+ * - Creates the per-request `postReply` closure that captures `sessionID`
+ *   (the one documented Discord-specific cast in the approval path — the
+ *   `result as Message` cast for `attachMessage`; Phase B will widen
+ *   `ReplySink.send` to return a typed result when needed).
+ *
+ * Returns a `PermissionCoordinatorDeps`-compatible `onPending` callback that
+ * the engine wires into `createPermissionCoordinator`. A future web transport
+ * would supply its own `onPending` (notification + HTTP callback) without
+ * touching this module.
+ *
+ * ### Transport seam
+ *
+ * The engine's `onPending` hook is the transport-neutral extension point.
+ * This module is the Discord implementation of that hook. A future web
+ * transport would create its own module implementing the same hook shape.
+ *
+ * ### register-before-send
+ *
+ * The registry entry is registered BEFORE the embed is posted so the button
+ * handler can look up the entry even if the send is still in-flight.
+ * `attachMessage` is called after a successful send to wire the render function.
+ * `markMessagePostFailed` is called on send failure so the entry stays
+ * registered (the permission can still be POSTed when it settles).
+ */
+
+import type {Message} from 'discord.js'
+
+import type {GatewayLogger} from '../discord/client.js'
+import type {ReplySink} from '../execute/launch-types.js'
+import type {PermissionReply, PermissionRequest, SettlementReason} from './coordinator.js'
+import type {ApprovalActor, ApprovalRegistry} from './registry.js'
+
+import {buildApprovalButtons, buildApprovalEmbed, buildSettledEmbed} from '../discord/approvals.js'
+import {editMessage} from '../discord/io.js'
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Factory for the per-request `postReply` function.
+ *
+ * The transport calls this once per `onPending` invocation to create a closure
+ * that captures the per-request `sessionID`. The factory receives the
+ * `sessionID` and returns a function that POSTs the decision to OpenCode.
+ *
+ * This is the seam that keeps the SDK call inside the transport (a clean
+ * Discord/OpenCode concern) while letting the engine remain transport-neutral.
+ */
+export type PostReplyFactory = (
+  sessionID: string,
+) => (
+  requestID: string,
+  directory: string,
+  decision: PermissionReply,
+) => Promise<{readonly ok: boolean; readonly error?: string}>
+
+export interface DiscordApprovalTransportDeps {
+  /** Program-scoped approval registry shared with the button handler. */
+  readonly approvalRegistry: ApprovalRegistry
+  /** Per-run reply sink — used to post the embed and the waiting-status message. */
+  readonly replySink: ReplySink
+  /**
+   * Thread ID for the approval scope binding.
+   * Set by the thread factory after thread creation; empty string for non-Discord paths.
+   * Used as `approvalScopeId` in the registry so the button handler can verify
+   * the interaction came from the correct thread/channel.
+   */
+  readonly threadId: string
+  /** Workspace directory for reply routing (passed to registry.register). */
+  readonly directory: string
+  /** Per-approval deadline in ms (passed to registry.register). */
+  readonly approvalDeadlineMs: number | undefined
+  /**
+   * Optional callback invoked when the deadline fires on an open entry.
+   * Passed to registry.register as `onDeadlineSettled`.
+   */
+  readonly onDeadlineSettled: (() => void | Promise<void>) | undefined
+  /**
+   * Factory for the per-request `postReply` closure.
+   * Called once per `onPending` invocation with the request's `sessionID`.
+   */
+  readonly postReplyFactory: PostReplyFactory
+  readonly logger: GatewayLogger
+}
+
+// ---------------------------------------------------------------------------
+// createDiscordApprovalOnPending
+// ---------------------------------------------------------------------------
+
+/**
+ * Create the Discord `onPending` callback for `createPermissionCoordinator`.
+ *
+ * The returned function is the Discord transport implementation of the
+ * transport-neutral `PermissionCoordinatorDeps.onPending` hook. It:
+ * 1. Creates the per-request `postReply` closure (captures `sessionID`).
+ * 2. Registers the entry in the approval registry (register-before-send).
+ * 3. Posts a "Waiting for tool approval…" status message (fire-and-forget).
+ * 4. Posts the approval embed + buttons (fire-and-forget).
+ * 5. Attaches the settled-embed render function on success.
+ *
+ * Must not throw — the coordinator wraps it defensively.
+ *
+ * @param deps - Discord transport dependencies.
+ */
+export function createDiscordApprovalOnPending(
+  deps: DiscordApprovalTransportDeps,
+): (request: PermissionRequest) => void {
+  const {
+    approvalRegistry,
+    replySink,
+    threadId,
+    directory,
+    approvalDeadlineMs,
+    onDeadlineSettled,
+    postReplyFactory,
+    logger,
+  } = deps
+
+  return function onPending(req: PermissionRequest): void {
+    const {requestID, sessionID} = req
+
+    // Per-request postReply closure — captures sessionID for the SDK call.
+    // FIX 4: AbortSignal.timeout(10_000) is used inside the factory to avoid
+    // the dangling-timer leak from the old Promise.race approach.
+    const postReplyForRequest = postReplyFactory(sessionID)
+
+    // register-before-send: register the entry in the shared registry
+    // BEFORE attempting the Discord embed post. This ensures the button
+    // handler can look up the entry even if the send is still in-flight.
+    // Registry owns the deadline timer (single-owner rule).
+    //
+    // approvalScopeId: use threadId (set by threadFactory after thread creation).
+    // For non-Discord paths (in-memory sinks), threadId is '' — the registry
+    // still works; the approvalScopeId is only used for button-handler lookup.
+    approvalRegistry.register({
+      requestID,
+      sessionID,
+      approvalScopeId: threadId,
+      directory,
+      request: req,
+      effects: {postReply: postReplyForRequest},
+      deadlineMs: approvalDeadlineMs,
+      onDeadlineSettled,
+    })
+
+    // Post a visible waiting-for-approval status BEFORE the embed so the
+    // user sees the run is blocked even if the embed send is slow.
+    // Fire-and-forget: status is best-effort; must not block onPending.
+    //
+    // Pending-visibility: mark the send as in-flight BEFORE the void send so
+    // timeout classification sees it as visible context even if the Discord
+    // round-trip has not completed yet. settle(true) on success promotes to
+    // permanently delivered; settle(false) on failure retracts the claim.
+    const settleWaitingStatus = replySink.markVisibleOutputPending()
+    // eslint-disable-next-line no-void
+    void replySink.send('thread', {content: 'Waiting for tool approval\u2026'}).then(result => {
+      // replySink.send returns unknown; cast to check success (one documented cast).
+      const r = result as {success?: boolean; error?: {message: string}} | undefined
+      if (r?.success === true) {
+        settleWaitingStatus(true)
+      } else {
+        settleWaitingStatus(false)
+        logger.warn(
+          {requestID, err: r?.error?.message ?? 'unknown'},
+          'discord-transport: failed to post waiting-for-approval status',
+        )
+      }
+    })
+
+    // Fire-and-forget: send the embed then attach the render function.
+    // onPending must not throw (coordinator catches internally anyway).
+    //
+    // Pending-visibility: same pattern as the waiting-status send above —
+    // mark in-flight before the void send, settle on resolution.
+    //
+    // replySink.send returns unknown; cast to get the posted message reference
+    // for attachMessage (Discord impl returns Result<Message, ...>).
+    // This is the one documented Discord-specific cast in the approval transport —
+    // the `result as Message` cast is resolved here (inside the transport where
+    // it's a clean Discord concern). Phase B will widen ReplySink.send to return
+    // a typed result when needed.
+    const settleEmbed = replySink.markVisibleOutputPending()
+    // eslint-disable-next-line no-void
+    void replySink
+      .send('thread', {embeds: [buildApprovalEmbed(req)], components: [buildApprovalButtons(requestID)]})
+      .then(result => {
+        const r = result as {success?: boolean; data?: Message; error?: {message: string}} | undefined
+        if (r?.success === true) {
+          // Embed send succeeded — settle pending claim as delivered so
+          // flush() does not add a misleading _(no output)_.
+          settleEmbed(true)
+          const postedMessage = r.data
+          if (postedMessage !== undefined) {
+            // Attach the render function now that we have a message reference.
+            // The `result as Message` cast is resolved here — inside the Discord
+            // transport where it's a clean Discord concern.
+            approvalRegistry.attachMessage(
+              requestID,
+              async (
+                permReq: PermissionRequest,
+                decision: PermissionReply,
+                actor: ApprovalActor | null,
+                reason: SettlementReason,
+              ) => {
+                // Derive a display string from the typed actor for the settled embed.
+                // Discord-specific: extract the userId for the decidedBy display.
+                const decidedBy =
+                  actor === null ? null : actor.kind === 'discord-user' ? actor.userId : actor.operatorId
+                const editResult = await editMessage(
+                  postedMessage,
+                  {
+                    embeds: [buildSettledEmbed(permReq, decision, {decidedBy: decidedBy ?? undefined, reason})],
+                    components: [],
+                  },
+                  logger,
+                )
+                if (editResult.success === false) {
+                  logger.warn(
+                    {requestID: permReq.requestID, err: editResult.error.message},
+                    'discord-transport: failed to edit approval message',
+                  )
+                }
+              },
+            )
+          }
+        } else {
+          settleEmbed(false)
+          logger.warn(
+            {requestID, err: r?.error?.message ?? 'unknown'},
+            'discord-transport: failed to post approval embed',
+          )
+          approvalRegistry.markMessagePostFailed(requestID)
+        }
+      })
+  }
+}

--- a/packages/gateway/src/approvals/registry.test.ts
+++ b/packages/gateway/src/approvals/registry.test.ts
@@ -7,11 +7,11 @@
  * ### Core scenarios
  *
  * 1. register / has / pending — basic lifecycle
- * 2. handleButtonDecision — unknown id (not-found)
- * 3. handleButtonDecision — channel mismatch
- * 4. handleButtonDecision — happy path (open→claimed→confirmed)
- * 5. handleButtonDecision — claimed blocks second click while in-flight (single-winner)
- * 6. handleButtonDecision — reply-failed resets to open, retry works
+ * 2. handleDecision — unknown id (not-found)
+ * 3. handleDecision — scope mismatch
+ * 4. handleDecision — happy path (open→claimed→confirmed)
+ * 5. handleDecision — claimed blocks second decision while in-flight (single-winner)
+ * 6. handleDecision — reply-failed resets to open, retry works
  * 7. applySettlement — replied path (renderFn called; no second postReply)
  * 8. applySettlement — deadline/cascade path on open entry
  * 9. disposeRun — only settles entries for the matching sessionID
@@ -19,7 +19,7 @@
 
 import type {GatewayLogger} from '../discord/client.js'
 import type {PermissionRequest} from './coordinator.js'
-import type {ApprovalSideEffects, DecisionOutcome, RegisterParams, RenderFn} from './registry.js'
+import type {ApprovalActor, ApprovalSideEffects, DecisionOutcome, RegisterParams, RenderFn} from './registry.js'
 
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
@@ -55,12 +55,16 @@ function makeRenderFn(): RenderFn {
   return vi.fn().mockResolvedValue(undefined)
 }
 
+function makeActor(overrides: Partial<ApprovalActor> = {}): ApprovalActor {
+  return {kind: 'discord-user', userId: 'user_A', ...overrides} as ApprovalActor
+}
+
 function makeParams(overrides: Partial<RegisterParams> = {}): RegisterParams {
   const request = overrides.request ?? makeRequest()
   return {
     requestID: request.requestID,
     sessionID: request.sessionID,
-    channelID: 'chan_1',
+    approvalScopeId: 'chan_1',
     directory: '/workspace/proj',
     request,
     effects: makeEffects(),
@@ -113,22 +117,22 @@ describe('register / has / pending', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Scenario 2: handleButtonDecision — unknown id
+// Scenario 2: handleDecision — unknown id
 // ---------------------------------------------------------------------------
 
-describe('handleButtonDecision — unknown id', () => {
+describe('handleDecision — unknown id', () => {
   it("returns 'not-found' and does NOT call postReply", async () => {
     // #given an empty registry
     const registry = createApprovalRegistry({logger: makeLogger()})
     const effects = makeEffects()
     registry.register(makeParams({effects}))
 
-    // #when clicking a button for an unknown requestID
-    const outcome = await registry.handleButtonDecision({
+    // #when a decision arrives for an unknown requestID
+    const outcome = await registry.handleDecision({
       requestID: 'per_UNKNOWN',
-      channelID: 'chan_1',
+      approvalScopeId: 'chan_1',
       decision: 'once',
-      decidedBy: 'user_A',
+      actor: makeActor(),
     })
 
     // #then not-found; no side effects
@@ -138,22 +142,22 @@ describe('handleButtonDecision — unknown id', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Scenario 3: handleButtonDecision — channel mismatch
+// Scenario 3: handleDecision — scope mismatch
 // ---------------------------------------------------------------------------
 
-describe('handleButtonDecision — channel mismatch', () => {
+describe('handleDecision — scope mismatch', () => {
   it("returns 'channel-mismatch' and does NOT call postReply", async () => {
     // #given a registry entry bound to chan_1
     const registry = createApprovalRegistry({logger: makeLogger()})
     const effects = makeEffects()
-    registry.register(makeParams({channelID: 'chan_1', effects}))
+    registry.register(makeParams({approvalScopeId: 'chan_1', effects}))
 
-    // #when a button arrives from a different channel
-    const outcome = await registry.handleButtonDecision({
+    // #when a decision arrives from a different scope
+    const outcome = await registry.handleDecision({
       requestID: 'per_1',
-      channelID: 'chan_WRONG',
+      approvalScopeId: 'chan_WRONG',
       decision: 'once',
-      decidedBy: 'user_A',
+      actor: makeActor(),
     })
 
     // #then channel-mismatch; no reply sent
@@ -163,22 +167,22 @@ describe('handleButtonDecision — channel mismatch', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Scenario 4: handleButtonDecision — happy path (open→claimed→confirmed)
+// Scenario 4: handleDecision — happy path (open→claimed→confirmed)
 // ---------------------------------------------------------------------------
 
-describe('handleButtonDecision — happy path', () => {
+describe('handleDecision — happy path', () => {
   it("returns 'ok', calls postReply once, state transitions to confirmed", async () => {
     // #given a registered entry
     const registry = createApprovalRegistry({logger: makeLogger()})
     const effects = makeEffects()
-    registry.register(makeParams({channelID: 'chan_1', directory: '/workspace/proj', effects}))
+    registry.register(makeParams({approvalScopeId: 'chan_1', directory: '/workspace/proj', effects}))
 
-    // #when the button is clicked with a valid channel
-    const outcome = await registry.handleButtonDecision({
+    // #when a decision arrives with a valid scope
+    const outcome = await registry.handleDecision({
       requestID: 'per_1',
-      channelID: 'chan_1',
+      approvalScopeId: 'chan_1',
       decision: 'once',
-      decidedBy: 'user_A',
+      actor: {kind: 'discord-user', userId: 'user_A'},
     })
 
     // #then ok; postReply called once with correct args; entry still exists (not yet settled)
@@ -188,17 +192,17 @@ describe('handleButtonDecision — happy path', () => {
   })
 
   it('confirmed entry does not call postReply on applySettlement(replied)', async () => {
-    // #given a confirmed entry (button clicked → postReply succeeded)
+    // #given a confirmed entry (decision submitted → postReply succeeded)
     const registry = createApprovalRegistry({logger: makeLogger()})
     const effects = makeEffects()
     const renderFn = makeRenderFn()
     registry.register(makeParams({effects}))
     registry.attachMessage('per_1', renderFn)
-    await registry.handleButtonDecision({
+    await registry.handleDecision({
       requestID: 'per_1',
-      channelID: 'chan_1',
+      approvalScopeId: 'chan_1',
       decision: 'once',
-      decidedBy: 'user_A',
+      actor: makeActor(),
     })
 
     // #when settled with reason 'replied'
@@ -213,28 +217,28 @@ describe('handleButtonDecision — happy path', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Scenario 5: handleButtonDecision — claimed blocks second click (single-winner)
+// Scenario 5: handleDecision — claimed blocks second decision (single-winner)
 // ---------------------------------------------------------------------------
 
-describe('handleButtonDecision — already-claimed (single-winner)', () => {
-  it("returns 'already-claimed' on second click; postReply called only ONCE total", async () => {
-    // #given first click already settled
+describe('handleDecision — already-claimed (single-winner)', () => {
+  it("returns 'already-claimed' on second decision; postReply called only ONCE total", async () => {
+    // #given first decision already submitted
     const registry = createApprovalRegistry({logger: makeLogger()})
     const effects = makeEffects()
     registry.register(makeParams({effects}))
-    await registry.handleButtonDecision({
+    await registry.handleDecision({
       requestID: 'per_1',
-      channelID: 'chan_1',
+      approvalScopeId: 'chan_1',
       decision: 'once',
-      decidedBy: 'user_A',
+      actor: {kind: 'discord-user', userId: 'user_A'},
     })
 
-    // #when a second click arrives
-    const outcome = await registry.handleButtonDecision({
+    // #when a second decision arrives
+    const outcome = await registry.handleDecision({
       requestID: 'per_1',
-      channelID: 'chan_1',
+      approvalScopeId: 'chan_1',
       decision: 'always',
-      decidedBy: 'user_B',
+      actor: {kind: 'discord-user', userId: 'user_B'},
     })
 
     // #then already-claimed; no second postReply
@@ -242,7 +246,7 @@ describe('handleButtonDecision — already-claimed (single-winner)', () => {
     expect(effects.postReply).toHaveBeenCalledOnce()
   })
 
-  it("'claimed' state (postReply in-flight) blocks concurrent second click", async () => {
+  it("'claimed' state (postReply in-flight) blocks concurrent second decision", async () => {
     // #given postReply is slow (controllable via deferred promise)
     const registry = createApprovalRegistry({logger: makeLogger()})
     let resolveReply!: (v: {ok: boolean}) => void
@@ -252,23 +256,23 @@ describe('handleButtonDecision — already-claimed (single-winner)', () => {
     const effects = makeEffects({postReply: vi.fn().mockReturnValue(replyPromise)})
     registry.register(makeParams({effects}))
 
-    // Start first click (in-flight, not yet resolved)
-    const firstClickPromise = registry.handleButtonDecision({
+    // Start first decision (in-flight, not yet resolved)
+    const firstClickPromise = registry.handleDecision({
       requestID: 'per_1',
-      channelID: 'chan_1',
+      approvalScopeId: 'chan_1',
       decision: 'once',
-      decidedBy: 'user_A',
+      actor: {kind: 'discord-user', userId: 'user_A'},
     })
 
-    // Second click while first is in-flight
-    const secondOutcome = await registry.handleButtonDecision({
+    // Second decision while first is in-flight
+    const secondOutcome = await registry.handleDecision({
       requestID: 'per_1',
-      channelID: 'chan_1',
+      approvalScopeId: 'chan_1',
       decision: 'once',
-      decidedBy: 'user_B',
+      actor: {kind: 'discord-user', userId: 'user_B'},
     })
 
-    // #then second click is blocked immediately (claimed)
+    // #then second decision is blocked immediately (claimed)
     expect(secondOutcome).toBe<DecisionOutcome>('already-claimed')
 
     // Resolve the in-flight reply
@@ -280,34 +284,34 @@ describe('handleButtonDecision — already-claimed (single-winner)', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Scenario 6: handleButtonDecision — reply-failed resets to open, retry works
+// Scenario 6: handleDecision — reply-failed resets to open, retry works
 // ---------------------------------------------------------------------------
 
-describe('handleButtonDecision — reply-failed', () => {
-  it("returns 'reply-failed' and resets to open so a subsequent click can retry", async () => {
+describe('handleDecision — reply-failed', () => {
+  it("returns 'reply-failed' and resets to open so a subsequent decision can retry", async () => {
     // #given postReply fails on first call, succeeds on retry
     const registry = createApprovalRegistry({logger: makeLogger()})
     const postReply = vi.fn().mockResolvedValueOnce({ok: false, error: 'timeout'}).mockResolvedValueOnce({ok: true})
     const effects = makeEffects({postReply})
     registry.register(makeParams({effects}))
 
-    // #when first click fails
-    const first = await registry.handleButtonDecision({
+    // #when first decision fails
+    const first = await registry.handleDecision({
       requestID: 'per_1',
-      channelID: 'chan_1',
+      approvalScopeId: 'chan_1',
       decision: 'once',
-      decidedBy: 'user_A',
+      actor: makeActor(),
     })
 
     // #then reply-failed; state reset to open
     expect(first).toBe<DecisionOutcome>('reply-failed')
 
-    // #when retry click
-    const retry = await registry.handleButtonDecision({
+    // #when retry decision
+    const retry = await registry.handleDecision({
       requestID: 'per_1',
-      channelID: 'chan_1',
+      approvalScopeId: 'chan_1',
       decision: 'once',
-      decidedBy: 'user_A',
+      actor: makeActor(),
     })
 
     // #then retry succeeds; postReply called twice total
@@ -321,19 +325,20 @@ describe('handleButtonDecision — reply-failed', () => {
 // ---------------------------------------------------------------------------
 
 describe("applySettlement — reason 'replied'", () => {
-  it('calls renderFn with stashed decidedBy; does NOT call postReply again; unregisters', async () => {
-    // #given a confirmed entry (button was clicked)
+  it('calls renderFn with stashed actor; does NOT call postReply again; unregisters', async () => {
+    // #given a confirmed entry (decision submitted → postReply succeeded)
     const registry = createApprovalRegistry({logger: makeLogger()})
     const effects = makeEffects()
     const request = makeRequest()
     const renderFn = makeRenderFn()
     registry.register(makeParams({request, effects}))
     registry.attachMessage('per_1', renderFn)
-    await registry.handleButtonDecision({
+    const actor: ApprovalActor = {kind: 'discord-user', userId: 'user_A'}
+    await registry.handleDecision({
       requestID: 'per_1',
-      channelID: 'chan_1',
+      approvalScopeId: 'chan_1',
       decision: 'once',
-      decidedBy: 'user_A',
+      actor,
     })
 
     // #when the coordinator fires settlement with reason 'replied'
@@ -341,7 +346,7 @@ describe("applySettlement — reason 'replied'", () => {
 
     // #then postReply NOT called again; renderFn called with correct args
     expect(effects.postReply).toHaveBeenCalledOnce()
-    expect(renderFn).toHaveBeenCalledExactlyOnceWith(request, 'once', 'user_A', 'replied')
+    expect(renderFn).toHaveBeenCalledExactlyOnceWith(request, 'once', actor, 'replied')
     expect(registry.has('per_1')).toBe(false)
   })
 
@@ -351,7 +356,7 @@ describe("applySettlement — reason 'replied'", () => {
     const effects = makeEffects()
     registry.register(makeParams({effects}))
     registry.markMessagePostFailed('per_1')
-    await registry.handleButtonDecision({requestID: 'per_1', channelID: 'chan_1', decision: 'once', decidedBy: 'u'})
+    await registry.handleDecision({requestID: 'per_1', approvalScopeId: 'chan_1', decision: 'once', actor: makeActor()})
 
     // #when settled
     await registry.applySettlement({requestID: 'per_1', decision: 'once', reason: 'replied'})
@@ -366,7 +371,7 @@ describe("applySettlement — reason 'replied'", () => {
 // ---------------------------------------------------------------------------
 
 describe("applySettlement — reason 'deadline' (unclaimed)", () => {
-  it('calls postReply(reject), renderFn(null, deadline), then unregisters', async () => {
+  it('calls postReply(reject), renderFn(null actor, deadline), then unregisters', async () => {
     // #given an open entry with a message attached
     const registry = createApprovalRegistry({logger: makeLogger()})
     const effects = makeEffects()
@@ -378,7 +383,7 @@ describe("applySettlement — reason 'deadline' (unclaimed)", () => {
     // #when deadline fires
     await registry.applySettlement({requestID: 'per_1', decision: 'reject', reason: 'deadline'})
 
-    // #then postReply called with reject; renderFn with decidedBy=null
+    // #then postReply called with reject; renderFn with actor=null
     expect(effects.postReply).toHaveBeenCalledExactlyOnceWith('per_1', '/workspace/proj', 'reject')
     expect(renderFn).toHaveBeenCalledExactlyOnceWith(request, 'reject', null, 'deadline')
     expect(registry.has('per_1')).toBe(false)
@@ -600,7 +605,7 @@ describe('markMessagePostFailed', () => {
 // ---------------------------------------------------------------------------
 
 describe('FIX 1 — cascadeReject skips claimed siblings', () => {
-  it('cascade from A reject does NOT send reject POST to B when B is claimed (button in-flight)', async () => {
+  it('cascade from A reject does NOT send reject POST to B when B is claimed (decision in-flight)', async () => {
     // #given two entries in the same session
     const registry = createApprovalRegistry({logger: makeLogger()})
 
@@ -617,7 +622,7 @@ describe('FIX 1 — cascadeReject skips claimed siblings', () => {
     )
     registry.attachMessage('per_A', renderFnA)
 
-    // Entry B: claimed (button approve in-flight — postReply held pending)
+    // Entry B: claimed (decision in-flight — postReply held pending)
     let resolveB!: (v: {ok: boolean}) => void
     const replyPromiseB = new Promise<{ok: boolean}>(res => {
       resolveB = res
@@ -634,12 +639,12 @@ describe('FIX 1 — cascadeReject skips claimed siblings', () => {
     )
     registry.attachMessage('per_B', renderFnB)
 
-    // Claim B (button click in-flight, not yet resolved)
-    const bClickPromise = registry.handleButtonDecision({
+    // Claim B (decision in-flight, not yet resolved)
+    const bClickPromise = registry.handleDecision({
       requestID: 'per_B',
-      channelID: 'chan_1',
+      approvalScopeId: 'chan_1',
       decision: 'once',
-      decidedBy: 'user_B',
+      actor: {kind: 'discord-user', userId: 'user_B'},
     })
 
     // #when A's confirmReply fires with reject (triggers cascade)
@@ -654,23 +659,23 @@ describe('FIX 1 — cascadeReject skips claimed siblings', () => {
     // #then B is still present (claimed, not cascaded)
     expect(registry.has('per_B')).toBe(true)
 
-    // #then effectsB.postReply was called ONCE (the button click), NOT a second time for cascade
+    // #then effectsB.postReply was called ONCE (the decision), NOT a second time for cascade
     // (it's still pending — the promise hasn't resolved yet)
     expect(effectsB.postReply).toHaveBeenCalledOnce()
 
-    // #when B's button postReply resolves successfully
+    // #when B's postReply resolves successfully
     resolveB({ok: true})
     const bOutcome = await bClickPromise
     expect(bOutcome).toBe<DecisionOutcome>('ok')
 
-    // #when B's confirmReply arrives (echo of the button approve)
+    // #when B's confirmReply arrives (echo of the decision)
     registry.confirmReply({requestID: 'per_B', sessionID: 'ses_1', reply: 'once'})
     await new Promise(resolve => setTimeout(resolve, 0))
 
     // #then B is now settled (rendered approved once)
     expect(registry.has('per_B')).toBe(false)
     expect(renderFnB).toHaveBeenCalledOnce()
-    // renderFn called with 'once' (the button decision), not 'reject'
+    // renderFn called with 'once' (the decision), not 'reject'
     const [, decision] = (renderFnB as ReturnType<typeof vi.fn>).mock.calls[0] as [unknown, string, ...unknown[]]
     expect(decision).toBe('once')
   })
@@ -680,7 +685,7 @@ describe('FIX 1 — cascadeReject skips claimed siblings', () => {
 // FIX 2: deadlineExpired flag — fail-close on button postReply failure after deadline
 // ---------------------------------------------------------------------------
 
-describe('FIX 2 — deadlineExpired: fail-close when button postReply fails after deadline fired', () => {
+describe('FIX 2 — deadlineExpired: fail-close when decision postReply fails after deadline fired', () => {
   beforeEach(() => {
     vi.useFakeTimers()
   })
@@ -702,12 +707,12 @@ describe('FIX 2 — deadlineExpired: fail-close when button postReply fails afte
     registry.register(makeParams({effects, deadlineMs: 5_000}))
     registry.attachMessage('per_1', renderFn)
 
-    // #when button is clicked (entry transitions to claimed)
-    const buttonClickPromise = registry.handleButtonDecision({
+    // #when decision is submitted (entry transitions to claimed)
+    const buttonClickPromise = registry.handleDecision({
       requestID: 'per_1',
-      channelID: 'chan_1',
+      approvalScopeId: 'chan_1',
       decision: 'once',
-      decidedBy: 'user_A',
+      actor: makeActor(),
     })
 
     // #when deadline fires while button is in-flight (no-op, sets deadlineExpired)
@@ -740,7 +745,7 @@ describe('FIX 2 — deadlineExpired: fail-close when button postReply fails afte
     expect(registry.has('per_1')).toBe(false)
   })
 
-  it('throw path — entry is fail-closed when button postReply throws after deadline fired', async () => {
+  it('throw path — entry is fail-closed when decision postReply throws after deadline fired', async () => {
     // #given an entry with a deadline
     const registry = createApprovalRegistry({logger: makeLogger()})
 
@@ -754,12 +759,12 @@ describe('FIX 2 — deadlineExpired: fail-close when button postReply fails afte
     registry.register(makeParams({effects, deadlineMs: 5_000}))
     registry.attachMessage('per_1', renderFn)
 
-    // #when button is clicked
-    const buttonClickPromise = registry.handleButtonDecision({
+    // #when decision is submitted
+    const buttonClickPromise = registry.handleDecision({
       requestID: 'per_1',
-      channelID: 'chan_1',
+      approvalScopeId: 'chan_1',
       decision: 'once',
-      decidedBy: 'user_A',
+      actor: makeActor(),
     })
 
     // #when deadline fires while button is in-flight
@@ -901,7 +906,13 @@ describe('P2 — confirmReply sessionID mismatch guard', () => {
     const logger = makeLogger()
     const registry = createApprovalRegistry({logger})
     const renderFn = makeRenderFn()
-    registry.register(makeParams({sessionID: 'ses_1', request: makeRequest({requestID: 'per_1', sessionID: 'ses_1'})}))
+    registry.register(
+      makeParams({
+        approvalScopeId: 'chan_1',
+        sessionID: 'ses_1',
+        request: makeRequest({requestID: 'per_1', sessionID: 'ses_1'}),
+      }),
+    )
     registry.attachMessage('per_1', renderFn)
 
     // #when confirmReply arrives with a different sessionID

--- a/packages/gateway/src/approvals/registry.ts
+++ b/packages/gateway/src/approvals/registry.ts
@@ -65,8 +65,8 @@ export interface DiscordApprovalActor {
 }
 
 /**
- * A future web operator who submitted an approval decision via the control surface (Phase B).
- * Shape is intentionally minimal — Phase B will extend this with session/auth fields.
+ * A future web operator who submitted an approval decision via the control surface.
+ * Shape is intentionally minimal — extend with session/auth fields when a web surface is added.
  */
 export interface WebOperatorActor {
   readonly kind: 'web-operator'

--- a/packages/gateway/src/approvals/registry.ts
+++ b/packages/gateway/src/approvals/registry.ts
@@ -1,10 +1,10 @@
 /**
  * Program-scoped approval registry bridge.
  *
- * Maps requestID → approval context across all in-flight runs so the Discord
- * button handler can: verify channel binding, claim exactly once
- * (single-winner), and POST the reply to OpenCode. All Discord/SDK side
- * effects are injected as closures — this module is pure and unit-testable.
+ * Maps requestID → approval context across all in-flight runs so any approval
+ * transport (Discord button, future web callback) can: verify scope binding,
+ * claim exactly once (single-winner), and POST the reply to OpenCode. All
+ * side effects are injected as closures — this module is pure and unit-testable.
  *
  * ### 3-state entry lifecycle
  *
@@ -51,11 +51,46 @@ import type {PermissionReply, PermissionReplyEvent, PermissionRequest, Settlemen
 // Public types
 // ---------------------------------------------------------------------------
 
-/** Render function injected after the Discord embed is posted successfully. */
+// ---------------------------------------------------------------------------
+// ApprovalActor — transport-neutral actor/operator identity
+// ---------------------------------------------------------------------------
+
+/**
+ * A Discord user who clicked an approval button.
+ */
+export interface DiscordApprovalActor {
+  readonly kind: 'discord-user'
+  /** Discord snowflake ID of the user who clicked the button. */
+  readonly userId: string
+}
+
+/**
+ * A future web operator who submitted an approval decision via the control surface (Phase B).
+ * Shape is intentionally minimal — Phase B will extend this with session/auth fields.
+ */
+export interface WebOperatorActor {
+  readonly kind: 'web-operator'
+  /** Stable operator identifier (e.g. GitHub login or internal operator ID). */
+  readonly operatorId: string
+}
+
+/**
+ * Transport-neutral actor identity for an approval decision.
+ *
+ * Discriminated on `kind` so callers can narrow without `as` casts:
+ * ```ts
+ * if (actor.kind === 'discord-user') {
+ *   // actor.userId is available here
+ * }
+ * ```
+ */
+export type ApprovalActor = DiscordApprovalActor | WebOperatorActor
+
+/** Render function injected after the approval embed/notification is posted successfully. */
 export type RenderFn = (
   request: PermissionRequest,
   decision: PermissionReply,
-  decidedBy: string | null,
+  actor: ApprovalActor | null,
   reason: SettlementReason,
 ) => Promise<void>
 
@@ -71,8 +106,17 @@ export interface ApprovalSideEffects {
 export interface RegisterParams {
   readonly requestID: string
   readonly sessionID: string
-  /** Thread/channel id where the embed will be posted — the binding. */
-  readonly channelID: string
+  /**
+   * Transport-neutral scope identifier for the approval entry.
+   *
+   * For Discord: the thread/channel ID where the embed is posted — used by the
+   * button handler to verify the interaction came from the correct channel.
+   * For a future web transport: an opaque scope token (e.g. session ID or
+   * request correlation ID) that the web callback verifies.
+   *
+   * Replaces the Discord-shaped `channelID` field.
+   */
+  readonly approvalScopeId: string
   /** Workspace dir for reply routing. */
   readonly directory: string
   readonly request: PermissionRequest
@@ -101,27 +145,32 @@ export type DecisionOutcome = 'ok' | 'not-found' | 'channel-mismatch' | 'already
 export type EntryState = 'open' | 'claimed' | 'confirmed'
 
 export interface ApprovalRegistry {
-  /** Register a new entry BEFORE sending the Discord embed. */
+  /** Register a new entry BEFORE sending the approval embed/notification. */
   register: (params: RegisterParams) => void
   /**
-   * Attach the settled-embed render function once the Discord message is
+   * Attach the settled-embed render function once the approval notification is
    * posted. Must be called after `register` and only when the send succeeds.
    */
   attachMessage: (requestID: string, renderFn: RenderFn) => void
   /**
-   * Mark that the Discord embed could not be posted. The entry stays
+   * Mark that the approval notification could not be posted. The entry stays
    * registered so the permission reply can still be POSTed on settlement;
-   * the embed edit step is skipped since there is nothing to edit.
+   * the render step is skipped since there is nothing to edit.
    */
   markMessagePostFailed: (requestID: string) => void
   has: (requestID: string) => boolean
   pending: () => readonly string[]
-  /** Button path: enforce channel binding, single-winner claim, POST reply. Does NOT edit the embed. */
-  handleButtonDecision: (args: {
+  /**
+   * Transport-neutral decision intake: enforce scope binding, single-winner
+   * claim, POST reply. Does NOT edit the embed/notification.
+   *
+   * Replaces the Discord-shaped `handleButtonDecision` method.
+   */
+  handleDecision: (args: {
     readonly requestID: string
-    readonly channelID: string
+    readonly approvalScopeId: string
     readonly decision: PermissionReply
-    readonly decidedBy: string
+    readonly actor: ApprovalActor
   }) => Promise<DecisionOutcome>
   /**
    * Authoritative settlement from `permission.replied`.
@@ -156,12 +205,12 @@ export interface ApprovalRegistry {
 interface RegistryEntry {
   readonly request: PermissionRequest
   readonly sessionID: string
-  readonly channelID: string
+  readonly approvalScopeId: string
   readonly directory: string
   readonly effects: ApprovalSideEffects
   state: EntryState
-  decidedBy: string | null
-  /** Set by attachMessage once the Discord embed is posted. */
+  actor: ApprovalActor | null
+  /** Set by attachMessage once the approval notification is posted. */
   renderFn: RenderFn | null
   /** Deadline timer handle — cleared on any terminal transition. */
   timer: ReturnType<typeof setTimeout> | null
@@ -206,7 +255,7 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
   ): Promise<void> {
     if (entry.renderFn !== null) {
       try {
-        await entry.renderFn(entry.request, decision, entry.decidedBy, reason)
+        await entry.renderFn(entry.request, decision, entry.actor, reason)
       } catch (error) {
         logger.error({requestID, reason, err: error}, 'ApprovalRegistry: renderFn threw during settlement — continuing')
       }
@@ -215,13 +264,13 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
 
   /**
    * Shared fail-close helper: POST reject + render 'deadline' + delete.
-   * Used by both the deadline open-path and the handleButtonDecision reset
+   * Used by both the deadline open-path and the handleDecision reset
    * path when deadlineExpired is true.
    */
   async function failCloseNow(requestID: string, entry: RegistryEntry): Promise<void> {
     logger.warn({requestID}, 'ApprovalRegistry: fail-closing entry (deadline already expired)')
     entry.state = 'claimed'
-    entry.decidedBy = null
+    entry.actor = null
     try {
       const r = await entry.effects.postReply(requestID, entry.directory, 'reject')
       if (!r.ok) {
@@ -242,7 +291,7 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
   // -------------------------------------------------------------------------
 
   function register(params: RegisterParams): void {
-    const {requestID, sessionID, channelID, directory, request, effects, deadlineMs, onDeadlineSettled} = params
+    const {requestID, sessionID, approvalScopeId, directory, request, effects, deadlineMs, onDeadlineSettled} = params
     if (entries.has(requestID)) {
       // FIX 3: clear the existing entry's timer before overwriting so the old
       // setTimeout cannot fire settleByDeadline on the replacement entry.
@@ -261,11 +310,11 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
     const entry: RegistryEntry = {
       request,
       sessionID,
-      channelID,
+      approvalScopeId,
       directory,
       effects,
       state: 'open',
-      decidedBy: null,
+      actor: null,
       renderFn: null,
       timer: null,
       deadlineExpired: false,
@@ -377,38 +426,38 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
   }
 
   // -------------------------------------------------------------------------
-  // handleButtonDecision
+  // handleDecision (transport-neutral decision intake)
   // -------------------------------------------------------------------------
 
-  async function handleButtonDecision(args: {
+  async function handleDecision(args: {
     readonly requestID: string
-    readonly channelID: string
+    readonly approvalScopeId: string
     readonly decision: PermissionReply
-    readonly decidedBy: string
+    readonly actor: ApprovalActor
   }): Promise<DecisionOutcome> {
-    const {requestID, channelID, decision, decidedBy} = args
+    const {requestID, approvalScopeId, decision, actor} = args
 
     const entry = entries.get(requestID)
     if (entry === undefined) {
       return 'not-found'
     }
 
-    if (entry.channelID !== channelID) {
+    if (entry.approvalScopeId !== approvalScopeId) {
       logger.warn(
-        {requestID, expected: entry.channelID, received: channelID},
-        'ApprovalRegistry: channel mismatch — ignoring button click',
+        {requestID, expected: entry.approvalScopeId, received: approvalScopeId},
+        'ApprovalRegistry: scope mismatch — ignoring decision',
       )
       return 'channel-mismatch'
     }
 
-    // Single-winner gate: claimed or confirmed both block a second click.
+    // Single-winner gate: claimed or confirmed both block a second decision.
     if (entry.state === 'claimed' || entry.state === 'confirmed') {
       return 'already-claimed'
     }
 
     // Atomic claim — transitions open → claimed
     entry.state = 'claimed'
-    entry.decidedBy = decidedBy
+    entry.actor = actor
 
     let result: {readonly ok: boolean; readonly error?: string}
     try {
@@ -422,7 +471,7 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
         void failCloseNow(requestID, entry)
       } else {
         entry.state = 'open'
-        entry.decidedBy = null
+        entry.actor = null
       }
       return 'reply-failed'
     }
@@ -438,7 +487,7 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
         void failCloseNow(requestID, entry)
       } else {
         entry.state = 'open'
-        entry.decidedBy = null
+        entry.actor = null
       }
       return 'reply-failed'
     }
@@ -476,9 +525,9 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
     clearTimer(entry)
 
     // Log if OpenCode's reply differs from our claimed decision (it wins).
-    if ((entry.state === 'claimed' || entry.state === 'confirmed') && entry.decidedBy !== null) {
+    if ((entry.state === 'claimed' || entry.state === 'confirmed') && entry.actor !== null) {
       // The reply is the echo of our POST. Render with OpenCode's reply.
-      logger.info({requestID, state: entry.state, reply}, 'ApprovalRegistry: confirmReply — button winner echo')
+      logger.info({requestID, state: entry.state, reply}, 'ApprovalRegistry: confirmReply — decision winner echo')
     } else {
       // Open entry: OpenCode-initiated (unsolicited reject or always-rule). No POST needed.
       logger.info({requestID, state: entry.state, reply}, 'ApprovalRegistry: confirmReply — OpenCode-initiated')
@@ -638,7 +687,7 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
     markMessagePostFailed,
     has,
     pending,
-    handleButtonDecision,
+    handleDecision,
     confirmReply,
     applySettlement,
     disposeRun,

--- a/packages/gateway/src/discord/io.boundary.test.ts
+++ b/packages/gateway/src/discord/io.boundary.test.ts
@@ -85,6 +85,13 @@ const ALLOWLISTED_FILES: readonly string[] = [
   // Contains `.send(` only in JSDoc block comments (not line comments) describing
   // the ReplySink interface contract. No runtime Discord calls here.
   'execute/launch-types.ts',
+
+  // Discord approval transport (Unit 4 — Phase A gateway control surface).
+  // Uses `replySink.send(...)` which is the transport-neutral ReplySink interface,
+  // NOT a raw Discord `.send()` call. The `allowedMentions:{parse:[]}` guard is
+  // enforced by the Discord adapter's ReplySink implementation in `runMention`.
+  // Also uses `editMessage(postedMessage, ...)` which IS the io.ts helper (not raw).
+  'approvals/discord-transport.ts',
 ]
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/discord/io.boundary.test.ts
+++ b/packages/gateway/src/discord/io.boundary.test.ts
@@ -73,7 +73,7 @@ const ALLOWLISTED_FILES: readonly string[] = [
   // Already sets allowedMentions:{parse:[]} and catches; same firm scope boundary.
   'execute/recovery.ts',
 
-  // Transport-neutral execution engine (Unit 2 — Phase A gateway control surface).
+  // Transport-neutral execution engine.
   // Uses `replySink.send(...)` which is the transport-neutral ReplySink interface,
   // NOT a raw Discord `.send()` call. The `allowedMentions:{parse:[]}` guard is
   // enforced by the Discord adapter's ReplySink implementation in `runMention`,
@@ -81,12 +81,12 @@ const ALLOWLISTED_FILES: readonly string[] = [
   // on the sink interface, not on a Discord Thread/Message object.
   'execute/run.ts',
 
-  // Transport-neutral type definitions (Unit 1 — Phase A gateway control surface).
+  // Transport-neutral type definitions.
   // Contains `.send(` only in JSDoc block comments (not line comments) describing
   // the ReplySink interface contract. No runtime Discord calls here.
   'execute/launch-types.ts',
 
-  // Discord approval transport (Unit 4 — Phase A gateway control surface).
+  // Discord approval transport.
   // Uses `replySink.send(...)` which is the transport-neutral ReplySink interface,
   // NOT a raw Discord `.send()` call. The `allowedMentions:{parse:[]}` guard is
   // enforced by the Discord adapter's ReplySink implementation in `runMention`.

--- a/packages/gateway/src/discord/io.boundary.test.ts
+++ b/packages/gateway/src/discord/io.boundary.test.ts
@@ -72,6 +72,19 @@ const ALLOWLISTED_FILES: readonly string[] = [
   // Deliberately-excluded best-effort site: recovery interruption note.
   // Already sets allowedMentions:{parse:[]} and catches; same firm scope boundary.
   'execute/recovery.ts',
+
+  // Transport-neutral execution engine (Unit 2 — Phase A gateway control surface).
+  // Uses `replySink.send(...)` which is the transport-neutral ReplySink interface,
+  // NOT a raw Discord `.send()` call. The `allowedMentions:{parse:[]}` guard is
+  // enforced by the Discord adapter's ReplySink implementation in `runMention`,
+  // not at the call site in the engine. The `.send(` pattern here is a method call
+  // on the sink interface, not on a Discord Thread/Message object.
+  'execute/run.ts',
+
+  // Transport-neutral type definitions (Unit 1 — Phase A gateway control surface).
+  // Contains `.send(` only in JSDoc block comments (not line comments) describing
+  // the ReplySink interface contract. No runtime Discord calls here.
+  'execute/launch-types.ts',
 ]
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/discord/mentions.test.ts
+++ b/packages/gateway/src/discord/mentions.test.ts
@@ -145,7 +145,7 @@ function makeRunMentionDeps(): MentionDeps['run'] {
       register: vi.fn(),
       has: vi.fn().mockReturnValue(false),
       pending: vi.fn().mockReturnValue([]),
-      handleButtonDecision: vi.fn().mockResolvedValue('ok'),
+      handleDecision: vi.fn().mockResolvedValue('ok'),
       applySettlement: vi.fn(),
       attachMessage: vi.fn(),
       markMessagePostFailed: vi.fn(),

--- a/packages/gateway/src/execute/launch-types.ts
+++ b/packages/gateway/src/execute/launch-types.ts
@@ -1,0 +1,430 @@
+/**
+ * Transport-neutral types for the `launchWork` execution engine.
+ *
+ * ## Design contract
+ *
+ * `LaunchWorkRequest` carries everything the engine needs to execute a unit of
+ * work without knowing the transport. The Discord adapter (`runMention`) maps a
+ * Discord `Message` → `LaunchWorkRequest`, constructs concrete `StatusSink` and
+ * `ReplySink` implementations over the existing Discord live-status/typing flow,
+ * and calls `launchWork`. A future web adapter (Phase B) will do the same with
+ * SSE or WebSocket implementations.
+ *
+ * ## Sink contract
+ *
+ * - `StatusSink` — the engine calls these methods to manage the working-state UX
+ *   (typing indicator, status message, source-message reactions). The Discord
+ *   adapter implements this by adapting `createStatusController` from
+ *   `discord/status-message.ts` and `setRunReaction` from `discord/reactions.ts`.
+ *   Do NOT reimplement `statusMode` logic — wrap the existing controller.
+ *
+ * - `ReplySink` — the engine calls these methods to deliver output and ephemeral
+ *   acks. The Discord adapter implements this over `createDiscordStreamSink` (for
+ *   streaming output) and `sendMessage`/`io.ts` (for acks). The `send` method
+ *   accepts `MessageContentOptions` from `discord/io.ts` so the Discord
+ *   implementation needs no cast at the call site.
+ *
+ * ## Phase B implementers
+ *
+ * To add a new transport:
+ * 1. Implement `StatusSink` (typing/progress/reaction equivalents for your transport).
+ * 2. Implement `ReplySink` (streaming output + ack delivery for your transport).
+ * 3. Construct a `LaunchWorkRequest` with a `RequesterIdentity` discriminated on
+ *    `kind: 'web-operator'` (or a new variant) and call `launchWork`.
+ * 4. The engine, queue, concurrency cap, lock, run-state, and approval registry
+ *    are all transport-agnostic — you get them for free.
+ */
+
+import type {RepoBinding} from '../bindings/types.js'
+import type {MessageContentOptions} from '../discord/io.js'
+import type {TransitionResult} from '../discord/status-message.js'
+
+// ---------------------------------------------------------------------------
+// RequesterIdentity — discriminated union for transport-neutral caller identity
+// ---------------------------------------------------------------------------
+
+/**
+ * A Discord user who triggered the run via a mention.
+ * `userId` is the Discord snowflake ID of the requester.
+ */
+export interface DiscordRequesterIdentity {
+  readonly kind: 'discord-user'
+  readonly userId: string
+}
+
+/**
+ * A future web operator who triggered the run via the control surface (Phase B).
+ * Shape is intentionally minimal — Phase B will extend this with session/auth fields.
+ */
+export interface WebOperatorIdentity {
+  readonly kind: 'web-operator'
+  /** Stable operator identifier (e.g. GitHub login or internal operator ID). */
+  readonly operatorId: string
+}
+
+/**
+ * Transport-neutral requester identity.
+ *
+ * Discriminated on `kind` so callers can narrow without `as` casts:
+ * ```ts
+ * if (request.requester.kind === 'discord-user') {
+ *   // request.requester.userId is available here
+ * }
+ * ```
+ */
+export type RequesterIdentity = DiscordRequesterIdentity | WebOperatorIdentity
+
+// ---------------------------------------------------------------------------
+// RunReactionState — transport-neutral reaction lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * The four states the engine transitions the source-message reaction through.
+ * Maps to the four `setRunReaction` calls in `run.ts` (`:370`, `:465`, `:574`, `:635`).
+ *
+ * The Discord adapter maps these to emoji reactions; a future transport may map
+ * them to status badges, SSE events, or no-ops.
+ */
+export type RunReactionState = 'working' | 'awaiting-approval' | 'succeeded' | 'failed'
+
+// ---------------------------------------------------------------------------
+// StatusSink — transport-neutral working-state UX
+// ---------------------------------------------------------------------------
+
+/**
+ * Transport-neutral interface for the engine's working-state UX.
+ *
+ * The engine calls these methods to manage the typing indicator, status message,
+ * and source-message reaction lifecycle. The Discord adapter implements this by
+ * wrapping `createStatusController` (from `discord/status-message.ts`) and
+ * `setRunReaction` (from `discord/reactions.ts`).
+ *
+ * ## Discord adapter pattern
+ *
+ * ```ts
+ * // In the Discord adapter (Unit 3):
+ * const statusController = createStatusController({ thread, mode: statusMode, logger })
+ * const statusSink: StatusSink = {
+ *   noteActivity: summary => statusController.noteActivity(summary),
+ *   setBusy: busy => statusController.setBusy(busy),
+ *   resolveToAnswer: text => statusController.resolveToAnswer(text),
+ *   resolveToFailure: note => statusController.resolveToFailure(note),
+ *   dispose: () => statusController.dispose(),
+ *   setReaction: state => setRunReaction(message, state, logger),
+ * }
+ * ```
+ *
+ * ## Phase B implementers
+ *
+ * A web transport may implement `noteActivity` as an SSE push, `setBusy` as a
+ * WebSocket heartbeat, and `setReaction` as a no-op or a status-badge update.
+ * The engine does not care — it only calls these methods.
+ */
+export interface StatusSink {
+  /**
+   * Record an essential-action summary and schedule a debounced status update.
+   * In `typing-only` mode (Discord), this is a no-op — the adapter decides.
+   * No-ops once a terminal transition has begun.
+   *
+   * Maps to `statusController.noteActivity(summary)` in the Discord adapter.
+   * Called by the engine's `onActivity` callback (`:558-560` in `run.ts`).
+   */
+  readonly noteActivity: (summary: string) => void
+
+  /**
+   * Start or stop the typing/busy indicator.
+   * - `true`: start pulsing (immediately and on a recurring interval).
+   * - `false`: stop pulsing (e.g. during an approval wait).
+   *
+   * Maps to `statusController.setBusy(busy)` in the Discord adapter.
+   * Called by the engine's `onBusy` callback (`:561-563` in `run.ts`).
+   */
+  readonly setBusy: (busy: boolean) => void
+
+  /**
+   * Settle, then resolve the status surface into the final answer.
+   * - `'handled'`: the sink delivered the answer in-place (e.g. edited the status
+   *   message); the engine must NOT flush the reply sink.
+   * - `'delegated'`: the sink could not deliver in-place; the engine must flush
+   *   the reply sink to deliver the answer.
+   *
+   * Maps to `statusController.resolveToAnswer(text)` in the Discord adapter.
+   * Called by the engine after `runOpenCodeCore` succeeds (`:608` in `run.ts`).
+   */
+  readonly resolveToAnswer: (text: string) => Promise<TransitionResult>
+
+  /**
+   * Settle, then resolve the status surface into a failure note.
+   * - `'handled'`: the sink delivered the failure note in-place.
+   * - `'delegated'`: the engine must post the failure note via `replySink.send`.
+   *
+   * Maps to `statusController.resolveToFailure(note)` in the Discord adapter.
+   * Called by the engine in the error path (`:696` in `run.ts`).
+   */
+  readonly resolveToFailure: (note: string) => Promise<TransitionResult>
+
+  /**
+   * Settle and clear all timers. Idempotent. Must be called in the run's
+   * `finally` block to guarantee no timer leaks.
+   *
+   * Maps to `statusController.dispose()` in the Discord adapter.
+   * Called by the engine's inner `finally` (`:716` in `run.ts`).
+   */
+  readonly dispose: () => Promise<void>
+
+  /**
+   * Transition the source-message reaction to reflect the current run state.
+   * Best-effort, fire-and-forget — failures must not abort the run.
+   *
+   * Maps to `setRunReaction(message, state, logger)` in the Discord adapter.
+   * Called at four points in the engine:
+   * - `'working'`          after EXECUTING transition (`:370`)
+   * - `'awaiting-approval'` when an approval is pending (`:465`)
+   * - `'succeeded'`        after `runOpenCodeCore` completes (`:574`)
+   * - `'failed'`           in the error path (`:635`)
+   */
+  readonly setReaction: (state: RunReactionState) => void
+}
+
+// ---------------------------------------------------------------------------
+// ReplySink — transport-neutral output + ack delivery
+// ---------------------------------------------------------------------------
+
+/**
+ * Transport-neutral interface for delivering run output and ephemeral acks.
+ *
+ * The engine uses two delivery modes:
+ * 1. **Streaming output** — `append`/`flush`/`buffered` for the agent's text
+ *    output (maps to `DiscordStreamSink` from `discord/streaming.ts`).
+ * 2. **Acks and failure notes** — `send` for pre-thread and post-thread
+ *    ephemeral messages (maps to `sendMessage` from `discord/io.ts`).
+ *
+ * ## Discord adapter pattern
+ *
+ * ```ts
+ * // In the Discord adapter (Unit 3):
+ * const streamSink = createDiscordStreamSink(thread, { logger })
+ * const replySink: ReplySink = {
+ *   // Streaming output — delegate to DiscordStreamSink
+ *   append: text => streamSink.append(text),
+ *   flush: () => streamSink.flush(),
+ *   buffered: () => streamSink.buffered(),
+ *   hasVisibleOutput: () => streamSink.hasVisibleOutput(),
+ *   markVisibleOutputSent: () => streamSink.markVisibleOutputSent(),
+ *   markVisibleOutputPending: () => streamSink.markVisibleOutputPending(),
+ *   // Acks — delegate to sendMessage (pre-thread: message; post-thread: thread)
+ *   send: (target, options) => sendMessage(target, options, logger),
+ * }
+ * ```
+ *
+ * ## Phase B implementers
+ *
+ * A web transport may implement `append`/`flush` as SSE pushes, `buffered` as
+ * an in-memory accumulator, and `send` as an HTTP response write. The engine
+ * does not care — it only calls these methods.
+ */
+export interface ReplySink {
+  // ── Streaming output (maps to DiscordStreamSink) ──────────────────────────
+
+  /**
+   * Append a text delta to the internal buffer.
+   * Called on each text event from the OpenCode event stream.
+   *
+   * Maps to `sink.append(text)` in the Discord adapter.
+   */
+  readonly append: (text: string) => void
+
+  /**
+   * Flush the current buffer to the transport.
+   * - Short text: single delivery.
+   * - Long text: summary + attachment (Discord) or chunked (web).
+   * - Empty/whitespace with no prior visible output: "no output" placeholder.
+   * - Empty/whitespace with prior visible output: no-op (`skipped-visible`).
+   *
+   * Maps to `sink.flush()` in the Discord adapter.
+   * Called after `runOpenCodeCore` completes (`:610` in `run.ts`).
+   */
+  readonly flush: () => Promise<unknown>
+
+  /**
+   * Read the current buffered text without flushing.
+   * Used by the engine to pass the buffered text to `statusSink.resolveToAnswer`
+   * before deciding whether to flush (`:607` in `run.ts`).
+   */
+  readonly buffered: () => string
+
+  /**
+   * Returns `true` if visible output has been delivered — either via a successful
+   * flush, via `markVisibleOutputSent`, or via a pending out-of-band send.
+   * Used by the engine to classify timeout messages (`:677` in `run.ts`).
+   */
+  readonly hasVisibleOutput: () => boolean
+
+  /**
+   * Mark that visible output has already been delivered outside the buffer
+   * (e.g. an approval waiting status). When set, `flush()` will NOT post a
+   * "no output" placeholder for an empty buffer.
+   *
+   * Maps to `sink.markVisibleOutputSent()` in the Discord adapter.
+   */
+  readonly markVisibleOutputSent: () => void
+
+  /**
+   * Mark an out-of-band visible send as in-flight. Returns a one-shot settle
+   * handle: `settle(true)` promotes to permanently delivered; `settle(false)`
+   * retracts the pending claim.
+   *
+   * Maps to `sink.markVisibleOutputPending()` in the Discord adapter.
+   * Used in the approval `onPending` closure (`:476`, `:493` in `run.ts`).
+   */
+  readonly markVisibleOutputPending: () => (delivered: boolean) => void
+
+  // ── Acks and failure notes (maps to sendMessage via io.ts) ────────────────
+
+  /**
+   * Send an ephemeral ack or failure note to the transport.
+   *
+   * Accepts `MessageContentOptions` from `discord/io.ts` so the Discord
+   * implementation (`sendMessage`) is structurally assignable without a cast.
+   * A web implementation may map `content` to an HTTP response body or SSE event.
+   *
+   * Used for:
+   * - Pre-thread acks on the source message (clone fail, not-ready, cap, queued)
+   *   — `:229`, `:252`, `:264`, `:793-803`, `:822` in `run.ts`
+   * - Post-thread acks on the thread (lock held, createRun fail, transition fail,
+   *   failure note when `resolveToFailure` delegates) — `:277`, `:284`, `:313`,
+   *   `:331`, `:701` in `run.ts`
+   * - Approval waiting status and deadline timeout — `:451`, `:478` in `run.ts`
+   *
+   * The Discord adapter routes pre-thread sends to `sendMessage(message, ...)` and
+   * post-thread sends to `sendMessage(thread, ...)`. The engine passes a
+   * `ReplySinkTarget` discriminant so the adapter can route correctly.
+   */
+  readonly send: (target: ReplySinkTarget, options: MessageContentOptions) => Promise<unknown>
+}
+
+// ---------------------------------------------------------------------------
+// ReplySinkTarget — routing discriminant for send()
+// ---------------------------------------------------------------------------
+
+/**
+ * Routing discriminant passed to `ReplySink.send` so the adapter can route
+ * pre-thread sends (to the source message) vs post-thread sends (to the thread).
+ *
+ * The Discord adapter maps:
+ * - `'source'` → `sendMessage(message, options, logger)` (reply to the original mention)
+ * - `'thread'` → `sendMessage(thread, options, logger)` (send to the run thread)
+ *
+ * A web adapter may ignore this discriminant if it has a single delivery channel,
+ * or map it to different SSE event types.
+ */
+export type ReplySinkTarget = 'source' | 'thread'
+
+// ---------------------------------------------------------------------------
+// LaunchWorkRequest — transport-neutral engine input
+// ---------------------------------------------------------------------------
+
+/**
+ * Transport-neutral input to the `launchWork` execution engine.
+ *
+ * Carries everything the engine needs to execute a unit of work without
+ * knowing the transport. The Discord adapter (`runMention`) constructs this
+ * from a Discord `Message`; a future web adapter (Phase B) constructs it from
+ * an authenticated HTTP request.
+ *
+ * ## Field derivation from `startRun` Message reads
+ *
+ * | `Message` read in `run.ts`                        | → `LaunchWorkRequest` field      |
+ * |---------------------------------------------------|----------------------------------|
+ * | `message.channel.id` (`:205`, `:807`)             | `channelId`                      |
+ * | `message.content` (`:376-382`)                    | `promptText`                     |
+ * | `surface: 'discord'` (`:273`, `:300`)             | `surface`                        |
+ * | `sendMessage(message, ...)` pre-thread acks       | `replySink.send('source', ...)`  |
+ * | `message.startThread(...)` (`:259-268`)           | `statusSink` (adapter creates thread, passes it to status controller) |
+ * | `setRunReaction(message, ...)` (`:370`, `:465`, `:574`, `:635`) | `statusSink.setReaction(state)` |
+ * | `createStatusController({thread, mode})` (`:347`) | `statusSink` (wraps controller)  |
+ * | `createDiscordStreamSink(thread)` (`:375`)        | `replySink` (wraps stream sink)  |
+ * | `sendMessage(thread, ...)` post-thread acks       | `replySink.send('thread', ...)`  |
+ *
+ * ## Usage
+ *
+ * ```ts
+ * // Discord adapter (Unit 3):
+ * const request: LaunchWorkRequest = {
+ *   promptText: stripMention(message.content, deps.botUserId),
+ *   channelId: message.channel.id,
+ *   guildId: message.guild?.id,
+ *   surface: 'discord',
+ *   binding,
+ *   requester: { kind: 'discord-user', userId: message.author.id },
+ *   statusSink,   // wraps createStatusController + setRunReaction
+ *   replySink,    // wraps createDiscordStreamSink + sendMessage
+ * }
+ * await launchWork(request, deps)
+ * ```
+ */
+export interface LaunchWorkRequest {
+  /**
+   * The prompt text to send to the agent.
+   *
+   * Must be a fully-stripped, non-empty string. The Discord adapter strips the
+   * bot mention via `botUserId` and fails fast on an empty result BEFORE calling
+   * `launchWork` (the accepted Phase A behavior change — see plan KTD). The engine
+   * does not re-strip or re-validate the prompt.
+   *
+   * Derived from `message.content` (`:376-382` in `run.ts`).
+   */
+  readonly promptText: string
+
+  /**
+   * The channel ID scoping the per-channel FIFO queue and concurrency slot.
+   *
+   * Derived from `message.channel.id` (`:205`, `:807` in `run.ts`).
+   */
+  readonly channelId: string
+
+  /**
+   * The guild (server) ID, if available. Used for logging and source metadata.
+   * `undefined` for DM channels or non-guild contexts.
+   */
+  readonly guildId: string | undefined
+
+  /**
+   * Transport-neutral surface identifier written into lock and run-state records.
+   * Replaces the hardcoded `'discord'` literal (`:273`, `:300` in `run.ts`) so
+   * a future web run is not recorded as a Discord run.
+   *
+   * The Discord adapter passes `'discord'`; a Phase B web adapter passes `'web'`.
+   */
+  readonly surface: string
+
+  /**
+   * The repo binding (owner, repo, channelId, workspacePath, …).
+   * Carried unchanged from `RunTask.binding`.
+   */
+  readonly binding: RepoBinding
+
+  /**
+   * Transport-neutral requester identity.
+   * Discriminated on `kind` — `'discord-user'` today; `'web-operator'` in Phase B.
+   */
+  readonly requester: RequesterIdentity
+
+  /**
+   * Working-state UX sink. The engine calls these methods to manage the typing
+   * indicator, status message, and source-message reaction lifecycle.
+   *
+   * The Discord adapter implements this by wrapping `createStatusController` and
+   * `setRunReaction`. See `StatusSink` for the full contract.
+   */
+  readonly statusSink: StatusSink
+
+  /**
+   * Output and ack delivery sink. The engine calls these methods to deliver
+   * streaming output and ephemeral acks.
+   *
+   * The Discord adapter implements this by wrapping `createDiscordStreamSink` and
+   * `sendMessage`. See `ReplySink` for the full contract.
+   */
+  readonly replySink: ReplySink
+}

--- a/packages/gateway/src/execute/launch-types.ts
+++ b/packages/gateway/src/execute/launch-types.ts
@@ -377,6 +377,30 @@ export interface LaunchWorkRequest {
   readonly promptText: string
 
   /**
+   * Optional thread factory called by the engine after `ensureClone` and `readyz`
+   * pass, before lock acquisition.
+   *
+   * The Discord adapter provides this to create the response thread at the right
+   * point in the pipeline (after gates pass, before lock). The factory creates the
+   * Discord thread, initializes the real `StatusSink`/`ReplySink` implementations
+   * (replacing any deferred proxies), and returns the thread ID for run-state.
+   *
+   * When absent (e.g. in-memory sink tests or future web transports that don't
+   * need a thread), the engine uses an empty string as the thread ID in run-state.
+   *
+   * This is the seam that keeps thread creation in the adapter while letting the
+   * engine trigger it at the correct pipeline stage. The engine never imports
+   * Discord types — it only calls this opaque factory.
+   *
+   * Returns `{ok: true, threadId}` on success or `{ok: false, error}` on failure.
+   * On failure the engine sends a coarse error via `replySink.send('source', ...)`
+   * and aborts the run (same behavior as the current `startThread` error path).
+   */
+  readonly threadFactory?: () => Promise<
+    {readonly ok: true; readonly threadId: string} | {readonly ok: false; readonly error: string}
+  >
+
+  /**
    * The channel ID scoping the per-channel FIFO queue and concurrency slot.
    *
    * Derived from `message.channel.id` (`:205`, `:807` in `run.ts`).

--- a/packages/gateway/src/execute/launch-types.ts
+++ b/packages/gateway/src/execute/launch-types.ts
@@ -7,8 +7,8 @@
  * work without knowing the transport. The Discord adapter (`runMention`) maps a
  * Discord `Message` → `LaunchWorkRequest`, constructs concrete `StatusSink` and
  * `ReplySink` implementations over the existing Discord live-status/typing flow,
- * and calls `launchWork`. A future web adapter (Phase B) will do the same with
- * SSE or WebSocket implementations.
+ * and calls `launchWork`. A future web adapter will do the same with SSE or
+ * WebSocket implementations.
  *
  * ## Sink contract
  *
@@ -24,7 +24,7 @@
  *   accepts `MessageContentOptions` from `discord/io.ts` so the Discord
  *   implementation needs no cast at the call site.
  *
- * ## Phase B implementers
+ * ## Adding a new transport
  *
  * To add a new transport:
  * 1. Implement `StatusSink` (typing/progress/reaction equivalents for your transport).
@@ -53,8 +53,8 @@ export interface DiscordRequesterIdentity {
 }
 
 /**
- * A future web operator who triggered the run via the control surface (Phase B).
- * Shape is intentionally minimal — Phase B will extend this with session/auth fields.
+ * A future web operator who triggered the run via the control surface.
+ * Shape is intentionally minimal — extend with session/auth fields when a web surface is added.
  */
 export interface WebOperatorIdentity {
   readonly kind: 'web-operator'
@@ -102,7 +102,7 @@ export type RunReactionState = 'working' | 'awaiting-approval' | 'succeeded' | '
  * ## Discord adapter pattern
  *
  * ```ts
- * // In the Discord adapter (Unit 3):
+ * // In the Discord adapter:
  * const statusController = createStatusController({ thread, mode: statusMode, logger })
  * const statusSink: StatusSink = {
  *   noteActivity: summary => statusController.noteActivity(summary),
@@ -114,7 +114,7 @@ export type RunReactionState = 'working' | 'awaiting-approval' | 'succeeded' | '
  * }
  * ```
  *
- * ## Phase B implementers
+ * ## Web transport implementers
  *
  * A web transport may implement `noteActivity` as an SSE push, `setBusy` as a
  * WebSocket heartbeat, and `setReaction` as a no-op or a status-badge update.
@@ -202,7 +202,7 @@ export interface StatusSink {
  * ## Discord adapter pattern
  *
  * ```ts
- * // In the Discord adapter (Unit 3):
+ * // In the Discord adapter:
  * const streamSink = createDiscordStreamSink(thread, { logger })
  * const replySink: ReplySink = {
  *   // Streaming output — delegate to DiscordStreamSink
@@ -217,7 +217,7 @@ export interface StatusSink {
  * }
  * ```
  *
- * ## Phase B implementers
+ * ## Web transport implementers
  *
  * A web transport may implement `append`/`flush` as SSE pushes, `buffered` as
  * an in-memory accumulator, and `send` as an HTTP response write. The engine
@@ -329,10 +329,10 @@ export type ReplySinkTarget = 'source' | 'thread'
  *
  * Carries everything the engine needs to execute a unit of work without
  * knowing the transport. The Discord adapter (`runMention`) constructs this
- * from a Discord `Message`; a future web adapter (Phase B) constructs it from
- * an authenticated HTTP request.
+ * from a Discord `Message`; a future web adapter constructs it from an
+ * authenticated HTTP request.
  *
- * ## Field derivation from `startRun` Message reads
+ * ## Field derivation from Discord Message reads
  *
  * | `Message` read in `run.ts`                        | → `LaunchWorkRequest` field      |
  * |---------------------------------------------------|----------------------------------|
@@ -349,7 +349,7 @@ export type ReplySinkTarget = 'source' | 'thread'
  * ## Usage
  *
  * ```ts
- * // Discord adapter (Unit 3):
+ * // Discord adapter:
  * const request: LaunchWorkRequest = {
  *   promptText: stripMention(message.content, deps.botUserId),
  *   channelId: message.channel.id,
@@ -369,8 +369,8 @@ export interface LaunchWorkRequest {
    *
    * Must be a fully-stripped, non-empty string. The Discord adapter strips the
    * bot mention via `botUserId` and fails fast on an empty result BEFORE calling
-   * `launchWork` (the accepted Phase A behavior change — see plan KTD). The engine
-   * does not re-strip or re-validate the prompt.
+   * `launchWork`. The engine also validates at the front door. Neither re-strips
+   * nor re-validates the prompt text beyond the empty check.
    *
    * Derived from `message.content` (`:376-382` in `run.ts`).
    */
@@ -415,10 +415,11 @@ export interface LaunchWorkRequest {
 
   /**
    * Transport-neutral surface identifier written into lock and run-state records.
-   * Replaces the hardcoded `'discord'` literal (`:273`, `:300` in `run.ts`) so
-   * a future web run is not recorded as a Discord run.
+   * Allows a future web run to be recorded as `'web'` rather than `'discord'`.
    *
-   * The Discord adapter passes `'discord'`; a Phase B web adapter passes `'web'`.
+   * The Discord adapter passes `'discord'`; a web adapter passes `'web'`.
+   * surface is a string for transport-neutrality; runtime Surface is currently
+   * 'github'|'discord' — widen when a web surface is added.
    */
   readonly surface: string
 
@@ -430,7 +431,7 @@ export interface LaunchWorkRequest {
 
   /**
    * Transport-neutral requester identity.
-   * Discriminated on `kind` — `'discord-user'` today; `'web-operator'` in Phase B.
+   * Discriminated on `kind` — `'discord-user'` today; `'web-operator'` when a web surface is added.
    */
   readonly requester: RequesterIdentity
 

--- a/packages/gateway/src/execute/run-core.ts
+++ b/packages/gateway/src/execute/run-core.ts
@@ -24,7 +24,6 @@
 import type {OpenCodeServerHandle} from '@fro-bot/runtime'
 import type {PermissionCoordinator} from '../approvals/coordinator.js'
 import type {GatewayLogger} from '../discord/client.js'
-import type {DiscordStreamSink} from '../discord/streaming.js'
 
 import {parsePermissionReply, parsePermissionRequest} from '../approvals/coordinator.js'
 import {formatToolPart} from './format-part.js'
@@ -60,6 +59,26 @@ export class RunCoreError extends Error {
 }
 
 // ---------------------------------------------------------------------------
+// Minimal sink interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal streaming sink interface required by `runOpenCodeCore`.
+ *
+ * `runOpenCodeCore` only calls `sink.append(text)` — it never calls `flush()`,
+ * `buffered()`, or any other method. The caller (`run.ts`) is responsible for
+ * flushing after `runOpenCodeCore` resolves.
+ *
+ * Both `ReplySink` (from `execute/launch-types.ts`) and `DiscordStreamSink`
+ * (from `discord/streaming.ts`) satisfy this interface structurally, so no
+ * cast is needed at the call site in `run.ts`.
+ */
+export interface CoreStreamSink {
+  /** Append a text delta to the internal buffer. */
+  readonly append: (text: string) => void
+}
+
+// ---------------------------------------------------------------------------
 // Params
 // ---------------------------------------------------------------------------
 
@@ -82,8 +101,11 @@ export interface RunCoreParams {
    * Streaming sink that receives text deltas.
    * Caller is responsible for calling `sink.flush()` after `runOpenCodeCore`
    * resolves (`run.ts` does this after transitioning to COMPLETED).
+   *
+   * Typed as `CoreStreamSink` (only `append` required) so both `ReplySink` and
+   * `DiscordStreamSink` are structurally assignable without a cast.
    */
-  readonly sink: DiscordStreamSink
+  readonly sink: CoreStreamSink
   /** Abort signal — aborts event iteration when signalled. */
   readonly signal: AbortSignal
   /** Injected logger. Internal details only — never leak session internals to Discord. */
@@ -190,7 +212,7 @@ interface ToolCallInfo {
  */
 function appendToolSummary(
   part: import('./format-part.js').ExtractedToolPart,
-  sink: DiscordStreamSink,
+  sink: CoreStreamSink,
   logger: GatewayLogger,
   onActivity?: (summary: string) => void,
 ): void {

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -7,7 +7,7 @@ import type {ChannelQueue} from './queue.js'
 import type {RunMentionDeps, RunTask} from './run.js'
 
 import * as runtimeModule from '@fro-bot/runtime'
-import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import * as coordinatorModule from '../approvals/coordinator.js'
 import * as discordApprovalsModule from '../discord/approvals.js'
 import * as reactionsModule from '../discord/reactions.js'
@@ -3957,12 +3957,11 @@ describe('formatTimeoutDuration', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Characterization tests — pin current Discord behavior as a zero-regression
-// gate for the Phase A refactor (Units 1–4).
+// Characterization tests — pin current Discord behavior as a zero-regression gate.
 //
 // These tests assert CURRENT observable behavior via the existing Message-based
 // entry points. They must be GREEN on unmodified production code and must
-// remain green after the refactor.
+// remain green after any refactor.
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
@@ -4445,16 +4444,13 @@ describe('statusMode typing-only: typing indicator only, no status message', () 
 // ---------------------------------------------------------------------------
 // EMPTY-PROMPT fail-fast: bare @fro-bot mention → immediate reply on source message
 //
-// Phase A Unit 3 behavior (post-change): the adapter strips the bot mention and
-// detects an empty prompt BEFORE calling launchWork. It replies on the SOURCE
-// message (not a thread), creates no thread, acquires no lock, writes no run-state.
-//
-// This deliberately changes the Unit 0 baseline (which surfaced EmptyPromptError
-// late in-thread after thread creation and lock acquisition). The change is an
-// accepted Phase A behavior delta — see plan KTD.
+// The adapter strips the bot mention and detects an empty prompt BEFORE calling
+// launchWork. It replies on the SOURCE message (not a thread), creates no thread,
+// acquires no lock, writes no run-state. This avoids the late EmptyPromptError
+// path (which surfaced in-thread after thread creation and lock acquisition).
 // ---------------------------------------------------------------------------
 
-describe('empty-prompt fail-fast: bare mention → immediate reply on source message (post-Unit-3 behavior)', () => {
+describe('empty-prompt fail-fast: bare mention → immediate reply on source message', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -4552,7 +4548,7 @@ describe('empty-prompt fail-fast: bare mention → immediate reply on source mes
 })
 
 // ---------------------------------------------------------------------------
-// launchWork — in-memory sink tests (Unit 2)
+// launchWork — in-memory sink tests
 //
 // These tests prove the engine runs with no Discord/Message dependency.
 // They use in-memory StatusSink/ReplySink implementations and verify:
@@ -4684,7 +4680,7 @@ function makeInMemoryRequest(
   }
 }
 
-describe('launchWork — in-memory sink tests (Unit 2)', () => {
+describe('launchWork — in-memory sink tests', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -4968,4 +4964,118 @@ describe('launchWork — in-memory sink tests (Unit 2)', () => {
     // The replySink is provided by the caller, not created internally
     expect(mockCreateDiscordStreamSink).not.toHaveBeenCalled()
   })
+})
+
+// ---------------------------------------------------------------------------
+// threadFactory failure path (FIX 4)
+// ---------------------------------------------------------------------------
+
+describe('threadFactory failure path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('threadFactory returns {ok:false} → replySink.send called with error message, acquireLock NOT called, createRun NOT called, transitionRun NOT called, slot released', async () => {
+    // #given — threadFactory fails immediately
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    const thread = makeThread()
+    const message = makeMessage(thread)
+    // Override startThread to return a rejected promise so threadFactory fails
+    ;(message.startThread as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Discord thread creation failed'))
+
+    const releaseFn = vi.fn()
+    const deps = makeDeps({
+      concurrency: {
+        tryAcquire: vi.fn().mockReturnValue('ok'),
+        release: releaseFn,
+        activeCount: vi.fn().mockReturnValue(1),
+        max: 3,
+      },
+    })
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — replySink.send called with coarse error message (via message.reply for 'source' target)
+    expect(message.reply).toHaveBeenCalledOnce()
+    const replyCall = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {content: string}
+    expect(replyCall.content).toContain('Could not start the task')
+
+    // #and — acquireLock NOT called (threadFactory failed before lock acquisition)
+    expect(mockRuntime.acquireLock).not.toHaveBeenCalled()
+
+    // #and — createRun NOT called (no lock acquired)
+    expect(mockRuntime.createRun).not.toHaveBeenCalled()
+
+    // #and — transitionRun NOT called (no run-state created)
+    expect(mockRuntime.transitionRun).not.toHaveBeenCalled()
+
+    // #and — concurrency slot released (no leak)
+    expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// threadFactory timeout path (FIX 5)
+// ---------------------------------------------------------------------------
+
+/** Bounded timeout for threadFactory calls (ms). Mirrors the constant in run.ts. */
+const THREAD_FACTORY_TIMEOUT_MS = 10_000
+
+describe('threadFactory timeout path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('threadFactory that never resolves → times out, replySink.send called with error, acquireLock NOT called, slot released', async () => {
+    // #given — threadFactory hangs indefinitely (simulates a hung Discord API call)
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    const thread = makeThread()
+    const message = makeMessage(thread)
+    // startThread returns a promise that never resolves — simulates a hung Discord call
+    const neverResolves = new Promise<never>(() => {
+      /* intentionally never resolves */
+    })
+    ;(message.startThread as ReturnType<typeof vi.fn>).mockReturnValue(neverResolves)
+
+    const releaseFn = vi.fn()
+    const deps = makeDeps({
+      concurrency: {
+        tryAcquire: vi.fn().mockReturnValue('ok'),
+        release: releaseFn,
+        activeCount: vi.fn().mockReturnValue(1),
+        max: 3,
+      },
+    })
+
+    // #when — start the run; advance fake timers past the threadFactory timeout while it's pending
+    // We must interleave timer advancement with the awaited promise so the setTimeout fires.
+    const runPromise = runMention(message, makeBinding(), deps)
+    // Advance past the threadFactory timeout (setTimeout in run.ts fires)
+    await vi.advanceTimersByTimeAsync(THREAD_FACTORY_TIMEOUT_MS + 100)
+    // Now the timeout rejection should have propagated; await the run to completion
+    await runPromise
+
+    // #then — replySink.send called with coarse error (via message.reply for 'source' target)
+    expect(message.reply).toHaveBeenCalledOnce()
+    const replyCall = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {content: string}
+    expect(replyCall.content).toContain('Could not start the task')
+
+    // #and — acquireLock NOT called (threadFactory timed out before lock acquisition)
+    expect(mockRuntime.acquireLock).not.toHaveBeenCalled()
+
+    // #and — createRun NOT called
+    expect(mockRuntime.createRun).not.toHaveBeenCalled()
+
+    // #and — concurrency slot released (no leak)
+    expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
+  }, 15_000)
 })

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -182,7 +182,7 @@ function makeApprovalRegistry(): ApprovalRegistry {
     register: vi.fn(),
     has: vi.fn().mockReturnValue(false),
     pending: vi.fn().mockReturnValue([]),
-    handleButtonDecision: vi.fn().mockResolvedValue('ok'),
+    handleDecision: vi.fn().mockResolvedValue('ok'),
     applySettlement: vi.fn().mockResolvedValue(undefined),
     attachMessage: vi.fn(),
     markMessagePostFailed: vi.fn(),
@@ -2142,7 +2142,7 @@ describe('runMention', () => {
       expect(approvalRegistry.register).toHaveBeenCalledWith(
         expect.objectContaining({
           requestID: 'req-abc-123',
-          channelID: thread.id,
+          approvalScopeId: thread.id,
           directory: canonicalPath,
         }),
       )
@@ -4086,7 +4086,7 @@ describe('approval timeout: registry deadline fires → fail-closed reject', () 
     registry.register({
       requestID: 'req-deadline-reg-1',
       sessionID: 'ses-deadline',
-      channelID: 'chan-deadline',
+      approvalScopeId: 'chan-deadline',
       directory: '/ws/deadline',
       request: {
         requestID: 'req-deadline-reg-1',
@@ -4132,7 +4132,7 @@ describe('approval timeout: registry deadline fires → fail-closed reject', () 
     registry.register({
       requestID: 'req-deadline-claimed-1',
       sessionID: 'ses-claimed',
-      channelID: 'chan-claimed',
+      approvalScopeId: 'chan-claimed',
       directory: '/ws/claimed',
       request: {
         requestID: 'req-deadline-claimed-1',
@@ -4146,12 +4146,12 @@ describe('approval timeout: registry deadline fires → fail-closed reject', () 
       onDeadlineSettled,
     })
 
-    // Claim the entry (button click) before deadline fires
-    const decisionPromise = registry.handleButtonDecision({
+    // Claim the entry (decision submitted) before deadline fires
+    const decisionPromise = registry.handleDecision({
       requestID: 'req-deadline-claimed-1',
-      channelID: 'chan-claimed',
+      approvalScopeId: 'chan-claimed',
       decision: 'once',
-      decidedBy: 'user-1',
+      actor: {kind: 'discord-user', userId: 'user-1'},
     })
 
     // #when — wait for deadline to fire (entry is claimed)
@@ -4196,7 +4196,7 @@ describe('approval dispose/shutdown: onDispose fail-closes pending registry entr
     registry.register({
       requestID: 'req-dispose-1',
       sessionID: 'ses-dispose',
-      channelID: 'chan-dispose',
+      approvalScopeId: 'chan-dispose',
       directory: '/ws/dispose',
       request: {
         requestID: 'req-dispose-1',
@@ -4252,7 +4252,7 @@ describe('approval dispose/shutdown: onDispose fail-closes pending registry entr
     registry.register({
       requestID: 'req-shutdown-A',
       sessionID: 'ses-A',
-      channelID: 'chan-A',
+      approvalScopeId: 'chan-A',
       directory: '/ws/a',
       request: {requestID: 'req-shutdown-A', sessionID: 'ses-A', permission: 'bash', patterns: [], title: 'cmd A'},
       effects: {postReply: postReplyA},
@@ -4260,7 +4260,7 @@ describe('approval dispose/shutdown: onDispose fail-closes pending registry entr
     registry.register({
       requestID: 'req-shutdown-B',
       sessionID: 'ses-B',
-      channelID: 'chan-B',
+      approvalScopeId: 'chan-B',
       directory: '/ws/b',
       request: {requestID: 'req-shutdown-B', sessionID: 'ses-B', permission: 'bash', patterns: [], title: 'cmd B'},
       effects: {postReply: postReplyB},

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -4443,114 +4443,111 @@ describe('statusMode typing-only: typing indicator only, no status message', () 
 })
 
 // ---------------------------------------------------------------------------
-// EMPTY-PROMPT baseline: bare @fro-bot mention → late EmptyPromptError in-thread
+// EMPTY-PROMPT fail-fast: bare @fro-bot mention → immediate reply on source message
 //
-// IMPORTANT: Phase A Unit 3 deliberately changes this to fail-fast in the
-// adapter before thread/lock/run-state — this test documents the pre-change
-// baseline and will be updated in Unit 3.
+// Phase A Unit 3 behavior (post-change): the adapter strips the bot mention and
+// detects an empty prompt BEFORE calling launchWork. It replies on the SOURCE
+// message (not a thread), creates no thread, acquires no lock, writes no run-state.
 //
-// Current behavior (pinned here): buildDiscordPrompt throws EmptyPromptError
-// LATE in startRun — AFTER thread creation, lock acquisition, and run-state
-// setup. The error surfaces in-thread (sent to the thread, not the source
-// message) with the "nothing to do" copy.
+// This deliberately changes the Unit 0 baseline (which surfaced EmptyPromptError
+// late in-thread after thread creation and lock acquisition). The change is an
+// accepted Phase A behavior delta — see plan KTD.
 // ---------------------------------------------------------------------------
 
-describe('empty-prompt baseline: bare mention → late EmptyPromptError in-thread', () => {
+describe('empty-prompt fail-fast: bare mention → immediate reply on source message (post-Unit-3 behavior)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('bare @fro-bot mention: EmptyPromptError surfaces in-thread AFTER thread creation and lock acquisition', async () => {
-    // BASELINE: Phase A Unit 3 deliberately changes this to fail-fast in the
-    // adapter before thread/lock/run-state — this test documents the pre-change
-    // baseline and will be updated in Unit 3.
-    //
-    // Current behavior: buildDiscordPrompt throws EmptyPromptError late in
-    // startRun (after thread creation, lock acquisition, run-state setup).
-    // The error is caught by the exec-error handler and the "nothing to do"
-    // message is sent to the THREAD (not the source message).
+  it('bare @fro-bot mention: fails fast BEFORE thread creation, lock, or run-state', async () => {
+    // Post-Unit-3 behavior: the adapter strips the bot mention and detects an
+    // empty prompt before calling launchWork. The "nothing to do" reply goes to
+    // the SOURCE message (not a thread). No thread is created, no lock acquired,
+    // no run-state written.
 
-    // #given — buildDiscordPrompt throws EmptyPromptError (bare mention, no prompt text)
+    // #given — message content is just the bot mention (empty prompt after strip)
     const {runMention} = await import('./run.js')
-    setupHappyPath()
-
-    // Override buildDiscordPrompt to throw EmptyPromptError (simulating bare mention)
-    const {EmptyPromptError} = promptModule
-    vi.mocked(promptModule.buildDiscordPrompt).mockImplementation(() => {
-      throw new EmptyPromptError()
-    })
+    // No setupHappyPath() — we must not reach the engine at all
 
     const thread = makeThread()
     const message = makeMessage(thread)
+    // Override content to be a bare mention (empty after strip)
+    ;(message as unknown as {content: string}).content = `<@${makeDeps().botUserId}>`
     const deps = makeDeps()
 
     // #when
     await runMention(message, makeBinding(), deps)
 
-    // #then — thread WAS created (EmptyPromptError fires AFTER startThread)
-    expect(message.startThread).toHaveBeenCalledOnce()
+    // #then — NO thread created (fail-fast fires before threadFactory)
+    expect(message.startThread).not.toHaveBeenCalled()
 
-    // #and — lock WAS acquired (EmptyPromptError fires AFTER acquireLock)
-    expect(mockRuntime.acquireLock).toHaveBeenCalledOnce()
+    // #and — NO lock acquired (fail-fast fires before launchWork)
+    expect(mockRuntime.acquireLock).not.toHaveBeenCalled()
 
-    // #and — run-state WAS created (EmptyPromptError fires AFTER createRun)
-    expect(mockRuntime.createRun).toHaveBeenCalledOnce()
+    // #and — NO run-state created (fail-fast fires before launchWork)
+    expect(mockRuntime.createRun).not.toHaveBeenCalled()
 
-    // #and — the "nothing to do" error message is sent to the THREAD (not the source message)
-    // This is the key behavior: the failure surfaces in-thread, not as a pre-thread reply.
-    const threadSends = thread.send.mock.calls.map(c => (c[0] as {content?: string}).content ?? '')
-    const nothingToDoSend = threadSends.find(c => c.includes('Nothing to do') || c.includes('nothing to do'))
-    expect(nothingToDoSend).toBeDefined()
+    // #and — the "nothing to do" reply is sent to the SOURCE message (not a thread)
+    expect(message.reply).toHaveBeenCalledOnce()
+    const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+      content: string
+      allowedMentions: unknown
+    }
+    expect(call.content).toMatch(/nothing to do/i)
+    expect(call.allowedMentions).toEqual({parse: []})
 
-    // #and — the source message did NOT receive the "nothing to do" reply
-    // (it would only receive a reply if the error fired before thread creation)
-    const messageSends = (message.reply as ReturnType<typeof vi.fn>).mock.calls.map(
-      c => (c[0] as {content?: string}).content ?? '',
-    )
-    const nothingToDoInMessage = messageSends.find(c => c.includes('Nothing to do') || c.includes('nothing to do'))
-    expect(nothingToDoInMessage).toBeUndefined()
+    // #and — the thread did NOT receive the "nothing to do" message
+    expect(thread.send).not.toHaveBeenCalled()
 
-    // #and — run transitioned to FAILED (EmptyPromptError is a failure)
-    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
-    expect(transitionPhases).toContain('FAILED')
-
-    // #and — failed reaction set on the source message
-    const reactionStates = vi.mocked(reactionsModule.setRunReaction).mock.calls.map(c => c[1])
-    expect(reactionStates).toContain('failed')
+    // #and — no run-state transitions (no FAILED, no COMPLETED)
+    expect(mockRuntime.transitionRun).not.toHaveBeenCalled()
   })
 
-  it('empty-prompt: lock and concurrency slot are released even when EmptyPromptError fires late', async () => {
-    // BASELINE: documents that the current late-failure path still cleans up
-    // correctly (lock released, concurrency slot freed). Phase A Unit 3 will
-    // move the failure earlier, but cleanup must remain correct.
+  it('empty-prompt fail-fast: concurrency slot is NOT acquired (no slot to release)', async () => {
+    // Post-Unit-3 behavior: fail-fast fires before launchWork, so the concurrency
+    // slot is never acquired and never needs to be released.
 
-    // #given — buildDiscordPrompt throws EmptyPromptError
+    // #given — message content is a bare mention
     const {runMention} = await import('./run.js')
-    setupHappyPath()
-
-    const {EmptyPromptError} = promptModule
-    vi.mocked(promptModule.buildDiscordPrompt).mockImplementation(() => {
-      throw new EmptyPromptError()
-    })
 
     const releaseFn = vi.fn()
+    const tryAcquireFn = vi.fn().mockReturnValue('ok')
     const message = makeMessage()
     const deps = makeDeps({
       concurrency: {
-        tryAcquire: vi.fn().mockReturnValue('ok'),
+        tryAcquire: tryAcquireFn,
         release: releaseFn,
-        activeCount: vi.fn().mockReturnValue(1),
+        activeCount: vi.fn().mockReturnValue(0),
         max: 3,
       },
     })
+    ;(message as unknown as {content: string}).content = `<@${deps.botUserId}>`
 
     // #when
     await runMention(message, makeBinding(), deps)
 
-    // #then — lock released in inner finally
-    expect(mockRuntime.releaseLock).toHaveBeenCalledOnce()
-    // #and — concurrency slot released in outer finally
-    expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
+    // #then — tryAcquire NOT called (fail-fast fires before launchWork)
+    expect(tryAcquireFn).not.toHaveBeenCalled()
+    // #and — release NOT called (slot was never acquired)
+    expect(releaseFn).not.toHaveBeenCalled()
+  })
+
+  it('empty-prompt fail-fast: whitespace-only prompt after mention strip also fails fast', async () => {
+    // #given — message content is mention + whitespace only
+    const {runMention} = await import('./run.js')
+
+    const message = makeMessage()
+    const deps = makeDeps()
+    ;(message as unknown as {content: string}).content = `<@${deps.botUserId}>   \t  `
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — fails fast: reply on source message, no thread
+    expect(message.reply).toHaveBeenCalledOnce()
+    const call = (message.reply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {content: string}
+    expect(call.content).toMatch(/nothing to do/i)
+    expect(message.startThread).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -3911,3 +3911,601 @@ describe('formatTimeoutDuration', () => {
     expect(formatTimeoutDuration(125_000)).toBe('2 minutes 5 seconds')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Characterization tests — pin current Discord behavior as a zero-regression
+// gate for the Phase A refactor (Units 1–4).
+//
+// These tests assert CURRENT observable behavior via the existing Message-based
+// entry points. They must be GREEN on unmodified production code and must
+// remain green after the refactor.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Approval: pending wait → decision → run continues (approved)
+// ---------------------------------------------------------------------------
+
+describe('approval: pending wait → decision → run continues', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('a pending approval that resolves with "once" allows the run to complete successfully', async () => {
+    // #given — coordinator.onPermissionAsked resolves with 'once' (approved)
+    // This pins the current behavior: when an approval is granted, the run
+    // continues to completion (COMPLETED transition, succeeded reaction).
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    // Wire a real coordinator that resolves the permission immediately with 'once'
+    mockCreatePermissionCoordinator.mockImplementation(_coordinatorDeps => {
+      return {
+        onPermissionAsked: vi.fn().mockResolvedValue('once' as const),
+        onPermissionReplied: vi.fn(),
+        pending: vi.fn().mockReturnValue([]),
+        dispose: vi.fn(),
+      }
+    })
+
+    // runOpenCodeCore calls onPermissionAsked and awaits the result
+    mockRunOpenCodeCore.mockImplementation(async params => {
+      const {coordinator} = params as {coordinator: import('../approvals/coordinator.js').PermissionCoordinator}
+      const reply = await coordinator.onPermissionAsked({
+        requestID: 'req-approved-1',
+        sessionID: 'sess-approved',
+        permission: 'bash',
+        patterns: ['ls'],
+        title: 'Run command: ls',
+      })
+      // Approved — run continues
+      expect(reply).toBe('once')
+    })
+
+    const message = makeMessage()
+    const deps = makeDeps()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — run completed (not failed)
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).toContain('COMPLETED')
+    expect(transitionPhases).not.toContain('FAILED')
+  })
+
+  it('a pending approval that resolves with "reject" causes the run to fail-close (run-core sees reject)', async () => {
+    // #given — coordinator.onPermissionAsked resolves with 'reject' (denied)
+    // This pins the current behavior: when an approval is rejected, run-core
+    // receives 'reject' and the run fails.
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    mockCreatePermissionCoordinator.mockImplementation(() => {
+      return {
+        onPermissionAsked: vi.fn().mockResolvedValue('reject' as const),
+        onPermissionReplied: vi.fn(),
+        pending: vi.fn().mockReturnValue([]),
+        dispose: vi.fn(),
+      }
+    })
+
+    // runOpenCodeCore calls onPermissionAsked, gets 'reject', and throws
+    mockRunOpenCodeCore.mockImplementation(async params => {
+      const {coordinator} = params as {coordinator: import('../approvals/coordinator.js').PermissionCoordinator}
+      const reply = await coordinator.onPermissionAsked({
+        requestID: 'req-rejected-1',
+        sessionID: 'sess-rejected',
+        permission: 'bash',
+        patterns: ['rm -rf /'],
+        title: 'Run command: rm -rf /',
+      })
+      expect(reply).toBe('reject')
+      // run-core would throw on reject — simulate that
+      const {RunCoreError} = runCoreModule
+      throw new RunCoreError('session-error', 'permission rejected')
+    })
+
+    const thread = makeThread()
+    const message = makeMessage(thread)
+    const deps = makeDeps()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — run transitioned to FAILED
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).toContain('FAILED')
+    expect(transitionPhases).not.toContain('COMPLETED')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Approval timeout: registry deadline → fail-closed reject (registry-level)
+// ---------------------------------------------------------------------------
+
+describe('approval timeout: registry deadline fires → fail-closed reject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('registry deadline fires on open entry → postReply called with reject, entry removed', async () => {
+    // #given — a registry entry with a very short deadline
+    // This pins the current registry behavior: when the deadline fires on an
+    // open entry, it POSTs reject and removes the entry (fail-closed).
+    const {createApprovalRegistry} = await import('../approvals/registry.js')
+    const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+    const registry = createApprovalRegistry({logger})
+
+    const postReply = vi.fn().mockResolvedValue({ok: true})
+    const onDeadlineSettled = vi.fn()
+
+    registry.register({
+      requestID: 'req-deadline-reg-1',
+      sessionID: 'ses-deadline',
+      channelID: 'chan-deadline',
+      directory: '/ws/deadline',
+      request: {
+        requestID: 'req-deadline-reg-1',
+        sessionID: 'ses-deadline',
+        permission: 'bash',
+        patterns: [],
+        title: 'Run command',
+      },
+      effects: {postReply},
+      deadlineMs: 10, // very short deadline
+      onDeadlineSettled,
+    })
+
+    expect(registry.has('req-deadline-reg-1')).toBe(true)
+
+    // #when — wait for deadline to fire
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    // #then — entry removed (fail-closed)
+    expect(registry.has('req-deadline-reg-1')).toBe(false)
+    // #and — postReply called with 'reject'
+    expect(postReply).toHaveBeenCalledWith('req-deadline-reg-1', '/ws/deadline', 'reject')
+    // #and — onDeadlineSettled callback invoked
+    expect(onDeadlineSettled).toHaveBeenCalledOnce()
+  })
+
+  it('registry deadline fires while entry is claimed (button in-flight) → deadline is a no-op (button wins)', async () => {
+    // #given — entry is claimed (button click in-flight) when deadline fires
+    // This pins the current winner-vs-loser rule: claimed state beats the deadline.
+    const {createApprovalRegistry} = await import('../approvals/registry.js')
+    const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+    const registry = createApprovalRegistry({logger})
+
+    // postReply hangs so the entry stays in 'claimed' state when deadline fires
+    let resolvePostReply!: (value: {ok: boolean}) => void
+    const postReply = vi.fn().mockReturnValue(
+      new Promise<{ok: boolean}>(resolve => {
+        resolvePostReply = resolve
+      }),
+    )
+    const onDeadlineSettled = vi.fn()
+
+    registry.register({
+      requestID: 'req-deadline-claimed-1',
+      sessionID: 'ses-claimed',
+      channelID: 'chan-claimed',
+      directory: '/ws/claimed',
+      request: {
+        requestID: 'req-deadline-claimed-1',
+        sessionID: 'ses-claimed',
+        permission: 'bash',
+        patterns: [],
+        title: 'Run command',
+      },
+      effects: {postReply},
+      deadlineMs: 20,
+      onDeadlineSettled,
+    })
+
+    // Claim the entry (button click) before deadline fires
+    const decisionPromise = registry.handleButtonDecision({
+      requestID: 'req-deadline-claimed-1',
+      channelID: 'chan-claimed',
+      decision: 'once',
+      decidedBy: 'user-1',
+    })
+
+    // #when — wait for deadline to fire (entry is claimed)
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    // #then — deadline is a no-op (entry still exists, claimed by button)
+    // onDeadlineSettled NOT called (deadline lost to button)
+    expect(onDeadlineSettled).not.toHaveBeenCalled()
+    // Entry still exists (button owns it)
+    expect(registry.has('req-deadline-claimed-1')).toBe(true)
+
+    // Cleanup: resolve the button's postReply
+    resolvePostReply({ok: true})
+    await decisionPromise
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Approval dispose/shutdown: onDispose → disposeRun fail-closes pending entries
+// ---------------------------------------------------------------------------
+
+describe('approval dispose/shutdown: onDispose fail-closes pending registry entries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('coordinator dispose calls onDispose which calls registry.disposeRun — pending entries fail-closed', async () => {
+    // #given — a coordinator wired to a real registry; a pending entry exists
+    // This pins the current behavior: coordinator.dispose → onDispose → registry.disposeRun
+    // → pending entries are fail-closed (postReply called with 'reject', entry removed).
+    //
+    // NOTE: coordinator.js is mocked at the module level in run.test.ts, so we use
+    // vi.importActual to get the real implementation for this integration test.
+    const {createApprovalRegistry} = await import('../approvals/registry.js')
+    const {createPermissionCoordinator: realCreatePermissionCoordinator} =
+      await vi.importActual<typeof import('../approvals/coordinator.js')>('../approvals/coordinator.js')
+
+    const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+    const registry = createApprovalRegistry({logger})
+
+    const postReply = vi.fn().mockResolvedValue({ok: true})
+    registry.register({
+      requestID: 'req-dispose-1',
+      sessionID: 'ses-dispose',
+      channelID: 'chan-dispose',
+      directory: '/ws/dispose',
+      request: {
+        requestID: 'req-dispose-1',
+        sessionID: 'ses-dispose',
+        permission: 'bash',
+        patterns: [],
+        title: 'Run command',
+      },
+      effects: {postReply},
+    })
+
+    expect(registry.has('req-dispose-1')).toBe(true)
+
+    const coordinator = realCreatePermissionCoordinator({
+      logger,
+      onDispose: sessionIDs => {
+        // eslint-disable-next-line no-void
+        void Promise.all(sessionIDs.map(async sid => registry.disposeRun(sid, 'run ended')))
+      },
+    })
+
+    // Register the request with the coordinator so it tracks the sessionID
+    // eslint-disable-next-line no-void
+    void coordinator.onPermissionAsked({
+      requestID: 'req-dispose-1',
+      sessionID: 'ses-dispose',
+      permission: 'bash',
+      patterns: [],
+      title: 'Run command',
+    })
+
+    // #when — coordinator disposed (run teardown)
+    coordinator.dispose('run ended')
+
+    // Allow async disposeRun to complete
+    await new Promise(resolve => setTimeout(resolve, 10))
+
+    // #then — entry fail-closed (removed from registry)
+    expect(registry.has('req-dispose-1')).toBe(false)
+    // #and — postReply called with 'reject' (fail-closed)
+    expect(postReply).toHaveBeenCalledWith('req-dispose-1', '/ws/dispose', 'reject')
+  })
+
+  it('registry.disposeAll fail-closes all pending entries across all sessions (gateway shutdown)', async () => {
+    // #given — multiple pending entries across different sessions
+    const {createApprovalRegistry} = await import('../approvals/registry.js')
+    const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+    const registry = createApprovalRegistry({logger})
+
+    const postReplyA = vi.fn().mockResolvedValue({ok: true})
+    const postReplyB = vi.fn().mockResolvedValue({ok: true})
+
+    registry.register({
+      requestID: 'req-shutdown-A',
+      sessionID: 'ses-A',
+      channelID: 'chan-A',
+      directory: '/ws/a',
+      request: {requestID: 'req-shutdown-A', sessionID: 'ses-A', permission: 'bash', patterns: [], title: 'cmd A'},
+      effects: {postReply: postReplyA},
+    })
+    registry.register({
+      requestID: 'req-shutdown-B',
+      sessionID: 'ses-B',
+      channelID: 'chan-B',
+      directory: '/ws/b',
+      request: {requestID: 'req-shutdown-B', sessionID: 'ses-B', permission: 'bash', patterns: [], title: 'cmd B'},
+      effects: {postReply: postReplyB},
+    })
+
+    expect(registry.has('req-shutdown-A')).toBe(true)
+    expect(registry.has('req-shutdown-B')).toBe(true)
+
+    // #when — gateway shutdown: disposeAll
+    await registry.disposeAll('gateway shutdown')
+
+    // #then — all entries removed
+    expect(registry.has('req-shutdown-A')).toBe(false)
+    expect(registry.has('req-shutdown-B')).toBe(false)
+    // #and — both postReply calls made with 'reject'
+    expect(postReplyA).toHaveBeenCalledWith('req-shutdown-A', '/ws/a', 'reject')
+    expect(postReplyB).toHaveBeenCalledWith('req-shutdown-B', '/ws/b', 'reject')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Thread creation: message.startThread called for a valid run
+// ---------------------------------------------------------------------------
+
+describe('thread creation: message.startThread called for a valid run', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('startThread is called with the repo name as the thread name', async () => {
+    // #given — happy path run
+    // This pins the current behavior: startThread is called with name `fro-bot: ${repo}`
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    const message = makeMessage()
+    const binding = makeBinding() // repo = 'widget'
+    const deps = makeDeps()
+
+    // #when
+    await runMention(message, binding, deps)
+
+    // #then — startThread called exactly once with the repo name
+    expect(message.startThread).toHaveBeenCalledOnce()
+    const call = (message.startThread as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {name: string}
+    expect(call.name).toBe(`fro-bot: ${REPO}`)
+  })
+
+  it('startThread is NOT called when workspace is not ready (pre-thread gate)', async () => {
+    // #given — workspace not ready
+    const {runMention} = await import('./run.js')
+    const readyz = makeReadyzFn('not-ready')
+    const message = makeMessage()
+    const deps = makeDeps({readyz})
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — startThread never called (gate fires before thread creation)
+    expect(message.startThread).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// statusMode 'live-status': status message posted AND edited as run progresses
+// ---------------------------------------------------------------------------
+
+describe('statusMode live-status: status message posted and edited', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('live-status: createStatusController called with mode live-status and the created thread', async () => {
+    // #given — live-status mode
+    // This pins the current behavior: createStatusController receives the thread
+    // created by startThread, not the original message channel.
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+    const ctrl = makeStatusControllerMock()
+
+    const thread = makeThread()
+    const message = makeMessage(thread)
+    const deps = makeDeps({statusMode: 'live-status'})
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — createStatusController called with the thread and live-status mode
+    expect(mockCreateStatusController).toHaveBeenCalledOnce()
+    const ctrlCall = mockCreateStatusController.mock.calls[0]?.[0] as {
+      thread: unknown
+      mode: string
+    }
+    expect(ctrlCall.mode).toBe('live-status')
+    // The thread passed is the one returned by startThread (not the message channel)
+    expect(ctrlCall.thread).toBe(thread)
+    // #and — resolveToAnswer called (status controller owns the answer transition)
+    expect(ctrl.resolveToAnswer).toHaveBeenCalledOnce()
+  })
+
+  it('live-status: resolveToAnswer(handled) → status message is the answer (no sink flush)', async () => {
+    // #given — status controller handles the answer (edits status message in place)
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+    makeStatusControllerMock({resolveToAnswerResult: {transition: 'handled'}})
+    const flushMock = vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 10})
+    mockCreateDiscordStreamSink.mockReturnValue({
+      append: vi.fn(),
+      flush: flushMock,
+      buffered: vi.fn().mockReturnValue('The answer'),
+      markVisibleOutputSent: vi.fn(),
+      markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
+      hasVisibleOutput: vi.fn().mockReturnValue(false),
+    })
+
+    const message = makeMessage()
+    const deps = makeDeps({statusMode: 'live-status'})
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — sink.flush NOT called (status controller owns the answer)
+    expect(flushMock).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// statusMode 'typing-only': typing indicator pulses; NO status message posted
+// ---------------------------------------------------------------------------
+
+describe('statusMode typing-only: typing indicator only, no status message', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('typing-only: createStatusController called with mode typing-only', async () => {
+    // #given — typing-only mode
+    // This pins the current behavior: createStatusController is called with
+    // mode 'typing-only', which suppresses the status message.
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+    makeStatusControllerMock({resolveToAnswerResult: {transition: 'delegated'}})
+
+    const message = makeMessage()
+    const deps = makeDeps({statusMode: 'typing-only'})
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — createStatusController called with typing-only mode
+    expect(mockCreateStatusController).toHaveBeenCalledOnce()
+    const ctrlCall = mockCreateStatusController.mock.calls[0]?.[0] as {mode: string}
+    expect(ctrlCall.mode).toBe('typing-only')
+  })
+
+  it('typing-only: resolveToAnswer always returns delegated → sink.flush called (no status message to edit)', async () => {
+    // #given — typing-only mode; controller always delegates (no status message)
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+    makeStatusControllerMock({resolveToAnswerResult: {transition: 'delegated'}})
+    const flushMock = vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 10})
+    mockCreateDiscordStreamSink.mockReturnValue({
+      append: vi.fn(),
+      flush: flushMock,
+      buffered: vi.fn().mockReturnValue('answer text'),
+      markVisibleOutputSent: vi.fn(),
+      markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
+      hasVisibleOutput: vi.fn().mockReturnValue(false),
+    })
+
+    const message = makeMessage()
+    const deps = makeDeps({statusMode: 'typing-only'})
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — sink.flush called (typing-only always delegates to sink)
+    expect(flushMock).toHaveBeenCalledOnce()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// EMPTY-PROMPT baseline: bare @fro-bot mention → late EmptyPromptError in-thread
+//
+// IMPORTANT: Phase A Unit 3 deliberately changes this to fail-fast in the
+// adapter before thread/lock/run-state — this test documents the pre-change
+// baseline and will be updated in Unit 3.
+//
+// Current behavior (pinned here): buildDiscordPrompt throws EmptyPromptError
+// LATE in startRun — AFTER thread creation, lock acquisition, and run-state
+// setup. The error surfaces in-thread (sent to the thread, not the source
+// message) with the "nothing to do" copy.
+// ---------------------------------------------------------------------------
+
+describe('empty-prompt baseline: bare mention → late EmptyPromptError in-thread', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('bare @fro-bot mention: EmptyPromptError surfaces in-thread AFTER thread creation and lock acquisition', async () => {
+    // BASELINE: Phase A Unit 3 deliberately changes this to fail-fast in the
+    // adapter before thread/lock/run-state — this test documents the pre-change
+    // baseline and will be updated in Unit 3.
+    //
+    // Current behavior: buildDiscordPrompt throws EmptyPromptError late in
+    // startRun (after thread creation, lock acquisition, run-state setup).
+    // The error is caught by the exec-error handler and the "nothing to do"
+    // message is sent to the THREAD (not the source message).
+
+    // #given — buildDiscordPrompt throws EmptyPromptError (bare mention, no prompt text)
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    // Override buildDiscordPrompt to throw EmptyPromptError (simulating bare mention)
+    const {EmptyPromptError} = promptModule
+    vi.mocked(promptModule.buildDiscordPrompt).mockImplementation(() => {
+      throw new EmptyPromptError()
+    })
+
+    const thread = makeThread()
+    const message = makeMessage(thread)
+    const deps = makeDeps()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — thread WAS created (EmptyPromptError fires AFTER startThread)
+    expect(message.startThread).toHaveBeenCalledOnce()
+
+    // #and — lock WAS acquired (EmptyPromptError fires AFTER acquireLock)
+    expect(mockRuntime.acquireLock).toHaveBeenCalledOnce()
+
+    // #and — run-state WAS created (EmptyPromptError fires AFTER createRun)
+    expect(mockRuntime.createRun).toHaveBeenCalledOnce()
+
+    // #and — the "nothing to do" error message is sent to the THREAD (not the source message)
+    // This is the key behavior: the failure surfaces in-thread, not as a pre-thread reply.
+    const threadSends = thread.send.mock.calls.map(c => (c[0] as {content?: string}).content ?? '')
+    const nothingToDoSend = threadSends.find(c => c.includes('Nothing to do') || c.includes('nothing to do'))
+    expect(nothingToDoSend).toBeDefined()
+
+    // #and — the source message did NOT receive the "nothing to do" reply
+    // (it would only receive a reply if the error fired before thread creation)
+    const messageSends = (message.reply as ReturnType<typeof vi.fn>).mock.calls.map(
+      c => (c[0] as {content?: string}).content ?? '',
+    )
+    const nothingToDoInMessage = messageSends.find(c => c.includes('Nothing to do') || c.includes('nothing to do'))
+    expect(nothingToDoInMessage).toBeUndefined()
+
+    // #and — run transitioned to FAILED (EmptyPromptError is a failure)
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).toContain('FAILED')
+
+    // #and — failed reaction set on the source message
+    const reactionStates = vi.mocked(reactionsModule.setRunReaction).mock.calls.map(c => c[1])
+    expect(reactionStates).toContain('failed')
+  })
+
+  it('empty-prompt: lock and concurrency slot are released even when EmptyPromptError fires late', async () => {
+    // BASELINE: documents that the current late-failure path still cleans up
+    // correctly (lock released, concurrency slot freed). Phase A Unit 3 will
+    // move the failure earlier, but cleanup must remain correct.
+
+    // #given — buildDiscordPrompt throws EmptyPromptError
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+
+    const {EmptyPromptError} = promptModule
+    vi.mocked(promptModule.buildDiscordPrompt).mockImplementation(() => {
+      throw new EmptyPromptError()
+    })
+
+    const releaseFn = vi.fn()
+    const message = makeMessage()
+    const deps = makeDeps({
+      concurrency: {
+        tryAcquire: vi.fn().mockReturnValue('ok'),
+        release: releaseFn,
+        activeCount: vi.fn().mockReturnValue(1),
+        max: 3,
+      },
+    })
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — lock released in inner finally
+    expect(mockRuntime.releaseLock).toHaveBeenCalledOnce()
+    // #and — concurrency slot released in outer finally
+    expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
+  })
+})

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -2,6 +2,7 @@ import type {CoordinationConfig, HeartbeatController} from '@fro-bot/runtime'
 import type {Message, ThreadChannel} from 'discord.js'
 import type {ApprovalRegistry} from '../approvals/registry.js'
 import type {RepoBinding} from '../bindings/types.js'
+import type {LaunchWorkRequest, ReplySink, StatusSink} from './launch-types.js'
 import type {ChannelQueue} from './queue.js'
 import type {RunMentionDeps, RunTask} from './run.js'
 
@@ -207,6 +208,49 @@ function makeDefaultQueue(): ChannelQueue<RunTask> {
     takeNext: vi.fn().mockReturnValue(undefined),
     clear: vi.fn().mockReturnValue(0),
   }
+}
+
+/**
+ * Build a minimal `LaunchWorkRequest` for use in pending-task construction.
+ * Uses no-op sinks since the pending task's sinks are not exercised in handoff tests.
+ */
+function makeMinimalRequest(message: Message, binding: RepoBinding): LaunchWorkRequest {
+  const noopSettle = (_delivered: boolean) => {
+    /* no-op */
+  }
+  return {
+    promptText: (message as unknown as {content: string}).content ?? '',
+    channelId: (message as unknown as {channel: {id: string}}).channel.id,
+    guildId: undefined,
+    surface: 'discord',
+    binding,
+    requester: {kind: 'discord-user', userId: 'user-111'},
+    statusSink: {
+      noteActivity: vi.fn(),
+      setBusy: vi.fn(),
+      resolveToAnswer: vi.fn().mockResolvedValue({transition: 'delegated'}),
+      resolveToFailure: vi.fn().mockResolvedValue({transition: 'delegated'}),
+      dispose: vi.fn().mockResolvedValue(undefined),
+      setReaction: vi.fn(),
+    },
+    replySink: {
+      send: vi.fn().mockResolvedValue({success: true, data: undefined}),
+      append: vi.fn(),
+      flush: vi.fn().mockResolvedValue({kind: 'sent', charCount: 0}),
+      buffered: vi.fn().mockReturnValue(''),
+      hasVisibleOutput: vi.fn().mockReturnValue(false),
+      markVisibleOutputSent: vi.fn(),
+      markVisibleOutputPending: vi.fn().mockReturnValue(noopSettle),
+    },
+  }
+}
+
+/**
+ * Build a `RunTask` for use in pending-task / handoff tests.
+ * Wraps `makeMinimalRequest` with the given deps.
+ */
+function makePendingTask(message: Message, binding: RepoBinding, deps: RunMentionDeps): RunTask {
+  return {request: makeMinimalRequest(message, binding), deps}
 }
 
 /**
@@ -3155,7 +3199,7 @@ describe('runMention', () => {
       const pendingMessage = makeMessage()
       const pendingBinding = makeBinding()
       const pendingDeps = makeDeps({concurrency: sharedConcurrency, queue})
-      const pendingTask: RunTask = {message: pendingMessage, binding: pendingBinding, deps: pendingDeps}
+      const pendingTask: RunTask = makePendingTask(pendingMessage, pendingBinding, pendingDeps)
 
       ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValueOnce(pendingTask).mockReturnValue(undefined)
 
@@ -3238,7 +3282,7 @@ describe('runMention', () => {
       // uses the same release fn and the same takeNext chain.
       const pendingMessage = makeMessage()
       const pendingDeps = makeDeps({concurrency: sharedConcurrency, queue})
-      const pendingTask: RunTask = {message: pendingMessage, binding: makeBinding(), deps: pendingDeps}
+      const pendingTask: RunTask = makePendingTask(pendingMessage, makeBinding(), pendingDeps)
 
       ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValueOnce(pendingTask).mockReturnValue(undefined)
 
@@ -3331,7 +3375,7 @@ describe('runMention', () => {
       // uses the same release fn and the same takeNext chain.
       const pendingMessage = makeMessage()
       const pendingDeps = makeDeps({concurrency: sharedConcurrency, queue, logger})
-      const pendingTask: RunTask = {message: pendingMessage, binding: makeBinding(), deps: pendingDeps}
+      const pendingTask: RunTask = makePendingTask(pendingMessage, makeBinding(), pendingDeps)
 
       ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValueOnce(pendingTask).mockReturnValue(undefined)
 
@@ -3498,7 +3542,7 @@ describe('isShuttingDown — handoff shutdown gate', () => {
 
     const pendingMessage = makeMessage()
     const pendingDeps = makeDeps({concurrency: sharedConcurrency, queue, isShuttingDown})
-    const pendingTask: RunTask = {message: pendingMessage, binding: makeBinding(), deps: pendingDeps}
+    const pendingTask: RunTask = makePendingTask(pendingMessage, makeBinding(), pendingDeps)
 
     ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValueOnce(pendingTask).mockReturnValue(undefined)
 
@@ -3526,7 +3570,7 @@ describe('isShuttingDown — handoff shutdown gate', () => {
     const queue = makeDefaultQueue()
     const pendingMessage = makeMessage()
     const pendingDeps = makeDeps({queue})
-    const pendingTask: RunTask = {message: pendingMessage, binding: makeBinding(), deps: pendingDeps}
+    const pendingTask: RunTask = makePendingTask(pendingMessage, makeBinding(), pendingDeps)
 
     ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValueOnce(pendingTask).mockReturnValue(undefined)
 
@@ -3633,7 +3677,7 @@ describe('handoff unit tests (F8)', () => {
 
     const pendingMessage = makeMessage()
     const pendingDeps = makeDeps({concurrency: sharedConcurrency, queue})
-    const pendingTask: RunTask = {message: pendingMessage, binding: makeBinding(), deps: pendingDeps}
+    const pendingTask: RunTask = makePendingTask(pendingMessage, makeBinding(), pendingDeps)
 
     // First takeNext returns the pending task; second returns undefined (queue empty)
     ;(queue.takeNext as ReturnType<typeof vi.fn>).mockReturnValueOnce(pendingTask).mockReturnValue(undefined)
@@ -4507,5 +4551,424 @@ describe('empty-prompt baseline: bare mention → late EmptyPromptError in-threa
     expect(mockRuntime.releaseLock).toHaveBeenCalledOnce()
     // #and — concurrency slot released in outer finally
     expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// launchWork — in-memory sink tests (Unit 2)
+//
+// These tests prove the engine runs with no Discord/Message dependency.
+// They use in-memory StatusSink/ReplySink implementations and verify:
+// - Happy path: completes + calls statusSink/replySink methods
+// - Timeout: respects runTimeoutMs; statusSink receives failure note
+// - Shutdown: isShuttingDown() → slot released immediately
+// - Queue/concurrency: still enforced via ChannelQueue (same as runMention)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an in-memory StatusSink that records calls.
+ */
+function makeInMemoryStatusSink(): StatusSink & {
+  readonly _reactions: string[]
+  readonly _activities: string[]
+  readonly _busyStates: boolean[]
+  readonly _resolvedAnswers: string[]
+  readonly _resolvedFailures: string[]
+  readonly _disposed: boolean[]
+} {
+  const reactions: string[] = []
+  const activities: string[] = []
+  const busyStates: boolean[] = []
+  const resolvedAnswers: string[] = []
+  const resolvedFailures: string[] = []
+  const disposed: boolean[] = []
+
+  return {
+    _reactions: reactions,
+    _activities: activities,
+    _busyStates: busyStates,
+    _resolvedAnswers: resolvedAnswers,
+    _resolvedFailures: resolvedFailures,
+    _disposed: disposed,
+    noteActivity: (summary: string) => {
+      activities.push(summary)
+    },
+    setBusy: (busy: boolean) => {
+      busyStates.push(busy)
+    },
+    resolveToAnswer: vi.fn().mockResolvedValue({transition: 'delegated'}),
+    resolveToFailure: vi.fn().mockResolvedValue({transition: 'delegated'}),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    setReaction: state => {
+      reactions.push(state)
+    },
+  }
+}
+
+/**
+ * Build an in-memory ReplySink that records calls.
+ */
+function makeInMemoryReplySink(): ReplySink & {
+  readonly _sends: {target: string; content: string}[]
+  readonly _appended: string[]
+  readonly _flushed: number
+} {
+  const sends: {target: string; content: string}[] = []
+  const appended: string[] = []
+  let flushed = 0
+  let visible = false
+  let pendingCount = 0
+
+  const sink = {
+    _sends: sends,
+    _appended: appended,
+    get _flushed() {
+      return flushed
+    },
+    send: vi.fn().mockImplementation(async (target: string, options: {content?: string}) => {
+      sends.push({target, content: options.content ?? ''})
+      return {success: true, data: undefined}
+    }),
+    append: (text: string) => {
+      appended.push(text)
+    },
+    flush: vi.fn().mockImplementation(async () => {
+      flushed++
+      visible = true
+      return {kind: 'sent', charCount: appended.join('').length}
+    }),
+    buffered: () => appended.join(''),
+    hasVisibleOutput: () => visible || pendingCount > 0,
+    markVisibleOutputSent: () => {
+      visible = true
+    },
+    markVisibleOutputPending: () => {
+      pendingCount++
+      let settled = false
+      return (delivered: boolean) => {
+        if (settled) return
+        settled = true
+        pendingCount--
+        if (delivered) visible = true
+      }
+    },
+  }
+  return sink
+}
+
+/**
+ * Build a minimal `LaunchWorkRequest` with in-memory sinks.
+ * No Discord dependency — suitable for launchWork tests.
+ */
+function makeInMemoryRequest(
+  overrides: {
+    readonly channelId?: string
+    readonly promptText?: string
+    readonly statusSink?: StatusSink
+    readonly replySink?: ReplySink
+  } = {},
+): LaunchWorkRequest & {
+  readonly _statusSink: ReturnType<typeof makeInMemoryStatusSink>
+  readonly _replySink: ReturnType<typeof makeInMemoryReplySink>
+} {
+  const statusSink = (overrides.statusSink as ReturnType<typeof makeInMemoryStatusSink>) ?? makeInMemoryStatusSink()
+  const replySink = (overrides.replySink as ReturnType<typeof makeInMemoryReplySink>) ?? makeInMemoryReplySink()
+  return {
+    promptText: overrides.promptText ?? 'do the thing',
+    channelId: overrides.channelId ?? CHANNEL_ID,
+    guildId: undefined,
+    surface: 'discord',
+    binding: makeBinding(),
+    requester: {kind: 'discord-user', userId: 'user-111'},
+    statusSink,
+    replySink,
+    _statusSink: statusSink,
+    _replySink: replySink,
+  }
+}
+
+describe('launchWork — in-memory sink tests (Unit 2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Happy path ─────────────────────────────────────────────────────────────
+
+  it('happy path: launchWork completes a run, calls statusSink.setReaction and replySink.flush', async () => {
+    // #given — in-memory sinks; happy path runtime mocks
+    const {launchWork} = await import('./run.js')
+    setupHappyPath()
+
+    const request = makeInMemoryRequest()
+    const deps = makeDeps()
+
+    // #when
+    await launchWork(request, deps)
+
+    // #then — run completed (COMPLETED transition)
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).toContain('COMPLETED')
+
+    // #and — statusSink.setReaction called with 'working' and 'succeeded'
+    const reactions = request._statusSink._reactions
+    expect(reactions).toContain('working')
+    expect(reactions).toContain('succeeded')
+
+    // #and — replySink.flush called (delegated answer path)
+    expect(request._replySink.flush).toHaveBeenCalled()
+  })
+
+  it('happy path: launchWork calls runOpenCodeCore with the request promptText', async () => {
+    // #given
+    const {launchWork} = await import('./run.js')
+    setupHappyPath()
+
+    const request = makeInMemoryRequest({promptText: 'fix the bug'})
+    const deps = makeDeps()
+
+    // #when
+    await launchWork(request, deps)
+
+    // #then — runOpenCodeCore called with a promptText derived from the request
+    expect(mockRunOpenCodeCore).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        promptText: expect.any(String) as unknown,
+      }),
+    )
+    // The promptText is built by buildDiscordPrompt from request.promptText
+    // (buildDiscordPrompt is mocked to return a fixed string)
+  })
+
+  it('happy path: launchWork acquires and releases the concurrency slot', async () => {
+    // #given
+    const {launchWork} = await import('./run.js')
+    setupHappyPath()
+
+    const releaseFn = vi.fn()
+    const request = makeInMemoryRequest()
+    const deps = makeDeps({
+      concurrency: {
+        tryAcquire: vi.fn().mockReturnValue('ok'),
+        release: releaseFn,
+        activeCount: vi.fn().mockReturnValue(1),
+        max: 3,
+      },
+    })
+
+    // #when
+    await launchWork(request, deps)
+
+    // #then — slot released in outer finally
+    expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
+  })
+
+  it('happy path: launchWork calls statusSink.dispose in finally', async () => {
+    // #given
+    const {launchWork} = await import('./run.js')
+    setupHappyPath()
+
+    const request = makeInMemoryRequest()
+    const deps = makeDeps()
+
+    // #when
+    await launchWork(request, deps)
+
+    // #then — statusSink.dispose called
+    expect(request._statusSink.dispose).toHaveBeenCalledOnce()
+  })
+
+  // ── Timeout ────────────────────────────────────────────────────────────────
+
+  it('timeout: launchWork respects runTimeoutMs; statusSink receives failed reaction; replySink.send called with timeout message', async () => {
+    // #given — runOpenCodeCore throws timeout
+    const {launchWork} = await import('./run.js')
+    const {RunCoreError} = runCoreModule
+    setupHappyPath()
+    mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
+
+    const request = makeInMemoryRequest()
+    const deps = makeDeps({runTimeoutMs: 600_000})
+
+    // #when
+    await launchWork(request, deps)
+
+    // #then — failed reaction set
+    expect(request._statusSink._reactions).toContain('failed')
+
+    // #and — replySink.send called with timeout message (via delegated failure path)
+    const sends = request._replySink._sends
+    const timeoutSend = sends.find(s => s.content.includes('time limit'))
+    expect(timeoutSend).toBeDefined()
+    expect(timeoutSend?.content).toMatch(/10.?min/i)
+  })
+
+  it('timeout: launchWork transitions to FAILED on timeout', async () => {
+    // #given
+    const {launchWork} = await import('./run.js')
+    const {RunCoreError} = runCoreModule
+    setupHappyPath()
+    mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
+
+    const request = makeInMemoryRequest()
+    const deps = makeDeps()
+
+    // #when
+    await launchWork(request, deps)
+
+    // #then — FAILED transition
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).toContain('FAILED')
+    expect(transitionPhases).not.toContain('COMPLETED')
+  })
+
+  // ── Shutdown ───────────────────────────────────────────────────────────────
+
+  it('shutdown: isShuttingDown() → slot released immediately, no handoff', async () => {
+    // #given — shutdown in progress
+    const {launchWork} = await import('./run.js')
+    setupHappyPath()
+
+    const releaseFn = vi.fn()
+    const queue = makeDefaultQueue()
+    const isShuttingDown = vi.fn().mockReturnValue(true)
+
+    const request = makeInMemoryRequest()
+    const deps = makeDeps({
+      concurrency: {
+        tryAcquire: vi.fn().mockReturnValue('ok'),
+        release: releaseFn,
+        activeCount: vi.fn().mockReturnValue(1),
+        max: 3,
+      },
+      queue,
+      isShuttingDown,
+    })
+
+    // #when
+    await launchWork(request, deps)
+
+    // #then — slot released immediately (no handoff)
+    expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
+    // #and — takeNext NOT called (shutdown gate fired)
+    expect(queue.takeNext).not.toHaveBeenCalled()
+  })
+
+  // ── Queue/concurrency ──────────────────────────────────────────────────────
+
+  it('queue: launchWork enqueues when channel is busy', async () => {
+    // #given — channel is busy
+    const {launchWork} = await import('./run.js')
+
+    const queue = makeDefaultQueue()
+    const request = makeInMemoryRequest()
+    const deps = makeDeps({
+      concurrency: {
+        tryAcquire: vi.fn().mockReturnValue('busy'),
+        release: vi.fn(),
+        activeCount: vi.fn().mockReturnValue(1),
+        max: 3,
+      },
+      queue,
+    })
+
+    // #when
+    await launchWork(request, deps)
+
+    // #then — task enqueued
+    expect(queue.enqueue).toHaveBeenCalledOnce()
+    // #and — queued ack sent via replySink.send('source', ...)
+    const sends = request._replySink._sends
+    const queuedAck = sends.find(s => s.target === 'source' && s.content.includes('Queued'))
+    expect(queuedAck).toBeDefined()
+  })
+
+  it('cap: launchWork sends capacity reply and does NOT enqueue', async () => {
+    // #given — global cap reached
+    const {launchWork} = await import('./run.js')
+
+    const queue = makeDefaultQueue()
+    const request = makeInMemoryRequest()
+    const deps = makeDeps({
+      concurrency: {
+        tryAcquire: vi.fn().mockReturnValue('cap'),
+        release: vi.fn(),
+        activeCount: vi.fn().mockReturnValue(3),
+        max: 3,
+      },
+      queue,
+    })
+
+    // #when
+    await launchWork(request, deps)
+
+    // #then — capacity reply sent via replySink.send('source', ...)
+    const sends = request._replySink._sends
+    const capReply = sends.find(s => s.target === 'source' && s.content.includes('capacity'))
+    expect(capReply).toBeDefined()
+    // #and — NOT enqueued
+    expect(queue.enqueue).not.toHaveBeenCalled()
+  })
+
+  it('fIFO gate: launchWork enqueues when pendingCount > 0 (even if slot is free)', async () => {
+    // #given — pending work exists; slot would be free
+    const {launchWork} = await import('./run.js')
+
+    const queue = makeDefaultQueue()
+    ;(queue.pendingCount as ReturnType<typeof vi.fn>).mockReturnValue(1)
+    const tryAcquireFn = vi.fn().mockReturnValue('ok')
+
+    const request = makeInMemoryRequest()
+    const deps = makeDeps({
+      concurrency: {
+        tryAcquire: tryAcquireFn,
+        release: vi.fn(),
+        activeCount: vi.fn().mockReturnValue(0),
+        max: 3,
+      },
+      queue,
+    })
+
+    // #when
+    await launchWork(request, deps)
+
+    // #then — task enqueued (FIFO gate)
+    expect(queue.enqueue).toHaveBeenCalledOnce()
+    // #and — tryAcquire NOT consulted (pending work has priority)
+    expect(tryAcquireFn).not.toHaveBeenCalled()
+  })
+
+  // ── No Discord dependency ──────────────────────────────────────────────────
+
+  it('no Discord dependency: launchWork does NOT call setRunReaction (no message)', async () => {
+    // #given — in-memory sinks; no Discord message
+    const {launchWork} = await import('./run.js')
+    setupHappyPath()
+
+    const request = makeInMemoryRequest()
+    const deps = makeDeps()
+
+    // #when
+    await launchWork(request, deps)
+
+    // #then — setRunReaction NOT called (no Discord message in launchWork path)
+    // Reactions are handled by the statusSink.setReaction method instead
+    const mockReaction = vi.mocked(reactionsModule.setRunReaction)
+    expect(mockReaction).not.toHaveBeenCalled()
+  })
+
+  it('no Discord dependency: launchWork does NOT call message.startThread', async () => {
+    // #given — in-memory sinks; no Discord message
+    const {launchWork} = await import('./run.js')
+    setupHappyPath()
+
+    const request = makeInMemoryRequest()
+    const deps = makeDeps()
+
+    // #when
+    await launchWork(request, deps)
+
+    // #then — createDiscordStreamSink NOT called (no thread in launchWork path)
+    // The replySink is provided by the caller, not created internally
+    expect(mockCreateDiscordStreamSink).not.toHaveBeenCalled()
   })
 })

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -168,7 +168,7 @@ export function computeApprovalDeadlineMs(remainingBudgetMs: number): number | u
   return Math.min(Math.max(60_000, Math.floor(remainingBudgetMs / 2)), remainingBudgetMs - 30_000, 13 * 60_000)
 }
 
-// (Unit 2 DiscordAdapterBridge removed in Unit 3 — thread creation now in adapter via threadFactory)
+// DiscordAdapterBridge was removed — thread creation now lives in the adapter via threadFactory
 
 // ---------------------------------------------------------------------------
 // executeWorkOnHeldSlot — the private slot-holding execution pipeline
@@ -274,9 +274,30 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
     // Called after gates pass, before lock acquisition. The Discord adapter provides this to
     // create the response thread at the right pipeline stage. Non-Discord callers (in-memory
     // sinks, future web transports) omit it — the engine uses an empty thread ID in run-state.
+    //
+    // Bounded timeout: a hung threadFactory would pin the concurrency slot indefinitely.
+    // Uses Promise.race with a setTimeout so the timeout is compatible with fake timers in tests.
+    const THREAD_FACTORY_TIMEOUT_MS = 10_000
     let threadId = ''
     if (request.threadFactory !== undefined) {
-      const threadResult = await request.threadFactory()
+      let threadResult: Awaited<ReturnType<NonNullable<typeof request.threadFactory>>>
+      try {
+        threadResult = await Promise.race([
+          request.threadFactory(),
+          new Promise<never>((_, reject) => {
+            setTimeout(() => {
+              reject(new Error(`threadFactory timed out after ${THREAD_FACTORY_TIMEOUT_MS}ms`))
+            }, THREAD_FACTORY_TIMEOUT_MS)
+          }),
+        ])
+      } catch (threadError) {
+        logger.error(
+          {channelId, repo, err: threadError instanceof Error ? threadError.message : String(threadError)},
+          'run: threadFactory threw or timed out — aborting',
+        )
+        await request.replySink.send('source', {content: 'Could not start the task — please try again.'})
+        return
+      }
       if (threadResult.ok === false) {
         logger.error({channelId, repo, err: threadResult.error}, 'run: threadFactory failed — aborting')
         await request.replySink.send('source', {content: 'Could not start the task — please try again.'})
@@ -290,6 +311,8 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
     // ── Acquire repo lock ─────────────────────────────────────────────────────────────────────────
 
     const coordLogger = toCoordLogger(logger)
+    // surface is a string for transport-neutrality; runtime Surface is currently
+    // 'github'|'discord' — widen when a web surface is added.
     const lockResult = await acquireLock(
       coordinationConfig,
       repo,
@@ -320,6 +343,8 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
     // ── Run-state lifecycle + heartbeat ────────────────────────────────────────────────────────
 
     const now = new Date().toISOString()
+    // surface is a string for transport-neutrality; runtime Surface is currently
+    // 'github'|'discord' — widen when a web surface is added.
     const initialRunState = {
       run_id: runId,
       surface: request.surface as Surface,
@@ -482,7 +507,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
           handle,
           directory: bindingWithEnsuredPath.workspacePath,
           promptText,
-          sink: replySink as unknown as import('../discord/streaming.js').DiscordStreamSink,
+          sink: replySink,
           signal: timeoutSignal,
           logger,
           coordinator,
@@ -704,7 +729,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
  * Transport-agnostic: accepts a `LaunchWorkRequest` with pre-constructed
  * `StatusSink` and `ReplySink` implementations. The Discord adapter
  * (`runMention`) calls this after mapping a Discord `Message` → `LaunchWorkRequest`.
- * A future web adapter (Phase B) will call this directly.
+ * A future web adapter will call this directly.
  *
  * Enforces the per-channel FIFO queue and global concurrency cap. A future
  * web caller goes through THIS and cannot bypass the queue/cap.
@@ -729,6 +754,18 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
 export async function launchWork(request: LaunchWorkRequest, deps: RunMentionDeps): Promise<void> {
   const {concurrency, queue} = deps
   const channelId = request.channelId
+
+  // ── Empty-prompt front-door guard ────────────────────────────────────────────
+  // Fail fast before any queue/concurrency/lock/run-state work.
+  // The Discord adapter already strips the mention and checks for empty before
+  // calling launchWork, but this guard ensures any future caller (e.g. a web
+  // transport) cannot enter the engine with an empty prompt and hit the late
+  // EmptyPromptError path (which would churn thread/lock/run-state before failing).
+  if (request.promptText.trim().length === 0) {
+    await request.replySink.send('source', {content: 'Nothing to do — please include a task in your message.'})
+    return
+  }
+
   const task: RunTask = {request, deps}
 
   // ── FIFO gate: if pending work exists, enqueue without consulting tryAcquire ──
@@ -778,7 +815,7 @@ async function ackEnqueueResult(request: LaunchWorkRequest, result: 'queued' | '
 }
 
 // ---------------------------------------------------------------------------
-// runMention — thin Discord adapter (Unit 3)
+// runMention — thin Discord adapter
 // ---------------------------------------------------------------------------
 
 /**
@@ -791,10 +828,10 @@ async function ackEnqueueResult(request: LaunchWorkRequest, result: 'queued' | '
  *
  * ## Adapter responsibilities
  *
- * 1. **Empty-prompt fail-fast (accepted Phase A behavior change):** strips the
- *    bot mention from `message.content` via `botUserId`. If the result is empty,
- *    replies on the SOURCE message (not a thread) and returns immediately — no
- *    thread created, no lock acquired, no run-state written.
+ * 1. **Empty-prompt fail-fast:** strips the bot mention from `message.content`
+ *    via `botUserId`. If the result is empty, replies on the SOURCE message
+ *    (not a thread) and returns immediately — no thread created, no lock
+ *    acquired, no run-state written.
  *
  * 2. **Pre-thread acks:** cap/queue acks go to the source message via
  *    `sendMessage(message, ...)` before a thread exists.
@@ -823,11 +860,11 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
   const {logger, botUserId} = deps
   const channelId = message.channel.id
 
-  // ── Empty-prompt fail-fast (accepted Phase A behavior change) ─────────────
+  // ── Empty-prompt fail-fast ────────────────────────────────────────────────
   // Strip the bot mention from the message content. If the result is empty,
   // fail fast BEFORE thread/lock/run-state — reply on the source message.
-  // This deliberately changes the Unit 0 baseline behavior (which surfaced
-  // EmptyPromptError late in-thread after thread creation and lock acquisition).
+  // This avoids the late EmptyPromptError path (which surfaced in-thread after
+  // thread creation and lock acquisition) for the common bare-mention case.
   const mentionPattern = new RegExp(`<@!?${botUserId}>`, 'g')
   const strippedPrompt = message.content.replace(mentionPattern, '').trim()
   if (strippedPrompt.length === 0) {
@@ -948,7 +985,9 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
     promptText: strippedPrompt,
     channelId,
     guildId: message.guild?.id,
-    surface: 'discord', // Phase B: 'web' — one documented cast in engine (request.surface as Surface)
+    // surface is a string for transport-neutrality; runtime Surface is currently 'github'|'discord' —
+    // widen when a web surface is added. The engine casts request.surface as Surface at lock/run-state.
+    surface: 'discord',
     binding,
     requester: {kind: 'discord-user', userId: message.author.id},
     statusSink,

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -13,8 +13,8 @@ import type {ChannelQueue} from './queue.js'
 import {acquireLock, createHeartbeatController, createRun, releaseLock, transitionRun} from '@fro-bot/runtime'
 
 import {createPermissionCoordinator} from '../approvals/coordinator.js'
-import {buildApprovalButtons, buildApprovalEmbed, buildSettledEmbed} from '../discord/approvals.js'
-import {editMessage, sendMessage} from '../discord/io.js'
+import {createDiscordApprovalOnPending} from '../approvals/discord-transport.js'
+import {sendMessage} from '../discord/io.js'
 import {setRunReaction} from '../discord/reactions.js'
 import {createStatusController} from '../discord/status-message.js'
 import {createDiscordStreamSink} from '../discord/streaming.js'
@@ -407,160 +407,64 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       // ── Approval coordinator — per-run, wired to the program-scoped registry ──
       const approvalDeadlineMs = computeApprovalDeadlineMs(remainingBudgetMs)
 
+      // ── Discord approval transport — owns embed render, registry wiring, and
+      // the Message-reference cast (a clean Discord concern). The engine's
+      // onPending hook is transport-neutral; the Discord transport supplies the
+      // Discord implementation. A future web transport would supply its own.
+      //
+      // postReplyFactory: creates a per-request postReply closure that captures
+      // sessionID. Called once per onPending invocation by the transport.
+      // FIX 4: AbortSignal.timeout(10_000) avoids the dangling-timer leak from
+      // the old Promise.race approach. AbortSignal.timeout is self-cleaning.
+      const discordOnPending = createDiscordApprovalOnPending({
+        approvalRegistry,
+        replySink,
+        threadId,
+        directory: bindingWithEnsuredPath.workspacePath,
+        approvalDeadlineMs,
+        onDeadlineSettled: async () => {
+          // markVisibleOutputSent AFTER the send succeeds so flush() still
+          // adds _(no output)_ if the send fails (user needs the fallback).
+          const deadlineResult = await replySink.send('thread', {
+            content: 'Approval timed out — the task could not continue.',
+          })
+          const dr = deadlineResult as {success?: boolean} | undefined
+          if (dr?.success === true) {
+            replySink.markVisibleOutputSent()
+          }
+        },
+        postReplyFactory: sessionID => async (rID, directory, decision) => {
+          // Call the OpenCode SDK permission reply endpoint.
+          // Uses the session-scoped API: POST /session/{id}/permissions/{permissionID}
+          try {
+            const res = await handle.client.postSessionIdPermissionsPermissionId({
+              path: {id: sessionID, permissionID: rID},
+              body: {response: decision},
+              query: {directory},
+              signal: AbortSignal.timeout(10_000),
+            })
+            const envelope = res as {error?: unknown} | undefined
+            if (envelope?.error != null) {
+              return {ok: false as const, error: String(envelope.error)}
+            }
+            return {ok: true as const}
+          } catch (error) {
+            return {ok: false as const, error: error instanceof Error ? error.message : String(error)}
+          }
+        },
+        logger,
+      })
+
       const coordinator = createPermissionCoordinator({
         logger,
         onPending: req => {
-          // Per-request closures — each captures its own sessionID.
-          const {requestID, sessionID} = req
-
-          // postReply: call the OpenCode SDK permission reply endpoint.
-          // Uses the session-scoped API: POST /session/{id}/permissions/{permissionID}
-          // A 10 s AbortSignal.timeout ensures we never hang indefinitely.
-          const postReplyForRequest = async (
-            rID: string,
-            directory: string,
-            decision: import('../approvals/coordinator.js').PermissionReply,
-          ) => {
-            // FIX 4: Use AbortSignal.timeout(10_000) passed directly to the SDK call.
-            // This avoids the dangling-timer leak from the old Promise.race approach
-            // (where the losing setTimeout would remain armed for 10 s after the SDK
-            // call resolved). AbortSignal.timeout is self-cleaning — no manual
-            // clearTimeout needed. The SDK's Config extends RequestInit which includes
-            // signal?: AbortSignal | null, so this is type-safe.
-            try {
-              const res = await handle.client.postSessionIdPermissionsPermissionId({
-                path: {id: sessionID, permissionID: rID},
-                body: {response: decision},
-                query: {directory},
-                signal: AbortSignal.timeout(10_000),
-              })
-              const envelope = res as {error?: unknown} | undefined
-              if (envelope?.error != null) {
-                return {ok: false as const, error: String(envelope.error)}
-              }
-              return {ok: true as const}
-            } catch (error) {
-              return {ok: false as const, error: error instanceof Error ? error.message : String(error)}
-            }
-          }
-
-          // register-before-send: register the entry in the shared registry
-          // BEFORE attempting the Discord embed post. This ensures the button
-          // handler can look up the entry even if the send is still in-flight.
-          // Registry owns the deadline timer (single-owner rule).
-          //
-          // channelID: use threadId (set by threadFactory after thread creation).
-          // For non-Discord paths (in-memory sinks), threadId is '' — the registry
-          // still works; the channelID is only used for button-handler lookup.
-          //
-          // onDeadlineSettled: post a visible timed-out status via replySink.send
-          // and mark the sink so flush() does not add a misleading _(no output)_.
-          approvalRegistry.register({
-            requestID,
-            sessionID,
-            channelID: threadId,
-            directory: bindingWithEnsuredPath.workspacePath,
-            request: req,
-            effects: {postReply: postReplyForRequest},
-            deadlineMs: approvalDeadlineMs,
-            onDeadlineSettled: async () => {
-              // markVisibleOutputSent AFTER the send succeeds so flush() still
-              // adds _(no output)_ if the send fails (user needs the fallback).
-              // replySink.send returns unknown; cast to check success (Discord impl
-              // returns Result<Message, {message: string}> — one documented cast).
-              const deadlineResult = await replySink.send('thread', {
-                content: 'Approval timed out — the task could not continue.',
-              })
-              const dr = deadlineResult as {success?: boolean} | undefined
-              if (dr?.success === true) {
-                replySink.markVisibleOutputSent()
-              }
-            },
-          })
-
           // Awaiting-approval reaction — best-effort, fire-and-forget.
           // Replaces the working reaction with the awaiting-approval cue.
+          // The reaction is set here (in the engine) because it's transport-neutral
+          // state management; the Discord embed/button rendering is in the transport.
           statusSink.setReaction('awaiting-approval')
-
-          // Post a visible waiting-for-approval status BEFORE the embed so the
-          // user sees the run is blocked even if the embed send is slow.
-          // Fire-and-forget: status is best-effort; must not block onPending.
-          // .catch() prevents an unhandled rejection if the Discord send fails.
-          //
-          // Pending-visibility: mark the send as in-flight BEFORE the void send so
-          // timeout classification sees it as visible context even if the Discord
-          // round-trip has not completed yet. settle(true) on success promotes to
-          // permanently delivered; settle(false) on failure retracts the claim.
-          const settleWaitingStatus = replySink.markVisibleOutputPending()
-          // eslint-disable-next-line no-void
-          void replySink.send('thread', {content: 'Waiting for tool approval…'}).then(result => {
-            // replySink.send returns unknown; cast to check success (one documented cast).
-            const r = result as {success?: boolean; error?: {message: string}} | undefined
-            if (r?.success === true) {
-              settleWaitingStatus(true)
-            } else {
-              settleWaitingStatus(false)
-              logger.warn(
-                {requestID, err: r?.error?.message ?? 'unknown'},
-                'run: failed to post waiting-for-approval status',
-              )
-            }
-          })
-
-          // Fire-and-forget: send the embed then attach the render function.
-          // onPending must not throw (coordinator catches internally anyway).
-          //
-          // Pending-visibility: same pattern as the waiting-status send above —
-          // mark in-flight before the void send, settle on resolution.
-          //
-          // replySink.send returns unknown; cast to get the posted message reference
-          // for attachMessage (Discord impl returns Result<Message, ...>).
-          // This is the one documented cast in the engine — Phase B will widen
-          // ReplySink.send to return a typed result when needed.
-          const settleEmbed = replySink.markVisibleOutputPending()
-          // eslint-disable-next-line no-void
-          void replySink
-            .send('thread', {embeds: [buildApprovalEmbed(req)], components: [buildApprovalButtons(requestID)]})
-            .then(result => {
-              const r = result as {success?: boolean; data?: Message; error?: {message: string}} | undefined
-              if (r?.success === true) {
-                // Embed send succeeded — settle pending claim as delivered so
-                // flush() does not add a misleading _(no output)_.
-                settleEmbed(true)
-                const postedMessage = r.data
-                if (postedMessage !== undefined) {
-                  // Attach the render function now that we have a message reference.
-                  approvalRegistry.attachMessage(
-                    requestID,
-                    async (
-                      permReq: import('../approvals/coordinator.js').PermissionRequest,
-                      decision: import('../approvals/coordinator.js').PermissionReply,
-                      decidedBy: string | null,
-                      reason: import('../approvals/coordinator.js').SettlementReason,
-                    ) => {
-                      const editResult = await editMessage(
-                        postedMessage,
-                        {
-                          embeds: [buildSettledEmbed(permReq, decision, {decidedBy: decidedBy ?? undefined, reason})],
-                          components: [],
-                        },
-                        logger,
-                      )
-                      if (editResult.success === false) {
-                        logger.warn(
-                          {requestID: permReq.requestID, err: editResult.error.message},
-                          'run: failed to edit approval message',
-                        )
-                      }
-                    },
-                  )
-                }
-              } else {
-                settleEmbed(false)
-                logger.warn({requestID, err: r?.error?.message ?? 'unknown'}, 'run: failed to post approval embed')
-                approvalRegistry.markMessagePostFailed(requestID)
-              }
-            })
+          // Delegate to the Discord transport for embed render + registry wiring.
+          discordOnPending(req)
         },
         onReplied: event => {
           // Authoritative echo from OpenCode — let the registry render + cascade.

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -168,26 +168,7 @@ export function computeApprovalDeadlineMs(remainingBudgetMs: number): number | u
   return Math.min(Math.max(60_000, Math.floor(remainingBudgetMs / 2)), remainingBudgetMs - 30_000, 13 * 60_000)
 }
 
-// ---------------------------------------------------------------------------
-// Unit 2 internal extension — Discord adapter bridge
-// ---------------------------------------------------------------------------
-
-/**
- * Internal extension carried on `RunTask` by the Discord adapter (`runMention`).
- *
- * Unit 2 bridge: thread creation still happens inside `executeWorkOnHeldSlot`
- * because the Discord sinks depend on the thread. The adapter provides:
- * - `_discordMessage`: the raw Discord `Message` used for thread creation.
- * - `_initSinks(thread, rawThread)`: called after thread creation to wire the
- *   real Discord sinks into the deferred proxy sinks on the `LaunchWorkRequest`.
- *
- * These fields are INTERNAL to Unit 2 and will be removed in Unit 3 when
- * thread creation moves fully into the Discord adapter.
- */
-interface DiscordAdapterBridge {
-  readonly _discordMessage: Message
-  readonly _initSinks: (thread: SinkThread, rawThread: Awaited<ReturnType<Message['startThread']>>) => void
-}
+// (Unit 2 DiscordAdapterBridge removed in Unit 3 — thread creation now in adapter via threadFactory)
 
 // ---------------------------------------------------------------------------
 // executeWorkOnHeldSlot — the private slot-holding execution pipeline
@@ -242,12 +223,6 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
   // deadline clearance are computed from the same wall-clock reference.
   const runStartMs = Date.now()
 
-  // ── Unit 2 bridge: extract Discord-specific fields from the task ──────────
-  // These are provided by the Discord adapter (runMention) and will be removed
-  // in Unit 3 when thread creation moves fully into the adapter.
-  const bridge = task as RunTask & Partial<DiscordAdapterBridge>
-  const discordMessage = bridge._discordMessage
-
   try {
     // ── Ensure workspace checkout exists ──────────────────────────────────────────────────────
     // Rehydrates a missing checkout (e.g. after container recreation) before OpenCode can start.
@@ -295,32 +270,22 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       return
     }
 
-    // ── Create response thread ─────────────────────────────────────────────────────────────────
-    // Unit 2: thread creation still uses the Discord message (via the bridge).
-    // Unit 3 will move thread creation into the Discord adapter.
-    if (discordMessage === undefined) {
-      // Non-Discord path (in-memory sinks, no thread needed): skip thread creation.
-      // The sinks are already fully initialized by the caller.
-      await executeWorkCore(task, bindingWithEnsuredPath, runStartMs)
-      return
+    // ── Thread factory (transport-specific, optional) ─────────────────────────────────────────
+    // Called after gates pass, before lock acquisition. The Discord adapter provides this to
+    // create the response thread at the right pipeline stage. Non-Discord callers (in-memory
+    // sinks, future web transports) omit it — the engine uses an empty thread ID in run-state.
+    let threadId = ''
+    if (request.threadFactory !== undefined) {
+      const threadResult = await request.threadFactory()
+      if (threadResult.ok === false) {
+        logger.error({channelId, repo, err: threadResult.error}, 'run: threadFactory failed — aborting')
+        await request.replySink.send('source', {content: 'Could not start the task — please try again.'})
+        return
+      }
+      threadId = threadResult.threadId
     }
 
     const runId = crypto.randomUUID()
-    let rawThread: Awaited<ReturnType<typeof discordMessage.startThread>>
-    try {
-      rawThread = await discordMessage.startThread({name: `fro-bot: ${binding.repo}`})
-    } catch (threadError) {
-      logger.error({channelId, repo, err: String(threadError)}, 'run: startThread threw — aborting')
-      await request.replySink.send('source', {content: 'Could not start the task — please try again.'})
-      return
-    }
-    const threadId = rawThread.id
-    const thread: SinkThread = rawThread
-
-    // ── Wire the real Discord sinks into the deferred proxy sinks ────────────
-    // The adapter's _initSinks callback initializes the real sinks now that we
-    // have the thread reference.
-    bridge._initSinks?.(thread, rawThread)
 
     // ── Acquire repo lock ─────────────────────────────────────────────────────────────────────────
 
@@ -358,7 +323,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
     const initialRunState = {
       run_id: runId,
       surface: request.surface as Surface,
-      thread_id: threadId,
+      thread_id: threadId, // empty string for non-Discord/in-memory paths
       entity_ref: repo,
       phase: 'PENDING' as const,
       started_at: now,
@@ -484,12 +449,16 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
           // handler can look up the entry even if the send is still in-flight.
           // Registry owns the deadline timer (single-owner rule).
           //
-          // onDeadlineSettled: post a visible timed-out status to the run thread
+          // channelID: use threadId (set by threadFactory after thread creation).
+          // For non-Discord paths (in-memory sinks), threadId is '' — the registry
+          // still works; the channelID is only used for button-handler lookup.
+          //
+          // onDeadlineSettled: post a visible timed-out status via replySink.send
           // and mark the sink so flush() does not add a misleading _(no output)_.
           approvalRegistry.register({
             requestID,
             sessionID,
-            channelID: rawThread.id,
+            channelID: threadId,
             directory: bindingWithEnsuredPath.workspacePath,
             request: req,
             effects: {postReply: postReplyForRequest},
@@ -497,12 +466,13 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
             onDeadlineSettled: async () => {
               // markVisibleOutputSent AFTER the send succeeds so flush() still
               // adds _(no output)_ if the send fails (user needs the fallback).
-              const deadlineResult = await sendMessage(
-                rawThread,
-                {content: 'Approval timed out — the task could not continue.'},
-                logger,
-              )
-              if (deadlineResult.success === true) {
+              // replySink.send returns unknown; cast to check success (Discord impl
+              // returns Result<Message, {message: string}> — one documented cast).
+              const deadlineResult = await replySink.send('thread', {
+                content: 'Approval timed out — the task could not continue.',
+              })
+              const dr = deadlineResult as {success?: boolean} | undefined
+              if (dr?.success === true) {
                 replySink.markVisibleOutputSent()
               }
             },
@@ -523,64 +493,74 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
           // permanently delivered; settle(false) on failure retracts the claim.
           const settleWaitingStatus = replySink.markVisibleOutputPending()
           // eslint-disable-next-line no-void
-          void sendMessage(rawThread, {content: 'Waiting for tool approval…'}, logger).then(result => {
-            if (result.success === true) {
+          void replySink.send('thread', {content: 'Waiting for tool approval…'}).then(result => {
+            // replySink.send returns unknown; cast to check success (one documented cast).
+            const r = result as {success?: boolean; error?: {message: string}} | undefined
+            if (r?.success === true) {
               settleWaitingStatus(true)
             } else {
               settleWaitingStatus(false)
-              logger.warn({requestID, err: result.error.message}, 'run: failed to post waiting-for-approval status')
+              logger.warn(
+                {requestID, err: r?.error?.message ?? 'unknown'},
+                'run: failed to post waiting-for-approval status',
+              )
             }
           })
 
           // Fire-and-forget: send the embed then attach the render function.
-          // rawThread has the full Discord.js API (embeds, components, edit).
           // onPending must not throw (coordinator catches internally anyway).
           //
           // Pending-visibility: same pattern as the waiting-status send above —
           // mark in-flight before the void send, settle on resolution.
+          //
+          // replySink.send returns unknown; cast to get the posted message reference
+          // for attachMessage (Discord impl returns Result<Message, ...>).
+          // This is the one documented cast in the engine — Phase B will widen
+          // ReplySink.send to return a typed result when needed.
           const settleEmbed = replySink.markVisibleOutputPending()
           // eslint-disable-next-line no-void
-          void sendMessage<Message>(
-            rawThread,
-            {embeds: [buildApprovalEmbed(req)], components: [buildApprovalButtons(requestID)]},
-            logger,
-          ).then(result => {
-            if (result.success === true) {
-              // Embed send succeeded — settle pending claim as delivered so
-              // flush() does not add a misleading _(no output)_.
-              settleEmbed(true)
-              const postedMessage = result.data
-              // Attach the render function now that we have a message reference.
-              approvalRegistry.attachMessage(
-                requestID,
-                async (
-                  permReq: import('../approvals/coordinator.js').PermissionRequest,
-                  decision: import('../approvals/coordinator.js').PermissionReply,
-                  decidedBy: string | null,
-                  reason: import('../approvals/coordinator.js').SettlementReason,
-                ) => {
-                  const editResult = await editMessage(
-                    postedMessage,
-                    {
-                      embeds: [buildSettledEmbed(permReq, decision, {decidedBy: decidedBy ?? undefined, reason})],
-                      components: [],
+          void replySink
+            .send('thread', {embeds: [buildApprovalEmbed(req)], components: [buildApprovalButtons(requestID)]})
+            .then(result => {
+              const r = result as {success?: boolean; data?: Message; error?: {message: string}} | undefined
+              if (r?.success === true) {
+                // Embed send succeeded — settle pending claim as delivered so
+                // flush() does not add a misleading _(no output)_.
+                settleEmbed(true)
+                const postedMessage = r.data
+                if (postedMessage !== undefined) {
+                  // Attach the render function now that we have a message reference.
+                  approvalRegistry.attachMessage(
+                    requestID,
+                    async (
+                      permReq: import('../approvals/coordinator.js').PermissionRequest,
+                      decision: import('../approvals/coordinator.js').PermissionReply,
+                      decidedBy: string | null,
+                      reason: import('../approvals/coordinator.js').SettlementReason,
+                    ) => {
+                      const editResult = await editMessage(
+                        postedMessage,
+                        {
+                          embeds: [buildSettledEmbed(permReq, decision, {decidedBy: decidedBy ?? undefined, reason})],
+                          components: [],
+                        },
+                        logger,
+                      )
+                      if (editResult.success === false) {
+                        logger.warn(
+                          {requestID: permReq.requestID, err: editResult.error.message},
+                          'run: failed to edit approval message',
+                        )
+                      }
                     },
-                    logger,
                   )
-                  if (editResult.success === false) {
-                    logger.warn(
-                      {requestID: permReq.requestID, err: editResult.error.message},
-                      'run: failed to edit approval message',
-                    )
-                  }
-                },
-              )
-            } else {
-              settleEmbed(false)
-              logger.warn({requestID, err: result.error.message}, 'run: failed to post approval embed')
-              approvalRegistry.markMessagePostFailed(requestID)
-            }
-          })
+                }
+              } else {
+                settleEmbed(false)
+                logger.warn({requestID, err: r?.error?.message ?? 'unknown'}, 'run: failed to post approval embed')
+                approvalRegistry.markMessagePostFailed(requestID)
+              }
+            })
         },
         onReplied: event => {
           // Authoritative echo from OpenCode — let the registry render + cascade.
@@ -811,344 +791,6 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// executeWorkCore — non-Discord execution path (in-memory sinks, no thread)
-// ---------------------------------------------------------------------------
-
-/**
- * Execute the core pipeline for a task that already has fully-initialized sinks
- * (no Discord thread creation needed). Used by the non-Discord path in Unit 2.
- *
- * This is a simplified version of the Discord path that skips thread creation,
- * lock acquisition, run-state lifecycle, and heartbeat — it runs the core
- * execution pipeline directly.
- *
- * NOTE: This is a placeholder for the in-memory sink tests in Unit 2. The full
- * non-Discord path (with lock, run-state, heartbeat) will be implemented in
- * Unit 3 when the Discord adapter is fully separated.
- */
-async function executeWorkCore(
-  task: RunTask,
-  bindingWithEnsuredPath: {readonly owner: string; readonly repo: string; readonly workspacePath: string},
-  runStartMs: number,
-): Promise<void> {
-  const {request, deps} = task
-  const {
-    coordinationConfig,
-    identity,
-    attachUrl,
-    attachToken,
-    runTimeoutMs,
-    botUserId,
-    persona,
-    logger,
-    approvalRegistry,
-    approvalMode,
-  } = deps
-
-  const channelId = request.channelId
-  const binding = request.binding
-  const repo = `${binding.owner}/${binding.repo}`
-  const coordLogger = toCoordLogger(logger)
-  const runId = crypto.randomUUID()
-
-  // ── Run-state lifecycle + heartbeat ────────────────────────────────────────────────────────
-
-  const now = new Date().toISOString()
-  const initialRunState = {
-    run_id: runId,
-    surface: request.surface as Surface,
-    thread_id: '',
-    entity_ref: repo,
-    phase: 'PENDING' as const,
-    started_at: now,
-    last_heartbeat: now,
-    holder_id: identity,
-    details: {channelId, owner: binding.owner, repo: binding.repo},
-  }
-
-  const lockResult = await acquireLock(
-    coordinationConfig,
-    repo,
-    identity,
-    request.surface as Surface,
-    runId,
-    coordLogger,
-  )
-  if (lockResult.success === false) {
-    logger.error({repo, runId, err: lockResult.error.message}, 'run: lock acquisition error')
-    await request.replySink.send('thread', {content: 'Could not start the task — please try again.'})
-    return
-  }
-  if (lockResult.data.acquired === false) {
-    logger.info({repo, runId, holder: lockResult.data.holder?.holder_id ?? 'unknown'}, 'run: lock held by another')
-    await request.replySink.send('thread', {
-      content: 'Another task is already in progress for this repo. Try again when it completes.',
-    })
-    return
-  }
-  let lockEtag = lockResult.data.etag
-
-  const createResult = await createRun(coordinationConfig, identity, repo, initialRunState, coordLogger)
-  if (createResult.success === false) {
-    logger.error({repo, runId, err: createResult.error.message}, 'run: createRun failed')
-    await request.replySink.send('thread', {content: 'Could not start the task — please try again.'})
-    await releaseLock(coordinationConfig, repo, lockEtag, coordLogger)
-    return
-  }
-  let runEtag = createResult.data.etag
-
-  const ackResult = await transitionRun(coordinationConfig, identity, repo, runId, 'ACKNOWLEDGED', runEtag, coordLogger)
-  if (ackResult.success === false) {
-    logger.error({repo, runId, err: ackResult.error.message}, 'run: transitionRun ACKNOWLEDGED failed')
-    await request.replySink.send('thread', {content: 'Could not start the task — please try again.'})
-    await releaseLock(coordinationConfig, repo, lockEtag, coordLogger)
-    return
-  }
-  runEtag = ackResult.data.etag
-
-  const heartbeat = createHeartbeatController(coordinationConfig, identity, repo, runId, lockEtag, coordLogger)
-  heartbeat.start()
-  let heartbeatStopped = false
-
-  const {statusSink, replySink} = request
-
-  try {
-    const execResult = await transitionRun(coordinationConfig, identity, repo, runId, 'EXECUTING', runEtag, coordLogger)
-    if (execResult.success === false) {
-      throw new Error(`transitionRun EXECUTING failed: ${execResult.error.message}`)
-    }
-    runEtag = execResult.data.etag
-
-    statusSink.setReaction('working')
-
-    const handle = attachOpencode(attachUrl, attachToken)
-    const promptText = buildDiscordPrompt({
-      messageText: request.promptText,
-      owner: bindingWithEnsuredPath.owner,
-      repo: bindingWithEnsuredPath.repo,
-      botUserId,
-      persona,
-    })
-
-    const elapsedMs = Date.now() - runStartMs
-    const remainingBudgetMs = Math.max(0, runTimeoutMs - elapsedMs)
-    const timeoutSignal = AbortSignal.timeout(remainingBudgetMs)
-    const approvalDeadlineMs = computeApprovalDeadlineMs(remainingBudgetMs)
-
-    const coordinator = createPermissionCoordinator({
-      logger,
-      onPending: req => {
-        const {requestID, sessionID} = req
-        const postReplyForRequest = async (
-          rID: string,
-          directory: string,
-          decision: import('../approvals/coordinator.js').PermissionReply,
-        ) => {
-          try {
-            const res = await handle.client.postSessionIdPermissionsPermissionId({
-              path: {id: sessionID, permissionID: rID},
-              body: {response: decision},
-              query: {directory},
-              signal: AbortSignal.timeout(10_000),
-            })
-            const envelope = res as {error?: unknown} | undefined
-            if (envelope?.error != null) {
-              return {ok: false as const, error: String(envelope.error)}
-            }
-            return {ok: true as const}
-          } catch (error) {
-            return {ok: false as const, error: error instanceof Error ? error.message : String(error)}
-          }
-        }
-        approvalRegistry.register({
-          requestID,
-          sessionID,
-          channelID: channelId,
-          directory: bindingWithEnsuredPath.workspacePath,
-          request: req,
-          effects: {postReply: postReplyForRequest},
-          deadlineMs: approvalDeadlineMs,
-          onDeadlineSettled: async () => {
-            const deadlineResult = await replySink.send('thread', {
-              content: 'Approval timed out — the task could not continue.',
-            })
-            if (deadlineResult !== undefined) {
-              const r = deadlineResult as {success?: boolean}
-              if (r.success === true) {
-                replySink.markVisibleOutputSent()
-              }
-            }
-          },
-        })
-        statusSink.setReaction('awaiting-approval')
-        const settleWaitingStatus = replySink.markVisibleOutputPending()
-        // eslint-disable-next-line no-void
-        void replySink.send('thread', {content: 'Waiting for tool approval…'}).then(result => {
-          const r = result as {success?: boolean; error?: {message: string}} | undefined
-          if (r?.success === true) {
-            settleWaitingStatus(true)
-          } else {
-            settleWaitingStatus(false)
-            logger.warn(
-              {requestID, err: r?.error?.message ?? 'unknown'},
-              'run: failed to post waiting-for-approval status',
-            )
-          }
-        })
-        const settleEmbed = replySink.markVisibleOutputPending()
-        // eslint-disable-next-line no-void
-        void replySink.send('thread', {content: `[approval-embed:${requestID}]`}).then(result => {
-          const r = result as {success?: boolean; error?: {message: string}} | undefined
-          if (r?.success === true) {
-            settleEmbed(true)
-          } else {
-            settleEmbed(false)
-            logger.warn({requestID, err: r?.error?.message ?? 'unknown'}, 'run: failed to post approval embed')
-            approvalRegistry.markMessagePostFailed(requestID)
-          }
-        })
-      },
-      onReplied: event => {
-        approvalRegistry.confirmReply(event)
-      },
-      onDispose: sessionIDs => {
-        // eslint-disable-next-line no-void
-        void Promise.all(sessionIDs.map(async sid => approvalRegistry.disposeRun(sid, 'run ended')))
-      },
-    })
-
-    try {
-      await runOpenCodeCore({
-        handle,
-        directory: bindingWithEnsuredPath.workspacePath,
-        promptText,
-        sink: replySink as unknown as import('../discord/streaming.js').DiscordStreamSink,
-        signal: timeoutSignal,
-        logger,
-        coordinator,
-        approvalMode,
-        onActivity: (summary: string) => {
-          statusSink.noteActivity(summary)
-        },
-        onBusy: (busy: boolean) => {
-          statusSink.setBusy(busy)
-        },
-      })
-    } finally {
-      coordinator.dispose('run ended')
-    }
-
-    statusSink.setReaction('succeeded')
-
-    const stopResult = await heartbeat.stop()
-    heartbeatStopped = true
-    if (stopResult.success === true) {
-      runEtag = stopResult.data.runEtag
-      lockEtag = stopResult.data.lockEtag
-    } else {
-      logger.warn({repo, runId, err: stopResult.error.message}, 'run: heartbeat stop failed; using last known etags')
-    }
-
-    const completedResult = await transitionRun(
-      coordinationConfig,
-      identity,
-      repo,
-      runId,
-      'COMPLETED',
-      runEtag,
-      coordLogger,
-    )
-    if (completedResult.success === false) {
-      logger.error({repo, runId, err: completedResult.error.message}, 'run: transitionRun COMPLETED failed')
-    }
-
-    const finalText = replySink.buffered()
-    const answerResult = await statusSink.resolveToAnswer(finalText)
-    if (answerResult.transition === 'delegated') {
-      await replySink.flush()
-    }
-  } catch (execError: unknown) {
-    const isCoreError = execError instanceof RunCoreError
-    const isTimeout = isCoreError && execError.kind === 'timeout'
-    const isStreamEnded = isCoreError && execError.kind === 'stream-ended'
-    const isReachability = isCoreError && (execError.kind === 'unreachable' || execError.kind === 'auth')
-    const isEmptyPrompt = execError instanceof EmptyPromptError
-
-    logger.error(
-      {
-        repo,
-        runId,
-        kind: isCoreError ? execError.kind : 'unknown',
-        err: execError instanceof Error ? execError.message : String(execError),
-      },
-      'run: execution failed',
-    )
-
-    statusSink.setReaction('failed')
-
-    if (heartbeatStopped === false) {
-      const stopResult = await heartbeat.stop()
-      heartbeatStopped = true
-      if (stopResult.success === true) {
-        runEtag = stopResult.data.runEtag
-        lockEtag = stopResult.data.lockEtag
-      } else {
-        logger.warn({repo, runId, err: stopResult.error.message}, 'run: heartbeat stop failed; using last known etags')
-      }
-    }
-
-    const failedResult = await transitionRun(coordinationConfig, identity, repo, runId, 'FAILED', runEtag, coordLogger)
-    if (failedResult.success === false) {
-      logger.error({repo, runId, err: failedResult.error.message}, 'run: transitionRun FAILED failed')
-    }
-
-    await replySink.flush().catch((flushError: unknown) => {
-      logger.warn({repo, runId, err: String(flushError)}, 'run: sink.flush failed in error path')
-    })
-
-    const timeoutDuration = formatTimeoutDuration(runTimeoutMs)
-    const hasVisibleOutput = replySink.hasVisibleOutput() === true
-    const userMessage =
-      isTimeout === true
-        ? hasVisibleOutput === true
-          ? `The task reached the ${timeoutDuration} time limit after posting updates above. Start a new @fro-bot request with what to do next and include any needed context from the output above.`
-          : `The task reached the ${timeoutDuration} time limit. Please try again.`
-        : isReachability === true
-          ? 'The workspace is not reachable right now. Please try again later.'
-          : isEmptyPrompt === true
-            ? 'Nothing to do — please include a task in your message.'
-            : isStreamEnded === true
-              ? 'The task stream closed unexpectedly. Please try again.'
-              : 'The task failed. Please try again.'
-
-    const failureResult = await statusSink.resolveToFailure(userMessage).catch((error: unknown) => {
-      logger.warn({repo, runId, err: String(error)}, 'run: statusController.resolveToFailure failed — delegating')
-      return {transition: 'delegated' as const}
-    })
-    if (failureResult.transition === 'delegated') {
-      await replySink.send('thread', {content: userMessage}).catch((sendError: unknown) => {
-        logger.warn({repo, runId, err: String(sendError)}, 'run: failed to send error reply to thread')
-      })
-    }
-  } finally {
-    if (heartbeatStopped === false) {
-      await heartbeat.stop().catch(() => {
-        /* best-effort */
-      })
-    }
-
-    await statusSink.dispose().catch((error: unknown) => {
-      logger.warn({repo, runId, err: String(error)}, 'run: statusController.dispose failed')
-    })
-
-    const releaseResult = await releaseLock(coordinationConfig, repo, lockEtag, coordLogger)
-    if (releaseResult.success === false) {
-      logger.warn({repo, runId, err: releaseResult.error.message}, 'run: releaseLock failed')
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
 // launchWork — the public, queue-and-cap-preserving front door
 // ---------------------------------------------------------------------------
 
@@ -1232,33 +874,66 @@ async function ackEnqueueResult(request: LaunchWorkRequest, result: 'queued' | '
 }
 
 // ---------------------------------------------------------------------------
-// runMention — the Discord adapter (Unit 2: constructs sinks inline)
+// runMention — thin Discord adapter (Unit 3)
 // ---------------------------------------------------------------------------
 
 /**
- * Discord adapter for mention-triggered runs.
+ * Thin Discord adapter for mention-triggered runs.
  *
  * Maps a Discord `Message` → `LaunchWorkRequest` and calls `launchWork`.
+ * This is the ONLY place in the codebase that touches a raw Discord `Message`
+ * for execution purposes — the engine (`launchWork`/`executeWorkOnHeldSlot`)
+ * is fully transport-neutral.
  *
- * In Unit 2, the Discord sinks are "deferred" — they are initialized inside
- * `executeWorkOnHeldSlot` after thread creation via the `_initSinks` callback.
- * Unit 3 will make this a proper thin adapter where thread creation moves here.
+ * ## Adapter responsibilities
  *
- * Hard invariants:
+ * 1. **Empty-prompt fail-fast (accepted Phase A behavior change):** strips the
+ *    bot mention from `message.content` via `botUserId`. If the result is empty,
+ *    replies on the SOURCE message (not a thread) and returns immediately — no
+ *    thread created, no lock acquired, no run-state written.
+ *
+ * 2. **Pre-thread acks:** cap/queue acks go to the source message via
+ *    `sendMessage(message, ...)` before a thread exists.
+ *
+ * 3. **Thread factory:** provides a `threadFactory` on the `LaunchWorkRequest`
+ *    that the engine calls after `ensureClone`/`readyz` pass (before lock).
+ *    The factory creates the Discord thread, initializes the real
+ *    `StatusSink`/`ReplySink` implementations (wrapping `createStatusController`
+ *    and `createDiscordStreamSink`), and returns the thread ID.
+ *    Thread creation is triggered by the engine at the correct pipeline stage
+ *    but the Discord call is owned entirely by this adapter.
+ *
+ * 4. **Deferred proxy sinks:** before the thread exists, the proxy sinks route
+ *    `send('source', ...)` to the source message and no-op everything else.
+ *    After `threadFactory` runs, the real sinks take over.
+ *
+ * ## Hard invariants
+ *
  * - `'cap'` is TERMINAL — no queue, no retry.
  * - Internal identifiers (lock etags, holder IDs, workspace URLs, run IDs,
  *   raw errors) are logged but NEVER posted to Discord.
  * - Bearer token (`attachToken`) is never logged.
- * - Every Discord send uses `allowedMentions: {parse: []}`.
+ * - Every Discord send uses `allowedMentions: {parse: []}` (enforced by `io.ts`).
  */
 export async function runMention(message: Message, binding: RepoBinding, deps: RunMentionDeps): Promise<void> {
-  const {concurrency, queue, logger} = deps
+  const {logger, botUserId} = deps
   const channelId = message.channel.id
 
-  // ── Build deferred Discord sinks ──────────────────────────────────────────
-  // The real sinks are initialized by _initSinks after thread creation inside
-  // executeWorkOnHeldSlot. Until then, pre-thread acks go directly to the message.
+  // ── Empty-prompt fail-fast (accepted Phase A behavior change) ─────────────
+  // Strip the bot mention from the message content. If the result is empty,
+  // fail fast BEFORE thread/lock/run-state — reply on the source message.
+  // This deliberately changes the Unit 0 baseline behavior (which surfaced
+  // EmptyPromptError late in-thread after thread creation and lock acquisition).
+  const mentionPattern = new RegExp(`<@!?${botUserId}>`, 'g')
+  const strippedPrompt = message.content.replace(mentionPattern, '').trim()
+  if (strippedPrompt.length === 0) {
+    await sendMessage(message, {content: 'Nothing to do — please include a task in your message.'}, logger)
+    return
+  }
 
+  // ── Deferred proxy sinks ──────────────────────────────────────────────────
+  // Before the thread exists, proxy sinks route 'source' sends to the message
+  // and no-op everything else. After threadFactory runs, real sinks take over.
   let realStatusSink: StatusSink | null = null
   let realReplySink: ReplySink | null = null
 
@@ -1307,84 +982,78 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
     markVisibleOutputPending: () => {
       if (realReplySink !== null) return realReplySink.markVisibleOutputPending()
       return (_delivered: boolean) => {
-        /* no-op settle handle — sink not yet initialized */
+        /* no-op settle handle — thread not yet created */
       }
     },
   }
 
+  // ── Thread factory ────────────────────────────────────────────────────────
+  // Called by the engine after ensureClone/readyz pass, before lock acquisition.
+  // Creates the Discord thread, initializes real sinks, returns the thread ID.
+  // The engine never imports Discord types — it only calls this opaque factory.
+  const threadFactory: LaunchWorkRequest['threadFactory'] = async () => {
+    let rawThread: Awaited<ReturnType<Message['startThread']>>
+    try {
+      rawThread = await message.startThread({name: `fro-bot: ${binding.repo}`})
+    } catch (threadError) {
+      return {ok: false, error: String(threadError)}
+    }
+
+    const thread: SinkThread = rawThread
+
+    // Initialize real StatusSink wrapping createStatusController
+    const statusController = createStatusController({
+      thread: rawThread,
+      mode: deps.statusMode,
+      logger,
+    })
+    realStatusSink = {
+      noteActivity: (summary: string) => statusController.noteActivity(summary),
+      setBusy: (busy: boolean) => statusController.setBusy(busy),
+      resolveToAnswer: async (text: string) => statusController.resolveToAnswer(text),
+      resolveToFailure: async (note: string) => statusController.resolveToFailure(note),
+      dispose: async () => statusController.dispose(),
+      setReaction: state => {
+        // eslint-disable-next-line no-void
+        void setRunReaction(message, state, logger)
+      },
+    }
+
+    // Initialize real ReplySink wrapping createDiscordStreamSink + sendMessage
+    const streamSink = createDiscordStreamSink(thread, {logger})
+    realReplySink = {
+      send: async (target, options) => {
+        if (target === 'source') return sendMessage(message, options, logger)
+        return sendMessage(rawThread, options, logger)
+      },
+      append: (text: string) => streamSink.append(text),
+      flush: async () => streamSink.flush(),
+      buffered: () => streamSink.buffered(),
+      hasVisibleOutput: () => streamSink.hasVisibleOutput(),
+      markVisibleOutputSent: () => streamSink.markVisibleOutputSent(),
+      markVisibleOutputPending: () => streamSink.markVisibleOutputPending(),
+    }
+
+    return {ok: true, threadId: rawThread.id}
+  }
+
+  // ── Build the LaunchWorkRequest ───────────────────────────────────────────
+  // promptText is the already-stripped prompt (mention removed, trimmed).
+  // The engine does not re-strip or re-validate.
   const request: LaunchWorkRequest = {
-    promptText: message.content,
+    promptText: strippedPrompt,
     channelId,
     guildId: message.guild?.id,
-    surface: 'discord',
+    surface: 'discord', // Phase B: 'web' — one documented cast in engine (request.surface as Surface)
     binding,
     requester: {kind: 'discord-user', userId: message.author.id},
     statusSink,
     replySink,
+    threadFactory,
   }
 
-  // ── Build the RunTask with the Unit 2 Discord bridge ──────────────────────
-  const task: RunTask & DiscordAdapterBridge = {
-    request,
-    deps,
-    _discordMessage: message,
-    _initSinks: (_thread: SinkThread, rawThread: Awaited<ReturnType<Message['startThread']>>) => {
-      // Create the real Discord sinks now that we have the thread.
-      const statusController = createStatusController({
-        thread: rawThread,
-        mode: deps.statusMode,
-        logger,
-      })
-      realStatusSink = {
-        noteActivity: (summary: string) => statusController.noteActivity(summary),
-        setBusy: (busy: boolean) => statusController.setBusy(busy),
-        resolveToAnswer: async (text: string) => statusController.resolveToAnswer(text),
-        resolveToFailure: async (note: string) => statusController.resolveToFailure(note),
-        dispose: async () => statusController.dispose(),
-        setReaction: state => {
-          // eslint-disable-next-line no-void
-          void setRunReaction(message, state, logger)
-        },
-      }
-
-      const streamSink = createDiscordStreamSink(rawThread, {logger})
-      realReplySink = {
-        send: async (target, options) => {
-          if (target === 'source') return sendMessage(message, options, logger)
-          return sendMessage(rawThread, options, logger)
-        },
-        append: (text: string) => streamSink.append(text),
-        flush: async () => streamSink.flush(),
-        buffered: () => streamSink.buffered(),
-        hasVisibleOutput: () => streamSink.hasVisibleOutput(),
-        markVisibleOutputSent: () => streamSink.markVisibleOutputSent(),
-        markVisibleOutputPending: () => streamSink.markVisibleOutputPending(),
-      }
-    },
-  }
-
-  // ── FIFO gate: if pending work exists, enqueue without consulting tryAcquire ──
-  // A new mention must never leapfrog older queued work, even if a slot is free.
-  // Only the handoff path (executeWorkOnHeldSlot's outer finally) may start the next task.
-  if (queue.pendingCount(channelId) > 0) {
-    await ackEnqueueResult(request, queue.enqueue(channelId, task))
-    return
-  }
-
-  // ── Concurrency cap + per-channel in-flight guard ──────────────────────────
-  const slotResult = concurrency.tryAcquire(channelId)
-
-  if (slotResult === 'cap') {
-    await sendMessage(message, {content: 'fro-bot is at capacity right now — please try again shortly.'}, logger)
-    return
-  }
-
-  if (slotResult === 'busy') {
-    // Channel has an in-flight run — enqueue instead of rejecting.
-    await ackEnqueueResult(request, queue.enqueue(channelId, task))
-    return
-  }
-
-  // Slot acquired — executeWorkOnHeldSlot owns the release (via atomic handoff in its outer finally).
-  await executeWorkOnHeldSlot(task)
+  // ── Delegate to launchWork (the transport-agnostic front door) ────────────
+  // Pre-thread acks (cap/queue) go via replySink.send('source', ...) which
+  // routes to sendMessage(message, ...) above. The engine handles everything else.
+  await launchWork(request, deps)
 }

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -1,4 +1,4 @@
-import type {CoordinationConfig, Result} from '@fro-bot/runtime'
+import type {CoordinationConfig, Result, Surface} from '@fro-bot/runtime'
 import type {Message} from 'discord.js'
 import type {ApprovalRegistry} from '../approvals/registry.js'
 import type {RepoBinding} from '../bindings/types.js'
@@ -7,6 +7,7 @@ import type {SinkThread} from '../discord/streaming.js'
 import type {EnsureCloneFailure} from '../workspace-api/ensure-clone.js'
 import type {ReadyzResponse, WorkspaceError} from '../workspace-api/types.js'
 import type {ConcurrencyRegistry} from './concurrency.js'
+import type {LaunchWorkRequest, ReplySink, StatusSink} from './launch-types.js'
 import type {ChannelQueue} from './queue.js'
 
 import {acquireLock, createHeartbeatController, createRun, releaseLock, transitionRun} from '@fro-bot/runtime'
@@ -92,11 +93,16 @@ export interface RunMentionDeps {
 
 /**
  * The task descriptor stored in the per-channel queue.
- * Exactly the three arguments `runMention` takes — the stable contract the queue stores.
+ *
+ * Carries a `LaunchWorkRequest` (transport-neutral engine input) instead of a
+ * raw Discord `Message`. The Discord adapter (`runMention`) constructs the
+ * `LaunchWorkRequest` from the `Message` before enqueuing.
+ *
+ * `deps` is still carried so the inner execution primitive can access
+ * coordination config, identity, concurrency, queue, and other deps.
  */
 export interface RunTask {
-  readonly message: Message
-  readonly binding: RepoBinding
+  readonly request: LaunchWorkRequest
   readonly deps: RunMentionDeps
 }
 
@@ -163,11 +169,36 @@ export function computeApprovalDeadlineMs(remainingBudgetMs: number): number | u
 }
 
 // ---------------------------------------------------------------------------
-// startRun — the slot-holding execution pipeline
+// Unit 2 internal extension — Discord adapter bridge
+// ---------------------------------------------------------------------------
+
+/**
+ * Internal extension carried on `RunTask` by the Discord adapter (`runMention`).
+ *
+ * Unit 2 bridge: thread creation still happens inside `executeWorkOnHeldSlot`
+ * because the Discord sinks depend on the thread. The adapter provides:
+ * - `_discordMessage`: the raw Discord `Message` used for thread creation.
+ * - `_initSinks(thread, rawThread)`: called after thread creation to wire the
+ *   real Discord sinks into the deferred proxy sinks on the `LaunchWorkRequest`.
+ *
+ * These fields are INTERNAL to Unit 2 and will be removed in Unit 3 when
+ * thread creation moves fully into the Discord adapter.
+ */
+interface DiscordAdapterBridge {
+  readonly _discordMessage: Message
+  readonly _initSinks: (thread: SinkThread, rawThread: Awaited<ReturnType<Message['startThread']>>) => void
+}
+
+// ---------------------------------------------------------------------------
+// executeWorkOnHeldSlot — the private slot-holding execution pipeline
 // ---------------------------------------------------------------------------
 
 /**
  * Execute the post-acquire pipeline for a task.
+ *
+ * PRIVATE — not exported. Callers must go through `launchWork` (the public
+ * front door) which enforces the per-channel FIFO queue and global concurrency
+ * cap. Exporting this function would allow callers to bypass the queue.
  *
  * ASSUMES the channel concurrency slot is already held by the caller.
  * Owns: clone → readyz → thread → lock → run-state → heartbeat → execute → cleanup.
@@ -177,12 +208,12 @@ export function computeApprovalDeadlineMs(remainingBudgetMs: number): number | u
  * - If a next task exists → starts it on the held slot (no release/re-acquire gap).
  * - If the queue is empty → calls `concurrency.release(channelId)` (only then is the slot freed).
  *
- * The handoff `startRun` is fire-and-forget from the completing run's perspective.
+ * The handoff `executeWorkOnHeldSlot` is fire-and-forget from the completing run's perspective.
  * Its own outer finally runs the same handoff/release logic, so the chain continues
  * and a thrown handoff still releases.
  */
-async function startRun(task: RunTask): Promise<void> {
-  const {message, binding, deps} = task
+async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
+  const {request, deps} = task
   const {
     concurrency,
     queue,
@@ -195,20 +226,27 @@ async function startRun(task: RunTask): Promise<void> {
     persona,
     logger,
   } = deps
-  const {approvalRegistry, approvalMode, statusMode, ensureClone, readyz} = deps
+  const {approvalRegistry, approvalMode, ensureClone, readyz} = deps
 
   // ── All mutable state that the outer finally needs is declared here so the
   // finally block can always reference channelId regardless of where execution
   // stopped. Async functions never throw synchronously, so the outer try/finally
   // always runs — but keeping these declarations before the try makes the
   // dependency explicit and avoids any ambiguity.
-  const channelId = message.channel.id
+  const channelId = request.channelId
+  const binding = request.binding
   const repo = `${binding.owner}/${binding.repo}`
 
   // ── Budget origin — single source of truth for hard abort and approval deadline ──
   // Captured once at run entry so both the AbortSignal.timeout and the approval
   // deadline clearance are computed from the same wall-clock reference.
   const runStartMs = Date.now()
+
+  // ── Unit 2 bridge: extract Discord-specific fields from the task ──────────
+  // These are provided by the Discord adapter (runMention) and will be removed
+  // in Unit 3 when thread creation moves fully into the adapter.
+  const bridge = task as RunTask & Partial<DiscordAdapterBridge>
+  const discordMessage = bridge._discordMessage
 
   try {
     // ── Ensure workspace checkout exists ──────────────────────────────────────────────────────
@@ -226,7 +264,9 @@ async function startRun(task: RunTask): Promise<void> {
         },
         'run: workspace clone unavailable — aborting',
       )
-      await sendMessage(message, {content: 'The workspace is not available right now. Please try again later.'}, logger)
+      await request.replySink.send('source', {
+        content: 'The workspace is not available right now. Please try again later.',
+      })
       return
     }
 
@@ -249,43 +289,63 @@ async function startRun(task: RunTask): Promise<void> {
 
     if (workspaceReady === false) {
       logger.warn({channelId, repo}, 'run: workspace not ready — aborting')
-      await sendMessage(message, {content: 'The workspace is not reachable right now. Please try again later.'}, logger)
+      await request.replySink.send('source', {
+        content: 'The workspace is not reachable right now. Please try again later.',
+      })
       return
     }
 
     // ── Create response thread ─────────────────────────────────────────────────────────────────
+    // Unit 2: thread creation still uses the Discord message (via the bridge).
+    // Unit 3 will move thread creation into the Discord adapter.
+    if (discordMessage === undefined) {
+      // Non-Discord path (in-memory sinks, no thread needed): skip thread creation.
+      // The sinks are already fully initialized by the caller.
+      await executeWorkCore(task, bindingWithEnsuredPath, runStartMs)
+      return
+    }
 
     const runId = crypto.randomUUID()
-    let rawThread: Awaited<ReturnType<typeof message.startThread>>
+    let rawThread: Awaited<ReturnType<typeof discordMessage.startThread>>
     try {
-      rawThread = await message.startThread({name: `fro-bot: ${binding.repo}`})
+      rawThread = await discordMessage.startThread({name: `fro-bot: ${binding.repo}`})
     } catch (threadError) {
       logger.error({channelId, repo, err: String(threadError)}, 'run: startThread threw — aborting')
-      await sendMessage(message, {content: 'Could not start the task — please try again.'}, logger)
+      await request.replySink.send('source', {content: 'Could not start the task — please try again.'})
       return
     }
     const threadId = rawThread.id
     const thread: SinkThread = rawThread
 
+    // ── Wire the real Discord sinks into the deferred proxy sinks ────────────
+    // The adapter's _initSinks callback initializes the real sinks now that we
+    // have the thread reference.
+    bridge._initSinks?.(thread, rawThread)
+
     // ── Acquire repo lock ─────────────────────────────────────────────────────────────────────────
 
     const coordLogger = toCoordLogger(logger)
-    const lockResult = await acquireLock(coordinationConfig, repo, identity, 'discord', runId, coordLogger)
+    const lockResult = await acquireLock(
+      coordinationConfig,
+      repo,
+      identity,
+      request.surface as Surface,
+      runId,
+      coordLogger,
+    )
 
     if (lockResult.success === false) {
       logger.error({repo, runId, err: lockResult.error.message}, 'run: lock acquisition error')
-      await sendMessage(thread, {content: 'Could not start the task — please try again.'}, logger)
+      await request.replySink.send('thread', {content: 'Could not start the task — please try again.'})
       return
     }
 
     if (lockResult.data.acquired === false) {
       // Lock held — terminal "waiting" reply; do NOT expose holder ID to Discord
       logger.info({repo, runId, holder: lockResult.data.holder?.holder_id ?? 'unknown'}, 'run: lock held by another')
-      await sendMessage(
-        thread,
-        {content: 'Another task is already in progress for this repo. Try again when it completes.'},
-        logger,
-      )
+      await request.replySink.send('thread', {
+        content: 'Another task is already in progress for this repo. Try again when it completes.',
+      })
       return
     }
 
@@ -297,7 +357,7 @@ async function startRun(task: RunTask): Promise<void> {
     const now = new Date().toISOString()
     const initialRunState = {
       run_id: runId,
-      surface: 'discord' as const,
+      surface: request.surface as Surface,
       thread_id: threadId,
       entity_ref: repo,
       phase: 'PENDING' as const,
@@ -310,7 +370,7 @@ async function startRun(task: RunTask): Promise<void> {
     const createResult = await createRun(coordinationConfig, identity, repo, initialRunState, coordLogger)
     if (createResult.success === false) {
       logger.error({repo, runId, err: createResult.error.message}, 'run: createRun failed')
-      await sendMessage(thread, {content: 'Could not start the task — please try again.'}, logger)
+      await request.replySink.send('thread', {content: 'Could not start the task — please try again.'})
       await releaseLock(coordinationConfig, repo, lockEtag, coordLogger)
       return
     }
@@ -328,7 +388,7 @@ async function startRun(task: RunTask): Promise<void> {
     )
     if (ackResult.success === false) {
       logger.error({repo, runId, err: ackResult.error.message}, 'run: transitionRun ACKNOWLEDGED failed')
-      await sendMessage(thread, {content: 'Could not start the task — please try again.'}, logger)
+      await request.replySink.send('thread', {content: 'Could not start the task — please try again.'})
       await releaseLock(coordinationConfig, repo, lockEtag, coordLogger)
       return
     }
@@ -338,17 +398,8 @@ async function startRun(task: RunTask): Promise<void> {
     heartbeat.start()
 
     let heartbeatStopped = false
-    let sink: ReturnType<typeof createDiscordStreamSink> | null = null
 
-    // ── Status controller — per-run, created after thread is available ────────────────────────
-    // Adapts rawThread to StatusThread: discord.js ThreadChannel has .send() and .sendTyping()
-    // which structurally satisfy the StatusThread interface. Messages returned by .send() have
-    // .edit() and .delete() which satisfy StatusMessage.
-    const statusController = createStatusController({
-      thread: rawThread,
-      mode: statusMode,
-      logger,
-    })
+    const {statusSink, replySink} = request
 
     try {
       const execResult = await transitionRun(
@@ -366,15 +417,13 @@ async function startRun(task: RunTask): Promise<void> {
       runEtag = execResult.data.etag
 
       // ── Working reaction — best-effort, fire-and-forget ───────────────────────────────────────────────────────────────────
-      // eslint-disable-next-line no-void
-      void setRunReaction(message, 'working', logger)
+      statusSink.setReaction('working')
 
       // ── Execute prompt via OpenCode ─────────────────────────────────────────────────────────────────────────────────────────
 
       const handle = attachOpencode(attachUrl, attachToken)
-      sink = createDiscordStreamSink(thread, {logger})
       const promptText = buildDiscordPrompt({
-        messageText: message.content,
+        messageText: request.promptText,
         owner: bindingWithEnsuredPath.owner,
         repo: bindingWithEnsuredPath.repo,
         botUserId,
@@ -395,9 +444,9 @@ async function startRun(task: RunTask): Promise<void> {
 
       const coordinator = createPermissionCoordinator({
         logger,
-        onPending: request => {
+        onPending: req => {
           // Per-request closures — each captures its own sessionID.
-          const {requestID, sessionID} = request
+          const {requestID, sessionID} = req
 
           // postReply: call the OpenCode SDK permission reply endpoint.
           // Uses the session-scoped API: POST /session/{id}/permissions/{permissionID}
@@ -442,7 +491,7 @@ async function startRun(task: RunTask): Promise<void> {
             sessionID,
             channelID: rawThread.id,
             directory: bindingWithEnsuredPath.workspacePath,
-            request,
+            request: req,
             effects: {postReply: postReplyForRequest},
             deadlineMs: approvalDeadlineMs,
             onDeadlineSettled: async () => {
@@ -454,15 +503,14 @@ async function startRun(task: RunTask): Promise<void> {
                 logger,
               )
               if (deadlineResult.success === true) {
-                sink?.markVisibleOutputSent()
+                replySink.markVisibleOutputSent()
               }
             },
           })
 
           // Awaiting-approval reaction — best-effort, fire-and-forget.
           // Replaces the working reaction with the awaiting-approval cue.
-          // eslint-disable-next-line no-void
-          void setRunReaction(message, 'awaiting-approval', logger)
+          statusSink.setReaction('awaiting-approval')
 
           // Post a visible waiting-for-approval status BEFORE the embed so the
           // user sees the run is blocked even if the embed send is slow.
@@ -473,13 +521,13 @@ async function startRun(task: RunTask): Promise<void> {
           // timeout classification sees it as visible context even if the Discord
           // round-trip has not completed yet. settle(true) on success promotes to
           // permanently delivered; settle(false) on failure retracts the claim.
-          const settleWaitingStatus = sink?.markVisibleOutputPending()
+          const settleWaitingStatus = replySink.markVisibleOutputPending()
           // eslint-disable-next-line no-void
           void sendMessage(rawThread, {content: 'Waiting for tool approval…'}, logger).then(result => {
             if (result.success === true) {
-              settleWaitingStatus?.(true)
+              settleWaitingStatus(true)
             } else {
-              settleWaitingStatus?.(false)
+              settleWaitingStatus(false)
               logger.warn({requestID, err: result.error.message}, 'run: failed to post waiting-for-approval status')
             }
           })
@@ -490,23 +538,23 @@ async function startRun(task: RunTask): Promise<void> {
           //
           // Pending-visibility: same pattern as the waiting-status send above —
           // mark in-flight before the void send, settle on resolution.
-          const settleEmbed = sink?.markVisibleOutputPending()
+          const settleEmbed = replySink.markVisibleOutputPending()
           // eslint-disable-next-line no-void
           void sendMessage<Message>(
             rawThread,
-            {embeds: [buildApprovalEmbed(request)], components: [buildApprovalButtons(requestID)]},
+            {embeds: [buildApprovalEmbed(req)], components: [buildApprovalButtons(requestID)]},
             logger,
           ).then(result => {
             if (result.success === true) {
               // Embed send succeeded — settle pending claim as delivered so
               // flush() does not add a misleading _(no output)_.
-              settleEmbed?.(true)
+              settleEmbed(true)
               const postedMessage = result.data
               // Attach the render function now that we have a message reference.
               approvalRegistry.attachMessage(
                 requestID,
                 async (
-                  req: import('../approvals/coordinator.js').PermissionRequest,
+                  permReq: import('../approvals/coordinator.js').PermissionRequest,
                   decision: import('../approvals/coordinator.js').PermissionReply,
                   decidedBy: string | null,
                   reason: import('../approvals/coordinator.js').SettlementReason,
@@ -514,21 +562,21 @@ async function startRun(task: RunTask): Promise<void> {
                   const editResult = await editMessage(
                     postedMessage,
                     {
-                      embeds: [buildSettledEmbed(req, decision, {decidedBy: decidedBy ?? undefined, reason})],
+                      embeds: [buildSettledEmbed(permReq, decision, {decidedBy: decidedBy ?? undefined, reason})],
                       components: [],
                     },
                     logger,
                   )
                   if (editResult.success === false) {
                     logger.warn(
-                      {requestID: req.requestID, err: editResult.error.message},
+                      {requestID: permReq.requestID, err: editResult.error.message},
                       'run: failed to edit approval message',
                     )
                   }
                 },
               )
             } else {
-              settleEmbed?.(false)
+              settleEmbed(false)
               logger.warn({requestID, err: result.error.message}, 'run: failed to post approval embed')
               approvalRegistry.markMessagePostFailed(requestID)
             }
@@ -550,16 +598,16 @@ async function startRun(task: RunTask): Promise<void> {
           handle,
           directory: bindingWithEnsuredPath.workspacePath,
           promptText,
-          sink,
+          sink: replySink as unknown as import('../discord/streaming.js').DiscordStreamSink,
           signal: timeoutSignal,
           logger,
           coordinator,
           approvalMode,
           onActivity: (summary: string) => {
-            statusController.noteActivity(summary)
+            statusSink.noteActivity(summary)
           },
           onBusy: (busy: boolean) => {
-            statusController.setBusy(busy)
+            statusSink.setBusy(busy)
           },
         })
       } finally {
@@ -570,8 +618,7 @@ async function startRun(task: RunTask): Promise<void> {
 
       // ── Succeeded reaction — best-effort, fire-and-forget ────────────────────────────────────
       // Replaces the working/awaiting reaction with the succeeded cue.
-      // eslint-disable-next-line no-void
-      void setRunReaction(message, 'succeeded', logger)
+      statusSink.setReaction('succeeded')
 
       // ── session.idle received — transition to COMPLETED ──────────────────────────────────────
 
@@ -604,10 +651,10 @@ async function startRun(task: RunTask): Promise<void> {
       // resolveToAnswer returns:
       //   'handled'   → controller edited the status message into the answer; skip sink flush.
       //   'delegated' → controller deleted the status (or typing-only); flush via sink as normal.
-      const finalText = sink.buffered()
-      const answerResult = await statusController.resolveToAnswer(finalText)
+      const finalText = replySink.buffered()
+      const answerResult = await statusSink.resolveToAnswer(finalText)
       if (answerResult.transition === 'delegated') {
-        await sink.flush()
+        await replySink.flush()
       }
       // 'handled': answer is already in the status message — do not flush (would double-post).
     } catch (execError: unknown) {
@@ -631,8 +678,7 @@ async function startRun(task: RunTask): Promise<void> {
 
       // ── Failed reaction — best-effort, fire-and-forget ────────────────────────────────────────
       // Replaces the working/awaiting reaction with the failed cue.
-      // eslint-disable-next-line no-void
-      void setRunReaction(message, 'failed', logger)
+      statusSink.setReaction('failed')
 
       // Stop heartbeat (best-effort) if not already stopped
       if (heartbeatStopped === false) {
@@ -665,16 +711,13 @@ async function startRun(task: RunTask): Promise<void> {
 
       // Flush partial output (best-effort) so the user sees whatever streamed before the failure.
       // Wrapped in its own try/catch so a flush failure does not mask the original error.
-      // Guard against double-post: sink is null when the error occurred before createDiscordStreamSink.
-      if (sink !== null) {
-        await sink.flush().catch((flushError: unknown) => {
-          logger.warn({repo, runId, err: String(flushError)}, 'run: sink.flush failed in error path')
-        })
-      }
+      await replySink.flush().catch((flushError: unknown) => {
+        logger.warn({repo, runId, err: String(flushError)}, 'run: sink.flush failed in error path')
+      })
 
       // Coarse user message — no internal detail
       const timeoutDuration = formatTimeoutDuration(runTimeoutMs)
-      const hasVisibleOutput = sink !== null && sink.hasVisibleOutput() === true
+      const hasVisibleOutput = replySink.hasVisibleOutput() === true
       const userMessage =
         isTimeout === true
           ? hasVisibleOutput === true
@@ -693,14 +736,17 @@ async function startRun(task: RunTask): Promise<void> {
       //   'handled'   → controller edited the status message into the failure note; skip sendMessage.
       //   'delegated' → no status to edit (or typing-only); post via sendMessage as normal.
       // Never both — single owner for the failure message.
-      const failureResult = await statusController.resolveToFailure(userMessage).catch((error: unknown) => {
+      const failureResult = await statusSink.resolveToFailure(userMessage).catch((error: unknown) => {
         logger.warn({repo, runId, err: String(error)}, 'run: statusController.resolveToFailure failed — delegating')
         return {transition: 'delegated' as const}
       })
       if (failureResult.transition === 'delegated') {
-        const failureSendResult = await sendMessage(thread, {content: userMessage}, logger)
-        if (failureSendResult.success === false) {
-          logger.warn({repo, runId, err: failureSendResult.error.message}, 'run: failed to send error reply to thread')
+        const failureSendResult = await replySink.send('thread', {content: userMessage})
+        if (failureSendResult !== undefined) {
+          const result = failureSendResult as {success?: boolean; error?: {message: string}}
+          if (result.success === false && result.error !== undefined) {
+            logger.warn({repo, runId, err: result.error.message}, 'run: failed to send error reply to thread')
+          }
         }
       }
     } finally {
@@ -713,7 +759,7 @@ async function startRun(task: RunTask): Promise<void> {
 
       // Dispose status controller — guaranteed cleanup of typing interval and debounce timer.
       // Must run in finally so timers never leak regardless of success or failure.
-      await statusController.dispose().catch((error: unknown) => {
+      await statusSink.dispose().catch((error: unknown) => {
         logger.warn({repo, runId, err: String(error)}, 'run: statusController.dispose failed')
       })
 
@@ -739,7 +785,7 @@ async function startRun(task: RunTask): Promise<void> {
     // This is consistent with the messageCreate guard in program.ts that refuses
     // new mentions once isShuttingDown() returns true.
     //
-    // The handed-off startRun is fire-and-forget from this run's perspective so
+    // The handed-off executeWorkOnHeldSlot is fire-and-forget from this run's perspective so
     // cleanup completes, but its own outer finally runs the same handoff/release
     // logic — so the chain continues and a thrown handoff still releases.
     if (deps.isShuttingDown?.() === true) {
@@ -753,7 +799,7 @@ async function startRun(task: RunTask): Promise<void> {
       } else {
         // Slot ownership transfers to the next run — do NOT call concurrency.release.
         // eslint-disable-next-line no-void
-        void startRun(nextTask).catch((error: unknown) => {
+        void executeWorkOnHeldSlot(nextTask).catch((error: unknown) => {
           logger.error(
             {channelId, err: error instanceof Error ? error.message : String(error)},
             'run: handoff startRun failed',
@@ -765,19 +811,438 @@ async function startRun(task: RunTask): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// runMention — the thin front door
+// executeWorkCore — non-Discord execution path (in-memory sinks, no thread)
 // ---------------------------------------------------------------------------
 
 /**
- * Front door for a mention-triggered run.
+ * Execute the core pipeline for a task that already has fully-initialized sinks
+ * (no Discord thread creation needed). Used by the non-Discord path in Unit 2.
+ *
+ * This is a simplified version of the Discord path that skips thread creation,
+ * lock acquisition, run-state lifecycle, and heartbeat — it runs the core
+ * execution pipeline directly.
+ *
+ * NOTE: This is a placeholder for the in-memory sink tests in Unit 2. The full
+ * non-Discord path (with lock, run-state, heartbeat) will be implemented in
+ * Unit 3 when the Discord adapter is fully separated.
+ */
+async function executeWorkCore(
+  task: RunTask,
+  bindingWithEnsuredPath: {readonly owner: string; readonly repo: string; readonly workspacePath: string},
+  runStartMs: number,
+): Promise<void> {
+  const {request, deps} = task
+  const {
+    coordinationConfig,
+    identity,
+    attachUrl,
+    attachToken,
+    runTimeoutMs,
+    botUserId,
+    persona,
+    logger,
+    approvalRegistry,
+    approvalMode,
+  } = deps
+
+  const channelId = request.channelId
+  const binding = request.binding
+  const repo = `${binding.owner}/${binding.repo}`
+  const coordLogger = toCoordLogger(logger)
+  const runId = crypto.randomUUID()
+
+  // ── Run-state lifecycle + heartbeat ────────────────────────────────────────────────────────
+
+  const now = new Date().toISOString()
+  const initialRunState = {
+    run_id: runId,
+    surface: request.surface as Surface,
+    thread_id: '',
+    entity_ref: repo,
+    phase: 'PENDING' as const,
+    started_at: now,
+    last_heartbeat: now,
+    holder_id: identity,
+    details: {channelId, owner: binding.owner, repo: binding.repo},
+  }
+
+  const lockResult = await acquireLock(
+    coordinationConfig,
+    repo,
+    identity,
+    request.surface as Surface,
+    runId,
+    coordLogger,
+  )
+  if (lockResult.success === false) {
+    logger.error({repo, runId, err: lockResult.error.message}, 'run: lock acquisition error')
+    await request.replySink.send('thread', {content: 'Could not start the task — please try again.'})
+    return
+  }
+  if (lockResult.data.acquired === false) {
+    logger.info({repo, runId, holder: lockResult.data.holder?.holder_id ?? 'unknown'}, 'run: lock held by another')
+    await request.replySink.send('thread', {
+      content: 'Another task is already in progress for this repo. Try again when it completes.',
+    })
+    return
+  }
+  let lockEtag = lockResult.data.etag
+
+  const createResult = await createRun(coordinationConfig, identity, repo, initialRunState, coordLogger)
+  if (createResult.success === false) {
+    logger.error({repo, runId, err: createResult.error.message}, 'run: createRun failed')
+    await request.replySink.send('thread', {content: 'Could not start the task — please try again.'})
+    await releaseLock(coordinationConfig, repo, lockEtag, coordLogger)
+    return
+  }
+  let runEtag = createResult.data.etag
+
+  const ackResult = await transitionRun(coordinationConfig, identity, repo, runId, 'ACKNOWLEDGED', runEtag, coordLogger)
+  if (ackResult.success === false) {
+    logger.error({repo, runId, err: ackResult.error.message}, 'run: transitionRun ACKNOWLEDGED failed')
+    await request.replySink.send('thread', {content: 'Could not start the task — please try again.'})
+    await releaseLock(coordinationConfig, repo, lockEtag, coordLogger)
+    return
+  }
+  runEtag = ackResult.data.etag
+
+  const heartbeat = createHeartbeatController(coordinationConfig, identity, repo, runId, lockEtag, coordLogger)
+  heartbeat.start()
+  let heartbeatStopped = false
+
+  const {statusSink, replySink} = request
+
+  try {
+    const execResult = await transitionRun(coordinationConfig, identity, repo, runId, 'EXECUTING', runEtag, coordLogger)
+    if (execResult.success === false) {
+      throw new Error(`transitionRun EXECUTING failed: ${execResult.error.message}`)
+    }
+    runEtag = execResult.data.etag
+
+    statusSink.setReaction('working')
+
+    const handle = attachOpencode(attachUrl, attachToken)
+    const promptText = buildDiscordPrompt({
+      messageText: request.promptText,
+      owner: bindingWithEnsuredPath.owner,
+      repo: bindingWithEnsuredPath.repo,
+      botUserId,
+      persona,
+    })
+
+    const elapsedMs = Date.now() - runStartMs
+    const remainingBudgetMs = Math.max(0, runTimeoutMs - elapsedMs)
+    const timeoutSignal = AbortSignal.timeout(remainingBudgetMs)
+    const approvalDeadlineMs = computeApprovalDeadlineMs(remainingBudgetMs)
+
+    const coordinator = createPermissionCoordinator({
+      logger,
+      onPending: req => {
+        const {requestID, sessionID} = req
+        const postReplyForRequest = async (
+          rID: string,
+          directory: string,
+          decision: import('../approvals/coordinator.js').PermissionReply,
+        ) => {
+          try {
+            const res = await handle.client.postSessionIdPermissionsPermissionId({
+              path: {id: sessionID, permissionID: rID},
+              body: {response: decision},
+              query: {directory},
+              signal: AbortSignal.timeout(10_000),
+            })
+            const envelope = res as {error?: unknown} | undefined
+            if (envelope?.error != null) {
+              return {ok: false as const, error: String(envelope.error)}
+            }
+            return {ok: true as const}
+          } catch (error) {
+            return {ok: false as const, error: error instanceof Error ? error.message : String(error)}
+          }
+        }
+        approvalRegistry.register({
+          requestID,
+          sessionID,
+          channelID: channelId,
+          directory: bindingWithEnsuredPath.workspacePath,
+          request: req,
+          effects: {postReply: postReplyForRequest},
+          deadlineMs: approvalDeadlineMs,
+          onDeadlineSettled: async () => {
+            const deadlineResult = await replySink.send('thread', {
+              content: 'Approval timed out — the task could not continue.',
+            })
+            if (deadlineResult !== undefined) {
+              const r = deadlineResult as {success?: boolean}
+              if (r.success === true) {
+                replySink.markVisibleOutputSent()
+              }
+            }
+          },
+        })
+        statusSink.setReaction('awaiting-approval')
+        const settleWaitingStatus = replySink.markVisibleOutputPending()
+        // eslint-disable-next-line no-void
+        void replySink.send('thread', {content: 'Waiting for tool approval…'}).then(result => {
+          const r = result as {success?: boolean; error?: {message: string}} | undefined
+          if (r?.success === true) {
+            settleWaitingStatus(true)
+          } else {
+            settleWaitingStatus(false)
+            logger.warn(
+              {requestID, err: r?.error?.message ?? 'unknown'},
+              'run: failed to post waiting-for-approval status',
+            )
+          }
+        })
+        const settleEmbed = replySink.markVisibleOutputPending()
+        // eslint-disable-next-line no-void
+        void replySink.send('thread', {content: `[approval-embed:${requestID}]`}).then(result => {
+          const r = result as {success?: boolean; error?: {message: string}} | undefined
+          if (r?.success === true) {
+            settleEmbed(true)
+          } else {
+            settleEmbed(false)
+            logger.warn({requestID, err: r?.error?.message ?? 'unknown'}, 'run: failed to post approval embed')
+            approvalRegistry.markMessagePostFailed(requestID)
+          }
+        })
+      },
+      onReplied: event => {
+        approvalRegistry.confirmReply(event)
+      },
+      onDispose: sessionIDs => {
+        // eslint-disable-next-line no-void
+        void Promise.all(sessionIDs.map(async sid => approvalRegistry.disposeRun(sid, 'run ended')))
+      },
+    })
+
+    try {
+      await runOpenCodeCore({
+        handle,
+        directory: bindingWithEnsuredPath.workspacePath,
+        promptText,
+        sink: replySink as unknown as import('../discord/streaming.js').DiscordStreamSink,
+        signal: timeoutSignal,
+        logger,
+        coordinator,
+        approvalMode,
+        onActivity: (summary: string) => {
+          statusSink.noteActivity(summary)
+        },
+        onBusy: (busy: boolean) => {
+          statusSink.setBusy(busy)
+        },
+      })
+    } finally {
+      coordinator.dispose('run ended')
+    }
+
+    statusSink.setReaction('succeeded')
+
+    const stopResult = await heartbeat.stop()
+    heartbeatStopped = true
+    if (stopResult.success === true) {
+      runEtag = stopResult.data.runEtag
+      lockEtag = stopResult.data.lockEtag
+    } else {
+      logger.warn({repo, runId, err: stopResult.error.message}, 'run: heartbeat stop failed; using last known etags')
+    }
+
+    const completedResult = await transitionRun(
+      coordinationConfig,
+      identity,
+      repo,
+      runId,
+      'COMPLETED',
+      runEtag,
+      coordLogger,
+    )
+    if (completedResult.success === false) {
+      logger.error({repo, runId, err: completedResult.error.message}, 'run: transitionRun COMPLETED failed')
+    }
+
+    const finalText = replySink.buffered()
+    const answerResult = await statusSink.resolveToAnswer(finalText)
+    if (answerResult.transition === 'delegated') {
+      await replySink.flush()
+    }
+  } catch (execError: unknown) {
+    const isCoreError = execError instanceof RunCoreError
+    const isTimeout = isCoreError && execError.kind === 'timeout'
+    const isStreamEnded = isCoreError && execError.kind === 'stream-ended'
+    const isReachability = isCoreError && (execError.kind === 'unreachable' || execError.kind === 'auth')
+    const isEmptyPrompt = execError instanceof EmptyPromptError
+
+    logger.error(
+      {
+        repo,
+        runId,
+        kind: isCoreError ? execError.kind : 'unknown',
+        err: execError instanceof Error ? execError.message : String(execError),
+      },
+      'run: execution failed',
+    )
+
+    statusSink.setReaction('failed')
+
+    if (heartbeatStopped === false) {
+      const stopResult = await heartbeat.stop()
+      heartbeatStopped = true
+      if (stopResult.success === true) {
+        runEtag = stopResult.data.runEtag
+        lockEtag = stopResult.data.lockEtag
+      } else {
+        logger.warn({repo, runId, err: stopResult.error.message}, 'run: heartbeat stop failed; using last known etags')
+      }
+    }
+
+    const failedResult = await transitionRun(coordinationConfig, identity, repo, runId, 'FAILED', runEtag, coordLogger)
+    if (failedResult.success === false) {
+      logger.error({repo, runId, err: failedResult.error.message}, 'run: transitionRun FAILED failed')
+    }
+
+    await replySink.flush().catch((flushError: unknown) => {
+      logger.warn({repo, runId, err: String(flushError)}, 'run: sink.flush failed in error path')
+    })
+
+    const timeoutDuration = formatTimeoutDuration(runTimeoutMs)
+    const hasVisibleOutput = replySink.hasVisibleOutput() === true
+    const userMessage =
+      isTimeout === true
+        ? hasVisibleOutput === true
+          ? `The task reached the ${timeoutDuration} time limit after posting updates above. Start a new @fro-bot request with what to do next and include any needed context from the output above.`
+          : `The task reached the ${timeoutDuration} time limit. Please try again.`
+        : isReachability === true
+          ? 'The workspace is not reachable right now. Please try again later.'
+          : isEmptyPrompt === true
+            ? 'Nothing to do — please include a task in your message.'
+            : isStreamEnded === true
+              ? 'The task stream closed unexpectedly. Please try again.'
+              : 'The task failed. Please try again.'
+
+    const failureResult = await statusSink.resolveToFailure(userMessage).catch((error: unknown) => {
+      logger.warn({repo, runId, err: String(error)}, 'run: statusController.resolveToFailure failed — delegating')
+      return {transition: 'delegated' as const}
+    })
+    if (failureResult.transition === 'delegated') {
+      await replySink.send('thread', {content: userMessage}).catch((sendError: unknown) => {
+        logger.warn({repo, runId, err: String(sendError)}, 'run: failed to send error reply to thread')
+      })
+    }
+  } finally {
+    if (heartbeatStopped === false) {
+      await heartbeat.stop().catch(() => {
+        /* best-effort */
+      })
+    }
+
+    await statusSink.dispose().catch((error: unknown) => {
+      logger.warn({repo, runId, err: String(error)}, 'run: statusController.dispose failed')
+    })
+
+    const releaseResult = await releaseLock(coordinationConfig, repo, lockEtag, coordLogger)
+    if (releaseResult.success === false) {
+      logger.warn({repo, runId, err: releaseResult.error.message}, 'run: releaseLock failed')
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// launchWork — the public, queue-and-cap-preserving front door
+// ---------------------------------------------------------------------------
+
+/**
+ * Public front door for launching a unit of work.
+ *
+ * Transport-agnostic: accepts a `LaunchWorkRequest` with pre-constructed
+ * `StatusSink` and `ReplySink` implementations. The Discord adapter
+ * (`runMention`) calls this after mapping a Discord `Message` → `LaunchWorkRequest`.
+ * A future web adapter (Phase B) will call this directly.
+ *
+ * Enforces the per-channel FIFO queue and global concurrency cap. A future
+ * web caller goes through THIS and cannot bypass the queue/cap.
  *
  * Decides whether to run immediately or enqueue, in this order:
  * 1. If `queue.pendingCount(channelId) > 0` → enqueue + queued ack (pending work has
  *    priority; never take an immediate slot ahead of it).
  * 2. Else `concurrency.tryAcquire(channelId)`:
- *    - `'ok'`   → `startRun(task)` (slot held).
+ *    - `'ok'`   → `executeWorkOnHeldSlot(task)` (slot held).
  *    - `'busy'` → enqueue + queued ack (or "queue is full" if at capacity). Return without blocking.
  *    - `'cap'`  → terminal capacity reply, no enqueue (global cap stays terminal).
+ *
+ * Hard invariants:
+ * - `'cap'` is TERMINAL — no queue, no retry.
+ * - Internal identifiers (lock etags, holder IDs, workspace URLs, run IDs,
+ *   raw errors) are logged but NEVER posted to the transport.
+ * - Bearer token (`attachToken`) is never logged.
+ *
+ * @param request - Transport-neutral engine input (prompt, sinks, binding, identity).
+ * @param deps - Runtime dependencies (concurrency, queue, coordination config, etc.).
+ */
+export async function launchWork(request: LaunchWorkRequest, deps: RunMentionDeps): Promise<void> {
+  const {concurrency, queue} = deps
+  const channelId = request.channelId
+  const task: RunTask = {request, deps}
+
+  // ── FIFO gate: if pending work exists, enqueue without consulting tryAcquire ──
+  // A new request must never leapfrog older queued work, even if a slot is free.
+  // Only the handoff path (executeWorkOnHeldSlot's outer finally) may start the next task.
+  if (queue.pendingCount(channelId) > 0) {
+    const enqueueResult = queue.enqueue(channelId, task)
+    await ackEnqueueResult(request, enqueueResult)
+    return
+  }
+
+  // ── Concurrency cap + per-channel in-flight guard ──────────────────────────
+  const slotResult = concurrency.tryAcquire(channelId)
+
+  if (slotResult === 'cap') {
+    await request.replySink.send('source', {content: 'fro-bot is at capacity right now — please try again shortly.'})
+    return
+  }
+
+  if (slotResult === 'busy') {
+    // Channel has an in-flight run — enqueue instead of rejecting.
+    const enqueueResult = queue.enqueue(channelId, task)
+    await ackEnqueueResult(request, enqueueResult)
+    return
+  }
+
+  // Slot acquired — executeWorkOnHeldSlot owns the release (via atomic handoff in its outer finally).
+  await executeWorkOnHeldSlot(task)
+}
+
+// ---------------------------------------------------------------------------
+// ackEnqueueResult — send the appropriate ephemeral ack for an enqueue result
+// ---------------------------------------------------------------------------
+
+/**
+ * Send the appropriate ephemeral ack for an enqueue result.
+ * Centralises the two reply strings so they live in exactly one place.
+ */
+async function ackEnqueueResult(request: LaunchWorkRequest, result: 'queued' | 'full'): Promise<void> {
+  if (result === 'queued') {
+    await request.replySink.send('source', {content: "Queued — I'll start this when the current task finishes."})
+  } else {
+    await request.replySink.send('source', {
+      content: 'The queue is full for this channel — please wait for pending tasks to complete.',
+    })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// runMention — the Discord adapter (Unit 2: constructs sinks inline)
+// ---------------------------------------------------------------------------
+
+/**
+ * Discord adapter for mention-triggered runs.
+ *
+ * Maps a Discord `Message` → `LaunchWorkRequest` and calls `launchWork`.
+ *
+ * In Unit 2, the Discord sinks are "deferred" — they are initialized inside
+ * `executeWorkOnHeldSlot` after thread creation via the `_initSinks` callback.
+ * Unit 3 will make this a proper thin adapter where thread creation moves here.
  *
  * Hard invariants:
  * - `'cap'` is TERMINAL — no queue, no retry.
@@ -786,32 +1251,123 @@ async function startRun(task: RunTask): Promise<void> {
  * - Bearer token (`attachToken`) is never logged.
  * - Every Discord send uses `allowedMentions: {parse: []}`.
  */
-/**
- * Send the appropriate ephemeral ack for an enqueue result.
- * Centralises the two reply strings so they live in exactly one place.
- */
-async function ackEnqueueResult(message: Message, result: 'queued' | 'full', logger: GatewayLogger): Promise<void> {
-  if (result === 'queued') {
-    await sendMessage(message, {content: "Queued — I'll start this when the current task finishes."}, logger)
-  } else {
-    await sendMessage(
-      message,
-      {content: 'The queue is full for this channel — please wait for pending tasks to complete.'},
-      logger,
-    )
-  }
-}
-
 export async function runMention(message: Message, binding: RepoBinding, deps: RunMentionDeps): Promise<void> {
   const {concurrency, queue, logger} = deps
   const channelId = message.channel.id
-  const task: RunTask = {message, binding, deps}
+
+  // ── Build deferred Discord sinks ──────────────────────────────────────────
+  // The real sinks are initialized by _initSinks after thread creation inside
+  // executeWorkOnHeldSlot. Until then, pre-thread acks go directly to the message.
+
+  let realStatusSink: StatusSink | null = null
+  let realReplySink: ReplySink | null = null
+
+  const statusSink: StatusSink = {
+    noteActivity: (summary: string) => {
+      realStatusSink?.noteActivity(summary)
+    },
+    setBusy: (busy: boolean) => {
+      realStatusSink?.setBusy(busy)
+    },
+    resolveToAnswer: async (text: string) => {
+      if (realStatusSink !== null) return realStatusSink.resolveToAnswer(text)
+      return {transition: 'delegated' as const}
+    },
+    resolveToFailure: async (note: string) => {
+      if (realStatusSink !== null) return realStatusSink.resolveToFailure(note)
+      return {transition: 'delegated' as const}
+    },
+    dispose: async () => {
+      if (realStatusSink !== null) await realStatusSink.dispose()
+    },
+    setReaction: state => {
+      // eslint-disable-next-line no-void
+      void setRunReaction(message, state, logger)
+    },
+  }
+
+  const replySink: ReplySink = {
+    send: async (target, options) => {
+      if (target === 'source') return sendMessage(message, options, logger)
+      if (realReplySink !== null) return realReplySink.send(target, options)
+      return undefined
+    },
+    append: (text: string) => {
+      realReplySink?.append(text)
+    },
+    flush: async () => {
+      if (realReplySink !== null) return realReplySink.flush()
+      return undefined
+    },
+    buffered: () => realReplySink?.buffered() ?? '',
+    hasVisibleOutput: () => realReplySink?.hasVisibleOutput() ?? false,
+    markVisibleOutputSent: () => {
+      realReplySink?.markVisibleOutputSent()
+    },
+    markVisibleOutputPending: () => {
+      if (realReplySink !== null) return realReplySink.markVisibleOutputPending()
+      return (_delivered: boolean) => {
+        /* no-op settle handle — sink not yet initialized */
+      }
+    },
+  }
+
+  const request: LaunchWorkRequest = {
+    promptText: message.content,
+    channelId,
+    guildId: message.guild?.id,
+    surface: 'discord',
+    binding,
+    requester: {kind: 'discord-user', userId: message.author.id},
+    statusSink,
+    replySink,
+  }
+
+  // ── Build the RunTask with the Unit 2 Discord bridge ──────────────────────
+  const task: RunTask & DiscordAdapterBridge = {
+    request,
+    deps,
+    _discordMessage: message,
+    _initSinks: (_thread: SinkThread, rawThread: Awaited<ReturnType<Message['startThread']>>) => {
+      // Create the real Discord sinks now that we have the thread.
+      const statusController = createStatusController({
+        thread: rawThread,
+        mode: deps.statusMode,
+        logger,
+      })
+      realStatusSink = {
+        noteActivity: (summary: string) => statusController.noteActivity(summary),
+        setBusy: (busy: boolean) => statusController.setBusy(busy),
+        resolveToAnswer: async (text: string) => statusController.resolveToAnswer(text),
+        resolveToFailure: async (note: string) => statusController.resolveToFailure(note),
+        dispose: async () => statusController.dispose(),
+        setReaction: state => {
+          // eslint-disable-next-line no-void
+          void setRunReaction(message, state, logger)
+        },
+      }
+
+      const streamSink = createDiscordStreamSink(rawThread, {logger})
+      realReplySink = {
+        send: async (target, options) => {
+          if (target === 'source') return sendMessage(message, options, logger)
+          return sendMessage(rawThread, options, logger)
+        },
+        append: (text: string) => streamSink.append(text),
+        flush: async () => streamSink.flush(),
+        buffered: () => streamSink.buffered(),
+        hasVisibleOutput: () => streamSink.hasVisibleOutput(),
+        markVisibleOutputSent: () => streamSink.markVisibleOutputSent(),
+        markVisibleOutputPending: () => streamSink.markVisibleOutputPending(),
+      }
+    },
+  }
 
   // ── FIFO gate: if pending work exists, enqueue without consulting tryAcquire ──
   // A new mention must never leapfrog older queued work, even if a slot is free.
-  // Only the handoff path (startRun's outer finally) may start the next task.
+  // Only the handoff path (executeWorkOnHeldSlot's outer finally) may start the next task.
   if (queue.pendingCount(channelId) > 0) {
-    await ackEnqueueResult(message, queue.enqueue(channelId, task), logger)
+    await ackEnqueueResult(request, queue.enqueue(channelId, task))
     return
   }
 
@@ -825,10 +1381,10 @@ export async function runMention(message: Message, binding: RepoBinding, deps: R
 
   if (slotResult === 'busy') {
     // Channel has an in-flight run — enqueue instead of rejecting.
-    await ackEnqueueResult(message, queue.enqueue(channelId, task), logger)
+    await ackEnqueueResult(request, queue.enqueue(channelId, task))
     return
   }
 
-  // Slot acquired — startRun owns the release (via atomic handoff in its outer finally).
-  await startRun(task)
+  // Slot acquired — executeWorkOnHeldSlot owns the release (via atomic handoff in its outer finally).
+  await executeWorkOnHeldSlot(task)
 }

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -607,7 +607,7 @@ describe('button interaction handler (approval flow)', () => {
       register: vi.fn(),
       has: vi.fn().mockReturnValue(false),
       pending: vi.fn().mockReturnValue([]),
-      handleButtonDecision: vi.fn().mockResolvedValue('ok'),
+      handleDecision: vi.fn().mockResolvedValue('ok'),
       applySettlement: vi.fn().mockResolvedValue(undefined),
       attachMessage: vi.fn(),
       markMessagePostFailed: vi.fn(),
@@ -711,11 +711,11 @@ describe('button interaction handler (approval flow)', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     // #then — no auth check, no registry interaction, no reply
-    expect(fakeRegistry.handleButtonDecision).not.toHaveBeenCalled()
+    expect(fakeRegistry.handleDecision).not.toHaveBeenCalled()
     expect(interaction.reply).not.toHaveBeenCalled()
   })
 
-  it('authorized approve click → handleButtonDecision called with decision=once, ephemeral Approved.', async () => {
+  it('authorized approve click → handleDecision called with decision=once, ephemeral Approved.', async () => {
     // #given
     const {interactionHandler, fakeRegistry} = await runAndCaptureHandler()
     const {parseApprovalCustomId} = await import('./discord/approvals.js')
@@ -723,7 +723,7 @@ describe('button interaction handler (approval flow)', () => {
 
     const {userIsAuthorized} = await import('./discord/mentions.js')
     vi.mocked(userIsAuthorized).mockResolvedValueOnce(true)
-    vi.mocked(fakeRegistry.handleButtonDecision).mockResolvedValueOnce('ok')
+    vi.mocked(fakeRegistry.handleDecision).mockResolvedValueOnce('ok')
 
     const interaction = makeFakeButtonInteraction({customId: 'fb-approve:req-abc'})
 
@@ -732,11 +732,11 @@ describe('button interaction handler (approval flow)', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     // #then — registry called with correct params
-    expect(fakeRegistry.handleButtonDecision).toHaveBeenCalledWith({
+    expect(fakeRegistry.handleDecision).toHaveBeenCalledWith({
       requestID: 'req-abc',
-      channelID: 'ch-test',
+      approvalScopeId: 'ch-test',
       decision: 'once',
-      decidedBy: 'user-decider',
+      actor: {kind: 'discord-user', userId: 'user-decider'},
     })
 
     // #and — deferred then edited with approved ack
@@ -793,7 +793,7 @@ describe('button interaction handler (approval flow)', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     // #then — no registry call
-    expect(fakeRegistry.handleButtonDecision).not.toHaveBeenCalled()
+    expect(fakeRegistry.handleDecision).not.toHaveBeenCalled()
 
     // #and — deferReply was called first (interaction acked)
     expect(interaction.deferReply).toHaveBeenCalledWith({ephemeral: true})
@@ -814,7 +814,7 @@ describe('button interaction handler (approval flow)', () => {
 
     const {userIsAuthorized} = await import('./discord/mentions.js')
     vi.mocked(userIsAuthorized).mockResolvedValueOnce(true)
-    vi.mocked(fakeRegistry.handleButtonDecision).mockResolvedValueOnce('ok')
+    vi.mocked(fakeRegistry.handleDecision).mockResolvedValueOnce('ok')
 
     const interaction = makeFakeButtonInteraction({customId: 'fb-deny:req-abc'})
 
@@ -823,7 +823,7 @@ describe('button interaction handler (approval flow)', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     // #then — decision is reject
-    expect(fakeRegistry.handleButtonDecision).toHaveBeenCalledWith(expect.objectContaining({decision: 'reject'}))
+    expect(fakeRegistry.handleDecision).toHaveBeenCalledWith(expect.objectContaining({decision: 'reject'}))
 
     // #and — deferred then edited with denied ack
     // editInteraction always injects allowedMentions: {parse: []}
@@ -841,7 +841,7 @@ describe('button interaction handler (approval flow)', () => {
 
     const {userIsAuthorized} = await import('./discord/mentions.js')
     vi.mocked(userIsAuthorized).mockResolvedValueOnce(true)
-    vi.mocked(fakeRegistry.handleButtonDecision).mockResolvedValueOnce('channel-mismatch')
+    vi.mocked(fakeRegistry.handleDecision).mockResolvedValueOnce('channel-mismatch')
 
     const interaction = makeFakeButtonInteraction()
 
@@ -863,7 +863,7 @@ describe('button interaction handler (approval flow)', () => {
 
     const {userIsAuthorized} = await import('./discord/mentions.js')
     vi.mocked(userIsAuthorized).mockResolvedValueOnce(true)
-    vi.mocked(fakeRegistry.handleButtonDecision).mockResolvedValueOnce('not-found')
+    vi.mocked(fakeRegistry.handleDecision).mockResolvedValueOnce('not-found')
 
     const interaction = makeFakeButtonInteraction()
 
@@ -885,7 +885,7 @@ describe('button interaction handler (approval flow)', () => {
 
     const {userIsAuthorized} = await import('./discord/mentions.js')
     vi.mocked(userIsAuthorized).mockResolvedValueOnce(true)
-    vi.mocked(fakeRegistry.handleButtonDecision).mockResolvedValueOnce('already-claimed')
+    vi.mocked(fakeRegistry.handleDecision).mockResolvedValueOnce('already-claimed')
 
     const interaction = makeFakeButtonInteraction()
 
@@ -907,7 +907,7 @@ describe('button interaction handler (approval flow)', () => {
 
     const {userIsAuthorized} = await import('./discord/mentions.js')
     vi.mocked(userIsAuthorized).mockResolvedValueOnce(true)
-    vi.mocked(fakeRegistry.handleButtonDecision).mockResolvedValueOnce('reply-failed')
+    vi.mocked(fakeRegistry.handleDecision).mockResolvedValueOnce('reply-failed')
 
     const interaction = makeFakeButtonInteraction()
 

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -231,11 +231,11 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
             }
 
             const decision = parsed.action === 'approve' ? ('once' as const) : ('reject' as const)
-            const outcome = await approvalRegistry.handleButtonDecision({
+            const outcome = await approvalRegistry.handleDecision({
               requestID: parsed.requestID,
-              channelID: interaction.channelId,
+              approvalScopeId: interaction.channelId,
               decision,
-              decidedBy: interaction.user.id,
+              actor: {kind: 'discord-user', userId: interaction.user.id},
             })
 
             const ackContent =


### PR DESCRIPTION
## What this does

Makes the gateway's mention-triggered execution and approval paths transport-agnostic, so a future web control surface can drive the same engine and the same approval gate that Discord uses today. This is the foundational seam the rest of the inbound control-surface work builds on. Advances #907 (Phase A only — the inbound web listener and operator auth, and the bindings read path, are separate follow-ups).

- **One execution engine, transport-neutral.** `launchWork(request, deps)` is the public entry point that owns queue acquisition, the concurrency cap, and FIFO handoff; a private inner primitive runs the post-acquire pipeline against `StatusSink`/`ReplySink` interfaces instead of a raw Discord `Message`. A non-Discord caller goes through the same front door and cannot bypass the queue.
- **`runMention` is now a thin Discord adapter.** It strips the mention, builds the transport-neutral request, and supplies Discord sinks that wrap the existing status controller and stream sink (via the safe `io.ts` send boundary). It also creates the thread through a thread factory the engine triggers at the right point.
- **One approval gate, multiple transports.** The Discord approval rendering and decision intake move into a dedicated transport module; the engine keeps a transport-neutral approval hook. The registry API is generalized (`approvalScopeId`, `handleDecision`, a typed approval actor) and a non-Discord decision settles through the same fail-closed registry — there is no second approval path.

## Behavior change

One intentional change: a bare mention with no prompt now replies on the source message immediately, instead of opening a thread and surfacing the failure inside it. The empty-prompt case is also guarded at the engine front door so no caller can churn thread/lock/run-state before failing. Everything else — queue/cap/FIFO, thread creation, reactions, live-status vs typing-only, the approval button flow, timeout/dispose — is unchanged.

## Verification

Characterization tests pin the pre-refactor Discord behavior and remain green through the refactor as the regression gate. New tests cover `launchWork` against in-memory sinks (no Discord dependency), the empty-prompt fail-fast, thread-factory failure and timeout, and a non-Discord approval decision settling through the same registry. Gateway suite green (1321 tests), type-check and lint clean.

## Follow-ups (not in this PR)

- Inbound authenticated web listener + operator session auth, and the bindings read path — each gets its own plan and PR.
- A few transport-neutral typing seams (widening the run surface type for a web surface, a typed reply-sink result) are documented in code and deferred until the web caller lands.

Advances #907
