### PR TITLE
feat(gateway): add operator GitHub OAuth foundation

### DIFF
--- a/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
+++ b/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
@@ -448,7 +448,7 @@ The web listener is an adapter layer. It authenticates the operator, projects sa
   **Verification:**
   - Audit seam is typed, redacted, and covered by captured-log tests.
 
-- [ ] **Unit 3c: GitHub OAuth state + PKCE identity verification**
+- [x] **Unit 3c: GitHub OAuth state + PKCE identity verification**
 
   **Goal:** Implement the GitHub App user OAuth web flow with PKCE S256 and state so the callback can verify human identity before any session is minted.
 

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -73,6 +73,12 @@ beforeEach(() => {
     'GATEWAY_OPERATOR_BIND_HOST',
     'GATEWAY_OPERATOR_BIND_PORT',
     'GATEWAY_OPERATOR_PUBLIC_ORIGIN',
+    'GATEWAY_OPERATOR_GITHUB_CLIENT_ID',
+    'GATEWAY_OPERATOR_GITHUB_CLIENT_SECRET',
+    'GATEWAY_OPERATOR_OAUTH_ALLOWED_RETURN_PATHS',
+    'GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS',
+    'GATEWAY_OPERATOR_OAUTH_MAX_OUTSTANDING_ATTEMPTS',
+    'GATEWAY_OPERATOR_GITHUB_CLIENT_ID_FILE',
   ]) {
     delete process.env[key]
   }
@@ -420,6 +426,18 @@ function setRequiredEnv(): void {
   process.env.GATEWAY_WEBHOOK_SECRET = 'test-webhook-secret'
   process.env.GATEWAY_PRESENCE_CHANNEL_ID = 'test-presence-channel-id'
   process.env.WORKSPACE_OPENCODE_TOKEN = 'test-opencode-token'
+}
+
+/**
+ * Set the minimum operator web env vars for a valid config.
+ * Call after setRequiredEnv() when testing operator web happy paths.
+ */
+function setOperatorWebEnv(overrides: {bindHost?: string; bindPort?: string; publicOrigin?: string} = {}): void {
+  process.env.GATEWAY_OPERATOR_BIND_HOST = overrides.bindHost ?? '172.20.0.2'
+  process.env.GATEWAY_OPERATOR_BIND_PORT = overrides.bindPort ?? '4000'
+  process.env.GATEWAY_OPERATOR_PUBLIC_ORIGIN = overrides.publicOrigin ?? 'https://operator.example.com'
+  process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_ID = 'test-oauth-client-id'
+  process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_SECRET = 'test-oauth-client-secret'
 }
 
 describe('loadGatewayConfig', () => {
@@ -1696,18 +1714,21 @@ describe('loadGatewayConfig — operator web surface', () => {
   it('happy path: all three operator vars set → operatorWeb is populated', () => {
     // #given
     setRequiredEnv()
-    process.env.GATEWAY_OPERATOR_BIND_HOST = '172.20.0.2'
-    process.env.GATEWAY_OPERATOR_BIND_PORT = '4000'
-    process.env.GATEWAY_OPERATOR_PUBLIC_ORIGIN = 'https://operator.example.com'
+    setOperatorWebEnv()
 
     // #when
     const config = loadGatewayConfig()
 
     // #then
-    expect(config.operatorWeb).toEqual({
+    expect(config.operatorWeb).toMatchObject({
       bindHost: '172.20.0.2',
       bindPort: 4000,
       publicOrigin: 'https://operator.example.com',
+      oauthClientId: 'test-oauth-client-id',
+      oauthClientSecret: 'test-oauth-client-secret',
+      oauthAllowedReturnPaths: ['/operator'],
+      oauthStateTtlMs: 600_000,
+      oauthMaxOutstandingAttemptsPerKey: 5,
     })
   })
 
@@ -1912,9 +1933,7 @@ describe('loadGatewayConfig — operator web surface', () => {
   it('happy path: GATEWAY_OPERATOR_BIND_HOST=172.20.0.5 → accepted (gateway-net address)', () => {
     // #given — gateway-net addresses (172.20.x.x) must remain valid
     setRequiredEnv()
-    process.env.GATEWAY_OPERATOR_BIND_HOST = '172.20.0.5'
-    process.env.GATEWAY_OPERATOR_BIND_PORT = '4000'
-    process.env.GATEWAY_OPERATOR_PUBLIC_ORIGIN = 'https://operator.example.com'
+    setOperatorWebEnv({bindHost: '172.20.0.5'})
 
     // #when
     const config = loadGatewayConfig()
@@ -1983,6 +2002,8 @@ function setOperatorEnv(origin: string): void {
   process.env.GATEWAY_OPERATOR_BIND_HOST = '172.20.0.2'
   process.env.GATEWAY_OPERATOR_BIND_PORT = '4000'
   process.env.GATEWAY_OPERATOR_PUBLIC_ORIGIN = origin
+  process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_ID = 'test-oauth-client-id'
+  process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_SECRET = 'test-oauth-client-secret'
 }
 
 describe('loadGatewayConfig — GATEWAY_OPERATOR_PUBLIC_ORIGIN canonical origin validation', () => {
@@ -2057,5 +2078,196 @@ describe('loadGatewayConfig — GATEWAY_OPERATOR_PUBLIC_ORIGIN canonical origin 
 
     // #then — stored as parsedPublicOrigin.origin which strips the trailing slash
     expect(config.operatorWeb?.publicOrigin).toBe('https://ops.example.com')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GATEWAY_OPERATOR_GITHUB_CLIENT_ID / CLIENT_SECRET — OAuth credential validation
+// ---------------------------------------------------------------------------
+
+describe('loadGatewayConfig — operator web OAuth credentials', () => {
+  it('error path: GATEWAY_OPERATOR_GITHUB_CLIENT_ID missing → throws', () => {
+    // #given — all three operator vars set but no OAuth client id
+    setRequiredEnv()
+    process.env.GATEWAY_OPERATOR_BIND_HOST = '172.20.0.2'
+    process.env.GATEWAY_OPERATOR_BIND_PORT = '4000'
+    process.env.GATEWAY_OPERATOR_PUBLIC_ORIGIN = 'https://operator.example.com'
+    process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_SECRET = 'test-secret'
+    // GATEWAY_OPERATOR_GITHUB_CLIENT_ID intentionally absent
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/GATEWAY_OPERATOR_GITHUB_CLIENT_ID/)
+  })
+
+  it('error path: GATEWAY_OPERATOR_GITHUB_CLIENT_SECRET missing → throws', () => {
+    // #given — all three operator vars set but no OAuth client secret
+    setRequiredEnv()
+    process.env.GATEWAY_OPERATOR_BIND_HOST = '172.20.0.2'
+    process.env.GATEWAY_OPERATOR_BIND_PORT = '4000'
+    process.env.GATEWAY_OPERATOR_PUBLIC_ORIGIN = 'https://operator.example.com'
+    process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_ID = 'test-client-id'
+    // GATEWAY_OPERATOR_GITHUB_CLIENT_SECRET intentionally absent
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/GATEWAY_OPERATOR_GITHUB_CLIENT_SECRET/)
+  })
+
+  it('happy path: OAuth credentials present → oauthClientId and oauthClientSecret populated', () => {
+    // #given
+    setRequiredEnv()
+    setOperatorWebEnv()
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.operatorWeb?.oauthClientId).toBe('test-oauth-client-id')
+    expect(config.operatorWeb?.oauthClientSecret).toBe('test-oauth-client-secret')
+  })
+
+  it('happy path: GATEWAY_OPERATOR_OAUTH_ALLOWED_RETURN_PATHS overrides default', () => {
+    // #given
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_OAUTH_ALLOWED_RETURN_PATHS = '/operator/dashboard,/operator/runs'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.operatorWeb?.oauthAllowedReturnPaths).toEqual(['/operator/dashboard', '/operator/runs'])
+  })
+
+  it('happy path: GATEWAY_OPERATOR_OAUTH_ALLOWED_RETURN_PATHS defaults to ["/operator"]', () => {
+    // #given — no override
+    setRequiredEnv()
+    setOperatorWebEnv()
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.operatorWeb?.oauthAllowedReturnPaths).toEqual(['/operator'])
+  })
+
+  it('happy path: GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS overrides default', () => {
+    // #given
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS = '300000'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.operatorWeb?.oauthStateTtlMs).toBe(300_000)
+  })
+
+  it('happy path: GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS defaults to 600000', () => {
+    // #given — no override
+    setRequiredEnv()
+    setOperatorWebEnv()
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.operatorWeb?.oauthStateTtlMs).toBe(600_000)
+  })
+
+  it('error path: GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS=0 → throws', () => {
+    // #given
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS = '0'
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS/)
+  })
+
+  it('happy path: GATEWAY_OPERATOR_OAUTH_MAX_OUTSTANDING_ATTEMPTS overrides default', () => {
+    // #given
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_OAUTH_MAX_OUTSTANDING_ATTEMPTS = '10'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.operatorWeb?.oauthMaxOutstandingAttemptsPerKey).toBe(10)
+  })
+
+  it('happy path: GATEWAY_OPERATOR_OAUTH_MAX_OUTSTANDING_ATTEMPTS defaults to 5', () => {
+    // #given — no override
+    setRequiredEnv()
+    setOperatorWebEnv()
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.operatorWeb?.oauthMaxOutstandingAttemptsPerKey).toBe(5)
+  })
+
+  it('error path: GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS=abc → throws (non-integer)', () => {
+    // #given
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS = 'abc'
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS/)
+  })
+
+  it('error path: GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS=-1 → throws (negative not allowed)', () => {
+    // #given
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS = '-1'
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS/)
+  })
+
+  it('error path: GATEWAY_OPERATOR_OAUTH_MAX_OUTSTANDING_ATTEMPTS=0 → throws', () => {
+    // #given
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_OAUTH_MAX_OUTSTANDING_ATTEMPTS = '0'
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/GATEWAY_OPERATOR_OAUTH_MAX_OUTSTANDING_ATTEMPTS/)
+  })
+
+  it('error path: GATEWAY_OPERATOR_OAUTH_MAX_OUTSTANDING_ATTEMPTS=banana → throws (non-integer)', () => {
+    // #given
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_OAUTH_MAX_OUTSTANDING_ATTEMPTS = 'banana'
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/GATEWAY_OPERATOR_OAUTH_MAX_OUTSTANDING_ATTEMPTS/)
+  })
+
+  it('happy path: GATEWAY_OPERATOR_GITHUB_CLIENT_ID_FILE → reads client id from file', () => {
+    // #given — client id provided via _FILE (the compose bind-mount pattern)
+    setRequiredEnv()
+    process.env.GATEWAY_OPERATOR_BIND_HOST = '172.20.0.2'
+    process.env.GATEWAY_OPERATOR_BIND_PORT = '4000'
+    process.env.GATEWAY_OPERATOR_PUBLIC_ORIGIN = 'https://operator.example.com'
+    process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_SECRET = 'test-oauth-client-secret'
+    delete process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_ID
+    const clientIdFile = join(tmpDir, 'github-client-id.txt')
+    writeFileSync(clientIdFile, 'file-client-id\n', {mode: 0o600})
+    process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_ID_FILE = clientIdFile
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then — _FILE value is read and trimmed
+    expect(config.operatorWeb?.oauthClientId).toBe('file-client-id')
+
+    delete process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_ID_FILE
   })
 })

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -121,6 +121,35 @@ export interface GatewayConfig {
      * Example: 'https://operator.example.com'
      */
     readonly publicOrigin: string
+    /**
+     * GitHub OAuth App client ID.
+     * Read from GATEWAY_OPERATOR_GITHUB_CLIENT_ID (or GATEWAY_OPERATOR_GITHUB_CLIENT_ID_FILE).
+     */
+    readonly oauthClientId: string
+    /**
+     * GitHub OAuth App client secret. Never logged or browser-visible.
+     * Read from GATEWAY_OPERATOR_GITHUB_CLIENT_SECRET (or _FILE variant).
+     */
+    readonly oauthClientSecret: string
+    /**
+     * Allowlisted same-origin return paths for post-auth redirect.
+     * Comma-separated list read from GATEWAY_OPERATOR_OAUTH_ALLOWED_RETURN_PATHS.
+     * Defaults to ['/operator'] when unset.
+     * Only paths in this list are accepted as return_to targets.
+     */
+    readonly oauthAllowedReturnPaths: readonly string[]
+    /**
+     * TTL for OAuth state entries in milliseconds.
+     * Read from GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS.
+     * Defaults to 600_000 (10 minutes).
+     */
+    readonly oauthStateTtlMs: number
+    /**
+     * Maximum outstanding (unconsumed) OAuth attempts per source key.
+     * Read from GATEWAY_OPERATOR_OAUTH_MAX_OUTSTANDING_ATTEMPTS.
+     * Defaults to 5.
+     */
+    readonly oauthMaxOutstandingAttemptsPerKey: number
   }
 }
 
@@ -674,12 +703,57 @@ export function loadGatewayConfig(): GatewayConfig {
       )
     }
 
+    // Read GitHub OAuth client credentials — required when operator web is enabled.
+    // GATEWAY_OPERATOR_GITHUB_CLIENT_ID: GitHub OAuth App client ID.
+    // Also accepts GATEWAY_OPERATOR_GITHUB_CLIENT_ID_FILE pointing to a file.
+    const oauthClientId = readSecret('GATEWAY_OPERATOR_GITHUB_CLIENT_ID')
+    const oauthClientSecret = readSecret('GATEWAY_OPERATOR_GITHUB_CLIENT_SECRET')
+
+    // Read optional OAuth tuning parameters with safe defaults.
+    const rawAllowedReturnPaths = readOptionalSecret('GATEWAY_OPERATOR_OAUTH_ALLOWED_RETURN_PATHS')
+    const oauthAllowedReturnPaths: readonly string[] =
+      rawAllowedReturnPaths === null
+        ? ['/operator']
+        : rawAllowedReturnPaths
+            .split(',')
+            .map(p => p.trim())
+            .filter(p => p.length > 0)
+
+    const rawStateTtlMs = readOptionalSecret('GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS')
+    let oauthStateTtlMs = 600_000 // 10 minutes default
+    if (rawStateTtlMs !== null) {
+      const parsed = Number.parseInt(rawStateTtlMs, 10)
+      if (Number.isFinite(parsed) === false || Number.isInteger(parsed) === false || parsed < 1) {
+        throw new Error(
+          `Invalid GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS value: "${rawStateTtlMs}" (must be a positive integer in milliseconds)`,
+        )
+      }
+      oauthStateTtlMs = parsed
+    }
+
+    const rawMaxOutstanding = readOptionalSecret('GATEWAY_OPERATOR_OAUTH_MAX_OUTSTANDING_ATTEMPTS')
+    let oauthMaxOutstandingAttemptsPerKey = 5 // default
+    if (rawMaxOutstanding !== null) {
+      const parsed = Number.parseInt(rawMaxOutstanding, 10)
+      if (Number.isFinite(parsed) === false || Number.isInteger(parsed) === false || parsed < 1) {
+        throw new Error(
+          `Invalid GATEWAY_OPERATOR_OAUTH_MAX_OUTSTANDING_ATTEMPTS value: "${rawMaxOutstanding}" (must be a positive integer)`,
+        )
+      }
+      oauthMaxOutstandingAttemptsPerKey = parsed
+    }
+
     // Normalize to parsedPublicOrigin.origin: strips trailing slash and default ports.
     // Stored value is always scheme+host+optional-non-default-port (no trailing slash).
     operatorWeb = {
       bindHost: operatorBindHost,
       bindPort: operatorBindPort,
       publicOrigin: parsedPublicOrigin.origin,
+      oauthClientId,
+      oauthClientSecret,
+      oauthAllowedReturnPaths,
+      oauthStateTtlMs,
+      oauthMaxOutstandingAttemptsPerKey,
     }
   }
 

--- a/packages/gateway/src/http/ingress-pin.test.ts
+++ b/packages/gateway/src/http/ingress-pin.test.ts
@@ -42,11 +42,13 @@
  */
 
 import type {Client} from 'discord.js'
+import type {GitHubOAuthConfig, GitHubOAuthDeps} from '../web/auth/github.js'
 import type {OperatorServerConfig, OperatorServerDeps} from '../web/server.js'
 import type {AnnounceLogger} from './announce-handler.js'
 import {readdirSync, readFileSync, statSync} from 'node:fs'
 import {join} from 'node:path'
 import {describe, expect, it, vi} from 'vitest'
+import {createInMemoryStateStore} from '../web/auth/github.js'
 import {buildOperatorApp} from '../web/server.js'
 import {buildAnnounceApp} from './server.js'
 
@@ -68,17 +70,32 @@ import {buildAnnounceApp} from './server.js'
 const EXPECTED_ANNOUNCE_ROUTES: readonly {method: string; path: string}[] = [{method: 'POST', path: '/v1/announce'}]
 
 /**
- * The complete set of HTTP routes the gateway exposes over gateway-net (operator surface).
+ * The complete set of HTTP routes the gateway exposes over gateway-net (operator surface)
+ * when GitHub OAuth is NOT configured (no deps.githubOAuth / config.githubOAuth).
  * Each entry is { method, path } matching Hono's app.routes shape.
  *
  * Current surface: exactly one endpoint — the unauthenticated health check.
- * Privileged routes (auth, launch, approvals, SSE) are added only after the auth boundary is in place
- * after the auth boundary is in place.
+ * GitHub OAuth routes (/operator/auth/github/start, /operator/auth/github/callback)
+ * are registered only when both deps.githubOAuth and config.githubOAuth are provided;
+ * see EXPECTED_OPERATOR_ROUTES_WITH_OAUTH below.
  *
  * SECURITY: No announce route may appear here. The operator surface is gateway-net only
  * and is not reachable from sandbox-net.
  */
 const EXPECTED_OPERATOR_ROUTES: readonly {method: string; path: string}[] = [{method: 'GET', path: '/operator/health'}]
+
+/**
+ * The complete set of HTTP routes the gateway exposes over gateway-net (operator surface)
+ * when GitHub OAuth IS configured (both deps.githubOAuth and config.githubOAuth provided).
+ *
+ * SECURITY: All three routes are public (unauthenticated pre-auth surface). No announce
+ * route may appear here.
+ */
+const EXPECTED_OPERATOR_ROUTES_WITH_OAUTH: readonly {method: string; path: string}[] = [
+  {method: 'GET', path: '/operator/health'},
+  {method: 'GET', path: '/operator/auth/github/start'},
+  {method: 'GET', path: '/operator/auth/github/callback'},
+]
 
 // ---------------------------------------------------------------------------
 // Minimal stubs — we only need to build the apps, not run requests.
@@ -120,6 +137,34 @@ function makeOperatorStubConfig(): OperatorServerConfig {
     bindHost: '10.0.0.1',
     bindPort: 0, // not used — we never call serve()
     publicOrigin: 'https://operator.example.com',
+  }
+}
+
+function makeOAuthStubDeps(): GitHubOAuthDeps {
+  return {
+    logger: {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()},
+    auditLogger: {info: vi.fn(), warn: vi.fn()},
+    fetch: vi.fn(async () => new Response('{}', {status: 200, headers: {'content-type': 'application/json'}})),
+    clock: () => 0,
+    generateVerifier: () => 'stub-verifier-32-bytes-long-enough-for-pkce',
+    generateState: () => 'stub-state-value-32-bytes-long-ok',
+    stateStore: createInMemoryStateStore(),
+    getSourceKey: () => 'stub-source-key',
+    // rateLimiter is overwritten by buildOperatorApp with the shared instance;
+    // provide a pass-through stub so the type is satisfied.
+    rateLimiter: {allow: () => true},
+  }
+}
+
+function makeOAuthStubConfig(): GitHubOAuthConfig {
+  return {
+    clientId: 'stub-client-id',
+    clientSecret: 'stub-client-secret',
+    publicOrigin: 'https://operator.example.com',
+    callbackPath: '/operator/auth/github/callback',
+    allowedReturnPaths: ['/operator/dashboard'],
+    maxOutstandingAttemptsPerKey: 5,
+    stateTtlMs: 10 * 60 * 1000,
   }
 }
 
@@ -207,6 +252,59 @@ describe('gateway operator ingress surface (gateway-net)', () => {
   it('every operator route has a path prefix of /operator/ — no route appears in both inventories', () => {
     // #given
     const operatorApp = buildOperatorApp(makeOperatorStubDeps(), makeOperatorStubConfig())
+    const operatorRoutes = extractRoutes(operatorApp)
+
+    // #when — check that all operator routes are namespaced
+    const nonOperatorPrefixed = operatorRoutes.filter(r => !r.path.startsWith('/operator/'))
+
+    // #then — all operator routes must be under /operator/
+    expect(nonOperatorPrefixed).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Operator surface pin test — OAuth-enabled
+// ---------------------------------------------------------------------------
+
+describe('gateway operator ingress surface (gateway-net) — OAuth-enabled', () => {
+  it('is exactly {GET /operator/health, GET /operator/auth/github/start, GET /operator/auth/github/callback} when OAuth deps and config are provided', () => {
+    // #given — build the Hono app with OAuth deps and config
+    const app = buildOperatorApp(
+      {...makeOperatorStubDeps(), githubOAuth: makeOAuthStubDeps()},
+      {...makeOperatorStubConfig(), githubOAuth: makeOAuthStubConfig()},
+    )
+
+    // #when — extract the registered user-defined routes as unique (method, path) pairs.
+    const actualRoutes = extractRoutes(app)
+
+    // #then — the inventory must match the pinned OAuth-enabled set exactly.
+    // Adding a route without updating this pin fails the test, requiring a
+    // security review of the new operator endpoint.
+    expect(actualRoutes).toEqual(EXPECTED_OPERATOR_ROUTES_WITH_OAUTH)
+  })
+
+  it('contains no announce routes when OAuth is enabled — surfaces remain disjoint', () => {
+    // #given
+    const operatorApp = buildOperatorApp(
+      {...makeOperatorStubDeps(), githubOAuth: makeOAuthStubDeps()},
+      {...makeOperatorStubConfig(), githubOAuth: makeOAuthStubConfig()},
+    )
+    const operatorRoutes = extractRoutes(operatorApp)
+    const announcePaths = new Set(EXPECTED_ANNOUNCE_ROUTES.map(r => r.path))
+
+    // #when — check for overlap
+    const overlap = operatorRoutes.filter(r => announcePaths.has(r.path))
+
+    // #then — no announce route appears in the operator surface
+    expect(overlap).toEqual([])
+  })
+
+  it('every OAuth-enabled operator route has a path prefix of /operator/', () => {
+    // #given
+    const operatorApp = buildOperatorApp(
+      {...makeOperatorStubDeps(), githubOAuth: makeOAuthStubDeps()},
+      {...makeOperatorStubConfig(), githubOAuth: makeOAuthStubConfig()},
+    )
     const operatorRoutes = extractRoutes(operatorApp)
 
     // #when — check that all operator routes are namespaced

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -168,6 +168,23 @@ function makeFakeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   }
 }
 
+/** Full operatorWeb config block for tests — includes all required OAuth fields. */
+function makeOperatorWebConfig(
+  overrides: Partial<NonNullable<GatewayConfig['operatorWeb']>> = {},
+): NonNullable<GatewayConfig['operatorWeb']> {
+  return {
+    bindHost: '172.20.0.2',
+    bindPort: 4000,
+    publicOrigin: 'https://operator.example.com',
+    oauthClientId: 'test-oauth-client-id',
+    oauthClientSecret: 'test-oauth-client-secret',
+    oauthAllowedReturnPaths: ['/operator'],
+    oauthStateTtlMs: 600_000,
+    oauthMaxOutstandingAttemptsPerKey: 5,
+    ...overrides,
+  }
+}
+
 /** Minimal fake Discord client for program tests. */
 function makeFakeClient() {
   return {
@@ -937,7 +954,7 @@ describe('button interaction handler (approval flow)', () => {
     // #given — config has operatorWeb present
     const fakeConfig = makeFakeConfig({
       announce: undefined,
-      operatorWeb: {bindHost: '172.20.0.2', bindPort: 4000, publicOrigin: 'https://operator.example.com'},
+      operatorWeb: makeOperatorWebConfig(),
     })
     const fakeClient = makeFakeClient()
     const fakeOperatorHandle = makeFakeServerHandle()
@@ -994,7 +1011,7 @@ describe('button interaction handler (approval flow)', () => {
     // #given — both announce and operatorWeb are configured
     const fakeConfig = makeFakeConfig({
       announce: {webhookSecret: 'test-webhook-secret', presenceChannelId: 'test-presence-channel-id', httpPort: 3000},
-      operatorWeb: {bindHost: '172.20.0.2', bindPort: 4000, publicOrigin: 'https://operator.example.com'},
+      operatorWeb: makeOperatorWebConfig(),
     })
     const fakeClient = makeFakeClient()
     const announceCloseSpy = vi.fn((cb?: (err?: Error) => void) => cb?.())
@@ -1023,7 +1040,7 @@ describe('button interaction handler (approval flow)', () => {
     // #given — both announce and operatorWeb are configured
     const fakeConfig = makeFakeConfig({
       announce: {webhookSecret: 'test-webhook-secret', presenceChannelId: 'test-presence-channel-id', httpPort: 3000},
-      operatorWeb: {bindHost: '172.20.0.2', bindPort: 4000, publicOrigin: 'https://operator.example.com'},
+      operatorWeb: makeOperatorWebConfig(),
     })
     const fakeClient = makeFakeClient()
     const fakeAnnounceHandle = makeFakeServerHandle()
@@ -1044,6 +1061,82 @@ describe('button interaction handler (approval flow)', () => {
     // #then — both factories were called (composite handle was built for shutdown)
     expect(deps.startAnnounceServer).toHaveBeenCalledOnce()
     expect(deps.startOperatorServer).toHaveBeenCalledOnce()
+  })
+
+  it('operator server receives githubOAuth deps and config when operatorWeb is configured', async () => {
+    // #given — config has operatorWeb with OAuth fields
+    const fakeConfig = makeFakeConfig({
+      announce: undefined,
+      operatorWeb: makeOperatorWebConfig({
+        oauthClientId: 'my-client-id',
+        oauthClientSecret: 'my-client-secret',
+        oauthAllowedReturnPaths: ['/operator/dashboard'],
+        oauthStateTtlMs: 300_000,
+        oauthMaxOutstandingAttemptsPerKey: 3,
+      }),
+    })
+    const fakeClient = makeFakeClient()
+    const fakeOperatorHandle = makeFakeServerHandle()
+    const startOperatorServerSpy = vi.fn().mockReturnValue(fakeOperatorHandle)
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: startOperatorServerSpy,
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    // #when
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then — operator server was started once
+    expect(startOperatorServerSpy).toHaveBeenCalledOnce()
+
+    // #and — deps include githubOAuth
+    const [serverDeps, serverConfig] = startOperatorServerSpy.mock.calls[0] as [
+      import('./web/server.js').OperatorServerDeps,
+      import('./web/server.js').OperatorServerConfig,
+    ]
+    expect(serverDeps.githubOAuth).toBeDefined()
+    expect(typeof serverDeps.githubOAuth?.fetch).toBe('function')
+    expect(typeof serverDeps.githubOAuth?.generateVerifier).toBe('function')
+    expect(typeof serverDeps.githubOAuth?.generateState).toBe('function')
+    expect(typeof serverDeps.githubOAuth?.getSourceKey).toBe('function')
+    expect(serverDeps.githubOAuth?.stateStore).toBeDefined()
+
+    // #and — config carries OAuth fields from GatewayConfig
+    expect(serverConfig.githubOAuth).toBeDefined()
+    expect(serverConfig.githubOAuth?.clientId).toBe('my-client-id')
+    expect(serverConfig.githubOAuth?.clientSecret).toBe('my-client-secret')
+    expect(serverConfig.githubOAuth?.allowedReturnPaths).toEqual(['/operator/dashboard'])
+    expect(serverConfig.githubOAuth?.stateTtlMs).toBe(300_000)
+    expect(serverConfig.githubOAuth?.maxOutstandingAttemptsPerKey).toBe(3)
+    expect(serverConfig.githubOAuth?.callbackPath).toBe('/operator/auth/github/callback')
+    expect(serverConfig.githubOAuth?.publicOrigin).toBe('https://operator.example.com')
+  })
+
+  it('operator server receives no githubOAuth when operatorWeb is absent', async () => {
+    // #given — no operatorWeb
+    const fakeConfig = makeFakeConfig({announce: undefined, operatorWeb: undefined})
+    const fakeClient = makeFakeClient()
+    const startOperatorServerSpy = vi.fn()
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: startOperatorServerSpy,
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    // #when
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then — operator server was never started
+    expect(startOperatorServerSpy).not.toHaveBeenCalled()
   })
 
   it('shutdown → approvalRegistry.disposeAll called', async () => {

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -1,5 +1,6 @@
 import type {CoordinationConfig, ObjectStoreAdapter} from '@fro-bot/runtime'
 import type {Client, GatewayIntentBits, Message} from 'discord.js'
+import type {Context} from 'hono'
 import type {GatewayConfig} from './config.js'
 import type {GatewayLogger} from './discord/client.js'
 import type {SinkThread} from './discord/streaming.js'
@@ -14,6 +15,7 @@ import {
   DEFAULT_LOCK_TTL_SECONDS,
   DEFAULT_STALE_THRESHOLD_MS,
 } from '@fro-bot/runtime'
+import {getConnInfo} from '@hono/node-server/conninfo'
 import {Effect} from 'effect'
 import {createApprovalRegistry} from './approvals/registry.js'
 import {createBindingsStore} from './bindings/store.js'
@@ -26,8 +28,10 @@ import {createConcurrencyRegistry} from './execute/concurrency.js'
 import {createChannelQueue, DEFAULT_MAX_QUEUE_DEPTH} from './execute/queue.js'
 import {recoverStaleRuns} from './execute/recovery.js'
 import {createAppClient} from './github/app-client.js'
+import {createRateLimiter} from './http/rate-limit.js'
 import {forceReleaseStaleLockEffect} from './runtime-effect.js'
 import {installShutdownHandlers, isShuttingDown} from './shutdown.js'
+import {buildGitHubOAuthDeps} from './web/auth/github.js'
 import {createWorkspaceClient} from './workspace-api/client.js'
 import {ensureWorkspaceClone} from './workspace-api/ensure-clone.js'
 
@@ -372,23 +376,52 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
     }
 
     // g2. Start operator web HTTP server (before shutdown handlers so the handle is available).
-    //     Operator web endpoint is opt-in: only started when all three required operator config
-    //     vars are set (GATEWAY_OPERATOR_BIND_HOST, GATEWAY_OPERATOR_BIND_PORT,
-    //     GATEWAY_OPERATOR_PUBLIC_ORIGIN). Partial config fails closed at loadGatewayConfig() time.
+    //     Operator web endpoint is opt-in: only started when all required operator config
+    //     vars are set. Partial config fails closed at loadGatewayConfig() time.
     //     When absent, operatorServerHandle is undefined and shutdown skips it.
     let operatorServerHandle: CloseableServer | undefined
     if (config.operatorWeb === undefined || deps.startOperatorServer === undefined) {
       logger.info({}, 'operator web endpoint disabled — no operator web config set')
     } else {
+      // Build the source key extractor for OAuth outstanding-attempt counting.
+      // Must use the TCP socket address (not caller-spoofable headers).
+      // getConnInfo may throw in environments without a real socket; fall back to 'unknown'.
+      const getSourceKey = (c: Context): string => {
+        try {
+          return getConnInfo(c).remote.address ?? 'unknown'
+        } catch {
+          return 'unknown'
+        }
+      }
+
+      // Build the shared rate limiter for the operator surface.
+      // Passed to both buildGitHubOAuthDeps and OperatorServerDeps so OAuth routes
+      // participate in the same per-socket budget as the health route.
+      const operatorRateLimiter = createRateLimiter({limit: 20, windowMs: 60_000})
+
+      // Build production GitHub OAuth deps with real CSPRNG, fetch, and clock.
+      const githubOAuthDeps = buildGitHubOAuthDeps(logger, logger, getSourceKey, operatorRateLimiter)
+
       operatorServerHandle = deps.startOperatorServer(
         {
           logger,
           isShuttingDown,
+          rateLimiter: operatorRateLimiter,
+          githubOAuth: githubOAuthDeps,
         },
         {
           bindHost: config.operatorWeb.bindHost,
           bindPort: config.operatorWeb.bindPort,
           publicOrigin: config.operatorWeb.publicOrigin,
+          githubOAuth: {
+            clientId: config.operatorWeb.oauthClientId,
+            clientSecret: config.operatorWeb.oauthClientSecret,
+            publicOrigin: config.operatorWeb.publicOrigin,
+            callbackPath: '/operator/auth/github/callback',
+            allowedReturnPaths: config.operatorWeb.oauthAllowedReturnPaths,
+            stateTtlMs: config.operatorWeb.oauthStateTtlMs,
+            maxOutstandingAttemptsPerKey: config.operatorWeb.oauthMaxOutstandingAttemptsPerKey,
+          },
         },
       )
       logger.info(

--- a/packages/gateway/src/web/audit.ts
+++ b/packages/gateway/src/web/audit.ts
@@ -15,6 +15,7 @@ export type AuthCallbackFailureReason =
   | 'provider_error'
   | 'token_exchange_failed'
   | 'user_fetch_failed'
+  | 'source_key_mismatch'
   | 'unknown'
 
 /** Safe reasons for authorization denial. */

--- a/packages/gateway/src/web/auth/github.test.ts
+++ b/packages/gateway/src/web/auth/github.test.ts
@@ -1,0 +1,1682 @@
+/**
+ * Tests for the GitHub OAuth PKCE + state flow.
+ *
+ * Covers:
+ *   - Happy path: auth start redirects to GitHub with correct params.
+ *   - Security: code verifier is never in cookie or browser-visible response.
+ *   - Security: absolute/cross-origin redirect targets rejected before state mint.
+ *   - Happy path: valid state + PKCE exchange returns numeric GitHub user id and login.
+ *   - Error path: invalid state, replayed state, expired state fail closed.
+ *   - Error path: token exchange failure fails closed.
+ *   - Error path: user fetch failure fails closed.
+ *   - Security: all auth failure branches return the same coarse 400 response shape.
+ *   - Security: OAuth callback accepts GitHub's cross-site redirect shape.
+ *   - Audit: auth.callback.success and auth.callback.failure events are emitted with reason.
+ *   - Outstanding attempt cap: exceeding cap per source key fails closed.
+ *   - Rate limiter: both start and callback routes are rate limited.
+ *   - Source key binding: callback rejects when source key differs from mint-time key.
+ *   - Provider error with valid state: state is consumed immediately.
+ *   - Fetch timeout/throw: token exchange and user fetch throw/timeout fail closed.
+ *   - Non-2xx responses: token exchange and user fetch non-2xx fail closed.
+ *   - Eviction: evictStale removes consumed and expired entries.
+ *   - Programming errors: partial deps/config throws at construction time.
+ *   - Route inventory: OAuth-enabled buildOperatorApp registers expected routes.
+ *
+ * Uses BDD comments (#given, #when, #then).
+ */
+
+import type {RateLimiter} from '../../http/rate-limit.js'
+import type {AuditLogger} from '../audit.js'
+import type {GitHubOAuthConfig, GitHubOAuthDeps, OAuthStateStore} from './github.js'
+import {createHash} from 'node:crypto'
+import {Hono} from 'hono'
+import {describe, expect, it, vi} from 'vitest'
+import {assertAllPrivilegedRoutesWrapped, isPublicRoute, registerPublicRoute} from '../operator-route.js'
+import {buildGitHubOAuthRoutes, createInMemoryStateStore} from './github.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Captured audit log record — kind + any additional fields. */
+interface CapturedAuditRecord {
+  readonly kind: string
+  readonly reason?: string
+  readonly [key: string]: unknown
+}
+
+function isCapturedAuditRecord(ctx: Record<string, unknown>): ctx is CapturedAuditRecord {
+  return typeof ctx.kind === 'string'
+}
+
+function makeAuditLogger(): AuditLogger & {records: CapturedAuditRecord[]} {
+  const records: CapturedAuditRecord[] = []
+  const capture = (ctx: Record<string, unknown>): void => {
+    if (isCapturedAuditRecord(ctx)) {
+      records.push(ctx)
+    }
+  }
+  return {
+    records,
+    info: vi.fn((ctx: Record<string, unknown>, _msg: string) => {
+      capture(ctx)
+    }),
+    warn: vi.fn((ctx: Record<string, unknown>, _msg: string) => {
+      capture(ctx)
+    }),
+  }
+}
+
+function makeLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+}
+
+function makePassRateLimiter(): RateLimiter {
+  return {allow: vi.fn(() => true)}
+}
+
+function makeBlockRateLimiter(): RateLimiter {
+  return {allow: vi.fn(() => false)}
+}
+
+/** Minimal stub fetch that returns a successful token exchange and user fetch. */
+function makeSuccessFetch(
+  opts: {
+    accessToken?: string
+    userId?: number
+    login?: string
+  } = {},
+): GitHubOAuthDeps['fetch'] {
+  const accessToken = opts.accessToken ?? 'ghs_TESTTOKEN'
+  const userId = opts.userId ?? 12345
+  const login = opts.login ?? 'octocat'
+
+  return vi.fn(async (url: string | URL | Request, _init?: RequestInit) => {
+    const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+    if (urlStr.includes('login/oauth/access_token')) {
+      return new Response(JSON.stringify({access_token: accessToken, token_type: 'bearer', scope: 'read:user'}), {
+        status: 200,
+        headers: {'content-type': 'application/json'},
+      })
+    }
+    if (urlStr.includes('api.github.com/user')) {
+      return new Response(JSON.stringify({id: userId, login}), {
+        status: 200,
+        headers: {'content-type': 'application/json'},
+      })
+    }
+    return new Response('not found', {status: 404})
+  })
+}
+
+function makeStubConfig(overrides?: Partial<GitHubOAuthConfig>): GitHubOAuthConfig {
+  return {
+    clientId: 'test-client-id',
+    clientSecret: 'test-client-secret',
+    publicOrigin: 'https://operator.example.com',
+    callbackPath: '/operator/auth/github/callback',
+    allowedReturnPaths: ['/operator/dashboard', '/operator/runs'],
+    maxOutstandingAttemptsPerKey: 5,
+    stateTtlMs: 10 * 60 * 1000, // 10 minutes
+    ...overrides,
+  }
+}
+
+function makeStubDeps(overrides?: Partial<GitHubOAuthDeps>): GitHubOAuthDeps {
+  return {
+    logger: makeLogger(),
+    auditLogger: makeAuditLogger(),
+    fetch: makeSuccessFetch(),
+    clock: () => Date.now(),
+    generateVerifier: () => 'test-verifier-32-bytes-long-enough-for-pkce',
+    generateState: () => 'test-state-value-32-bytes-long-ok',
+    stateStore: createInMemoryStateStore(),
+    // In tests, return a fixed source key — no real socket available.
+    getSourceKey: () => 'test-source-key',
+    rateLimiter: makePassRateLimiter(),
+    ...overrides,
+  }
+}
+
+/** Derive the expected S256 code challenge for a given verifier (mirrors production logic). */
+function deriveExpectedChallenge(verifier: string): string {
+  const hash = createHash('sha256').update(verifier, 'ascii').digest()
+  return hash.toString('base64').replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '')
+}
+
+/** Build a Hono app with the OAuth routes registered. */
+function buildTestApp(deps: GitHubOAuthDeps, config: GitHubOAuthConfig): Hono {
+  const app = new Hono()
+  // Register health as public so assertAllPrivilegedRoutesWrapped passes
+  registerPublicRoute(app, 'GET', '/operator/health', c => c.json({ok: true}))
+  buildGitHubOAuthRoutes(app, deps, config)
+  assertAllPrivilegedRoutesWrapped(app)
+  return app
+}
+
+// ---------------------------------------------------------------------------
+// Auth start — happy path
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/auth/github/start — happy path', () => {
+  it('redirects to GitHub authorization URL with required PKCE and state params', async () => {
+    // #given
+    const deps = makeStubDeps()
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request('https://operator.example.com/operator/auth/github/start')
+    const res = await app.fetch(req)
+
+    // #then — redirect to GitHub
+    expect(res.status).toBe(302)
+    const location = res.headers.get('location') ?? ''
+    expect(location).toBeTruthy()
+    const redirectUrl = new URL(location)
+    expect(redirectUrl.hostname).toBe('github.com')
+    expect(redirectUrl.pathname).toBe('/login/oauth/authorize')
+    expect(redirectUrl.searchParams.get('client_id')).toBe('test-client-id')
+    expect(redirectUrl.searchParams.get('state')).toBe('test-state-value-32-bytes-long-ok')
+    expect(redirectUrl.searchParams.get('code_challenge_method')).toBe('S256')
+    // Exact deterministic PKCE challenge derived from the injected verifier
+    expect(redirectUrl.searchParams.get('code_challenge')).toBe(
+      deriveExpectedChallenge('test-verifier-32-bytes-long-enough-for-pkce'),
+    )
+    expect(redirectUrl.searchParams.get('redirect_uri')).toBe(
+      'https://operator.example.com/operator/auth/github/callback',
+    )
+    // Exact scope assertion
+    expect(redirectUrl.searchParams.get('scope')).toBe('read:user')
+  })
+
+  it('stores state server-side with codeVerifier, issuedAt, consumed=false', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const deps = makeStubDeps({stateStore})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request('https://operator.example.com/operator/auth/github/start')
+    await app.fetch(req)
+
+    // #then — state is stored server-side
+    const stored = stateStore.get('test-state-value-32-bytes-long-ok')
+    if (stored === undefined) throw new Error('expected state to be stored')
+    expect(stored.codeVerifier).toBe('test-verifier-32-bytes-long-enough-for-pkce')
+    expect(stored.consumed).toBe(false)
+    expect(stored.issuedAt).toBeGreaterThan(0)
+  })
+
+  it('includes redirect_target in stored state when a valid same-origin path is provided', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const deps = makeStubDeps({stateStore})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — provide a valid same-origin return path
+    const req = new Request('https://operator.example.com/operator/auth/github/start?return_to=%2Foperator%2Fdashboard')
+    await app.fetch(req)
+
+    // #then — redirect target is stored
+    const stored = stateStore.get('test-state-value-32-bytes-long-ok')
+    if (stored === undefined) throw new Error('expected state to be stored')
+    expect(stored.redirectTarget).toBe('/operator/dashboard')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Auth start — code verifier never browser-visible
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/auth/github/start — code verifier security', () => {
+  it('does not include code verifier in the redirect URL', async () => {
+    // #given
+    const deps = makeStubDeps()
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request('https://operator.example.com/operator/auth/github/start')
+    const res = await app.fetch(req)
+
+    // #then — verifier is NOT in the redirect URL
+    const location = res.headers.get('location') ?? ''
+    expect(location).not.toContain('test-verifier-32-bytes-long-enough-for-pkce')
+    expect(location).not.toContain('code_verifier')
+  })
+
+  it('does not include code verifier in any response header', async () => {
+    // #given
+    const deps = makeStubDeps()
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request('https://operator.example.com/operator/auth/github/start')
+    const res = await app.fetch(req)
+
+    // #then — verifier is NOT in any response header
+    const allHeaders = [...res.headers.entries()].map(([k, v]) => `${k}: ${v}`).join('\n')
+    expect(allHeaders).not.toContain('test-verifier-32-bytes-long-enough-for-pkce')
+    expect(allHeaders).not.toContain('code_verifier')
+  })
+
+  it('does not set a cookie containing the code verifier', async () => {
+    // #given
+    const deps = makeStubDeps()
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request('https://operator.example.com/operator/auth/github/start')
+    const res = await app.fetch(req)
+
+    // #then — no cookie contains the verifier
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    expect(setCookie).not.toContain('test-verifier-32-bytes-long-enough-for-pkce')
+    expect(setCookie).not.toContain('code_verifier')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Auth start — redirect target validation
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/auth/github/start — redirect target validation', () => {
+  it('rejects absolute URL redirect targets before state is minted', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const deps = makeStubDeps({stateStore})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — absolute URL as return_to
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/start?return_to=https%3A%2F%2Fevil.attacker.com%2Fsteal',
+    )
+    const res = await app.fetch(req)
+
+    // #then — rejected; no state minted
+    expect(res.status).toBe(400)
+    const stateCount = stateStore.size()
+    expect(stateCount).toBe(0)
+  })
+
+  it('rejects cross-origin redirect targets before state is minted', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const deps = makeStubDeps({stateStore})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — cross-origin URL
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/start?return_to=%2F%2Fevil.attacker.com%2Fsteal',
+    )
+    const res = await app.fetch(req)
+
+    // #then — rejected; no state minted
+    expect(res.status).toBe(400)
+    expect(stateStore.size()).toBe(0)
+  })
+
+  it('rejects paths not in the allowlist before state is minted', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const deps = makeStubDeps({stateStore})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — path not in allowlist
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/start?return_to=%2Fsome%2Funknown%2Fpath',
+    )
+    const res = await app.fetch(req)
+
+    // #then — rejected; no state minted
+    expect(res.status).toBe(400)
+    expect(stateStore.size()).toBe(0)
+  })
+
+  it('accepts a valid allowlisted path as redirect target', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const deps = makeStubDeps({stateStore})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — valid allowlisted path
+    const req = new Request('https://operator.example.com/operator/auth/github/start?return_to=%2Foperator%2Fruns')
+    const res = await app.fetch(req)
+
+    // #then — accepted; state minted
+    expect(res.status).toBe(302)
+    expect(stateStore.size()).toBe(1)
+  })
+
+  it('accepts no return_to param (defaults to no redirect target)', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const deps = makeStubDeps({stateStore})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — no return_to
+    const req = new Request('https://operator.example.com/operator/auth/github/start')
+    const res = await app.fetch(req)
+
+    // #then — accepted; state minted with no redirectTarget
+    expect(res.status).toBe(302)
+    expect(stateStore.size()).toBe(1)
+    const stored = stateStore.get('test-state-value-32-bytes-long-ok')
+    if (stored === undefined) throw new Error('expected state to be stored')
+    expect(stored.redirectTarget).toBeUndefined()
+  })
+
+  it('rejects when allowedReturnPaths is empty and return_to is provided', async () => {
+    // #given — empty allowlist
+    const stateStore = createInMemoryStateStore()
+    const deps = makeStubDeps({stateStore})
+    const config = makeStubConfig({allowedReturnPaths: []})
+    const app = buildTestApp(deps, config)
+
+    // #when — any path is rejected when allowlist is empty
+    const req = new Request('https://operator.example.com/operator/auth/github/start?return_to=%2Foperator%2Fdashboard')
+    const res = await app.fetch(req)
+
+    // #then — rejected; no state minted
+    expect(res.status).toBe(400)
+    expect(stateStore.size()).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Auth start — outstanding attempt cap
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/auth/github/start — outstanding attempt cap', () => {
+  it('rejects when outstanding attempts per source key exceed the cap', async () => {
+    // #given — cap of 2 outstanding attempts
+    let stateCounter = 0
+    const deps = makeStubDeps({
+      generateState: () => `state-${++stateCounter}`,
+      stateStore: createInMemoryStateStore(),
+    })
+    const config = makeStubConfig({maxOutstandingAttemptsPerKey: 2})
+    const app = buildTestApp(deps, config)
+
+    // #when — exhaust the cap
+    const makeReq = () => new Request('https://operator.example.com/operator/auth/github/start')
+    const res1 = await app.fetch(makeReq())
+    const res2 = await app.fetch(makeReq())
+    const res3 = await app.fetch(makeReq())
+
+    // #then — first two succeed, third is rejected
+    expect(res1.status).toBe(302)
+    expect(res2.status).toBe(302)
+    expect(res3.status).toBe(429)
+  })
+
+  it('allows new starts after previously-outstanding entries expire (evict-before-count)', async () => {
+    // #given — cap of 2; two entries minted at t=0 (will expire at ttlMs+1)
+    const ttlMs = 10 * 60 * 1000
+    const stateStore = createInMemoryStateStore()
+    let stateCounter = 0
+    let currentTime = 1000
+
+    const deps = makeStubDeps({
+      stateStore,
+      generateState: () => `state-${++stateCounter}`,
+      clock: () => currentTime,
+    })
+    const config = makeStubConfig({maxOutstandingAttemptsPerKey: 2, stateTtlMs: ttlMs})
+    const app = buildTestApp(deps, config)
+
+    const makeReq = () => new Request('https://operator.example.com/operator/auth/github/start')
+
+    // #when — exhaust the cap at t=1000
+    const res1 = await app.fetch(makeReq())
+    const res2 = await app.fetch(makeReq())
+    expect(res1.status).toBe(302)
+    expect(res2.status).toBe(302)
+
+    // Verify cap is hit before expiry
+    const resCapped = await app.fetch(makeReq())
+    expect(resCapped.status).toBe(429)
+
+    // #when — advance clock past TTL so the two entries are now expired
+    currentTime = 1000 + ttlMs + 1
+
+    // #then — new start succeeds because evictStale runs before countOutstanding
+    const resAfterExpiry = await app.fetch(makeReq())
+    expect(resAfterExpiry.status).toBe(302)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Auth start — rate limiter
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/auth/github/start — rate limiter', () => {
+  it('returns 429 when the shared rate limiter rejects the request', async () => {
+    // #given — rate limiter always blocks
+    const deps = makeStubDeps({rateLimiter: makeBlockRateLimiter()})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request('https://operator.example.com/operator/auth/github/start')
+    const res = await app.fetch(req)
+
+    // #then — rate limited before any work
+    expect(res.status).toBe(429)
+  })
+
+  it('calls rateLimiter.allow with the source key on start', async () => {
+    // #given
+    const rateLimiter = makePassRateLimiter()
+    const deps = makeStubDeps({rateLimiter, getSourceKey: () => 'fixed-key'})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request('https://operator.example.com/operator/auth/github/start')
+    await app.fetch(req)
+
+    // #then — rate limiter was called with the source key
+    expect(rateLimiter.allow).toHaveBeenCalledWith('fixed-key')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// OAuth callback — happy path
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/auth/github/callback — happy path', () => {
+  it('returns numeric GitHub user id and login on valid state + code exchange', async () => {
+    // #given — pre-seed state store
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000, // 1 second after issuedAt
+      fetch: makeSuccessFetch({userId: 99999, login: 'testuser'}),
+    })
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — success response with verified identity
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({
+      githubUserId: 99999,
+      login: 'testuser',
+    })
+  })
+
+  it('includes code_verifier in the token exchange request', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'my-specific-verifier-value',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const fetchSpy = vi.fn(makeSuccessFetch())
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: fetchSpy,
+    })
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    await app.fetch(req)
+
+    // #then — token exchange includes code_verifier
+    const tokenCall = fetchSpy.mock.calls.find(([url]: [string | URL | Request, RequestInit?]) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+      return urlStr.includes('login/oauth/access_token')
+    })
+    expect(tokenCall).toBeDefined()
+    const tokenCallInit = tokenCall?.[1]
+    const body = tokenCallInit?.body
+    const bodyStr = typeof body === 'string' ? body : body instanceof URLSearchParams ? body.toString() : ''
+    expect(bodyStr).toContain('code_verifier=my-specific-verifier-value')
+  })
+
+  it('emits auth.callback.success audit event with numeric id and login', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const auditLogger = makeAuditLogger()
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      auditLogger,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    await app.fetch(req)
+
+    // #then — success audit event emitted
+    const successEvent = auditLogger.records.find(r => r.kind === 'auth.callback.success')
+    expect(successEvent).toBeDefined()
+    expect(successEvent?.githubUserId).toBe(42)
+    expect(successEvent?.login).toBe('octocat')
+  })
+
+  it('consumes state (one-time use) after successful callback', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+    })
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — first callback succeeds
+    const req1 = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res1 = await app.fetch(req1)
+    expect(res1.status).toBe(200)
+
+    // #when — replay the same state
+    const req2 = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res2 = await app.fetch(req2)
+
+    // #then — replayed state is rejected
+    expect(res2.status).toBe(400)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// OAuth callback — rate limiter
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/auth/github/callback — rate limiter', () => {
+  it('returns 429 when the shared rate limiter rejects the callback', async () => {
+    // #given — rate limiter always blocks
+    const deps = makeStubDeps({rateLimiter: makeBlockRateLimiter()})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request('https://operator.example.com/operator/auth/github/callback?code=abc&state=some-state')
+    const res = await app.fetch(req)
+
+    // #then — rate limited before any work
+    expect(res.status).toBe(429)
+  })
+
+  it('calls rateLimiter.allow with the source key on callback', async () => {
+    // #given
+    const rateLimiter = makePassRateLimiter()
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+    const deps = makeStubDeps({rateLimiter, stateStore, clock: () => now + 1000, getSourceKey: () => 'fixed-key'})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    await app.fetch(req)
+
+    // #then — rate limiter was called with the source key
+    expect(rateLimiter.allow).toHaveBeenCalledWith('fixed-key')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// OAuth callback — source key binding
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/auth/github/callback — source key binding', () => {
+  it('rejects callback when source key differs from mint-time source key', async () => {
+    // #given — state minted with source key 'ip-1', callback comes from 'ip-2'
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+      sourceKey: 'ip-1',
+    })
+
+    const auditLogger = makeAuditLogger()
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      auditLogger,
+      getSourceKey: () => 'ip-2', // different from mint-time key
+    })
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — rejected with 400
+    expect(res.status).toBe(400)
+
+    // #and — failure audit event emitted with source_key_mismatch reason
+    const failureEvent = auditLogger.records.find(r => r.kind === 'auth.callback.failure')
+    expect(failureEvent).toBeDefined()
+    expect(failureEvent?.reason).toBe('source_key_mismatch')
+  })
+
+  it('accepts callback when source key matches mint-time source key', async () => {
+    // #given — state minted with source key 'ip-1', callback also from 'ip-1'
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+      sourceKey: 'ip-1',
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      getSourceKey: () => 'ip-1',
+    })
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — accepted
+    expect(res.status).toBe(200)
+  })
+
+  it('accepts callback when state has no sourceKey bound (legacy/test entries)', async () => {
+    // #given — state minted without a sourceKey
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+      // no sourceKey
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      getSourceKey: () => 'any-key',
+    })
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — accepted (no sourceKey bound means no binding check)
+    expect(res.status).toBe(200)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// OAuth callback — provider error consumes state
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/auth/github/callback — provider error state consumption', () => {
+  it('consumes valid known state immediately on provider error (does not hold outstanding budget)', async () => {
+    // #given — state is valid and unconsumed
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+      sourceKey: 'test-source-key',
+    })
+
+    const deps = makeStubDeps({stateStore, clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — GitHub sends error param with a valid known state
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?error=access_denied&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — fail closed
+    expect(res.status).toBe(400)
+
+    // #and — state is consumed (not holding outstanding budget until TTL)
+    const entry = stateStore.get('valid-state-value')
+    expect(entry?.consumed).toBe(true)
+  })
+
+  it('emits provider_error audit reason on provider error', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+    const auditLogger = makeAuditLogger()
+    const deps = makeStubDeps({stateStore, clock: () => now + 1000, auditLogger})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?error=access_denied&state=valid-state-value',
+    )
+    await app.fetch(req)
+
+    // #then — failure audit event with provider_error reason
+    const failureEvent = auditLogger.records.find(r => r.kind === 'auth.callback.failure')
+    expect(failureEvent).toBeDefined()
+    expect(failureEvent?.reason).toBe('provider_error')
+  })
+
+  it('does not consume state on provider error when source key differs from mint-time key', async () => {
+    // #given — state minted with 'ip-1', error callback arrives from 'ip-2'
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+      sourceKey: 'ip-1',
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      getSourceKey: () => 'ip-2', // different source
+    })
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — error callback from a different source
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?error=access_denied&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — fail closed
+    expect(res.status).toBe(400)
+
+    // #and — state is NOT consumed (source key mismatch prevented the burn)
+    const entry = stateStore.get('valid-state-value')
+    expect(entry?.consumed).toBe(false)
+  })
+
+  it('does not consume state on provider error when state is expired', async () => {
+    // #given — state is past TTL
+    const stateStore = createInMemoryStateStore()
+    const ttlMs = 10 * 60 * 1000
+    const issuedAt = 1000
+    stateStore.set('expired-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt,
+      consumed: false,
+      sourceKey: 'test-source-key',
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => issuedAt + ttlMs + 1, // 1ms past TTL
+    })
+    const config = makeStubConfig({stateTtlMs: ttlMs})
+    const app = buildTestApp(deps, config)
+
+    // #when — error callback with expired state
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?error=access_denied&state=expired-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — fail closed
+    expect(res.status).toBe(400)
+
+    // #and — state is NOT consumed (expired entries are not burned)
+    const entry = stateStore.get('expired-state-value')
+    expect(entry?.consumed).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// OAuth callback — error paths (fail closed)
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/auth/github/callback — error paths', () => {
+  it('returns 400 for missing state param', async () => {
+    // #given
+    const deps = makeStubDeps()
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — no state param
+    const req = new Request('https://operator.example.com/operator/auth/github/callback?code=github-code-abc')
+    const res = await app.fetch(req)
+
+    // #then — fail closed
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for missing code param', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+    const deps = makeStubDeps({stateStore, clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — no code param
+    const req = new Request('https://operator.example.com/operator/auth/github/callback?state=valid-state-value')
+    const res = await app.fetch(req)
+
+    // #then — fail closed
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for unknown state (state mismatch)', async () => {
+    // #given — empty state store
+    const deps = makeStubDeps()
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — unknown state value
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=unknown-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — fail closed
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for replayed (already consumed) state', async () => {
+    // #given — state already consumed
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('consumed-state', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: true, // already consumed
+    })
+
+    const deps = makeStubDeps({stateStore, clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=consumed-state',
+    )
+    const res = await app.fetch(req)
+
+    // #then — fail closed
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for expired state (TTL exceeded)', async () => {
+    // #given — state issued long ago
+    const stateStore = createInMemoryStateStore()
+    const issuedAt = 1000
+    stateStore.set('expired-state', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt,
+      consumed: false,
+    })
+
+    const ttlMs = 10 * 60 * 1000 // 10 minutes
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => issuedAt + ttlMs + 1, // 1ms past TTL
+    })
+    const config = makeStubConfig({stateTtlMs: ttlMs})
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=expired-state',
+    )
+    const res = await app.fetch(req)
+
+    // #then — fail closed
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when GitHub returns an error in the callback (provider_error)', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+    const deps = makeStubDeps({stateStore, clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — GitHub sends error param
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?error=access_denied&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — fail closed
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when token exchange returns no access_token (missing field)', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const failFetch: GitHubOAuthDeps['fetch'] = vi.fn(async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+      if (urlStr.includes('login/oauth/access_token')) {
+        return new Response(JSON.stringify({error: 'bad_verification_code'}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        })
+      }
+      return new Response('not found', {status: 404})
+    })
+
+    const deps = makeStubDeps({stateStore, clock: () => now + 1000, fetch: failFetch})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — fail closed
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when token exchange returns non-2xx HTTP status', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const failFetch: GitHubOAuthDeps['fetch'] = vi.fn(async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+      if (urlStr.includes('login/oauth/access_token')) {
+        return new Response('server error', {status: 500})
+      }
+      return new Response('not found', {status: 404})
+    })
+
+    const auditLogger = makeAuditLogger()
+    const deps = makeStubDeps({stateStore, clock: () => now + 1000, fetch: failFetch, auditLogger})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — fail closed
+    expect(res.status).toBe(400)
+
+    // #and — correct audit reason
+    const failureEvent = auditLogger.records.find(r => r.kind === 'auth.callback.failure')
+    expect(failureEvent?.reason).toBe('token_exchange_failed')
+  })
+
+  it('returns 400 when token exchange throws (network error / timeout)', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const throwFetch: GitHubOAuthDeps['fetch'] = vi.fn(async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+      if (urlStr.includes('login/oauth/access_token')) {
+        throw new Error('network timeout')
+      }
+      return new Response('not found', {status: 404})
+    })
+
+    const auditLogger = makeAuditLogger()
+    const deps = makeStubDeps({stateStore, clock: () => now + 1000, fetch: throwFetch, auditLogger})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — fail closed
+    expect(res.status).toBe(400)
+
+    // #and — correct audit reason
+    const failureEvent = auditLogger.records.find(r => r.kind === 'auth.callback.failure')
+    expect(failureEvent?.reason).toBe('token_exchange_failed')
+  })
+
+  it('returns 400 when user fetch returns non-2xx HTTP status', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const failFetch: GitHubOAuthDeps['fetch'] = vi.fn(async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+      if (urlStr.includes('login/oauth/access_token')) {
+        return new Response(JSON.stringify({access_token: 'ghs_TOKEN', token_type: 'bearer', scope: 'read:user'}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        })
+      }
+      if (urlStr.includes('api.github.com/user')) {
+        return new Response('unauthorized', {status: 401})
+      }
+      return new Response('not found', {status: 404})
+    })
+
+    const auditLogger = makeAuditLogger()
+    const deps = makeStubDeps({stateStore, clock: () => now + 1000, fetch: failFetch, auditLogger})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — fail closed
+    expect(res.status).toBe(400)
+
+    // #and — correct audit reason
+    const failureEvent = auditLogger.records.find(r => r.kind === 'auth.callback.failure')
+    expect(failureEvent?.reason).toBe('user_fetch_failed')
+  })
+
+  it('returns 400 when user fetch throws (network error / timeout)', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const throwFetch: GitHubOAuthDeps['fetch'] = vi.fn(async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+      if (urlStr.includes('login/oauth/access_token')) {
+        return new Response(JSON.stringify({access_token: 'ghs_TOKEN', token_type: 'bearer', scope: 'read:user'}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        })
+      }
+      if (urlStr.includes('api.github.com/user')) {
+        throw new Error('connection reset')
+      }
+      return new Response('not found', {status: 404})
+    })
+
+    const auditLogger = makeAuditLogger()
+    const deps = makeStubDeps({stateStore, clock: () => now + 1000, fetch: throwFetch, auditLogger})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — fail closed
+    expect(res.status).toBe(400)
+
+    // #and — correct audit reason
+    const failureEvent = auditLogger.records.find(r => r.kind === 'auth.callback.failure')
+    expect(failureEvent?.reason).toBe('user_fetch_failed')
+  })
+
+  it('emits auth.callback.failure audit event with state_mismatch reason on unknown state', async () => {
+    // #given
+    const auditLogger = makeAuditLogger()
+    const deps = makeStubDeps({auditLogger})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — unknown state
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=unknown-state',
+    )
+    await app.fetch(req)
+
+    // #then — failure audit event emitted with reason
+    const failureEvent = auditLogger.records.find(r => r.kind === 'auth.callback.failure')
+    expect(failureEvent).toBeDefined()
+    expect(failureEvent?.reason).toBe('state_mismatch')
+  })
+
+  it('emits auth.callback.failure audit event with token_exchange_failed reason on token failure', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const failFetch: GitHubOAuthDeps['fetch'] = vi.fn(async () => {
+      return new Response(JSON.stringify({error: 'bad_verification_code'}), {
+        status: 200,
+        headers: {'content-type': 'application/json'},
+      })
+    })
+
+    const auditLogger = makeAuditLogger()
+    const deps = makeStubDeps({stateStore, clock: () => now + 1000, fetch: failFetch, auditLogger})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    await app.fetch(req)
+
+    // #then — failure audit event emitted with reason
+    const failureEvent = auditLogger.records.find(r => r.kind === 'auth.callback.failure')
+    expect(failureEvent).toBeDefined()
+    expect(failureEvent?.reason).toBe('token_exchange_failed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// OAuth callback — coarse failure response shape
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/auth/github/callback — coarse failure response shape', () => {
+  it('all failure branches return the same coarse 400 response shape', async () => {
+    // #given — multiple failure scenarios
+    const scenarios: {name: string; url: string; storeSetup?: (s: OAuthStateStore) => void}[] = [
+      {name: 'missing state', url: 'https://operator.example.com/operator/auth/github/callback?code=abc'},
+      {name: 'missing code', url: 'https://operator.example.com/operator/auth/github/callback?state=unknown'},
+      {
+        name: 'unknown state',
+        url: 'https://operator.example.com/operator/auth/github/callback?code=abc&state=unknown',
+      },
+      {
+        name: 'provider error',
+        url: 'https://operator.example.com/operator/auth/github/callback?error=access_denied&state=valid-state',
+        storeSetup: s => {
+          s.set('valid-state', {
+            codeVerifier: 'verifier',
+            issuedAt: Date.now(),
+            consumed: false,
+          })
+        },
+      },
+    ]
+
+    for (const scenario of scenarios) {
+      const stateStore = createInMemoryStateStore()
+      if (scenario.storeSetup !== undefined) scenario.storeSetup(stateStore)
+      const deps = makeStubDeps({stateStore})
+      const config = makeStubConfig()
+      const app = buildTestApp(deps, config)
+
+      // #when
+      const req = new Request(scenario.url)
+      const res = await app.fetch(req)
+
+      // #then — coarse 400 with consistent shape
+      expect(res.status, `scenario: ${scenario.name}`).toBe(400)
+      const body = (await res.json()) as Record<string, unknown>
+      expect(body, `scenario: ${scenario.name}`).toHaveProperty('error')
+      // Error message must be coarse — no internal details
+      const errorMsg = String(body.error)
+      expect(errorMsg, `scenario: ${scenario.name}`).not.toContain('state_mismatch')
+      expect(errorMsg, `scenario: ${scenario.name}`).not.toContain('verifier')
+      expect(errorMsg, `scenario: ${scenario.name}`).not.toContain('token')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// OAuth callback — future Fetch Metadata compatibility
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/auth/github/callback — future Fetch Metadata compatibility', () => {
+  it('accepts cross-site Sec-Fetch-Site header on the callback route', async () => {
+    // #given — state pre-seeded
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const deps = makeStubDeps({stateStore, clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — GitHub redirects cross-site (Sec-Fetch-Site: cross-site)
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+      {
+        headers: {
+          'sec-fetch-site': 'cross-site',
+          'sec-fetch-mode': 'navigate',
+        },
+      },
+    )
+    const res = await app.fetch(req)
+
+    // #then — callback accepts GitHub's cross-site redirect shape
+    expect(res.status).toBe(200)
+  })
+
+  it('callback route is registered as public (not privileged)', async () => {
+    // #given
+    const deps = makeStubDeps()
+    const config = makeStubConfig()
+    const app = new Hono()
+    registerPublicRoute(app, 'GET', '/operator/health', c => c.json({ok: true}))
+    buildGitHubOAuthRoutes(app, deps, config)
+
+    // #then — callback is public
+    expect(isPublicRoute(app, 'GET', '/operator/auth/github/callback')).toBe(true)
+  })
+
+  it('start route is registered as public (not privileged)', async () => {
+    // #given
+    const deps = makeStubDeps()
+    const config = makeStubConfig()
+    const app = new Hono()
+    registerPublicRoute(app, 'GET', '/operator/health', c => c.json({ok: true}))
+    buildGitHubOAuthRoutes(app, deps, config)
+
+    // #then — start is public
+    expect(isPublicRoute(app, 'GET', '/operator/auth/github/start')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Route inventory — OAuth-enabled buildOperatorApp
+// ---------------------------------------------------------------------------
+
+describe('buildGitHubOAuthRoutes — route inventory', () => {
+  it('registers exactly the expected OAuth routes as public', () => {
+    // #given
+    const deps = makeStubDeps()
+    const config = makeStubConfig()
+    const app = new Hono()
+    registerPublicRoute(app, 'GET', '/operator/health', c => c.json({ok: true}))
+    buildGitHubOAuthRoutes(app, deps, config)
+
+    // #then — both OAuth routes are registered as public
+    expect(isPublicRoute(app, 'GET', '/operator/auth/github/start')).toBe(true)
+    expect(isPublicRoute(app, 'GET', '/operator/auth/github/callback')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createInMemoryStateStore — unit tests
+// ---------------------------------------------------------------------------
+
+describe('createInMemoryStateStore', () => {
+  it('stores and retrieves state entries', () => {
+    // #given
+    const store = createInMemoryStateStore()
+    const entry = {codeVerifier: 'verifier', issuedAt: 1000, consumed: false}
+
+    // #when
+    store.set('state-key', entry)
+
+    // #then
+    expect(store.get('state-key')).toEqual(entry)
+  })
+
+  it('returns undefined for unknown keys', () => {
+    // #given
+    const store = createInMemoryStateStore()
+
+    // #when / #then
+    expect(store.get('nonexistent')).toBeUndefined()
+  })
+
+  it('marks an entry as consumed', () => {
+    // #given
+    const store = createInMemoryStateStore()
+    store.set('state-key', {codeVerifier: 'verifier', issuedAt: 1000, consumed: false})
+
+    // #when
+    store.consume('state-key')
+
+    // #then
+    const entry = store.get('state-key')
+    if (entry === undefined) throw new Error('expected entry to exist')
+    expect(entry.consumed).toBe(true)
+  })
+
+  it('counts outstanding (unconsumed) entries for a source key', () => {
+    // #given
+    const store = createInMemoryStateStore()
+    store.set('state-1', {codeVerifier: 'v1', issuedAt: 1000, consumed: false, sourceKey: 'ip-1'})
+    store.set('state-2', {codeVerifier: 'v2', issuedAt: 1000, consumed: false, sourceKey: 'ip-1'})
+    store.set('state-3', {codeVerifier: 'v3', issuedAt: 1000, consumed: true, sourceKey: 'ip-1'})
+    store.set('state-4', {codeVerifier: 'v4', issuedAt: 1000, consumed: false, sourceKey: 'ip-2'})
+
+    // #when / #then — only unconsumed entries for ip-1
+    expect(store.countOutstanding('ip-1')).toBe(2)
+    expect(store.countOutstanding('ip-2')).toBe(1)
+  })
+
+  it('reports correct size', () => {
+    // #given
+    const store = createInMemoryStateStore()
+
+    // #when
+    store.set('s1', {codeVerifier: 'v1', issuedAt: 1000, consumed: false})
+    store.set('s2', {codeVerifier: 'v2', issuedAt: 1000, consumed: false})
+
+    // #then
+    expect(store.size()).toBe(2)
+  })
+
+  it('evictStale removes consumed entries', () => {
+    // #given
+    const store = createInMemoryStateStore()
+    const now = 10_000
+    store.set('consumed', {codeVerifier: 'v1', issuedAt: now - 100, consumed: true})
+    store.set('active', {codeVerifier: 'v2', issuedAt: now - 100, consumed: false})
+
+    // #when
+    store.evictStale(now, 600_000)
+
+    // #then — consumed entry is removed; active entry remains
+    expect(store.get('consumed')).toBeUndefined()
+    expect(store.get('active')).toBeDefined()
+    expect(store.size()).toBe(1)
+  })
+
+  it('evictStale removes expired entries', () => {
+    // #given
+    const store = createInMemoryStateStore()
+    const ttlMs = 10 * 60 * 1000
+    const now = 100_000
+    store.set('expired', {codeVerifier: 'v1', issuedAt: now - ttlMs - 1, consumed: false})
+    store.set('fresh', {codeVerifier: 'v2', issuedAt: now - 1000, consumed: false})
+
+    // #when
+    store.evictStale(now, ttlMs)
+
+    // #then — expired entry is removed; fresh entry remains
+    expect(store.get('expired')).toBeUndefined()
+    expect(store.get('fresh')).toBeDefined()
+    expect(store.size()).toBe(1)
+  })
+
+  it('evictStale removes both consumed and expired entries in one pass', () => {
+    // #given
+    const store = createInMemoryStateStore()
+    const ttlMs = 10 * 60 * 1000
+    const now = 100_000
+    store.set('consumed', {codeVerifier: 'v1', issuedAt: now - 100, consumed: true})
+    store.set('expired', {codeVerifier: 'v2', issuedAt: now - ttlMs - 1, consumed: false})
+    store.set('active', {codeVerifier: 'v3', issuedAt: now - 1000, consumed: false})
+
+    // #when
+    store.evictStale(now, ttlMs)
+
+    // #then — only active entry remains
+    expect(store.size()).toBe(1)
+    expect(store.get('active')).toBeDefined()
+  })
+
+  it('evictStale with empty store is a no-op', () => {
+    // #given
+    const store = createInMemoryStateStore()
+
+    // #when / #then — no throw
+    expect(() => store.evictStale(Date.now(), 600_000)).not.toThrow()
+    expect(store.size()).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Auth start — global store ceiling (prevents unbounded Map growth)
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/auth/github/start — global store ceiling', () => {
+  it('rejects new starts when total live entries across all source keys meet the global cap', async () => {
+    // #given — many distinct source keys, each with one outstanding entry
+    // Use a small per-source cap (1) so each source key can mint exactly one entry.
+    // The global cap is what we are testing here: once total live entries reach it,
+    // /start must fail closed regardless of which source key is requesting.
+    const stateStore = createInMemoryStateStore()
+    let stateCounter = 0
+    let sourceCounter = 0
+
+    const deps = makeStubDeps({
+      stateStore,
+      generateState: () => `state-${++stateCounter}`,
+      // Each request gets a unique source key so per-source cap never triggers.
+      getSourceKey: () => `source-${++sourceCounter}`,
+    })
+    // Per-source cap is high (100) so it never fires; global cap is what we hit.
+    const config = makeStubConfig({maxOutstandingAttemptsPerKey: 100})
+    const app = buildTestApp(deps, config)
+
+    const makeReq = () => new Request('https://operator.example.com/operator/auth/github/start')
+
+    // #when — fill the store up to the global ceiling
+    // We need to know the ceiling value; import it from the module under test.
+    // Since it's an internal constant, we drive it via observable behavior:
+    // keep minting until we get a 429, then verify the store size is bounded.
+    const responses: Response[] = []
+    for (let i = 0; i < 1100; i++) {
+      const res = await app.fetch(makeReq())
+      responses.push(res)
+      if (res.status === 429) break
+    }
+
+    // #then — at least one request was rejected (global cap enforced)
+    const rejectedCount = responses.filter(r => r.status === 429).length
+    expect(rejectedCount).toBeGreaterThan(0)
+
+    // #and — the store size is bounded (did not grow to 1100)
+    expect(stateStore.size()).toBeLessThan(1100)
+  })
+
+  it('allows new starts after global ceiling entries expire (evict-before-count)', async () => {
+    // #given — fill store to global ceiling with distinct source keys, then advance clock
+    const ttlMs = 10 * 60 * 1000
+    const stateStore = createInMemoryStateStore()
+    let stateCounter = 0
+    let sourceCounter = 0
+    let currentTime = 1000
+
+    const deps = makeStubDeps({
+      stateStore,
+      generateState: () => `state-${++stateCounter}`,
+      getSourceKey: () => `source-${++sourceCounter}`,
+      clock: () => currentTime,
+    })
+    const config = makeStubConfig({maxOutstandingAttemptsPerKey: 100, stateTtlMs: ttlMs})
+    const app = buildTestApp(deps, config)
+
+    const makeReq = () => new Request('https://operator.example.com/operator/auth/github/start')
+
+    // Fill until we hit the global cap
+    for (let i = 0; i < 1100; i++) {
+      const res = await app.fetch(makeReq())
+      if (res.status === 429) break
+    }
+
+    // Verify we hit the cap
+    const capHitRes = await app.fetch(makeReq())
+    expect(capHitRes.status).toBe(429)
+
+    // #when — advance clock past TTL so all entries expire
+    currentTime = 1000 + ttlMs + 1
+
+    // #then — new start succeeds because evictStale runs before global size check
+    const resAfterExpiry = await app.fetch(makeReq())
+    expect(resAfterExpiry.status).toBe(302)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateReturnPath — backslash and encoded-slash regression tests
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/auth/github/start — validateReturnPath backslash/encoded-slash', () => {
+  it(String.raw`rejects backslash-prefixed path (\\evil.com open-redirect attempt)`, async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const deps = makeStubDeps({stateStore})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — backslash prefix: \evil.com
+    const req = new Request('https://operator.example.com/operator/auth/github/start?return_to=%5Cevil.com')
+    const res = await app.fetch(req)
+
+    // #then — rejected; no state minted (backslash does not start with /)
+    expect(res.status).toBe(400)
+    expect(stateStore.size()).toBe(0)
+  })
+
+  it('rejects encoded-slash path (/%2fevil.com open-redirect attempt)', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const deps = makeStubDeps({stateStore})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — encoded slash: /%2fevil.com (not in allowlist)
+    const req = new Request('https://operator.example.com/operator/auth/github/start?return_to=%2F%2Fevil.com')
+    const res = await app.fetch(req)
+
+    // #then — rejected; not in allowlist (exact-match allowlist prevents bypass)
+    expect(res.status).toBe(400)
+    expect(stateStore.size()).toBe(0)
+  })
+
+  it('rejects uppercase encoded-slash path (/%2Fevil.com)', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const deps = makeStubDeps({stateStore})
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config)
+
+    // #when — uppercase encoded slash: /%2Fevil.com
+    const req = new Request('https://operator.example.com/operator/auth/github/start?return_to=%2F%2Fevil.com')
+    const res = await app.fetch(req)
+
+    // #then — rejected; not in allowlist
+    expect(res.status).toBe(400)
+    expect(stateStore.size()).toBe(0)
+  })
+})

--- a/packages/gateway/src/web/auth/github.ts
+++ b/packages/gateway/src/web/auth/github.ts
@@ -1,0 +1,606 @@
+/**
+ * GitHub OAuth PKCE + state flow for the operator web surface.
+ *
+ * Implements:
+ *   - GET /operator/auth/github/start: generate PKCE S256 verifier server-side,
+ *     derive code challenge, generate cryptographic state, store server-side with
+ *     short TTL and outstanding-attempt cap, redirect to GitHub.
+ *   - GET /operator/auth/github/callback: validate state (one-time, TTL), exchange
+ *     code with PKCE verifier, fetch GitHub user, extract stable numeric id and
+ *     display login, emit audit events.
+ *
+ * Security invariants:
+ *   - Code verifier is NEVER written to a cookie or included in any browser-visible
+ *     response. It lives only in the server-side state store.
+ *   - State is one-time: consumed on first use, rejected on replay.
+ *   - Redirect targets are validated as same-origin/path-allowlisted before state mint.
+ *   - Callback route must remain compatible with future Fetch Metadata middleware
+ *     because GitHub redirects cross-site after authorization.
+ *   - All auth failure branches return the same coarse 400 response shape (no-oracle).
+ *   - Numeric GitHub user id is the authority; login is display metadata only.
+ *   - Source key for outstanding-attempt counting is injected by the caller and must
+ *     be derived from the TCP socket address, not from caller-spoofable headers.
+ *   - Callback validates that the current source key matches the source key bound at
+ *     state mint time, preventing cross-IP state replay.
+ */
+
+import type {Context, Hono} from 'hono'
+import type {RateLimiter} from '../../http/rate-limit.js'
+import type {AuditLogger} from '../audit.js'
+import {createHash, randomBytes} from 'node:crypto'
+import {emitAudit} from '../audit.js'
+import {registerPublicRoute} from '../operator-route.js'
+import {badRequestResponse, rateLimitedResponse} from '../safe-response.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A single OAuth state entry stored server-side. */
+export interface OAuthStateEntry {
+  /** PKCE code verifier — server-side only, never browser-visible. */
+  readonly codeVerifier: string
+  /** Timestamp (ms since epoch) when this state was issued. */
+  readonly issuedAt: number
+  /** Whether this state has been consumed (one-time use). */
+  consumed: boolean
+  /** Optional same-origin return path bound at state mint time. */
+  readonly redirectTarget?: string
+  /** Source key (socket IP) for outstanding-attempt counting. */
+  readonly sourceKey?: string
+}
+
+/** Server-side state store interface for OAuth state entries. */
+export interface OAuthStateStore {
+  /** Store a state entry. */
+  set: (stateValue: string, entry: OAuthStateEntry) => void
+  /** Retrieve a state entry by value. Returns undefined if not found. */
+  get: (stateValue: string) => OAuthStateEntry | undefined
+  /** Mark a state entry as consumed (one-time use). */
+  consume: (stateValue: string) => void
+  /** Count outstanding (unconsumed) entries for a given source key. */
+  countOutstanding: (sourceKey: string) => number
+  /** Total number of entries in the store. */
+  size: () => number
+  /**
+   * Evict consumed and expired entries from the store.
+   * Call periodically to bound memory growth.
+   */
+  evictStale: (nowMs: number, ttlMs: number) => void
+}
+
+/** Logger interface for the OAuth module. */
+export interface OAuthLogger {
+  readonly debug: (ctx: Record<string, unknown>, msg: string) => void
+  readonly info: (ctx: Record<string, unknown>, msg: string) => void
+  readonly warn: (ctx: Record<string, unknown>, msg: string) => void
+  readonly error: (ctx: Record<string, unknown>, msg: string) => void
+}
+
+/** Dependencies for the GitHub OAuth routes (injectable for testing). */
+export interface GitHubOAuthDeps {
+  readonly logger: OAuthLogger
+  readonly auditLogger: AuditLogger
+  /** Injectable fetch for token exchange and user fetch. Defaults to global fetch. */
+  readonly fetch: typeof globalThis.fetch
+  /** Injectable clock for TTL checks. Defaults to Date.now. */
+  readonly clock: () => number
+  /**
+   * Injectable PKCE code verifier generator.
+   * Must return a cryptographically random string of at least 43 characters.
+   * Defaults to a CSPRNG-based generator.
+   */
+  readonly generateVerifier: () => string
+  /**
+   * Injectable state value generator.
+   * Must return a cryptographically random string.
+   * Defaults to a CSPRNG-based generator.
+   */
+  readonly generateState: () => string
+  /** Server-side state store. */
+  readonly stateStore: OAuthStateStore
+  /**
+   * Injectable source key extractor for outstanding-attempt counting.
+   * Must return a key derived from the TCP socket address — NOT from
+   * caller-spoofable headers like X-Forwarded-For or X-Real-IP.
+   *
+   * In production, wire this to getConnInfo(c).remote.address with a
+   * 'unknown' fallback. In tests, return a fixed string.
+   *
+   * The global rate limiter in buildOperatorApp already applies socket-keyed
+   * limits; this key is used only for the per-OAuth-flow outstanding-attempt cap
+   * and for source key binding validation on callback.
+   */
+  readonly getSourceKey: (c: Context) => string
+  /**
+   * Rate limiter shared with the operator app.
+   * Applied to both /start and /callback before any work is performed.
+   * Must be the same instance as the one used in buildOperatorApp so that
+   * OAuth routes participate in the same per-socket budget.
+   */
+  readonly rateLimiter: RateLimiter
+}
+
+/** Configuration for the GitHub OAuth PKCE + state routes. */
+export interface GitHubOAuthConfig {
+  /** GitHub OAuth App client ID. */
+  readonly clientId: string
+  /** GitHub OAuth App client secret. Never logged or browser-visible. */
+  readonly clientSecret: string
+  /**
+   * Public HTTPS origin for the operator surface.
+   * Used to build the callback redirect_uri and validate return paths.
+   * Example: 'https://operator.example.com'
+   */
+  readonly publicOrigin: string
+  /**
+   * Path for the OAuth callback route.
+   * Example: '/operator/auth/github/callback'
+   */
+  readonly callbackPath: string
+  /**
+   * Allowlisted same-origin return paths for post-auth redirect.
+   * Only paths in this list are accepted as return_to targets.
+   */
+  readonly allowedReturnPaths: readonly string[]
+  /**
+   * Maximum outstanding (unconsumed) OAuth attempts per source key.
+   * Prevents state store exhaustion from unauthenticated floods.
+   */
+  readonly maxOutstandingAttemptsPerKey: number
+  /**
+   * TTL for OAuth state entries in milliseconds.
+   * State older than this is rejected as expired.
+   * Default: 10 minutes (600_000 ms).
+   */
+  readonly stateTtlMs: number
+}
+
+// ---------------------------------------------------------------------------
+// Production factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build production GitHubOAuthDeps with real CSPRNG generators, global fetch,
+ * Date.now clock, and a fresh in-memory state store.
+ *
+ * The caller must supply logger, auditLogger, getSourceKey, and rateLimiter
+ * because those depend on the surrounding server context (logger from program.ts,
+ * source key from getConnInfo which requires the Hono context, rateLimiter from
+ * the shared operator app instance).
+ */
+export function buildGitHubOAuthDeps(
+  logger: OAuthLogger,
+  auditLogger: AuditLogger,
+  getSourceKey: (c: Context) => string,
+  rateLimiter: RateLimiter,
+): GitHubOAuthDeps {
+  return {
+    logger,
+    auditLogger,
+    fetch: globalThis.fetch,
+    clock: () => Date.now(),
+    generateVerifier: () => randomBytes(32).toString('base64url'),
+    generateState: () => randomBytes(32).toString('base64url'),
+    stateStore: createInMemoryStateStore(),
+    getSourceKey,
+    rateLimiter,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory state store
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a simple in-memory OAuth state store.
+ *
+ * Suitable for v1 single-process deployment. Gateway restart clears all state
+ * (global logout for in-flight OAuth flows — acceptable for v1).
+ *
+ * Supports eviction of consumed and expired entries via evictStale() to bound
+ * memory growth. Call evictStale() periodically or on each request.
+ */
+export function createInMemoryStateStore(): OAuthStateStore {
+  const entries = new Map<string, OAuthStateEntry>()
+
+  return {
+    set(stateValue: string, entry: OAuthStateEntry): void {
+      entries.set(stateValue, entry)
+    },
+
+    get(stateValue: string): OAuthStateEntry | undefined {
+      return entries.get(stateValue)
+    },
+
+    consume(stateValue: string): void {
+      const entry = entries.get(stateValue)
+      if (entry !== undefined) {
+        entry.consumed = true
+      }
+    },
+
+    countOutstanding(sourceKey: string): number {
+      let count = 0
+      for (const entry of entries.values()) {
+        if (entry.sourceKey === sourceKey && entry.consumed === false) {
+          count++
+        }
+      }
+      return count
+    },
+
+    size(): number {
+      return entries.size
+    },
+
+    evictStale(nowMs: number, ttlMs: number): void {
+      for (const [key, entry] of entries) {
+        if (entry.consumed === true || nowMs - entry.issuedAt > ttlMs) {
+          entries.delete(key)
+        }
+      }
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PKCE helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the S256 code challenge from a PKCE code verifier.
+ * SHA-256 hash of the verifier, base64url-encoded (no padding).
+ */
+function deriveCodeChallenge(verifier: string): string {
+  const hash = createHash('sha256').update(verifier, 'ascii').digest()
+  // base64url: replace + with -, / with _, strip trailing =
+  return hash.toString('base64').replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '')
+}
+
+// ---------------------------------------------------------------------------
+// Redirect target validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a return_to path as same-origin and allowlisted.
+ *
+ * Returns the validated path string, or null if invalid.
+ * Rejects:
+ *   - Absolute URLs (http://, https://, //)
+ *   - Paths not in the allowlist
+ *   - Empty strings
+ */
+function validateReturnPath(returnTo: string, allowedPaths: readonly string[]): string | null {
+  if (returnTo === '') return null
+
+  // Reject absolute URLs and protocol-relative URLs
+  if (/^https?:\/\//i.test(returnTo)) return null
+  if (returnTo.startsWith('//')) return null
+
+  // Must start with /
+  if (returnTo.startsWith('/') === false) return null
+
+  // Must be in the allowlist (exact match)
+  if (allowedPaths.includes(returnTo) === false) return null
+
+  return returnTo
+}
+
+// ---------------------------------------------------------------------------
+// Typed JSON parse helpers
+// ---------------------------------------------------------------------------
+
+interface TokenResponse {
+  readonly access_token: string
+}
+
+interface UserResponse {
+  readonly id: number
+  readonly login: string
+}
+
+function parseTokenResponse(data: unknown): TokenResponse | null {
+  if (typeof data !== 'object' || data === null) return null
+  const obj = data as Record<string, unknown>
+  if (typeof obj.access_token !== 'string' || obj.access_token === '') return null
+  return {access_token: obj.access_token}
+}
+
+function parseUserResponse(data: unknown): UserResponse | null {
+  if (typeof data !== 'object' || data === null) return null
+  const obj = data as Record<string, unknown>
+  if (typeof obj.id !== 'number' || Number.isInteger(obj.id) === false || obj.id <= 0) return null
+  if (typeof obj.login !== 'string' || obj.login === '') return null
+  return {id: obj.id, login: obj.login}
+}
+
+// ---------------------------------------------------------------------------
+// Fetch timeout
+// ---------------------------------------------------------------------------
+
+/** Timeout for external GitHub API calls (token exchange and user fetch). */
+const GITHUB_FETCH_TIMEOUT_MS = 8_000
+
+/**
+ * Global ceiling on total live entries in the OAuth state store across all source keys.
+ *
+ * Prevents unbounded Map growth when many distinct source keys each stay below the
+ * per-source outstanding cap. Once the store reaches this size, /start fails closed
+ * until stale entries are evicted (evictStale runs before the check on every request).
+ *
+ * Sized to be generous for legitimate concurrent flows (1000 simultaneous OAuth starts
+ * across all users) while bounding worst-case memory to ~1 MB (each entry is ~200 bytes).
+ */
+const MAX_GLOBAL_STATE_STORE_ENTRIES = 1_000
+
+// ---------------------------------------------------------------------------
+// Route builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Register the GitHub OAuth start and callback routes on the given Hono app.
+ *
+ * Both routes are registered as public (unauthenticated) via registerPublicRoute.
+ * The callback route is compatible with future Fetch Metadata middleware because
+ * GitHub redirects cross-site after authorization.
+ *
+ * Both routes apply the shared rate limiter before any work. The rate limiter
+ * must be the same instance used in buildOperatorApp so OAuth routes participate
+ * in the same per-socket budget.
+ *
+ * Call this from buildOperatorApp after the global middleware is set up.
+ */
+export function buildGitHubOAuthRoutes(app: Hono, deps: GitHubOAuthDeps, config: GitHubOAuthConfig): void {
+  const callbackUri = `${config.publicOrigin}${config.callbackPath}`
+
+  // ── GET /operator/auth/github/start ────────────────────────────────────────
+
+  registerPublicRoute(app, 'GET', '/operator/auth/github/start', async (c: Context): Promise<Response> => {
+    // Determine source key for rate limiting and outstanding-attempt counting.
+    // Must be derived from the TCP socket address (not caller-spoofable headers).
+    const sourceKey = deps.getSourceKey(c)
+
+    // Rate limit check — shared with the operator app, keyed on socket address.
+    if (deps.rateLimiter.allow(sourceKey) === false) {
+      deps.logger.warn({}, 'oauth start rejected: rate limited')
+      return rateLimitedResponse(c)
+    }
+
+    // Evict stale entries before counting outstanding so expired unconsumed
+    // entries do not permanently block new starts once the cap is reached.
+    deps.stateStore.evictStale(deps.clock(), config.stateTtlMs)
+
+    // Check outstanding attempt cap before doing any work.
+    const outstanding = deps.stateStore.countOutstanding(sourceKey)
+    if (outstanding >= config.maxOutstandingAttemptsPerKey) {
+      deps.logger.warn({}, 'oauth start rejected: outstanding attempt cap exceeded')
+      return rateLimitedResponse(c)
+    }
+
+    // Check global store ceiling to prevent unbounded Map growth across distinct source keys.
+    if (deps.stateStore.size() >= MAX_GLOBAL_STATE_STORE_ENTRIES) {
+      deps.logger.warn({}, 'oauth start rejected: global state store ceiling reached')
+      return rateLimitedResponse(c)
+    }
+
+    // Validate return_to before minting state.
+    const returnTo = c.req.query('return_to')
+    let redirectTarget: string | undefined
+    if (returnTo !== undefined && returnTo !== '') {
+      const validated = validateReturnPath(returnTo, config.allowedReturnPaths)
+      if (validated === null) {
+        deps.logger.warn({}, 'oauth start rejected: invalid return_to target')
+        return badRequestResponse(c)
+      }
+      redirectTarget = validated
+    }
+
+    // Generate PKCE verifier and state — server-side only.
+    const codeVerifier = deps.generateVerifier()
+    const stateValue = deps.generateState()
+    const codeChallenge = deriveCodeChallenge(codeVerifier)
+
+    // Store state server-side. Code verifier NEVER leaves the server.
+    deps.stateStore.set(stateValue, {
+      codeVerifier,
+      issuedAt: deps.clock(),
+      consumed: false,
+      ...(redirectTarget === undefined ? {} : {redirectTarget}),
+      sourceKey,
+    })
+
+    // Emit auth.start audit event.
+    emitAudit({kind: 'auth.start', correlationId: stateValue}, deps.auditLogger)
+
+    // Build GitHub authorization URL.
+    const authUrl = new URL('https://github.com/login/oauth/authorize')
+    authUrl.searchParams.set('client_id', config.clientId)
+    authUrl.searchParams.set('redirect_uri', callbackUri)
+    authUrl.searchParams.set('state', stateValue)
+    authUrl.searchParams.set('code_challenge', codeChallenge)
+    authUrl.searchParams.set('code_challenge_method', 'S256')
+    authUrl.searchParams.set('scope', 'read:user')
+
+    return c.redirect(authUrl.toString(), 302)
+  })
+
+  // ── GET /operator/auth/github/callback ─────────────────────────────────────
+  //
+  // GitHub redirects the browser cross-site after authorization, so future
+  // Fetch Metadata middleware must allow this callback route to receive
+  // Sec-Fetch-Site: cross-site.
+
+  registerPublicRoute(app, 'GET', config.callbackPath, async (c: Context): Promise<Response> => {
+    // Determine source key for rate limiting and source key binding validation.
+    const sourceKey = deps.getSourceKey(c)
+
+    // Rate limit check — shared with the operator app, keyed on socket address.
+    if (deps.rateLimiter.allow(sourceKey) === false) {
+      deps.logger.warn({}, 'oauth callback rejected: rate limited')
+      return rateLimitedResponse(c)
+    }
+
+    // Correlation ID for audit events — use state value if present, else 'unknown'.
+    const stateParam = c.req.query('state')
+    const correlationId = stateParam ?? 'unknown'
+
+    // Check for GitHub error param (provider_error).
+    const errorParam = c.req.query('error')
+    if (errorParam !== undefined) {
+      // Only consume the state if it exists, is unconsumed, is not expired, and
+      // the source key matches the one bound at mint time. This prevents a
+      // different source from burning another source's state via a crafted
+      // error callback.
+      if (stateParam !== undefined && stateParam !== '') {
+        const stateEntry = deps.stateStore.get(stateParam)
+        const nowMs = deps.clock()
+        if (
+          stateEntry !== undefined &&
+          stateEntry.consumed === false &&
+          nowMs - stateEntry.issuedAt <= config.stateTtlMs &&
+          (stateEntry.sourceKey === undefined || stateEntry.sourceKey === sourceKey)
+        ) {
+          deps.stateStore.consume(stateParam)
+        }
+      }
+      deps.logger.warn({}, 'oauth callback: provider returned error')
+      emitAudit({kind: 'auth.callback.failure', correlationId, reason: 'provider_error'}, deps.auditLogger)
+      return badRequestResponse(c)
+    }
+
+    // Validate required params.
+    const codeParam = c.req.query('code')
+    if (stateParam === undefined || stateParam === '') {
+      deps.logger.warn({}, 'oauth callback: missing state param')
+      emitAudit({kind: 'auth.callback.failure', correlationId: 'unknown', reason: 'state_mismatch'}, deps.auditLogger)
+      return badRequestResponse(c)
+    }
+    if (codeParam === undefined || codeParam === '') {
+      deps.logger.warn({}, 'oauth callback: missing code param')
+      emitAudit({kind: 'auth.callback.failure', correlationId, reason: 'state_mismatch'}, deps.auditLogger)
+      return badRequestResponse(c)
+    }
+
+    // Look up state server-side.
+    const stateEntry = deps.stateStore.get(stateParam)
+    if (stateEntry === undefined) {
+      deps.logger.warn({}, 'oauth callback: unknown state')
+      emitAudit({kind: 'auth.callback.failure', correlationId, reason: 'state_mismatch'}, deps.auditLogger)
+      return badRequestResponse(c)
+    }
+
+    // One-time consumption check.
+    if (stateEntry.consumed === true) {
+      deps.logger.warn({}, 'oauth callback: replayed state')
+      emitAudit({kind: 'auth.callback.failure', correlationId, reason: 'state_mismatch'}, deps.auditLogger)
+      return badRequestResponse(c)
+    }
+
+    // TTL check.
+    const now = deps.clock()
+    if (now - stateEntry.issuedAt > config.stateTtlMs) {
+      deps.logger.warn({}, 'oauth callback: expired state')
+      emitAudit({kind: 'auth.callback.failure', correlationId, reason: 'state_mismatch'}, deps.auditLogger)
+      return badRequestResponse(c)
+    }
+
+    // Source key binding check — reject if the callback comes from a different
+    // socket address than the one that initiated the flow. Uses the socket-derived
+    // key only; never caller-spoofable headers.
+    if (stateEntry.sourceKey !== undefined && stateEntry.sourceKey !== sourceKey) {
+      deps.logger.warn({}, 'oauth callback: source key mismatch')
+      emitAudit({kind: 'auth.callback.failure', correlationId, reason: 'source_key_mismatch'}, deps.auditLogger)
+      return badRequestResponse(c)
+    }
+
+    // Consume state (one-time use) before any external calls.
+    // This preserves the consume-before-external-await invariant.
+    deps.stateStore.consume(stateParam)
+
+    // Exchange code for access token using PKCE verifier.
+    let accessToken: string
+    try {
+      const tokenBody = new URLSearchParams({
+        client_id: config.clientId,
+        client_secret: config.clientSecret,
+        code: codeParam,
+        redirect_uri: callbackUri,
+        code_verifier: stateEntry.codeVerifier,
+      })
+
+      const tokenRes = await deps.fetch('https://github.com/login/oauth/access_token', {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        body: tokenBody,
+        signal: AbortSignal.timeout(GITHUB_FETCH_TIMEOUT_MS),
+      })
+
+      if (tokenRes.ok === false) {
+        deps.logger.warn({}, 'oauth callback: token exchange HTTP error')
+        emitAudit({kind: 'auth.callback.failure', correlationId, reason: 'token_exchange_failed'}, deps.auditLogger)
+        return badRequestResponse(c)
+      }
+
+      const tokenData = parseTokenResponse(await tokenRes.json())
+      if (tokenData === null) {
+        deps.logger.warn({}, 'oauth callback: token exchange returned no access_token')
+        emitAudit({kind: 'auth.callback.failure', correlationId, reason: 'token_exchange_failed'}, deps.auditLogger)
+        return badRequestResponse(c)
+      }
+
+      accessToken = tokenData.access_token
+    } catch {
+      deps.logger.warn({}, 'oauth callback: token exchange threw')
+      emitAudit({kind: 'auth.callback.failure', correlationId, reason: 'token_exchange_failed'}, deps.auditLogger)
+      return badRequestResponse(c)
+    }
+
+    // Fetch authenticated GitHub user.
+    let githubUserId: number
+    let login: string
+    try {
+      const userRes = await deps.fetch('https://api.github.com/user', {
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          accept: 'application/vnd.github+json',
+          'x-github-api-version': '2022-11-28',
+        },
+        signal: AbortSignal.timeout(GITHUB_FETCH_TIMEOUT_MS),
+      })
+
+      if (userRes.ok === false) {
+        deps.logger.warn({}, 'oauth callback: user fetch HTTP error')
+        emitAudit({kind: 'auth.callback.failure', correlationId, reason: 'user_fetch_failed'}, deps.auditLogger)
+        return badRequestResponse(c)
+      }
+
+      const userData = parseUserResponse(await userRes.json())
+      if (userData === null) {
+        deps.logger.warn({}, 'oauth callback: user fetch returned invalid id or login')
+        emitAudit({kind: 'auth.callback.failure', correlationId, reason: 'user_fetch_failed'}, deps.auditLogger)
+        return badRequestResponse(c)
+      }
+
+      githubUserId = userData.id
+      login = userData.login
+    } catch {
+      deps.logger.warn({}, 'oauth callback: user fetch threw')
+      emitAudit({kind: 'auth.callback.failure', correlationId, reason: 'user_fetch_failed'}, deps.auditLogger)
+      return badRequestResponse(c)
+    }
+
+    // Emit success audit event.
+    emitAudit({kind: 'auth.callback.success', correlationId, githubUserId, login}, deps.auditLogger)
+
+    deps.logger.info({githubUserId}, 'oauth callback: identity verified')
+
+    // Identity is verified. Session minting is handled by the session layer
+    // (not yet wired). Return a coarse success response until the session layer
+    // is in place; the session layer will replace this with a cookie + redirect.
+    return c.json({githubUserId, login}, 200)
+  })
+}

--- a/packages/gateway/src/web/server.test.ts
+++ b/packages/gateway/src/web/server.test.ts
@@ -18,12 +18,14 @@
 import type {AddressInfo} from 'node:net'
 import type {ServerType} from '@hono/node-server'
 
+import type {GitHubOAuthConfig, GitHubOAuthDeps} from './auth/github.js'
 import type {OperatorServerConfig, OperatorServerDeps} from './server.js'
 import {Buffer} from 'node:buffer'
 import {createServer} from 'node:http'
 
 import {describe, expect, it, vi} from 'vitest'
 import {createRateLimiter} from '../http/rate-limit.js'
+import {createInMemoryStateStore} from './auth/github.js'
 import {buildOperatorApp, createOperatorServer} from './server.js'
 
 // ---------------------------------------------------------------------------
@@ -120,6 +122,118 @@ describe('buildOperatorApp — route inventory', () => {
 
     // #then — only the health route is registered (no privileged routes yet)
     expect(routes).toEqual([{method: 'GET', path: '/operator/health'}])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Helpers — GitHub OAuth stubs (used only in the OAuth route tests below)
+// ---------------------------------------------------------------------------
+
+function makeStubGitHubOAuthDeps(overrides?: Partial<GitHubOAuthDeps>): GitHubOAuthDeps {
+  return {
+    logger: makeLogger(),
+    auditLogger: {info: vi.fn(), warn: vi.fn()},
+    fetch: vi.fn(async () => new Response('{}', {status: 200, headers: {'content-type': 'application/json'}})),
+    clock: () => Date.now(),
+    generateVerifier: () => 'stub-verifier-32-bytes-long-enough-for-pkce',
+    generateState: () => 'stub-state-value-32-bytes-long-ok',
+    stateStore: createInMemoryStateStore(),
+    getSourceKey: () => 'stub-source-key',
+    // rateLimiter is overwritten by buildOperatorApp with the shared instance;
+    // provide a pass-through stub so the type is satisfied.
+    rateLimiter: {allow: () => true},
+    ...overrides,
+  }
+}
+
+function makeStubGitHubOAuthConfig(overrides?: Partial<GitHubOAuthConfig>): GitHubOAuthConfig {
+  return {
+    clientId: 'stub-client-id',
+    clientSecret: 'stub-client-secret',
+    publicOrigin: 'https://operator.example.com',
+    callbackPath: '/operator/auth/github/callback',
+    allowedReturnPaths: ['/operator/dashboard'],
+    maxOutstandingAttemptsPerKey: 5,
+    stateTtlMs: 10 * 60 * 1000,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// buildOperatorApp — OAuth route registration
+// ---------------------------------------------------------------------------
+
+describe('buildOperatorApp — OAuth route registration', () => {
+  it('registers /operator/auth/github/start and /operator/auth/github/callback when both deps.githubOAuth and config.githubOAuth are provided', () => {
+    // #given — both OAuth deps and config are present
+    const app = buildOperatorApp(
+      makeStubDeps({githubOAuth: makeStubGitHubOAuthDeps()}),
+      makeStubConfig({githubOAuth: makeStubGitHubOAuthConfig()}),
+    )
+
+    // #when — extract unique logical routes (excluding global middleware)
+    const seen = new Set<string>()
+    const routes = app.routes
+      .map((route: RouteEntry) => ({method: route.method, path: route.path}))
+      .filter((route: RouteEntry) => {
+        if (route.method === 'ALL' && route.path === '/*') return false
+        const key = `${route.method}:${route.path}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+
+    // #then — health + both OAuth routes are registered
+    expect(routes).toContainEqual({method: 'GET', path: '/operator/health'})
+    expect(routes).toContainEqual({method: 'GET', path: '/operator/auth/github/start'})
+    expect(routes).toContainEqual({method: 'GET', path: '/operator/auth/github/callback'})
+    expect(routes).toHaveLength(3)
+  })
+
+  it('registers only /operator/health when neither deps.githubOAuth nor config.githubOAuth are provided', () => {
+    // #given — no OAuth deps or config
+    const app = buildOperatorApp(makeStubDeps(), makeStubConfig())
+
+    // #when
+    const seen = new Set<string>()
+    const routes = app.routes
+      .map((route: RouteEntry) => ({method: route.method, path: route.path}))
+      .filter((route: RouteEntry) => {
+        if (route.method === 'ALL' && route.path === '/*') return false
+        const key = `${route.method}:${route.path}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+
+    // #then — only health route
+    expect(routes).toEqual([{method: 'GET', path: '/operator/health'}])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildOperatorApp — partial OAuth config is a programming error
+// ---------------------------------------------------------------------------
+
+describe('buildOperatorApp — partial OAuth config programming error', () => {
+  it('throws when deps.githubOAuth is set but config.githubOAuth is absent', () => {
+    // #given — only deps side is provided
+    expect(() =>
+      buildOperatorApp(
+        makeStubDeps({githubOAuth: makeStubGitHubOAuthDeps()}),
+        makeStubConfig(), // no githubOAuth in config
+      ),
+    ).toThrow('programming error')
+  })
+
+  it('throws when config.githubOAuth is set but deps.githubOAuth is absent', () => {
+    // #given — only config side is provided
+    expect(() =>
+      buildOperatorApp(
+        makeStubDeps(), // no githubOAuth in deps
+        makeStubConfig({githubOAuth: makeStubGitHubOAuthConfig()}),
+      ),
+    ).toThrow('programming error')
   })
 })
 

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -5,7 +5,7 @@
  * returns the @hono/node-server handle so the caller (program.ts) can close
  * it during graceful shutdown.
  *
- * Current posture (classification/guardrail only — no auth yet):
+ * Current posture:
  *   - Listener binds to the configured gateway-net host/port only.
  *     Never 0.0.0.0, loopback, or sandbox-net for production config.
  *   - TLS is terminated by the infra reverse proxy at GATEWAY_OPERATOR_PUBLIC_ORIGIN.
@@ -14,17 +14,21 @@
  *     Requests with mismatched forwarded headers are rejected 400.
  *   - Unauthenticated socket-keyed rate limiting and body-size limits are applied.
  *   - All responses pass through safe-response helpers (coarse, no-oracle).
- *   - No privileged routes registered yet; auth routes land when the auth boundary is in place.
+ *   - GitHub OAuth start and callback routes are registered as public (unauthenticated).
+ *     The callback route must remain compatible with future Fetch Metadata middleware
+ *     because GitHub redirects cross-site after authorization.
  *
  * Mirror of packages/gateway/src/http/server.ts for the serve()/handle pattern.
  */
 
 import type {ServerType} from '@hono/node-server'
+import type {GitHubOAuthConfig, GitHubOAuthDeps} from './auth/github.js'
 import {serve} from '@hono/node-server'
 import {getConnInfo} from '@hono/node-server/conninfo'
 import {Hono} from 'hono'
 import {bodyLimit} from 'hono/body-limit'
 import {createRateLimiter} from '../http/rate-limit.js'
+import {buildGitHubOAuthRoutes} from './auth/github.js'
 import {assertAllPrivilegedRoutesWrapped, registerPublicRoute} from './operator-route.js'
 import {
   badRequestResponse,
@@ -80,6 +84,12 @@ export interface OperatorServerDeps {
   readonly rateLimiter?: import('../http/rate-limit.js').RateLimiter
   /** Injectable clock for testability. */
   readonly clock?: () => number
+  /**
+   * Optional GitHub OAuth dependencies for the auth routes.
+   * When present, the GitHub OAuth start and callback routes are registered.
+   * When absent, the auth routes are not registered (opt-in).
+   */
+  readonly githubOAuth?: GitHubOAuthDeps
 }
 
 export interface OperatorServerConfig {
@@ -97,6 +107,13 @@ export interface OperatorServerConfig {
    * Example: 'https://operator.example.com'
    */
   readonly publicOrigin: string
+  /**
+   * Optional GitHub OAuth configuration for the auth routes.
+   * When present (alongside deps.githubOAuth), the GitHub OAuth start and
+   * callback routes are registered. When absent, the auth routes are not
+   * registered (opt-in).
+   */
+  readonly githubOAuth?: GitHubOAuthConfig
 }
 
 // ---------------------------------------------------------------------------
@@ -296,6 +313,27 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
     }
     return okResponse(c)
   })
+
+  // ── GitHub OAuth routes ────────────────────────────────────────────────────
+  //
+  // Registered only when both deps.githubOAuth and config.githubOAuth are present.
+  // Both must be provided together — partial config is a programming error.
+  //
+  // Routes registered:
+  //   GET /operator/auth/github/start    — public, unauthenticated
+  //   GET /operator/auth/github/callback — public OAuth redirect callback
+  if (deps.githubOAuth !== undefined && config.githubOAuth !== undefined) {
+    // Thread the shared rate limiter into the OAuth deps so both OAuth routes
+    // participate in the same per-socket budget as the health route.
+    const oauthDepsWithRateLimiter = {...deps.githubOAuth, rateLimiter}
+    buildGitHubOAuthRoutes(app, oauthDepsWithRateLimiter, config.githubOAuth)
+  } else if (deps.githubOAuth !== undefined || config.githubOAuth !== undefined) {
+    // Partial config: one is set but not the other. This is a programming error.
+    throw new Error(
+      'buildOperatorApp: deps.githubOAuth and config.githubOAuth must both be present or both absent. ' +
+        'Partial GitHub OAuth config is a programming error.',
+    )
+  }
 
   // ── Catch-all ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds the Gateway operator web GitHub OAuth foundation:

- registers public OAuth start/callback routes behind explicit operator-web config
- implements PKCE S256, server-side state, return-path validation, source-key binding, bounded state eviction, and GitHub fetch timeouts
- wires OAuth config/dependencies through gateway config and program startup
- extends audit failure reasons and route inventory pins for the new auth surface

This does not mint sessions, enforce allowlists, add CSRF middleware, or expose privileged operator actions. Those stay in later Phase B units.

## Verification

- `pnpm --filter @fro-bot/gateway test -- src/web/auth/github.test.ts src/web/server.test.ts src/http/ingress-pin.test.ts src/config.test.ts src/program.test.ts src/web/audit.test.ts`
- `pnpm --filter @fro-bot/gateway check-types`
- `pnpm --filter @fro-bot/gateway lint`
- `pnpm --filter @fro-bot/gateway build`
