### PR TITLE
feat(gateway): add operator browser auth gate

### DIFF
--- a/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
+++ b/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
@@ -523,56 +523,53 @@ The web listener is an adapter layer. It authenticates the operator, projects sa
   **Verification:**
   - Session store is bounded, revocable, and covered by deterministic typed tests.
 
-- [ ] **Unit 3e: Origin / Fetch Metadata / CSRF middleware**
+- [x] **Unit 3e: Allowlist authorization + Origin / Fetch Metadata / CSRF middleware** *(corrected scope — 2026-06-18)*
 
-  **Goal:** Implement the layered browser-origin protection stack that all mutating operator routes must pass through.
+  **Goal:** Implement the complete authorization boundary: operator allowlist check AND the layered browser-origin protection stack. This is the corrected gate per fro-bot/.github#3512 issuecomment 4738952239.
 
-  **Requirements:** R3, R4
+  **Requirements:** R1, R3, R4, R14
 
   **Dependencies:** Unit 3d
 
   **Files:**
-  - Create: `packages/gateway/src/web/auth/csrf.ts`
-  - Create: `packages/gateway/src/web/auth/csrf.test.ts`
-  - Modify: `packages/gateway/src/web/operator-route.ts`
+  - Created: `packages/gateway/src/web/auth/allowlist.ts`
+  - Created: `packages/gateway/src/web/auth/allowlist.test.ts`
+  - Created: `packages/gateway/src/web/auth/csrf.ts`
+  - Created: `packages/gateway/src/web/auth/csrf.test.ts`
+  - Created: `packages/gateway/src/web/auth/csrf-route.ts`
+  - Modified: `packages/gateway/src/web/operator-route.ts` (added `registerPublicCrossSiteRoute`, `isPublicCrossSiteRoute`)
+  - Modified: `packages/gateway/src/web/auth/github.ts` (callback uses `registerPublicCrossSiteRoute`)
+  - Modified: `packages/gateway/src/web/server.ts` (wired CSRF endpoint, added `allowlist`/`csrfSecret`/`auditLogger` deps)
+  - Modified: `packages/gateway/src/web/audit.ts` (added `BrowserGuardRejectedEvent`)
+  - Modified: `packages/gateway/src/web/audit.test.ts` (tests for new audit events)
+  - Modified: `packages/gateway/src/web/server.test.ts` (integration tests for CSRF endpoint and browser guard)
+  - Modified: `packages/gateway/src/web/operator-route.test.ts` (cross-site route classification tests)
 
   **Approach:**
-  - Do not rely on `hono/csrf` for JSON mutating routes. Implement custom signed double-submit CSRF tokens: tokens are bound to session id, operator id, issued-at, and a nonce/version; signed with the CSRF signing key from config; rotated on login, refresh, and a 15-minute interval; invalidated on logout, expiry, and revocation.
-  - Guard mutating routes in this order: (1) reject non-cookie credential schemes (`Authorization`, `Proxy-Authorization`, `X-API-Key`) and audit without logging credential values; (2) validate session; (3) validate `Host`/`Origin` against `GATEWAY_OPERATOR_PUBLIC_ORIGIN`; (4) reject unsafe Fetch Metadata combinations (`Sec-Fetch-Site: cross-site` on non-exempted routes, `Sec-Fetch-Mode: navigate` on non-navigation routes) when headers are present; (5) parse and verify CSRF token.
-  - The OAuth callback is narrowly exempted from Fetch Metadata cross-site rejection (established in Unit 3c); no other route is exempted.
-  - Add a `GET /operator/session/csrf` route that returns a fresh signed double-submit token for an authenticated session.
-
-  **Patterns to follow:**
-  - OWASP CSRF Prevention Cheat Sheet: signed double-submit + origin/Fetch Metadata defense in depth.
-  - No-oracle auth failure behavior from signed webhook ingress.
-
-  **Test scenarios:**
-  - Security: mutating routes reject missing CSRF token, invalid CSRF signature, expired CSRF token, and mismatched session binding.
-  - Security: mutating routes reject `Origin` header that does not match `GATEWAY_OPERATOR_PUBLIC_ORIGIN`.
-  - Security: `Sec-Fetch-Site: cross-site` on a non-exempted mutating route is rejected.
-  - Security: non-cookie credential schemes are rejected and audited without logging the credential value.
-  - Security: CSRF token refresh requires a valid session and rotates tokens on schedule.
-  - Happy path: a valid session + matching origin + valid CSRF token passes all checks.
+  - Allowlist: file-backed (text, one numeric GitHub user ID per line, comments with #). Fail-closed: missing/empty/malformed startup config rejects; browser guard denies non-allowlisted session-bound identities and audits the numeric GitHub user ID.
+  - CSRF tokens: HMAC-SHA256, bound to session ID + operator ID + 15-minute interval. 30-second grace window for previous interval. Timing-safe comparison. CSRF signing key must be strict base64url with at least 256 bits of decoded entropy. Token format: `base64url(payload).base64url(hmac)`.
+  - Browser guard (`applyBrowserGuard`): (a) reject non-cookie credential schemes; (b) validate session cookie; (c) enforce allowlist; (d) validate Origin exactly against `publicOrigin`; reject `Origin: null`; (e) validate Fetch Metadata; (f) verify CSRF token for mutating routes.
+  - OAuth callback registered via `registerPublicCrossSiteRoute` — exempt from cross-site Fetch Metadata rejection only. All other security checks remain.
+  - `GET /operator/session/csrf`: privileged route, requires session + allowlist + origin/fetch-metadata pass. Returns token in response body only.
+  - New audit event: `browser.guard.rejected` — safe enums only, no header values.
+  - `Vary: Origin, Sec-Fetch-Site, Sec-Fetch-Mode, Sec-Fetch-Dest` on guard responses and CSRF endpoint responses.
 
   **Verification:**
-  - CSRF and origin middleware are tested in isolation and wired into the route guardrail from Unit 3a.
+  - 52/52 test files pass. Type check clean. Lint clean. Build succeeds.
 
-- [ ] **Unit 3f: Allowlist + repo authorization helper**
+- [ ] **Unit 3f: Repo authorization helper**
 
-  **Goal:** Implement the operator allowlist check and the single repo authorization helper used by all privileged routes.
+  **Goal:** Implement the single repo authorization helper used by all privileged routes.
 
   **Requirements:** R1, R14, R19
 
-  **Dependencies:** Unit 3d
+  **Dependencies:** Unit 3e
 
   **Files:**
-  - Create: `packages/gateway/src/web/auth/allowlist.ts`
   - Create: `packages/gateway/src/web/auth/repo-authz.ts`
-  - Create: `packages/gateway/src/web/auth/allowlist.test.ts`
   - Create: `packages/gateway/src/web/auth/repo-authz.test.ts`
 
   **Approach:**
-  - Load the operator allowlist from a hardened config/file path. v1 uses a file-backed allowlist; hot reload can be added later. Allowlist entries are stable numeric GitHub user IDs, not logins.
   - Add one `checkRepoAuthz(operatorId, owner, repo, userOAuthToken, logger)` helper used by launch, run-state, approvals, and binding reads. v1 rule: allowlist membership plus verified GitHub read access to the target repo using the user OAuth token (not only app installation auth). Failures deny.
   - Cache repo authorization by operator/repo: 5-minute positive TTL, 30-second negative TTL, TTL jitter, request coalescing for concurrent misses, fail-closed on lookup errors. GitHub rate-limit responses are cached through their retry window.
   - Normalize and validate owner/repo names before any authz or queueing work.
@@ -593,7 +590,7 @@ The web listener is an adapter layer. It authenticates the operator, projects sa
   - Validation: malformed owner/repo names are rejected before authz work begins.
 
   **Verification:**
-  - Allowlist and repo authz are deterministic, fail-closed, and covered by typed tests.
+  - Repo authz is deterministic, fail-closed, and covered by typed tests.
 
 - [ ] **Unit 3g: Minimal session routes**
 

--- a/packages/gateway/src/config.test.ts
+++ b/packages/gateway/src/config.test.ts
@@ -1,5 +1,6 @@
 import type {GatewayConfig} from './config.js'
 
+import {Buffer} from 'node:buffer'
 import {mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync} from 'node:fs'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
@@ -79,6 +80,10 @@ beforeEach(() => {
     'GATEWAY_OPERATOR_OAUTH_STATE_TTL_MS',
     'GATEWAY_OPERATOR_OAUTH_MAX_OUTSTANDING_ATTEMPTS',
     'GATEWAY_OPERATOR_GITHUB_CLIENT_ID_FILE',
+    'GATEWAY_OPERATOR_CSRF_SECRET',
+    'GATEWAY_OPERATOR_CSRF_SECRET_FILE',
+    'GATEWAY_OPERATOR_ALLOWLIST',
+    'GATEWAY_OPERATOR_ALLOWLIST_FILE',
   ]) {
     delete process.env[key]
   }
@@ -431,6 +436,7 @@ function setRequiredEnv(): void {
 /**
  * Set the minimum operator web env vars for a valid config.
  * Call after setRequiredEnv() when testing operator web happy paths.
+ * Includes CSRF secret and allowlist (required for Unit 3e production wiring).
  */
 function setOperatorWebEnv(overrides: {bindHost?: string; bindPort?: string; publicOrigin?: string} = {}): void {
   process.env.GATEWAY_OPERATOR_BIND_HOST = overrides.bindHost ?? '172.20.0.2'
@@ -438,6 +444,9 @@ function setOperatorWebEnv(overrides: {bindHost?: string; bindPort?: string; pub
   process.env.GATEWAY_OPERATOR_PUBLIC_ORIGIN = overrides.publicOrigin ?? 'https://operator.example.com'
   process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_ID = 'test-oauth-client-id'
   process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_SECRET = 'test-oauth-client-secret'
+  // Unit 3e: CSRF secret and allowlist are required when operator web is enabled.
+  process.env.GATEWAY_OPERATOR_CSRF_SECRET = 'dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nISE'
+  process.env.GATEWAY_OPERATOR_ALLOWLIST = '42\n99'
 }
 
 describe('loadGatewayConfig', () => {
@@ -2004,6 +2013,9 @@ function setOperatorEnv(origin: string): void {
   process.env.GATEWAY_OPERATOR_PUBLIC_ORIGIN = origin
   process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_ID = 'test-oauth-client-id'
   process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_SECRET = 'test-oauth-client-secret'
+  // Unit 3e: CSRF secret and allowlist are required when operator web is enabled.
+  process.env.GATEWAY_OPERATOR_CSRF_SECRET = 'dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nISE'
+  process.env.GATEWAY_OPERATOR_ALLOWLIST = '42\n99'
 }
 
 describe('loadGatewayConfig — GATEWAY_OPERATOR_PUBLIC_ORIGIN canonical origin validation', () => {
@@ -2257,6 +2269,8 @@ describe('loadGatewayConfig — operator web OAuth credentials', () => {
     process.env.GATEWAY_OPERATOR_BIND_PORT = '4000'
     process.env.GATEWAY_OPERATOR_PUBLIC_ORIGIN = 'https://operator.example.com'
     process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_SECRET = 'test-oauth-client-secret'
+    process.env.GATEWAY_OPERATOR_CSRF_SECRET = 'dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nISE'
+    process.env.GATEWAY_OPERATOR_ALLOWLIST = '42\n99'
     delete process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_ID
     const clientIdFile = join(tmpDir, 'github-client-id.txt')
     writeFileSync(clientIdFile, 'file-client-id\n', {mode: 0o600})
@@ -2269,5 +2283,198 @@ describe('loadGatewayConfig — operator web OAuth credentials', () => {
     expect(config.operatorWeb?.oauthClientId).toBe('file-client-id')
 
     delete process.env.GATEWAY_OPERATOR_GITHUB_CLIENT_ID_FILE
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GATEWAY_OPERATOR_CSRF_SECRET and GATEWAY_OPERATOR_ALLOWLIST — Unit 3e gaps
+// ---------------------------------------------------------------------------
+
+describe('loadGatewayConfig — CSRF secret and operator allowlist (Unit 3e production wiring)', () => {
+  it('error path: operator web enabled but GATEWAY_OPERATOR_CSRF_SECRET missing → throws', () => {
+    // #given — all operator web vars set but no CSRF secret
+    setRequiredEnv()
+    setOperatorWebEnv()
+    // Explicitly remove the CSRF secret that setOperatorWebEnv() sets
+    delete process.env.GATEWAY_OPERATOR_CSRF_SECRET
+    delete process.env.GATEWAY_OPERATOR_CSRF_SECRET_FILE
+
+    // #when / #then — must fail closed, not silently disable the gate
+    expect(() => loadGatewayConfig()).toThrow(/GATEWAY_OPERATOR_CSRF_SECRET/)
+  })
+
+  it('error path: operator web enabled but GATEWAY_OPERATOR_ALLOWLIST missing → throws', () => {
+    // #given — all operator web vars + CSRF secret set but no allowlist
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_CSRF_SECRET = 'dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nISE'
+    // Explicitly remove the allowlist that setOperatorWebEnv() sets
+    delete process.env.GATEWAY_OPERATOR_ALLOWLIST
+    delete process.env.GATEWAY_OPERATOR_ALLOWLIST_FILE
+
+    // #when / #then — must fail closed
+    expect(() => loadGatewayConfig()).toThrow(/GATEWAY_OPERATOR_ALLOWLIST/)
+  })
+
+  it('error path: GATEWAY_OPERATOR_ALLOWLIST file is empty → throws (fail closed)', () => {
+    // #given — allowlist file exists but is empty
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_CSRF_SECRET = 'dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nISE'
+    const allowlistFile = join(tmpDir, 'allowlist-empty.txt')
+    writeFileSync(allowlistFile, '', {mode: 0o600})
+    process.env.GATEWAY_OPERATOR_ALLOWLIST_FILE = allowlistFile
+
+    // #when / #then — empty allowlist must fail closed
+    expect(() => loadGatewayConfig()).toThrow(/allowlist/i)
+  })
+
+  it('error path: GATEWAY_OPERATOR_ALLOWLIST file has malformed entries → throws (fail closed)', () => {
+    // #given — allowlist file with non-numeric entries
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_CSRF_SECRET = 'dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nISE'
+    const allowlistFile = join(tmpDir, 'allowlist-bad.txt')
+    writeFileSync(allowlistFile, 'not-a-number\n', {mode: 0o600})
+    process.env.GATEWAY_OPERATOR_ALLOWLIST_FILE = allowlistFile
+
+    // #when / #then — malformed allowlist must fail closed
+    expect(() => loadGatewayConfig()).toThrow(/allowlist/i)
+  })
+
+  it('happy path: CSRF secret and allowlist both present → config includes csrfSecret and allowlist', () => {
+    // #given — all operator web vars + CSRF secret + valid allowlist
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_CSRF_SECRET = 'dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nISE'
+    const allowlistFile = join(tmpDir, 'allowlist-valid.txt')
+    writeFileSync(allowlistFile, '# comment\n42\n99\n', {mode: 0o600})
+    process.env.GATEWAY_OPERATOR_ALLOWLIST_FILE = allowlistFile
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then — csrfSecret and allowlist are present in operatorWeb
+    expect(config.operatorWeb?.csrfSecret).toBe('dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nISE')
+    expect(config.operatorWeb?.allowlist).toBeDefined()
+    expect(config.operatorWeb?.allowlist?.isAuthorized(42)).toBe(true)
+    expect(config.operatorWeb?.allowlist?.isAuthorized(99)).toBe(true)
+    expect(config.operatorWeb?.allowlist?.isAuthorized(1)).toBe(false)
+  })
+
+  it('happy path: GATEWAY_OPERATOR_ALLOWLIST env var (inline text) → parsed as allowlist', () => {
+    // #given — allowlist provided inline via env var (not file)
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_CSRF_SECRET = 'dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nISE'
+    process.env.GATEWAY_OPERATOR_ALLOWLIST = '42\n99'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.operatorWeb?.allowlist?.isAuthorized(42)).toBe(true)
+    expect(config.operatorWeb?.allowlist?.isAuthorized(99)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GATEWAY_OPERATOR_CSRF_SECRET — strict base64url validation (Fix 1)
+// ---------------------------------------------------------------------------
+
+describe('loadGatewayConfig — CSRF secret strict base64url validation', () => {
+  it('happy path: valid base64url CSRF secret (32 bytes) → parses and stores csrfSecret', () => {
+    // #given — 32 bytes of CSPRNG entropy, base64url-encoded (no padding)
+    setRequiredEnv()
+    setOperatorWebEnv()
+    // 32 bytes → 43 base64url chars (no padding)
+    const validSecret = 'dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nISE'
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then — csrfSecret is stored as-is
+    expect(config.operatorWeb?.csrfSecret).toBe(validSecret)
+  })
+
+  it('happy path: valid base64url CSRF secret (64 bytes) → accepted (more than minimum)', () => {
+    // #given — 64 bytes → 86 base64url chars
+    setRequiredEnv()
+    setOperatorWebEnv()
+    // Generate a valid 64-byte base64url string (no padding)
+    const secret64 = Buffer.alloc(64, 0xab).toString('base64url')
+    process.env.GATEWAY_OPERATOR_CSRF_SECRET = secret64
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.operatorWeb?.csrfSecret).toBe(secret64)
+  })
+
+  it('error path: CSRF secret with base64 padding (=) → throws (not strict base64url)', () => {
+    // #given — base64 with padding is not strict base64url
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_CSRF_SECRET = 'dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nISE='
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/strict base64url/)
+  })
+
+  it('error path: CSRF secret with + character → throws (not base64url)', () => {
+    // #given — base64 standard uses + which is not base64url
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_CSRF_SECRET = 'dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nIS+='
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/strict base64url/)
+  })
+
+  it('error path: CSRF secret with / character → throws (not base64url)', () => {
+    // #given — base64 standard uses / which is not base64url
+    setRequiredEnv()
+    setOperatorWebEnv()
+    process.env.GATEWAY_OPERATOR_CSRF_SECRET = 'dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nIS/='
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/strict base64url/)
+  })
+
+  it('error path: CSRF secret decodes to fewer than 32 bytes → throws (too short)', () => {
+    // #given — 16 bytes → 22 base64url chars (below 32-byte minimum)
+    setRequiredEnv()
+    setOperatorWebEnv()
+    const shortSecret = Buffer.alloc(16, 0xaa).toString('base64url')
+    process.env.GATEWAY_OPERATOR_CSRF_SECRET = shortSecret
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/at least 32 bytes/)
+  })
+
+  it('error path: CSRF secret decodes to exactly 31 bytes → throws (one byte short)', () => {
+    // #given — 31 bytes is one byte below the 32-byte minimum
+    setRequiredEnv()
+    setOperatorWebEnv()
+    const shortSecret = Buffer.alloc(31, 0xbb).toString('base64url')
+    process.env.GATEWAY_OPERATOR_CSRF_SECRET = shortSecret
+
+    // #when / #then
+    expect(() => loadGatewayConfig()).toThrow(/at least 32 bytes/)
+  })
+
+  it('happy path: CSRF secret decodes to exactly 32 bytes → accepted (minimum boundary)', () => {
+    // #given — exactly 32 bytes is the minimum
+    setRequiredEnv()
+    setOperatorWebEnv()
+    const minSecret = Buffer.alloc(32, 0xcc).toString('base64url')
+    process.env.GATEWAY_OPERATOR_CSRF_SECRET = minSecret
+
+    // #when
+    const config = loadGatewayConfig()
+
+    // #then
+    expect(config.operatorWeb?.csrfSecret).toBe(minSecret)
   })
 })

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -1,10 +1,13 @@
 import type {AwsCredentials, ObjectStoreConfig} from './runtime-effect.js'
+import type {OperatorAllowlist} from './web/auth/allowlist.js'
 
+import {Buffer} from 'node:buffer'
 import {closeSync, constants, fstatSync, openSync, readFileSync} from 'node:fs'
 import {isIP} from 'node:net'
 import process from 'node:process'
 
 import {GatewayIntentBits} from 'discord.js'
+import {parseAllowlistText} from './web/auth/allowlist.js'
 
 const DEFAULT_S3_PREFIX = 'fro-bot-state'
 const DEFAULT_GATEWAY_IDENTITY = 'discord-gateway'
@@ -150,6 +153,20 @@ export interface GatewayConfig {
      * Defaults to 5.
      */
     readonly oauthMaxOutstandingAttemptsPerKey: number
+    /**
+     * CSRF token signing key (HMAC-SHA256), base64url-encoded with no padding/newlines.
+     * Read from GATEWAY_OPERATOR_CSRF_SECRET (or _FILE variant).
+     * Required when operator web is enabled — startup fails if absent.
+     * Must decode to at least 32 bytes (256 bits) of CSPRNG entropy.
+     */
+    readonly csrfSecret: string
+    /**
+     * Operator allowlist — set of authorized numeric GitHub user IDs.
+     * Loaded from GATEWAY_OPERATOR_ALLOWLIST_FILE or GATEWAY_OPERATOR_ALLOWLIST env var.
+     * Required when operator web is enabled — startup fails if absent, empty, or malformed.
+     * Fail-closed: missing/unreadable/empty/malformed allowlist denies everyone.
+     */
+    readonly allowlist: OperatorAllowlist
   }
 }
 
@@ -743,6 +760,59 @@ export function loadGatewayConfig(): GatewayConfig {
       oauthMaxOutstandingAttemptsPerKey = parsed
     }
 
+    // Read and validate CSRF signing secret — required when operator web is enabled.
+    // Must be a strict base64url string (no padding, no newlines, no non-base64url chars),
+    // decode to at least 32 bytes (256 bits of HMAC-SHA256 key entropy), and be round-trip
+    // stable (re-encoding the decoded bytes must reproduce the original string).
+    //
+    // GATEWAY_OPERATOR_CSRF_SECRET is an HMAC-SHA256 key with at least 256 bits of CSPRNG
+    // entropy, encoded as base64url with no padding and no newlines.
+    const rawCsrfSecret = readSecret('GATEWAY_OPERATOR_CSRF_SECRET')
+    // Strict base64url: only A-Z, a-z, 0-9, -, _ (no padding, no whitespace, no +, /)
+    // Use \w (word chars: [A-Za-z0-9_]) plus - for the full base64url alphabet.
+    if (/^[\w-]+$/.test(rawCsrfSecret) === false) {
+      throw new Error(
+        String.raw`Invalid GATEWAY_OPERATOR_CSRF_SECRET: must be strict base64url encoding (characters A-Z, a-z, 0-9, -, _ only; no padding, no whitespace, no + or /). Generate with: node -e "require('crypto').randomBytes(32).toString('base64url')" | tr -d '\n'`,
+      )
+    }
+    // Decode and check minimum length (32 bytes = 256 bits)
+    const csrfKeyBytes = Buffer.from(rawCsrfSecret, 'base64url')
+    if (csrfKeyBytes.length < 32) {
+      throw new Error(
+        String.raw`Invalid GATEWAY_OPERATOR_CSRF_SECRET: decoded to ${csrfKeyBytes.length} bytes but at least 32 bytes (256 bits) are required. Generate a new secret with: node -e "require('crypto').randomBytes(32).toString('base64url')" | tr -d '\n'`,
+      )
+    }
+    // Round-trip stability: re-encoding must reproduce the original string
+    const csrfSecretRoundTrip = csrfKeyBytes.toString('base64url')
+    if (csrfSecretRoundTrip !== rawCsrfSecret) {
+      throw new Error(
+        'Invalid GATEWAY_OPERATOR_CSRF_SECRET: value is not round-trip stable (re-encoding the decoded bytes does not reproduce the original string). Ensure the value is canonical base64url with no padding.',
+      )
+    }
+    const csrfSecret = rawCsrfSecret
+
+    // Read operator allowlist — required when operator web is enabled.
+    // Supports both file-backed (GATEWAY_OPERATOR_ALLOWLIST_FILE) and inline
+    // (GATEWAY_OPERATOR_ALLOWLIST) variants. Fail-closed: missing/empty/malformed → throw.
+    const rawAllowlistText = readOptionalMultilineSecret('GATEWAY_OPERATOR_ALLOWLIST')
+    if (rawAllowlistText === null) {
+      throw new Error(
+        'Missing required operator allowlist: set GATEWAY_OPERATOR_ALLOWLIST env var (newline-separated numeric GitHub user IDs) or GATEWAY_OPERATOR_ALLOWLIST_FILE pointing to a file. The operator web surface requires an explicit allowlist — it cannot start without one.',
+      )
+    }
+    const allowlistParseResult = parseAllowlistText(rawAllowlistText)
+    if (allowlistParseResult.ok === false) {
+      throw new Error(
+        `Invalid operator allowlist: ${allowlistParseResult.reason}. Fix GATEWAY_OPERATOR_ALLOWLIST or GATEWAY_OPERATOR_ALLOWLIST_FILE. The operator web surface requires a valid, non-empty allowlist — it cannot start with a malformed or empty one.`,
+      )
+    }
+    // Construct OperatorAllowlist directly from the parse result — no double parse, no dead logger.
+    const {ids: allowlistIds} = allowlistParseResult
+    const allowlist: OperatorAllowlist = {
+      isAuthorized: (githubUserId: number) => allowlistIds.has(githubUserId),
+      size: allowlistIds.size,
+    }
+
     // Normalize to parsedPublicOrigin.origin: strips trailing slash and default ports.
     // Stored value is always scheme+host+optional-non-default-port (no trailing slash).
     operatorWeb = {
@@ -754,6 +824,8 @@ export function loadGatewayConfig(): GatewayConfig {
       oauthAllowedReturnPaths,
       oauthStateTtlMs,
       oauthMaxOutstandingAttemptsPerKey,
+      csrfSecret,
+      allowlist,
     }
   }
 

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -172,6 +172,8 @@ function makeFakeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
 function makeOperatorWebConfig(
   overrides: Partial<NonNullable<GatewayConfig['operatorWeb']>> = {},
 ): NonNullable<GatewayConfig['operatorWeb']> {
+  // Build a minimal deny-all allowlist for tests that don't need real allowlist behavior.
+  const denyAllAllowlist = {isAuthorized: () => false, size: 0}
   return {
     bindHost: '172.20.0.2',
     bindPort: 4000,
@@ -181,6 +183,8 @@ function makeOperatorWebConfig(
     oauthAllowedReturnPaths: ['/operator'],
     oauthStateTtlMs: 600_000,
     oauthMaxOutstandingAttemptsPerKey: 5,
+    csrfSecret: 'dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nISE',
+    allowlist: denyAllAllowlist,
     ...overrides,
   }
 }
@@ -1137,6 +1141,47 @@ describe('button interaction handler (approval flow)', () => {
 
     // #then — operator server was never started
     expect(startOperatorServerSpy).not.toHaveBeenCalled()
+  })
+
+  it('operator server receives allowlist and csrfSecret from config when operatorWeb is configured', async () => {
+    // #given — config has operatorWeb with csrfSecret and allowlist
+    const testAllowlist = {isAuthorized: (id: number) => id === 42, size: 1}
+    const fakeConfig = makeFakeConfig({
+      announce: undefined,
+      operatorWeb: makeOperatorWebConfig({
+        csrfSecret: 'dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nISE',
+        allowlist: testAllowlist,
+      }),
+    })
+    const fakeClient = makeFakeClient()
+    const fakeOperatorHandle = makeFakeServerHandle()
+    const startOperatorServerSpy = vi.fn().mockReturnValue(fakeOperatorHandle)
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: startOperatorServerSpy,
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    // #when
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then — operator server was started
+    expect(startOperatorServerSpy).toHaveBeenCalledOnce()
+
+    // #and — deps include allowlist and csrfSecret
+    const [serverDeps] = startOperatorServerSpy.mock.calls[0] as [
+      import('./web/server.js').OperatorServerDeps,
+      import('./web/server.js').OperatorServerConfig,
+    ]
+    expect(serverDeps.allowlist).toBeDefined()
+    expect(serverDeps.allowlist?.isAuthorized(42)).toBe(true)
+    expect(serverDeps.allowlist?.isAuthorized(99)).toBe(false)
+    expect(serverDeps.csrfSecret).toBe('dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nISE')
+    expect(serverDeps.auditLogger).toBeDefined()
   })
 
   it('shutdown → approvalRegistry.disposeAll called', async () => {

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -411,6 +411,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
 
       // Build production GitHub OAuth deps with real CSPRNG, fetch, and clock.
       // Pass the session store so successful callbacks mint a fresh session.
+      // Pass the allowlist so non-allowlisted users are denied before session creation.
       const githubOAuthDeps = buildGitHubOAuthDeps(
         logger,
         logger,
@@ -418,6 +419,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
         operatorRateLimiter,
         sessionStore,
         sessionDeps,
+        config.operatorWeb.allowlist,
       )
 
       operatorServerHandle = deps.startOperatorServer(
@@ -428,6 +430,9 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           githubOAuth: githubOAuthDeps,
           sessionStore,
           sessionDeps,
+          allowlist: config.operatorWeb.allowlist,
+          csrfSecret: config.operatorWeb.csrfSecret,
+          auditLogger: logger,
         },
         {
           bindHost: config.operatorWeb.bindHost,

--- a/packages/gateway/src/web/audit.test.ts
+++ b/packages/gateway/src/web/audit.test.ts
@@ -931,6 +931,61 @@ describe('emitAudit — redaction edge cases', () => {
 })
 
 // ---------------------------------------------------------------------------
+// browser.guard.rejected
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — browser.guard.rejected', () => {
+  it('emits a structured warn record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {
+      kind: 'browser.guard.rejected',
+      correlationId: 'corr-014',
+      reason: 'origin_mismatch',
+    }
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.warn).toHaveBeenCalledOnce()
+    expect(logger.info).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.warn)).toBe('audit: browser.guard.rejected')
+    expect(firstCallCtx(logger.warn)).toMatchObject({
+      kind: 'browser.guard.rejected',
+      correlationId: 'corr-014',
+      reason: 'origin_mismatch',
+    })
+  })
+
+  it('redacts sensitive values planted in correlationId; reason enum is preserved', () => {
+    // #given
+    for (const planted of [
+      PLANTED_COOKIE,
+      PLANTED_TOKEN,
+      PLANTED_BEARER,
+      PLANTED_SECRET,
+      PLANTED_PROMPT,
+      PLANTED_INTERNAL_URL,
+    ]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {
+        kind: 'browser.guard.rejected',
+        correlationId: planted,
+        reason: 'fetch_site_cross_site',
+      }
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+      expect(serializeAllCalls(logger)).toContain('fetch_site_cross_site')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Sink resilience — throwing logger must not propagate
 // ---------------------------------------------------------------------------
 

--- a/packages/gateway/src/web/audit.ts
+++ b/packages/gateway/src/web/audit.ts
@@ -16,6 +16,7 @@ export type AuthCallbackFailureReason =
   | 'token_exchange_failed'
   | 'user_fetch_failed'
   | 'source_key_mismatch'
+  | 'not_allowlisted'
   | 'unknown'
 
 /** Safe reasons for authorization denial. */
@@ -29,6 +30,24 @@ export type ApprovalRejectedReason = 'already_claimed' | 'not_found' | 'deadline
 
 /** Safe reasons for bearer token rejection. */
 export type BearerRejectedReason = 'missing_token' | 'invalid_signature' | 'expired' | 'unknown'
+
+/** Safe reasons for browser-origin guard rejection. */
+export type BrowserGuardRejectedReason =
+  | 'non_cookie_credential'
+  | 'no_session'
+  | 'invalid_session'
+  | 'not_allowlisted'
+  | 'origin_null'
+  | 'origin_mismatch'
+  | 'origin_missing'
+  | 'fetch_site_cross_site'
+  | 'fetch_site_same_site'
+  | 'fetch_mode_navigate'
+  | 'fetch_mode_no_cors'
+  | 'fetch_dest_object_embed'
+  | 'csrf_missing'
+  | 'csrf_invalid'
+  | 'unknown'
 
 /** OAuth flow initiated. */
 export interface AuthStartEvent {
@@ -126,6 +145,20 @@ export interface BearerRejectedEvent {
   readonly reason: BearerRejectedReason
 }
 
+/** Browser-origin guard rejected a request. */
+export interface BrowserGuardRejectedEvent {
+  readonly kind: 'browser.guard.rejected'
+  readonly correlationId: string
+  /** Safe enum — never header values, origins, or credential values. */
+  readonly reason: BrowserGuardRejectedReason
+  /**
+   * GitHub numeric user ID — present only when reason is 'not_allowlisted'
+   * (i.e. the session was valid but the user is not in the allowlist).
+   * Absent for all other rejection reasons where identity is not yet established.
+   */
+  readonly githubUserId?: number
+}
+
 /** All security-critical audit events. */
 export type AuditEvent =
   | AuthStartEvent
@@ -140,6 +173,7 @@ export type AuditEvent =
   | ApprovalRejectedEvent
   | BindingReadEvent
   | BearerRejectedEvent
+  | BrowserGuardRejectedEvent
 
 // ---------------------------------------------------------------------------
 // Redaction
@@ -207,6 +241,7 @@ const LOG_LEVEL: Record<AuditEvent['kind'], 'info' | 'warn'> = {
   'approval.rejected': 'warn',
   'binding.read': 'info',
   'bearer.rejected': 'warn',
+  'browser.guard.rejected': 'warn',
 }
 
 /** Compile-time exhaustiveness guard — unreachable at runtime. */
@@ -243,6 +278,7 @@ export function emitAudit(event: AuditEvent, logger: AuditLogger): void {
     case 'authz.denied':
     case 'launch.rejected':
     case 'bearer.rejected':
+    case 'browser.guard.rejected':
       // No additional caller-controlled string fields on these variants.
       break
     default:

--- a/packages/gateway/src/web/auth/allowlist.test.ts
+++ b/packages/gateway/src/web/auth/allowlist.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for the operator allowlist authorization module.
+ *
+ * Covers:
+ *   - Fail closed: missing/unreadable/empty/malformed allowlist denies everyone.
+ *   - Happy path: allowlisted numeric GitHub user ID is authorized.
+ *   - Security: non-allowlisted user is denied.
+ *   - Security: authorization uses session-bound identity, never request headers.
+ *   - Security: login strings are not authoritative — only numeric IDs.
+ *   - Audit: authz.denied emitted on every denial.
+ *
+ * Uses BDD comments (#given, #when, #then).
+ */
+
+import {describe, expect, it, vi} from 'vitest'
+import {loadAllowlistFromText, parseAllowlistText} from './allowlist.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// parseAllowlistText — parsing
+// ---------------------------------------------------------------------------
+
+describe('parseAllowlistText — parsing', () => {
+  it('parses a single numeric ID', () => {
+    // #given
+    const text = '12345\n'
+
+    // #when
+    const result = parseAllowlistText(text)
+
+    // #then
+    expect(result).toEqual({ok: true, ids: new Set([12345])})
+  })
+
+  it('parses multiple numeric IDs (newline-separated)', () => {
+    // #given
+    const text = '12345\n67890\n11111\n'
+
+    // #when
+    const result = parseAllowlistText(text)
+
+    // #then
+    expect(result).toEqual({ok: true, ids: new Set([12345, 67890, 11111])})
+  })
+
+  it('ignores blank lines and whitespace', () => {
+    // #given
+    const text = '\n  12345  \n\n  67890\n\n'
+
+    // #when
+    const result = parseAllowlistText(text)
+
+    // #then
+    expect(result).toEqual({ok: true, ids: new Set([12345, 67890])})
+  })
+
+  it('ignores comment lines starting with #', () => {
+    // #given
+    const text = '# operator allowlist\n12345\n# another comment\n67890\n'
+
+    // #when
+    const result = parseAllowlistText(text)
+
+    // #then
+    expect(result).toEqual({ok: true, ids: new Set([12345, 67890])})
+  })
+
+  it('returns error for empty text (no IDs)', () => {
+    // #given
+    const text = ''
+
+    // #when
+    const result = parseAllowlistText(text)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('returns error for whitespace-only text', () => {
+    // #given
+    const text = '   \n\n   \n'
+
+    // #when
+    const result = parseAllowlistText(text)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('returns error for comment-only text (no IDs)', () => {
+    // #given
+    const text = '# just a comment\n# another comment\n'
+
+    // #when
+    const result = parseAllowlistText(text)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('returns error when any line is non-numeric (malformed)', () => {
+    // #given — login string mixed in
+    const text = '12345\noctocat\n67890\n'
+
+    // #when
+    const result = parseAllowlistText(text)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('returns error for zero as a user ID (invalid)', () => {
+    // #given
+    const text = '0\n'
+
+    // #when
+    const result = parseAllowlistText(text)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('returns error for negative numbers', () => {
+    // #given
+    const text = '-1\n'
+
+    // #when
+    const result = parseAllowlistText(text)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('returns error for floating-point numbers', () => {
+    // #given
+    const text = '123.45\n'
+
+    // #when
+    const result = parseAllowlistText(text)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('returns error for an all-digits value exceeding Number.MAX_SAFE_INTEGER', () => {
+    // #given — 9007199254740992 is Number.MAX_SAFE_INTEGER + 1 (all digits, no decimal)
+    const oversized = String(Number.MAX_SAFE_INTEGER + 1)
+    const text = `${oversized}\n`
+
+    // #when
+    const result = parseAllowlistText(text)
+
+    // #then — must reject; integer precision is lost above MAX_SAFE_INTEGER
+    expect(result.ok).toBe(false)
+  })
+
+  it('accepts a valid ID well within Number.MAX_SAFE_INTEGER', () => {
+    // #given — a realistic GitHub user ID
+    const text = '12345678\n'
+
+    // #when
+    const result = parseAllowlistText(text)
+
+    // #then — must pass
+    expect(result).toEqual({ok: true, ids: new Set([12345678])})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// loadAllowlistFromText — fail-closed posture
+// ---------------------------------------------------------------------------
+
+describe('loadAllowlistFromText — fail-closed posture', () => {
+  it('returns a deny-all allowlist when text is empty', () => {
+    // #given
+    const logger = makeLogger()
+
+    // #when
+    const allowlist = loadAllowlistFromText('', logger)
+
+    // #then — deny-all: no ID is authorized
+    expect(allowlist.isAuthorized(12345)).toBe(false)
+    expect(allowlist.isAuthorized(1)).toBe(false)
+  })
+
+  it('returns a deny-all allowlist when text is malformed', () => {
+    // #given
+    const logger = makeLogger()
+
+    // #when
+    const allowlist = loadAllowlistFromText('octocat\n', logger)
+
+    // #then — deny-all
+    expect(allowlist.isAuthorized(12345)).toBe(false)
+  })
+
+  it('logs a warning when allowlist is empty or malformed', () => {
+    // #given
+    const logger = makeLogger()
+
+    // #when
+    loadAllowlistFromText('', logger)
+
+    // #then
+    expect(logger.warn).toHaveBeenCalled()
+  })
+})

--- a/packages/gateway/src/web/auth/allowlist.ts
+++ b/packages/gateway/src/web/auth/allowlist.ts
@@ -1,0 +1,126 @@
+/**
+ * Operator allowlist authorization module.
+ *
+ * Loads a file-backed allowlist of stable numeric GitHub user IDs.
+ * Authorization is fail-closed: missing/unreadable/empty/malformed allowlist
+ * denies everyone.
+ *
+ * Security invariants:
+ *   - Allowlist entries are stable numeric GitHub user IDs, not logins.
+ *   - Login strings are never authoritative — only numeric IDs.
+ *   - Authorization uses session-bound identity, never request headers.
+ *   - Fail closed: any config/read failure denies everyone.
+ *   - No session IDs, tokens, or credential values in audit records.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Logger interface for the allowlist module. */
+export interface AllowlistLogger {
+  readonly debug: (ctx: Record<string, unknown>, msg: string) => void
+  readonly info: (ctx: Record<string, unknown>, msg: string) => void
+  readonly warn: (ctx: Record<string, unknown>, msg: string) => void
+  readonly error: (ctx: Record<string, unknown>, msg: string) => void
+}
+
+/** Parse result for allowlist text. */
+export type ParseAllowlistResult =
+  | {readonly ok: true; readonly ids: ReadonlySet<number>}
+  | {readonly ok: false; readonly reason: string}
+
+/** An operator allowlist — a set of authorized numeric GitHub user IDs. */
+export interface OperatorAllowlist {
+  /** Returns true if the given numeric GitHub user ID is in the allowlist. */
+  readonly isAuthorized: (githubUserId: number) => boolean
+  /** Number of entries in the allowlist. */
+  readonly size: number
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse allowlist text into a set of numeric GitHub user IDs.
+ *
+ * Format:
+ *   - One numeric user ID per line.
+ *   - Lines starting with # are comments (ignored).
+ *   - Blank lines and leading/trailing whitespace are ignored.
+ *   - Any non-numeric, zero, or negative entry is a parse error.
+ *   - An empty result (no IDs after filtering) is an error.
+ *
+ * Returns {ok: true, ids} on success, {ok: false, reason} on failure.
+ */
+export function parseAllowlistText(text: string): ParseAllowlistResult {
+  const ids = new Set<number>()
+
+  const lines = text.split('\n')
+  for (const rawLine of lines) {
+    const line = rawLine.trim()
+
+    // Skip blank lines and comments
+    if (line === '' || line.startsWith('#')) continue
+
+    // Must be a positive integer
+    if (/^\d+$/.test(line) === false) {
+      return {ok: false, reason: `Non-numeric entry in allowlist: "${line}"`}
+    }
+
+    const id = Number.parseInt(line, 10)
+    if (Number.isFinite(id) === false || Number.isInteger(id) === false || id <= 0) {
+      return {ok: false, reason: `Invalid numeric ID in allowlist: "${line}"`}
+    }
+
+    if (Number.isSafeInteger(id) === false) {
+      return {ok: false, reason: `Numeric ID exceeds safe integer range in allowlist: "${line}"`}
+    }
+
+    ids.add(id)
+  }
+
+  if (ids.size === 0) {
+    return {ok: false, reason: 'Allowlist is empty — no authorized user IDs found'}
+  }
+
+  return {ok: true, ids}
+}
+
+// ---------------------------------------------------------------------------
+// Deny-all sentinel
+// ---------------------------------------------------------------------------
+
+/** A deny-all allowlist returned when the allowlist is missing/malformed/empty. */
+const DENY_ALL: OperatorAllowlist = {
+  isAuthorized: () => false,
+  size: 0,
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Load an operator allowlist from raw text content.
+ *
+ * Fail-closed: if the text is empty, malformed, or contains no valid IDs,
+ * returns a deny-all allowlist and logs a warning.
+ *
+ * The caller is responsible for reading the file; this function only parses.
+ */
+export function loadAllowlistFromText(text: string, logger: AllowlistLogger): OperatorAllowlist {
+  const result = parseAllowlistText(text)
+
+  if (result.ok === false) {
+    logger.warn({}, `operator allowlist: fail-closed — ${result.reason}`)
+    return DENY_ALL
+  }
+
+  const ids = result.ids
+  return {
+    isAuthorized: (githubUserId: number) => ids.has(githubUserId),
+    size: ids.size,
+  }
+}

--- a/packages/gateway/src/web/auth/csrf-route.ts
+++ b/packages/gateway/src/web/auth/csrf-route.ts
@@ -1,0 +1,72 @@
+/**
+ * CSRF token endpoint for the operator web surface.
+ *
+ * GET /operator/session/csrf
+ *
+ * Returns a fresh signed CSRF token for an authenticated, allowlisted session.
+ * The token is returned in the response body only — never in a cookie or header.
+ * The caller must include this token in the X-CSRF-Token header for mutating requests.
+ *
+ * Security invariants:
+ *   - Requires a valid session cookie (authenticated session).
+ *   - Requires the session's GitHub user ID to be in the operator allowlist.
+ *   - Origin and Fetch Metadata checks are applied before returning the token.
+ *   - Token is never logged.
+ *   - No CSRF token required to GET the CSRF token (safe method).
+ *
+ * The browser guard is applied automatically by the privileged-route guard seam
+ * installed in server.ts (via setOperatorRouteGuard). The handler reads the
+ * authenticated context (githubUserId, sessionId) from the Hono context variables
+ * set by the guard wrapper — no double session lookup.
+ */
+
+import type {Hono} from 'hono'
+import type {BrowserGuardDeps} from './csrf.js'
+import {getOperatorAuthContext, registerOperatorRoute} from '../operator-route.js'
+import {generateCsrfToken} from './csrf.js'
+
+/**
+ * Register the GET /operator/session/csrf route on the given Hono app.
+ *
+ * Registered as a privileged operator route (requires session + allowlist).
+ * The browser guard is applied automatically by the privileged-route guard seam
+ * (setOperatorRouteGuard in server.ts). No CSRF token is required to GET the
+ * CSRF token (safe method — guard uses requireCsrf=false for GET).
+ *
+ * The handler reads the authenticated context from Hono context variables set
+ * by the guard wrapper, avoiding a double session lookup.
+ */
+export function buildCsrfRoute(app: Hono, deps: BrowserGuardDeps): void {
+  registerOperatorRoute(app, 'GET', '/operator/session/csrf', c => {
+    // The browser guard has already run (via the privileged-route guard seam).
+    // Read the authenticated context stored by the guard wrapper.
+    const authCtx = getOperatorAuthContext(c)
+    if (authCtx === undefined) {
+      // Guard not installed. This path is unreachable in production — buildCsrfRoute
+      // is only called when browserGuardDeps is present, which also installs the guard.
+      // Return 401 as a safe fallback.
+      return c.json({error: 'unauthorized'}, 401)
+    }
+
+    const {githubUserId, sessionId} = authCtx
+    const nowMs = deps.clock()
+
+    // Generate a fresh CSRF token bound to this session and operator.
+    const token = generateCsrfToken({
+      sessionId,
+      operatorId: githubUserId,
+      nowMs,
+      secret: deps.csrfSecret,
+    })
+
+    // Prevent caching of the CSRF token — it is session-bound and must not be
+    // served from any cache (browser, CDN, or proxy).
+    c.header('Cache-Control', 'no-store, private')
+    // Vary on the headers the browser guard inspects so intermediaries cannot
+    // serve a cached response to a different origin or fetch context.
+    c.header('Vary', 'Origin, Sec-Fetch-Site, Sec-Fetch-Mode, Sec-Fetch-Dest')
+
+    // Return token in response body only — never in a cookie or header.
+    return c.json({csrfToken: token}, 200)
+  })
+}

--- a/packages/gateway/src/web/auth/csrf.test.ts
+++ b/packages/gateway/src/web/auth/csrf.test.ts
@@ -1,0 +1,1134 @@
+/**
+ * Tests for the CSRF token module and browser-origin guard middleware.
+ *
+ * Covers:
+ *   - Token generation and verification (happy path).
+ *   - Session/operator binding mismatch rejection.
+ *   - Token expiry.
+ *   - Malformed token rejection.
+ *   - Timing-safe compare path (no short-circuit on mismatch).
+ *   - No token leakage in logs or responses.
+ *   - Browser guard: credential headers reject without value leakage.
+ *   - Browser guard: Origin exact match / null / mismatch.
+ *   - Browser guard: Fetch Metadata cross-site / same-site / navigate / no-cors / object / embed.
+ *   - Browser guard: absent-header behavior.
+ *   - Browser guard: Vary header on rejects.
+ *   - CSRF endpoint: requires session + allowlist, returns token in body only.
+ *
+ * Uses BDD comments (#given, #when, #then).
+ */
+
+import {Buffer} from 'node:buffer'
+import {Hono} from 'hono'
+import {describe, expect, it, vi} from 'vitest'
+import {loadAllowlistFromText} from './allowlist.js'
+import {
+  applyBrowserGuard,
+  CSRF_TOKEN_GRACE_MS,
+  CSRF_TOKEN_INTERVAL_MS,
+  CSRF_TOKEN_MAX_LENGTH,
+  generateCsrfToken,
+  verifyCsrfToken,
+} from './csrf.js'
+import {createInMemorySessionStore, SESSION_COOKIE_NAME} from './session.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_CSRF_SECRET = Buffer.from('test-csrf-secret-32-bytes-long!!', 'utf8').toString('base64url')
+
+// ---------------------------------------------------------------------------
+// generateCsrfToken / verifyCsrfToken — happy path
+// ---------------------------------------------------------------------------
+
+describe('generateCsrfToken / verifyCsrfToken — happy path', () => {
+  it('generates a token that verifies successfully', () => {
+    // #given
+    const sessionId = 'session-abc-123'
+    const operatorId = 42
+    const nowMs = Date.now()
+
+    // #when
+    const token = generateCsrfToken({sessionId, operatorId, nowMs, secret: TEST_CSRF_SECRET})
+    const result = verifyCsrfToken({token, sessionId, operatorId, nowMs, secret: TEST_CSRF_SECRET})
+
+    // #then
+    expect(result.ok).toBe(true)
+  })
+
+  it('token is a non-empty string', () => {
+    // #given
+    const nowMs = Date.now()
+
+    // #when
+    const token = generateCsrfToken({sessionId: 'sid', operatorId: 1, nowMs, secret: TEST_CSRF_SECRET})
+
+    // #then
+    expect(typeof token).toBe('string')
+    expect(token.length).toBeGreaterThan(0)
+  })
+
+  it('two tokens generated at the same time for the same session are identical (deterministic within interval)', () => {
+    // #given
+    const sessionId = 'session-abc-123'
+    const operatorId = 42
+    const nowMs = 1_000_000 // fixed time
+
+    // #when
+    const token1 = generateCsrfToken({sessionId, operatorId, nowMs, secret: TEST_CSRF_SECRET})
+    const token2 = generateCsrfToken({sessionId, operatorId, nowMs, secret: TEST_CSRF_SECRET})
+
+    // #then — same inputs produce same token (HMAC is deterministic)
+    expect(token1).toBe(token2)
+  })
+
+  it('tokens for different sessions are different', () => {
+    // #given
+    const nowMs = 1_000_000
+
+    // #when
+    const token1 = generateCsrfToken({sessionId: 'session-A', operatorId: 42, nowMs, secret: TEST_CSRF_SECRET})
+    const token2 = generateCsrfToken({sessionId: 'session-B', operatorId: 42, nowMs, secret: TEST_CSRF_SECRET})
+
+    // #then
+    expect(token1).not.toBe(token2)
+  })
+
+  it('tokens for different operators are different', () => {
+    // #given
+    const nowMs = 1_000_000
+
+    // #when
+    const token1 = generateCsrfToken({sessionId: 'session-A', operatorId: 42, nowMs, secret: TEST_CSRF_SECRET})
+    const token2 = generateCsrfToken({sessionId: 'session-A', operatorId: 99, nowMs, secret: TEST_CSRF_SECRET})
+
+    // #then
+    expect(token1).not.toBe(token2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// verifyCsrfToken — session/operator binding mismatch
+// ---------------------------------------------------------------------------
+
+describe('verifyCsrfToken — session/operator binding mismatch', () => {
+  it('rejects token when session ID does not match', () => {
+    // #given
+    const nowMs = 1_000_000
+    const token = generateCsrfToken({sessionId: 'session-A', operatorId: 42, nowMs, secret: TEST_CSRF_SECRET})
+
+    // #when — verify with different session ID
+    const result = verifyCsrfToken({
+      token,
+      sessionId: 'session-B',
+      operatorId: 42,
+      nowMs,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects token when operator ID does not match', () => {
+    // #given
+    const nowMs = 1_000_000
+    const token = generateCsrfToken({sessionId: 'session-A', operatorId: 42, nowMs, secret: TEST_CSRF_SECRET})
+
+    // #when — verify with different operator ID
+    const result = verifyCsrfToken({
+      token,
+      sessionId: 'session-A',
+      operatorId: 99,
+      nowMs,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects token signed with a different secret', () => {
+    // #given
+    const nowMs = 1_000_000
+    const otherSecret = Buffer.from('other-csrf-secret-32-bytes-long!', 'utf8').toString('base64url')
+    const token = generateCsrfToken({sessionId: 'session-A', operatorId: 42, nowMs, secret: otherSecret})
+
+    // #when — verify with the test secret
+    const result = verifyCsrfToken({
+      token,
+      sessionId: 'session-A',
+      operatorId: 42,
+      nowMs,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// verifyCsrfToken — expiry
+// ---------------------------------------------------------------------------
+
+describe('verifyCsrfToken — expiry', () => {
+  it('accepts a token within the current interval', () => {
+    // #given — token issued at start of interval
+    const intervalStart = 0
+    const token = generateCsrfToken({
+      sessionId: 'sid',
+      operatorId: 1,
+      nowMs: intervalStart,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #when — verify just before interval ends
+    const result = verifyCsrfToken({
+      token,
+      sessionId: 'sid',
+      operatorId: 1,
+      nowMs: intervalStart + CSRF_TOKEN_INTERVAL_MS - 1,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #then
+    expect(result.ok).toBe(true)
+  })
+
+  it('accepts a token from the previous interval within the grace window', () => {
+    // #given — token issued at start of interval 0
+    const intervalStart = 0
+    const token = generateCsrfToken({
+      sessionId: 'sid',
+      operatorId: 1,
+      nowMs: intervalStart,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #when — verify just after interval boundary (within grace)
+    const result = verifyCsrfToken({
+      token,
+      sessionId: 'sid',
+      operatorId: 1,
+      nowMs: intervalStart + CSRF_TOKEN_INTERVAL_MS + CSRF_TOKEN_GRACE_MS - 1,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #then — still valid within grace window
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects a token from the previous interval after the grace window', () => {
+    // #given — token issued at start of interval 0
+    const intervalStart = 0
+    const token = generateCsrfToken({
+      sessionId: 'sid',
+      operatorId: 1,
+      nowMs: intervalStart,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #when — verify after grace window expires
+    const result = verifyCsrfToken({
+      token,
+      sessionId: 'sid',
+      operatorId: 1,
+      nowMs: intervalStart + CSRF_TOKEN_INTERVAL_MS + CSRF_TOKEN_GRACE_MS + 1,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #then — expired
+    expect(result.ok).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// verifyCsrfToken — malformed token
+// ---------------------------------------------------------------------------
+
+describe('verifyCsrfToken — malformed token', () => {
+  it('rejects an empty token', () => {
+    // #given
+    const nowMs = Date.now()
+
+    // #when
+    const result = verifyCsrfToken({token: '', sessionId: 'sid', operatorId: 1, nowMs, secret: TEST_CSRF_SECRET})
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a token with wrong format (no dot separator)', () => {
+    // #given
+    const nowMs = Date.now()
+
+    // #when
+    const result = verifyCsrfToken({
+      token: 'notavalidtoken',
+      sessionId: 'sid',
+      operatorId: 1,
+      nowMs,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a token with tampered payload', () => {
+    // #given
+    const nowMs = 1_000_000
+    const token = generateCsrfToken({sessionId: 'sid', operatorId: 1, nowMs, secret: TEST_CSRF_SECRET})
+    // Tamper with the payload part
+    const parts = token.split('.')
+    const tamperedToken = `tampered${parts[0]}.${parts[1]}`
+
+    // #when
+    const result = verifyCsrfToken({
+      token: tamperedToken,
+      sessionId: 'sid',
+      operatorId: 1,
+      nowMs,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a token with tampered signature', () => {
+    // #given
+    const nowMs = 1_000_000
+    const token = generateCsrfToken({sessionId: 'sid', operatorId: 1, nowMs, secret: TEST_CSRF_SECRET})
+    // Tamper with the signature part
+    const parts = token.split('.')
+    const tamperedToken = `${parts[0]}.tamperedsignature`
+
+    // #when
+    const result = verifyCsrfToken({
+      token: tamperedToken,
+      sessionId: 'sid',
+      operatorId: 1,
+      nowMs,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Token leakage — tokens must not appear in error reasons
+// ---------------------------------------------------------------------------
+
+describe('verifyCsrfToken — no token leakage', () => {
+  it('rejection result does not contain the token value', () => {
+    // #given
+    const nowMs = 1_000_000
+    const token = generateCsrfToken({sessionId: 'sid', operatorId: 1, nowMs, secret: TEST_CSRF_SECRET})
+
+    // #when — verify with wrong session
+    const result = verifyCsrfToken({
+      token,
+      sessionId: 'wrong-session',
+      operatorId: 1,
+      nowMs,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #then — result must not contain the token value
+    expect(result.ok).toBe(false)
+    const serialized = JSON.stringify(result)
+    expect(serialized).not.toContain(token)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CSRF_TOKEN_INTERVAL_MS and CSRF_TOKEN_GRACE_MS — exported constants
+// ---------------------------------------------------------------------------
+
+describe('CSRF token constants', () => {
+  it('cSRF_TOKEN_INTERVAL_MS is 15 minutes', () => {
+    expect(CSRF_TOKEN_INTERVAL_MS).toBe(15 * 60 * 1000)
+  })
+
+  it('cSRF_TOKEN_GRACE_MS is 30 seconds', () => {
+    expect(CSRF_TOKEN_GRACE_MS).toBe(30 * 1000)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applyBrowserGuard — absent Origin on mutating requests (Unit 3e gap #5)
+// ---------------------------------------------------------------------------
+
+function makeBrowserGuardDeps(sessionStore: ReturnType<typeof createInMemorySessionStore>) {
+  const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+  const auditLogger = {info: vi.fn(), warn: vi.fn()}
+  const allowlist = loadAllowlistFromText('42\n', logger)
+  return {
+    logger,
+    auditLogger,
+    sessionStore,
+    allowlist,
+    csrfSecret: TEST_CSRF_SECRET,
+    publicOrigin: 'https://operator.example.com',
+    clock: () => Date.now(),
+  }
+}
+
+describe('applyBrowserGuard — absent Origin on mutating requests (Unit 3e gap #5)', () => {
+  it('rejects POST with no Origin and no Fetch Metadata headers', async () => {
+    // #given — valid session, no Origin, no Sec-Fetch-* headers
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const deps = {...makeBrowserGuardDeps(sessionStore), clock: () => now + 1000}
+    const csrfToken = generateCsrfToken({sessionId, operatorId: 42, nowMs: now + 1000, secret: TEST_CSRF_SECRET})
+
+    const app = new Hono()
+    app.post('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, true)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — POST with no Origin and no Sec-Fetch-Site (absent both)
+    const req = new Request('http://operator.example.com/test', {
+      method: 'POST',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        'x-csrf-token': csrfToken,
+        // No Origin, no Sec-Fetch-Site
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — must reject (absent Origin on mutating request is not allowed)
+    expect(res.status).toBe(400)
+  })
+
+  it('allows GET with no Origin (safe method — no mutation risk)', async () => {
+    // #given — valid session, no Origin, GET method
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const deps = {...makeBrowserGuardDeps(sessionStore), clock: () => now + 1000}
+
+    const app = new Hono()
+    app.get('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, false)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — GET with no Origin (safe method)
+    const req = new Request('http://operator.example.com/test', {
+      method: 'GET',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        // No Origin — safe method, should be allowed
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — allowed (GET is safe)
+    expect(res.status).toBe(200)
+  })
+
+  it('allows POST with Sec-Fetch-Site: same-origin and no Origin (Fetch Metadata fallback)', async () => {
+    // #given — valid session, no Origin but Sec-Fetch-Site: same-origin
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const deps = {...makeBrowserGuardDeps(sessionStore), clock: () => now + 1000}
+    const csrfToken = generateCsrfToken({sessionId, operatorId: 42, nowMs: now + 1000, secret: TEST_CSRF_SECRET})
+
+    const app = new Hono()
+    app.post('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, true)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — POST with Sec-Fetch-Site: same-origin (no Origin header)
+    const req = new Request('http://operator.example.com/test', {
+      method: 'POST',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        'x-csrf-token': csrfToken,
+        'sec-fetch-site': 'same-origin',
+        // No Origin header — Fetch Metadata fallback should allow same-origin
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — allowed via Fetch Metadata fallback
+    expect(res.status).toBe(200)
+  })
+
+  it('allows mutating request with no Origin, Sec-Fetch-Site: same-origin, no Sec-Fetch-Mode, valid CSRF/session/allowlist', async () => {
+    // #given — valid session + allowlist, no Origin, Sec-Fetch-Site: same-origin, Sec-Fetch-Mode absent
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const deps = {...makeBrowserGuardDeps(sessionStore), clock: () => now + 1000}
+    const csrfToken = generateCsrfToken({sessionId, operatorId: 42, nowMs: now + 1000, secret: TEST_CSRF_SECRET})
+
+    const app = new Hono()
+    app.post('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, true)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — POST with no Origin, Sec-Fetch-Site: same-origin, no Sec-Fetch-Mode
+    // Sec-Fetch-Mode absent is not a rejection signal when Sec-Fetch-Site is same-origin.
+    const req = new Request('http://operator.example.com/test', {
+      method: 'POST',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        'x-csrf-token': csrfToken,
+        'sec-fetch-site': 'same-origin',
+        // No Origin header
+        // No Sec-Fetch-Mode header — absent is fine when Sec-Fetch-Site is same-origin
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — must pass (Sec-Fetch-Site: same-origin is sufficient without Sec-Fetch-Mode)
+    expect(res.status).toBe(200)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applyBrowserGuard — typed audit events (Unit 3e gap #4)
+// ---------------------------------------------------------------------------
+
+describe('applyBrowserGuard — typed audit events (Unit 3e gap #4)', () => {
+  it('emits browser.guard.rejected with reason non_cookie_credential for Authorization header', async () => {
+    // #given — valid session but Authorization header present
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = {
+      ...makeBrowserGuardDeps(sessionStore),
+      auditLogger,
+      clock: () => now + 1000,
+    }
+
+    const app = new Hono()
+    app.get('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, false)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — request with Authorization header (non-cookie credential)
+    const req = new Request('http://operator.example.com/test', {
+      method: 'GET',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        authorization: 'Bearer some-token',
+      },
+    })
+    await app.fetch(req)
+
+    // #then — audit event must be browser.guard.rejected with reason non_cookie_credential
+    const warnCalls = auditLogger.warn.mock.calls as [Record<string, unknown>, string][]
+    const auditCall = warnCalls.find(([ctx]) => ctx.kind === 'browser.guard.rejected')
+    expect(auditCall).toBeDefined()
+    expect(auditCall?.[0]).toMatchObject({kind: 'browser.guard.rejected', reason: 'non_cookie_credential'})
+    // Must NOT use bearer.rejected for this case
+    const bearerCall = warnCalls.find(([ctx]) => ctx.kind === 'bearer.rejected')
+    expect(bearerCall).toBeUndefined()
+  })
+
+  it('emits browser.guard.rejected with reason origin_mismatch for wrong Origin', async () => {
+    // #given — valid session, valid allowlist, wrong Origin
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = {
+      ...makeBrowserGuardDeps(sessionStore),
+      auditLogger,
+      clock: () => now + 1000,
+    }
+
+    const app = new Hono()
+    app.get('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, false)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — request with wrong Origin
+    const req = new Request('http://operator.example.com/test', {
+      method: 'GET',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://evil.attacker.com',
+      },
+    })
+    await app.fetch(req)
+
+    // #then — audit event must be browser.guard.rejected with reason origin_mismatch
+    const warnCalls = auditLogger.warn.mock.calls as [Record<string, unknown>, string][]
+    const auditCall = warnCalls.find(([ctx]) => ctx.kind === 'browser.guard.rejected')
+    expect(auditCall).toBeDefined()
+    expect(auditCall?.[0]).toMatchObject({kind: 'browser.guard.rejected', reason: 'origin_mismatch'})
+  })
+
+  it('emits browser.guard.rejected with reason csrf_missing for missing CSRF token', async () => {
+    // #given — valid session, valid allowlist, correct Origin, no CSRF token
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = {
+      ...makeBrowserGuardDeps(sessionStore),
+      auditLogger,
+      clock: () => now + 1000,
+    }
+
+    const app = new Hono()
+    app.post('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, true)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — POST with correct Origin but no CSRF token
+    const req = new Request('http://operator.example.com/test', {
+      method: 'POST',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+        // No x-csrf-token
+      },
+    })
+    await app.fetch(req)
+
+    // #then — audit event must be browser.guard.rejected with reason csrf_missing
+    const warnCalls = auditLogger.warn.mock.calls as [Record<string, unknown>, string][]
+    const auditCall = warnCalls.find(([ctx]) => ctx.kind === 'browser.guard.rejected')
+    expect(auditCall).toBeDefined()
+    expect(auditCall?.[0]).toMatchObject({kind: 'browser.guard.rejected', reason: 'csrf_missing'})
+  })
+
+  it('emits browser.guard.rejected with reason csrf_invalid for invalid CSRF token', async () => {
+    // #given — valid session, valid allowlist, correct Origin, invalid CSRF token
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = {
+      ...makeBrowserGuardDeps(sessionStore),
+      auditLogger,
+      clock: () => now + 1000,
+    }
+
+    const app = new Hono()
+    app.post('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, true)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — POST with correct Origin but invalid CSRF token
+    const req = new Request('http://operator.example.com/test', {
+      method: 'POST',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+        'x-csrf-token': 'invalid.token',
+      },
+    })
+    await app.fetch(req)
+
+    // #then — audit event must be browser.guard.rejected with reason csrf_invalid
+    const warnCalls = auditLogger.warn.mock.calls as [Record<string, unknown>, string][]
+    const auditCall = warnCalls.find(([ctx]) => ctx.kind === 'browser.guard.rejected')
+    expect(auditCall).toBeDefined()
+    expect(auditCall?.[0]).toMatchObject({kind: 'browser.guard.rejected', reason: 'csrf_invalid'})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applyBrowserGuard — touch only after allowlist passes (Fix 3)
+// ---------------------------------------------------------------------------
+
+describe('applyBrowserGuard — touch not called for non-allowlisted session (Fix 3)', () => {
+  it('does not call touch when operator is not in allowlist', async () => {
+    // #given — session for user 99 who is NOT in the allowlist (allowlist has 42)
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 99, login: 'notallowed'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const touchSpy = vi.spyOn(sessionStore, 'touch')
+    const deps = {...makeBrowserGuardDeps(sessionStore), clock: () => now + 1000}
+
+    const app = new Hono()
+    app.get('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, false)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — GET with valid session but non-allowlisted user
+    const req = new Request('http://operator.example.com/test', {
+      method: 'GET',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected 403
+    expect(res.status).toBe(403)
+
+    // #and — touch was NOT called (idle TTL must not be extended for non-allowlisted sessions)
+    expect(touchSpy).not.toHaveBeenCalled()
+  })
+
+  it('calls touch when operator IS in allowlist', async () => {
+    // #given — session for user 42 who IS in the allowlist
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const touchSpy = vi.spyOn(sessionStore, 'touch')
+    const deps = {...makeBrowserGuardDeps(sessionStore), clock: () => now + 1000}
+
+    const app = new Hono()
+    app.get('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, false)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — GET with valid session and allowlisted user
+    const req = new Request('http://operator.example.com/test', {
+      method: 'GET',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — allowed
+    expect(res.status).toBe(200)
+
+    // #and — touch WAS called (idle TTL extended for allowlisted sessions)
+    expect(touchSpy).toHaveBeenCalledOnce()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applyBrowserGuard — audit includes githubUserId on not_allowlisted (Fix 6)
+// ---------------------------------------------------------------------------
+
+describe('applyBrowserGuard — not_allowlisted audit includes githubUserId (Fix 6)', () => {
+  it('browser.guard.rejected audit event includes githubUserId when reason is not_allowlisted', async () => {
+    // #given — session for user 99 who is NOT in the allowlist
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 99, login: 'notallowed'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = {...makeBrowserGuardDeps(sessionStore), auditLogger, clock: () => now + 1000}
+
+    const app = new Hono()
+    app.get('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, false)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when
+    const req = new Request('http://operator.example.com/test', {
+      method: 'GET',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+      },
+    })
+    await app.fetch(req)
+
+    // #then — audit event includes githubUserId
+    const warnCalls = auditLogger.warn.mock.calls as [Record<string, unknown>, string][]
+    const auditCall = warnCalls.find(([ctx]) => ctx.kind === 'browser.guard.rejected')
+    expect(auditCall).toBeDefined()
+    expect(auditCall?.[0]).toMatchObject({
+      kind: 'browser.guard.rejected',
+      reason: 'not_allowlisted',
+      githubUserId: 99,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applyBrowserGuard — Fetch Metadata rejection branches (Fix 8)
+// ---------------------------------------------------------------------------
+
+describe('applyBrowserGuard — Fetch Metadata rejection branches (Fix 8)', () => {
+  it('rejects Origin: null (opaque origin)', async () => {
+    // #given — valid session, Origin: null
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const deps = {...makeBrowserGuardDeps(sessionStore), clock: () => now + 1000}
+    const app = new Hono()
+    app.get('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, false)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — Origin: null (sandboxed iframe or cross-site navigation)
+    const req = new Request('http://operator.example.com/test', {
+      method: 'GET',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'null',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected 400
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects Sec-Fetch-Site: cross-site', async () => {
+    // #given — valid session, Sec-Fetch-Site: cross-site
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const deps = {...makeBrowserGuardDeps(sessionStore), clock: () => now + 1000}
+    const app = new Hono()
+    app.get('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, false)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — Sec-Fetch-Site: cross-site (not a public cross-site route)
+    const req = new Request('http://operator.example.com/test', {
+      method: 'GET',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+        'sec-fetch-site': 'cross-site',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected 400
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects Sec-Fetch-Site: same-site (not same-origin)', async () => {
+    // #given — valid session, Sec-Fetch-Site: same-site
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const deps = {...makeBrowserGuardDeps(sessionStore), clock: () => now + 1000}
+    const app = new Hono()
+    app.get('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, false)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — Sec-Fetch-Site: same-site (not same-origin — rejected for security)
+    const req = new Request('http://operator.example.com/test', {
+      method: 'GET',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+        'sec-fetch-site': 'same-site',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected 400
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects Sec-Fetch-Mode: navigate on mutating request', async () => {
+    // #given — valid session, Sec-Fetch-Mode: navigate on POST
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const deps = {...makeBrowserGuardDeps(sessionStore), clock: () => now + 1000}
+    const csrfToken = generateCsrfToken({sessionId, operatorId: 42, nowMs: now + 1000, secret: TEST_CSRF_SECRET})
+    const app = new Hono()
+    app.post('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, true)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — POST with Sec-Fetch-Mode: navigate
+    const req = new Request('http://operator.example.com/test', {
+      method: 'POST',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+        'x-csrf-token': csrfToken,
+        'sec-fetch-site': 'same-origin',
+        'sec-fetch-mode': 'navigate',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected 400
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects Sec-Fetch-Mode: no-cors on mutating request', async () => {
+    // #given — valid session, Sec-Fetch-Mode: no-cors on POST
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const deps = {...makeBrowserGuardDeps(sessionStore), clock: () => now + 1000}
+    const csrfToken = generateCsrfToken({sessionId, operatorId: 42, nowMs: now + 1000, secret: TEST_CSRF_SECRET})
+    const app = new Hono()
+    app.post('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, true)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — POST with Sec-Fetch-Mode: no-cors
+    const req = new Request('http://operator.example.com/test', {
+      method: 'POST',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+        'x-csrf-token': csrfToken,
+        'sec-fetch-site': 'same-origin',
+        'sec-fetch-mode': 'no-cors',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected 400
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects Sec-Fetch-Dest: object', async () => {
+    // #given — valid session, Sec-Fetch-Dest: object
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const deps = {...makeBrowserGuardDeps(sessionStore), clock: () => now + 1000}
+    const app = new Hono()
+    app.get('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, false)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — GET with Sec-Fetch-Dest: object (plugin/embed context)
+    const req = new Request('http://operator.example.com/test', {
+      method: 'GET',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+        'sec-fetch-dest': 'object',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected 400
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects Sec-Fetch-Dest: embed', async () => {
+    // #given — valid session, Sec-Fetch-Dest: embed
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const deps = {...makeBrowserGuardDeps(sessionStore), clock: () => now + 1000}
+    const app = new Hono()
+    app.get('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, false)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — GET with Sec-Fetch-Dest: embed
+    const req = new Request('http://operator.example.com/test', {
+      method: 'GET',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+        'sec-fetch-dest': 'embed',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected 400
+    expect(res.status).toBe(400)
+  })
+
+  it('adds Vary header on rejection responses', async () => {
+    // #given — valid session, wrong Origin (will be rejected)
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const deps = {...makeBrowserGuardDeps(sessionStore), clock: () => now + 1000}
+    const app = new Hono()
+    app.get('/test', async c => {
+      const result = await applyBrowserGuard(c, deps, false, false)
+      if (result.ok === false) return result.response
+      return c.json({ok: true})
+    })
+
+    // #when — GET with wrong Origin
+    const req = new Request('http://operator.example.com/test', {
+      method: 'GET',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://evil.attacker.com',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected with Vary header
+    expect(res.status).toBe(400)
+    const vary = res.headers.get('vary') ?? ''
+    expect(vary).toContain('Origin')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// verifyCsrfToken — overlong token and wrong-length signature (Fix 8)
+// ---------------------------------------------------------------------------
+
+describe('verifyCsrfToken — overlong token rejected before Buffer allocation (Fix 8)', () => {
+  it('rejects a token exceeding CSRF_TOKEN_MAX_LENGTH without allocating large buffers', () => {
+    // #given — token longer than the max allowed length
+    const nowMs = Date.now()
+    const overlong = 'a'.repeat(CSRF_TOKEN_MAX_LENGTH + 1)
+
+    // #when
+    const result = verifyCsrfToken({
+      token: overlong,
+      sessionId: 'sid',
+      operatorId: 1,
+      nowMs,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #then — rejected as malformed_token
+    expect(result.ok).toBe(false)
+    expect(result.ok === false && result.reason).toBe('malformed_token')
+  })
+
+  it('cSRF_TOKEN_MAX_LENGTH is 512', () => {
+    expect(CSRF_TOKEN_MAX_LENGTH).toBe(512)
+  })
+
+  it('wrong-length signature returns invalid_signature without throwing', () => {
+    // #given — valid payload but signature of wrong length (1 char)
+    const nowMs = 1_000_000
+    const token = generateCsrfToken({sessionId: 'sid', operatorId: 1, nowMs, secret: TEST_CSRF_SECRET})
+    const payloadPart = token.split('.')[0]
+    // Construct a token with a 1-char signature (wrong length)
+    const wrongLengthSigToken = `${payloadPart}.x`
+
+    // #when
+    const result = verifyCsrfToken({
+      token: wrongLengthSigToken,
+      sessionId: 'sid',
+      operatorId: 1,
+      nowMs,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #then — returns false / invalid_signature without throwing
+    expect(result.ok).toBe(false)
+    expect(result.ok === false && result.reason).toBe('invalid_signature')
+  })
+
+  it('cSRF token binding mismatch for session ID returns binding_mismatch', () => {
+    // #given — token bound to session-A, verified against session-B
+    const nowMs = 1_000_000
+    const token = generateCsrfToken({sessionId: 'session-A', operatorId: 42, nowMs, secret: TEST_CSRF_SECRET})
+
+    // #when — verify with different session ID
+    const result = verifyCsrfToken({
+      token,
+      sessionId: 'session-B',
+      operatorId: 42,
+      nowMs,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #then
+    expect(result.ok).toBe(false)
+    expect(result.ok === false && result.reason).toBe('binding_mismatch')
+  })
+
+  it('cSRF token binding mismatch for operator ID returns binding_mismatch', () => {
+    // #given — token bound to operator 42, verified against operator 99
+    const nowMs = 1_000_000
+    const token = generateCsrfToken({sessionId: 'session-A', operatorId: 42, nowMs, secret: TEST_CSRF_SECRET})
+
+    // #when — verify with different operator ID
+    const result = verifyCsrfToken({
+      token,
+      sessionId: 'session-A',
+      operatorId: 99,
+      nowMs,
+      secret: TEST_CSRF_SECRET,
+    })
+
+    // #then
+    expect(result.ok).toBe(false)
+    expect(result.ok === false && result.reason).toBe('binding_mismatch')
+  })
+})

--- a/packages/gateway/src/web/auth/csrf.ts
+++ b/packages/gateway/src/web/auth/csrf.ts
@@ -1,0 +1,536 @@
+/**
+ * CSRF token module for the operator web surface.
+ *
+ * Implements signed, session-bound CSRF tokens using HMAC-SHA256.
+ * Tokens are bound to session ID, operator ID, and a 15-minute interval.
+ * A 30-second grace window allows the previous interval's token to remain valid
+ * during rotation.
+ *
+ * Security invariants:
+ *   - Tokens are signed with a separate CSRF signing key (never reuse session secret).
+ *   - Tokens are bound to session ID + operator ID + interval.
+ *   - Verification uses timing-safe comparison (timingSafeEqual).
+ *   - Tokens are never logged, never in query/body, never in cookies.
+ *   - Token format: base64url(payload).base64url(hmac)
+ *   - Payload: JSON {sid, oid, iv} where iv = Math.floor(nowMs / INTERVAL_MS)
+ *
+ * Browser-origin guard middleware:
+ *   - Rejects non-cookie credential schemes (Authorization, Proxy-Authorization, X-API-Key).
+ *   - Validates Origin exactly against canonical publicOrigin.
+ *   - Rejects Origin: null.
+ *   - Uses Fetch Metadata fallback when Origin is absent.
+ *   - Rejects unsafe Fetch Metadata combinations.
+ *   - Verifies signed CSRF token for mutating routes.
+ *   - Adds Vary header on rejection responses.
+ */
+
+import type {Context} from 'hono'
+import type {AuditLogger, BrowserGuardRejectedReason} from '../audit.js'
+import type {OperatorAllowlist} from './allowlist.js'
+import type {SessionStore} from './session.js'
+import {Buffer} from 'node:buffer'
+import {createHmac, timingSafeEqual} from 'node:crypto'
+import {emitAudit} from '../audit.js'
+import {parseSessionCookie} from './session.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** CSRF token rotation interval: 15 minutes. */
+export const CSRF_TOKEN_INTERVAL_MS = 15 * 60 * 1000
+
+/** Grace window for the previous interval's token: 30 seconds. */
+export const CSRF_TOKEN_GRACE_MS = 30 * 1000
+
+/** Header name for CSRF token on mutating requests. */
+export const CSRF_TOKEN_HEADER = 'x-csrf-token'
+
+/** Vary header value to add on CSRF/origin/fetch-metadata rejection responses. */
+const VARY_HEADER = 'Origin, Sec-Fetch-Site, Sec-Fetch-Mode, Sec-Fetch-Dest'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Parameters for generating a CSRF token. */
+export interface GenerateCsrfTokenParams {
+  readonly sessionId: string
+  readonly operatorId: number
+  readonly nowMs: number
+  readonly secret: string
+}
+
+/** Parameters for verifying a CSRF token. */
+export interface VerifyCsrfTokenParams {
+  readonly token: string
+  readonly sessionId: string
+  readonly operatorId: number
+  readonly nowMs: number
+  readonly secret: string
+}
+
+/** Result of CSRF token verification. */
+export type VerifyCsrfTokenResult = {readonly ok: true} | {readonly ok: false; readonly reason: string}
+
+/** Logger interface for the CSRF/browser-guard module. */
+export interface CsrfLogger {
+  readonly debug: (ctx: Record<string, unknown>, msg: string) => void
+  readonly info: (ctx: Record<string, unknown>, msg: string) => void
+  readonly warn: (ctx: Record<string, unknown>, msg: string) => void
+  readonly error: (ctx: Record<string, unknown>, msg: string) => void
+}
+
+/** Dependencies for the browser-origin guard middleware. */
+export interface BrowserGuardDeps {
+  readonly logger: CsrfLogger
+  readonly auditLogger: AuditLogger
+  readonly sessionStore: SessionStore
+  readonly allowlist: OperatorAllowlist
+  readonly csrfSecret: string
+  readonly publicOrigin: string
+  readonly clock: () => number
+}
+
+// ---------------------------------------------------------------------------
+// CSRF token payload
+// ---------------------------------------------------------------------------
+
+interface CsrfPayload {
+  readonly sid: string
+  readonly oid: number
+  readonly iv: number
+}
+
+function buildPayload(sessionId: string, operatorId: number, intervalIndex: number): string {
+  const payload: CsrfPayload = {sid: sessionId, oid: operatorId, iv: intervalIndex}
+  return Buffer.from(JSON.stringify(payload)).toString('base64url')
+}
+
+function computeHmac(payloadB64: string, secret: string): string {
+  const keyBytes = Buffer.from(secret, 'base64url')
+  return createHmac('sha256', keyBytes).update(payloadB64).digest('base64url')
+}
+
+function intervalIndex(nowMs: number): number {
+  return Math.floor(nowMs / CSRF_TOKEN_INTERVAL_MS)
+}
+
+// ---------------------------------------------------------------------------
+// Token generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a signed CSRF token bound to the given session and operator.
+ *
+ * Token format: base64url(payload).base64url(hmac)
+ * Payload: JSON {sid, oid, iv} where iv = Math.floor(nowMs / INTERVAL_MS)
+ *
+ * The token is deterministic within a 15-minute interval for the same inputs.
+ */
+export function generateCsrfToken(params: GenerateCsrfTokenParams): string {
+  const {sessionId, operatorId, nowMs, secret} = params
+  const iv = intervalIndex(nowMs)
+  const payloadB64 = buildPayload(sessionId, operatorId, iv)
+  const sig = computeHmac(payloadB64, secret)
+  return `${payloadB64}.${sig}`
+}
+
+// ---------------------------------------------------------------------------
+// Token verification
+// ---------------------------------------------------------------------------
+
+/**
+ * Maximum CSRF token length in characters.
+ * Tokens are base64url(payload).base64url(hmac) — a legitimate token is well under 512 chars.
+ * Rejecting overlong tokens before any Buffer allocation prevents memory exhaustion from
+ * crafted inputs.
+ */
+export const CSRF_TOKEN_MAX_LENGTH = 512
+
+/**
+ * Verify a CSRF token against the given session and operator.
+ *
+ * Accepts tokens from the current interval and the previous interval within
+ * the grace window (CSRF_TOKEN_GRACE_MS).
+ *
+ * Uses timing-safe comparison to prevent timing oracle attacks.
+ */
+export function verifyCsrfToken(params: VerifyCsrfTokenParams): VerifyCsrfTokenResult {
+  const {token, sessionId, operatorId, nowMs, secret} = params
+
+  // Reject overlong tokens before any Buffer allocation — prevents memory exhaustion.
+  if (token.length > CSRF_TOKEN_MAX_LENGTH) {
+    return {ok: false, reason: 'malformed_token'}
+  }
+
+  if (token === '' || token.includes('.') === false) {
+    return {ok: false, reason: 'malformed_token'}
+  }
+
+  const dotIdx = token.indexOf('.')
+  const payloadB64 = token.slice(0, dotIdx)
+  const providedSig = token.slice(dotIdx + 1)
+
+  if (payloadB64 === '' || providedSig === '') {
+    return {ok: false, reason: 'malformed_token'}
+  }
+
+  // Decode and parse payload
+  let payload: unknown
+  try {
+    payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf8'))
+  } catch {
+    return {ok: false, reason: 'malformed_token'}
+  }
+
+  if (typeof payload !== 'object' || payload === null) {
+    return {ok: false, reason: 'malformed_token'}
+  }
+
+  const raw = payload as Record<string, unknown>
+  if (typeof raw.sid !== 'string' || typeof raw.oid !== 'number' || typeof raw.iv !== 'number') {
+    return {ok: false, reason: 'malformed_token'}
+  }
+
+  // Narrow to typed payload after field-type guards above.
+  const parsed: CsrfPayload = {sid: raw.sid, oid: raw.oid, iv: raw.iv}
+
+  // Check session and operator binding
+  if (parsed.sid !== sessionId || parsed.oid !== operatorId) {
+    return {ok: false, reason: 'binding_mismatch'}
+  }
+
+  // Check interval — accept current and previous (within grace window)
+  const currentIv = intervalIndex(nowMs)
+  const prevIv = currentIv - 1
+  const tokenIv = parsed.iv
+
+  let isValidInterval = false
+  if (tokenIv === currentIv) {
+    isValidInterval = true
+  } else if (tokenIv === prevIv) {
+    // Previous interval — only valid within grace window
+    const intervalBoundaryMs = currentIv * CSRF_TOKEN_INTERVAL_MS
+    const msSinceBoundary = nowMs - intervalBoundaryMs
+    if (msSinceBoundary <= CSRF_TOKEN_GRACE_MS) {
+      isValidInterval = true
+    }
+  }
+
+  if (isValidInterval === false) {
+    return {ok: false, reason: 'expired'}
+  }
+
+  // Timing-safe signature verification
+  const expectedSig = computeHmac(payloadB64, secret)
+
+  let sigsMatch = false
+  try {
+    const expectedBuf = Buffer.from(expectedSig, 'base64url')
+    const providedBuf = Buffer.from(providedSig, 'base64url')
+    // timingSafeEqual requires same-length buffers; pad/truncate to expected length
+    if (expectedBuf.length === providedBuf.length) {
+      sigsMatch = timingSafeEqual(expectedBuf, providedBuf)
+    } else {
+      // Different lengths — still do a timing-safe compare against a dummy to avoid
+      // short-circuit timing leak, then return false
+      timingSafeEqual(expectedBuf, expectedBuf)
+      sigsMatch = false
+    }
+  } catch {
+    return {ok: false, reason: 'malformed_token'}
+  }
+
+  if (sigsMatch === false) {
+    return {ok: false, reason: 'invalid_signature'}
+  }
+
+  return {ok: true}
+}
+
+// ---------------------------------------------------------------------------
+// Browser-origin guard middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine if the request uses a non-cookie credential scheme.
+ * Returns the header name (without value) if a non-cookie credential is present.
+ */
+function detectNonCookieCredential(c: Context): string | null {
+  if (c.req.header('authorization') !== undefined) return 'Authorization'
+  if (c.req.header('proxy-authorization') !== undefined) return 'Proxy-Authorization'
+  if (c.req.header('x-api-key') !== undefined) return 'X-API-Key'
+  return null
+}
+
+/**
+ * Safe methods that do not require CSRF protection.
+ * GET, HEAD, OPTIONS are safe (no state mutation).
+ */
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
+/**
+ * Add Vary header for CSRF/origin/fetch-metadata rejection responses.
+ */
+function addVaryHeader(c: Context): void {
+  c.header('Vary', VARY_HEADER)
+}
+
+/**
+ * Validate the Origin header against the canonical public origin.
+ *
+ * Returns true if the origin is valid (matches publicOrigin or absent for safe methods).
+ * Returns false if the origin is null, mismatched, or absent for mutating methods.
+ *
+ * Security: absent Origin on mutating requests is rejected. Fetch Metadata fallback
+ * is checked separately — if Sec-Fetch-Site is present and indicates same-origin/none,
+ * the caller may allow the request. But absent Origin alone on a mutating request is
+ * not sufficient — the caller must check Fetch Metadata before allowing.
+ */
+function validateOrigin(
+  originHeader: string | undefined,
+  publicOrigin: string,
+  method: string,
+): {readonly ok: boolean; readonly reason?: BrowserGuardRejectedReason; readonly needsFetchMetadataFallback?: boolean} {
+  if (originHeader !== undefined) {
+    // Reject Origin: null (opaque origin — cross-site navigation or sandboxed iframe)
+    if (originHeader === 'null') {
+      return {ok: false, reason: 'origin_null'}
+    }
+
+    // Exact match against canonical public origin
+    if (originHeader !== publicOrigin) {
+      return {ok: false, reason: 'origin_mismatch'}
+    }
+
+    return {ok: true}
+  }
+
+  // Origin absent — safe methods are allowed (no mutation risk)
+  if (SAFE_METHODS.has(method)) {
+    return {ok: true}
+  }
+
+  // Origin absent on mutating method — signal that Fetch Metadata fallback is needed.
+  // The caller must check Fetch Metadata; if absent too, reject.
+  return {ok: false, reason: 'origin_missing', needsFetchMetadataFallback: true}
+}
+
+/**
+ * Validate Fetch Metadata headers for a request.
+ *
+ * Returns true if the request passes Fetch Metadata checks.
+ * Returns false with a reason if the request should be rejected.
+ *
+ * Rules:
+ *   - Sec-Fetch-Site: cross-site → reject (except OAuth callback exemption)
+ *   - Sec-Fetch-Site: same-site → reject (same-site is not same-origin)
+ *   - Sec-Fetch-Site: same-origin or none → allow
+ *   - Sec-Fetch-Mode: navigate or no-cors → reject for mutating JSON routes
+ *   - Sec-Fetch-Dest: object or embed → reject when present
+ *   - Absent headers → allow (older browsers, direct API calls)
+ */
+function validateFetchMetadata(
+  c: Context,
+  method: string,
+  isPublicCrossSiteRoute: boolean,
+): {readonly ok: boolean; readonly reason?: BrowserGuardRejectedReason} {
+  const fetchSite = c.req.header('sec-fetch-site')
+  const fetchMode = c.req.header('sec-fetch-mode')
+  const fetchDest = c.req.header('sec-fetch-dest')
+
+  // Sec-Fetch-Dest: object or embed — reject when present (plugin/embed context)
+  if (fetchDest === 'object' || fetchDest === 'embed') {
+    return {ok: false, reason: 'fetch_dest_object_embed'}
+  }
+
+  if (fetchSite !== undefined) {
+    if (fetchSite === 'cross-site') {
+      // OAuth callback is the only cross-site exemption
+      if (isPublicCrossSiteRoute === false) {
+        return {ok: false, reason: 'fetch_site_cross_site'}
+      }
+    } else if (fetchSite === 'same-site') {
+      // same-site is not same-origin — reject for security
+      return {ok: false, reason: 'fetch_site_same_site'}
+    }
+    // same-origin and none are allowed
+  }
+
+  // Sec-Fetch-Mode: navigate or no-cors — reject for mutating JSON routes
+  if (fetchMode !== undefined && SAFE_METHODS.has(method) === false) {
+    if (fetchMode === 'navigate') {
+      return {ok: false, reason: 'fetch_mode_navigate'}
+    }
+    if (fetchMode === 'no-cors') {
+      return {ok: false, reason: 'fetch_mode_no_cors'}
+    }
+  }
+
+  return {ok: true}
+}
+
+/**
+ * Apply the browser-origin guard to a request.
+ *
+ * Checks in order:
+ *   a) Reject non-cookie credential schemes
+ *   b) Validate session cookie and get session identity
+ *   c) Enforce allowlist against session-bound GitHub numeric ID
+ *   d) Validate Origin against canonical publicOrigin
+ *   e) Validate Fetch Metadata
+ *   f) Verify CSRF token for mutating routes
+ *
+ * Returns the session entry if all checks pass, or a Response to return immediately.
+ */
+export async function applyBrowserGuard(
+  c: Context,
+  deps: BrowserGuardDeps,
+  isPublicCrossSiteRoute: boolean,
+  requireCsrf: boolean,
+): Promise<
+  | {readonly ok: true; readonly githubUserId: number; readonly sessionId: string}
+  | {readonly ok: false; readonly response: Response}
+> {
+  const method = c.req.method.toUpperCase()
+
+  // a) Reject non-cookie credential schemes — without logging values
+  const nonCookieCred = detectNonCookieCredential(c)
+  if (nonCookieCred !== null) {
+    deps.logger.warn({}, `browser guard: rejected non-cookie credential scheme (${nonCookieCred})`)
+    emitAudit(
+      {kind: 'browser.guard.rejected', correlationId: 'browser-guard', reason: 'non_cookie_credential'},
+      deps.auditLogger,
+    )
+    addVaryHeader(c)
+    return {ok: false, response: c.json({error: 'bad request'}, 400)}
+  }
+
+  // b) Validate session cookie
+  const cookieHeader = c.req.header('cookie')
+  const sessionId = parseSessionCookie(cookieHeader)
+  if (sessionId === undefined) {
+    deps.logger.warn({}, 'browser guard: no session cookie')
+    emitAudit({kind: 'browser.guard.rejected', correlationId: 'browser-guard', reason: 'no_session'}, deps.auditLogger)
+    addVaryHeader(c)
+    return {ok: false, response: c.json({error: 'unauthorized'}, 401)}
+  }
+
+  const nowMs = deps.clock()
+  const session = deps.sessionStore.get(sessionId, nowMs)
+  if (session === undefined) {
+    deps.logger.warn({}, 'browser guard: invalid or expired session')
+    emitAudit(
+      {kind: 'browser.guard.rejected', correlationId: 'browser-guard', reason: 'invalid_session'},
+      deps.auditLogger,
+    )
+    addVaryHeader(c)
+    return {ok: false, response: c.json({error: 'unauthorized'}, 401)}
+  }
+
+  const {githubUserId} = session
+
+  // c) Enforce allowlist against session-bound GitHub numeric ID
+  // Touch session ONLY after allowlist passes — non-allowlisted sessions must not
+  // extend their idle TTL (they should expire naturally).
+  if (deps.allowlist.isAuthorized(githubUserId) === false) {
+    deps.logger.warn({githubUserId}, 'browser guard: operator not in allowlist')
+    emitAudit(
+      {kind: 'browser.guard.rejected', correlationId: 'browser-guard', reason: 'not_allowlisted', githubUserId},
+      deps.auditLogger,
+    )
+    addVaryHeader(c)
+    return {ok: false, response: c.json({error: 'forbidden'}, 403)}
+  }
+
+  // Touch session to extend idle TTL — only after allowlist authorization passes.
+  deps.sessionStore.touch(sessionId, nowMs)
+
+  // d) Validate Origin
+  const originHeader = c.req.header('origin')
+  const originResult = validateOrigin(originHeader, deps.publicOrigin, method)
+
+  if (originResult.ok === false && originResult.needsFetchMetadataFallback !== true) {
+    // Hard origin rejection (null, mismatch) — no fallback
+    const reason: BrowserGuardRejectedReason = originResult.reason ?? 'unknown'
+    deps.logger.warn({}, `browser guard: origin rejected (${reason})`)
+    emitAudit({kind: 'browser.guard.rejected', correlationId: 'browser-guard', reason}, deps.auditLogger)
+    addVaryHeader(c)
+    return {ok: false, response: c.json({error: 'bad request'}, 400)}
+  }
+
+  // e) Validate Fetch Metadata
+  // Also handles the absent-Origin-on-mutating-request case: if validateOrigin signaled
+  // needsFetchMetadataFallback, we require Fetch Metadata to be present and safe.
+  const fetchMetaResult = validateFetchMetadata(c, method, isPublicCrossSiteRoute)
+
+  if (originResult.needsFetchMetadataFallback === true) {
+    // Origin was absent on a mutating request — Fetch Metadata must confirm same-origin/none.
+    // If Fetch Metadata is also absent or indicates cross-site, reject.
+    if (fetchMetaResult.ok === false) {
+      const reason: BrowserGuardRejectedReason = fetchMetaResult.reason ?? 'unknown'
+      deps.logger.warn({}, `browser guard: fetch metadata rejected (${reason})`)
+      emitAudit({kind: 'browser.guard.rejected', correlationId: 'browser-guard', reason}, deps.auditLogger)
+      addVaryHeader(c)
+      return {ok: false, response: c.json({error: 'bad request'}, 400)}
+    }
+    // Fetch Metadata passed — check if sec-fetch-site is present and safe.
+    // Note: Sec-Fetch-Site: same-origin or none is accepted here even when
+    // Sec-Fetch-Mode is absent — Sec-Fetch-Mode is only checked for mutating
+    // requests when it IS present (see validateFetchMetadata). An absent
+    // Sec-Fetch-Mode with a safe Sec-Fetch-Site value is not a rejection signal.
+    const fetchSite = c.req.header('sec-fetch-site')
+    if (fetchSite === undefined) {
+      // Both Origin and Sec-Fetch-Site absent on mutating request — reject
+      deps.logger.warn({}, 'browser guard: absent origin and absent fetch metadata on mutating request')
+      emitAudit(
+        {kind: 'browser.guard.rejected', correlationId: 'browser-guard', reason: 'origin_missing'},
+        deps.auditLogger,
+      )
+      addVaryHeader(c)
+      return {ok: false, response: c.json({error: 'bad request'}, 400)}
+    }
+    // Sec-Fetch-Site is present and passed validateFetchMetadata — allow
+  } else if (fetchMetaResult.ok === false) {
+    const reason: BrowserGuardRejectedReason = fetchMetaResult.reason ?? 'unknown'
+    deps.logger.warn({}, `browser guard: fetch metadata rejected (${reason})`)
+    emitAudit({kind: 'browser.guard.rejected', correlationId: 'browser-guard', reason}, deps.auditLogger)
+    addVaryHeader(c)
+    return {ok: false, response: c.json({error: 'bad request'}, 400)}
+  }
+
+  // f) Verify CSRF token for mutating routes
+  if (requireCsrf && SAFE_METHODS.has(method) === false) {
+    const csrfToken = c.req.header(CSRF_TOKEN_HEADER)
+    if (csrfToken === undefined || csrfToken === '') {
+      deps.logger.warn({}, 'browser guard: missing CSRF token')
+      emitAudit(
+        {kind: 'browser.guard.rejected', correlationId: 'browser-guard', reason: 'csrf_missing'},
+        deps.auditLogger,
+      )
+      addVaryHeader(c)
+      return {ok: false, response: c.json({error: 'bad request'}, 400)}
+    }
+
+    const csrfResult = verifyCsrfToken({
+      token: csrfToken,
+      sessionId,
+      operatorId: githubUserId,
+      nowMs,
+      secret: deps.csrfSecret,
+    })
+
+    if (csrfResult.ok === false) {
+      deps.logger.warn({}, 'browser guard: CSRF token invalid')
+      emitAudit(
+        {kind: 'browser.guard.rejected', correlationId: 'browser-guard', reason: 'csrf_invalid'},
+        deps.auditLogger,
+      )
+      addVaryHeader(c)
+      return {ok: false, response: c.json({error: 'bad request'}, 400)}
+    }
+  }
+
+  return {ok: true, githubUserId, sessionId}
+}

--- a/packages/gateway/src/web/auth/github.test.ts
+++ b/packages/gateway/src/web/auth/github.test.ts
@@ -2111,3 +2111,173 @@ describe('GET /operator/auth/github/callback — session minting', () => {
     expect(revocationHook).toHaveBeenCalledExactlyOnceWith(staleSessionId)
   })
 })
+
+// ---------------------------------------------------------------------------
+// OAuth callback — allowlist check before session creation (Fix 2)
+// ---------------------------------------------------------------------------
+
+function buildTestAppWithSessionAndAllowlist(
+  deps: GitHubOAuthDeps,
+  config: GitHubOAuthConfig,
+  sessionStore: SessionStore,
+  sessionDeps: SessionDeps,
+  allowlist: import('./allowlist.js').OperatorAllowlist,
+): Hono {
+  const app = new Hono()
+  registerPublicRoute(app, 'GET', '/operator/health', c => c.json({ok: true}))
+  buildGitHubOAuthRoutes(app, {...deps, sessionStore, sessionDeps, allowlist}, config)
+  assertAllPrivilegedRoutesWrapped(app)
+  return app
+}
+
+describe('GET /operator/auth/github/callback — allowlist check before session creation', () => {
+  it('returns 403 and does not mint a session when user is not in allowlist', async () => {
+    // #given — allowlist only contains user 99, callback returns user 42
+    const stateStore = createInMemoryStateStore()
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const allowlist: import('./allowlist.js').OperatorAllowlist = {
+      isAuthorized: (id: number) => id === 99, // only user 99 is allowed
+      size: 1,
+    }
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}), // user 42 is NOT in allowlist
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestAppWithSessionAndAllowlist(deps, config, sessionStore, sessionDeps, allowlist)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — 403 Forbidden (not allowlisted)
+    expect(res.status).toBe(403)
+
+    // #and — no session was created
+    expect(sessionStore.size()).toBe(0)
+  })
+
+  it('does not set a session cookie when user is not in allowlist', async () => {
+    // #given — allowlist only contains user 99, callback returns user 42
+    const stateStore = createInMemoryStateStore()
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const allowlist: import('./allowlist.js').OperatorAllowlist = {
+      isAuthorized: (id: number) => id === 99,
+      size: 1,
+    }
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestAppWithSessionAndAllowlist(deps, config, sessionStore, sessionDeps, allowlist)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — no session cookie in response
+    const setCookieHeaders = res.headers.getSetCookie()
+    const sessionCookie = setCookieHeaders.find(h => h.startsWith(`${SESSION_COOKIE_NAME}=`))
+    expect(sessionCookie).toBeUndefined()
+  })
+
+  it('emits auth.callback.failure with reason not_allowlisted when user is not in allowlist', async () => {
+    // #given — allowlist only contains user 99, callback returns user 42
+    const stateStore = createInMemoryStateStore()
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const allowlist: import('./allowlist.js').OperatorAllowlist = {
+      isAuthorized: (id: number) => id === 99,
+      size: 1,
+    }
+
+    const auditLogger = makeAuditLogger()
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+      auditLogger,
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestAppWithSessionAndAllowlist(deps, config, sessionStore, sessionDeps, allowlist)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    await app.fetch(req)
+
+    // #then — audit event emitted with reason not_allowlisted
+    const failureRecord = auditLogger.records.find(r => r.kind === 'auth.callback.failure')
+    expect(failureRecord).toBeDefined()
+    expect(failureRecord?.reason).toBe('not_allowlisted')
+  })
+
+  it('allows session creation when user IS in allowlist', async () => {
+    // #given — allowlist contains user 42, callback returns user 42
+    const stateStore = createInMemoryStateStore()
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+    })
+
+    const allowlist: import('./allowlist.js').OperatorAllowlist = {
+      isAuthorized: (id: number) => id === 42, // user 42 is allowed
+      size: 1,
+    }
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestAppWithSessionAndAllowlist(deps, config, sessionStore, sessionDeps, allowlist)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — 200 OK, session created
+    expect(res.status).toBe(200)
+    expect(sessionStore.size()).toBe(1)
+  })
+})

--- a/packages/gateway/src/web/auth/github.ts
+++ b/packages/gateway/src/web/auth/github.ts
@@ -27,11 +27,12 @@
 import type {Context, Hono} from 'hono'
 import type {RateLimiter} from '../../http/rate-limit.js'
 import type {AuditLogger} from '../audit.js'
+import type {OperatorAllowlist} from './allowlist.js'
 import type {SessionDeps, SessionStore} from './session.js'
 import {createHash, randomBytes} from 'node:crypto'
 import {emitAudit} from '../audit.js'
-import {registerPublicRoute} from '../operator-route.js'
-import {badRequestResponse, rateLimitedResponse, unavailableResponse} from '../safe-response.js'
+import {registerPublicCrossSiteRoute, registerPublicRoute} from '../operator-route.js'
+import {badRequestResponse, forbiddenResponse, rateLimitedResponse, unavailableResponse} from '../safe-response.js'
 import {buildSessionCookieValue, parseSessionCookie} from './session.js'
 
 // ---------------------------------------------------------------------------
@@ -132,6 +133,13 @@ export interface GitHubOAuthDeps {
    * Required when sessionStore is present; ignored otherwise.
    */
   readonly sessionDeps?: SessionDeps
+  /**
+   * Operator allowlist for post-authentication authorization.
+   * When present (alongside sessionStore), the callback checks the allowlist
+   * BEFORE minting a session — non-allowlisted users are denied 403 and never
+   * get a session cookie. When absent, no allowlist check is performed.
+   */
+  readonly allowlist?: OperatorAllowlist
 }
 
 /** Configuration for the GitHub OAuth PKCE + state routes. */
@@ -189,6 +197,7 @@ export function buildGitHubOAuthDeps(
   rateLimiter: RateLimiter,
   sessionStore?: SessionStore,
   sessionDeps?: SessionDeps,
+  allowlist?: OperatorAllowlist,
 ): GitHubOAuthDeps {
   return {
     logger,
@@ -202,6 +211,7 @@ export function buildGitHubOAuthDeps(
     rateLimiter,
     ...(sessionStore === undefined ? {} : {sessionStore}),
     ...(sessionDeps === undefined ? {} : {sessionDeps}),
+    ...(allowlist === undefined ? {} : {allowlist}),
   }
 }
 
@@ -444,11 +454,12 @@ export function buildGitHubOAuthRoutes(app: Hono, deps: GitHubOAuthDeps, config:
 
   // ── GET /operator/auth/github/callback ─────────────────────────────────────
   //
-  // GitHub redirects the browser cross-site after authorization, so future
-  // Fetch Metadata middleware must allow this callback route to receive
-  // Sec-Fetch-Site: cross-site.
+  // GitHub redirects the browser cross-site after authorization, so this route
+  // is registered as a public cross-site route to allow Sec-Fetch-Site: cross-site.
+  // The Fetch Metadata browser guard exempts this route from cross-site rejection.
+  // All other security checks (state validation, PKCE, source key binding) remain.
 
-  registerPublicRoute(app, 'GET', config.callbackPath, async (c: Context): Promise<Response> => {
+  registerPublicCrossSiteRoute(app, 'GET', config.callbackPath, async (c: Context): Promise<Response> => {
     // Determine source key for rate limiting and source key binding validation.
     const sourceKey = deps.getSourceKey(c)
 
@@ -614,6 +625,14 @@ export function buildGitHubOAuthRoutes(app: Hono, deps: GitHubOAuthDeps, config:
 
     // Mint a server-side session when a session store is wired.
     if (deps.sessionStore !== undefined && deps.sessionDeps !== undefined) {
+      // Check allowlist BEFORE minting a session — non-allowlisted users must not
+      // receive a session cookie. This is the authoritative allowlist gate for OAuth.
+      if (deps.allowlist !== undefined && deps.allowlist.isAuthorized(githubUserId) === false) {
+        deps.logger.warn({githubUserId}, 'oauth callback: operator not in allowlist — session not minted')
+        emitAudit({kind: 'auth.callback.failure', correlationId, reason: 'not_allowlisted' as const}, deps.auditLogger)
+        return forbiddenResponse(c)
+      }
+
       const nowMs = deps.sessionDeps.clock()
 
       // Clear any stale pre-auth session cookie before setting the new one

--- a/packages/gateway/src/web/auth/session.test.ts
+++ b/packages/gateway/src/web/auth/session.test.ts
@@ -16,10 +16,14 @@
  */
 
 import type {AuditLogger} from '../audit.js'
+import type {BrowserGuardDeps} from './csrf.js'
 import type {SessionDeps, SessionStore} from './session.js'
+import {Buffer} from 'node:buffer'
 import {Hono} from 'hono'
 import {describe, expect, it, vi} from 'vitest'
-import {assertAllPrivilegedRoutesWrapped, registerPublicRoute} from '../operator-route.js'
+import {assertAllPrivilegedRoutesWrapped, registerPublicRoute, setOperatorRouteGuard} from '../operator-route.js'
+import {loadAllowlistFromText} from './allowlist.js'
+import {applyBrowserGuard, generateCsrfToken} from './csrf.js'
 import {
   buildLogoutRoutes,
   buildSessionCookieValue,
@@ -630,28 +634,66 @@ describe('parseSessionCookie', () => {
 // Logout route
 // ---------------------------------------------------------------------------
 
-function buildTestLogoutApp(store: SessionStore, deps: SessionDeps): Hono {
+const TEST_CSRF_SECRET = Buffer.from('test-csrf-secret-32-bytes-long!!', 'utf8').toString('base64url')
+const PUBLIC_ORIGIN = 'https://operator.example.com'
+
+/**
+ * Build a test app with the full browser guard installed and the logout route registered.
+ * Logout is always a privileged route — this helper mirrors the production wiring in server.ts.
+ */
+function buildTestLogoutApp(
+  store: SessionStore,
+  deps: SessionDeps,
+  guardDepsOverrides?: Partial<BrowserGuardDeps>,
+): Hono {
+  const logger = makeLogger()
+  const auditLogger = makeAuditLogger()
+  const allowlist = loadAllowlistFromText('42\n', logger)
+  const browserGuardDeps: BrowserGuardDeps = {
+    logger,
+    auditLogger,
+    sessionStore: store,
+    allowlist,
+    csrfSecret: TEST_CSRF_SECRET,
+    publicOrigin: PUBLIC_ORIGIN,
+    clock: deps.clock,
+    ...guardDepsOverrides,
+  }
+
   const app = new Hono()
   registerPublicRoute(app, 'GET', '/operator/health', c => c.json({ok: true}))
-  buildLogoutRoutes(app, store, deps)
+
+  // Install the browser guard before registering privileged routes — mirrors server.ts.
+  const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+  setOperatorRouteGuard(app, async (c, method, _path) => {
+    const requireCsrf = SAFE_METHODS.has(method.toUpperCase()) === false
+    return applyBrowserGuard(c, browserGuardDeps, false, requireCsrf)
+  })
+
+  buildLogoutRoutes(app, store, deps, browserGuardDeps)
   assertAllPrivilegedRoutesWrapped(app)
   return app
 }
 
-describe('POST /operator/auth/logout — happy path', () => {
-  it('returns 200 and clears the session cookie when a valid session exists', async () => {
+describe('POST /operator/auth/logout — happy path (privileged route)', () => {
+  it('returns 200 and clears the session cookie when session + CSRF are valid', async () => {
     // #given
     const store = createInMemorySessionStore()
     const now = 1_000_000
     const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
     if (sessionId === undefined) throw new Error('expected session ID to be defined')
     const deps = makeStubDeps({clock: () => now + 1_000})
+    const csrfToken = generateCsrfToken({sessionId, operatorId: 42, nowMs: now + 1_000, secret: TEST_CSRF_SECRET})
     const app = buildTestLogoutApp(store, deps)
 
     // #when
-    const req = new Request('https://operator.example.com/operator/auth/logout', {
+    const req = new Request(`${PUBLIC_ORIGIN}/operator/auth/logout`, {
       method: 'POST',
-      headers: {cookie: `${SESSION_COOKIE_NAME}=${sessionId}`},
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: PUBLIC_ORIGIN,
+        'x-csrf-token': csrfToken,
+      },
     })
     const res = await app.fetch(req)
 
@@ -669,12 +711,17 @@ describe('POST /operator/auth/logout — happy path', () => {
     const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
     if (sessionId === undefined) throw new Error('expected session ID to be defined')
     const deps = makeStubDeps({clock: () => now + 1_000})
+    const csrfToken = generateCsrfToken({sessionId, operatorId: 42, nowMs: now + 1_000, secret: TEST_CSRF_SECRET})
     const app = buildTestLogoutApp(store, deps)
 
     // #when
-    const req = new Request('https://operator.example.com/operator/auth/logout', {
+    const req = new Request(`${PUBLIC_ORIGIN}/operator/auth/logout`, {
       method: 'POST',
-      headers: {cookie: `${SESSION_COOKIE_NAME}=${sessionId}`},
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: PUBLIC_ORIGIN,
+        'x-csrf-token': csrfToken,
+      },
     })
     const res = await app.fetch(req)
 
@@ -692,16 +739,22 @@ describe('POST /operator/auth/logout — happy path', () => {
     if (sessionId === undefined) throw new Error('expected session ID to be defined')
     const auditLogger = makeAuditLogger()
     const deps = makeStubDeps({clock: () => now + 1_000, auditLogger})
-    const app = buildTestLogoutApp(store, deps)
+    const csrfToken = generateCsrfToken({sessionId, operatorId: 42, nowMs: now + 1_000, secret: TEST_CSRF_SECRET})
+    // Pass the same auditLogger to the guard deps so we capture guard audit events too
+    const app = buildTestLogoutApp(store, deps, {auditLogger, clock: () => now + 1_000})
 
     // #when
-    const req = new Request('https://operator.example.com/operator/auth/logout', {
+    const req = new Request(`${PUBLIC_ORIGIN}/operator/auth/logout`, {
       method: 'POST',
-      headers: {cookie: `${SESSION_COOKIE_NAME}=${sessionId}`},
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: PUBLIC_ORIGIN,
+        'x-csrf-token': csrfToken,
+      },
     })
     await app.fetch(req)
 
-    // #then — audit event emitted
+    // #then — auth.logout audit event emitted (from the handler, not the guard)
     const logoutEvent = auditLogger.records.find(r => r.kind === 'auth.logout')
     expect(logoutEvent).toBeDefined()
     expect(logoutEvent?.githubUserId).toBe(42)
@@ -715,12 +768,17 @@ describe('POST /operator/auth/logout — happy path', () => {
     if (sessionId === undefined) throw new Error('expected session ID to be defined')
     const auditLogger = makeAuditLogger()
     const deps = makeStubDeps({clock: () => now + 1_000, auditLogger})
-    const app = buildTestLogoutApp(store, deps)
+    const csrfToken = generateCsrfToken({sessionId, operatorId: 42, nowMs: now + 1_000, secret: TEST_CSRF_SECRET})
+    const app = buildTestLogoutApp(store, deps, {auditLogger, clock: () => now + 1_000})
 
     // #when
-    const req = new Request('https://operator.example.com/operator/auth/logout', {
+    const req = new Request(`${PUBLIC_ORIGIN}/operator/auth/logout`, {
       method: 'POST',
-      headers: {cookie: `${SESSION_COOKIE_NAME}=${sessionId}`},
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: PUBLIC_ORIGIN,
+        'x-csrf-token': csrfToken,
+      },
     })
     await app.fetch(req)
 
@@ -739,72 +797,118 @@ describe('POST /operator/auth/logout — happy path', () => {
   })
 })
 
-describe('POST /operator/auth/logout — no session cookie', () => {
-  it('returns 200 even when no session cookie is present (idempotent logout)', async () => {
-    // #given
+describe('POST /operator/auth/logout — guard enforcement (privileged route)', () => {
+  it('returns 401 when no session cookie is present (guard rejects unauthenticated requests)', async () => {
+    // #given — logout is a privileged route; no session = 401
     const store = createInMemorySessionStore()
     const deps = makeStubDeps()
     const app = buildTestLogoutApp(store, deps)
 
     // #when — no cookie header
-    const req = new Request('https://operator.example.com/operator/auth/logout', {method: 'POST'})
+    const req = new Request(`${PUBLIC_ORIGIN}/operator/auth/logout`, {
+      method: 'POST',
+      headers: {origin: PUBLIC_ORIGIN},
+    })
     const res = await app.fetch(req)
 
-    // #then — idempotent; still 200
-    expect(res.status).toBe(200)
+    // #then — guard rejects with 401 (no session)
+    expect(res.status).toBe(401)
   })
 
-  it('still clears the cookie even when no session cookie is present', async () => {
-    // #given
+  it('returns 400 when session is valid but CSRF token is missing', async () => {
+    // #given — valid session but no CSRF token
     const store = createInMemorySessionStore()
-    const deps = makeStubDeps()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+    const deps = makeStubDeps({clock: () => now + 1_000})
+    const app = buildTestLogoutApp(store, deps)
+
+    // #when — no x-csrf-token header
+    const req = new Request(`${PUBLIC_ORIGIN}/operator/auth/logout`, {
+      method: 'POST',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: PUBLIC_ORIGIN,
+        // No x-csrf-token
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — guard rejects with 400 (missing CSRF token)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when Origin header is absent on mutating request', async () => {
+    // #given — valid session and CSRF token but no Origin header
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+    const deps = makeStubDeps({clock: () => now + 1_000})
+    const csrfToken = generateCsrfToken({sessionId, operatorId: 42, nowMs: now + 1_000, secret: TEST_CSRF_SECRET})
+    const app = buildTestLogoutApp(store, deps)
+
+    // #when — no Origin header (absent origin on mutating request is rejected)
+    const req = new Request(`${PUBLIC_ORIGIN}/operator/auth/logout`, {
+      method: 'POST',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        'x-csrf-token': csrfToken,
+        // No origin header
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — guard rejects with 400 (absent origin on mutating request)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 403 when operator is not in allowlist', async () => {
+    // #given — session for user 99 who is NOT in the allowlist (allowlist has 42)
+    const store = createInMemorySessionStore()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 99, login: 'notallowed'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+    const deps = makeStubDeps({clock: () => now + 1_000})
+    const csrfToken = generateCsrfToken({sessionId, operatorId: 99, nowMs: now + 1_000, secret: TEST_CSRF_SECRET})
     const app = buildTestLogoutApp(store, deps)
 
     // #when
-    const req = new Request('https://operator.example.com/operator/auth/logout', {method: 'POST'})
+    const req = new Request(`${PUBLIC_ORIGIN}/operator/auth/logout`, {
+      method: 'POST',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: PUBLIC_ORIGIN,
+        'x-csrf-token': csrfToken,
+      },
+    })
     const res = await app.fetch(req)
 
-    // #then — clear-cookie header is still set
-    const setCookie = res.headers.get('set-cookie') ?? ''
-    expect(setCookie).toContain(SESSION_COOKIE_NAME)
-    expect(setCookie.toLowerCase()).toContain('max-age=0')
+    // #then — guard rejects with 403 (not allowlisted)
+    expect(res.status).toBe(403)
   })
 })
 
 describe('POST /operator/auth/logout — unknown session ID', () => {
-  it('returns 200 for an unknown session ID (no oracle)', async () => {
-    // #given
+  it('returns 401 for an unknown session ID (guard rejects invalid session)', async () => {
+    // #given — unknown session ID; guard rejects before handler runs
     const store = createInMemorySessionStore()
     const deps = makeStubDeps()
     const app = buildTestLogoutApp(store, deps)
 
     // #when — send a session cookie with an unknown ID
-    const req = new Request('https://operator.example.com/operator/auth/logout', {
+    const req = new Request(`${PUBLIC_ORIGIN}/operator/auth/logout`, {
       method: 'POST',
-      headers: {cookie: `${SESSION_COOKIE_NAME}=unknown-session-id-xyz`},
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=unknown-session-id-xyz`,
+        origin: PUBLIC_ORIGIN,
+      },
     })
     const res = await app.fetch(req)
 
-    // #then — no oracle; still 200
-    expect(res.status).toBe(200)
-  })
-
-  it('does NOT emit an audit event for an unknown session ID (no oracle)', async () => {
-    // #given
-    const store = createInMemorySessionStore()
-    const auditLogger = makeAuditLogger()
-    const deps = makeStubDeps({auditLogger})
-    const app = buildTestLogoutApp(store, deps)
-
-    // #when — send a session cookie with an unknown ID
-    const req = new Request('https://operator.example.com/operator/auth/logout', {
-      method: 'POST',
-      headers: {cookie: `${SESSION_COOKIE_NAME}=unknown-session-id-xyz`},
-    })
-    await app.fetch(req)
-
-    // #then — no audit event emitted (unknown session = no oracle)
-    expect(auditLogger.records).toHaveLength(0)
+    // #then — guard rejects with 401 (invalid session)
+    expect(res.status).toBe(401)
   })
 })
 
@@ -948,14 +1052,25 @@ describe('parseSessionCookie — empty value', () => {
 // ---------------------------------------------------------------------------
 
 describe('POST /operator/auth/logout — response body', () => {
-  it('response body is {ok: true}', async () => {
-    // #given
+  it('response body is {ok: true} when session + CSRF are valid', async () => {
+    // #given — valid session and CSRF token
     const store = createInMemorySessionStore()
-    const deps = makeStubDeps()
+    const now = 1_000_000
+    const sessionId = store.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session ID to be defined')
+    const deps = makeStubDeps({clock: () => now + 1_000})
+    const csrfToken = generateCsrfToken({sessionId, operatorId: 42, nowMs: now + 1_000, secret: TEST_CSRF_SECRET})
     const app = buildTestLogoutApp(store, deps)
 
     // #when
-    const req = new Request('https://operator.example.com/operator/auth/logout', {method: 'POST'})
+    const req = new Request(`${PUBLIC_ORIGIN}/operator/auth/logout`, {
+      method: 'POST',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: PUBLIC_ORIGIN,
+        'x-csrf-token': csrfToken,
+      },
+    })
     const res = await app.fetch(req)
 
     // #then — body is {ok: true}

--- a/packages/gateway/src/web/auth/session.ts
+++ b/packages/gateway/src/web/auth/session.ts
@@ -18,9 +18,10 @@
 import type {Context, Hono} from 'hono'
 import type {RateLimiter} from '../../http/rate-limit.js'
 import type {AuditLogger} from '../audit.js'
+import type {BrowserGuardDeps} from './csrf.js'
 import {randomBytes} from 'node:crypto'
 import {emitAudit} from '../audit.js'
-import {registerPublicRoute} from '../operator-route.js'
+import {getOperatorAuthContext, registerOperatorRoute} from '../operator-route.js'
 import {okResponse, rateLimitedResponse} from '../safe-response.js'
 
 // ---------------------------------------------------------------------------
@@ -310,12 +311,31 @@ export function parseSessionCookie(cookieHeader: string | undefined): string | u
 /**
  * Register the POST /operator/auth/logout route on the given Hono app.
  *
- * Registered as a public route (no session required to call logout — idempotent).
+ * Logout is a privileged route protected by session + allowlist + origin + CSRF.
+ * The browser guard (applied automatically by the privileged-route guard seam
+ * installed in server.ts) runs before this handler. The handler reads the
+ * authenticated context (sessionId, githubUserId) from Hono context variables
+ * set by the guard wrapper.
+ *
  * Invalidates the session server-side and clears the session cookie.
- * Returns 200 regardless of whether a valid session was found (no oracle).
+ * Returns 200 after successful authenticated logout.
+ *
+ * @throws {Error} Programming error if browserGuardDeps is not provided.
+ *   Logout must always be protected — a public mutating logout path is a
+ *   CSRF footgun and is not supported.
  */
-export function buildLogoutRoutes(app: Hono, store: SessionStore, deps: SessionDeps): void {
-  registerPublicRoute(app, 'POST', '/operator/auth/logout', async (c: Context): Promise<Response> => {
+export function buildLogoutRoutes(
+  app: Hono,
+  store: SessionStore,
+  deps: SessionDeps,
+  _browserGuardDeps: BrowserGuardDeps,
+): void {
+  // Protected logout — requires session + allowlist + origin + CSRF.
+  // Registered as a privileged route so the static guardrail enforces it.
+  // The browser guard is applied automatically by the privileged-route guard seam
+  // (setOperatorRouteGuard in server.ts). The handler reads the authenticated context
+  // (sessionId, githubUserId) from Hono context variables set by the guard wrapper.
+  registerOperatorRoute(app, 'POST', '/operator/auth/logout', async (c: Context): Promise<Response> => {
     // Rate limit check — shared with the operator app, keyed on socket address.
     if (deps.rateLimiter !== undefined) {
       const sourceKey = deps.getSourceKey === undefined ? 'unknown' : deps.getSourceKey(c)
@@ -325,29 +345,29 @@ export function buildLogoutRoutes(app: Hono, store: SessionStore, deps: SessionD
       }
     }
 
-    const cookieHeader = c.req.header('cookie')
-    const sessionId = parseSessionCookie(cookieHeader)
-
-    if (sessionId !== undefined) {
-      const nowMs = deps.clock()
-      const entry = store.get(sessionId, nowMs)
-
-      if (entry !== undefined) {
-        // Emit audit event before deleting the session.
-        // correlationId must NOT be the session ID — session IDs are never logged.
-        emitAudit(
-          {
-            kind: 'auth.logout',
-            correlationId: 'logout',
-            githubUserId: entry.githubUserId,
-          },
-          deps.auditLogger,
-        )
-        deps.logger.info({githubUserId: entry.githubUserId}, 'session logout')
-      }
-
-      store.delete(sessionId)
+    // Read the authenticated context stored by the guard wrapper.
+    // The browser guard (session + allowlist + origin + CSRF) has already run.
+    const authCtx = getOperatorAuthContext(c)
+    if (authCtx === undefined) {
+      // Guard not installed — this is a programming error. buildLogoutRoutes requires
+      // browserGuardDeps and the guard must be installed before registering privileged routes.
+      return c.json({error: 'unauthorized'}, 401)
     }
+
+    const {sessionId, githubUserId} = authCtx
+
+    // Emit audit event before deleting the session.
+    emitAudit(
+      {
+        kind: 'auth.logout',
+        correlationId: 'logout',
+        githubUserId,
+      },
+      deps.auditLogger,
+    )
+    deps.logger.info({githubUserId}, 'session logout')
+
+    store.delete(sessionId)
 
     // Always clear the cookie — idempotent logout
     const clearCookie = buildSessionCookieValue('', {clear: true})

--- a/packages/gateway/src/web/operator-route.test.ts
+++ b/packages/gateway/src/web/operator-route.test.ts
@@ -12,13 +12,18 @@
 
 import type {Context} from 'hono'
 import {Hono} from 'hono'
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 import {
   assertAllPrivilegedRoutesWrapped,
+  getOperatorAuthContext,
+  getOperatorRouteGuard,
   isPrivilegedRoute,
+  isPublicCrossSiteRoute,
   isPublicRoute,
   registerOperatorRoute,
+  registerPublicCrossSiteRoute,
   registerPublicRoute,
+  setOperatorRouteGuard,
 } from './operator-route.js'
 
 // ---------------------------------------------------------------------------
@@ -219,6 +224,277 @@ describe('registerOperatorRoute — duplicate detection', () => {
     expect(() => {
       registerPublicRoute(app, 'GET', '/operator/runs', (c: Context) => c.json({runs: []}))
     }).toThrow(/duplicate registration/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// registerPublicCrossSiteRoute — cross-site public route classification
+// ---------------------------------------------------------------------------
+
+describe('registerPublicCrossSiteRoute — cross-site public route metadata', () => {
+  it('marks a registered route as public cross-site', () => {
+    // #given
+    const app = new Hono()
+
+    // #when
+    registerPublicCrossSiteRoute(app, 'GET', '/operator/auth/github/callback', (c: Context) => c.json({ok: true}))
+
+    // #then — the route is marked as public cross-site
+    expect(isPublicCrossSiteRoute(app, 'GET', '/operator/auth/github/callback')).toBe(true)
+  })
+
+  it('also marks a cross-site route as public (not privileged)', () => {
+    // #given
+    const app = new Hono()
+
+    // #when
+    registerPublicCrossSiteRoute(app, 'GET', '/operator/auth/github/callback', (c: Context) => c.json({ok: true}))
+
+    // #then — cross-site routes are public, not privileged
+    expect(isPublicRoute(app, 'GET', '/operator/auth/github/callback')).toBe(true)
+    expect(isPrivilegedRoute(app, 'GET', '/operator/auth/github/callback')).toBe(false)
+  })
+
+  it('assertAllPrivilegedRoutesWrapped accepts cross-site public routes as classified', () => {
+    // #given
+    const app = new Hono()
+    registerPublicRoute(app, 'GET', '/operator/health', (c: Context) => c.json({ok: true}))
+    registerPublicCrossSiteRoute(app, 'GET', '/operator/auth/github/callback', (c: Context) => c.json({ok: true}))
+
+    // #when / #then — no throw
+    expect(() => assertAllPrivilegedRoutesWrapped(app)).not.toThrow()
+  })
+
+  it('throws on duplicate registration across all registries', () => {
+    // #given
+    const app = new Hono()
+    registerPublicCrossSiteRoute(app, 'GET', '/operator/auth/github/callback', (c: Context) => c.json({ok: true}))
+
+    // #when / #then — second registration must throw
+    expect(() => {
+      registerPublicCrossSiteRoute(app, 'GET', '/operator/auth/github/callback', (c: Context) => c.json({ok: true}))
+    }).toThrow(/duplicate registration/)
+  })
+
+  it('throws when registerPublicRoute is called after registerPublicCrossSiteRoute for the same path', () => {
+    // #given
+    const app = new Hono()
+    registerPublicCrossSiteRoute(app, 'GET', '/operator/auth/github/callback', (c: Context) => c.json({ok: true}))
+
+    // #when / #then
+    expect(() => {
+      registerPublicRoute(app, 'GET', '/operator/auth/github/callback', (c: Context) => c.json({ok: true}))
+    }).toThrow(/duplicate registration/)
+  })
+
+  it('non-cross-site route returns false for isPublicCrossSiteRoute', () => {
+    // #given
+    const app = new Hono()
+    registerPublicRoute(app, 'GET', '/operator/health', (c: Context) => c.json({ok: true}))
+
+    // #when / #then
+    expect(isPublicCrossSiteRoute(app, 'GET', '/operator/health')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// setOperatorRouteGuard / getOperatorRouteGuard — guard seam
+// ---------------------------------------------------------------------------
+
+describe('setOperatorRouteGuard — guard installation', () => {
+  it('getOperatorRouteGuard returns undefined when no guard is installed', () => {
+    // #given
+    const app = new Hono()
+
+    // #when / #then — no guard installed
+    expect(getOperatorRouteGuard(app)).toBeUndefined()
+  })
+
+  it('getOperatorRouteGuard returns the installed guard', () => {
+    // #given
+    const app = new Hono()
+    const guard = vi.fn(async () => ({ok: true as const, githubUserId: 42, sessionId: 'sid'}))
+
+    // #when
+    setOperatorRouteGuard(app, guard)
+
+    // #then — guard is retrievable
+    expect(getOperatorRouteGuard(app)).toBe(guard)
+  })
+
+  it('throws when setOperatorRouteGuard is called twice for the same app', () => {
+    // #given
+    const app = new Hono()
+    const guard = vi.fn(async () => ({ok: true as const, githubUserId: 42, sessionId: 'sid'}))
+    setOperatorRouteGuard(app, guard)
+
+    // #when / #then — second installation must throw
+    expect(() => setOperatorRouteGuard(app, guard)).toThrow(/already installed/)
+  })
+
+  it('guards are isolated per app instance', () => {
+    // #given — two separate app instances
+    const app1 = new Hono()
+    const app2 = new Hono()
+    const guard1 = vi.fn(async () => ({ok: true as const, githubUserId: 1, sessionId: 'sid1'}))
+    const guard2 = vi.fn(async () => ({ok: true as const, githubUserId: 2, sessionId: 'sid2'}))
+
+    // #when
+    setOperatorRouteGuard(app1, guard1)
+    setOperatorRouteGuard(app2, guard2)
+
+    // #then — each app has its own guard
+    expect(getOperatorRouteGuard(app1)).toBe(guard1)
+    expect(getOperatorRouteGuard(app2)).toBe(guard2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// registerOperatorRoute — auto-guard wrapping
+// ---------------------------------------------------------------------------
+
+describe('registerOperatorRoute — auto-guard wrapping', () => {
+  it('guard is called before handler when guard allows the request', async () => {
+    // #given
+    const app = new Hono()
+    const guard = vi.fn(async () => ({ok: true as const, githubUserId: 42, sessionId: 'test-sid'}))
+    setOperatorRouteGuard(app, guard)
+
+    const handler = vi.fn((c: Context) => c.json({ok: true}))
+    registerOperatorRoute(app, 'GET', '/operator/test', handler)
+
+    // #when
+    const req = new Request('http://localhost/operator/test')
+    const res = await app.fetch(req)
+
+    // #then — guard was called
+    expect(guard).toHaveBeenCalledOnce()
+    // #and — handler was called (guard allowed)
+    expect(handler).toHaveBeenCalledOnce()
+    expect(res.status).toBe(200)
+  })
+
+  it('guard rejects the request before handler runs when guard returns ok=false', async () => {
+    // #given
+    const app = new Hono()
+    const rejectionResponse = new Response(JSON.stringify({error: 'unauthorized'}), {status: 401})
+    const guard = vi.fn(async () => ({ok: false as const, response: rejectionResponse}))
+    setOperatorRouteGuard(app, guard)
+
+    const handler = vi.fn((c: Context) => c.json({ok: true}))
+    registerOperatorRoute(app, 'GET', '/operator/test', handler)
+
+    // #when
+    const req = new Request('http://localhost/operator/test')
+    const res = await app.fetch(req)
+
+    // #then — guard was called
+    expect(guard).toHaveBeenCalledOnce()
+    // #and — handler was NOT called (guard rejected)
+    expect(handler).not.toHaveBeenCalled()
+    expect(res.status).toBe(401)
+  })
+
+  it('authenticated context is available via getOperatorAuthContext when guard allows', async () => {
+    // #given
+    const app = new Hono()
+    const guard = vi.fn(async () => ({ok: true as const, githubUserId: 99, sessionId: 'my-session'}))
+    setOperatorRouteGuard(app, guard)
+
+    let capturedCtx: ReturnType<typeof getOperatorAuthContext> | undefined
+    registerOperatorRoute(app, 'GET', '/operator/test', (c: Context) => {
+      capturedCtx = getOperatorAuthContext(c)
+      return c.json({ok: true})
+    })
+
+    // #when
+    const req = new Request('http://localhost/operator/test')
+    await app.fetch(req)
+
+    // #then — auth context is set correctly
+    expect(capturedCtx).toEqual({githubUserId: 99, sessionId: 'my-session'})
+  })
+
+  it('getOperatorAuthContext returns undefined when no guard is installed (legacy path)', async () => {
+    // #given — no guard installed
+    const app = new Hono()
+
+    let capturedCtx: ReturnType<typeof getOperatorAuthContext> | undefined
+    registerOperatorRoute(app, 'GET', '/operator/test', (c: Context) => {
+      capturedCtx = getOperatorAuthContext(c)
+      return c.json({ok: true})
+    })
+
+    // #when
+    const req = new Request('http://localhost/operator/test')
+    await app.fetch(req)
+
+    // #then — no auth context (guard not installed)
+    expect(capturedCtx).toBeUndefined()
+  })
+
+  it('public routes are NOT wrapped by the guard', async () => {
+    // #given — guard installed
+    const app = new Hono()
+    const guard = vi.fn(async () => ({ok: true as const, githubUserId: 42, sessionId: 'sid'}))
+    setOperatorRouteGuard(app, guard)
+
+    const handler = vi.fn((c: Context) => c.json({ok: true}))
+    registerPublicRoute(app, 'GET', '/operator/health', handler)
+
+    // #when
+    const req = new Request('http://localhost/operator/health')
+    const res = await app.fetch(req)
+
+    // #then — guard was NOT called for public route
+    expect(guard).not.toHaveBeenCalled()
+    // #and — handler was called directly
+    expect(handler).toHaveBeenCalledOnce()
+    expect(res.status).toBe(200)
+  })
+
+  it('guard receives the correct method and path', async () => {
+    // #given
+    const app = new Hono()
+    let capturedMethod: string | undefined
+    let capturedPath: string | undefined
+    const guard = vi.fn(async (_c: Context, method: string, path: string) => {
+      capturedMethod = method
+      capturedPath = path
+      return {ok: true as const, githubUserId: 1, sessionId: 'sid'}
+    })
+    setOperatorRouteGuard(app, guard)
+
+    registerOperatorRoute(app, 'POST', '/operator/runs', (c: Context) => c.json({ok: true}))
+
+    // #when
+    const req = new Request('http://localhost/operator/runs', {method: 'POST'})
+    await app.fetch(req)
+
+    // #then — guard received correct method and path
+    expect(capturedMethod).toBe('POST')
+    expect(capturedPath).toBe('/operator/runs')
+  })
+
+  it('routes registered before setOperatorRouteGuard are not wrapped (guard must be installed first)', async () => {
+    // #given — register route BEFORE installing guard
+    const app = new Hono()
+    const handler = vi.fn((c: Context) => c.json({ok: true}))
+    registerOperatorRoute(app, 'GET', '/operator/early', handler)
+
+    // Install guard AFTER route registration
+    const guard = vi.fn(async () => ({ok: false as const, response: new Response('rejected', {status: 401})}))
+    setOperatorRouteGuard(app, guard)
+
+    // #when
+    const req = new Request('http://localhost/operator/early')
+    const res = await app.fetch(req)
+
+    // #then — guard was NOT called (route was registered before guard installation)
+    expect(guard).not.toHaveBeenCalled()
+    // #and — handler ran directly (no guard wrapping)
+    expect(handler).toHaveBeenCalledOnce()
+    expect(res.status).toBe(200)
   })
 })
 

--- a/packages/gateway/src/web/operator-route.ts
+++ b/packages/gateway/src/web/operator-route.ts
@@ -8,11 +8,79 @@
  * if any /operator or /operator/* route is registered without going through one of the two
  * explicit registration helpers.
  *
- * Classification only — no auth, rate limiting, origin, or CSRF enforcement yet.
- * Real middleware replaces this seam when the auth boundary lands.
+ * When a guard is installed via `setOperatorRouteGuard`, every privileged route registered
+ * through `registerOperatorRoute` is automatically wrapped: the guard runs first, and the
+ * handler only executes if the guard allows the request. This ensures future privileged routes
+ * cannot forget browser guard / allowlist / CSRF enforcement.
+ *
+ * Public routes are never wrapped by the guard.
  */
 
-import type {Context, Hono} from 'hono'
+import type {Context, Env, Hono} from 'hono'
+
+/** A Context with an open Variables map — used for c.set/c.get without generic constraints. */
+type OpenContext = Context<Env & {Variables: Record<string, unknown>}>
+
+// ---------------------------------------------------------------------------
+// Guard types
+// ---------------------------------------------------------------------------
+
+/**
+ * Authenticated context stored on the Hono context after a successful guard check.
+ * Handlers can read this via `getOperatorAuthContext(c)`.
+ */
+export interface OperatorAuthContext {
+  readonly githubUserId: number
+  readonly sessionId: string
+}
+
+/**
+ * A privileged-route guard function.
+ *
+ * Called before every privileged route handler when installed via `setOperatorRouteGuard`.
+ * Receives the Hono context, HTTP method, and route path.
+ *
+ * Returns:
+ *   - `{ok: true, githubUserId, sessionId}` to allow the request (handler runs next).
+ *   - `{ok: false, response}` to reject the request (response is returned immediately).
+ *
+ * The guard MUST NOT call the handler — `registerOperatorRoute` handles that.
+ */
+export type OperatorRouteGuard = (
+  c: Context,
+  method: string,
+  path: string,
+) => Promise<
+  | {readonly ok: true; readonly githubUserId: number; readonly sessionId: string}
+  | {readonly ok: false; readonly response: Response}
+>
+
+// ---------------------------------------------------------------------------
+// Hono context variable key for authenticated operator context
+// ---------------------------------------------------------------------------
+
+/**
+ * Key used to store the authenticated operator context on the Hono context.
+ * Set by the auto-guard wrapper; read by handlers via `getOperatorAuthContext`.
+ */
+const OPERATOR_AUTH_CONTEXT_KEY = '__operatorAuthContext'
+
+/**
+ * Read the authenticated operator context set by the auto-guard.
+ *
+ * Returns the context if the guard ran and allowed the request, or undefined
+ * if no guard is installed.
+ *
+ * Handlers that require authentication MUST check for undefined and return 401.
+ * In production (guard installed), undefined is unreachable — the guard rejects first.
+ */
+export function getOperatorAuthContext(c: Context): OperatorAuthContext | undefined {
+  // Use Hono's c.get() API to read context variables set by c.set().
+  // Cast to OpenContext to access the open Variables map without generic constraints.
+  const ctx = (c as OpenContext).get(OPERATOR_AUTH_CONTEXT_KEY)
+  if (ctx === undefined || ctx === null) return undefined
+  return ctx as OperatorAuthContext
+}
 
 // ---------------------------------------------------------------------------
 // Internal registry
@@ -43,9 +111,54 @@ function makeRouteRegistry() {
 
 const privilegedRoutes = makeRouteRegistry()
 const publicRoutes = makeRouteRegistry()
+const publicCrossSiteRoutes = makeRouteRegistry()
+
+/**
+ * Per-app guard registry.
+ * WeakMap so the guard is garbage-collected when the app is GC'd.
+ */
+const guardRegistry = new WeakMap<object, OperatorRouteGuard>()
 
 function routeKey(method: string, path: string): string {
   return `${method.toUpperCase()}:${path}`
+}
+
+// ---------------------------------------------------------------------------
+// Guard installation
+// ---------------------------------------------------------------------------
+
+/**
+ * Install a privileged-route guard for the given app.
+ *
+ * When installed, every subsequent call to `registerOperatorRoute` will wrap
+ * the handler: the guard runs first, and the handler only executes if the guard
+ * allows the request. The guard result (githubUserId, sessionId) is stored on
+ * the Hono context and readable via `getOperatorAuthContext(c)`.
+ *
+ * Must be called BEFORE any `registerOperatorRoute` calls that should be guarded.
+ * Routes registered before `setOperatorRouteGuard` are NOT wrapped retroactively.
+ *
+ * Public routes (registered via `registerPublicRoute` or `registerPublicCrossSiteRoute`)
+ * are never wrapped by the guard.
+ *
+ * Throws if a guard is already installed for this app (programming error).
+ */
+export function setOperatorRouteGuard(app: Hono, guard: OperatorRouteGuard): void {
+  if (guardRegistry.has(app)) {
+    throw new Error(
+      'Operator route guardrail: a guard is already installed for this app. ' +
+        'setOperatorRouteGuard must be called at most once per app instance.',
+    )
+  }
+  guardRegistry.set(app, guard)
+}
+
+/**
+ * Returns the installed guard for the given app, or undefined if none is installed.
+ * Used internally by `registerOperatorRoute` to wrap handlers.
+ */
+export function getOperatorRouteGuard(app: Hono): OperatorRouteGuard | undefined {
+  return guardRegistry.get(app)
 }
 
 // ---------------------------------------------------------------------------
@@ -83,21 +196,53 @@ function applyMethod(app: Hono, method: SupportedMethod, path: string, handler: 
  * `assertAllPrivilegedRoutesWrapped` throws at startup if any /operator or /operator/*
  * route bypasses it.
  *
- * Classification only — no auth middleware yet. Real guards replace this seam when
- * the auth boundary lands.
+ * When a guard is installed via `setOperatorRouteGuard`, the handler is automatically
+ * wrapped: the guard runs first (browser guard / allowlist / CSRF enforcement), and the
+ * handler only executes if the guard allows the request. The authenticated context
+ * (githubUserId, sessionId) is stored on the Hono context and readable via
+ * `getOperatorAuthContext(c)`.
+ *
+ * When no guard is installed, the raw handler is applied directly. Production operator
+ * apps install a guard before privileged routes; unguarded registration is for isolated
+ * route-helper tests only.
  *
  * Throws if the same method+path is registered twice (duplicate detection).
  */
 export function registerOperatorRoute(app: Hono, method: SupportedMethod, path: string, handler: RouteHandler): void {
   const key = routeKey(method, path)
-  if (privilegedRoutes.has(app, key) || publicRoutes.has(app, key)) {
+  if (privilegedRoutes.has(app, key) || publicRoutes.has(app, key) || publicCrossSiteRoutes.has(app, key)) {
     throw new Error(
       `Operator route guardrail: duplicate registration for ${method} ${path}. ` +
-        `Each route may only be registered once via registerOperatorRoute or registerPublicRoute.`,
+        `Each route may only be registered once via registerOperatorRoute, registerPublicRoute, or registerPublicCrossSiteRoute.`,
     )
   }
   privilegedRoutes.add(app, key)
-  applyMethod(app, method, path, handler)
+
+  const guard = guardRegistry.get(app)
+  if (guard === undefined) {
+    // No guard installed — apply raw handler. Production operator apps install a guard
+    // before privileged routes; this path supports isolated route-helper tests.
+    applyMethod(app, method, path, handler)
+  } else {
+    // Wrap the handler with the guard.
+    // The guard runs first; if it rejects, the response is returned immediately.
+    // If it allows, the authenticated context is stored on the Hono context and
+    // the handler is called.
+    const wrappedHandler: RouteHandler = async (c: Context): Promise<Response> => {
+      const guardResult = await guard(c, method, path)
+      if (guardResult.ok === false) {
+        return guardResult.response
+      }
+      // Store authenticated context for the handler to read via getOperatorAuthContext(c).
+      // Cast to OpenContext to access the open Variables map without generic constraints.
+      ;(c as OpenContext).set(OPERATOR_AUTH_CONTEXT_KEY, {
+        githubUserId: guardResult.githubUserId,
+        sessionId: guardResult.sessionId,
+      })
+      return handler(c)
+    }
+    applyMethod(app, method, path, wrappedHandler)
+  }
 }
 
 /**
@@ -110,13 +255,45 @@ export function registerOperatorRoute(app: Hono, method: SupportedMethod, path: 
  */
 export function registerPublicRoute(app: Hono, method: SupportedMethod, path: string, handler: RouteHandler): void {
   const key = routeKey(method, path)
-  if (privilegedRoutes.has(app, key) || publicRoutes.has(app, key)) {
+  if (privilegedRoutes.has(app, key) || publicRoutes.has(app, key) || publicCrossSiteRoutes.has(app, key)) {
     throw new Error(
       `Operator route guardrail: duplicate registration for ${method} ${path}. ` +
-        `Each route may only be registered once via registerOperatorRoute or registerPublicRoute.`,
+        `Each route may only be registered once via registerOperatorRoute, registerPublicRoute, or registerPublicCrossSiteRoute.`,
     )
   }
   publicRoutes.add(app, key)
+  applyMethod(app, method, path, handler)
+}
+
+/**
+ * Register a public cross-site operator route.
+ *
+ * Use for routes that must accept cross-site requests (e.g. OAuth callback from GitHub).
+ * These routes are classified as public (unauthenticated) AND cross-site-allowed.
+ * `assertAllPrivilegedRoutesWrapped` recognizes these as explicitly classified.
+ * The browser-origin guard exempts these routes from Fetch Metadata cross-site rejection.
+ *
+ * Currently only the OAuth callback should be registered this way.
+ * Do NOT broaden this exemption — it bypasses the cross-site Fetch Metadata check.
+ *
+ * Throws if the same method+path is registered twice (duplicate detection).
+ */
+export function registerPublicCrossSiteRoute(
+  app: Hono,
+  method: SupportedMethod,
+  path: string,
+  handler: RouteHandler,
+): void {
+  const key = routeKey(method, path)
+  if (privilegedRoutes.has(app, key) || publicRoutes.has(app, key) || publicCrossSiteRoutes.has(app, key)) {
+    throw new Error(
+      `Operator route guardrail: duplicate registration for ${method} ${path}. ` +
+        `Each route may only be registered once via registerOperatorRoute, registerPublicRoute, or registerPublicCrossSiteRoute.`,
+    )
+  }
+  // Cross-site routes are also public (not privileged)
+  publicRoutes.add(app, key)
+  publicCrossSiteRoutes.add(app, key)
   applyMethod(app, method, path, handler)
 }
 
@@ -132,10 +309,19 @@ export function isPrivilegedRoute(app: Hono, method: string, path: string): bool
 }
 
 /**
- * Returns true if the given route was registered through `registerPublicRoute`.
+ * Returns true if the given route was registered through `registerPublicRoute`
+ * or `registerPublicCrossSiteRoute`.
  */
 export function isPublicRoute(app: Hono, method: string, path: string): boolean {
   return publicRoutes.has(app, routeKey(method, path))
+}
+
+/**
+ * Returns true if the given route was registered through `registerPublicCrossSiteRoute`.
+ * These routes are exempt from Fetch Metadata cross-site rejection.
+ */
+export function isPublicCrossSiteRoute(app: Hono, method: string, path: string): boolean {
+  return publicCrossSiteRoutes.has(app, routeKey(method, path))
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/web/safe-response.ts
+++ b/packages/gateway/src/web/safe-response.ts
@@ -44,6 +44,17 @@ export function badRequestResponse<E extends Env, P extends string, I extends In
 }
 
 /**
+ * Return a coarse 403 Forbidden.
+ * Use when an authenticated user is denied access (e.g. not in allowlist).
+ * Never include the specific reason in the response body.
+ */
+export function forbiddenResponse<E extends Env, P extends string, I extends Input>(
+  c: OperatorResponseContext<E, P, I>,
+): Response {
+  return c.json({error: 'forbidden'}, 403)
+}
+
+/**
  * Return a coarse 404 Not Found.
  * Use for unknown routes and resources that do not exist or are not visible
  * to the current operator. Never distinguish between "not found" and "not authorized".

--- a/packages/gateway/src/web/server.test.ts
+++ b/packages/gateway/src/web/server.test.ts
@@ -26,9 +26,11 @@ import {createServer} from 'node:http'
 
 import {describe, expect, it, vi} from 'vitest'
 import {createRateLimiter} from '../http/rate-limit.js'
+import {loadAllowlistFromText} from './auth/allowlist.js'
+import {generateCsrfToken} from './auth/csrf.js'
 import {createInMemoryStateStore} from './auth/github.js'
-import {createInMemorySessionStore} from './auth/session.js'
-import {isPublicRoute} from './operator-route.js'
+import {createInMemorySessionStore, SESSION_COOKIE_NAME} from './auth/session.js'
+import {isPrivilegedRoute, isPublicCrossSiteRoute, isPublicRoute} from './operator-route.js'
 import {buildOperatorApp, createOperatorServer} from './server.js'
 
 // ---------------------------------------------------------------------------
@@ -758,11 +760,15 @@ function makeStubSessionDeps(overrides?: Partial<SessionDeps>): SessionDeps {
 }
 
 describe('buildOperatorApp — logout route registration', () => {
-  it('registers POST /operator/auth/logout when sessionStore and sessionDeps are provided', () => {
-    // #given
+  it('registers POST /operator/auth/logout when sessionStore, sessionDeps, and browser guard deps are provided', () => {
+    // #given — all required deps for logout (sessionStore + sessionDeps + browser guard deps)
     const sessionStore = createInMemorySessionStore()
     const sessionDeps = makeStubSessionDeps()
-    const app = buildOperatorApp(makeStubDeps({sessionStore, sessionDeps}), makeStubConfig())
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({sessionStore, sessionDeps, allowlist, csrfSecret, auditLogger, logger}),
+      makeStubConfig(),
+    )
 
     // #when — extract unique logical routes
     const seen = new Set<string>()
@@ -800,34 +806,63 @@ describe('buildOperatorApp — logout route registration', () => {
     expect(routes).not.toContainEqual({method: 'POST', path: '/operator/auth/logout'})
   })
 
-  it('logout route is classified as public (no session required to call logout)', () => {
-    // #given
+  it('throws a programming error when sessionStore/sessionDeps are present but browser guard deps are absent', () => {
+    // #given — sessionStore + sessionDeps without allowlist/csrfSecret/auditLogger
     const sessionStore = createInMemorySessionStore()
     const sessionDeps = makeStubSessionDeps()
-    const app = buildOperatorApp(makeStubDeps({sessionStore, sessionDeps}), makeStubConfig())
 
-    // #when / #then — logout is public (idempotent, no oracle)
-    expect(isPublicRoute(app, 'POST', '/operator/auth/logout')).toBe(true)
+    // #when / #then — must throw: public mutating logout is a CSRF footgun
+    expect(() => buildOperatorApp(makeStubDeps({sessionStore, sessionDeps}), makeStubConfig())).toThrow(
+      'programming error',
+    )
   })
 
-  it('logout route returns 200 and clears the session cookie', async () => {
-    // #given
+  it('logout route is classified as privileged (requires session + CSRF)', () => {
+    // #given — all required deps for logout
+    const sessionStore = createInMemorySessionStore()
+    const sessionDeps = makeStubSessionDeps()
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({sessionStore, sessionDeps, allowlist, csrfSecret, auditLogger, logger}),
+      makeStubConfig(),
+    )
+
+    // #when / #then — logout is privileged (not public)
+    expect(isPrivilegedRoute(app, 'POST', '/operator/auth/logout')).toBe(true)
+    expect(isPublicRoute(app, 'POST', '/operator/auth/logout')).toBe(false)
+  })
+
+  it('logout route returns 200 and clears the session cookie when session + CSRF are valid', async () => {
+    // #given — all required deps for logout
     const sessionStore = createInMemorySessionStore()
     const now = Date.now()
     const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
     if (sessionId === undefined) throw new Error('expected session to be created')
 
     const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const csrfToken = generateCsrfToken({sessionId, operatorId: 42, nowMs: now + 1000, secret: csrfSecret})
     const app = buildOperatorApp(
-      makeStubDeps({sessionStore, sessionDeps, rateLimiter: {allow: () => true}}),
-      makeStubConfig(),
+      makeStubDeps({
+        sessionStore,
+        sessionDeps,
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
     )
 
     // #when
-    const {SESSION_COOKIE_NAME} = await import('./auth/session.js')
     const req = new Request('http://127.0.0.1/operator/auth/logout', {
       method: 'POST',
-      headers: {cookie: `${SESSION_COOKIE_NAME}=${sessionId}`},
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+        'x-csrf-token': csrfToken,
+      },
     })
     const res = await app.fetch(req)
 
@@ -843,20 +878,38 @@ describe('buildOperatorApp — logout route registration', () => {
     expect(setCookie.toLowerCase()).toContain('max-age=0')
   })
 
-  it('logout route returns 429 when rate limiter rejects', async () => {
-    // #given — rate limiter always blocks
+  it('logout route returns 429 when rate limiter rejects (after guard passes)', async () => {
+    // #given — valid session + CSRF, but rate limiter always blocks
+    // Rate limit check runs inside the handler after the guard passes.
     const sessionStore = createInMemorySessionStore()
-    const sessionDeps = makeStubSessionDeps()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const csrfToken = generateCsrfToken({sessionId, operatorId: 42, nowMs: now + 1000, secret: csrfSecret})
     const app = buildOperatorApp(
-      makeStubDeps({sessionStore, sessionDeps, rateLimiter: {allow: () => false}}),
-      makeStubConfig(),
+      makeStubDeps({
+        sessionStore,
+        sessionDeps,
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => false},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
     )
 
-    // #when
-    const {SESSION_COOKIE_NAME} = await import('./auth/session.js')
+    // #when — valid session + CSRF but rate limiter blocks
     const req = new Request('http://127.0.0.1/operator/auth/logout', {
       method: 'POST',
-      headers: {cookie: `${SESSION_COOKIE_NAME}=some-session-id`},
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+        'x-csrf-token': csrfToken,
+      },
     })
     const res = await app.fetch(req)
 
@@ -865,23 +918,36 @@ describe('buildOperatorApp — logout route registration', () => {
   })
 
   it('logout route clears cookie and invalidates session when rate limiter allows', async () => {
-    // #given — rate limiter allows
+    // #given — rate limiter allows; valid session + CSRF
     const sessionStore = createInMemorySessionStore()
     const now = Date.now()
     const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
     if (sessionId === undefined) throw new Error('expected session to be created')
 
     const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const csrfToken = generateCsrfToken({sessionId, operatorId: 42, nowMs: now + 1000, secret: csrfSecret})
     const app = buildOperatorApp(
-      makeStubDeps({sessionStore, sessionDeps, rateLimiter: {allow: () => true}}),
-      makeStubConfig(),
+      makeStubDeps({
+        sessionStore,
+        sessionDeps,
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
     )
 
     // #when
-    const {SESSION_COOKIE_NAME} = await import('./auth/session.js')
     const req = new Request('http://127.0.0.1/operator/auth/logout', {
       method: 'POST',
-      headers: {cookie: `${SESSION_COOKIE_NAME}=${sessionId}`},
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+        'x-csrf-token': csrfToken,
+      },
     })
     const res = await app.fetch(req)
 
@@ -890,5 +956,665 @@ describe('buildOperatorApp — logout route registration', () => {
     expect(sessionStore.get(sessionId, now + 2000)).toBeUndefined()
     const setCookie = res.headers.get('set-cookie') ?? ''
     expect(setCookie.toLowerCase()).toContain('max-age=0')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CSRF endpoint — GET /operator/session/csrf
+// ---------------------------------------------------------------------------
+
+const TEST_CSRF_SECRET = Buffer.from('test-csrf-secret-32-bytes-long!!', 'utf8').toString('base64url')
+
+function makeStubBrowserGuardDeps(sessionStore: ReturnType<typeof createInMemorySessionStore>) {
+  const logger = makeLogger()
+  const auditLogger = {info: vi.fn(), warn: vi.fn()}
+  const allowlist = loadAllowlistFromText('42\n', logger)
+  return {
+    logger,
+    auditLogger,
+    sessionStore,
+    allowlist,
+    csrfSecret: TEST_CSRF_SECRET,
+  }
+}
+
+describe('buildOperatorApp — CSRF endpoint registration', () => {
+  it('registers GET /operator/session/csrf when allowlist, csrfSecret, auditLogger, and sessionStore are provided', () => {
+    // #given
+    const sessionStore = createInMemorySessionStore()
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({sessionStore, sessionDeps: makeStubSessionDeps(), allowlist, csrfSecret, auditLogger, logger}),
+      makeStubConfig(),
+    )
+
+    // #when — extract unique logical routes
+    const seen = new Set<string>()
+    const routes = app.routes
+      .map((route: RouteEntry) => ({method: route.method, path: route.path}))
+      .filter((route: RouteEntry) => {
+        if (route.method === 'ALL' && route.path === '/*') return false
+        const key = `${route.method}:${route.path}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+
+    // #then — CSRF endpoint is registered
+    expect(routes).toContainEqual({method: 'GET', path: '/operator/session/csrf'})
+  })
+
+  it('does NOT register GET /operator/session/csrf when allowlist is absent', () => {
+    // #given — no allowlist
+    const app = buildOperatorApp(makeStubDeps(), makeStubConfig())
+
+    // #when
+    const seen = new Set<string>()
+    const routes = app.routes
+      .map((route: RouteEntry) => ({method: route.method, path: route.path}))
+      .filter((route: RouteEntry) => {
+        if (route.method === 'ALL' && route.path === '/*') return false
+        const key = `${route.method}:${route.path}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+
+    // #then — CSRF endpoint is NOT registered
+    expect(routes).not.toContainEqual({method: 'GET', path: '/operator/session/csrf'})
+  })
+})
+
+describe('GET /operator/session/csrf — happy path', () => {
+  it('returns 200 with csrfToken when session is valid and operator is allowlisted', async () => {
+    // #given
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({
+        sessionStore,
+        sessionDeps: makeStubSessionDeps({clock: () => now}),
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
+    )
+
+    // #when
+    const req = new Request('http://127.0.0.1/operator/session/csrf', {
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+      },
+    })
+    const res = await app.fetch(req)
+    const body = (await res.json()) as {csrfToken?: unknown}
+
+    // #then
+    expect(res.status).toBe(200)
+    expect(typeof body.csrfToken).toBe('string')
+    expect((body.csrfToken as string).length).toBeGreaterThan(0)
+  })
+
+  it('returns 401 when no session cookie is present', async () => {
+    // #given
+    const sessionStore = createInMemorySessionStore()
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({
+        sessionStore,
+        sessionDeps: makeStubSessionDeps(),
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
+    )
+
+    // #when — no session cookie
+    const req = new Request('http://127.0.0.1/operator/session/csrf', {
+      headers: {origin: 'https://operator.example.com'},
+    })
+    const res = await app.fetch(req)
+
+    // #then
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when operator is not in allowlist', async () => {
+    // #given — session for user 99 who is NOT in the allowlist (allowlist has 42)
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 99, login: 'notallowed'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({
+        sessionStore,
+        sessionDeps: makeStubSessionDeps({clock: () => now}),
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
+    )
+
+    // #when
+    const req = new Request('http://127.0.0.1/operator/session/csrf', {
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 400 when Origin does not match publicOrigin', async () => {
+    // #given
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({
+        sessionStore,
+        sessionDeps: makeStubSessionDeps({clock: () => now}),
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
+    )
+
+    // #when — wrong origin
+    const req = new Request('http://127.0.0.1/operator/session/csrf', {
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://evil.attacker.com',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when non-cookie credential scheme is present', async () => {
+    // #given
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({
+        sessionStore,
+        sessionDeps: makeStubSessionDeps({clock: () => now}),
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
+    )
+
+    // #when — Authorization header present (non-cookie credential)
+    const req = new Request('http://127.0.0.1/operator/session/csrf', {
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+        authorization: 'Bearer some-token',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected without logging the credential value
+    expect(res.status).toBe(400)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Auto-guard: registerOperatorRoute applies browser guard automatically (Unit 3e gap #2)
+// ---------------------------------------------------------------------------
+
+describe('registerOperatorRoute — auto-guard applies browser guard to privileged routes', () => {
+  it('a privileged route registered via registerOperatorRoute rejects unauthenticated requests with 401', async () => {
+    // #given — build app with browser guard deps and a privileged route
+    const sessionStore = createInMemorySessionStore()
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({
+        sessionStore,
+        sessionDeps: makeStubSessionDeps(),
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
+    )
+
+    // #when — GET a privileged route (CSRF endpoint) without a session cookie
+    const req = new Request('http://127.0.0.1/operator/session/csrf', {
+      headers: {origin: 'https://operator.example.com'},
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected 401 (no session)
+    expect(res.status).toBe(401)
+  })
+
+  it('a privileged route registered via registerOperatorRoute rejects non-allowlisted operators with 403', async () => {
+    // #given — session for user 99 who is NOT in the allowlist (allowlist has 42)
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 99, login: 'notallowed'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({
+        sessionStore,
+        sessionDeps: makeStubSessionDeps({clock: () => now}),
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
+    )
+
+    // #when — GET privileged route with non-allowlisted session
+    const req = new Request('http://127.0.0.1/operator/session/csrf', {
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected 403 (not allowlisted)
+    expect(res.status).toBe(403)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Logout protection: POST /operator/auth/logout requires session + CSRF (Unit 3e gap #3)
+// ---------------------------------------------------------------------------
+
+describe('POST /operator/auth/logout — browser guard protection (Unit 3e gap #3)', () => {
+  it('rejects logout without session cookie with 401 when browser guard is enabled', async () => {
+    // #given — app with browser guard deps
+    const sessionStore = createInMemorySessionStore()
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({
+        sessionStore,
+        sessionDeps: makeStubSessionDeps(),
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
+    )
+
+    // #when — POST logout without session cookie
+    const req = new Request('http://127.0.0.1/operator/auth/logout', {
+      method: 'POST',
+      headers: {origin: 'https://operator.example.com'},
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected 401 (no session)
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects logout without CSRF token with 400 when browser guard is enabled', async () => {
+    // #given — valid session but no CSRF token
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({
+        sessionStore,
+        sessionDeps: makeStubSessionDeps({clock: () => now}),
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
+    )
+
+    // #when — POST logout with session but no CSRF token
+    const req = new Request('http://127.0.0.1/operator/auth/logout', {
+      method: 'POST',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+        // No x-csrf-token
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected 400 (missing CSRF token)
+    expect(res.status).toBe(400)
+  })
+
+  it('allows logout with valid session and CSRF token when browser guard is enabled', async () => {
+    // #given — valid session and valid CSRF token
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const {generateCsrfToken: genToken} = await import('./auth/csrf.js')
+    const csrfToken = genToken({sessionId, operatorId: 42, nowMs: now + 1000, secret: csrfSecret})
+
+    const app = buildOperatorApp(
+      makeStubDeps({
+        sessionStore,
+        sessionDeps: makeStubSessionDeps({clock: () => now + 1000}),
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
+    )
+
+    // #when — POST logout with valid session and CSRF token
+    const req = new Request('http://127.0.0.1/operator/auth/logout', {
+      method: 'POST',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+        'x-csrf-token': csrfToken,
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — success
+    expect(res.status).toBe(200)
+    // #and — session is invalidated
+    expect(sessionStore.get(sessionId, now + 2000)).toBeUndefined()
+  })
+})
+
+describe('buildOperatorApp — OAuth callback is cross-site public', () => {
+  it('oAuth callback is registered as public cross-site when OAuth is configured', () => {
+    // #given
+    const app = buildOperatorApp(
+      makeStubDeps({githubOAuth: makeStubGitHubOAuthDeps()}),
+      makeStubConfig({githubOAuth: makeStubGitHubOAuthConfig()}),
+    )
+
+    // #when / #then — callback is cross-site public
+    expect(isPublicCrossSiteRoute(app, 'GET', '/operator/auth/github/callback')).toBe(true)
+    expect(isPublicRoute(app, 'GET', '/operator/auth/github/callback')).toBe(true)
+  })
+
+  it('oAuth start is NOT cross-site public (only callback is)', () => {
+    // #given
+    const app = buildOperatorApp(
+      makeStubDeps({githubOAuth: makeStubGitHubOAuthDeps()}),
+      makeStubConfig({githubOAuth: makeStubGitHubOAuthConfig()}),
+    )
+
+    // #when / #then — start is public but NOT cross-site
+    expect(isPublicCrossSiteRoute(app, 'GET', '/operator/auth/github/start')).toBe(false)
+    expect(isPublicRoute(app, 'GET', '/operator/auth/github/start')).toBe(true)
+  })
+})
+
+describe('server integration — forwarded-header rejection before CSRF', () => {
+  it('rejects with 400 on bad forwarded headers before reaching CSRF check', async () => {
+    // #given — server with browser guard enabled
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({
+        sessionStore,
+        sessionDeps: makeStubSessionDeps({clock: () => now}),
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
+    )
+
+    // #when — bad forwarded headers (should reject before CSRF check)
+    const req = new Request('http://127.0.0.1/operator/session/csrf', {
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+        'x-forwarded-host': 'evil.attacker.com',
+        'x-forwarded-proto': 'https',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected at forwarded-header check (400), not at CSRF check
+    expect(res.status).toBe(400)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildOperatorApp — partial browser guard deps throws (Fix 4)
+// ---------------------------------------------------------------------------
+
+describe('buildOperatorApp — partial browser guard deps throws at construction time (Fix 4)', () => {
+  it('throws when allowlist is provided but csrfSecret is absent', () => {
+    // #given — allowlist present but csrfSecret and auditLogger absent
+    const sessionStore = createInMemorySessionStore()
+    const {allowlist} = makeStubBrowserGuardDeps(sessionStore)
+
+    // #when / #then — partial deps must throw at construction time
+    expect(() =>
+      buildOperatorApp(
+        makeStubDeps({allowlist, sessionStore}), // csrfSecret and auditLogger absent
+        makeStubConfig(),
+      ),
+    ).toThrow(/partial browser guard deps/)
+  })
+
+  it('throws when csrfSecret is provided but allowlist is absent', () => {
+    // #given — csrfSecret present but allowlist and auditLogger absent
+    const sessionStore = createInMemorySessionStore()
+    const {csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+
+    // #when / #then
+    expect(() =>
+      buildOperatorApp(
+        makeStubDeps({csrfSecret, sessionStore}), // allowlist and auditLogger absent
+        makeStubConfig(),
+      ),
+    ).toThrow(/partial browser guard deps/)
+  })
+
+  it('throws when auditLogger is provided but allowlist and csrfSecret are absent', () => {
+    // #given — auditLogger present but allowlist and csrfSecret absent
+    const sessionStore = createInMemorySessionStore()
+    const {auditLogger} = makeStubBrowserGuardDeps(sessionStore)
+
+    // #when / #then
+    expect(() =>
+      buildOperatorApp(
+        makeStubDeps({auditLogger, sessionStore}), // allowlist and csrfSecret absent
+        makeStubConfig(),
+      ),
+    ).toThrow(/partial browser guard deps/)
+  })
+
+  it('does NOT throw when all four browser guard deps are absent (guard disabled)', () => {
+    // #given — no browser guard deps at all
+    // #when / #then — all absent is valid (guard disabled)
+    expect(() => buildOperatorApp(makeStubDeps(), makeStubConfig())).not.toThrow()
+  })
+
+  it('does NOT throw when all four browser guard deps are present (guard enabled)', () => {
+    // #given — all four browser guard deps present
+    const sessionStore = createInMemorySessionStore()
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+
+    // #when / #then — all present is valid (guard enabled)
+    expect(() =>
+      buildOperatorApp(
+        makeStubDeps({allowlist, csrfSecret, auditLogger, sessionStore, sessionDeps: makeStubSessionDeps(), logger}),
+        makeStubConfig(),
+      ),
+    ).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GET /operator/session/csrf — Cache-Control and Vary headers (Fix 7)
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/session/csrf — Cache-Control and Vary headers (Fix 7)', () => {
+  it('returns Cache-Control: no-store, private on successful CSRF token response', async () => {
+    // #given — valid session and allowlisted operator
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({
+        sessionStore,
+        sessionDeps: makeStubSessionDeps({clock: () => now}),
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
+    )
+
+    // #when
+    const req = new Request('http://127.0.0.1/operator/session/csrf', {
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — success with Cache-Control: no-store, private
+    expect(res.status).toBe(200)
+    const cacheControl = res.headers.get('cache-control') ?? ''
+    expect(cacheControl).toContain('no-store')
+    expect(cacheControl).toContain('private')
+  })
+
+  it('returns Vary header on successful CSRF token response', async () => {
+    // #given — valid session and allowlisted operator
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({
+        sessionStore,
+        sessionDeps: makeStubSessionDeps({clock: () => now}),
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
+    )
+
+    // #when
+    const req = new Request('http://127.0.0.1/operator/session/csrf', {
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — Vary header present
+    expect(res.status).toBe(200)
+    const vary = res.headers.get('vary') ?? ''
+    expect(vary).toContain('Origin')
+  })
+
+  it('returns Vary header on rejection response (origin mismatch)', async () => {
+    // #given — valid session but wrong Origin
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, now)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
+    const app = buildOperatorApp(
+      makeStubDeps({
+        sessionStore,
+        sessionDeps: makeStubSessionDeps({clock: () => now}),
+        allowlist,
+        csrfSecret,
+        auditLogger,
+        logger,
+        rateLimiter: {allow: () => true},
+      }),
+      makeStubConfig({publicOrigin: 'https://operator.example.com'}),
+    )
+
+    // #when — wrong Origin
+    const req = new Request('http://127.0.0.1/operator/session/csrf', {
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://evil.attacker.com',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — rejected with Vary header
+    expect(res.status).toBe(400)
+    const vary = res.headers.get('vary') ?? ''
+    expect(vary).toContain('Origin')
   })
 })

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -22,6 +22,8 @@
  */
 
 import type {ServerType} from '@hono/node-server'
+import type {AuditLogger} from './audit.js'
+import type {OperatorAllowlist} from './auth/allowlist.js'
 import type {GitHubOAuthConfig, GitHubOAuthDeps} from './auth/github.js'
 import type {SessionDeps, SessionStore} from './auth/session.js'
 import {serve} from '@hono/node-server'
@@ -29,9 +31,11 @@ import {getConnInfo} from '@hono/node-server/conninfo'
 import {Hono} from 'hono'
 import {bodyLimit} from 'hono/body-limit'
 import {createRateLimiter} from '../http/rate-limit.js'
+import {buildCsrfRoute} from './auth/csrf-route.js'
+import {applyBrowserGuard} from './auth/csrf.js'
 import {buildGitHubOAuthRoutes} from './auth/github.js'
 import {buildLogoutRoutes} from './auth/session.js'
-import {assertAllPrivilegedRoutesWrapped, registerPublicRoute} from './operator-route.js'
+import {assertAllPrivilegedRoutesWrapped, registerPublicRoute, setOperatorRouteGuard} from './operator-route.js'
 import {
   badRequestResponse,
   notFoundResponse,
@@ -102,6 +106,23 @@ export interface OperatorServerDeps {
    * Required when sessionStore is present; ignored otherwise.
    */
   readonly sessionDeps?: SessionDeps
+  /**
+   * Optional operator allowlist for the browser guard.
+   * When present (alongside csrfSecret and auditLogger), the browser guard is applied
+   * to authenticated operator routes and the CSRF endpoint is registered.
+   */
+  readonly allowlist?: OperatorAllowlist
+  /**
+   * CSRF token signing key (HMAC-SHA256), base64url-encoded with no padding/newlines.
+   * Required when allowlist is present; ignored otherwise.
+   * Must decode to at least 32 bytes (256 bits) of CSPRNG entropy.
+   */
+  readonly csrfSecret?: string
+  /**
+   * Audit logger for security events.
+   * Required when allowlist is present; ignored otherwise.
+   */
+  readonly auditLogger?: AuditLogger
 }
 
 export interface OperatorServerConfig {
@@ -347,13 +368,80 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
     )
   }
 
+  // ── Browser guard deps (shared by logout and CSRF endpoint) ───────────────
+  //
+  // Built when allowlist, csrfSecret, auditLogger, and sessionStore are all present.
+  // Used to protect both the logout route and the CSRF endpoint.
+  //
+  // Partial deps (some but not all of allowlist/csrfSecret/auditLogger/sessionStore)
+  // is a programming error — fail closed with a clear error instead of silently
+  // disabling the guard. The guard is all-or-nothing.
+  const browserGuardPieces = [deps.allowlist, deps.csrfSecret, deps.auditLogger, deps.sessionStore]
+  const browserGuardPresentCount = browserGuardPieces.filter(v => v !== undefined).length
+  if (browserGuardPresentCount > 0 && browserGuardPresentCount < 4) {
+    const missing: string[] = []
+    if (deps.allowlist === undefined) missing.push('allowlist')
+    if (deps.csrfSecret === undefined) missing.push('csrfSecret')
+    if (deps.auditLogger === undefined) missing.push('auditLogger')
+    if (deps.sessionStore === undefined) missing.push('sessionStore')
+    throw new Error(
+      `buildOperatorApp: partial browser guard deps — all four of allowlist, csrfSecret, auditLogger, and sessionStore must be provided together to enable the browser guard, or none to disable it. Missing: ${missing.join(', ')}. This is a programming error — partial browser guard wiring silently disables security enforcement.`,
+    )
+  }
+  const browserGuardDeps =
+    deps.allowlist !== undefined &&
+    deps.csrfSecret !== undefined &&
+    deps.auditLogger !== undefined &&
+    deps.sessionStore !== undefined
+      ? {
+          logger: deps.logger,
+          auditLogger: deps.auditLogger,
+          sessionStore: deps.sessionStore,
+          allowlist: deps.allowlist,
+          csrfSecret: deps.csrfSecret,
+          publicOrigin: config.publicOrigin,
+          clock: deps.sessionDeps?.clock ?? (() => Date.now()),
+        }
+      : undefined
+
+  // ── Privileged-route guard installation ────────────────────────────────────
+  //
+  // When browserGuardDeps is present, install a generic guard on the app before
+  // registering any privileged routes. Every subsequent `registerOperatorRoute`
+  // call will automatically wrap its handler: the guard runs first (browser guard /
+  // allowlist / CSRF enforcement), and the handler only executes if the guard allows.
+  //
+  // The guard calls applyBrowserGuard with:
+  //   - isPublicCrossSiteRoute=false (privileged routes are never cross-site)
+  //   - requireCsrf=true for mutating methods (POST/PUT/PATCH/DELETE), false for safe methods
+  //
+  // This ensures future privileged routes cannot forget browser guard enforcement.
+  // Routes registered before this point (health, OAuth) are public and unaffected.
+  if (browserGuardDeps !== undefined) {
+    const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+    setOperatorRouteGuard(app, async (c, method, _path) => {
+      const requireCsrf = SAFE_METHODS.has(method.toUpperCase()) === false
+      return applyBrowserGuard(c, browserGuardDeps, false, requireCsrf)
+    })
+  }
+
   // ── Logout route ───────────────────────────────────────────────────────────
   //
-  // Registered only when both sessionStore and sessionDeps are present.
-  // Route: POST /operator/auth/logout — public (no session required to call logout).
+  // Registered only when sessionStore, sessionDeps, AND browserGuardDeps are all present.
+  // Logout is always a privileged route protected by session + allowlist + origin + CSRF.
+  // Providing sessionStore/sessionDeps without browserGuardDeps is a programming error —
+  // a public mutating logout path is a CSRF footgun and is not supported.
   // Thread the shared rate limiter and socket-derived source key into the logout route
   // so it participates in the same per-socket budget as the health and OAuth routes.
   if (deps.sessionStore !== undefined && deps.sessionDeps !== undefined) {
+    if (browserGuardDeps === undefined) {
+      throw new Error(
+        'buildOperatorApp: sessionStore and sessionDeps are present but browserGuardDeps is absent. ' +
+          'Logout must always be protected by the browser guard (session + allowlist + origin + CSRF). ' +
+          'Provide allowlist, csrfSecret, and auditLogger alongside sessionStore, or omit sessionStore entirely. ' +
+          'This is a programming error — a public mutating logout path is a CSRF footgun.',
+      )
+    }
     const sessionDepsWithRateLimiter = {
       ...deps.sessionDeps,
       rateLimiter,
@@ -366,7 +454,16 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
         }
       },
     }
-    buildLogoutRoutes(app, deps.sessionStore, sessionDepsWithRateLimiter)
+    buildLogoutRoutes(app, deps.sessionStore, sessionDepsWithRateLimiter, browserGuardDeps)
+  }
+
+  // ── CSRF endpoint ──────────────────────────────────────────────────────────
+  //
+  // Registered only when allowlist, csrfSecret, auditLogger, and sessionStore are present.
+  // Route: GET /operator/session/csrf — privileged (requires session + allowlist).
+  // Returns a fresh signed CSRF token for the authenticated session.
+  if (browserGuardDeps !== undefined) {
+    buildCsrfRoute(app, browserGuardDeps)
   }
 
   // ── Catch-all ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds the browser-side authorization gate for the Gateway operator surface:

- requires GitHub OAuth identities to be in the configured operator allowlist before sessions are minted
- protects privileged operator routes with session, allowlist, Origin, Fetch Metadata, and CSRF checks
- adds a session-bound CSRF token endpoint for browser clients
- validates CSRF signing key format and operator allowlist config at startup
- hardens logout so it is no longer a public mutating route

## Verification

- `pnpm exec vitest run packages/gateway/src/config.test.ts packages/gateway/src/web/auth/csrf.test.ts packages/gateway/src/web/auth/allowlist.test.ts packages/gateway/src/web/auth/session.test.ts packages/gateway/src/web/auth/github.test.ts packages/gateway/src/web/server.test.ts packages/gateway/src/program.test.ts packages/gateway/src/web/audit.test.ts packages/gateway/src/web/operator-route.test.ts`
- `pnpm --filter @fro-bot/gateway check-types`
- `pnpm --filter @fro-bot/gateway lint`
- `pnpm --filter @fro-bot/gateway build`