### PR TITLE
feat(gateway): add operator session foundation

### DIFF
--- a/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
+++ b/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
@@ -485,7 +485,7 @@ The web listener is an adapter layer. It authenticates the operator, projects sa
   **Verification:**
   - OAuth flow is PKCE-enforced, state-validated, and identity-anchored to stable numeric GitHub id.
 
-- [ ] **Unit 3d: Session store, cookies, logout, and revocation hook**
+- [x] **Unit 3d: Session store, cookies, logout, and revocation hook**
 
   **Goal:** Mint server-side opaque sessions after successful identity verification, enforce session lifetime and revocation, and provide the logout route.
 

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -32,6 +32,7 @@ import {createRateLimiter} from './http/rate-limit.js'
 import {forceReleaseStaleLockEffect} from './runtime-effect.js'
 import {installShutdownHandlers, isShuttingDown} from './shutdown.js'
 import {buildGitHubOAuthDeps} from './web/auth/github.js'
+import {createInMemorySessionStore} from './web/auth/session.js'
 import {createWorkspaceClient} from './workspace-api/client.js'
 import {ensureWorkspaceClone} from './workspace-api/ensure-clone.js'
 
@@ -399,8 +400,25 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
       // participate in the same per-socket budget as the health route.
       const operatorRateLimiter = createRateLimiter({limit: 20, windowMs: 60_000})
 
+      // Build the shared in-memory session store for the operator surface.
+      // Gateway restart is global logout — acceptable for v1.
+      const sessionStore = createInMemorySessionStore()
+      const sessionDeps = {
+        logger,
+        auditLogger: logger,
+        clock: () => Date.now(),
+      }
+
       // Build production GitHub OAuth deps with real CSPRNG, fetch, and clock.
-      const githubOAuthDeps = buildGitHubOAuthDeps(logger, logger, getSourceKey, operatorRateLimiter)
+      // Pass the session store so successful callbacks mint a fresh session.
+      const githubOAuthDeps = buildGitHubOAuthDeps(
+        logger,
+        logger,
+        getSourceKey,
+        operatorRateLimiter,
+        sessionStore,
+        sessionDeps,
+      )
 
       operatorServerHandle = deps.startOperatorServer(
         {
@@ -408,6 +426,8 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           isShuttingDown,
           rateLimiter: operatorRateLimiter,
           githubOAuth: githubOAuthDeps,
+          sessionStore,
+          sessionDeps,
         },
         {
           bindHost: config.operatorWeb.bindHost,

--- a/packages/gateway/src/web/auth/github.test.ts
+++ b/packages/gateway/src/web/auth/github.test.ts
@@ -28,11 +28,13 @@
 import type {RateLimiter} from '../../http/rate-limit.js'
 import type {AuditLogger} from '../audit.js'
 import type {GitHubOAuthConfig, GitHubOAuthDeps, OAuthStateStore} from './github.js'
+import type {SessionDeps, SessionStore} from './session.js'
 import {createHash} from 'node:crypto'
 import {Hono} from 'hono'
 import {describe, expect, it, vi} from 'vitest'
 import {assertAllPrivilegedRoutesWrapped, isPublicRoute, registerPublicRoute} from '../operator-route.js'
 import {buildGitHubOAuthRoutes, createInMemoryStateStore} from './github.js'
+import {createInMemorySessionStore, SESSION_COOKIE_NAME} from './session.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1678,5 +1680,434 @@ describe('GET /operator/auth/github/start — validateReturnPath backslash/encod
     // #then — rejected; not in allowlist
     expect(res.status).toBe(400)
     expect(stateStore.size()).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// OAuth callback — session minting
+// ---------------------------------------------------------------------------
+
+function makeStubSessionDeps(overrides?: Partial<SessionDeps>): SessionDeps {
+  return {
+    logger: makeLogger(),
+    auditLogger: {info: vi.fn(), warn: vi.fn()},
+    clock: () => Date.now(),
+    ...overrides,
+  }
+}
+
+/** Build a test app with session store wired into OAuth deps. */
+function buildTestAppWithSession(
+  deps: GitHubOAuthDeps,
+  config: GitHubOAuthConfig,
+  sessionStore: SessionStore,
+  sessionDeps: SessionDeps,
+): Hono {
+  const app = new Hono()
+  registerPublicRoute(app, 'GET', '/operator/health', c => c.json({ok: true}))
+  buildGitHubOAuthRoutes(app, {...deps, sessionStore, sessionDeps}, config)
+  assertAllPrivilegedRoutesWrapped(app)
+  return app
+}
+
+describe('GET /operator/auth/github/callback — session minting', () => {
+  it('mints a fresh session on successful callback and sets __Host- session cookie', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestAppWithSession(deps, config, sessionStore, sessionDeps)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — success
+    expect(res.status).toBe(200)
+
+    // #and — session was created in the store
+    expect(sessionStore.size()).toBe(1)
+
+    // #and — Set-Cookie header contains the session cookie
+    const setCookieHeaders = res.headers.getSetCookie()
+    const sessionCookie = setCookieHeaders.find(h => h.startsWith(`${SESSION_COOKIE_NAME}=`))
+    expect(sessionCookie).toBeDefined()
+  })
+
+  it('session cookie has HttpOnly, Secure, SameSite=Lax, Path=/ attributes', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestAppWithSession(deps, config, sessionStore, sessionDeps)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — cookie attributes
+    const setCookieHeaders = res.headers.getSetCookie()
+    const sessionCookie = setCookieHeaders.find(h => h.startsWith(`${SESSION_COOKIE_NAME}=`)) ?? ''
+    expect(sessionCookie.toLowerCase()).toContain('httponly')
+    expect(sessionCookie.toLowerCase()).toContain('secure')
+    expect(sessionCookie.toLowerCase()).toContain('samesite=lax')
+    expect(sessionCookie).toContain('Path=/')
+    expect(sessionCookie.toLowerCase()).not.toContain('domain=')
+  })
+
+  it('session cookie does not have Max-Age=0 (not a clear cookie)', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestAppWithSession(deps, config, sessionStore, sessionDeps)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — the session cookie is not a clear cookie
+    const setCookieHeaders = res.headers.getSetCookie()
+    const sessionCookie = setCookieHeaders.find(h => h.startsWith(`${SESSION_COOKIE_NAME}=`)) ?? ''
+    expect(sessionCookie.toLowerCase()).not.toContain('max-age=0')
+  })
+
+  it('clears stale pre-auth session cookie before setting the new session cookie', async () => {
+    // #given — a stale session already exists in the store
+    const stateStore = createInMemoryStateStore()
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+
+    const staleSessionId = sessionStore.create({githubUserId: 99, login: 'stale'}, now)
+    if (staleSessionId === undefined) throw new Error('expected stale session to be created')
+
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestAppWithSession(deps, config, sessionStore, sessionDeps)
+
+    // #when — callback with stale session cookie in request
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+      {headers: {cookie: `${SESSION_COOKIE_NAME}=${staleSessionId}`}},
+    )
+    const res = await app.fetch(req)
+
+    // #then — success
+    expect(res.status).toBe(200)
+
+    // #and — stale session is revoked server-side
+    expect(sessionStore.get(staleSessionId, now + 2000)).toBeUndefined()
+
+    // #and — a clear-cookie header is emitted for the stale session
+    const setCookieHeaders = res.headers.getSetCookie()
+    const clearCookie = setCookieHeaders.find(
+      h => h.startsWith(`${SESSION_COOKIE_NAME}=`) && h.toLowerCase().includes('max-age=0'),
+    )
+    expect(clearCookie).toBeDefined()
+
+    // #and — a new session cookie is also set
+    const newSessionCookie = setCookieHeaders.find(
+      h => h.startsWith(`${SESSION_COOKIE_NAME}=`) && !h.toLowerCase().includes('max-age=0'),
+    )
+    expect(newSessionCookie).toBeDefined()
+  })
+
+  it('session cookie value is the minted session ID (retrievable from store)', async () => {
+    // #given
+    const stateStore = createInMemoryStateStore()
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestAppWithSession(deps, config, sessionStore, sessionDeps)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — extract session ID from cookie
+    const setCookieHeaders = res.headers.getSetCookie()
+    const sessionCookieHeader = setCookieHeaders.find(
+      h => h.startsWith(`${SESSION_COOKIE_NAME}=`) && !h.toLowerCase().includes('max-age=0'),
+    )
+    if (sessionCookieHeader === undefined) throw new Error('expected session cookie to be set')
+
+    // Parse the session ID from the cookie value
+    const cookieValue = sessionCookieHeader.split(';')[0]
+    if (cookieValue === undefined) throw new Error('expected cookie value')
+    const sessionId = cookieValue.slice(SESSION_COOKIE_NAME.length + 1)
+
+    // #and — the session ID is valid in the store
+    const entry = sessionStore.get(sessionId, now + 2000)
+    expect(entry).toBeDefined()
+    expect(entry?.githubUserId).toBe(42)
+    expect(entry?.login).toBe('octocat')
+  })
+
+  it('falls back to coarse JSON response when no session store is wired', async () => {
+    // #given — no session store in deps
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config) // no session store
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — still returns 200 with identity JSON
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({githubUserId: 42, login: 'octocat'})
+
+    // #and — no session cookie set
+    const setCookieHeaders = res.headers.getSetCookie()
+    const sessionCookie = setCookieHeaders.find(h => h.startsWith(`${SESSION_COOKIE_NAME}=`))
+    expect(sessionCookie).toBeUndefined()
+  })
+
+  it('returns 503 (service unavailable) when session cap is exhausted after scavenge', async () => {
+    // #given — session store at cap with all live sessions (no expired/revoked to scavenge)
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    // Create a session store stub that always returns undefined from create()
+    const fullSessionStore: SessionStore = {
+      create: () => undefined,
+      get: () => undefined,
+      touch: () => undefined,
+      delete: () => undefined,
+      onRevoke: () => undefined,
+      scavenge: () => undefined,
+      size: () => 10_000,
+    }
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestAppWithSession(deps, config, fullSessionStore, sessionDeps)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — 503 Service Unavailable (capacity issue, not a bad request)
+    expect(res.status).toBe(503)
+  })
+
+  it('503 response on session cap exhaustion includes Retry-After header', async () => {
+    // #given — session store that always returns undefined from create()
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const fullSessionStore: SessionStore = {
+      create: () => undefined,
+      get: () => undefined,
+      touch: () => undefined,
+      delete: () => undefined,
+      onRevoke: () => undefined,
+      scavenge: () => undefined,
+      size: () => 10_000,
+    }
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestAppWithSession(deps, config, fullSessionStore, sessionDeps)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — Retry-After header is present
+    expect(res.headers.get('retry-after')).toBe('60')
+  })
+
+  it('does NOT emit auth.callback.success when session cap is exhausted (503 path)', async () => {
+    // #given — session store that always returns undefined from create()
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const fullSessionStore: SessionStore = {
+      create: () => undefined,
+      get: () => undefined,
+      touch: () => undefined,
+      delete: () => undefined,
+      onRevoke: () => undefined,
+      scavenge: () => undefined,
+      size: () => 10_000,
+    }
+
+    const auditLogger = makeAuditLogger()
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+      auditLogger,
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestAppWithSession(deps, config, fullSessionStore, sessionDeps)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — 503 (capacity issue)
+    expect(res.status).toBe(503)
+
+    // #and — auth.callback.success must NOT have been emitted
+    const successEvent = auditLogger.records.find(r => r.kind === 'auth.callback.success')
+    expect(successEvent).toBeUndefined()
+  })
+
+  it('stale-session revocation hook fires during OAuth callback replacement', async () => {
+    // #given — a stale session with a revocation hook registered
+    const stateStore = createInMemoryStateStore()
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+
+    const staleSessionId = sessionStore.create({githubUserId: 99, login: 'stale'}, now)
+    if (staleSessionId === undefined) throw new Error('expected stale session to be created')
+
+    // Register a revocation hook on the stale session
+    const revocationHook = vi.fn()
+    sessionStore.onRevoke(staleSessionId, revocationHook)
+
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestAppWithSession(deps, config, sessionStore, sessionDeps)
+
+    // #when — callback with stale session cookie in request
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+      {headers: {cookie: `${SESSION_COOKIE_NAME}=${staleSessionId}`}},
+    )
+    await app.fetch(req)
+
+    // #then — revocation hook was called (stale session was deleted)
+    expect(revocationHook).toHaveBeenCalledExactlyOnceWith(staleSessionId)
   })
 })

--- a/packages/gateway/src/web/auth/github.ts
+++ b/packages/gateway/src/web/auth/github.ts
@@ -27,10 +27,12 @@
 import type {Context, Hono} from 'hono'
 import type {RateLimiter} from '../../http/rate-limit.js'
 import type {AuditLogger} from '../audit.js'
+import type {SessionDeps, SessionStore} from './session.js'
 import {createHash, randomBytes} from 'node:crypto'
 import {emitAudit} from '../audit.js'
 import {registerPublicRoute} from '../operator-route.js'
-import {badRequestResponse, rateLimitedResponse} from '../safe-response.js'
+import {badRequestResponse, rateLimitedResponse, unavailableResponse} from '../safe-response.js'
+import {buildSessionCookieValue, parseSessionCookie} from './session.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -119,6 +121,17 @@ export interface GitHubOAuthDeps {
    * OAuth routes participate in the same per-socket budget.
    */
   readonly rateLimiter: RateLimiter
+  /**
+   * Server-side session store. When present, a successful OAuth callback mints
+   * a fresh session and sets the __Host- session cookie. When absent, the
+   * callback returns a coarse JSON identity response (pre-session-layer posture).
+   */
+  readonly sessionStore?: SessionStore
+  /**
+   * Session deps (logger, auditLogger, clock) for session operations.
+   * Required when sessionStore is present; ignored otherwise.
+   */
+  readonly sessionDeps?: SessionDeps
 }
 
 /** Configuration for the GitHub OAuth PKCE + state routes. */
@@ -174,6 +187,8 @@ export function buildGitHubOAuthDeps(
   auditLogger: AuditLogger,
   getSourceKey: (c: Context) => string,
   rateLimiter: RateLimiter,
+  sessionStore?: SessionStore,
+  sessionDeps?: SessionDeps,
 ): GitHubOAuthDeps {
   return {
     logger,
@@ -185,6 +200,8 @@ export function buildGitHubOAuthDeps(
     stateStore: createInMemoryStateStore(),
     getSourceKey,
     rateLimiter,
+    ...(sessionStore === undefined ? {} : {sessionStore}),
+    ...(sessionDeps === undefined ? {} : {sessionDeps}),
   }
 }
 
@@ -593,14 +610,44 @@ export function buildGitHubOAuthRoutes(app: Hono, deps: GitHubOAuthDeps, config:
       return badRequestResponse(c)
     }
 
-    // Emit success audit event.
-    emitAudit({kind: 'auth.callback.success', correlationId, githubUserId, login}, deps.auditLogger)
-
     deps.logger.info({githubUserId}, 'oauth callback: identity verified')
 
-    // Identity is verified. Session minting is handled by the session layer
-    // (not yet wired). Return a coarse success response until the session layer
-    // is in place; the session layer will replace this with a cookie + redirect.
+    // Mint a server-side session when a session store is wired.
+    if (deps.sessionStore !== undefined && deps.sessionDeps !== undefined) {
+      const nowMs = deps.sessionDeps.clock()
+
+      // Clear any stale pre-auth session cookie before setting the new one
+      // to prevent session fixation.
+      const existingCookieHeader = c.req.header('cookie')
+      const existingSessionId = parseSessionCookie(existingCookieHeader)
+      if (existingSessionId !== undefined) {
+        deps.sessionStore.delete(existingSessionId)
+      }
+
+      const newSessionId = deps.sessionStore.create({githubUserId, login}, nowMs)
+      if (newSessionId === undefined) {
+        // Session cap reached — return 503 with Retry-After so clients know to retry.
+        // This is a capacity issue, not a bad request; 400 would be semantically wrong.
+        deps.sessionDeps.logger.warn({githubUserId}, 'oauth callback: session cap reached')
+        return unavailableResponse(c, 60)
+      }
+
+      // Emit success audit event only after session is successfully minted.
+      emitAudit({kind: 'auth.callback.success', correlationId, githubUserId, login}, deps.auditLogger)
+
+      // Clear stale cookie first, then set the new session cookie.
+      // Hono's c.header() appends when called multiple times for Set-Cookie.
+      if (existingSessionId !== undefined) {
+        c.header('Set-Cookie', buildSessionCookieValue('', {clear: true}), {append: true})
+      }
+      c.header('Set-Cookie', buildSessionCookieValue(newSessionId), {append: true})
+
+      deps.sessionDeps.logger.info({githubUserId}, 'oauth callback: session minted')
+      return c.json({githubUserId, login}, 200)
+    }
+
+    // No session store wired — identity verified, emit success audit before returning.
+    emitAudit({kind: 'auth.callback.success', correlationId, githubUserId, login}, deps.auditLogger)
     return c.json({githubUserId, login}, 200)
   })
 }

--- a/packages/gateway/src/web/auth/session.test.ts
+++ b/packages/gateway/src/web/auth/session.test.ts
@@ -1,0 +1,965 @@
+/**
+ * Tests for the server-side session store, cookie helpers, and logout route.
+ *
+ * Covers:
+ *   - Session store: create, get, touch, delete with correct field shapes.
+ *   - Session IDs have at least 128 bits of entropy (32 hex chars minimum).
+ *   - Absolute expiry (8 hours) and idle expiry (30 minutes) enforced.
+ *   - Scavenge removes expired sessions; cap prevents unbounded growth.
+ *   - Cookie attributes: __Host- prefix, HttpOnly, Secure, SameSite=Lax, Path=/, no Domain.
+ *   - Stale pre-auth cookie is cleared before the new session cookie is set.
+ *   - Logout invalidates session server-side and clears cookie.
+ *   - Revocation hook is triggered when a session is revoked; concurrent sessions independently revocable.
+ *   - Simulated restart: previously valid session IDs are not found in a new store.
+ *
+ * Uses BDD comments (#given, #when, #then).
+ */
+
+import type {AuditLogger} from '../audit.js'
+import type {SessionDeps, SessionStore} from './session.js'
+import {Hono} from 'hono'
+import {describe, expect, it, vi} from 'vitest'
+import {assertAllPrivilegedRoutesWrapped, registerPublicRoute} from '../operator-route.js'
+import {
+  buildLogoutRoutes,
+  buildSessionCookieValue,
+  createInMemorySessionStore,
+  parseSessionCookie,
+  SESSION_ABSOLUTE_TTL_MS,
+  SESSION_COOKIE_NAME,
+  SESSION_IDLE_TTL_MS,
+  SESSION_MAX_ENTRIES,
+} from './session.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAuditLogger(): AuditLogger & {records: Record<string, unknown>[]} {
+  const records: Record<string, unknown>[] = []
+  return {
+    records,
+    info: vi.fn((ctx: Record<string, unknown>, _msg: string) => {
+      records.push(ctx)
+    }),
+    warn: vi.fn((ctx: Record<string, unknown>, _msg: string) => {
+      records.push(ctx)
+    }),
+  }
+}
+
+function makeLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+}
+
+function makeStubDeps(overrides?: Partial<SessionDeps>): SessionDeps {
+  return {
+    logger: makeLogger(),
+    auditLogger: makeAuditLogger(),
+    clock: () => Date.now(),
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Session store — create
+// ---------------------------------------------------------------------------
+
+describe('createInMemorySessionStore — create', () => {
+  it('creates a session entry with the given identity and returns a session ID', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+
+    // #when
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+
+    // #then — session ID is a non-empty string
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+    expect(typeof sessionId).toBe('string')
+    expect(sessionId.length).toBeGreaterThan(0)
+  })
+
+  it('session ID has at least 128 bits of entropy (32 hex chars minimum)', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+
+    // #when
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+
+    // #then — 32 hex chars = 128 bits; base64url 22 chars = ~132 bits
+    // Accept either hex (64 chars for 256 bits) or base64url (43+ chars for 256 bits)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+    expect(sessionId.length).toBeGreaterThanOrEqual(22)
+  })
+
+  it('each create call returns a unique session ID', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+
+    // #when
+    const ids = new Set<string>()
+    for (let i = 0; i < 20; i++) {
+      const id = store.create({githubUserId: 42, login: 'octocat'}, now)
+      if (id === undefined) throw new Error('expected session ID to be defined')
+      ids.add(id)
+    }
+
+    // #then — all IDs are unique
+    expect(ids.size).toBe(20)
+  })
+
+  it('stored entry has correct identity, issuedAt, lastAccessedAt, and not revoked', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+
+    // #when
+    const sessionId = store.create({githubUserId: 99, login: 'testuser'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+    const entry = store.get(sessionId, now)
+
+    // #then
+    expect(entry).toBeDefined()
+    expect(entry?.githubUserId).toBe(99)
+    expect(entry?.login).toBe('testuser')
+    expect(entry?.issuedAt).toBe(now)
+    expect(entry?.lastAccessedAt).toBe(now)
+    expect(entry?.revoked).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Session store — get (expiry enforcement)
+// ---------------------------------------------------------------------------
+
+describe('createInMemorySessionStore — get with expiry', () => {
+  it('returns the entry when within absolute and idle TTL', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+
+    // #when — access 1 second later
+    const entry = store.get(sessionId, now + 1_000)
+
+    // #then
+    expect(entry).toBeDefined()
+  })
+
+  it('returns undefined when absolute TTL (8 hours) is exceeded', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+
+    // #when — access 1ms past absolute TTL
+    const entry = store.get(sessionId, now + SESSION_ABSOLUTE_TTL_MS + 1)
+
+    // #then — expired
+    expect(entry).toBeUndefined()
+  })
+
+  it('returns undefined when idle TTL (30 minutes) is exceeded since last access', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+
+    // #when — access 1ms past idle TTL without any touch
+    const entry = store.get(sessionId, now + SESSION_IDLE_TTL_MS + 1)
+
+    // #then — idle expired
+    expect(entry).toBeUndefined()
+  })
+
+  it('returns undefined for an unknown session ID', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+
+    // #when
+    const entry = store.get('nonexistent-session-id', now)
+
+    // #then
+    expect(entry).toBeUndefined()
+  })
+
+  it('returns undefined for a revoked session', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+    store.delete(sessionId)
+
+    // #when
+    const entry = store.get(sessionId, now + 1_000)
+
+    // #then — revoked
+    expect(entry).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Session store — touch (idle TTL reset)
+// ---------------------------------------------------------------------------
+
+describe('createInMemorySessionStore — touch', () => {
+  it('touch updates lastAccessedAt and extends idle TTL', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+
+    // #when — touch at 25 minutes (within idle TTL)
+    const touchTime = now + 25 * 60 * 1000
+    store.touch(sessionId, touchTime)
+
+    // #then — session is still valid 10 minutes after touch (35 min total, but only 10 since touch)
+    const entry = store.get(sessionId, touchTime + 10 * 60 * 1000)
+    expect(entry).toBeDefined()
+    expect(entry?.lastAccessedAt).toBe(touchTime)
+  })
+
+  it('touch does not extend absolute TTL', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+
+    // #when — touch just before absolute TTL expires
+    const touchTime = now + SESSION_ABSOLUTE_TTL_MS - 1_000
+    store.touch(sessionId, touchTime)
+
+    // #then — session expires at absolute TTL regardless of touch
+    const entry = store.get(sessionId, now + SESSION_ABSOLUTE_TTL_MS + 1)
+    expect(entry).toBeUndefined()
+  })
+
+  it('touch on unknown session ID is a no-op (does not throw)', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+
+    // #when / #then — no throw
+    expect(() => store.touch('nonexistent-id', now)).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Session store — delete (revocation)
+// ---------------------------------------------------------------------------
+
+describe('createInMemorySessionStore — delete', () => {
+  it('delete makes the session immediately unavailable', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+
+    // #when
+    store.delete(sessionId)
+
+    // #then
+    expect(store.get(sessionId, now + 1_000)).toBeUndefined()
+  })
+
+  it('delete on unknown session ID is a no-op (does not throw)', () => {
+    // #given
+    const store = createInMemorySessionStore()
+
+    // #when / #then — no throw
+    expect(() => store.delete('nonexistent-id')).not.toThrow()
+  })
+
+  it('concurrent sessions are independently revocable', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionA = store.create({githubUserId: 42, login: 'octocat'}, now)
+    const sessionB = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionA === undefined || sessionB === undefined) throw new Error('expected session IDs to be defined')
+
+    // #when — revoke only session A
+    store.delete(sessionA)
+
+    // #then — session A is gone, session B is still valid
+    expect(store.get(sessionA, now + 1_000)).toBeUndefined()
+    expect(store.get(sessionB, now + 1_000)).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Session store — revocation hook
+// ---------------------------------------------------------------------------
+
+describe('createInMemorySessionStore — revocation hook', () => {
+  it('revocation hook is called when a session is deleted', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+
+    const hookCalled = vi.fn()
+    store.onRevoke(sessionId, hookCalled)
+
+    // #when
+    store.delete(sessionId)
+
+    // #then
+    expect(hookCalled).toHaveBeenCalledOnce()
+  })
+
+  it('revocation hook is called with the session ID', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+
+    const hookCalled = vi.fn()
+    store.onRevoke(sessionId, hookCalled)
+
+    // #when
+    store.delete(sessionId)
+
+    // #then
+    expect(hookCalled).toHaveBeenCalledWith(sessionId)
+  })
+
+  it('revocation hooks for different sessions are independent', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionA = store.create({githubUserId: 42, login: 'octocat'}, now)
+    const sessionB = store.create({githubUserId: 43, login: 'other'}, now)
+    if (sessionA === undefined || sessionB === undefined) throw new Error('expected session IDs to be defined')
+
+    const hookA = vi.fn()
+    const hookB = vi.fn()
+    store.onRevoke(sessionA, hookA)
+    store.onRevoke(sessionB, hookB)
+
+    // #when — revoke only session A
+    store.delete(sessionA)
+
+    // #then — only hook A was called
+    expect(hookA).toHaveBeenCalledOnce()
+    expect(hookB).not.toHaveBeenCalled()
+  })
+
+  it('revocation hook is not called when a different session is deleted', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionA = store.create({githubUserId: 42, login: 'octocat'}, now)
+    const sessionB = store.create({githubUserId: 43, login: 'other'}, now)
+    if (sessionA === undefined || sessionB === undefined) throw new Error('expected session IDs to be defined')
+
+    const hookA = vi.fn()
+    store.onRevoke(sessionA, hookA)
+
+    // #when — delete session B (not A)
+    store.delete(sessionB)
+
+    // #then — hook A was NOT called
+    expect(hookA).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Session store — scavenge
+// ---------------------------------------------------------------------------
+
+describe('createInMemorySessionStore — scavenge', () => {
+  it('scavenge removes expired sessions', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    store.create({githubUserId: 42, login: 'octocat'}, now)
+    store.create({githubUserId: 43, login: 'other'}, now)
+
+    // #when — scavenge past absolute TTL
+    store.scavenge(now + SESSION_ABSOLUTE_TTL_MS + 1)
+
+    // #then — size is 0
+    expect(store.size()).toBe(0)
+  })
+
+  it('scavenge does not remove sessions within TTL', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    store.create({githubUserId: 42, login: 'octocat'}, now)
+
+    // #when — scavenge 1 second after creation (well within TTL)
+    store.scavenge(now + 1_000)
+
+    // #then — session still present
+    expect(store.size()).toBe(1)
+  })
+
+  it('scavenge removes revoked sessions', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+    store.delete(sessionId)
+
+    // #when — scavenge at any time
+    store.scavenge(now + 1_000)
+
+    // #then — revoked session is removed
+    expect(store.size()).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Session store — cap
+// ---------------------------------------------------------------------------
+
+describe('createInMemorySessionStore — cap', () => {
+  it('create returns undefined when the session cap is reached', () => {
+    // #given — fill the store to the cap
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+
+    for (let i = 0; i < SESSION_MAX_ENTRIES; i++) {
+      store.create({githubUserId: i, login: `user${i}`}, now)
+    }
+
+    // #when — one more create
+    const result = store.create({githubUserId: 99999, login: 'overflow'}, now)
+
+    // #then — cap enforced; returns undefined
+    expect(result).toBeUndefined()
+  })
+
+  it('create succeeds after scavenge frees space below the cap', () => {
+    // #given — fill to cap with sessions that will expire
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+
+    for (let i = 0; i < SESSION_MAX_ENTRIES; i++) {
+      store.create({githubUserId: i, login: `user${i}`}, now)
+    }
+
+    // #when — scavenge past absolute TTL, then create
+    store.scavenge(now + SESSION_ABSOLUTE_TTL_MS + 1)
+    const result = store.create({githubUserId: 99999, login: 'new'}, now + SESSION_ABSOLUTE_TTL_MS + 2)
+
+    // #then — create succeeds
+    expect(result).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Session store — simulated restart
+// ---------------------------------------------------------------------------
+
+describe('createInMemorySessionStore — simulated restart', () => {
+  it('previously valid session IDs are not found in a new store instance', () => {
+    // #given — create a session in store A
+    const storeA = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = storeA.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+    expect(storeA.get(sessionId, now + 1_000)).toBeDefined()
+
+    // #when — create a new store (simulating restart)
+    const storeB = createInMemorySessionStore()
+
+    // #then — session ID from store A is not found in store B
+    expect(storeB.get(sessionId, now + 1_000)).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cookie helpers
+// ---------------------------------------------------------------------------
+
+describe('SESSION_COOKIE_NAME', () => {
+  it('uses the __Host- prefix', () => {
+    // #then — __Host- prefix enforces Secure, Path=/, no Domain
+    expect(SESSION_COOKIE_NAME).toMatch(/^__Host-/)
+  })
+})
+
+describe('buildSessionCookieValue', () => {
+  it('returns a Set-Cookie string with the session ID as value', () => {
+    // #given
+    const sessionId = 'test-session-id-abc123'
+
+    // #when
+    const cookieValue = buildSessionCookieValue(sessionId)
+
+    // #then
+    expect(cookieValue).toContain(sessionId)
+  })
+
+  it('includes HttpOnly attribute', () => {
+    // #given / #when
+    const cookieValue = buildSessionCookieValue('test-id')
+
+    // #then
+    expect(cookieValue.toLowerCase()).toContain('httponly')
+  })
+
+  it('includes Secure attribute', () => {
+    // #given / #when
+    const cookieValue = buildSessionCookieValue('test-id')
+
+    // #then
+    expect(cookieValue.toLowerCase()).toContain('secure')
+  })
+
+  it('includes SameSite=Lax attribute', () => {
+    // #given / #when
+    const cookieValue = buildSessionCookieValue('test-id')
+
+    // #then
+    expect(cookieValue.toLowerCase()).toContain('samesite=lax')
+  })
+
+  it('includes Path=/ attribute', () => {
+    // #given / #when
+    const cookieValue = buildSessionCookieValue('test-id')
+
+    // #then
+    expect(cookieValue).toContain('Path=/')
+  })
+
+  it('does NOT include Domain attribute', () => {
+    // #given / #when
+    const cookieValue = buildSessionCookieValue('test-id')
+
+    // #then — __Host- prefix forbids Domain
+    expect(cookieValue.toLowerCase()).not.toContain('domain=')
+  })
+
+  it('uses the __Host- cookie name', () => {
+    // #given / #when
+    const cookieValue = buildSessionCookieValue('test-id')
+
+    // #then
+    expect(cookieValue).toMatch(new RegExp(`^${SESSION_COOKIE_NAME}=`))
+  })
+})
+
+describe('buildSessionCookieValue — clear cookie', () => {
+  it('clear cookie sets Max-Age=0 to expire the cookie', () => {
+    // #given / #when
+    const cookieValue = buildSessionCookieValue('', {clear: true})
+
+    // #then
+    expect(cookieValue.toLowerCase()).toContain('max-age=0')
+  })
+
+  it('clear cookie still includes HttpOnly, Secure, SameSite=Lax, Path=/', () => {
+    // #given / #when
+    const cookieValue = buildSessionCookieValue('', {clear: true})
+
+    // #then
+    expect(cookieValue.toLowerCase()).toContain('httponly')
+    expect(cookieValue.toLowerCase()).toContain('secure')
+    expect(cookieValue.toLowerCase()).toContain('samesite=lax')
+    expect(cookieValue).toContain('Path=/')
+  })
+})
+
+describe('parseSessionCookie', () => {
+  it('returns the session ID from a valid Cookie header', () => {
+    // #given
+    const cookieHeader = `${SESSION_COOKIE_NAME}=my-session-id-abc`
+
+    // #when
+    const sessionId = parseSessionCookie(cookieHeader)
+
+    // #then
+    expect(sessionId).toBe('my-session-id-abc')
+  })
+
+  it('returns undefined when the cookie header is absent', () => {
+    // #given / #when
+    const sessionId = parseSessionCookie(undefined)
+
+    // #then
+    expect(sessionId).toBeUndefined()
+  })
+
+  it('returns undefined when the session cookie is not present in the header', () => {
+    // #given
+    const cookieHeader = 'other-cookie=some-value; another=thing'
+
+    // #when
+    const sessionId = parseSessionCookie(cookieHeader)
+
+    // #then
+    expect(sessionId).toBeUndefined()
+  })
+
+  it('handles multiple cookies and extracts the session cookie', () => {
+    // #given
+    const cookieHeader = `other=value; ${SESSION_COOKIE_NAME}=target-session-id; another=thing`
+
+    // #when
+    const sessionId = parseSessionCookie(cookieHeader)
+
+    // #then
+    expect(sessionId).toBe('target-session-id')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Logout route
+// ---------------------------------------------------------------------------
+
+function buildTestLogoutApp(store: SessionStore, deps: SessionDeps): Hono {
+  const app = new Hono()
+  registerPublicRoute(app, 'GET', '/operator/health', c => c.json({ok: true}))
+  buildLogoutRoutes(app, store, deps)
+  assertAllPrivilegedRoutesWrapped(app)
+  return app
+}
+
+describe('POST /operator/auth/logout — happy path', () => {
+  it('returns 200 and clears the session cookie when a valid session exists', async () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+    const deps = makeStubDeps({clock: () => now + 1_000})
+    const app = buildTestLogoutApp(store, deps)
+
+    // #when
+    const req = new Request('https://operator.example.com/operator/auth/logout', {
+      method: 'POST',
+      headers: {cookie: `${SESSION_COOKIE_NAME}=${sessionId}`},
+    })
+    const res = await app.fetch(req)
+
+    // #then — success
+    expect(res.status).toBe(200)
+
+    // #and — session is invalidated server-side
+    expect(store.get(sessionId, now + 2_000)).toBeUndefined()
+  })
+
+  it('sets a clear-cookie header on logout', async () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+    const deps = makeStubDeps({clock: () => now + 1_000})
+    const app = buildTestLogoutApp(store, deps)
+
+    // #when
+    const req = new Request('https://operator.example.com/operator/auth/logout', {
+      method: 'POST',
+      headers: {cookie: `${SESSION_COOKIE_NAME}=${sessionId}`},
+    })
+    const res = await app.fetch(req)
+
+    // #then — Set-Cookie header clears the session cookie
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    expect(setCookie).toContain(SESSION_COOKIE_NAME)
+    expect(setCookie.toLowerCase()).toContain('max-age=0')
+  })
+
+  it('emits auth.logout audit event with githubUserId', async () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+    const auditLogger = makeAuditLogger()
+    const deps = makeStubDeps({clock: () => now + 1_000, auditLogger})
+    const app = buildTestLogoutApp(store, deps)
+
+    // #when
+    const req = new Request('https://operator.example.com/operator/auth/logout', {
+      method: 'POST',
+      headers: {cookie: `${SESSION_COOKIE_NAME}=${sessionId}`},
+    })
+    await app.fetch(req)
+
+    // #then — audit event emitted
+    const logoutEvent = auditLogger.records.find(r => r.kind === 'auth.logout')
+    expect(logoutEvent).toBeDefined()
+    expect(logoutEvent?.githubUserId).toBe(42)
+  })
+
+  it('audit event correlationId does NOT contain the raw session ID', async () => {
+    // #given — session IDs are never logged (security invariant)
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+    const auditLogger = makeAuditLogger()
+    const deps = makeStubDeps({clock: () => now + 1_000, auditLogger})
+    const app = buildTestLogoutApp(store, deps)
+
+    // #when
+    const req = new Request('https://operator.example.com/operator/auth/logout', {
+      method: 'POST',
+      headers: {cookie: `${SESSION_COOKIE_NAME}=${sessionId}`},
+    })
+    await app.fetch(req)
+
+    // #then — correlationId must not be the raw session ID
+    const logoutEvent = auditLogger.records.find(r => r.kind === 'auth.logout')
+    expect(logoutEvent).toBeDefined()
+    expect(logoutEvent?.correlationId).not.toBe(sessionId)
+
+    // #and — correlationId must be the safe static sentinel
+    expect(logoutEvent?.correlationId).toBe('logout')
+
+    // #and — no field in the audit record contains the raw session ID
+    for (const [key, value] of Object.entries(logoutEvent ?? {})) {
+      expect(value, `field '${key}' must not contain the raw session ID`).not.toBe(sessionId)
+    }
+  })
+})
+
+describe('POST /operator/auth/logout — no session cookie', () => {
+  it('returns 200 even when no session cookie is present (idempotent logout)', async () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const deps = makeStubDeps()
+    const app = buildTestLogoutApp(store, deps)
+
+    // #when — no cookie header
+    const req = new Request('https://operator.example.com/operator/auth/logout', {method: 'POST'})
+    const res = await app.fetch(req)
+
+    // #then — idempotent; still 200
+    expect(res.status).toBe(200)
+  })
+
+  it('still clears the cookie even when no session cookie is present', async () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const deps = makeStubDeps()
+    const app = buildTestLogoutApp(store, deps)
+
+    // #when
+    const req = new Request('https://operator.example.com/operator/auth/logout', {method: 'POST'})
+    const res = await app.fetch(req)
+
+    // #then — clear-cookie header is still set
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    expect(setCookie).toContain(SESSION_COOKIE_NAME)
+    expect(setCookie.toLowerCase()).toContain('max-age=0')
+  })
+})
+
+describe('POST /operator/auth/logout — unknown session ID', () => {
+  it('returns 200 for an unknown session ID (no oracle)', async () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const deps = makeStubDeps()
+    const app = buildTestLogoutApp(store, deps)
+
+    // #when — send a session cookie with an unknown ID
+    const req = new Request('https://operator.example.com/operator/auth/logout', {
+      method: 'POST',
+      headers: {cookie: `${SESSION_COOKIE_NAME}=unknown-session-id-xyz`},
+    })
+    const res = await app.fetch(req)
+
+    // #then — no oracle; still 200
+    expect(res.status).toBe(200)
+  })
+
+  it('does NOT emit an audit event for an unknown session ID (no oracle)', async () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const auditLogger = makeAuditLogger()
+    const deps = makeStubDeps({auditLogger})
+    const app = buildTestLogoutApp(store, deps)
+
+    // #when — send a session cookie with an unknown ID
+    const req = new Request('https://operator.example.com/operator/auth/logout', {
+      method: 'POST',
+      headers: {cookie: `${SESSION_COOKIE_NAME}=unknown-session-id-xyz`},
+    })
+    await app.fetch(req)
+
+    // #then — no audit event emitted (unknown session = no oracle)
+    expect(auditLogger.records).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Session store — create scavenges before cap check
+// ---------------------------------------------------------------------------
+
+describe('createInMemorySessionStore — create scavenges before cap check', () => {
+  it('create succeeds after revoked entries are scavenged at cap (re-auth after stale session)', () => {
+    // #given — fill to cap with sessions, then revoke one
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+
+    const ids: string[] = []
+    for (let i = 0; i < SESSION_MAX_ENTRIES; i++) {
+      const id = store.create({githubUserId: i, login: `user${i}`}, now)
+      if (id === undefined) throw new Error('expected session ID to be defined')
+      ids.push(id)
+    }
+
+    // Revoke the first session (simulating logout before re-auth)
+    const firstId = ids[0]
+    if (firstId === undefined) throw new Error('expected first session ID to be defined')
+    store.delete(firstId)
+
+    // #when — create a new session without calling scavenge() manually
+    const newId = store.create({githubUserId: 99999, login: 'reauth-user'}, now + 1_000)
+
+    // #then — create succeeds because revoked entry was scavenged opportunistically
+    expect(newId).toBeDefined()
+  })
+
+  it('create succeeds after expired entries are scavenged at cap', () => {
+    // #given — fill to cap with sessions that will expire
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+
+    for (let i = 0; i < SESSION_MAX_ENTRIES; i++) {
+      store.create({githubUserId: i, login: `user${i}`}, now)
+    }
+
+    // #when — create at a time past absolute TTL (entries are expired)
+    const newId = store.create({githubUserId: 99999, login: 'new-user'}, now + SESSION_ABSOLUTE_TTL_MS + 1)
+
+    // #then — create succeeds because expired entries were scavenged opportunistically
+    expect(newId).toBeDefined()
+  })
+
+  it('create still returns undefined when all entries are live at cap', () => {
+    // #given — fill to cap with fresh sessions
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+
+    for (let i = 0; i < SESSION_MAX_ENTRIES; i++) {
+      store.create({githubUserId: i, login: `user${i}`}, now)
+    }
+
+    // #when — create at same time (all entries still live)
+    const result = store.create({githubUserId: 99999, login: 'overflow'}, now)
+
+    // #then — cap enforced; returns undefined
+    expect(result).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Session store — get returns Readonly
+// ---------------------------------------------------------------------------
+
+describe('createInMemorySessionStore — get returns Readonly', () => {
+  it('get returns an entry that satisfies the Readonly<SessionEntry> type', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+
+    // #when
+    const entry = store.get(sessionId, now)
+
+    // #then — entry is defined and has expected shape
+    expect(entry).toBeDefined()
+    expect(entry?.githubUserId).toBe(42)
+    expect(entry?.login).toBe('octocat')
+    expect(entry?.revoked).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Session ID entropy
+// ---------------------------------------------------------------------------
+
+describe('generateSessionId — entropy', () => {
+  it('session ID is exactly 43 characters (256-bit base64url)', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+
+    // #when
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+
+    // #then — 32 bytes base64url = 43 chars (no padding)
+    expect(sessionId.length).toBe(43)
+  })
+
+  it('session ID contains only base64url characters (A-Z, a-z, 0-9, -, _)', () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+
+    // #when
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+
+    // #then — only base64url charset (no +, /, or =)
+    // base64url uses A-Z, a-z, 0-9, -, _ (no +, /, or = padding)
+    expect(sessionId).toMatch(/^[\w-]+$/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseSessionCookie — empty value returns undefined
+// ---------------------------------------------------------------------------
+
+describe('parseSessionCookie — empty value', () => {
+  it('returns undefined when session cookie value is empty (clear cookie)', () => {
+    // #given — cookie header with empty session cookie value followed by another cookie
+    const cookieHeader = `${SESSION_COOKIE_NAME}=; other=value`
+
+    // #when
+    const sessionId = parseSessionCookie(cookieHeader)
+
+    // #then — empty value treated as absent
+    expect(sessionId).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Logout response body
+// ---------------------------------------------------------------------------
+
+describe('POST /operator/auth/logout — response body', () => {
+  it('response body is {ok: true}', async () => {
+    // #given
+    const store = createInMemorySessionStore()
+    const deps = makeStubDeps()
+    const app = buildTestLogoutApp(store, deps)
+
+    // #when
+    const req = new Request('https://operator.example.com/operator/auth/logout', {method: 'POST'})
+    const res = await app.fetch(req)
+
+    // #then — body is {ok: true}
+    const body = await res.json()
+    expect(body).toEqual({ok: true})
+  })
+})

--- a/packages/gateway/src/web/auth/session.ts
+++ b/packages/gateway/src/web/auth/session.ts
@@ -1,0 +1,358 @@
+/**
+ * Server-side opaque session store for the operator web surface.
+ *
+ * - In-memory store: create, get, touch, delete, scavenge, size.
+ * - 8-hour absolute TTL and 30-minute idle TTL enforced on every get().
+ * - Session IDs: 256-bit CSPRNG entropy (base64url, 43 chars).
+ * - Session cap to bound memory growth.
+ * - Revocation hooks: called on delete().
+ * - Cookie helpers: buildSessionCookieValue, parseSessionCookie.
+ * - POST /operator/auth/logout route builder.
+ *
+ * Security invariants:
+ *   - Session IDs are never logged or included in error responses.
+ *   - Logout is idempotent: unknown session IDs return 200 (no oracle).
+ *   - Gateway restart is global logout: in-memory sessions are gone.
+ */
+
+import type {Context, Hono} from 'hono'
+import type {RateLimiter} from '../../http/rate-limit.js'
+import type {AuditLogger} from '../audit.js'
+import {randomBytes} from 'node:crypto'
+import {emitAudit} from '../audit.js'
+import {registerPublicRoute} from '../operator-route.js'
+import {okResponse, rateLimitedResponse} from '../safe-response.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Cookie name — __Host- prefix enforces Secure, Path=/, no Domain. */
+export const SESSION_COOKIE_NAME = '__Host-session'
+
+/** Absolute session lifetime: 8 hours. */
+export const SESSION_ABSOLUTE_TTL_MS = 8 * 60 * 60 * 1000
+
+/** Idle session lifetime: 30 minutes since last access. */
+export const SESSION_IDLE_TTL_MS = 30 * 60 * 1000
+
+/**
+ * Maximum number of live sessions in the store.
+ * Prevents unbounded Map growth. Sized for a single-operator deployment.
+ */
+export const SESSION_MAX_ENTRIES = 10_000
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Identity bound to a session. */
+export interface SessionIdentity {
+  /** Stable GitHub numeric user ID. */
+  readonly githubUserId: number
+  /** GitHub display login — mutable, for display only. */
+  readonly login: string
+}
+
+/** A single session entry stored server-side. */
+export interface SessionEntry extends SessionIdentity {
+  /** Timestamp (ms since epoch) when this session was created. */
+  readonly issuedAt: number
+  /** Timestamp (ms since epoch) of the last access (create or touch). */
+  lastAccessedAt: number
+  /** Whether this session has been explicitly revoked. */
+  revoked: boolean
+}
+
+/** Revocation hook callback — called with the session ID when the session is deleted. */
+export type RevocationHook = (sessionId: string) => void
+
+/** Server-side session store interface. */
+export interface SessionStore {
+  /**
+   * Create a new session for the given identity.
+   * Returns the new session ID, or undefined if the session cap is reached.
+   */
+  create: (identity: SessionIdentity, nowMs: number) => string | undefined
+  /**
+   * Retrieve a session entry by ID.
+   * Returns undefined if not found, expired (absolute or idle), or revoked.
+   * Does NOT update lastAccessedAt — call touch() separately.
+   * Returns a Readonly view to prevent external mutation of revoked/lastAccessedAt bypassing hooks.
+   */
+  get: (sessionId: string, nowMs: number) => Readonly<SessionEntry> | undefined
+  /**
+   * Update lastAccessedAt to extend the idle TTL.
+   * No-op for unknown or revoked sessions.
+   */
+  touch: (sessionId: string, nowMs: number) => void
+  /**
+   * Revoke a session immediately.
+   * No-op for unknown sessions.
+   * Triggers any registered revocation hooks.
+   */
+  delete: (sessionId: string) => void
+  /**
+   * Register a revocation hook for a specific session ID.
+   * The hook is called with the session ID when delete() is called for that session.
+   * Multiple hooks per session are supported.
+   */
+  onRevoke: (sessionId: string, hook: RevocationHook) => void
+  /**
+   * Remove expired and revoked entries from the store.
+   * Call periodically to bound memory growth.
+   */
+  scavenge: (nowMs: number) => void
+  /** Total number of entries in the store (including revoked, not yet scavenged). */
+  size: () => number
+}
+
+/** Logger interface for the session module. */
+export interface SessionLogger {
+  readonly debug: (ctx: Record<string, unknown>, msg: string) => void
+  readonly info: (ctx: Record<string, unknown>, msg: string) => void
+  readonly warn: (ctx: Record<string, unknown>, msg: string) => void
+  readonly error: (ctx: Record<string, unknown>, msg: string) => void
+}
+
+/** Dependencies for session-related routes (injectable for testing). */
+export interface SessionDeps {
+  readonly logger: SessionLogger
+  readonly auditLogger: AuditLogger
+  /** Injectable clock for TTL checks. Defaults to Date.now. */
+  readonly clock: () => number
+  /**
+   * Shared rate limiter for the logout route.
+   * Must be the same instance used in buildOperatorApp so logout participates
+   * in the same per-socket budget. When absent, no rate limiting is applied
+   * (backwards-compatible for tests that don't care about rate limiting).
+   */
+  readonly rateLimiter?: RateLimiter
+  /**
+   * Source key extractor for rate limiting.
+   * Must be derived from the TCP socket address — NOT from caller-spoofable headers.
+   * When absent, falls back to 'unknown' (backwards-compatible for tests).
+   */
+  readonly getSourceKey?: (c: Context) => string
+}
+
+// ---------------------------------------------------------------------------
+// Session ID generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a cryptographically random session ID with 256 bits of entropy.
+ * Returns a base64url-encoded string (43 characters, no padding).
+ */
+function generateSessionId(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+// ---------------------------------------------------------------------------
+// In-memory session store
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a simple in-memory session store.
+ *
+ * Suitable for v1 single-process deployment. Gateway restart clears all sessions
+ * (global logout — acceptable for v1).
+ *
+ * Session IDs are 256-bit CSPRNG values (base64url, 43 chars). At that entropy
+ * level, enumeration is computationally infeasible; Map.get() is the correct
+ * lookup — no timing-safe comparison is needed or useful here.
+ */
+export function createInMemorySessionStore(): SessionStore {
+  const entries = new Map<string, SessionEntry>()
+  const hooks = new Map<string, RevocationHook[]>()
+
+  function isExpired(entry: SessionEntry, nowMs: number): boolean {
+    if (nowMs - entry.issuedAt > SESSION_ABSOLUTE_TTL_MS) return true
+    if (nowMs - entry.lastAccessedAt > SESSION_IDLE_TTL_MS) return true
+    return false
+  }
+
+  return {
+    create(identity: SessionIdentity, nowMs: number): string | undefined {
+      // Opportunistically scavenge expired/revoked entries before checking the cap.
+      // This makes cap behavior live-entry-based and fixes re-auth after stale session
+      // deletion: the revoked slot is reclaimed without requiring a manual scavenge() call.
+      if (entries.size >= SESSION_MAX_ENTRIES) {
+        for (const [key, entry] of entries) {
+          if (entry.revoked === true || isExpired(entry, nowMs)) {
+            entries.delete(key)
+            hooks.delete(key)
+          }
+        }
+      }
+
+      if (entries.size >= SESSION_MAX_ENTRIES) return undefined
+
+      const sessionId = generateSessionId()
+      const entry: SessionEntry = {
+        githubUserId: identity.githubUserId,
+        login: identity.login,
+        issuedAt: nowMs,
+        lastAccessedAt: nowMs,
+        revoked: false,
+      }
+      entries.set(sessionId, entry)
+      return sessionId
+    },
+
+    get(sessionId: string, nowMs: number): SessionEntry | undefined {
+      const entry = entries.get(sessionId)
+      if (entry === undefined) return undefined
+      if (entry.revoked === true) return undefined
+      if (isExpired(entry, nowMs)) return undefined
+      return entry
+    },
+
+    touch(sessionId: string, nowMs: number): void {
+      const entry = entries.get(sessionId)
+      if (entry === undefined) return
+      if (entry.revoked === true) return
+      entry.lastAccessedAt = nowMs
+    },
+
+    delete(sessionId: string): void {
+      const entry = entries.get(sessionId)
+      if (entry === undefined) return
+      entry.revoked = true
+
+      const sessionHooks = hooks.get(sessionId)
+      if (sessionHooks !== undefined) {
+        for (const hook of sessionHooks) {
+          try {
+            hook(sessionId)
+          } catch {
+            // Swallow hook failures — revocation must not be blocked by hook errors.
+          }
+        }
+        hooks.delete(sessionId)
+      }
+    },
+
+    onRevoke(sessionId: string, hook: RevocationHook): void {
+      const existing = hooks.get(sessionId)
+      if (existing === undefined) {
+        hooks.set(sessionId, [hook])
+      } else {
+        existing.push(hook)
+      }
+    },
+
+    scavenge(nowMs: number): void {
+      for (const [key, entry] of entries) {
+        if (entry.revoked === true || isExpired(entry, nowMs)) {
+          entries.delete(key)
+          hooks.delete(key)
+        }
+      }
+    },
+
+    size(): number {
+      return entries.size
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cookie helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Set-Cookie header value for the session cookie.
+ *
+ * Attributes:
+ *   - __Host- prefix: enforces Secure, Path=/, no Domain (browser-enforced).
+ *   - HttpOnly: not accessible via JavaScript.
+ *   - Secure: HTTPS only.
+ *   - SameSite=Lax: CSRF mitigation for cross-site navigations.
+ *   - Path=/: required by __Host- prefix.
+ *
+ * When clear=true, sets Max-Age=0 to expire the cookie immediately.
+ */
+export function buildSessionCookieValue(sessionId: string, opts?: {clear?: boolean}): string {
+  const value = opts?.clear === true ? '' : sessionId
+  const parts = [`${SESSION_COOKIE_NAME}=${value}`, 'HttpOnly', 'Secure', 'SameSite=Lax', 'Path=/']
+  if (opts?.clear === true) {
+    parts.push('Max-Age=0')
+  }
+  return parts.join('; ')
+}
+
+/**
+ * Parse the session ID from a Cookie header string.
+ * Returns the session ID if the session cookie is present, or undefined.
+ */
+export function parseSessionCookie(cookieHeader: string | undefined): string | undefined {
+  if (cookieHeader === undefined || cookieHeader === '') return undefined
+
+  // Split on '; ' and find the session cookie
+  const cookies = cookieHeader.split(/;\s*/)
+  for (const cookie of cookies) {
+    const eqIdx = cookie.indexOf('=')
+    if (eqIdx === -1) continue
+    const name = cookie.slice(0, eqIdx).trim()
+    const value = cookie.slice(eqIdx + 1).trim()
+    if (name === SESSION_COOKIE_NAME) {
+      return value === '' ? undefined : value
+    }
+  }
+  return undefined
+}
+
+// ---------------------------------------------------------------------------
+// Logout route builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Register the POST /operator/auth/logout route on the given Hono app.
+ *
+ * Registered as a public route (no session required to call logout — idempotent).
+ * Invalidates the session server-side and clears the session cookie.
+ * Returns 200 regardless of whether a valid session was found (no oracle).
+ */
+export function buildLogoutRoutes(app: Hono, store: SessionStore, deps: SessionDeps): void {
+  registerPublicRoute(app, 'POST', '/operator/auth/logout', async (c: Context): Promise<Response> => {
+    // Rate limit check — shared with the operator app, keyed on socket address.
+    if (deps.rateLimiter !== undefined) {
+      const sourceKey = deps.getSourceKey === undefined ? 'unknown' : deps.getSourceKey(c)
+      if (deps.rateLimiter.allow(sourceKey) === false) {
+        deps.logger.warn({}, 'logout rejected: rate limited')
+        return rateLimitedResponse(c)
+      }
+    }
+
+    const cookieHeader = c.req.header('cookie')
+    const sessionId = parseSessionCookie(cookieHeader)
+
+    if (sessionId !== undefined) {
+      const nowMs = deps.clock()
+      const entry = store.get(sessionId, nowMs)
+
+      if (entry !== undefined) {
+        // Emit audit event before deleting the session.
+        // correlationId must NOT be the session ID — session IDs are never logged.
+        emitAudit(
+          {
+            kind: 'auth.logout',
+            correlationId: 'logout',
+            githubUserId: entry.githubUserId,
+          },
+          deps.auditLogger,
+        )
+        deps.logger.info({githubUserId: entry.githubUserId}, 'session logout')
+      }
+
+      store.delete(sessionId)
+    }
+
+    // Always clear the cookie — idempotent logout
+    const clearCookie = buildSessionCookieValue('', {clear: true})
+    c.header('Set-Cookie', clearCookie)
+
+    return okResponse(c)
+  })
+}

--- a/packages/gateway/src/web/safe-response.ts
+++ b/packages/gateway/src/web/safe-response.ts
@@ -80,10 +80,15 @@ export function rateLimitedResponse<E extends Env, P extends string, I extends I
 
 /**
  * Return a coarse 503 Service Unavailable.
- * Use during graceful shutdown drain.
+ * Use during graceful shutdown drain or when server capacity is exhausted.
+ * When retryAfterSeconds is provided, sets a Retry-After header.
  */
 export function unavailableResponse<E extends Env, P extends string, I extends Input>(
   c: OperatorResponseContext<E, P, I>,
+  retryAfterSeconds?: number,
 ): Response {
+  if (retryAfterSeconds !== undefined) {
+    c.header('Retry-After', String(retryAfterSeconds))
+  }
   return c.json({error: 'unavailable'}, 503)
 }

--- a/packages/gateway/src/web/server.test.ts
+++ b/packages/gateway/src/web/server.test.ts
@@ -19,6 +19,7 @@ import type {AddressInfo} from 'node:net'
 import type {ServerType} from '@hono/node-server'
 
 import type {GitHubOAuthConfig, GitHubOAuthDeps} from './auth/github.js'
+import type {SessionDeps} from './auth/session.js'
 import type {OperatorServerConfig, OperatorServerDeps} from './server.js'
 import {Buffer} from 'node:buffer'
 import {createServer} from 'node:http'
@@ -26,6 +27,8 @@ import {createServer} from 'node:http'
 import {describe, expect, it, vi} from 'vitest'
 import {createRateLimiter} from '../http/rate-limit.js'
 import {createInMemoryStateStore} from './auth/github.js'
+import {createInMemorySessionStore} from './auth/session.js'
+import {isPublicRoute} from './operator-route.js'
 import {buildOperatorApp, createOperatorServer} from './server.js'
 
 // ---------------------------------------------------------------------------
@@ -738,5 +741,154 @@ describe('operator server — warning log on rejection paths', () => {
     const warnCalls = (logger.warn as ReturnType<typeof vi.fn>).mock.calls as [Record<string, unknown>, string][]
     const fallbackWarning = warnCalls.find(([, msg]) => msg.includes('getConnInfo unavailable'))
     expect(fallbackWarning).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildOperatorApp — logout route registration
+// ---------------------------------------------------------------------------
+
+function makeStubSessionDeps(overrides?: Partial<SessionDeps>): SessionDeps {
+  return {
+    logger: makeLogger(),
+    auditLogger: {info: vi.fn(), warn: vi.fn()},
+    clock: () => Date.now(),
+    ...overrides,
+  }
+}
+
+describe('buildOperatorApp — logout route registration', () => {
+  it('registers POST /operator/auth/logout when sessionStore and sessionDeps are provided', () => {
+    // #given
+    const sessionStore = createInMemorySessionStore()
+    const sessionDeps = makeStubSessionDeps()
+    const app = buildOperatorApp(makeStubDeps({sessionStore, sessionDeps}), makeStubConfig())
+
+    // #when — extract unique logical routes
+    const seen = new Set<string>()
+    const routes = app.routes
+      .map((route: {method: string; path: string}) => ({method: route.method, path: route.path}))
+      .filter((route: {method: string; path: string}) => {
+        if (route.method === 'ALL' && route.path === '/*') return false
+        const key = `${route.method}:${route.path}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+
+    // #then — logout route is registered
+    expect(routes).toContainEqual({method: 'POST', path: '/operator/auth/logout'})
+  })
+
+  it('does NOT register POST /operator/auth/logout when sessionStore is absent', () => {
+    // #given — no session store
+    const app = buildOperatorApp(makeStubDeps(), makeStubConfig())
+
+    // #when
+    const seen = new Set<string>()
+    const routes = app.routes
+      .map((route: {method: string; path: string}) => ({method: route.method, path: route.path}))
+      .filter((route: {method: string; path: string}) => {
+        if (route.method === 'ALL' && route.path === '/*') return false
+        const key = `${route.method}:${route.path}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+
+    // #then — logout route is NOT registered
+    expect(routes).not.toContainEqual({method: 'POST', path: '/operator/auth/logout'})
+  })
+
+  it('logout route is classified as public (no session required to call logout)', () => {
+    // #given
+    const sessionStore = createInMemorySessionStore()
+    const sessionDeps = makeStubSessionDeps()
+    const app = buildOperatorApp(makeStubDeps({sessionStore, sessionDeps}), makeStubConfig())
+
+    // #when / #then — logout is public (idempotent, no oracle)
+    expect(isPublicRoute(app, 'POST', '/operator/auth/logout')).toBe(true)
+  })
+
+  it('logout route returns 200 and clears the session cookie', async () => {
+    // #given
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const app = buildOperatorApp(
+      makeStubDeps({sessionStore, sessionDeps, rateLimiter: {allow: () => true}}),
+      makeStubConfig(),
+    )
+
+    // #when
+    const {SESSION_COOKIE_NAME} = await import('./auth/session.js')
+    const req = new Request('http://127.0.0.1/operator/auth/logout', {
+      method: 'POST',
+      headers: {cookie: `${SESSION_COOKIE_NAME}=${sessionId}`},
+    })
+    const res = await app.fetch(req)
+
+    // #then — success
+    expect(res.status).toBe(200)
+
+    // #and — session is invalidated
+    expect(sessionStore.get(sessionId, now + 2000)).toBeUndefined()
+
+    // #and — clear-cookie header is set
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    expect(setCookie).toContain(SESSION_COOKIE_NAME)
+    expect(setCookie.toLowerCase()).toContain('max-age=0')
+  })
+
+  it('logout route returns 429 when rate limiter rejects', async () => {
+    // #given — rate limiter always blocks
+    const sessionStore = createInMemorySessionStore()
+    const sessionDeps = makeStubSessionDeps()
+    const app = buildOperatorApp(
+      makeStubDeps({sessionStore, sessionDeps, rateLimiter: {allow: () => false}}),
+      makeStubConfig(),
+    )
+
+    // #when
+    const {SESSION_COOKIE_NAME} = await import('./auth/session.js')
+    const req = new Request('http://127.0.0.1/operator/auth/logout', {
+      method: 'POST',
+      headers: {cookie: `${SESSION_COOKIE_NAME}=some-session-id`},
+    })
+    const res = await app.fetch(req)
+
+    // #then — rate limited
+    expect(res.status).toBe(429)
+  })
+
+  it('logout route clears cookie and invalidates session when rate limiter allows', async () => {
+    // #given — rate limiter allows
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const app = buildOperatorApp(
+      makeStubDeps({sessionStore, sessionDeps, rateLimiter: {allow: () => true}}),
+      makeStubConfig(),
+    )
+
+    // #when
+    const {SESSION_COOKIE_NAME} = await import('./auth/session.js')
+    const req = new Request('http://127.0.0.1/operator/auth/logout', {
+      method: 'POST',
+      headers: {cookie: `${SESSION_COOKIE_NAME}=${sessionId}`},
+    })
+    const res = await app.fetch(req)
+
+    // #then — allowed; session cleared
+    expect(res.status).toBe(200)
+    expect(sessionStore.get(sessionId, now + 2000)).toBeUndefined()
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    expect(setCookie.toLowerCase()).toContain('max-age=0')
   })
 })

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -23,12 +23,14 @@
 
 import type {ServerType} from '@hono/node-server'
 import type {GitHubOAuthConfig, GitHubOAuthDeps} from './auth/github.js'
+import type {SessionDeps, SessionStore} from './auth/session.js'
 import {serve} from '@hono/node-server'
 import {getConnInfo} from '@hono/node-server/conninfo'
 import {Hono} from 'hono'
 import {bodyLimit} from 'hono/body-limit'
 import {createRateLimiter} from '../http/rate-limit.js'
 import {buildGitHubOAuthRoutes} from './auth/github.js'
+import {buildLogoutRoutes} from './auth/session.js'
 import {assertAllPrivilegedRoutesWrapped, registerPublicRoute} from './operator-route.js'
 import {
   badRequestResponse,
@@ -90,6 +92,16 @@ export interface OperatorServerDeps {
    * When absent, the auth routes are not registered (opt-in).
    */
   readonly githubOAuth?: GitHubOAuthDeps
+  /**
+   * Optional session store for the logout route.
+   * When present (alongside sessionDeps), POST /operator/auth/logout is registered.
+   */
+  readonly sessionStore?: SessionStore
+  /**
+   * Session deps (logger, auditLogger, clock) for the logout route.
+   * Required when sessionStore is present; ignored otherwise.
+   */
+  readonly sessionDeps?: SessionDeps
 }
 
 export interface OperatorServerConfig {
@@ -333,6 +345,28 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
       'buildOperatorApp: deps.githubOAuth and config.githubOAuth must both be present or both absent. ' +
         'Partial GitHub OAuth config is a programming error.',
     )
+  }
+
+  // ── Logout route ───────────────────────────────────────────────────────────
+  //
+  // Registered only when both sessionStore and sessionDeps are present.
+  // Route: POST /operator/auth/logout — public (no session required to call logout).
+  // Thread the shared rate limiter and socket-derived source key into the logout route
+  // so it participates in the same per-socket budget as the health and OAuth routes.
+  if (deps.sessionStore !== undefined && deps.sessionDeps !== undefined) {
+    const sessionDepsWithRateLimiter = {
+      ...deps.sessionDeps,
+      rateLimiter,
+      getSourceKey: (c: Parameters<typeof getConnInfo>[0]) => {
+        try {
+          const connInfo = getConnInfo(c)
+          return connInfo.remote.address ?? 'unknown'
+        } catch {
+          return 'unknown'
+        }
+      },
+    }
+    buildLogoutRoutes(app, deps.sessionStore, sessionDepsWithRateLimiter)
   }
 
   // ── Catch-all ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds the Gateway operator session foundation:

- mints server-side opaque sessions after successful GitHub OAuth callbacks
- sets `__Host-` session cookies with secure browser attributes and stale-cookie replacement
- adds bounded in-memory session storage with absolute/idle expiry, revocation hooks, cap handling, and opportunistic scavenging
- registers `POST /operator/auth/logout` with shared socket-keyed rate limiting, idempotent cookie clearing, and no session-ID audit leakage
- updates the Phase B plan to mark Unit 3d complete

This does not add allowlist authorization, CSRF/fetch-metadata middleware, a session inspection endpoint, or privileged operator routes. Those remain later Phase B units.

## Verification

- `pnpm --filter @fro-bot/gateway test -- src/web/auth/session.test.ts src/web/auth/github.test.ts src/web/server.test.ts src/web/audit.test.ts src/program.test.ts`
- `pnpm --filter @fro-bot/gateway check-types`
- `pnpm --filter @fro-bot/gateway lint`
- `pnpm --filter @fro-bot/gateway build`
