### PR TITLE
feat(gateway): add operator route guardrail seam

### DIFF
--- a/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
+++ b/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
@@ -328,7 +328,7 @@ The web listener is an adapter layer. It authenticates the operator, projects sa
   - Runtime and gateway typechecks pass.
   - No `as any`, `@ts-ignore`, or broad `unknown as` casts are introduced.
 
-- [ ] **Unit 2: Operator listener topology and security pin**
+- [x] **Unit 2: Operator listener topology and security pin**
 
   **Goal:** Add the operator web listener skeleton and deployment guardrails without exposing privileged behavior yet.
 
@@ -384,73 +384,252 @@ The web listener is an adapter layer. It authenticates the operator, projects sa
   - Gateway tests cover listener opt-in/out and ingress inventory.
   - Deploy validation tests cover the new topology with positive and negative controls.
 
-- [ ] **Unit 3: Operator authentication, sessions, CSRF, and audit seam**
+- [x] **Unit 3a: Config + operator route guardrail seam**
 
-  **Goal:** Add the browser auth boundary that all operator routes must pass through.
+  **Goal:** Establish the config plumbing and a mechanical route-wrapper that makes it structurally impossible for new privileged operator routes to skip rate-limiting, auth, origin, or CSRF checks.
 
-  **Requirements:** R1, R2, R3, R4, R5, R14, R16, R17
+  **Requirements:** R1, R3, R4, R13
 
   **Dependencies:** Unit 2
 
   **Files:**
-  - Create: `packages/gateway/src/web/auth/github.ts`
-  - Create: `packages/gateway/src/web/auth/session.ts`
-  - Create: `packages/gateway/src/web/auth/allowlist.ts`
-  - Create: `packages/gateway/src/web/auth/csrf.ts`
-  - Create: `packages/gateway/src/web/auth/repo-authz.ts`
-  - Create: `packages/gateway/src/web/audit.ts`
-  - Create: `packages/gateway/src/web/auth.test.ts`
-  - Create: `packages/gateway/src/web/audit.test.ts`
   - Modify: `packages/gateway/src/config.ts`
+  - Create: `packages/gateway/src/web/operator-route.ts`
+  - Create: `packages/gateway/src/web/operator-route.test.ts`
+  - Modify: `packages/gateway/src/web/server.ts`
+
+  **Approach:**
+  - Add config keys for `GATEWAY_OPERATOR_PUBLIC_ORIGIN`, GitHub App OAuth client id/secret, allowlist path, session secret, and CSRF signing key. Validate `GATEWAY_OPERATOR_PUBLIC_ORIGIN` as a canonical origin only: scheme + host + optional port, no path, query, hash, or userinfo component. Reject any value that does not parse as a valid `URL` with an empty pathname, no search, no hash, and no username/password.
+  - Add a `registerOperatorRoute` wrapper (or equivalent Hono middleware chain factory) that every privileged operator route must use. The wrapper enforces, in order: body-size limit, socket-keyed unauthenticated rate limit, session validation, Host/Origin/public-origin check, Fetch Metadata rejection, and CSRF verification for mutating methods. New routes that skip the wrapper fail a static test.
+  - Add a static test that enumerates all registered operator routes and asserts each one is wrapped; this is the mechanical guard that prevents future omissions.
+  - Use `readSecret` and hardened file/env helpers already in `packages/gateway/src/config.ts`.
+
+  **Patterns to follow:**
+  - Hardened config readers in `packages/gateway/src/config.ts`.
+  - Announce server lifecycle in `packages/gateway/src/http/server.ts`.
+
+  **Test scenarios:**
+  - Config: `GATEWAY_OPERATOR_PUBLIC_ORIGIN` with a path, query, hash, or userinfo component is rejected at startup.
+  - Config: a valid canonical origin (`https://ops.example.com`) is accepted.
+  - Static guard: a route registered without the wrapper causes the static test to fail.
+  - Static guard: all routes registered through the wrapper pass the static test.
+
+  **Verification:**
+  - Config validation and route-wrapper tests pass; no operator route can be added without the guardrail.
+
+- [ ] **Unit 3b: Audit seam and redaction guarantees**
+
+  **Goal:** Add a single typed audit seam for security-critical events so all subsequent units can emit structured, redacted audit records without duplicating sink logic.
+
+  **Requirements:** R4, R14, R16, R17
+
+  **Dependencies:** Unit 3a
+
+  **Files:**
+  - Create: `packages/gateway/src/web/audit.ts`
+  - Create: `packages/gateway/src/web/audit.test.ts`
+
+  **Approach:**
+  - Define a typed `AuditEvent` discriminated union covering: `auth.start`, `auth.callback.success`, `auth.callback.failure`, `auth.logout`, `auth.revocation`, `authz.denied`, `launch.accepted`, `launch.rejected`, `approval.decision`, `approval.rejected`, `binding.read`, `bearer.rejected`.
+  - Implement a single `emitAudit(event, logger)` function. Route success is reported only after the local audit sink accepts the event; downstream export may be asynchronous.
+  - Redaction: audit records must never include cookies, session secrets, GitHub tokens, raw request bodies, prompts, bearer values, or internal URLs. Add captured-log tests that assert these fields are absent from emitted records.
+  - Treat Gateway restart as clearing all in-flight audit state; durable export is a deployment concern.
+  - Audit retention: structured gateway logs are acceptable for v1 if deployment guarantees 30-day retention, access control, and redaction posture.
+
+  **Patterns to follow:**
+  - Logger redaction conventions in gateway tests.
+  - `docs/solutions/best-practices/signed-webhook-ingress-hardening-2026-05-29.md` redaction test patterns.
+
+  **Test scenarios:**
+  - Happy path: each event variant emits a structured record with the expected typed fields.
+  - Security: captured log output for every event variant contains no cookie, secret, token, prompt, or bearer value.
+  - Security: `bearer.rejected` event records the rejection without logging the credential value.
+
+  **Verification:**
+  - Audit seam is typed, redacted, and covered by captured-log tests.
+
+- [ ] **Unit 3c: GitHub OAuth state + PKCE identity verification**
+
+  **Goal:** Implement the GitHub App user OAuth web flow with PKCE S256 and state so the callback can verify human identity before any session is minted.
+
+  **Requirements:** R1, R4, R5, R14
+
+  **Dependencies:** Unit 3b
+
+  **Files:**
+  - Create: `packages/gateway/src/web/auth/github.ts`
+  - Create: `packages/gateway/src/web/auth/github.test.ts`
+  - Modify: `packages/gateway/src/web/server.ts`
+
+  **Approach:**
+  - Implement `GET /operator/auth/github/start`: generate a PKCE S256 code verifier (server-side only, never in a cookie), derive the code challenge, generate a cryptographic state value, store `{ codeVerifier, redirectTarget, issuedAt, consumed: false }` server-side with a short TTL and a cap on outstanding attempts per socket. Redirect to GitHub with `state`, `code_challenge`, and `code_challenge_method=S256`.
+  - Implement `GET /operator/auth/github/callback`: validate `state` (constant-time comparison, one-time consumption, TTL check), exchange `code` for a GitHub access token using the stored `codeVerifier` in the PKCE exchange. PKCE is not optional and is not a deploy-time detail.
+  - After token exchange, fetch the authenticated GitHub user and extract the stable numeric `id`. The numeric `id` is the authority for all subsequent identity checks; `login` is display metadata only.
+  - Bind and validate the OAuth return path as same-origin/path-allowlisted; reject absolute URLs and cross-origin redirects before OAuth state is minted.
+  - The OAuth callback route must be narrowly exempted from strict Fetch Metadata cross-site rejection (GitHub redirects cross-site); all other operator routes remain subject to full Fetch Metadata enforcement.
+  - Emit `auth.callback.success` or `auth.callback.failure` audit events via the Unit 3b seam.
+  - Repo authorization must verify human user access using the user OAuth token, not only app installation auth.
+
+  **Patterns to follow:**
+  - GitHub App user-to-server auth docs: PKCE S256/state flow.
+  - No-oracle auth failure behavior from signed webhook ingress.
+
+  **Test scenarios:**
+  - Happy path: valid state + PKCE exchange returns the numeric GitHub user id and display login.
+  - Error path: invalid state, replayed state, expired state, PKCE verifier mismatch, and oversized verifier records all fail closed and emit audit without leaking specifics.
+  - Error path: absolute URL or cross-origin redirect target in state is rejected before OAuth state is minted.
+  - Security: code verifier is never written to a cookie or included in any browser-visible response.
+  - Security: every auth failure branch returns the same coarse response shape.
+  - Security: OAuth callback is narrowly exempted from Fetch Metadata cross-site rejection; other routes are not.
+
+  **Verification:**
+  - OAuth flow is PKCE-enforced, state-validated, and identity-anchored to stable numeric GitHub id.
+
+- [ ] **Unit 3d: Session store, cookies, logout, and revocation hook**
+
+  **Goal:** Mint server-side opaque sessions after successful identity verification, enforce session lifetime and revocation, and provide the logout route.
+
+  **Requirements:** R2, R4, R14
+
+  **Dependencies:** Unit 3c
+
+  **Files:**
+  - Create: `packages/gateway/src/web/auth/session.ts`
+  - Create: `packages/gateway/src/web/auth/session.test.ts`
+  - Modify: `packages/gateway/src/web/server.ts`
+
+  **Approach:**
+  - v1 session store owns `create`, `get`, `touch`, `delete`, enforces 8-hour absolute and 30-minute idle expiry, scavenges expired entries, and caps stored sessions.
+  - Session IDs have at least 128 bits of CSPRNG entropy (preferably 256 bits); comparisons are constant-time.
+  - Store the session ID in a `__Host-` cookie: `HttpOnly`, `Secure`, `SameSite=Lax`, `Path=/`, no `Domain` attribute.
+  - Always mint a fresh session ID after successful OAuth callback and clear any stale pre-auth cookie to prevent session fixation.
+  - Revocation is immediate for future requests; in-flight approval decisions already accepted by `handleDecision` continue to settlement and are not rolled back.
+  - Treat Gateway restart as global logout for v1: all sessions, CSRF tokens, idempotency records, and SSE subscriptions are gone. Browser clients must re-authenticate and snapshot-read after reconnect.
+  - Expose a revocation hook so SSE streams can be notified within one heartbeat/auth-check interval when a session is revoked.
+
+  **Patterns to follow:**
+  - `readSecret` and related file/env helpers in `packages/gateway/src/config.ts`.
+  - `userIsAuthorized` fail-closed posture in `packages/gateway/src/discord/mentions.ts`.
+
+  **Test scenarios:**
+  - Happy path: successful OAuth callback mints a fresh session and sets a `__Host-` cookie with correct attributes.
+  - Security: session cookie tests assert `__Host-` invariants: `Secure`, `HttpOnly`, `Path=/`, no `Domain` attribute.
+  - Security: stale pre-auth cookie is cleared before the new session cookie is set.
+  - Revocation: logout invalidates the session server-side and clears the cookie.
+  - Revocation: revoking a session triggers the revocation hook; concurrent sessions are independently revocable.
+  - Expiry: expired sessions are scavenged and return unauthorized on next request.
+  - Restart: after a simulated restart, previously valid session IDs are not found.
+
+  **Verification:**
+  - Session store is bounded, revocable, and covered by deterministic typed tests.
+
+- [ ] **Unit 3e: Origin / Fetch Metadata / CSRF middleware**
+
+  **Goal:** Implement the layered browser-origin protection stack that all mutating operator routes must pass through.
+
+  **Requirements:** R3, R4
+
+  **Dependencies:** Unit 3d
+
+  **Files:**
+  - Create: `packages/gateway/src/web/auth/csrf.ts`
+  - Create: `packages/gateway/src/web/auth/csrf.test.ts`
+  - Modify: `packages/gateway/src/web/operator-route.ts`
+
+  **Approach:**
+  - Do not rely on `hono/csrf` for JSON mutating routes. Implement custom signed double-submit CSRF tokens: tokens are bound to session id, operator id, issued-at, and a nonce/version; signed with the CSRF signing key from config; rotated on login, refresh, and a 15-minute interval; invalidated on logout, expiry, and revocation.
+  - Guard mutating routes in this order: (1) reject non-cookie credential schemes (`Authorization`, `Proxy-Authorization`, `X-API-Key`) and audit without logging credential values; (2) validate session; (3) validate `Host`/`Origin` against `GATEWAY_OPERATOR_PUBLIC_ORIGIN`; (4) reject unsafe Fetch Metadata combinations (`Sec-Fetch-Site: cross-site` on non-exempted routes, `Sec-Fetch-Mode: navigate` on non-navigation routes) when headers are present; (5) parse and verify CSRF token.
+  - The OAuth callback is narrowly exempted from Fetch Metadata cross-site rejection (established in Unit 3c); no other route is exempted.
+  - Add a `GET /operator/session/csrf` route that returns a fresh signed double-submit token for an authenticated session.
+
+  **Patterns to follow:**
+  - OWASP CSRF Prevention Cheat Sheet: signed double-submit + origin/Fetch Metadata defense in depth.
+  - No-oracle auth failure behavior from signed webhook ingress.
+
+  **Test scenarios:**
+  - Security: mutating routes reject missing CSRF token, invalid CSRF signature, expired CSRF token, and mismatched session binding.
+  - Security: mutating routes reject `Origin` header that does not match `GATEWAY_OPERATOR_PUBLIC_ORIGIN`.
+  - Security: `Sec-Fetch-Site: cross-site` on a non-exempted mutating route is rejected.
+  - Security: non-cookie credential schemes are rejected and audited without logging the credential value.
+  - Security: CSRF token refresh requires a valid session and rotates tokens on schedule.
+  - Happy path: a valid session + matching origin + valid CSRF token passes all checks.
+
+  **Verification:**
+  - CSRF and origin middleware are tested in isolation and wired into the route guardrail from Unit 3a.
+
+- [ ] **Unit 3f: Allowlist + repo authorization helper**
+
+  **Goal:** Implement the operator allowlist check and the single repo authorization helper used by all privileged routes.
+
+  **Requirements:** R1, R14, R19
+
+  **Dependencies:** Unit 3d
+
+  **Files:**
+  - Create: `packages/gateway/src/web/auth/allowlist.ts`
+  - Create: `packages/gateway/src/web/auth/repo-authz.ts`
+  - Create: `packages/gateway/src/web/auth/allowlist.test.ts`
+  - Create: `packages/gateway/src/web/auth/repo-authz.test.ts`
+
+  **Approach:**
+  - Load the operator allowlist from a hardened config/file path. v1 uses a file-backed allowlist; hot reload can be added later. Allowlist entries are stable numeric GitHub user IDs, not logins.
+  - Add one `checkRepoAuthz(operatorId, owner, repo, userOAuthToken, logger)` helper used by launch, run-state, approvals, and binding reads. v1 rule: allowlist membership plus verified GitHub read access to the target repo using the user OAuth token (not only app installation auth). Failures deny.
+  - Cache repo authorization by operator/repo: 5-minute positive TTL, 30-second negative TTL, TTL jitter, request coalescing for concurrent misses, fail-closed on lookup errors. GitHub rate-limit responses are cached through their retry window.
+  - Normalize and validate owner/repo names before any authz or queueing work.
+  - Emit `authz.denied` audit events via the Unit 3b seam on every denial.
+
+  **Patterns to follow:**
+  - `userIsAuthorized` fail-closed posture in `packages/gateway/src/discord/mentions.ts`.
+  - `docs/solutions/best-practices/centralize-s3-key-identity-construction-2026-06-09.md` for centralized helper patterns.
+
+  **Test scenarios:**
+  - Happy path: an allowlisted operator with GitHub read access to a repo is authorized.
+  - Error path: an allowlisted operator without GitHub read access is denied and audited.
+  - Error path: a non-allowlisted numeric user id is denied regardless of GitHub access.
+  - Caching: a positive authz result is cached; a negative result is cached with a shorter TTL.
+  - Caching: concurrent misses for the same operator/repo coalesce into one GitHub API call.
+  - Caching: a GitHub rate-limit response is cached through its retry window.
+  - Error path: GitHub API lookup failure fails closed and emits an audit event.
+  - Validation: malformed owner/repo names are rejected before authz work begins.
+
+  **Verification:**
+  - Allowlist and repo authz are deterministic, fail-closed, and covered by typed tests.
+
+- [ ] **Unit 3g: Minimal session routes**
+
+  **Goal:** Wire the three minimal session-management routes that the browser flow requires: current session info, CSRF token refresh, and logout.
+
+  **Requirements:** R2, R3, R4, R14
+
+  **Dependencies:** Units 3d and 3e
+
+  **Files:**
+  - Create: `packages/gateway/src/web/routes/session.ts`
+  - Create: `packages/gateway/src/web/routes/session.test.ts`
   - Modify: `packages/gateway/src/web/server.ts`
   - Modify: `deploy/README.md`
 
   **Approach:**
-  - Implement GitHub App user OAuth with state and PKCE.
-  - OAuth callback validation must require both state and PKCE verifier binding; PKCE is not optional and is not a deploy-time detail.
-  - Store OAuth verifier state server-side with redirect target, issued-at timestamp, one-time consumption flag, short TTL, and capped outstanding attempts per socket.
-  - Bind and validate the OAuth return path as same-origin/path-allowlisted state; reject absolute URLs and cross-origin redirects.
-  - Mint server-side opaque sessions after successful identity verification and allowlist authorization.
-  - Store the session ID in a secure `__Host-` cookie with HttpOnly, Secure, SameSite, `Path=/`, and no `Domain` attribute. Session IDs have at least 128 bits of CSPRNG entropy, preferably 256 bits, and comparisons are constant-time.
-  - Always mint a fresh session ID after successful OAuth callback and clear any stale pre-auth cookie to prevent session fixation.
-  - Enforce session lifetime, logout, revocation, origin checks, and CSRF defense on state-changing routes.
-  - Add a CSRF token bootstrap/refresh path for the signed double-submit token used by mutating JSON routes. Tokens are bound to session id, operator id, issued-at, and nonce/version; rotate on login, refresh, and a 15-minute interval; invalidate on logout, expiry, and revocation.
-  - Guard mutating routes in this order: reject non-cookie credential schemes, validate session, validate Host/Origin/public-origin, reject unsafe Fetch Metadata combinations when present, then parse and verify CSRF.
-  - Use stable GitHub numeric user IDs for authorization/audit and keep login only as display metadata.
-  - Add one repo authorization helper used by launch, run-state, approvals, and binding reads. v1 requires allowlist membership plus verified GitHub read access to the target repo; failures deny.
-  - Cache repo authorization by operator/repo with a 5-minute positive TTL, 30-second negative TTL, TTL jitter, request coalescing for concurrent misses, and fail-closed behavior on lookup errors. GitHub rate-limit responses are cached through their retry window.
-  - Add a single audit seam for auth, launch, approval, reject, binding-read, and authorization-denial events.
-  - Emit security-critical audit events through one typed seam. Route success is reported only after the local audit sink accepts the event; downstream export may be asynchronous.
-  - Reject standalone bearer/API callers in v1 with structured audit events.
-  - v1 session store owns create/get/touch/delete, enforces 8-hour absolute and 30-minute idle expiry, scavenges expired entries, and caps stored sessions.
-  - Treat Gateway restart as global logout for v1: all sessions, CSRF tokens, idempotency records, and SSE subscriptions are gone. Browser clients must re-authenticate and snapshot-read after reconnect.
+  - `GET /operator/session`: returns operator numeric id, display login, and session expiry for a valid session; returns `401` with a coarse body for invalid/expired sessions.
+  - `GET /operator/session/csrf`: returns a fresh signed double-submit token for an authenticated session (delegates to Unit 3e CSRF module).
+  - `POST /operator/session/logout`: invalidates the session server-side, clears the cookie, triggers the revocation hook from Unit 3d, and emits an `auth.logout` audit event.
+  - All three routes go through the `registerOperatorRoute` wrapper from Unit 3a. Logout additionally requires origin and CSRF checks.
+  - Update `deploy/README.md` to document the OAuth callback URL (`{GATEWAY_OPERATOR_PUBLIC_ORIGIN}/operator/auth/github/callback`), required secrets, and the distinction between OAuth client id/secret and GitHub App id/private key.
 
   **Patterns to follow:**
-  - `userIsAuthorized` fail-closed posture in `packages/gateway/src/discord/mentions.ts`.
-  - `readSecret` and related file/env helpers in `packages/gateway/src/config.ts`.
+  - Route wiring in `packages/gateway/src/web/server.ts`.
   - No-oracle auth failure behavior from signed webhook ingress.
-  - Logger redaction conventions in gateway tests.
 
   **Test scenarios:**
-  - Happy path: valid GitHub OAuth callback for an allowlisted numeric user creates a session cookie and audit record.
-  - Error path: invalid state, missing PKCE verifier, denied GitHub user, non-allowlisted user, expired session, revoked session, and invalid origin all fail closed.
-  - Error path: PKCE verifier mismatch, replayed state, expired verifier, and oversized verifier records fail closed and audit without leaking specifics.
-  - Security: every auth failure branch returns the same coarse response shape.
-  - Security: mutating routes reject missing/invalid CSRF or origin signals before changing state.
-  - Security: CSRF token bootstrap/refresh requires a valid session and rotates or expires tokens on schedule.
-  - Security: session cookie tests assert `__Host-` invariants: Secure, HttpOnly, `Path=/`, and no `Domain` attribute.
-  - Security: revoking a session closes associated SSE streams within one heartbeat/auth-check interval; concurrent sessions are independently revocable.
-  - Security: non-cookie credential schemes such as `Authorization`, `Proxy-Authorization`, and `X-API-Key` are rejected and audited without logging credential values.
-  - Abuse: OAuth start/callback and session endpoints apply bounded per-socket/per-session throttles with tests.
-  - Security: captured logs and audit records omit cookies, session secrets, GitHub tokens, request bodies, prompts, and bearer values.
-  - Revocation: logout invalidates the session server-side and clears the cookie.
-  - v1 boundary: `Authorization: Bearer` callers are denied and audited rather than accepted.
-  - Authz: an allowlisted operator without GitHub read access to a repo cannot launch, stream, approve, or read bindings for that repo.
-  - Validation: launch owner/repo names are normalized server-side, prompt and idempotency key lengths/formats are bounded, and canonical repo resolution happens before authz or queueing.
+  - Happy path: `GET /operator/session` returns operator id, login, and expiry for a valid session.
+  - Error path: `GET /operator/session` returns `401` for an expired or missing session.
+  - Happy path: `GET /operator/session/csrf` returns a fresh token for a valid session.
+  - Happy path: `POST /operator/session/logout` invalidates the session, clears the cookie, and emits an audit event.
+  - Security: `POST /operator/session/logout` requires a valid origin and CSRF token.
+  - Security: all three routes are covered by the static route-wrapper guard from Unit 3a.
 
   **Verification:**
-  - Operator routes cannot be reached without a valid session.
-  - Session and allowlist behavior is deterministic, typed, and redacted.
+  - Session routes are wired, tested, and covered by the route guardrail.
 
 - [ ] **Unit 4: SSE run observation and safe browser projections**
 

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -1973,3 +1973,89 @@ describe('loadGatewayConfig — operator web surface', () => {
     expect(() => loadGatewayConfig()).toThrow(/must not be an IPv6 address/)
   })
 })
+
+// ---------------------------------------------------------------------------
+// GATEWAY_OPERATOR_PUBLIC_ORIGIN — canonical origin validation
+// ---------------------------------------------------------------------------
+
+function setOperatorEnv(origin: string): void {
+  setRequiredEnv()
+  process.env.GATEWAY_OPERATOR_BIND_HOST = '172.20.0.2'
+  process.env.GATEWAY_OPERATOR_BIND_PORT = '4000'
+  process.env.GATEWAY_OPERATOR_PUBLIC_ORIGIN = origin
+}
+
+describe('loadGatewayConfig — GATEWAY_OPERATOR_PUBLIC_ORIGIN canonical origin validation', () => {
+  it('happy path: bare https origin with no path → accepted', () => {
+    // #given
+    setOperatorEnv('https://ops.example.com')
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.operatorWeb?.publicOrigin).toBe('https://ops.example.com')
+  })
+
+  it('happy path: https origin with explicit port → accepted', () => {
+    // #given
+    setOperatorEnv('https://ops.example.com:8443')
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.operatorWeb?.publicOrigin).toBe('https://ops.example.com:8443')
+  })
+
+  it('error path: origin with a path beyond / → rejected', () => {
+    // #given — paths beyond the root are not allowed in a canonical origin
+    setOperatorEnv('https://ops.example.com/some/path')
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/canonical origin/)
+  })
+
+  it('error path: origin with a query string → rejected', () => {
+    // #given
+    setOperatorEnv('https://ops.example.com?foo=bar')
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/canonical origin/)
+  })
+
+  it('error path: origin with a hash fragment → rejected', () => {
+    // #given
+    setOperatorEnv('https://ops.example.com#section')
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/canonical origin/)
+  })
+
+  it('error path: origin with a username → rejected', () => {
+    // #given
+    setOperatorEnv('https://user@ops.example.com')
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/canonical origin/)
+  })
+
+  it('error path: origin with a password → rejected', () => {
+    // #given
+    setOperatorEnv('https://user:pass@ops.example.com')
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/canonical origin/)
+  })
+
+  it('edge: origin with trailing slash only (/) → accepted and normalized (trailing slash stripped)', () => {
+    // #given — https://ops.example.com/ is a valid canonical origin (pathname='/'); accepted
+    setOperatorEnv('https://ops.example.com/')
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then — stored as parsedPublicOrigin.origin which strips the trailing slash
+    expect(config.operatorWeb?.publicOrigin).toBe('https://ops.example.com')
+  })
+})

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -613,7 +613,11 @@ export function loadGatewayConfig(): GatewayConfig {
       )
     }
 
-    // Validate public origin — must be a valid https:// URL.
+    // Validate public origin — must be a canonical https:// origin:
+    //   scheme + host + optional port, no path beyond /, no query, no hash, no userinfo.
+    // A canonical origin is used for OAuth callbacks, cookies, CORS, and CSRF checks.
+    // Any extra component (path, query, hash, credentials) indicates a misconfiguration
+    // that would silently break those checks at runtime.
     let parsedPublicOrigin: URL
     try {
       parsedPublicOrigin = new URL(operatorPublicOrigin)
@@ -627,11 +631,55 @@ export function loadGatewayConfig(): GatewayConfig {
         `Invalid GATEWAY_OPERATOR_PUBLIC_ORIGIN value: "${operatorPublicOrigin}" (must use https:// — the operator listener does not terminate TLS; TLS is handled by the infra reverse proxy)`,
       )
     }
+    // Reject non-canonical origin components. A canonical origin has:
+    //   - pathname of exactly '/' (URL always normalizes to '/' when no path is given)
+    //   - no search (query string)
+    //   - no hash
+    //   - no username or password (userinfo)
+    // pathname === '/' is the root — the only acceptable value. Any deeper path
+    // (e.g. '/some/path') means the value is a URL, not an origin.
+    if (parsedPublicOrigin.pathname !== '/') {
+      throw new Error(
+        `Invalid GATEWAY_OPERATOR_PUBLIC_ORIGIN value: "${operatorPublicOrigin}" — must be a canonical origin (scheme + host + optional port only). ` +
+          `Remove the path component. A canonical origin has no path beyond /, no query, no hash, and no username/password. ` +
+          `Example: https://operator.example.com`,
+      )
+    }
+    if (parsedPublicOrigin.search !== '') {
+      throw new Error(
+        `Invalid GATEWAY_OPERATOR_PUBLIC_ORIGIN value: "${operatorPublicOrigin}" — must be a canonical origin (scheme + host + optional port only). ` +
+          `Remove the query string. A canonical origin has no path beyond /, no query, no hash, and no username/password. ` +
+          `Example: https://operator.example.com`,
+      )
+    }
+    if (parsedPublicOrigin.hash !== '') {
+      throw new Error(
+        `Invalid GATEWAY_OPERATOR_PUBLIC_ORIGIN value: "${operatorPublicOrigin}" — must be a canonical origin (scheme + host + optional port only). ` +
+          `Remove the hash fragment. A canonical origin has no path beyond /, no query, no hash, and no username/password. ` +
+          `Example: https://operator.example.com`,
+      )
+    }
+    if (parsedPublicOrigin.username !== '') {
+      throw new Error(
+        `Invalid GATEWAY_OPERATOR_PUBLIC_ORIGIN value: "${operatorPublicOrigin}" — must be a canonical origin (scheme + host + optional port only). ` +
+          `Remove the username. A canonical origin has no path beyond /, no query, no hash, and no username/password. ` +
+          `Example: https://operator.example.com`,
+      )
+    }
+    if (parsedPublicOrigin.password !== '') {
+      throw new Error(
+        `Invalid GATEWAY_OPERATOR_PUBLIC_ORIGIN value: "${operatorPublicOrigin}" — must be a canonical origin (scheme + host + optional port only). ` +
+          `Remove the password. A canonical origin has no path beyond /, no query, no hash, and no username/password. ` +
+          `Example: https://operator.example.com`,
+      )
+    }
 
+    // Normalize to parsedPublicOrigin.origin: strips trailing slash and default ports.
+    // Stored value is always scheme+host+optional-non-default-port (no trailing slash).
     operatorWeb = {
       bindHost: operatorBindHost,
       bindPort: operatorBindPort,
-      publicOrigin: operatorPublicOrigin,
+      publicOrigin: parsedPublicOrigin.origin,
     }
   }
 

--- a/packages/gateway/src/web/operator-route.test.ts
+++ b/packages/gateway/src/web/operator-route.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for the operator route guardrail seam.
+ *
+ * Covers:
+ *   - Static guard: a route registered without the wrapper causes the static test to fail.
+ *   - Static guard: all routes registered through the wrapper pass the static test.
+ *   - Static guard: the health route is explicitly public/unprivileged.
+ *   - Wrapper metadata: registerOperatorRoute marks routes as privileged.
+ *
+ * Uses BDD comments (#given, #when, #then).
+ */
+
+import type {Context} from 'hono'
+import {Hono} from 'hono'
+import {describe, expect, it} from 'vitest'
+import {
+  assertAllPrivilegedRoutesWrapped,
+  isPrivilegedRoute,
+  isPublicRoute,
+  registerOperatorRoute,
+  registerPublicRoute,
+} from './operator-route.js'
+
+// ---------------------------------------------------------------------------
+// registerOperatorRoute — wrapper metadata
+// ---------------------------------------------------------------------------
+
+describe('registerOperatorRoute — wrapper metadata', () => {
+  it('marks a registered route as privileged', () => {
+    // #given
+    const app = new Hono()
+
+    // #when
+    registerOperatorRoute(app, 'GET', '/operator/test', (c: Context) => {
+      return c.json({ok: true})
+    })
+
+    // #then — the route is marked as privileged
+    expect(isPrivilegedRoute(app, 'GET', '/operator/test')).toBe(true)
+  })
+
+  it('marks multiple routes as privileged', () => {
+    // #given
+    const app = new Hono()
+
+    // #when
+    registerOperatorRoute(app, 'GET', '/operator/runs', (c: Context) => c.json({runs: []}))
+    registerOperatorRoute(app, 'POST', '/operator/runs', (c: Context) => c.json({runId: 'r1'}))
+
+    // #then — both routes are marked as privileged
+    expect(isPrivilegedRoute(app, 'GET', '/operator/runs')).toBe(true)
+    expect(isPrivilegedRoute(app, 'POST', '/operator/runs')).toBe(true)
+  })
+
+  it('does not mark a route as privileged when registered directly on the app', () => {
+    // #given
+    const app = new Hono()
+
+    // #when — register directly without the wrapper
+    app.get('/operator/unwrapped', (c: Context) => c.json({ok: true}))
+
+    // #then — the route is NOT marked as privileged
+    expect(isPrivilegedRoute(app, 'GET', '/operator/unwrapped')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// registerPublicRoute — public route metadata
+// ---------------------------------------------------------------------------
+
+describe('registerPublicRoute — public route metadata', () => {
+  it('marks a registered route as public', () => {
+    // #given
+    const app = new Hono()
+
+    // #when
+    registerPublicRoute(app, 'GET', '/operator/health', (c: Context) => c.json({ok: true}))
+
+    // #then — the route is marked as public
+    expect(isPublicRoute(app, 'GET', '/operator/health')).toBe(true)
+  })
+
+  it('does not mark a public route as privileged', () => {
+    // #given
+    const app = new Hono()
+
+    // #when
+    registerPublicRoute(app, 'GET', '/operator/health', (c: Context) => c.json({ok: true}))
+
+    // #then — public routes are not privileged
+    expect(isPrivilegedRoute(app, 'GET', '/operator/health')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// assertAllPrivilegedRoutesWrapped — static guard
+// ---------------------------------------------------------------------------
+
+describe('assertAllPrivilegedRoutesWrapped — static guard', () => {
+  it('passes when all non-health operator routes are wrapped', () => {
+    // #given
+    const app = new Hono()
+    registerPublicRoute(app, 'GET', '/operator/health', (c: Context) => c.json({ok: true}))
+    registerOperatorRoute(app, 'GET', '/operator/runs', (c: Context) => c.json({runs: []}))
+
+    // #when / #then — no throw
+    expect(() => assertAllPrivilegedRoutesWrapped(app)).not.toThrow()
+  })
+
+  it('passes when only the health route is registered (no privileged routes)', () => {
+    // #given
+    const app = new Hono()
+    registerPublicRoute(app, 'GET', '/operator/health', (c: Context) => c.json({ok: true}))
+
+    // #when / #then — no throw
+    expect(() => assertAllPrivilegedRoutesWrapped(app)).not.toThrow()
+  })
+
+  it('throws when an operator route is registered without the wrapper', () => {
+    // #given — a route registered directly (bypassing the wrapper)
+    const app = new Hono()
+    registerPublicRoute(app, 'GET', '/operator/health', (c: Context) => c.json({ok: true}))
+    // Directly register without wrapper — this is the violation
+    app.get('/operator/runs', (c: Context) => c.json({runs: []}))
+
+    // #when / #then — must throw naming the unwrapped route
+    expect(() => assertAllPrivilegedRoutesWrapped(app)).toThrow(/\/operator\/runs/)
+  })
+
+  it('throws when multiple operator routes are registered without the wrapper', () => {
+    // #given
+    const app = new Hono()
+    registerPublicRoute(app, 'GET', '/operator/health', (c: Context) => c.json({ok: true}))
+    app.get('/operator/runs', (c: Context) => c.json({runs: []}))
+    app.post('/operator/runs', (c: Context) => c.json({runId: 'r1'}))
+
+    // #when / #then — must throw naming the unwrapped routes
+    expect(() => assertAllPrivilegedRoutesWrapped(app)).toThrow()
+  })
+
+  it('passes when app has no operator routes at all', () => {
+    // #given — empty app
+    const app = new Hono()
+
+    // #when / #then — no throw
+    expect(() => assertAllPrivilegedRoutesWrapped(app)).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// assertAllPrivilegedRoutesWrapped — bare /operator and ALL-method violations
+// ---------------------------------------------------------------------------
+
+describe('assertAllPrivilegedRoutesWrapped — bare /operator and ALL-method routes', () => {
+  it('throws when bare /operator route is registered directly', () => {
+    // #given — direct registration on the exact /operator path (no trailing slash)
+    const app = new Hono()
+    app.get('/operator', (c: Context) => c.json({ok: true}))
+
+    // #when / #then — bare /operator must be caught
+    expect(() => assertAllPrivilegedRoutesWrapped(app)).toThrow(/\/operator/)
+  })
+
+  it('throws when app.use registers a handler on an operator path (ALL method)', () => {
+    // #given — app.use('/operator/bypass', ...) registers an ALL-method entry
+    const app = new Hono()
+    app.use('/operator/bypass', async (c, _next) => {
+      // simulates a direct response handler registered via app.use
+      return c.json({bypassed: true})
+    })
+
+    // #when / #then — ALL-method operator path must be caught
+    expect(() => assertAllPrivilegedRoutesWrapped(app)).toThrow(/\/operator\/bypass/)
+  })
+
+  it('throws when app.all registers a handler on an operator path', () => {
+    // #given — app.all('/operator/bypass', ...) registers an ALL-method route
+    const app = new Hono()
+    app.all('/operator/bypass', (c: Context) => c.json({bypassed: true}))
+
+    // #when / #then — ALL-method operator route must be caught
+    expect(() => assertAllPrivilegedRoutesWrapped(app)).toThrow(/\/operator\/bypass/)
+  })
+
+  it('throws when a wrapped route is also registered directly (duplicate same method+path)', () => {
+    // #given — registerOperatorRoute wraps GET /operator/x, then app.get registers it again
+    const app = new Hono()
+    registerOperatorRoute(app, 'GET', '/operator/x', (c: Context) => c.json({wrapped: true}))
+    // Direct registration after wrapping — duplicate
+    app.get('/operator/x', (c: Context) => c.json({direct: true}))
+
+    // #when / #then — duplicate must throw
+    expect(() => assertAllPrivilegedRoutesWrapped(app)).toThrow(/\/operator\/x/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// registerOperatorRoute — duplicate detection
+// ---------------------------------------------------------------------------
+
+describe('registerOperatorRoute — duplicate detection', () => {
+  it('throws when the same method+path is registered twice via registerOperatorRoute', () => {
+    // #given
+    const app = new Hono()
+    registerOperatorRoute(app, 'GET', '/operator/runs', (c: Context) => c.json({runs: []}))
+
+    // #when / #then — second registration must throw
+    expect(() => {
+      registerOperatorRoute(app, 'GET', '/operator/runs', (c: Context) => c.json({runs: []}))
+    }).toThrow(/duplicate registration/)
+  })
+
+  it('throws when registerPublicRoute is called after registerOperatorRoute for the same path', () => {
+    // #given
+    const app = new Hono()
+    registerOperatorRoute(app, 'GET', '/operator/runs', (c: Context) => c.json({runs: []}))
+
+    // #when / #then
+    expect(() => {
+      registerPublicRoute(app, 'GET', '/operator/runs', (c: Context) => c.json({runs: []}))
+    }).toThrow(/duplicate registration/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Health route in buildOperatorApp — explicitly public/unprivileged
+// ---------------------------------------------------------------------------
+
+describe('buildOperatorApp — health route is explicitly public', () => {
+  it('health route is registered as a public route, not a privileged route', async () => {
+    // #given — import the real buildOperatorApp to verify the health route classification
+    const {buildOperatorApp} = await import('./server.js')
+    const app = buildOperatorApp(
+      {
+        logger: {debug: () => undefined, info: () => undefined, warn: () => undefined, error: () => undefined},
+        isShuttingDown: () => false,
+      },
+      {bindHost: '127.0.0.1', bindPort: 0, publicOrigin: 'https://operator.example.com'},
+    )
+
+    // #when / #then — health route is public, not privileged
+    expect(isPublicRoute(app, 'GET', '/operator/health')).toBe(true)
+    expect(isPrivilegedRoute(app, 'GET', '/operator/health')).toBe(false)
+  })
+
+  it('assertAllPrivilegedRoutesWrapped passes for the real buildOperatorApp', async () => {
+    // #given
+    const {buildOperatorApp} = await import('./server.js')
+    const app = buildOperatorApp(
+      {
+        logger: {debug: () => undefined, info: () => undefined, warn: () => undefined, error: () => undefined},
+        isShuttingDown: () => false,
+      },
+      {bindHost: '127.0.0.1', bindPort: 0, publicOrigin: 'https://operator.example.com'},
+    )
+
+    // #when / #then — all operator routes are wrapped or explicitly public
+    expect(() => assertAllPrivilegedRoutesWrapped(app)).not.toThrow()
+  })
+})

--- a/packages/gateway/src/web/operator-route.ts
+++ b/packages/gateway/src/web/operator-route.ts
@@ -1,0 +1,210 @@
+/**
+ * Operator route guardrail seam.
+ *
+ * Every privileged operator route MUST be registered through `registerOperatorRoute`.
+ * Public/unauthenticated routes (e.g. health) MUST be registered through `registerPublicRoute`.
+ *
+ * `assertAllPrivilegedRoutesWrapped` inspects the Hono app's route inventory and throws
+ * if any /operator or /operator/* route is registered without going through one of the two
+ * explicit registration helpers.
+ *
+ * Classification only — no auth, rate limiting, origin, or CSRF enforcement yet.
+ * Real middleware replaces this seam when the auth boundary lands.
+ */
+
+import type {Context, Hono} from 'hono'
+
+// ---------------------------------------------------------------------------
+// Internal registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-app registry of route keys that have been explicitly classified.
+ * Key format: `${method.toUpperCase()}:${path}`
+ *
+ * WeakMap so the registry is garbage-collected when the app is GC'd.
+ */
+function makeRouteRegistry() {
+  const map = new WeakMap<object, Set<string>>()
+  return {
+    add(app: object, key: string): void {
+      let set = map.get(app)
+      if (set === undefined) {
+        set = new Set()
+        map.set(app, set)
+      }
+      set.add(key)
+    },
+    has(app: object, key: string): boolean {
+      return map.get(app)?.has(key) ?? false
+    },
+  }
+}
+
+const privilegedRoutes = makeRouteRegistry()
+const publicRoutes = makeRouteRegistry()
+
+function routeKey(method: string, path: string): string {
+  return `${method.toUpperCase()}:${path}`
+}
+
+// ---------------------------------------------------------------------------
+// Registration helpers
+// ---------------------------------------------------------------------------
+
+type SupportedMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+type RouteHandler = (c: Context) => Response | Promise<Response>
+
+/** Apply a route handler to the app for the given method. */
+function applyMethod(app: Hono, method: SupportedMethod, path: string, handler: RouteHandler): void {
+  switch (method) {
+    case 'GET':
+      app.get(path, handler)
+      break
+    case 'POST':
+      app.post(path, handler)
+      break
+    case 'PUT':
+      app.put(path, handler)
+      break
+    case 'PATCH':
+      app.patch(path, handler)
+      break
+    case 'DELETE':
+      app.delete(path, handler)
+      break
+  }
+}
+
+/**
+ * Register a privileged operator route.
+ *
+ * Every route that requires auth MUST go through this function.
+ * `assertAllPrivilegedRoutesWrapped` throws at startup if any /operator or /operator/*
+ * route bypasses it.
+ *
+ * Classification only — no auth middleware yet. Real guards replace this seam when
+ * the auth boundary lands.
+ *
+ * Throws if the same method+path is registered twice (duplicate detection).
+ */
+export function registerOperatorRoute(app: Hono, method: SupportedMethod, path: string, handler: RouteHandler): void {
+  const key = routeKey(method, path)
+  if (privilegedRoutes.has(app, key) || publicRoutes.has(app, key)) {
+    throw new Error(
+      `Operator route guardrail: duplicate registration for ${method} ${path}. ` +
+        `Each route may only be registered once via registerOperatorRoute or registerPublicRoute.`,
+    )
+  }
+  privilegedRoutes.add(app, key)
+  applyMethod(app, method, path, handler)
+}
+
+/**
+ * Register a public (unauthenticated) operator route.
+ *
+ * Use for routes that are intentionally unauthenticated (e.g. health check).
+ * `assertAllPrivilegedRoutesWrapped` recognizes these as explicitly classified.
+ *
+ * Throws if the same method+path is registered twice (duplicate detection).
+ */
+export function registerPublicRoute(app: Hono, method: SupportedMethod, path: string, handler: RouteHandler): void {
+  const key = routeKey(method, path)
+  if (privilegedRoutes.has(app, key) || publicRoutes.has(app, key)) {
+    throw new Error(
+      `Operator route guardrail: duplicate registration for ${method} ${path}. ` +
+        `Each route may only be registered once via registerOperatorRoute or registerPublicRoute.`,
+    )
+  }
+  publicRoutes.add(app, key)
+  applyMethod(app, method, path, handler)
+}
+
+// ---------------------------------------------------------------------------
+// Inspection helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the given route was registered through `registerOperatorRoute`.
+ */
+export function isPrivilegedRoute(app: Hono, method: string, path: string): boolean {
+  return privilegedRoutes.has(app, routeKey(method, path))
+}
+
+/**
+ * Returns true if the given route was registered through `registerPublicRoute`.
+ */
+export function isPublicRoute(app: Hono, method: string, path: string): boolean {
+  return publicRoutes.has(app, routeKey(method, path))
+}
+
+// ---------------------------------------------------------------------------
+// Static guard
+// ---------------------------------------------------------------------------
+
+interface RouteEntry {
+  readonly method: string
+  readonly path: string
+}
+
+/**
+ * Assert that every /operator and /operator/* route in the app is either:
+ *   - Registered through `registerOperatorRoute` (privileged), or
+ *   - Registered through `registerPublicRoute` (explicitly public).
+ *
+ * Throws if any operator route is registered directly on the app without going
+ * through one of the two explicit registration helpers, or if a route is
+ * registered both via a helper and directly (duplicate same method+path).
+ *
+ * Call this after all routes are registered (e.g. at the end of buildOperatorApp).
+ */
+export function assertAllPrivilegedRoutesWrapped(app: Hono): void {
+  const seen = new Set<string>()
+  const unwrapped: string[] = []
+  const duplicates: string[] = []
+
+  for (const route of app.routes as RouteEntry[]) {
+    // Skip global middleware catch-alls (ALL /* or ALL *) — these are app.use('*', ...)
+    // registrations, not operator routes.
+    if (route.method === 'ALL' && (route.path === '/*' || route.path === '*')) continue
+
+    // Inspect /operator (exact) and /operator/* routes.
+    // ALL method entries on operator paths (e.g. app.use('/operator/x', ...) or app.all('/operator/x', ...))
+    // are NOT skipped — they must be classified or they are a violation.
+    const isOperatorPath = route.path === '/operator' || route.path.startsWith('/operator/')
+    if (isOperatorPath === false) continue
+
+    const key = routeKey(route.method, route.path)
+
+    if (seen.has(key)) {
+      // Same method+path seen twice — one was registered via helper, one directly.
+      if (privilegedRoutes.has(app, key) || publicRoutes.has(app, key)) {
+        duplicates.push(`${route.method} ${route.path}`)
+      }
+      continue
+    }
+    seen.add(key)
+
+    const isClassified = privilegedRoutes.has(app, key) || publicRoutes.has(app, key)
+    if (isClassified === false) {
+      unwrapped.push(`${route.method} ${route.path}`)
+    }
+  }
+
+  if (duplicates.length > 0) {
+    throw new Error(
+      `Operator route guardrail violation: the following routes are registered both via a helper ` +
+        `and directly on the app. Each route must be registered exactly once.\n` +
+        `Duplicate routes:\n${duplicates.map(r => `  ${r}`).join('\n')}`,
+    )
+  }
+
+  if (unwrapped.length > 0) {
+    throw new Error(
+      `Operator route guardrail violation: the following operator routes are registered without ` +
+        `registerOperatorRoute or registerPublicRoute. Every privileged operator route must use ` +
+        `registerOperatorRoute; unauthenticated routes must use registerPublicRoute.\n` +
+        `Unwrapped routes:\n${unwrapped.map(r => `  ${r}`).join('\n')}`,
+    )
+  }
+}

--- a/packages/gateway/src/web/server.test.ts
+++ b/packages/gateway/src/web/server.test.ts
@@ -381,15 +381,16 @@ describe('operator server — trusted origin enforcement', () => {
     expect(res.status).toBe(400)
   })
 
-  it('accepts X-Forwarded-Host with port suffix (host:port form)', async () => {
-    // #given — publicOrigin has no port; forwarded host includes port
-    // Inject a stub rate limiter so getConnInfo (which needs a real socket) is not reached
+  it('rejects X-Forwarded-Host with port suffix when publicOrigin has no port (full-host mismatch)', async () => {
+    // #given — publicOrigin has no explicit port (default 443 for https);
+    // publicOriginHost is 'operator.example.com' (no port suffix).
+    // Forwarded host includes ':443' — does not match exactly.
     const app = buildOperatorApp(
       makeStubDeps({rateLimiter: {allow: () => true}}),
       makeStubConfig({publicOrigin: 'https://operator.example.com'}),
     )
 
-    // #when — host with port suffix should match after stripping port
+    // #when — host with port suffix does NOT match the stored publicOriginHost
     const req = new Request('http://127.0.0.1/operator/health', {
       headers: {
         'x-forwarded-host': 'operator.example.com:443',
@@ -398,8 +399,8 @@ describe('operator server — trusted origin enforcement', () => {
     })
     const res = await app.fetch(req)
 
-    // #then — port suffix is stripped for comparison; accepted
-    expect(res.status).toBe(200)
+    // #then — full-host comparison: 'operator.example.com:443' !== 'operator.example.com'; rejected
+    expect(res.status).toBe(400)
   })
 
   it('rejects comma-separated X-Forwarded-Host (multi-value header)', async () => {
@@ -416,6 +417,46 @@ describe('operator server — trusted origin enforcement', () => {
     const res = await app.fetch(req)
 
     // #then — comma-separated host does not match the expected host; reject
+    expect(res.status).toBe(400)
+  })
+
+  it('accepts X-Forwarded-Host matching publicOrigin with non-default port (exact host:port match)', async () => {
+    // #given — publicOrigin includes a non-default port; forwarded host must match exactly
+    const app = buildOperatorApp(
+      makeStubDeps({rateLimiter: {allow: () => true}}),
+      makeStubConfig({publicOrigin: 'https://operator.example.com:8443'}),
+    )
+
+    // #when — forwarded host matches the stored publicOriginHost exactly
+    const req = new Request('http://127.0.0.1/operator/health', {
+      headers: {
+        'x-forwarded-host': 'operator.example.com:8443',
+        'x-forwarded-proto': 'https',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — exact match; accepted
+    expect(res.status).toBe(200)
+  })
+
+  it('rejects X-Forwarded-Host with mismatched port (port in forwarded but not in publicOrigin)', async () => {
+    // #given — publicOrigin has no explicit port; forwarded host includes a non-standard port
+    const app = buildOperatorApp(
+      makeStubDeps({rateLimiter: {allow: () => true}}),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
+    )
+
+    // #when — forwarded host has port 8443 but publicOriginHost is 'operator.example.com'
+    const req = new Request('http://127.0.0.1/operator/health', {
+      headers: {
+        'x-forwarded-host': 'operator.example.com:8443',
+        'x-forwarded-proto': 'https',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — 'operator.example.com:8443' !== 'operator.example.com'; rejected
     expect(res.status).toBe(400)
   })
 
@@ -564,5 +605,24 @@ describe('operator server — warning log on rejection paths', () => {
 
     // #then — warn was called once
     expect(logger.warn).toHaveBeenCalledOnce()
+  })
+
+  it('logs a warning when getConnInfo is unavailable (no-socket fallback path)', async () => {
+    // #given — use app.fetch() directly (no real socket) so getConnInfo throws;
+    // inject a rate limiter that always allows so the fallback path is reached.
+    const logger = makeLogger()
+    const app = buildOperatorApp(makeStubDeps({logger, rateLimiter: {allow: () => true}}), makeStubConfig())
+
+    // #when — direct app.fetch() has no underlying socket; getConnInfo will throw
+    const req = new Request('http://127.0.0.1/operator/health')
+    const res = await app.fetch(req)
+
+    // #then — request still succeeds (fallback key is used)
+    expect(res.status).toBe(200)
+
+    // #and — a warning was emitted for the collapsed rate-limit key
+    const warnCalls = (logger.warn as ReturnType<typeof vi.fn>).mock.calls as [Record<string, unknown>, string][]
+    const fallbackWarning = warnCalls.find(([, msg]) => msg.includes('getConnInfo unavailable'))
+    expect(fallbackWarning).toBeDefined()
   })
 })

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -5,18 +5,16 @@
  * returns the @hono/node-server handle so the caller (program.ts) can close
  * it during graceful shutdown.
  *
- * Security posture:
+ * Current posture (classification/guardrail only — no auth yet):
  *   - Listener binds to the configured gateway-net host/port only.
  *     Never 0.0.0.0, loopback, or sandbox-net for production config.
  *   - TLS is terminated by the infra reverse proxy at GATEWAY_OPERATOR_PUBLIC_ORIGIN.
  *     The operator listener receives plain HTTP over gateway-net.
- *   - Forwarded-host/proto headers are validated against publicOrigin.
+ *   - Forwarded-host/proto headers are validated against publicOrigin (full host:port match).
  *     Requests with mismatched forwarded headers are rejected 400.
- *   - Unauthenticated socket-keyed rate limiting and body-size limits are
- *     enforced before any handler runs.
+ *   - Unauthenticated socket-keyed rate limiting and body-size limits are applied.
  *   - All responses pass through safe-response helpers (coarse, no-oracle).
- *   - No privileged routes are registered in this skeleton; auth routes are
- *     added only after the auth boundary is in place.
+ *   - No privileged routes registered yet; auth routes land when the auth boundary is in place.
  *
  * Mirror of packages/gateway/src/http/server.ts for the serve()/handle pattern.
  */
@@ -27,6 +25,7 @@ import {getConnInfo} from '@hono/node-server/conninfo'
 import {Hono} from 'hono'
 import {bodyLimit} from 'hono/body-limit'
 import {createRateLimiter} from '../http/rate-limit.js'
+import {assertAllPrivilegedRoutesWrapped, registerPublicRoute} from './operator-route.js'
 import {
   badRequestResponse,
   notFoundResponse,
@@ -153,19 +152,20 @@ function validateForwardedHeaders(
   const hasHost = forwardedHost !== undefined && forwardedHost !== ''
   const hasProto = forwardedProto !== undefined && forwardedProto !== ''
 
-  // No forwarded headers — direct connection, no proxy in path. Allow.
+  // No forwarded headers — direct connection on gateway-net (operator listener
+  // topology owns direct-socket reachability for Unit 3a). Allow here, but
+  // privileged routes must not rely on this alone when auth lands; they must
+  // enforce their own identity checks regardless of connection path.
   if (hasHost === false && hasProto === false) return true
 
   // Partial forwarded headers — suspicious. Reject.
   if (hasHost !== hasProto) return false
 
   // Both present — validate against public origin.
-  // X-Forwarded-Host may include port; strip it for comparison.
+  // X-Forwarded-Host must match publicOriginHost exactly, including port.
+  // A proxy forwarding from https://ops.example.com:8443 must send that full host.
   // hasHost/hasProto guards above ensure these are non-empty strings here.
-  const hostWithoutPort = (forwardedHost ?? '').split(':')[0]
-  const expectedHost = publicOriginHost.split(':')[0]
-
-  if (hostWithoutPort !== expectedHost) return false
+  if ((forwardedHost ?? '') !== publicOriginHost) return false
   if ((forwardedProto ?? '').toLowerCase() !== 'https') return false
 
   return true
@@ -271,11 +271,12 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
    * Returns 200 {ok:true} when the listener is running and not draining.
    * (Drain gate above returns 503 before this handler is reached.)
    *
+   * Registered as a public route via registerPublicRoute — explicitly unauthenticated.
    * Rate limit is applied here (not in middleware) to avoid Hono's middleware
    * context type mismatch with getConnInfo. This matches the announce server pattern.
    * Keyed on socket/proxy IP; per-client/post-auth identity keying is added with auth routes.
    */
-  app.get('/operator/health', c => {
+  registerPublicRoute(app, 'GET', '/operator/health', c => {
     // Rate limit keyed on actual TCP socket remote address (not X-Forwarded-For).
     // Socket/proxy IP is the coarse key for unauthenticated requests; per-client
     // identity keying is added when auth routes land.
@@ -286,6 +287,9 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
       sourceKey = connInfo.remote.address ?? 'unknown'
     } catch {
       // No real socket (e.g. direct app.fetch() in tests) — use 'unknown' key.
+      // Warn in production: all rate-limit keys collapse to 'unknown', which
+      // defeats per-client isolation. Investigate if this appears in prod logs.
+      deps.logger.warn({}, 'getConnInfo unavailable — rate-limit key collapsed to unknown')
     }
     if (rateLimiter.allow(sourceKey) === false) {
       deps.logger.warn({}, 'operator request rate limited (unauthenticated)')
@@ -297,6 +301,12 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
   // ── Catch-all ──────────────────────────────────────────────────────────────
 
   app.notFound(c => notFoundResponse(c))
+
+  // ── Static guardrail ───────────────────────────────────────────────────────
+  // Verify every /operator/* route is explicitly classified as privileged or public.
+  // This throws at startup if any route was added without registerOperatorRoute or
+  // registerPublicRoute during app construction.
+  assertAllPrivilegedRoutesWrapped(app)
 
   return app
 }


### PR DESCRIPTION
## What changed

- Splits Gateway operator Unit 3 into smaller security slices in the Phase B plan.
- Adds a route guardrail seam for the operator listener:
  - privileged routes must use `registerOperatorRoute`
  - public routes must use `registerPublicRoute`
  - unclassified `/operator` and `/operator/*` routes fail at app construction
  - duplicate same-method/same-path registrations fail closed
- Hardens `GATEWAY_OPERATOR_PUBLIC_ORIGIN` validation to canonical HTTPS origins only and normalizes stored origins.
- Tightens forwarded-host validation to include the configured port.

## Verification

- `pnpm --filter @fro-bot/gateway test -- packages/gateway/src/web/operator-route.test.ts packages/gateway/src/web/server.test.ts packages/gateway/src/config.test.ts`
- `pnpm --filter @fro-bot/gateway check-types`
- `pnpm --filter @fro-bot/gateway lint`
- Focused security validation: no remaining blockers

## Notes

This PR intentionally does not add OAuth, sessions, CSRF, allowlists, audit logging, launch, SSE, or approvals. It lands the classification seam and config hardening only.
