### PR TITLE
feat(gateway): add operator repo authorization helper

### DIFF
--- a/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
+++ b/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
@@ -557,7 +557,7 @@ The web listener is an adapter layer. It authenticates the operator, projects sa
   **Verification:**
   - 52/52 test files pass. Type check clean. Lint clean. Build succeeds.
 
-- [ ] **Unit 3f: Repo authorization helper**
+- [x] **Unit 3f: Repo authorization helper**
 
   **Goal:** Implement the single repo authorization helper used by all privileged routes.
 

--- a/packages/gateway/src/web/audit.ts
+++ b/packages/gateway/src/web/audit.ts
@@ -20,7 +20,14 @@ export type AuthCallbackFailureReason =
   | 'unknown'
 
 /** Safe reasons for authorization denial. */
-export type AuthzDeniedReason = 'not_allowlisted' | 'suspended' | 'unknown'
+export type AuthzDeniedReason =
+  | 'not_allowlisted'
+  | 'suspended'
+  | 'invalid_repo_name'
+  | 'github_denied'
+  | 'rate_limited'
+  | 'lookup_error'
+  | 'unknown'
 
 /** Safe reasons for launch rejection. */
 export type LaunchRejectedReason = 'binding_not_found' | 'concurrency_cap' | 'authz_denied' | 'unknown'

--- a/packages/gateway/src/web/auth/repo-authz.test.ts
+++ b/packages/gateway/src/web/auth/repo-authz.test.ts
@@ -1,0 +1,1725 @@
+/**
+ * Tests for the repo authorization helper.
+ *
+ * Covers:
+ *   - Happy path: allowlisted operator with GitHub read access is authorized.
+ *   - Error path: allowlisted operator without GitHub read access is denied and audited.
+ *   - Error path: non-allowlisted operator is denied without making a GitHub API call.
+ *   - Caching: positive authz result cached for 5 minutes; negative cached for 30 seconds.
+ *   - Caching: concurrent misses for same operator/repo/token coalesce into one GitHub API call.
+ *   - Caching: GitHub rate-limit response cached through retry window.
+ *   - Caching: max-size cap evicts oldest entry; cache does not grow unbounded.
+ *   - Error path: GitHub API lookup failure fails closed and emits audit event.
+ *   - Validation: malformed owner/repo names are rejected before authz work begins.
+ *   - Token safety: audit/logs never include userOAuthToken; cache key must not expose token.
+ *   - Rate-limit classification: 403 without remaining=0 is not rate-limited.
+ *   - 5xx responses return lookup_error, not github_denied.
+ *   - Response bodies are canceled/drained on all paths.
+ *
+ * Uses BDD comments (#given, #when, #then).
+ */
+
+import type {AuditLogger} from '../audit.js'
+import type {OperatorAllowlist} from './allowlist.js'
+import type {RepoAuthzDeniedReason, RepoAuthzDeps, RepoAuthzLogger} from './repo-authz.js'
+import {describe, expect, it, vi, type Mock} from 'vitest'
+import {checkRepoAuthz, createRepoAuthzCache} from './repo-authz.js'
+
+// ---------------------------------------------------------------------------
+// Typed mock helpers (following audit.test.ts pattern)
+// ---------------------------------------------------------------------------
+
+type AuditLogFn = AuditLogger['info']
+type AuditLogMock = ReturnType<typeof vi.fn<AuditLogFn>>
+
+interface MockAuditLogger extends AuditLogger {
+  readonly info: AuditLogMock
+  readonly warn: AuditLogMock
+}
+
+function makeAuditLogger(): MockAuditLogger {
+  return {
+    info: vi.fn<AuditLogFn>(),
+    warn: vi.fn<AuditLogFn>(),
+  }
+}
+
+type LogFn = RepoAuthzLogger['info']
+type LogMock = ReturnType<typeof vi.fn<LogFn>>
+
+interface MockLogger extends RepoAuthzLogger {
+  readonly debug: LogMock
+  readonly info: LogMock
+  readonly warn: LogMock
+  readonly error: LogMock
+}
+
+function makeLogger(): MockLogger {
+  return {
+    debug: vi.fn<LogFn>(),
+    info: vi.fn<LogFn>(),
+    warn: vi.fn<LogFn>(),
+    error: vi.fn<LogFn>(),
+  }
+}
+
+function makeAllowlist(authorizedIds: readonly number[]): OperatorAllowlist {
+  const set = new Set(authorizedIds)
+  return {
+    isAuthorized: (id: number) => set.has(id),
+    size: set.size,
+  }
+}
+
+/** Build a Response for fetch stubs with a cancelable body. */
+function makeResponse(status: number, headers: Record<string, string> = {}): Response {
+  return new Response(null, {status, headers})
+}
+
+/** Build a Response with a trackable body cancel. */
+function makeResponseWithBody(
+  status: number,
+  headers: Record<string, string> = {},
+): {response: Response; cancelSpy: ReturnType<typeof vi.fn>} {
+  const cancelSpy = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+  // Create a ReadableStream with a cancel hook
+  const stream = new ReadableStream({cancel: cancelSpy})
+  const response = new Response(stream, {status, headers})
+  return {response, cancelSpy}
+}
+
+type FetchMock = Mock<typeof globalThis.fetch>
+
+/** Build a fetch stub that returns a given status code. */
+function makeFetch(status: number, headers: Record<string, string> = {}): FetchMock {
+  return vi.fn<typeof globalThis.fetch>().mockResolvedValue(makeResponse(status, headers))
+}
+
+/** Build a fetch stub that throws. */
+function makeThrowingFetch(error: unknown): FetchMock {
+  return vi.fn<typeof globalThis.fetch>().mockRejectedValue(error)
+}
+
+const OPERATOR_ID = 12345
+const OTHER_OPERATOR_ID = 99999
+const OWNER = 'acme'
+const REPO = 'widget'
+const TOKEN = 'ghp_testtoken'
+
+function makeDeps(overrides: Partial<RepoAuthzDeps> = {}): RepoAuthzDeps {
+  return {
+    allowlist: makeAllowlist([OPERATOR_ID]),
+    fetch: makeFetch(200),
+    clock: () => 0,
+    random: () => 0.5,
+    auditLogger: makeAuditLogger(),
+    logger: makeLogger(),
+    cache: createRepoAuthzCache(),
+    ...overrides,
+  }
+}
+
+/** Serialize all captured audit log calls to a single string for redaction assertions. */
+function serializeAuditCalls(logger: MockAuditLogger): string {
+  return JSON.stringify([...logger.info.mock.calls, ...logger.warn.mock.calls])
+}
+
+/** Serialize all captured logger calls to a single string for redaction assertions. */
+function serializeLogCalls(logger: MockLogger): string {
+  return JSON.stringify([
+    ...logger.debug.mock.calls,
+    ...logger.info.mock.calls,
+    ...logger.warn.mock.calls,
+    ...logger.error.mock.calls,
+  ])
+}
+
+// ---------------------------------------------------------------------------
+// Validation — malformed owner/repo names
+// ---------------------------------------------------------------------------
+
+describe('checkRepoAuthz — validation', () => {
+  it('rejects empty owner', async () => {
+    // #given
+    const deps = makeDeps()
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, '', REPO, TOKEN, deps)
+
+    // #then
+    expect(result).toMatchObject({authorized: false, reason: 'invalid_repo_name'})
+    // No GitHub call made
+    expect(deps.fetch).not.toHaveBeenCalled()
+  })
+
+  it('emits authz.denied with reason invalid_repo_name on empty owner', async () => {
+    // #given
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({auditLogger})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, '', REPO, TOKEN, deps)
+
+    // #then
+    expect(auditLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining<Partial<{kind: string; githubUserId: number; reason: RepoAuthzDeniedReason}>>({
+        kind: 'authz.denied',
+        githubUserId: OPERATOR_ID,
+        reason: 'invalid_repo_name',
+      }),
+      expect.stringContaining('audit:'),
+    )
+  })
+
+  it('rejects empty repo', async () => {
+    // #given
+    const deps = makeDeps()
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, '', TOKEN, deps)
+
+    // #then
+    expect(result).toMatchObject({authorized: false, reason: 'invalid_repo_name'})
+    expect(deps.fetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects repo name "."', async () => {
+    // #given
+    const deps = makeDeps()
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, '.', TOKEN, deps)
+
+    // #then
+    expect(result).toMatchObject({authorized: false, reason: 'invalid_repo_name'})
+    expect(deps.fetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects repo name ".."', async () => {
+    // #given
+    const deps = makeDeps()
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, '..', TOKEN, deps)
+
+    // #then
+    expect(result).toMatchObject({authorized: false, reason: 'invalid_repo_name'})
+    expect(deps.fetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects owner with path traversal (..) characters', async () => {
+    // #given
+    const deps = makeDeps()
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, '..', REPO, TOKEN, deps)
+
+    // #then
+    expect(result).toMatchObject({authorized: false, reason: 'invalid_repo_name'})
+    expect(deps.fetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects repo with slash characters', async () => {
+    // #given
+    const deps = makeDeps()
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, 'foo/bar', TOKEN, deps)
+
+    // #then
+    expect(result).toMatchObject({authorized: false, reason: 'invalid_repo_name'})
+    expect(deps.fetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects owner with special characters', async () => {
+    // #given
+    const deps = makeDeps()
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, 'owner<script>', REPO, TOKEN, deps)
+
+    // #then
+    expect(result).toMatchObject({authorized: false, reason: 'invalid_repo_name'})
+    expect(deps.fetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects repo with null bytes', async () => {
+    // #given
+    const deps = makeDeps()
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, 'repo\u0000name', TOKEN, deps)
+
+    // #then
+    expect(result).toMatchObject({authorized: false, reason: 'invalid_repo_name'})
+    expect(deps.fetch).not.toHaveBeenCalled()
+  })
+
+  it('accepts valid owner/repo names', async () => {
+    // #given
+    const deps = makeDeps({fetch: makeFetch(200)})
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, 'my-org', 'my-repo.js', TOKEN, deps)
+
+    // #then — validation passes, GitHub call is made, result is authorized
+    expect(result.authorized).toBe(true)
+    expect(deps.fetch).toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Allowlist gate
+// ---------------------------------------------------------------------------
+
+describe('checkRepoAuthz — allowlist gate', () => {
+  it('denies non-allowlisted operator without making a GitHub API call', async () => {
+    // #given
+    const fetchSpy = makeFetch(200)
+    const deps = makeDeps({fetch: fetchSpy})
+
+    // #when
+    const result = await checkRepoAuthz(OTHER_OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    expect(result).toMatchObject({authorized: false, reason: 'not_allowlisted'})
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('emits authz.denied audit event for non-allowlisted operator', async () => {
+    // #given
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({auditLogger})
+
+    // #when
+    await checkRepoAuthz(OTHER_OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    expect(auditLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining<Partial<{kind: string; githubUserId: number; reason: RepoAuthzDeniedReason}>>({
+        kind: 'authz.denied',
+        githubUserId: OTHER_OPERATOR_ID,
+        reason: 'not_allowlisted',
+      }),
+      expect.stringContaining('audit:'),
+    )
+  })
+
+  it('audit event for non-allowlisted operator never includes token', async () => {
+    // #given
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({auditLogger})
+
+    // #when
+    await checkRepoAuthz(OTHER_OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — token must not appear in any audit call
+    const serialized = serializeAuditCalls(auditLogger)
+    expect(serialized).not.toContain(TOKEN)
+    expect(serialized).not.toContain('ghp_')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe('checkRepoAuthz — happy path', () => {
+  it('authorizes allowlisted operator with GitHub read access', async () => {
+    // #given
+    const deps = makeDeps({fetch: makeFetch(200)})
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    expect(result.authorized).toBe(true)
+  })
+
+  it('calls GitHub repos API with correct URL and auth header', async () => {
+    // #given
+    const fetchSpy = makeFetch(200)
+    const deps = makeDeps({fetch: fetchSpy})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — inspect call args directly
+    const firstCall = fetchSpy.mock.calls[0]
+    if (firstCall === undefined) throw new Error('expected fetch to be called')
+    const [url, init] = firstCall
+    expect(url).toBe(`https://api.github.com/repos/${OWNER}/${REPO}`)
+    const headers = init?.headers as Record<string, string>
+    expect(headers.authorization).toBe(`Bearer ${TOKEN}`)
+  })
+
+  it('includes Accept and API version headers in GitHub call', async () => {
+    // #given
+    const fetchSpy = makeFetch(200)
+    const deps = makeDeps({fetch: fetchSpy})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — inspect call args directly
+    const firstCall = fetchSpy.mock.calls[0]
+    if (firstCall === undefined) throw new Error('expected fetch to be called')
+    const [, init] = firstCall
+    const headers = init?.headers as Record<string, string>
+    expect(headers.accept).toBe('application/vnd.github+json')
+    expect(headers['x-github-api-version']).toBe('2022-11-28')
+  })
+
+  it('does not emit audit event on successful authorization', async () => {
+    // #given
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({fetch: makeFetch(200), auditLogger})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — no authz.denied audit events
+    const deniedCalls = auditLogger.warn.mock.calls.filter(c => c[0]?.kind === 'authz.denied')
+    expect(deniedCalls).toHaveLength(0)
+  })
+
+  it('cancels response body on success', async () => {
+    // #given
+    const {response, cancelSpy} = makeResponseWithBody(200)
+    const fetchSpy = vi.fn<typeof globalThis.fetch>().mockResolvedValue(response)
+    const deps = makeDeps({fetch: fetchSpy})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — body was canceled/drained
+    expect(cancelSpy).toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Denial paths
+// ---------------------------------------------------------------------------
+
+describe('checkRepoAuthz — denial paths', () => {
+  it('denies allowlisted operator with 404 from GitHub (no read access)', async () => {
+    // #given
+    const deps = makeDeps({fetch: makeFetch(404)})
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    expect(result).toMatchObject({authorized: false, reason: 'github_denied'})
+  })
+
+  it('emits authz.denied audit event with reason github_denied when GitHub returns 404', async () => {
+    // #given
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({fetch: makeFetch(404), auditLogger})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    expect(auditLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining<Partial<{kind: string; githubUserId: number; reason: RepoAuthzDeniedReason}>>({
+        kind: 'authz.denied',
+        githubUserId: OPERATOR_ID,
+        reason: 'github_denied',
+      }),
+      expect.stringContaining('audit:'),
+    )
+  })
+
+  it('denies allowlisted operator with 403 from GitHub (no rate-limit headers)', async () => {
+    // #given
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({fetch: makeFetch(403), auditLogger})
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    expect(result).toMatchObject({authorized: false, reason: 'github_denied'})
+    expect(auditLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining<Partial<{kind: string; githubUserId: number; reason: RepoAuthzDeniedReason}>>({
+        kind: 'authz.denied',
+        githubUserId: OPERATOR_ID,
+        reason: 'github_denied',
+      }),
+      expect.stringContaining('audit:'),
+    )
+  })
+
+  it('403 with only x-ratelimit-reset (no remaining=0) is github_denied, not rate_limited', async () => {
+    // #given — reset header present but remaining is not '0'
+    const deps = makeDeps({fetch: makeFetch(403, {'x-ratelimit-reset': '9999999999'})})
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — must NOT be rate_limited
+    expect(result).toMatchObject({authorized: false, reason: 'github_denied'})
+  })
+
+  it('denies on GitHub API fetch error (fail closed)', async () => {
+    // #given
+    const deps = makeDeps({fetch: makeThrowingFetch(new Error('network error'))})
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    expect(result).toMatchObject({authorized: false, reason: 'lookup_error'})
+  })
+
+  it('emits authz.denied audit event with reason lookup_error on GitHub API fetch error', async () => {
+    // #given
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({fetch: makeThrowingFetch(new Error('network error')), auditLogger})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    expect(auditLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining<Partial<{kind: string; githubUserId: number; reason: RepoAuthzDeniedReason}>>({
+        kind: 'authz.denied',
+        githubUserId: OPERATOR_ID,
+        reason: 'lookup_error',
+      }),
+      expect.stringContaining('audit:'),
+    )
+  })
+
+  it('does not log error.message in lookup_error path (safe error kind only)', async () => {
+    // #given — error with a message that could be hostile
+    const logger = makeLogger()
+    const hostileMessage = 'HOSTILE_MESSAGE_THAT_MUST_NOT_APPEAR'
+    const deps = makeDeps({fetch: makeThrowingFetch(new Error(hostileMessage)), logger})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — raw error message must not appear in any log call
+    const serialized = serializeLogCalls(logger)
+    expect(serialized).not.toContain(hostileMessage)
+  })
+
+  it('fail-closed even when thrown value has hostile toString()', async () => {
+    // #given — thrown value with a toString() that returns a hostile string
+    const hostileToString = 'HOSTILE_TOSTRING_CONTENT'
+    const hostileThrown = {
+      toString: () => hostileToString,
+    }
+    const logger = makeLogger()
+    const deps = makeDeps({fetch: makeThrowingFetch(hostileThrown), logger})
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — still fails closed
+    expect(result).toMatchObject({authorized: false, reason: 'lookup_error'})
+    // hostile toString output must not appear in logs
+    const serialized = serializeLogCalls(logger)
+    expect(serialized).not.toContain(hostileToString)
+  })
+
+  it('returns lookup_error (not github_denied) on 503', async () => {
+    // #given
+    const deps = makeDeps({fetch: makeFetch(503)})
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — 5xx is lookup_error, not github_denied
+    expect(result).toMatchObject({authorized: false, reason: 'lookup_error'})
+  })
+
+  it('returns lookup_error (not github_denied) on 500', async () => {
+    // #given
+    const deps = makeDeps({fetch: makeFetch(500)})
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    expect(result).toMatchObject({authorized: false, reason: 'lookup_error'})
+  })
+
+  it('cancels response body on github_denied path', async () => {
+    // #given
+    const {response, cancelSpy} = makeResponseWithBody(404)
+    const fetchSpy = vi.fn<typeof globalThis.fetch>().mockResolvedValue(response)
+    const deps = makeDeps({fetch: fetchSpy})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    expect(cancelSpy).toHaveBeenCalled()
+  })
+
+  it('cancels response body on 5xx lookup_error path', async () => {
+    // #given
+    const {response, cancelSpy} = makeResponseWithBody(503)
+    const fetchSpy = vi.fn<typeof globalThis.fetch>().mockResolvedValue(response)
+    const deps = makeDeps({fetch: fetchSpy})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    expect(cancelSpy).toHaveBeenCalled()
+  })
+
+  it('audit event on denial never includes token value', async () => {
+    // #given
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({fetch: makeFetch(404), auditLogger})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    const serialized = serializeAuditCalls(auditLogger)
+    expect(serialized).not.toContain(TOKEN)
+    expect(serialized).not.toContain('ghp_')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Rate-limit handling
+// ---------------------------------------------------------------------------
+
+describe('checkRepoAuthz — rate-limit handling', () => {
+  it('denies and caches through retry window on 429 with Retry-After', async () => {
+    // #given — clock starts at 0; Retry-After: 60 seconds
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(429, {'retry-after': '60'})
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache})
+
+    // #when — first call hits rate limit
+    const result1 = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — denied
+    expect(result1).toMatchObject({authorized: false, reason: 'rate_limited'})
+
+    // #when — second call within retry window (30 seconds later)
+    now = 30_000
+    const result2 = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — still denied from cache, no second GitHub call
+    expect(result2.authorized).toBe(false)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits authz.denied audit event with reason rate_limited on 429', async () => {
+    // #given
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({fetch: makeFetch(429, {'retry-after': '60'}), auditLogger})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    expect(auditLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining<Partial<{kind: string; githubUserId: number; reason: RepoAuthzDeniedReason}>>({
+        kind: 'authz.denied',
+        githubUserId: OPERATOR_ID,
+        reason: 'rate_limited',
+      }),
+      expect.stringContaining('audit:'),
+    )
+  })
+
+  it('denies and caches through retry window on 403 with Retry-After', async () => {
+    // #given
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(403, {'retry-after': '30'})
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache})
+
+    // #when
+    const result1 = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    expect(result1.authorized).toBe(false)
+
+    // #when — within retry window
+    now = 15_000
+    const result2 = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — cached, no second call
+    expect(result2.authorized).toBe(false)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries after retry window expires', async () => {
+    // #given
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse(429, {'retry-after': '10'}))
+      .mockResolvedValueOnce(makeResponse(200))
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache})
+
+    // #when — first call hits rate limit
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #when — after retry window (11 seconds)
+    now = 11_000
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — second GitHub call made, now authorized
+    expect(result.authorized).toBe(true)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses x-ratelimit-reset when Retry-After is absent and remaining=0', async () => {
+    // #given — clock at 0; reset at epoch second 60; remaining=0
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(403, {'x-ratelimit-reset': '60', 'x-ratelimit-remaining': '0'})
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache})
+
+    // #when
+    const result1 = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    expect(result1).toMatchObject({authorized: false, reason: 'rate_limited'})
+
+    // #when — 30 seconds later (before reset)
+    now = 30_000
+    const result2 = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — still cached
+    expect(result2.authorized).toBe(false)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('caps Retry-After > 15 minutes to MAX_RATE_LIMIT_CACHE_MS', async () => {
+    // #given — Retry-After: 3600 seconds (1 hour) — should be capped to 15 min
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(429, {'retry-after': '3600'})
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache, random: () => 0})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #when — 15 minutes + 1ms later (just past cap)
+    now = 15 * 60 * 1000 + 1
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — cache expired (capped at 15 min), second GitHub call made
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    expect(result.authorized).toBe(false)
+  })
+
+  it('caps x-ratelimit-reset > 15 minutes to MAX_RATE_LIMIT_CACHE_MS', async () => {
+    // #given — reset 1 hour from now; remaining=0
+    let now = 0
+    const resetEpochSec = Math.floor((now + 3600 * 1000) / 1000) // 1 hour from now
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(403, {
+      'x-ratelimit-reset': String(resetEpochSec),
+      'x-ratelimit-remaining': '0',
+    })
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache, random: () => 0})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #when — 15 minutes + 1ms later (just past cap)
+    now = 15 * 60 * 1000 + 1
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — cache expired (capped at 15 min), second GitHub call made
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses NEGATIVE_TTL_MS when x-ratelimit-reset is in the past', async () => {
+    // #given — reset in the past; remaining=0
+    let now = 60_000 // 60 seconds in
+    const pastResetEpochSec = 30 // 30 seconds ago
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(429, {
+      'x-ratelimit-reset': String(pastResetEpochSec),
+      'x-ratelimit-remaining': '0',
+    })
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache, random: () => 0})
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — still rate_limited (falls back to NEGATIVE_TTL_MS = 30s)
+    expect(result).toMatchObject({authorized: false, reason: 'rate_limited'})
+
+    // #when — 20 seconds later (within 30s NEGATIVE_TTL_MS)
+    now = 80_000
+    const result2 = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    expect(result2.authorized).toBe(false)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('retry-After of 0 is not treated as rate-limit signal — falls back to NEGATIVE_TTL_MS', async () => {
+    // #given — Retry-After: 0 (zero/non-positive should not be a rate-limit window)
+    const deps = makeDeps({fetch: makeFetch(429, {'retry-after': '0'})})
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — still rate_limited (429 always is), but window falls back to NEGATIVE_TTL_MS
+    expect(result).toMatchObject({authorized: false, reason: 'rate_limited'})
+  })
+
+  it('empty Retry-After header is not treated as rate-limit signal', async () => {
+    // #given — empty Retry-After header
+    const deps = makeDeps({fetch: makeFetch(429, {'retry-after': ''})})
+
+    // #when
+    const result = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — still rate_limited (429 always is), window falls back to NEGATIVE_TTL_MS
+    expect(result).toMatchObject({authorized: false, reason: 'rate_limited'})
+  })
+
+  it('cancels response body on rate-limit path', async () => {
+    // #given
+    const {response, cancelSpy} = makeResponseWithBody(429, {'retry-after': '60'})
+    const fetchSpy = vi.fn<typeof globalThis.fetch>().mockResolvedValue(response)
+    const deps = makeDeps({fetch: fetchSpy})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    expect(cancelSpy).toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Caching
+// ---------------------------------------------------------------------------
+
+describe('checkRepoAuthz — caching', () => {
+  it('caches positive authz result for 5 minutes', async () => {
+    // #given
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(200)
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache})
+
+    // #when — first call
+    const result1 = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    expect(result1.authorized).toBe(true)
+
+    // #when — second call within 5 minutes
+    now = 4 * 60 * 1000 // 4 minutes
+    const result2 = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — cached, only one GitHub call
+    expect(result2.authorized).toBe(true)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-fetches after positive cache TTL expires', async () => {
+    // #given
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(200)
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache, random: () => 0})
+
+    // #when — first call
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #when — after 5 minutes + jitter
+    now = 5 * 60 * 1000 + 1
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — two GitHub calls
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('caches negative authz result for 30 seconds', async () => {
+    // #given
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(404)
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache})
+
+    // #when — first call
+    const result1 = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    expect(result1.authorized).toBe(false)
+
+    // #when — second call within 30 seconds
+    now = 20_000
+    const result2 = await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — cached, only one GitHub call
+    expect(result2.authorized).toBe(false)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-fetches after negative cache TTL expires', async () => {
+    // #given
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(404)
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache, random: () => 0})
+
+    // #when — first call
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #when — after 30 seconds + jitter
+    now = 30_000 + 1
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — two GitHub calls
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('different tokens for same operator/repo are cached independently (different token identities)', async () => {
+    // #given
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(200)
+    const deps = makeDeps({fetch: fetchSpy, cache})
+
+    // #when — two calls with different tokens
+    // Each token gets a distinct random identity, so they map to different cache keys.
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, 'ghp_token1', deps)
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, 'ghp_token2', deps)
+
+    // #then — two GitHub calls (different token identities = different cache keys)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('different operators for same repo are cached independently', async () => {
+    // #given
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(200)
+    const allowlist = makeAllowlist([OPERATOR_ID, 54321])
+    const deps = makeDeps({fetch: fetchSpy, cache, allowlist})
+
+    // #when — two calls with different operators
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    await checkRepoAuthz(54321, OWNER, REPO, TOKEN, deps)
+
+    // #then — two GitHub calls
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('positive cache hits do not emit audit events', async () => {
+    // #given
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const auditLogger = makeAuditLogger()
+    const fetchSpy = makeFetch(200)
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache, auditLogger})
+
+    // #when — first call (cache miss)
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    const auditCallsAfterFirst = auditLogger.warn.mock.calls.length + auditLogger.info.mock.calls.length
+
+    // #when — second call (cache hit)
+    now = 1_000
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — no additional audit events on cache hit
+    const auditCallsAfterSecond = auditLogger.warn.mock.calls.length + auditLogger.info.mock.calls.length
+    expect(auditCallsAfterSecond).toBe(auditCallsAfterFirst)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cache max-size cap
+// ---------------------------------------------------------------------------
+
+describe('checkRepoAuthz — cache max-size cap', () => {
+  it('evicts oldest entry when cache reaches max size', () => {
+    // #given — cache with max size 3
+    const cache = createRepoAuthzCache(3)
+    const nowMs = 0
+    const futureExpiry = 999_999_999
+
+    // #when — fill to capacity
+    cache.set('key1', {authorized: true, expiresAt: futureExpiry})
+    cache.set('key2', {authorized: true, expiresAt: futureExpiry})
+    cache.set('key3', {authorized: true, expiresAt: futureExpiry})
+
+    // All three present
+    expect(cache.get('key1', nowMs)).toBeDefined()
+    expect(cache.get('key2', nowMs)).toBeDefined()
+    expect(cache.get('key3', nowMs)).toBeDefined()
+
+    // #when — add a fourth entry (exceeds cap)
+    cache.set('key4', {authorized: true, expiresAt: futureExpiry})
+
+    // #then — oldest entry (key1) evicted; key2, key3, key4 remain
+    expect(cache.get('key1', nowMs)).toBeUndefined()
+    expect(cache.get('key2', nowMs)).toBeDefined()
+    expect(cache.get('key3', nowMs)).toBeDefined()
+    expect(cache.get('key4', nowMs)).toBeDefined()
+  })
+
+  it('updating an existing key does not evict when at cap', () => {
+    // #given — cache with max size 2
+    const cache = createRepoAuthzCache(2)
+    const nowMs = 0
+    const futureExpiry = 999_999_999
+
+    cache.set('key1', {authorized: true, expiresAt: futureExpiry})
+    cache.set('key2', {authorized: true, expiresAt: futureExpiry})
+
+    // #when — update key1 (already present, no eviction needed)
+    cache.set('key1', {authorized: false, reason: 'github_denied', expiresAt: futureExpiry})
+
+    // #then — both keys still present, key1 updated
+    expect(cache.get('key1', nowMs)).toMatchObject({authorized: false, reason: 'github_denied'})
+    expect(cache.get('key2', nowMs)).toBeDefined()
+  })
+
+  it('cache does not grow beyond max size under sustained load', () => {
+    // #given — cache with max size 5
+    const cache = createRepoAuthzCache(5)
+    const nowMs = 0
+    const futureExpiry = 999_999_999
+
+    // #when — insert 20 unique keys
+    for (let i = 0; i < 20; i++) {
+      cache.set(`key${i}`, {authorized: true, expiresAt: futureExpiry})
+    }
+
+    // #then — only the last 5 keys remain (oldest evicted)
+    let presentCount = 0
+    for (let i = 0; i < 20; i++) {
+      if (cache.get(`key${i}`, nowMs) !== undefined) presentCount++
+    }
+    expect(presentCount).toBe(5)
+
+    // The last 5 keys (15–19) must be present
+    for (let i = 15; i < 20; i++) {
+      expect(cache.get(`key${i}`, nowMs)).toBeDefined()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Request coalescing
+// ---------------------------------------------------------------------------
+
+describe('checkRepoAuthz — request coalescing', () => {
+  it('concurrent misses for same operator/repo/token issue only one GitHub API call', async () => {
+    // #given
+    let resolveFirst!: (value: Response) => void
+    const firstCallPromise = new Promise<Response>(resolve => {
+      resolveFirst = resolve
+    })
+    const fetchSpy = vi.fn().mockReturnValueOnce(firstCallPromise)
+    const cache = createRepoAuthzCache()
+    const deps = makeDeps({fetch: fetchSpy, cache})
+
+    // #when — fire two concurrent requests before the first resolves
+    const p1 = checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    const p2 = checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // Resolve the first fetch
+    resolveFirst(makeResponse(200))
+
+    const [result1, result2] = await Promise.all([p1, p2])
+
+    // #then — both authorized, only one GitHub call
+    expect(result1.authorized).toBe(true)
+    expect(result2.authorized).toBe(true)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('after coalesced miss resolves, subsequent calls use the cache', async () => {
+    // #given
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(200)
+    const deps = makeDeps({fetch: fetchSpy, cache})
+
+    // #when — first call populates cache
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #when — second call hits cache
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — only one GitHub call
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cached negative audit emission
+// ---------------------------------------------------------------------------
+
+/** Count audit warn calls with kind === 'authz.denied'. */
+function countDeniedAuditCalls(auditLogger: MockAuditLogger): number {
+  return auditLogger.warn.mock.calls.filter(c => c[0]?.kind === 'authz.denied').length
+}
+
+describe('checkRepoAuthz — cached negative audit emission', () => {
+  it('emits authz.denied audit event on each request that hits a cached negative result', async () => {
+    // #given — first call populates negative cache
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({fetch: makeFetch(404), clock: () => now, cache, auditLogger})
+
+    // #when — first call (cache miss, GitHub returns 404)
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    const callsAfterFirst = countDeniedAuditCalls(auditLogger)
+
+    // #when — second call within TTL (cache hit)
+    now = 10_000
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — audit emitted for both the original miss AND the cached hit
+    expect(countDeniedAuditCalls(auditLogger)).toBe(callsAfterFirst + 1)
+    const lastCall = auditLogger.warn.mock.calls.at(-1)
+    expect(lastCall?.[0]).toMatchObject({
+      kind: 'authz.denied',
+      githubUserId: OPERATOR_ID,
+      reason: 'github_denied',
+    })
+  })
+
+  it('emits authz.denied on every cached negative hit, not just the first', async () => {
+    // #given
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({fetch: makeFetch(404), clock: () => now, cache, auditLogger})
+
+    // #when — first call (miss)
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    const afterFirst = countDeniedAuditCalls(auditLogger)
+
+    // #when — two more calls within TTL
+    now = 5_000
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — two additional audit events (one per cached hit)
+    expect(countDeniedAuditCalls(auditLogger)).toBe(afterFirst + 2)
+  })
+
+  it('cached negative emits structured logger.warn as well as audit event', async () => {
+    // #given
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const logger = makeLogger()
+    const deps = makeDeps({fetch: makeFetch(404), clock: () => now, cache, logger})
+
+    // #when — first call (miss)
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    const warnCallsAfterFirst = logger.warn.mock.calls.length
+
+    // #when — second call (cache hit)
+    now = 5_000
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — structured logger.warn emitted for cached denial
+    expect(logger.warn.mock.calls.length).toBeGreaterThan(warnCallsAfterFirst)
+    const cachedWarnCall = logger.warn.mock.calls.at(-1)
+    expect(cachedWarnCall?.[0]).toMatchObject({githubUserId: OPERATOR_ID, reason: 'github_denied'})
+    // Must not include token
+    expect(JSON.stringify(cachedWarnCall)).not.toContain(TOKEN)
+    expect(JSON.stringify(cachedWarnCall)).not.toContain('ghp_')
+  })
+
+  it('cached negative audit reason propagates rate_limited correctly', async () => {
+    // #given — first call hits rate limit
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({
+      fetch: makeFetch(429, {'retry-after': '60'}),
+      clock: () => now,
+      cache,
+      auditLogger,
+    })
+
+    // #when — first call (miss, rate limited)
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    const afterFirst = countDeniedAuditCalls(auditLogger)
+
+    // #when — second call within retry window (cache hit)
+    now = 10_000
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — cached hit emits rate_limited reason, not github_denied
+    expect(countDeniedAuditCalls(auditLogger)).toBe(afterFirst + 1)
+    const lastCall = auditLogger.warn.mock.calls.at(-1)
+    expect(lastCall?.[0]).toMatchObject({
+      kind: 'authz.denied',
+      reason: 'rate_limited',
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Coalesced concurrent denial audit emission
+// ---------------------------------------------------------------------------
+
+describe('checkRepoAuthz — coalesced concurrent denial audit emission', () => {
+  it('emits authz.denied for each concurrent caller when the shared request denies', async () => {
+    // #given — a fetch that denies (404), held until we control resolution
+    let resolveFirst!: (value: Response) => void
+    const firstCallPromise = new Promise<Response>(resolve => {
+      resolveFirst = resolve
+    })
+    const fetchSpy = vi.fn().mockReturnValueOnce(firstCallPromise)
+    const cache = createRepoAuthzCache()
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({fetch: fetchSpy, cache, auditLogger})
+
+    // #when — fire two concurrent requests before the first resolves
+    const p1 = checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    const p2 = checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // Resolve the shared fetch with a denial
+    resolveFirst(makeResponse(404))
+
+    const [result1, result2] = await Promise.all([p1, p2])
+
+    // #then — both denied
+    expect(result1.authorized).toBe(false)
+    expect(result2.authorized).toBe(false)
+    // Only one GitHub call
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    // But two audit events — one per caller
+    expect(countDeniedAuditCalls(auditLogger)).toBe(2)
+  })
+
+  it('does not emit audit for coalesced caller when the shared request succeeds', async () => {
+    // #given — a fetch that succeeds, held until we control resolution
+    let resolveFirst!: (value: Response) => void
+    const firstCallPromise = new Promise<Response>(resolve => {
+      resolveFirst = resolve
+    })
+    const fetchSpy = vi.fn().mockReturnValueOnce(firstCallPromise)
+    const cache = createRepoAuthzCache()
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({fetch: fetchSpy, cache, auditLogger})
+
+    // #when — fire two concurrent requests
+    const p1 = checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    const p2 = checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    resolveFirst(makeResponse(200))
+    await Promise.all([p1, p2])
+
+    // #then — no authz.denied audit events
+    expect(countDeniedAuditCalls(auditLogger)).toBe(0)
+  })
+
+  it('emits authz.denied for coalesced caller when shared request is rate_limited (429)', async () => {
+    // #given — a fetch that returns 429, held until we control resolution
+    let resolveFirst!: (value: Response) => void
+    const firstCallPromise = new Promise<Response>(resolve => {
+      resolveFirst = resolve
+    })
+    const fetchSpy = vi.fn().mockReturnValueOnce(firstCallPromise)
+    const cache = createRepoAuthzCache()
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({fetch: fetchSpy, cache, auditLogger})
+
+    // #when — fire two concurrent requests
+    const p1 = checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    const p2 = checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    resolveFirst(makeResponse(429, {'retry-after': '60'}))
+    const [result1, result2] = await Promise.all([p1, p2])
+
+    // #then — both denied with rate_limited
+    expect(result1).toMatchObject({authorized: false, reason: 'rate_limited'})
+    expect(result2).toMatchObject({authorized: false, reason: 'rate_limited'})
+    expect(countDeniedAuditCalls(auditLogger)).toBe(2)
+  })
+
+  it('emits authz.denied for coalesced caller when shared request throws (lookup_error)', async () => {
+    // #given — a fetch that throws, held until we control resolution
+    let rejectFirst!: (err: Error) => void
+    const firstCallPromise = new Promise<Response>((_, reject) => {
+      rejectFirst = reject
+    })
+    const fetchSpy = vi.fn().mockReturnValueOnce(firstCallPromise)
+    const cache = createRepoAuthzCache()
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({fetch: fetchSpy, cache, auditLogger})
+
+    // #when — fire two concurrent requests
+    const p1 = checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    const p2 = checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    rejectFirst(new Error('network failure'))
+    const [result1, result2] = await Promise.all([p1, p2])
+
+    // #then — both denied with lookup_error; two audit events
+    expect(result1).toMatchObject({authorized: false, reason: 'lookup_error'})
+    expect(result2).toMatchObject({authorized: false, reason: 'lookup_error'})
+    expect(countDeniedAuditCalls(auditLogger)).toBe(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Invalid repo audit correlationId safety
+// ---------------------------------------------------------------------------
+
+describe('checkRepoAuthz — invalid repo audit correlationId safety', () => {
+  it('uses sentinel correlationId for invalid owner/repo — does not include raw invalid input', async () => {
+    // #given — path traversal in owner
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({auditLogger})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, '../../../etc/passwd', REPO, TOKEN, deps)
+
+    // #then — correlationId must be the safe sentinel, not include raw input
+    const call = auditLogger.warn.mock.calls.find(c => c[0]?.kind === 'authz.denied')
+    expect(call).toBeDefined()
+    expect(call?.[0]?.correlationId).toBe('repo-authz:invalid-repo-name')
+    expect(String(call?.[0]?.correlationId)).not.toContain('../../../etc/passwd')
+  })
+
+  it('uses sentinel correlationId for null-byte repo — does not include raw invalid input', async () => {
+    // #given — null byte in repo name
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({auditLogger})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, 'repo\u0000name', TOKEN, deps)
+
+    // #then
+    const call = auditLogger.warn.mock.calls.find(c => c[0]?.kind === 'authz.denied')
+    expect(call?.[0]?.correlationId).toBe('repo-authz:invalid-repo-name')
+    expect(String(call?.[0]?.correlationId)).not.toContain('\u0000')
+  })
+
+  it('invalid repo audit event does not include raw owner/repo in any field', async () => {
+    // #given — junk input
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({auditLogger})
+    const badOwner = '<script>alert(1)</script>'
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, badOwner, REPO, TOKEN, deps)
+
+    // #then — raw invalid input must not appear in any audit call
+    const serialized = serializeAuditCalls(auditLogger)
+    expect(serialized).not.toContain(badOwner)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Token safety
+// ---------------------------------------------------------------------------
+
+describe('checkRepoAuthz — token safety', () => {
+  it('logger never receives the userOAuthToken value on success', async () => {
+    // #given
+    const logger = makeLogger()
+    const deps = makeDeps({logger, fetch: makeFetch(200)})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — token must not appear in any log call
+    const serialized = serializeLogCalls(logger)
+    expect(serialized).not.toContain(TOKEN)
+    expect(serialized).not.toContain('ghp_')
+  })
+
+  it('audit logger never receives the userOAuthToken value on success', async () => {
+    // #given
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({auditLogger, fetch: makeFetch(200)})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    const serialized = serializeAuditCalls(auditLogger)
+    expect(serialized).not.toContain(TOKEN)
+    expect(serialized).not.toContain('ghp_')
+  })
+
+  it('logger never receives the userOAuthToken value on github_denied', async () => {
+    // #given
+    const logger = makeLogger()
+    const deps = makeDeps({logger, fetch: makeFetch(404)})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    const serialized = serializeLogCalls(logger)
+    expect(serialized).not.toContain(TOKEN)
+    expect(serialized).not.toContain('ghp_')
+  })
+
+  it('logger never receives the userOAuthToken value on rate_limited', async () => {
+    // #given
+    const logger = makeLogger()
+    const deps = makeDeps({logger, fetch: makeFetch(429, {'retry-after': '60'})})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    const serialized = serializeLogCalls(logger)
+    expect(serialized).not.toContain(TOKEN)
+    expect(serialized).not.toContain('ghp_')
+  })
+
+  it('logger never receives the userOAuthToken value on lookup_error', async () => {
+    // #given
+    const logger = makeLogger()
+    const deps = makeDeps({logger, fetch: makeThrowingFetch(new Error('network error'))})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    const serialized = serializeLogCalls(logger)
+    expect(serialized).not.toContain(TOKEN)
+    expect(serialized).not.toContain('ghp_')
+  })
+
+  it('logger never receives the userOAuthToken value on invalid_repo_name', async () => {
+    // #given
+    const logger = makeLogger()
+    const deps = makeDeps({logger})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, '', REPO, TOKEN, deps)
+
+    // #then
+    const serialized = serializeLogCalls(logger)
+    expect(serialized).not.toContain(TOKEN)
+    expect(serialized).not.toContain('ghp_')
+  })
+
+  it('logger never receives the userOAuthToken value on not_allowlisted', async () => {
+    // #given
+    const logger = makeLogger()
+    const deps = makeDeps({logger})
+
+    // #when
+    await checkRepoAuthz(OTHER_OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    const serialized = serializeLogCalls(logger)
+    expect(serialized).not.toContain(TOKEN)
+    expect(serialized).not.toContain('ghp_')
+  })
+
+  it('logger never receives the userOAuthToken value on cached negative', async () => {
+    // #given
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const logger = makeLogger()
+    const deps = makeDeps({logger, fetch: makeFetch(404), clock: () => now, cache})
+
+    // #when — first call (miss)
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #when — second call (cache hit)
+    now = 5_000
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then
+    const serialized = serializeLogCalls(logger)
+    expect(serialized).not.toContain(TOKEN)
+    expect(serialized).not.toContain('ghp_')
+  })
+
+  it('logger never receives the userOAuthToken value on coalesced denial', async () => {
+    // #given
+    let resolveFirst!: (value: Response) => void
+    const firstCallPromise = new Promise<Response>(resolve => {
+      resolveFirst = resolve
+    })
+    const fetchSpy = vi.fn().mockReturnValueOnce(firstCallPromise)
+    const cache = createRepoAuthzCache()
+    const logger = makeLogger()
+    const deps = makeDeps({fetch: fetchSpy, cache, logger})
+
+    // #when — fire two concurrent requests
+    const p1 = checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    const p2 = checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    resolveFirst(makeResponse(404))
+    await Promise.all([p1, p2])
+
+    // #then
+    const serialized = serializeLogCalls(logger)
+    expect(serialized).not.toContain(TOKEN)
+    expect(serialized).not.toContain('ghp_')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createRepoAuthzCache — token identity registry
+// ---------------------------------------------------------------------------
+
+describe('createRepoAuthzCache — tokenIdentityFor', () => {
+  it('returns the same identity for the same token (cache hit)', () => {
+    // #given
+    const cache = createRepoAuthzCache()
+    const token = 'ghp_sometoken'
+
+    // #when
+    const id1 = cache.tokenIdentityFor(token)
+    const id2 = cache.tokenIdentityFor(token)
+
+    // #then — stable identity across repeated calls
+    expect(id1).toBe(id2)
+    expect(typeof id1).toBe('string')
+    expect(id1.length).toBeGreaterThan(0)
+  })
+
+  it('returns different identities for different tokens', () => {
+    // #given
+    const cache = createRepoAuthzCache()
+
+    // #when
+    const id1 = cache.tokenIdentityFor('ghp_token1')
+    const id2 = cache.tokenIdentityFor('ghp_token2')
+
+    // #then — distinct identities
+    expect(id1).not.toBe(id2)
+  })
+
+  it('token identity does not contain the raw token value', () => {
+    // #given
+    const cache = createRepoAuthzCache()
+    const token = 'ghp_supersecrettoken'
+
+    // #when
+    const identity = cache.tokenIdentityFor(token)
+
+    // #then — opaque identity must not expose the raw token
+    expect(identity).not.toContain(token)
+    expect(identity).not.toContain('ghp_')
+  })
+
+  it('identities from different cache instances are independent', () => {
+    // #given — two separate cache instances
+    const cache1 = createRepoAuthzCache()
+    const cache2 = createRepoAuthzCache()
+    const token = 'ghp_sharedtoken'
+
+    // #when
+    const id1 = cache1.tokenIdentityFor(token)
+    const id2 = cache2.tokenIdentityFor(token)
+
+    // #then — different instances assign independent identities (no shared state)
+    expect(id1).not.toBe(id2)
+  })
+})
+
+describe('checkRepoAuthz — cache key token safety', () => {
+  it('same token in same cache instance produces a cache hit (one GitHub call)', async () => {
+    // #given
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(200)
+    const deps = makeDeps({fetch: fetchSpy, cache})
+
+    // #when — two calls with the same token
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — only one GitHub call (same token identity = same cache key)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('cache key does not contain the raw token value', async () => {
+    // #given — intercept cache.set to capture the key used
+    const capturedKeys: string[] = []
+    const realCache = createRepoAuthzCache()
+    const spyCache: typeof realCache = {
+      ...realCache,
+      set(key, entry) {
+        capturedKeys.push(key)
+        realCache.set(key, entry)
+      },
+    }
+    const deps = makeDeps({fetch: makeFetch(200), cache: spyCache})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — at least one key was written, and none contain the raw token
+    expect(capturedKeys.length).toBeGreaterThan(0)
+    for (const key of capturedKeys) {
+      expect(key).not.toContain(TOKEN)
+      expect(key).not.toContain('ghp_')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createRepoAuthzCache — invalid maxSize hardening (fix 2)
+// ---------------------------------------------------------------------------
+
+describe('createRepoAuthzCache — invalid maxSize hardening', () => {
+  const futureExpiry = 999_999_999
+  const nowMs = 0
+
+  it('maxSize=0 falls back to default and accepts entries', () => {
+    // #given
+    const cache = createRepoAuthzCache(0)
+
+    // #when
+    cache.set('key1', {authorized: true, expiresAt: futureExpiry})
+
+    // #then — cache works; entry is retrievable
+    expect(cache.get('key1', nowMs)).toBeDefined()
+  })
+
+  it('maxSize=-1 falls back to default and accepts entries', () => {
+    // #given
+    const cache = createRepoAuthzCache(-1)
+
+    // #when
+    cache.set('key1', {authorized: true, expiresAt: futureExpiry})
+
+    // #then
+    expect(cache.get('key1', nowMs)).toBeDefined()
+  })
+
+  it('maxSize=NaN falls back to default and accepts entries', () => {
+    // #given
+    const cache = createRepoAuthzCache(Number.NaN)
+
+    // #when
+    cache.set('key1', {authorized: true, expiresAt: futureExpiry})
+
+    // #then
+    expect(cache.get('key1', nowMs)).toBeDefined()
+  })
+
+  it('maxSize=Infinity falls back to default and accepts entries', () => {
+    // #given
+    const cache = createRepoAuthzCache(Infinity)
+
+    // #when
+    cache.set('key1', {authorized: true, expiresAt: futureExpiry})
+
+    // #then
+    expect(cache.get('key1', nowMs)).toBeDefined()
+  })
+
+  it('maxSize=-Infinity falls back to default and accepts entries', () => {
+    // #given
+    const cache = createRepoAuthzCache(-Infinity)
+
+    // #when
+    cache.set('key1', {authorized: true, expiresAt: futureExpiry})
+
+    // #then
+    expect(cache.get('key1', nowMs)).toBeDefined()
+  })
+
+  it('maxSize=1 is valid — evicts on second unique key', () => {
+    // #given
+    const cache = createRepoAuthzCache(1)
+
+    // #when
+    cache.set('key1', {authorized: true, expiresAt: futureExpiry})
+    cache.set('key2', {authorized: true, expiresAt: futureExpiry})
+
+    // #then — key1 evicted, key2 present
+    expect(cache.get('key1', nowMs)).toBeUndefined()
+    expect(cache.get('key2', nowMs)).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseRateLimitWindowMs — strict numeric parsing (fix 3)
+// ---------------------------------------------------------------------------
+
+describe('checkRepoAuthz — rate-limit strict numeric parsing', () => {
+  it('retry-After: "60junk" is not treated as a valid rate-limit window', async () => {
+    // #given — junk suffix on Retry-After
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(429, {'retry-after': '60junk'})
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache, random: () => 0})
+
+    // #when — first call
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #when — 31 seconds later (past NEGATIVE_TTL_MS=30s, not 60s)
+    now = 31_000
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — cache expired after NEGATIVE_TTL_MS (not 60s), second GitHub call made
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('x-ratelimit-reset: "123junk" is not treated as a valid reset epoch', async () => {
+    // #given — junk suffix on x-ratelimit-reset; remaining=0
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(403, {
+      'x-ratelimit-reset': '123junk',
+      'x-ratelimit-remaining': '0',
+    })
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache, random: () => 0})
+
+    // #when — first call
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #when — 31 seconds later (past NEGATIVE_TTL_MS=30s, not 123s)
+    now = 31_000
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — cache expired after NEGATIVE_TTL_MS, second GitHub call made
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('retry-After: "60" (clean digits) is still parsed correctly', async () => {
+    // #given — clean digit string
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(429, {'retry-after': '60'})
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache, random: () => 0})
+
+    // #when — first call
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #when — 31 seconds later (within 60s window)
+    now = 31_000
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — still cached (60s window), only one GitHub call
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('x-ratelimit-reset: "0x1F4" (hex) is not treated as a valid reset epoch', async () => {
+    // #given — hex string: parseInt("0x1F4", 10) = 0, but parseInt("0x1F4") = 500
+    // The strict /^\d+$/ regex rejects it entirely.
+    let now = 0
+    const cache = createRepoAuthzCache()
+    const fetchSpy = makeFetch(403, {
+      'x-ratelimit-reset': '0x1F4',
+      'x-ratelimit-remaining': '0',
+    })
+    const deps = makeDeps({fetch: fetchSpy, clock: () => now, cache, random: () => 0})
+
+    // #when
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #when — 31 seconds later (past NEGATIVE_TTL_MS=30s)
+    now = 31_000
+    await checkRepoAuthz(OPERATOR_ID, OWNER, REPO, TOKEN, deps)
+
+    // #then — cache expired after NEGATIVE_TTL_MS, second call made
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/gateway/src/web/auth/repo-authz.ts
+++ b/packages/gateway/src/web/auth/repo-authz.ts
@@ -1,0 +1,554 @@
+/**
+ * Repo authorization helper for the operator web surface.
+ *
+ * Single helper used by all privileged routes (launch, run-state, approvals,
+ * binding reads). v1 rule: operator must be in the allowlist AND the user OAuth
+ * token must prove GitHub read access to the target repo.
+ *
+ * Security invariants:
+ *   - Fail closed: any lookup error, network failure, or unexpected status denies.
+ *   - Allowlist check runs first; non-allowlisted operators never trigger a GitHub call.
+ *   - User OAuth token is NEVER logged, audited, or included in cache keys that
+ *     could be serialized/debugged. Cache key uses a random opaque token identity
+ *     (UUID, assigned per token per cache instance) so the raw token never appears
+ *     in any key.
+ *   - Audit events include numeric GitHub user ID and safe owner/repo; never token values.
+ *   - Owner/repo names are validated before any authz or GitHub call.
+ *   - Positive TTL: 5 minutes. Negative TTL: 30 seconds. Both with jitter.
+ *   - Concurrent misses for the same effective cache key coalesce into one GitHub call.
+ *   - GitHub rate-limit responses (403/429 with Retry-After or x-ratelimit-remaining=0)
+ *     are cached through the retry window.
+ */
+
+import type {AuditLogger, AuthzDeniedReason} from '../audit.js'
+import type {OperatorAllowlist} from './allowlist.js'
+import {randomUUID} from 'node:crypto'
+import {emitAudit} from '../audit.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Logger interface for the repo authz module. */
+export interface RepoAuthzLogger {
+  readonly debug: (ctx: Record<string, unknown>, msg: string) => void
+  readonly info: (ctx: Record<string, unknown>, msg: string) => void
+  readonly warn: (ctx: Record<string, unknown>, msg: string) => void
+  readonly error: (ctx: Record<string, unknown>, msg: string) => void
+}
+
+/** Result of a repo authorization check. */
+export type RepoAuthzResult =
+  | {readonly authorized: true}
+  | {readonly authorized: false; readonly reason: RepoAuthzDeniedReason}
+
+type AuditableRepoAuthzDeniedReason<T extends AuthzDeniedReason> = T
+
+/**
+ * Reasons for repo authorization denial surfaced by checkRepoAuthz.
+ *
+ * Intentionally excludes audit-only outer reasons like `unknown` and `suspended`
+ * until this helper owns those paths.
+ */
+export type RepoAuthzDeniedReason = AuditableRepoAuthzDeniedReason<
+  'invalid_repo_name' | 'not_allowlisted' | 'github_denied' | 'rate_limited' | 'lookup_error'
+>
+
+/**
+ * A single cache entry — discriminated union to make impossible states impossible.
+ * Authorized entries never carry a reason; denied entries always carry one.
+ */
+type CacheEntry =
+  | {readonly authorized: true; readonly expiresAt: number}
+  | {readonly authorized: false; readonly reason: RepoAuthzDeniedReason; readonly expiresAt: number}
+
+/** In-flight coalescing promise for a cache key. */
+type InFlight = Promise<RepoAuthzResult>
+
+/** The repo authz cache — holds positive/negative results and in-flight coalescing promises. */
+export interface RepoAuthzCache {
+  /** Get a cached entry by key. Returns undefined if absent or expired. */
+  readonly get: (key: string, nowMs: number) => CacheEntry | undefined
+  /** Set a cache entry. */
+  readonly set: (key: string, entry: CacheEntry) => void
+  /** Get an in-flight promise for a key (coalescing). */
+  readonly getInFlight: (key: string) => InFlight | undefined
+  /** Set an in-flight promise for a key. */
+  readonly setInFlight: (key: string, promise: InFlight) => void
+  /** Remove an in-flight promise for a key. */
+  readonly deleteInFlight: (key: string) => void
+  /**
+   * Return a stable opaque identity string for the given token, scoped to this cache instance.
+   *
+   * The identity is a random UUID assigned on first call and reused on subsequent calls with
+   * the same token. The raw token is held only as an in-memory Map key within this cache
+   * instance — it is never serialized, logged, or included in any cache entry key.
+   */
+  readonly tokenIdentityFor: (token: string) => string
+}
+
+/** Injectable dependencies for checkRepoAuthz. */
+export interface RepoAuthzDeps {
+  /** Operator allowlist — checked before any GitHub call. */
+  readonly allowlist: OperatorAllowlist
+  /** Injectable fetch for GitHub API calls. Defaults to globalThis.fetch. */
+  readonly fetch: typeof globalThis.fetch
+  /** Injectable clock for TTL checks. Defaults to Date.now. */
+  readonly clock: () => number
+  /**
+   * Injectable random() for TTL jitter. Must return a value in [0, 1).
+   * Defaults to Math.random.
+   */
+  readonly random: () => number
+  /** Audit logger for security events. */
+  readonly auditLogger: AuditLogger
+  /** Structured logger. */
+  readonly logger: RepoAuthzLogger
+  /** Shared cache instance. Pass createRepoAuthzCache() for isolation in tests. */
+  readonly cache: RepoAuthzCache
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Positive authz TTL: 5 minutes in ms. */
+const POSITIVE_TTL_MS = 5 * 60 * 1000
+
+/** Negative authz TTL: 30 seconds in ms. */
+const NEGATIVE_TTL_MS = 30 * 1000
+
+/** Maximum TTL jitter: 10% of the base TTL. */
+const JITTER_FRACTION = 0.1
+
+/** GitHub API timeout. */
+const GITHUB_FETCH_TIMEOUT_MS = 8_000
+
+/**
+ * Maximum rate-limit cache duration cap.
+ * If Retry-After or x-ratelimit-reset implies a window longer than this,
+ * cap it to avoid caching denials indefinitely.
+ */
+const MAX_RATE_LIMIT_CACHE_MS = 15 * 60 * 1000
+
+/** Default maximum number of entries in the in-memory cache. */
+const DEFAULT_CACHE_MAX_SIZE = 10_000
+
+// ---------------------------------------------------------------------------
+// Response body cleanup
+// ---------------------------------------------------------------------------
+
+/**
+ * Cancel a response body best-effort and non-blocking.
+ * Swallows any rejection so callers never get an unhandled promise rejection.
+ */
+function cancelResponseBody(response: Response): void {
+  response.body?.cancel().catch(() => undefined)
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * GitHub owner/repo name validation.
+ *
+ * GitHub owner names: alphanumeric and hyphens, 1–39 chars, no leading/trailing hyphen.
+ * GitHub repo names: alphanumeric, hyphens, underscores, dots; 1–100 chars.
+ * We are intentionally strict to reject path traversal, null bytes, and injection attempts.
+ * Single-segment names `.` and `..` are explicitly rejected as path traversal.
+ */
+const OWNER_RE = /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i
+const REPO_RE = /^[\w.-]{1,100}$/
+
+function isValidOwner(owner: string): boolean {
+  return OWNER_RE.test(owner)
+}
+
+function isValidRepo(repo: string): boolean {
+  if (repo === '.' || repo === '..') return false
+  if (repo.includes('\u0000')) return false
+  return REPO_RE.test(repo)
+}
+
+// ---------------------------------------------------------------------------
+// Cache key
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a cache key for operator/repo/token identity.
+ *
+ * The token identity is a random opaque UUID assigned per token per cache instance
+ * (see RepoAuthzCache.tokenIdentityFor). The raw token value never appears in the
+ * cache key, preventing accidental exposure in debug output or serialization.
+ * The key is scoped to operator ID + owner/repo + token identity.
+ */
+function buildCacheKey(operatorId: number, owner: string, repo: string, tokenIdentity: string): string {
+  return `${operatorId}:${owner}/${repo}:${tokenIdentity}`
+}
+
+// ---------------------------------------------------------------------------
+// TTL with jitter
+// ---------------------------------------------------------------------------
+
+function withJitter(baseTtlMs: number, random: () => number): number {
+  const jitter = Math.floor(baseTtlMs * JITTER_FRACTION * random())
+  return baseTtlMs + jitter
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit window parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the rate-limit retry window from response headers.
+ *
+ * Priority:
+ *   1. Retry-After (seconds, integer, must be > 0)
+ *   2. x-ratelimit-reset (Unix epoch seconds, only when x-ratelimit-remaining === '0')
+ *
+ * Returns the number of milliseconds to cache the denial, or null if neither
+ * header is present or parseable.
+ *
+ * Caps the result at MAX_RATE_LIMIT_CACHE_MS.
+ * Empty or missing headers are not treated as rate-limit signals.
+ */
+function parseRateLimitWindowMs(headers: {get: (name: string) => string | null}, nowMs: number): number | null {
+  const retryAfter = headers.get('retry-after')
+  if (retryAfter !== null && retryAfter !== '') {
+    const seconds = /^\d+$/.test(retryAfter) ? Number.parseInt(retryAfter, 10) : Number.NaN
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return Math.min(seconds * 1000, MAX_RATE_LIMIT_CACHE_MS)
+    }
+    // Retry-After present but zero/negative/non-numeric — not a rate-limit signal
+    return null
+  }
+
+  // Only treat x-ratelimit-reset as a rate-limit signal when remaining === '0'
+  const remaining = headers.get('x-ratelimit-remaining')
+  if (remaining !== '0') return null
+
+  const resetHeader = headers.get('x-ratelimit-reset')
+  if (resetHeader !== null && resetHeader !== '') {
+    const resetEpochSec = /^\d+$/.test(resetHeader) ? Number.parseInt(resetHeader, 10) : Number.NaN
+    if (Number.isFinite(resetEpochSec)) {
+      const resetMs = resetEpochSec * 1000
+      const windowMs = resetMs - nowMs
+      if (windowMs > 0) {
+        return Math.min(windowMs, MAX_RATE_LIMIT_CACHE_MS)
+      }
+      // Reset is in the past — fall through to return null (use NEGATIVE_TTL_MS)
+    }
+  }
+
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Cache factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a fresh in-memory repo authz cache.
+ *
+ * Suitable for v1 single-process deployment. Gateway restart clears all cache
+ * entries (acceptable for v1).
+ *
+ * Pass a fresh instance per test for isolation.
+ *
+ * @param maxSize - Maximum number of entries before oldest is evicted (default: 10_000).
+ *   Uses Map insertion-order LRU-lite: when at cap, the oldest entry is evicted on set().
+ */
+export function createRepoAuthzCache(maxSize: number = DEFAULT_CACHE_MAX_SIZE): RepoAuthzCache {
+  // Harden against 0, negative, NaN, and non-finite values — clamp to at least 1.
+  const effectiveMaxSize = Number.isFinite(maxSize) && maxSize >= 1 ? Math.floor(maxSize) : DEFAULT_CACHE_MAX_SIZE
+  const entries = new Map<string, CacheEntry>()
+  const inFlight = new Map<string, InFlight>()
+  // Token identity registry: maps raw token (in-memory only) → opaque random UUID.
+  // The raw token is never serialized, logged, or included in any entry key.
+  const tokenIdentities = new Map<string, string>()
+
+  return {
+    get(key: string, nowMs: number): CacheEntry | undefined {
+      const entry = entries.get(key)
+      if (entry === undefined) return undefined
+      if (nowMs >= entry.expiresAt) {
+        entries.delete(key)
+        return undefined
+      }
+      return entry
+    },
+
+    set(key: string, entry: CacheEntry): void {
+      // Evict oldest entry when at cap (Map preserves insertion order)
+      if (entries.size >= effectiveMaxSize && !entries.has(key)) {
+        const oldestKey = entries.keys().next().value
+        if (oldestKey !== undefined) {
+          entries.delete(oldestKey)
+        }
+      }
+      entries.set(key, entry)
+    },
+
+    getInFlight(key: string): InFlight | undefined {
+      return inFlight.get(key)
+    },
+
+    setInFlight(key: string, promise: InFlight): void {
+      inFlight.set(key, promise)
+    },
+
+    deleteInFlight(key: string): void {
+      inFlight.delete(key)
+    },
+
+    tokenIdentityFor(token: string): string {
+      const existing = tokenIdentities.get(token)
+      if (existing !== undefined) return existing
+      const id = randomUUID()
+      tokenIdentities.set(token, id)
+      return id
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether the given operator is authorized to access the given repo.
+ *
+ * v1 rule:
+ *   1. Validate owner/repo names — reject malformed names immediately.
+ *   2. Check operator allowlist — deny without GitHub call if not allowlisted.
+ *   3. Check cache — return cached result if present and not expired.
+ *   4. Coalesce concurrent misses — if an in-flight request exists for the same
+ *      cache key, wait for it instead of issuing a duplicate GitHub call.
+ *   5. Call GitHub repos API with the user OAuth token — treat 2xx as authorized,
+ *      non-2xx as denied. Rate-limit responses are cached through the retry window.
+ *   6. Cache the result and return.
+ *
+ * Emits `authz.denied` audit events on every denial.
+ *
+ * @param operatorId - Stable numeric GitHub user ID of the operator. Must come from
+ *   the authenticated session — route integration must pass the authenticated operator id.
+ * @param owner - Repository owner (GitHub org or user login).
+ * @param repo - Repository name.
+ * @param userOAuthToken - User OAuth token for GitHub API call. Must come from the
+ *   authenticated session. NEVER logged, persisted, or passed outside this function.
+ * @param deps - Injectable dependencies.
+ */
+export async function checkRepoAuthz(
+  operatorId: number,
+  owner: string,
+  repo: string,
+  userOAuthToken: string,
+  deps: RepoAuthzDeps,
+): Promise<RepoAuthzResult> {
+  const {allowlist, clock, auditLogger, logger, cache} = deps
+
+  // ── Step 1: Validate owner/repo names ──────────────────────────────────────
+  if (isValidOwner(owner) === false || isValidRepo(repo) === false) {
+    logger.warn({githubUserId: operatorId}, 'repo-authz: invalid owner/repo name — rejecting before authz')
+    emitAudit(
+      {
+        kind: 'authz.denied',
+        correlationId: 'repo-authz:invalid-repo-name',
+        githubUserId: operatorId,
+        reason: 'invalid_repo_name',
+      },
+      auditLogger,
+    )
+    return {authorized: false, reason: 'invalid_repo_name'}
+  }
+
+  // ── Step 2: Allowlist check ─────────────────────────────────────────────────
+  if (allowlist.isAuthorized(operatorId) === false) {
+    logger.warn({githubUserId: operatorId, owner, repo}, 'repo-authz: operator not in allowlist')
+    emitAudit(
+      {
+        kind: 'authz.denied',
+        correlationId: `repo-authz:${operatorId}:${owner}/${repo}`,
+        githubUserId: operatorId,
+        reason: 'not_allowlisted',
+      },
+      auditLogger,
+    )
+    return {authorized: false, reason: 'not_allowlisted'}
+  }
+
+  // ── Step 3: Cache lookup ────────────────────────────────────────────────────
+  const tokenIdentity = cache.tokenIdentityFor(userOAuthToken)
+  const cacheKey = buildCacheKey(operatorId, owner, repo, tokenIdentity)
+  const nowMs = clock()
+  const cached = cache.get(cacheKey, nowMs)
+  if (cached !== undefined) {
+    if (cached.authorized === true) {
+      return {authorized: true}
+    }
+    // Cached negative — emit audit and structured warn for this request.
+    // (The original miss already audited once; we re-emit per request for traceability.)
+    const cachedReason = cached.reason
+    logger.warn({githubUserId: operatorId, owner, repo, reason: cachedReason}, 'repo-authz: cached denial')
+    emitAudit(
+      {
+        kind: 'authz.denied',
+        correlationId: `repo-authz:${operatorId}:${owner}/${repo}`,
+        githubUserId: operatorId,
+        reason: cachedReason,
+      },
+      auditLogger,
+    )
+    return {authorized: false, reason: cachedReason}
+  }
+
+  // ── Step 4: Coalesce concurrent misses ─────────────────────────────────────
+  const existing = cache.getInFlight(cacheKey)
+  if (existing !== undefined) {
+    // Wait for the in-flight request; if it denies, emit audit for this caller.
+    const coalesced = await existing
+    if (coalesced.authorized === false) {
+      emitAudit(
+        {
+          kind: 'authz.denied',
+          correlationId: `repo-authz:${operatorId}:${owner}/${repo}`,
+          githubUserId: operatorId,
+          reason: coalesced.reason,
+        },
+        auditLogger,
+      )
+    }
+    return coalesced
+  }
+
+  // ── Step 5: GitHub API call ─────────────────────────────────────────────────
+  const promise = performGitHubCheck(operatorId, owner, repo, userOAuthToken, cacheKey, deps)
+  cache.setInFlight(cacheKey, promise)
+
+  try {
+    return await promise
+  } finally {
+    cache.deleteInFlight(cacheKey)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GitHub check (inner — called once per cache miss)
+// ---------------------------------------------------------------------------
+
+async function performGitHubCheck(
+  operatorId: number,
+  owner: string,
+  repo: string,
+  userOAuthToken: string,
+  cacheKey: string,
+  deps: RepoAuthzDeps,
+): Promise<RepoAuthzResult> {
+  const {fetch: fetchFn, random, auditLogger, logger, cache} = deps
+
+  const deny = (reason: RepoAuthzDeniedReason, ttlMs: number, writeTimeMs: number): RepoAuthzResult => {
+    // TTL computed from clock() at cache-write time (writeTimeMs), not request-start time.
+    const expiresAt = writeTimeMs + withJitter(ttlMs, random)
+    cache.set(cacheKey, {authorized: false, reason, expiresAt})
+    emitAudit(
+      {
+        kind: 'authz.denied',
+        correlationId: `repo-authz:${operatorId}:${owner}/${repo}`,
+        githubUserId: operatorId,
+        reason,
+      },
+      auditLogger,
+    )
+    return {authorized: false, reason}
+  }
+
+  let response: Response | undefined
+  try {
+    response = await fetchFn(`https://api.github.com/repos/${owner}/${repo}`, {
+      method: 'GET',
+      headers: {
+        // Token is passed in the header but NEVER logged or cached in plaintext.
+        authorization: `Bearer ${userOAuthToken}`,
+        accept: 'application/vnd.github+json',
+        'x-github-api-version': '2022-11-28',
+      },
+      signal: AbortSignal.timeout(GITHUB_FETCH_TIMEOUT_MS),
+    })
+
+    // Snapshot clock at response-received time for accurate TTL computation.
+    const {clock} = deps
+    const writeTimeMs = clock()
+
+    // Rate-limit handling: 429 always; 403 only when Retry-After or (remaining=0 + reset)
+    if (response.status === 429 || (response.status === 403 && isRateLimitResponse(response))) {
+      const windowMs = parseRateLimitWindowMs(response.headers, writeTimeMs)
+      const ttlMs = windowMs === null ? NEGATIVE_TTL_MS : windowMs
+      logger.warn({githubUserId: operatorId, owner, repo, status: response.status}, 'repo-authz: GitHub rate limited')
+      cancelResponseBody(response)
+      return deny('rate_limited', ttlMs, writeTimeMs)
+    }
+
+    if (response.ok === true) {
+      // Authorized — cache positive result
+      const expiresAt = writeTimeMs + withJitter(POSITIVE_TTL_MS, random)
+      cache.set(cacheKey, {authorized: true, expiresAt})
+      logger.info({githubUserId: operatorId, owner, repo}, 'repo-authz: authorized')
+      cancelResponseBody(response)
+      return {authorized: true}
+    }
+
+    // 5xx — server error, not a definitive denial; return lookup_error
+    if (response.status >= 500) {
+      logger.warn(
+        {githubUserId: operatorId, owner, repo, status: response.status},
+        'repo-authz: GitHub server error — failing closed',
+      )
+      cancelResponseBody(response)
+      return deny('lookup_error', NEGATIVE_TTL_MS, writeTimeMs)
+    }
+
+    // Non-2xx, non-rate-limit, non-5xx — denied
+    logger.warn({githubUserId: operatorId, owner, repo, status: response.status}, 'repo-authz: GitHub denied access')
+    cancelResponseBody(response)
+    return deny('github_denied', NEGATIVE_TTL_MS, writeTimeMs)
+  } catch (error: unknown) {
+    // Network error, timeout, etc. — fail closed.
+    // Log only a safe error kind; never log error.message or String(error) which
+    // could contain hostile content from a thrown value with a custom toString().
+    const errorKind =
+      error instanceof Error ? (error.constructor.name === 'Error' ? 'Error' : error.constructor.name) : typeof error
+    logger.warn(
+      {githubUserId: operatorId, owner, repo, errorKind},
+      'repo-authz: GitHub API lookup failed — failing closed',
+    )
+    const {clock} = deps
+    return deny('lookup_error', NEGATIVE_TTL_MS, clock())
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine whether a 403 response is a rate-limit response.
+ *
+ * GitHub returns 403 for both access denial and rate limiting. We treat a 403
+ * as a rate-limit response only if:
+ *   - Retry-After header is present and non-empty, OR
+ *   - x-ratelimit-remaining === '0' AND x-ratelimit-reset is present and non-empty.
+ *
+ * A 403 with only x-ratelimit-reset (but remaining not '0') is NOT treated as
+ * rate-limited — it is a plain access denial.
+ */
+function isRateLimitResponse(response: {headers: {get: (name: string) => string | null}}): boolean {
+  const retryAfter = response.headers.get('retry-after')
+  if (retryAfter !== null && retryAfter !== '') return true
+
+  const remaining = response.headers.get('x-ratelimit-remaining')
+  if (remaining !== '0') return false
+
+  const reset = response.headers.get('x-ratelimit-reset')
+  return reset !== null && reset !== ''
+}


### PR DESCRIPTION
## Summary

Adds the Phase B repo authorization helper for the Gateway operator web surface.

- checks the operator allowlist before any GitHub lookup
- verifies repo access with the authenticated user's OAuth token via GitHub's repos API
- caches positive, negative, and rate-limit results with bounded in-memory storage and request coalescing
- emits safe denial audit events without logging tokens or unvalidated repo names
- marks Unit 3f complete in the Phase B plan

## Verification

- `pnpm exec vitest run packages/gateway/src/web/auth/repo-authz.test.ts packages/gateway/src/web/audit.test.ts`
- `pnpm --filter @fro-bot/gateway check-types`
- `pnpm --filter @fro-bot/gateway lint`
- `pnpm --filter @fro-bot/gateway build`
- `git diff --exit-code -- dist`