### PR TITLE
ci(renovate): hold release-pipeline packages for 3 days

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -142,6 +142,14 @@
       semanticCommitType: 'build',
     },
     {
+      // Let release-pipeline packages settle before they reach the release job. A
+      // broken same-day publish (e.g. semantic-release 25.0.4 shipped a missing
+      // @semantic-release/core import) would otherwise break Perform Release before
+      // upstream ships a fix.
+      matchPackageNames: ['semantic-release', 'conventional-changelog-conventionalcommits', '/^@semantic-release//'],
+      minimumReleaseAge: '3 days',
+    },
+    {
       matchPackageNames: ['conventional-changelog-conventionalcommits', 'semantic-release'],
       matchUpdateTypes: ['major'],
       groupName: 'semantic-release and conventionalcommits',


### PR DESCRIPTION
## What this does

Applies a 3-day minimum release age to the release-pipeline packages — `semantic-release`, the `@semantic-release/*` family, and `conventional-changelog-conventionalcommits` — so a broken same-day publish can't reach the Perform Release job before upstream ships a fix.

This is a direct response to a real incident: `semantic-release@25.0.4` shipped with a missing `@semantic-release/core` import and broke Perform Release until `25.0.5` landed. A settle window prevents that class of failure from gating a release again, while leaving every other package's update cadence unchanged.

## Verification

`renovate.json5` parses cleanly (10 package rules); the new rule scopes `minimumReleaseAge: '3 days'` to exactly the named release packages plus the `/^@semantic-release//` regex. No other rule is affected.
