### PR TITLE
feat(gateway): add operator audit seam

### DIFF
--- a/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
+++ b/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
@@ -417,7 +417,7 @@ The web listener is an adapter layer. It authenticates the operator, projects sa
   **Verification:**
   - Config validation and route-wrapper tests pass; no operator route can be added without the guardrail.
 
-- [ ] **Unit 3b: Audit seam and redaction guarantees**
+- [x] **Unit 3b: Audit seam and redaction guarantees**
 
   **Goal:** Add a single typed audit seam for security-critical events so all subsequent units can emit structured, redacted audit records without duplicating sink logic.
 

--- a/packages/gateway/src/web/audit.test.ts
+++ b/packages/gateway/src/web/audit.test.ts
@@ -1,0 +1,965 @@
+/**
+ * Tests for the operator audit seam.
+ *
+ * Covers:
+ *   - Happy path: each AuditEvent variant emits a structured log record with expected typed fields.
+ *   - Security: no cookie, secret, token, prompt, or bearer value appears in any emitted record.
+ *   - Security: bearer.rejected records the rejection without logging the credential value.
+ *   - Security: embedded credentials, lowercase bearer, bare localhost/internal URLs, common cookie names.
+ *   - Resilience: sink failures are swallowed and do not throw.
+ *
+ * Uses BDD comments (#given, #when, #then).
+ */
+
+import type {AuditEvent, AuditLogger} from './audit.js'
+import {describe, expect, it, vi} from 'vitest'
+import {emitAudit} from './audit.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Derived from AuditLogger so the mock stays in sync with the interface.
+type LogFn = AuditLogger['info']
+
+type LogMock = ReturnType<typeof vi.fn<LogFn>>
+
+interface MockLogger extends AuditLogger {
+  readonly info: LogMock
+  readonly warn: LogMock
+}
+
+function makeLogger(): MockLogger {
+  return {
+    info: vi.fn<LogFn>(),
+    warn: vi.fn<LogFn>(),
+  }
+}
+
+/** Extract the context object from the first call to a mock logger method. */
+function firstCallCtx(mockFn: LogMock): Record<string, unknown> {
+  const call = mockFn.mock.calls[0]
+  if (call === undefined) throw new Error('expected at least one call')
+  return call[0]
+}
+
+/** Extract the message string from the first call to a mock logger method. */
+function firstCallMsg(mockFn: LogMock): string {
+  const call = mockFn.mock.calls[0]
+  if (call === undefined) throw new Error('expected at least one call')
+  return call[1]
+}
+
+/** Serialize all captured log calls to a single string for redaction assertions. */
+function serializeAllCalls(logger: MockLogger): string {
+  return JSON.stringify([...logger.info.mock.calls, ...logger.warn.mock.calls])
+}
+
+// Planted sensitive values that must never appear in any log output.
+const PLANTED_COOKIE = 'session=abc123secret'
+const PLANTED_TOKEN = 'ghp_SUPERSECRETTOKEN'
+const PLANTED_BEARER = 'Bearer eyJhbGciOiJSUzI1NiJ9.SECRETPAYLOAD'
+const PLANTED_SECRET = 'client_secret_VERYSECRET'
+const PLANTED_PROMPT = 'PROMPT_CONTENT_THAT_IS_PRIVATE'
+const PLANTED_INTERNAL_URL = 'http://10.0.0.5/internal'
+const PLANTED_BOUNDARY_SCOPED_COOKIE = 'mysession=abc123secret'
+
+/** Assert none of the planted sentinels appear in the serialized log output. */
+function assertNoSensitiveValues(logger: MockLogger): void {
+  const serialized = serializeAllCalls(logger)
+  expect(serialized).not.toContain(PLANTED_COOKIE)
+  expect(serialized).not.toContain(PLANTED_TOKEN)
+  expect(serialized).not.toContain(PLANTED_BEARER)
+  expect(serialized).not.toContain(PLANTED_SECRET)
+  expect(serialized).not.toContain(PLANTED_PROMPT)
+  expect(serialized).not.toContain(PLANTED_INTERNAL_URL)
+}
+
+// ---------------------------------------------------------------------------
+// auth.start
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — auth.start', () => {
+  it('emits a structured info record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'auth.start', correlationId: 'corr-001'}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.info).toHaveBeenCalledOnce()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.info)).toBe('audit: auth.start')
+    expect(firstCallCtx(logger.info)).toMatchObject({kind: 'auth.start', correlationId: 'corr-001'})
+  })
+
+  it('redacts sensitive values planted in correlationId', () => {
+    // #given — plant each sentinel in correlationId
+    for (const planted of [
+      PLANTED_COOKIE,
+      PLANTED_TOKEN,
+      PLANTED_BEARER,
+      PLANTED_SECRET,
+      PLANTED_PROMPT,
+      PLANTED_INTERNAL_URL,
+    ]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {kind: 'auth.start', correlationId: planted}
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// auth.callback.success
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — auth.callback.success', () => {
+  it('emits a structured info record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {
+      kind: 'auth.callback.success',
+      correlationId: 'corr-002',
+      githubUserId: 42,
+      login: 'octocat',
+    }
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.info).toHaveBeenCalledOnce()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.info)).toBe('audit: auth.callback.success')
+    expect(firstCallCtx(logger.info)).toMatchObject({
+      kind: 'auth.callback.success',
+      correlationId: 'corr-002',
+      githubUserId: 42,
+      login: 'octocat',
+    })
+  })
+
+  it('preserves safe typed fields when caller-controlled strings are redacted', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {
+      kind: 'auth.callback.success',
+      correlationId: 'corr-safe-typed-field',
+      githubUserId: 42,
+      login: `octo-${PLANTED_TOKEN}`,
+    }
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(firstCallCtx(logger.info)).toMatchObject({githubUserId: 42, login: '[redacted]'})
+    assertNoSensitiveValues(logger)
+  })
+
+  it('redacts sensitive values planted in correlationId and login', () => {
+    // #given — plant each sentinel in both caller-controlled string fields
+    for (const planted of [
+      PLANTED_COOKIE,
+      PLANTED_TOKEN,
+      PLANTED_BEARER,
+      PLANTED_SECRET,
+      PLANTED_PROMPT,
+      PLANTED_INTERNAL_URL,
+    ]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {
+        kind: 'auth.callback.success',
+        correlationId: planted,
+        githubUserId: 42,
+        login: planted,
+      }
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+    }
+  })
+})
+
+describe('emitAudit — redaction boundaries', () => {
+  it('keeps non-session cookie-name substrings visible by design', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'auth.start', correlationId: PLANTED_BOUNDARY_SCOPED_COOKIE}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(firstCallCtx(logger.info)).toMatchObject({correlationId: PLANTED_BOUNDARY_SCOPED_COOKIE})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// auth.callback.failure
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — auth.callback.failure', () => {
+  it('emits a structured warn record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {
+      kind: 'auth.callback.failure',
+      correlationId: 'corr-003',
+      reason: 'state_mismatch',
+    }
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.warn).toHaveBeenCalledOnce()
+    expect(logger.info).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.warn)).toBe('audit: auth.callback.failure')
+    expect(firstCallCtx(logger.warn)).toMatchObject({
+      kind: 'auth.callback.failure',
+      correlationId: 'corr-003',
+      reason: 'state_mismatch',
+    })
+  })
+
+  it('redacts sensitive values planted in correlationId; reason enum is preserved', () => {
+    // #given — plant each sentinel in correlationId
+    for (const planted of [
+      PLANTED_COOKIE,
+      PLANTED_TOKEN,
+      PLANTED_BEARER,
+      PLANTED_SECRET,
+      PLANTED_PROMPT,
+      PLANTED_INTERNAL_URL,
+    ]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {
+        kind: 'auth.callback.failure',
+        correlationId: planted,
+        reason: 'provider_error',
+      }
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+      // Safe enum reason must survive redaction
+      expect(serializeAllCalls(logger)).toContain('provider_error')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// auth.logout
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — auth.logout', () => {
+  it('emits a structured info record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {
+      kind: 'auth.logout',
+      correlationId: 'corr-004',
+      githubUserId: 42,
+    }
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.info).toHaveBeenCalledOnce()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.info)).toBe('audit: auth.logout')
+    expect(firstCallCtx(logger.info)).toMatchObject({kind: 'auth.logout', correlationId: 'corr-004', githubUserId: 42})
+  })
+
+  it('redacts sensitive values planted in correlationId', () => {
+    // #given
+    for (const planted of [
+      PLANTED_COOKIE,
+      PLANTED_TOKEN,
+      PLANTED_BEARER,
+      PLANTED_SECRET,
+      PLANTED_PROMPT,
+      PLANTED_INTERNAL_URL,
+    ]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {kind: 'auth.logout', correlationId: planted, githubUserId: 42}
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// auth.revocation
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — auth.revocation', () => {
+  it('emits a structured info record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {
+      kind: 'auth.revocation',
+      correlationId: 'corr-005',
+      githubUserId: 42,
+    }
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.info).toHaveBeenCalledOnce()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.info)).toBe('audit: auth.revocation')
+    expect(firstCallCtx(logger.info)).toMatchObject({
+      kind: 'auth.revocation',
+      correlationId: 'corr-005',
+      githubUserId: 42,
+    })
+  })
+
+  it('redacts sensitive values planted in correlationId', () => {
+    // #given
+    for (const planted of [
+      PLANTED_COOKIE,
+      PLANTED_TOKEN,
+      PLANTED_BEARER,
+      PLANTED_SECRET,
+      PLANTED_PROMPT,
+      PLANTED_INTERNAL_URL,
+    ]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {kind: 'auth.revocation', correlationId: planted, githubUserId: 42}
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// authz.denied
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — authz.denied', () => {
+  it('emits a structured warn record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {
+      kind: 'authz.denied',
+      correlationId: 'corr-006',
+      githubUserId: 42,
+      reason: 'not_allowlisted',
+    }
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.warn).toHaveBeenCalledOnce()
+    expect(logger.info).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.warn)).toBe('audit: authz.denied')
+    expect(firstCallCtx(logger.warn)).toMatchObject({
+      kind: 'authz.denied',
+      correlationId: 'corr-006',
+      githubUserId: 42,
+      reason: 'not_allowlisted',
+    })
+  })
+
+  it('redacts sensitive values planted in correlationId; reason enum is preserved', () => {
+    // #given
+    for (const planted of [
+      PLANTED_COOKIE,
+      PLANTED_TOKEN,
+      PLANTED_BEARER,
+      PLANTED_SECRET,
+      PLANTED_PROMPT,
+      PLANTED_INTERNAL_URL,
+    ]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {
+        kind: 'authz.denied',
+        correlationId: planted,
+        githubUserId: 42,
+        reason: 'not_allowlisted',
+      }
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+      expect(serializeAllCalls(logger)).toContain('not_allowlisted')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// launch.accepted
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — launch.accepted', () => {
+  it('emits a structured info record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {
+      kind: 'launch.accepted',
+      correlationId: 'corr-007',
+      githubUserId: 42,
+      repoFullName: 'org/repo',
+    }
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.info).toHaveBeenCalledOnce()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.info)).toBe('audit: launch.accepted')
+    expect(firstCallCtx(logger.info)).toMatchObject({
+      kind: 'launch.accepted',
+      correlationId: 'corr-007',
+      githubUserId: 42,
+      repoFullName: 'org/repo',
+    })
+  })
+
+  it('redacts sensitive values planted in correlationId and repoFullName', () => {
+    // #given — plant each sentinel in both caller-controlled string fields
+    for (const planted of [
+      PLANTED_COOKIE,
+      PLANTED_TOKEN,
+      PLANTED_BEARER,
+      PLANTED_SECRET,
+      PLANTED_PROMPT,
+      PLANTED_INTERNAL_URL,
+    ]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {
+        kind: 'launch.accepted',
+        correlationId: planted,
+        githubUserId: 42,
+        repoFullName: planted,
+      }
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// launch.rejected
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — launch.rejected', () => {
+  it('emits a structured warn record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {
+      kind: 'launch.rejected',
+      correlationId: 'corr-008',
+      githubUserId: 42,
+      reason: 'binding_not_found',
+    }
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.warn).toHaveBeenCalledOnce()
+    expect(logger.info).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.warn)).toBe('audit: launch.rejected')
+    expect(firstCallCtx(logger.warn)).toMatchObject({
+      kind: 'launch.rejected',
+      correlationId: 'corr-008',
+      githubUserId: 42,
+      reason: 'binding_not_found',
+    })
+  })
+
+  it('redacts sensitive values planted in correlationId; reason enum is preserved', () => {
+    // #given
+    for (const planted of [
+      PLANTED_COOKIE,
+      PLANTED_TOKEN,
+      PLANTED_BEARER,
+      PLANTED_SECRET,
+      PLANTED_PROMPT,
+      PLANTED_INTERNAL_URL,
+    ]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {
+        kind: 'launch.rejected',
+        correlationId: planted,
+        githubUserId: 42,
+        reason: 'binding_not_found',
+      }
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+      expect(serializeAllCalls(logger)).toContain('binding_not_found')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// approval.decision
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — approval.decision', () => {
+  it('emits a structured info record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {
+      kind: 'approval.decision',
+      correlationId: 'corr-009',
+      githubUserId: 42,
+      requestId: 'req-abc',
+      decision: 'approve',
+    }
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.info).toHaveBeenCalledOnce()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.info)).toBe('audit: approval.decision')
+    expect(firstCallCtx(logger.info)).toMatchObject({
+      kind: 'approval.decision',
+      correlationId: 'corr-009',
+      githubUserId: 42,
+      requestId: 'req-abc',
+      decision: 'approve',
+    })
+  })
+
+  it('redacts sensitive values planted in correlationId and requestId', () => {
+    // #given — plant each sentinel in both caller-controlled string fields
+    for (const planted of [
+      PLANTED_COOKIE,
+      PLANTED_TOKEN,
+      PLANTED_BEARER,
+      PLANTED_SECRET,
+      PLANTED_PROMPT,
+      PLANTED_INTERNAL_URL,
+    ]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {
+        kind: 'approval.decision',
+        correlationId: planted,
+        githubUserId: 42,
+        requestId: planted,
+        decision: 'deny',
+      }
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// approval.rejected
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — approval.rejected', () => {
+  it('emits a structured warn record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {
+      kind: 'approval.rejected',
+      correlationId: 'corr-010',
+      githubUserId: 42,
+      requestId: 'req-abc',
+      reason: 'already_claimed',
+    }
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.warn).toHaveBeenCalledOnce()
+    expect(logger.info).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.warn)).toBe('audit: approval.rejected')
+    expect(firstCallCtx(logger.warn)).toMatchObject({
+      kind: 'approval.rejected',
+      correlationId: 'corr-010',
+      githubUserId: 42,
+      requestId: 'req-abc',
+      reason: 'already_claimed',
+    })
+  })
+
+  it('redacts sensitive values planted in correlationId and requestId; reason enum is preserved', () => {
+    // #given
+    for (const planted of [
+      PLANTED_COOKIE,
+      PLANTED_TOKEN,
+      PLANTED_BEARER,
+      PLANTED_SECRET,
+      PLANTED_PROMPT,
+      PLANTED_INTERNAL_URL,
+    ]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {
+        kind: 'approval.rejected',
+        correlationId: planted,
+        githubUserId: 42,
+        requestId: planted,
+        reason: 'already_claimed',
+      }
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+      expect(serializeAllCalls(logger)).toContain('already_claimed')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// binding.read
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — binding.read', () => {
+  it('emits a structured info record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {
+      kind: 'binding.read',
+      correlationId: 'corr-011',
+      githubUserId: 42,
+      repoFullName: 'org/repo',
+    }
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.info).toHaveBeenCalledOnce()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.info)).toBe('audit: binding.read')
+    expect(firstCallCtx(logger.info)).toMatchObject({
+      kind: 'binding.read',
+      correlationId: 'corr-011',
+      githubUserId: 42,
+      repoFullName: 'org/repo',
+    })
+  })
+
+  it('redacts sensitive values planted in correlationId and repoFullName', () => {
+    // #given
+    for (const planted of [
+      PLANTED_COOKIE,
+      PLANTED_TOKEN,
+      PLANTED_BEARER,
+      PLANTED_SECRET,
+      PLANTED_PROMPT,
+      PLANTED_INTERNAL_URL,
+    ]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {
+        kind: 'binding.read',
+        correlationId: planted,
+        githubUserId: 42,
+        repoFullName: planted,
+      }
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// bearer.rejected — critical: credential must never appear in log output
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — bearer.rejected', () => {
+  it('emits a structured warn record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {
+      kind: 'bearer.rejected',
+      correlationId: 'corr-012',
+      reason: 'invalid_signature',
+    }
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.warn).toHaveBeenCalledOnce()
+    expect(logger.info).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.warn)).toBe('audit: bearer.rejected')
+    expect(firstCallCtx(logger.warn)).toMatchObject({
+      kind: 'bearer.rejected',
+      correlationId: 'corr-012',
+      reason: 'invalid_signature',
+    })
+  })
+
+  it('redacts sensitive values planted in correlationId; reason enum and kind are preserved', () => {
+    // #given — plant each sentinel in correlationId
+    for (const planted of [
+      PLANTED_COOKIE,
+      PLANTED_TOKEN,
+      PLANTED_BEARER,
+      PLANTED_SECRET,
+      PLANTED_PROMPT,
+      PLANTED_INTERNAL_URL,
+    ]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {
+        kind: 'bearer.rejected',
+        correlationId: planted,
+        reason: 'expired',
+      }
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+      // Safe enum reason and kind must survive redaction
+      const serialized = serializeAllCalls(logger)
+      expect(serialized).toContain('expired')
+      expect(serialized).toContain('bearer.rejected')
+    }
+  })
+
+  it('emits no sensitive values for missing_token reason', () => {
+    // #given
+    for (const planted of [
+      PLANTED_COOKIE,
+      PLANTED_TOKEN,
+      PLANTED_BEARER,
+      PLANTED_SECRET,
+      PLANTED_PROMPT,
+      PLANTED_INTERNAL_URL,
+    ]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {
+        kind: 'bearer.rejected',
+        correlationId: planted,
+        reason: 'missing_token',
+      }
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Redaction — embedded / edge-case patterns
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — redaction edge cases', () => {
+  it('redacts GitHub tokens embedded mid-string (no ^ anchor)', () => {
+    // #given — token embedded inside a longer string
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'auth.start', correlationId: 'prefix-ghp_SUPERSECRETTOKEN-suffix'}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(serializeAllCalls(logger)).not.toContain('ghp_SUPERSECRETTOKEN')
+  })
+
+  it('redacts lowercase bearer token', () => {
+    // #given — lowercase "bearer" header value
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'auth.start', correlationId: 'bearer eyJhbGciOiJSUzI1NiJ9.SECRET'}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(serializeAllCalls(logger)).not.toContain('eyJhbGciOiJSUzI1NiJ9.SECRET')
+  })
+
+  it('redacts mixed-case bearer token', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'auth.start', correlationId: 'BEARER eyJhbGciOiJSUzI1NiJ9.SECRET'}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(serializeAllCalls(logger)).not.toContain('eyJhbGciOiJSUzI1NiJ9.SECRET')
+  })
+
+  it('redacts bare http://localhost URL (no trailing slash)', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'auth.start', correlationId: 'http://localhost'}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(serializeAllCalls(logger)).not.toContain('http://localhost')
+  })
+
+  it('redacts http://localhost with path', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'auth.start', correlationId: 'http://localhost/api/secret'}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(serializeAllCalls(logger)).not.toContain('http://localhost/api/secret')
+  })
+
+  it('redacts http://localhost with port', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'auth.start', correlationId: 'http://localhost:3000/api'}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(serializeAllCalls(logger)).not.toContain('http://localhost:3000/api')
+  })
+
+  it('redacts host.docker.internal URL', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'auth.start', correlationId: 'http://host.docker.internal/service'}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(serializeAllCalls(logger)).not.toContain('host.docker.internal')
+  })
+
+  it('redacts svc.cluster.local URL', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'auth.start', correlationId: 'http://myservice.svc.cluster.local/api'}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(serializeAllCalls(logger)).not.toContain('myservice.svc.cluster.local')
+  })
+
+  it('redacts common cookie names: sid', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'auth.start', correlationId: 'sid=abc123secret'}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(serializeAllCalls(logger)).not.toContain('abc123secret')
+  })
+
+  it('redacts common cookie names: sessionid', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'auth.start', correlationId: 'sessionid=abc123secret'}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(serializeAllCalls(logger)).not.toContain('abc123secret')
+  })
+
+  it('redacts common cookie names: connect.sid', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'auth.start', correlationId: 'connect.sid=abc123secret'}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(serializeAllCalls(logger)).not.toContain('abc123secret')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Sink resilience — throwing logger must not propagate
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — sink failure resilience', () => {
+  it('does not throw when logger.info throws', () => {
+    // #given
+    const logger: AuditLogger = {
+      info: () => {
+        throw new Error('sink exploded')
+      },
+      warn: vi.fn<LogFn>(),
+    }
+    const event: AuditEvent = {kind: 'auth.start', correlationId: 'corr-resilience-1'}
+
+    // #when / #then — must not throw
+    expect(() => emitAudit(event, logger)).not.toThrow()
+  })
+
+  it('does not throw when logger.warn throws', () => {
+    // #given
+    const logger: AuditLogger = {
+      info: vi.fn<LogFn>(),
+      warn: () => {
+        throw new Error('sink exploded')
+      },
+    }
+    const event: AuditEvent = {kind: 'bearer.rejected', correlationId: 'corr-resilience-2', reason: 'expired'}
+
+    // #when / #then — must not throw
+    expect(() => emitAudit(event, logger)).not.toThrow()
+  })
+})

--- a/packages/gateway/src/web/audit.ts
+++ b/packages/gateway/src/web/audit.ts
@@ -1,0 +1,261 @@
+/**
+ * Typed audit seam for security-critical operator web events.
+ * All security-relevant events flow through emitAudit(event, logger).
+ * Gateway restart clears all in-flight audit state; no durable queue in v1.
+ */
+
+export interface AuditLogger {
+  readonly info: (ctx: Record<string, unknown>, msg: string) => void
+  readonly warn: (ctx: Record<string, unknown>, msg: string) => void
+}
+
+/** Safe reasons for auth callback failure. */
+export type AuthCallbackFailureReason =
+  | 'state_mismatch'
+  | 'provider_error'
+  | 'token_exchange_failed'
+  | 'user_fetch_failed'
+  | 'unknown'
+
+/** Safe reasons for authorization denial. */
+export type AuthzDeniedReason = 'not_allowlisted' | 'suspended' | 'unknown'
+
+/** Safe reasons for launch rejection. */
+export type LaunchRejectedReason = 'binding_not_found' | 'concurrency_cap' | 'authz_denied' | 'unknown'
+
+/** Safe reasons for approval rejection. */
+export type ApprovalRejectedReason = 'already_claimed' | 'not_found' | 'deadline_expired' | 'scope_mismatch' | 'unknown'
+
+/** Safe reasons for bearer token rejection. */
+export type BearerRejectedReason = 'missing_token' | 'invalid_signature' | 'expired' | 'unknown'
+
+/** OAuth flow initiated. */
+export interface AuthStartEvent {
+  readonly kind: 'auth.start'
+  readonly correlationId: string
+}
+
+/** OAuth callback completed successfully. */
+export interface AuthCallbackSuccessEvent {
+  readonly kind: 'auth.callback.success'
+  readonly correlationId: string
+  /** Stable GitHub numeric user ID. */
+  readonly githubUserId: number
+  /** GitHub display login — mutable, for display only. */
+  readonly login: string
+}
+
+/** OAuth callback failed. */
+export interface AuthCallbackFailureEvent {
+  readonly kind: 'auth.callback.failure'
+  readonly correlationId: string
+  readonly reason: AuthCallbackFailureReason
+}
+
+/** Operator session logged out. */
+export interface AuthLogoutEvent {
+  readonly kind: 'auth.logout'
+  readonly correlationId: string
+  readonly githubUserId: number
+}
+
+/** OAuth token revoked (e.g. GitHub webhook revocation). */
+export interface AuthRevocationEvent {
+  readonly kind: 'auth.revocation'
+  readonly correlationId: string
+  readonly githubUserId: number
+}
+
+/** Authenticated operator denied access (not on allowlist, suspended, etc.). */
+export interface AuthzDeniedEvent {
+  readonly kind: 'authz.denied'
+  readonly correlationId: string
+  readonly githubUserId: number
+  readonly reason: AuthzDeniedReason
+}
+
+/** Launch request accepted and queued. */
+export interface LaunchAcceptedEvent {
+  readonly kind: 'launch.accepted'
+  readonly correlationId: string
+  readonly githubUserId: number
+  readonly repoFullName: string
+}
+
+/** Launch request rejected before queuing. */
+export interface LaunchRejectedEvent {
+  readonly kind: 'launch.rejected'
+  readonly correlationId: string
+  readonly githubUserId: number
+  readonly reason: LaunchRejectedReason
+}
+
+/** Approval decision submitted by operator. */
+export interface ApprovalDecisionEvent {
+  readonly kind: 'approval.decision'
+  readonly correlationId: string
+  readonly githubUserId: number
+  readonly requestId: string
+  /** Pass-through enum: 'approve' | 'deny' — never a free-form string. */
+  readonly decision: 'approve' | 'deny'
+}
+
+/** Approval submission rejected (already claimed, not found, etc.). */
+export interface ApprovalRejectedEvent {
+  readonly kind: 'approval.rejected'
+  readonly correlationId: string
+  readonly githubUserId: number
+  readonly requestId: string
+  readonly reason: ApprovalRejectedReason
+}
+
+/** Operator read a repo binding. */
+export interface BindingReadEvent {
+  readonly kind: 'binding.read'
+  readonly correlationId: string
+  readonly githubUserId: number
+  readonly repoFullName: string
+}
+
+/** Bearer token rejected on an authenticated route. */
+export interface BearerRejectedEvent {
+  readonly kind: 'bearer.rejected'
+  readonly correlationId: string
+  /** Safe enum — never the raw token value. */
+  readonly reason: BearerRejectedReason
+}
+
+/** All security-critical audit events. */
+export type AuditEvent =
+  | AuthStartEvent
+  | AuthCallbackSuccessEvent
+  | AuthCallbackFailureEvent
+  | AuthLogoutEvent
+  | AuthRevocationEvent
+  | AuthzDeniedEvent
+  | LaunchAcceptedEvent
+  | LaunchRejectedEvent
+  | ApprovalDecisionEvent
+  | ApprovalRejectedEvent
+  | BindingReadEvent
+  | BearerRejectedEvent
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+/**
+ * Patterns for sensitive string values that must never reach the log sink.
+ * Redaction is whole-value and intentionally biased toward over-redaction.
+ */
+const SENSITIVE_PATTERNS: readonly RegExp[] = [
+  // Cookie / session header values — common names only, with a boundary before the cookie name.
+  /(?:^|[;,\s])(?:session|sid|sessionid|connect\.sid)\s*=/i,
+  // GitHub tokens — match anywhere in the string (embedded in URLs, headers, etc.)
+  /ghp_/,
+  /ghs_/,
+  /github_pat_/,
+  // Bearer token header values — case-insensitive, matches embedded occurrences
+  /bearer\s+/i,
+  // Client secret
+  /client_secret/i,
+  // Prompt sentinel
+  /PROMPT_CONTENT/,
+  // Internal / RFC-1918 / loopback URLs — case-insensitive, match bare host and with path
+  /https?:\/\/localhost(?:[/:?#]|$)/i,
+  /https?:\/\/127\./i,
+  /https?:\/\/10\./i,
+  /https?:\/\/172\.(1[6-9]|2\d|3[01])\./i,
+  /https?:\/\/192\.168\./i,
+  /https?:\/\/169\.254\./i,
+  // IPv6 loopback
+  /https?:\/\/\[::1\]/i,
+  // IPv6 ULA (fc00::/7) and link-local (fe80::/10)
+  /https?:\/\/\[f[ce][0-9a-f]{2}:/i,
+  // Docker / Kubernetes internal hostnames
+  /https?:\/\/host\.docker\.internal(?:[/:?#]|$)/i,
+  /https?:\/\/[a-z0-9-]+\.svc\.cluster\.local(?:[/:?#]|$)/i,
+]
+
+/** Returns '[redacted]' if the value matches any sensitive pattern; otherwise returns the value unchanged. */
+function redactIfSensitive(value: string): string {
+  for (const pattern of SENSITIVE_PATTERNS) {
+    if (pattern.test(value)) return '[redacted]'
+  }
+  return value
+}
+
+// ---------------------------------------------------------------------------
+// Sink
+// ---------------------------------------------------------------------------
+
+/**
+ * Exhaustive log-level map: every AuditEvent kind must be present.
+ * Adding a new variant without updating this map is a compile-time error.
+ */
+const LOG_LEVEL: Record<AuditEvent['kind'], 'info' | 'warn'> = {
+  'auth.start': 'info',
+  'auth.callback.success': 'info',
+  'auth.callback.failure': 'warn',
+  'auth.logout': 'info',
+  'auth.revocation': 'info',
+  'authz.denied': 'warn',
+  'launch.accepted': 'info',
+  'launch.rejected': 'warn',
+  'approval.decision': 'info',
+  'approval.rejected': 'warn',
+  'binding.read': 'info',
+  'bearer.rejected': 'warn',
+}
+
+/** Compile-time exhaustiveness guard — unreachable at runtime. */
+function assertNever(x: never): never {
+  throw new Error(`Unhandled AuditEvent kind: ${JSON.stringify(x)}`)
+}
+
+/** Emit a structured audit record. Sink failures are swallowed so audit logging cannot crash handlers. */
+export function emitAudit(event: AuditEvent, logger: AuditLogger): void {
+  const msg = `audit: ${event.kind}`
+  // Build a sanitized context: spread all fields, then overwrite caller-controlled strings.
+  const ctx: Record<string, unknown> = {...event}
+
+  // Sanitize correlationId — present on every variant.
+  ctx.correlationId = redactIfSensitive(event.correlationId)
+
+  // Sanitize variant-specific caller-controlled string fields.
+  switch (event.kind) {
+    case 'auth.callback.success':
+      ctx.login = redactIfSensitive(event.login)
+      break
+    case 'launch.accepted':
+    case 'binding.read':
+      ctx.repoFullName = redactIfSensitive(event.repoFullName)
+      break
+    case 'approval.decision':
+    case 'approval.rejected':
+      ctx.requestId = redactIfSensitive(event.requestId)
+      break
+    case 'auth.start':
+    case 'auth.callback.failure':
+    case 'auth.logout':
+    case 'auth.revocation':
+    case 'authz.denied':
+    case 'launch.rejected':
+    case 'bearer.rejected':
+      // No additional caller-controlled string fields on these variants.
+      break
+    default:
+      // Exhaustiveness guard: TypeScript will error here if a new variant is added without a case.
+      assertNever(event)
+  }
+
+  try {
+    if (LOG_LEVEL[event.kind] === 'warn') {
+      logger.warn(ctx, msg)
+    } else {
+      logger.info(ctx, msg)
+    }
+  } catch {
+    // Swallow sink failures — audit loss is preferable to propagating errors from the log sink.
+  }
+}

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -152,10 +152,9 @@ function validateForwardedHeaders(
   const hasHost = forwardedHost !== undefined && forwardedHost !== ''
   const hasProto = forwardedProto !== undefined && forwardedProto !== ''
 
-  // No forwarded headers — direct connection on gateway-net (operator listener
-  // topology owns direct-socket reachability for Unit 3a). Allow here, but
-  // privileged routes must not rely on this alone when auth lands; they must
-  // enforce their own identity checks regardless of connection path.
+  // No forwarded headers — direct connection on gateway-net. Network topology
+  // owns socket reachability; allow here, but authenticated routes must enforce
+  // identity independently of connection path.
   if (hasHost === false && hasProto === false) return true
 
   // Partial forwarded headers — suspicious. Reject.
@@ -256,9 +255,9 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
   // X-Forwarded-For, which is caller-spoofable). Use getConnInfo(c).remote.address
   // with a fallback to 'unknown' for test environments without a real socket.
   //
-  // For authenticated routes (added in Unit 3+): key on the authenticated
-  // identity (user ID / session ID) in addition to the socket key, so that
-  // a single authenticated user cannot exhaust the unauthenticated burst budget.
+  // For authenticated routes: key on the authenticated identity (user ID /
+  // session ID) so that a single authenticated user cannot exhaust the
+  // unauthenticated burst budget.
   //
   // Failure to call rateLimiter.allow() in a new route is a security defect.
   // The ingress-pin test (http/ingress-pin.test.ts) will catch any new route


### PR DESCRIPTION
## Summary

Adds the Gateway operator web audit seam for upcoming authenticated control-surface routes.

## Changes

- Add typed audit events for auth, authorization, launches, approvals, binding reads, and rejected bearer tokens.
- Add structured `emitAudit()` logging with exhaustive event handling and info/warn routing.
- Add defensive redaction for credentials, cookies, prompt-like content, client secrets, internal URLs, and embedded sensitive substrings.
- Guard audit sink failures so logging cannot crash operator request handlers.
- Update the Phase B plan status for the completed audit-seam slice.

## Verification

- `pnpm --filter @fro-bot/gateway test -- packages/gateway/src/web/audit.test.ts packages/gateway/src/web/server.test.ts`
- `pnpm --filter @fro-bot/gateway check-types`
- `pnpm --filter @fro-bot/gateway lint`