### PR TITLE
feat(gateway): add operator session-info route

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -258,6 +258,63 @@ The gateway auto-discovers the installation ID at runtime — you do not need to
 - **Under-privileged** (e.g. `contents: none`): the gateway returns an error at `/add-project` time with a message naming the missing permissions and a link to the installation settings page.
 - **Over-privileged** (e.g. `contents: write` when only `read` is required): the gateway logs a `WARN` entry listing the over-privileged scopes but does not block the request. Operators should review and reduce permissions to the minimum needed.
 
+## Operator OAuth (Web Surface)
+
+The gateway exposes a browser-facing operator API at `GATEWAY_OPERATOR_PUBLIC_ORIGIN`. Human operators authenticate via GitHub OAuth before accessing any privileged endpoint. This is separate from the GitHub App used for repository access — they serve different purposes and use different credentials.
+
+| Credential                      | Purpose                                 |
+| ------------------------------- | --------------------------------------- |
+| GitHub OAuth client ID + secret | Human operator login (browser session)  |
+| GitHub App ID + private key     | Installation auth for repository access |
+
+### OAuth callback URL
+
+When creating the GitHub OAuth App, set the callback URL to:
+
+```
+{GATEWAY_OPERATOR_PUBLIC_ORIGIN}/operator/auth/github/callback
+```
+
+For example, if `GATEWAY_OPERATOR_PUBLIC_ORIGIN=https://operator.example.com`, the callback URL is `https://operator.example.com/operator/auth/github/callback`.
+
+### Required secrets
+
+```bash
+# GitHub OAuth App credentials (required for operator web login)
+echo -n 'YOUR_OAUTH_CLIENT_ID'     > deploy/secrets/github-oauth-client-id
+echo -n 'YOUR_OAUTH_CLIENT_SECRET' > deploy/secrets/github-oauth-client-secret
+
+# CSRF signing key — 256-bit CSPRNG entropy, base64url-encoded, no padding
+openssl rand -base64 32 | tr '+/' '-_' | tr -d '=' > deploy/secrets/gateway-csrf-secret
+
+# Operator allowlist — one GitHub numeric user ID per line
+echo -n 'YOUR_GITHUB_USER_ID' > deploy/secrets/gateway-operator-allowlist
+
+chmod 0600 deploy/secrets/github-oauth-client-id \
+           deploy/secrets/github-oauth-client-secret \
+           deploy/secrets/gateway-csrf-secret \
+           deploy/secrets/gateway-operator-allowlist
+```
+
+> **OAuth App vs GitHub App:** The OAuth App is for human login only — it authenticates the browser session. The GitHub App (App ID + private key) is for installation auth — it lets the gateway call the GitHub API on behalf of installed repositories. Both are required for a full deployment; they are independent credentials.
+
+> **Allowlist:** Only GitHub user IDs listed in `gateway-operator-allowlist` can log in. Add one numeric user ID per line. Find your numeric ID at `https://api.github.com/users/<your-login>` (the `id` field).
+
+### Operator API surface
+
+All privileged operator endpoints are under `/operator/` and require a valid session cookie. The browser guard enforces session validity, allowlist membership, and origin/Fetch Metadata checks on every request.
+
+| Method | Path                             | Auth           | Purpose                                                 |
+| ------ | -------------------------------- | -------------- | ------------------------------------------------------- |
+| `GET`  | `/operator/health`               | None           | Health check                                            |
+| `GET`  | `/operator/auth/github/start`    | None           | Start OAuth login                                       |
+| `GET`  | `/operator/auth/github/callback` | None           | OAuth callback (GitHub redirects here)                  |
+| `POST` | `/operator/auth/logout`          | Session + CSRF | Invalidate session and clear cookie                     |
+| `GET`  | `/operator/session/csrf`         | Session        | Get a signed CSRF token for mutating requests           |
+| `GET`  | `/operator/session`              | Session        | Get current session info (operatorId, login, expiresAt) |
+
+Sessions have an 8-hour absolute lifetime and a 30-minute idle timeout. The gateway restart clears all sessions (global logout).
+
 ## Workspace Port Model
 
 The workspace container exposes two internal ports, both accessible only within the Docker Compose sandbox network:

--- a/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
+++ b/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
@@ -592,41 +592,45 @@ The web listener is an adapter layer. It authenticates the operator, projects sa
   **Verification:**
   - Repo authz is deterministic, fail-closed, and covered by typed tests.
 
-- [ ] **Unit 3g: Minimal session routes**
+- [ ] **Unit 3g: Operator session-info route**
 
-  **Goal:** Wire the three minimal session-management routes that the browser flow requires: current session info, CSRF token refresh, and logout.
+  **Goal:** Add the one remaining session-management route the browser flow needs — current session info — and document the operator OAuth deployment surface.
 
-  **Requirements:** R2, R3, R4, R14
+  **Requirements:** R2, R4, R14
 
   **Dependencies:** Units 3d and 3e
 
+  > **Reconciliation (2026-06-18, against `main` `85dd30ee`):** the CSRF and logout routes this unit originally enumerated already shipped and are wired:
+  > - `GET /operator/session/csrf` → `buildCsrfRoute` in `packages/gateway/src/web/auth/csrf-route.ts`, wired in `server.ts` (`buildCsrfRoute(app, browserGuardDeps)`).
+  > - logout → `buildLogoutRoutes` in `packages/gateway/src/web/auth/session.ts` at `POST /operator/auth/logout` (the shipped path; this unit's earlier `/operator/session/logout` text was never built), wired in `server.ts`, emits `auth.logout`, protected by session + allowlist + origin + CSRF.
+  >
+  > The shipped logout/CSRF routes are NOT moved or renamed — shipped reality is canonical and re-pathing tested, wired routes is churn with regression risk and no functional gain. Unit 3g's real delta is the new `GET /operator/session` route plus the deploy doc.
+
   **Files:**
-  - Create: `packages/gateway/src/web/routes/session.ts`
-  - Create: `packages/gateway/src/web/routes/session.test.ts`
+  - Create: `packages/gateway/src/web/auth/session-info-route.ts`
+  - Create: `packages/gateway/src/web/auth/session-info-route.test.ts`
   - Modify: `packages/gateway/src/web/server.ts`
   - Modify: `deploy/README.md`
 
   **Approach:**
-  - `GET /operator/session`: returns operator numeric id, display login, and session expiry for a valid session; returns `401` with a coarse body for invalid/expired sessions.
-  - `GET /operator/session/csrf`: returns a fresh signed double-submit token for an authenticated session (delegates to Unit 3e CSRF module).
-  - `POST /operator/session/logout`: invalidates the session server-side, clears the cookie, triggers the revocation hook from Unit 3d, and emits an `auth.logout` audit event.
-  - All three routes go through the `registerOperatorRoute` wrapper from Unit 3a. Logout additionally requires origin and CSRF checks.
+  - `GET /operator/session`: returns the operator numeric id (`githubUserId`), display login, and session absolute expiry for a valid session; returns `401` with a coarse body for invalid/expired/missing sessions. Safe method — no CSRF token required (the guard uses `requireCsrf=false` for GET).
+  - Registered via `registerOperatorRoute` so the privileged-route guard seam (`setOperatorRouteGuard` in `server.ts`) applies session + allowlist + origin checks automatically; the handler reads the authenticated context (`githubUserId`, `sessionId`) via `getOperatorAuthContext(c)` — no double session lookup, matching `buildCsrfRoute`/`buildLogoutRoutes`.
+  - Source the display login + expiry from the session store entry: `store.get(sessionId, now)` returns a `Readonly<SessionEntry>` carrying `githubUserId`, `login` (always present), `issuedAt`, and `lastAccessedAt`. Report effective expiry as `min(issuedAt + SESSION_ABSOLUTE_TTL_MS, lastAccessedAt + SESSION_IDLE_TTL_MS)` (whichever bounds the session sooner). If `store.get` returns `undefined` (raced revocation/expiry between guard and handler), return the coarse `401`. No GitHub lookup is needed. Set `Cache-Control: no-store, private` and `Vary: Origin, Sec-Fetch-Site, Sec-Fetch-Mode, Sec-Fetch-Dest` like the CSRF route.
+  - Wire in `server.ts` alongside the CSRF endpoint, gated on the same `browserGuardDeps` presence (and `sessionStore`) so it is only registered when the auth boundary is in place.
   - Update `deploy/README.md` to document the OAuth callback URL (`{GATEWAY_OPERATOR_PUBLIC_ORIGIN}/operator/auth/github/callback`), required secrets, and the distinction between OAuth client id/secret and GitHub App id/private key.
 
   **Patterns to follow:**
-  - Route wiring in `packages/gateway/src/web/server.ts`.
-  - No-oracle auth failure behavior from signed webhook ingress.
+  - `buildCsrfRoute` in `packages/gateway/src/web/auth/csrf-route.ts` (privileged GET, reads auth context, no-store headers) — the closest sibling.
+  - Coarse auth-failure behavior from signed webhook ingress.
 
   **Test scenarios:**
   - Happy path: `GET /operator/session` returns operator id, login, and expiry for a valid session.
   - Error path: `GET /operator/session` returns `401` for an expired or missing session.
-  - Happy path: `GET /operator/session/csrf` returns a fresh token for a valid session.
-  - Happy path: `POST /operator/session/logout` invalidates the session, clears the cookie, and emits an audit event.
-  - Security: `POST /operator/session/logout` requires a valid origin and CSRF token.
-  - Security: all three routes are covered by the static route-wrapper guard from Unit 3a.
+  - Headers: response sets `Cache-Control: no-store, private` and the `Vary` header.
+  - Security: the route is covered by the static route-wrapper guard (`assertAllPrivilegedRoutesWrapped`) and only registered when the browser guard is installed.
 
   **Verification:**
-  - Session routes are wired, tested, and covered by the route guardrail.
+  - The session-info route is wired, tested, coarse on failure, and covered by the route guardrail; the deploy doc reflects the operator OAuth surface.
 
 - [ ] **Unit 4: SSE run observation and safe browser projections**
 

--- a/packages/gateway/src/http/ingress-pin.test.ts
+++ b/packages/gateway/src/http/ingress-pin.test.ts
@@ -45,10 +45,13 @@ import type {Client} from 'discord.js'
 import type {GitHubOAuthConfig, GitHubOAuthDeps} from '../web/auth/github.js'
 import type {OperatorServerConfig, OperatorServerDeps} from '../web/server.js'
 import type {AnnounceLogger} from './announce-handler.js'
+
 import {readdirSync, readFileSync, statSync} from 'node:fs'
 import {join} from 'node:path'
 import {describe, expect, it, vi} from 'vitest'
+import {loadAllowlistFromText} from '../web/auth/allowlist.js'
 import {createInMemoryStateStore} from '../web/auth/github.js'
+import {createInMemorySessionStore} from '../web/auth/session.js'
 import {buildOperatorApp} from '../web/server.js'
 import {buildAnnounceApp} from './server.js'
 
@@ -95,6 +98,25 @@ const EXPECTED_OPERATOR_ROUTES_WITH_OAUTH: readonly {method: string; path: strin
   {method: 'GET', path: '/operator/health'},
   {method: 'GET', path: '/operator/auth/github/start'},
   {method: 'GET', path: '/operator/auth/github/callback'},
+]
+
+/**
+ * The complete set of HTTP routes the gateway exposes over gateway-net (operator surface)
+ * when the full browser guard is configured (OAuth + allowlist + csrfSecret + sessionStore).
+ *
+ * This is the production-ready surface: OAuth routes (public), logout (privileged, CSRF-gated),
+ * CSRF token endpoint (privileged, safe GET), and session info endpoint (privileged, safe GET).
+ *
+ * SECURITY: All privileged routes are wrapped by the browser guard (session + allowlist +
+ * origin + Fetch Metadata). Adding a route here requires a deliberate security review.
+ */
+const EXPECTED_OPERATOR_ROUTES_WITH_BROWSER_GUARD: readonly {method: string; path: string}[] = [
+  {method: 'GET', path: '/operator/health'},
+  {method: 'GET', path: '/operator/auth/github/start'},
+  {method: 'GET', path: '/operator/auth/github/callback'},
+  {method: 'POST', path: '/operator/auth/logout'},
+  {method: 'GET', path: '/operator/session/csrf'},
+  {method: 'GET', path: '/operator/session'},
 ]
 
 // ---------------------------------------------------------------------------
@@ -165,6 +187,23 @@ function makeOAuthStubConfig(): GitHubOAuthConfig {
     allowedReturnPaths: ['/operator/dashboard'],
     maxOutstandingAttemptsPerKey: 5,
     stateTtlMs: 10 * 60 * 1000,
+  }
+}
+
+function makeBrowserGuardStubDeps(): OperatorServerDeps {
+  const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+  return {
+    ...makeOperatorStubDeps(),
+    githubOAuth: makeOAuthStubDeps(),
+    sessionStore: createInMemorySessionStore(),
+    sessionDeps: {
+      logger,
+      auditLogger: {info: vi.fn(), warn: vi.fn()},
+      clock: () => 0,
+    },
+    allowlist: loadAllowlistFromText('12345', logger),
+    csrfSecret: 'stub-csrf-secret-base64url-32bytes-ok',
+    auditLogger: {info: vi.fn(), warn: vi.fn()},
   }
 }
 
@@ -312,6 +351,44 @@ describe('gateway operator ingress surface (gateway-net) — OAuth-enabled', () 
 
     // #then — all operator routes must be under /operator/
     expect(nonOperatorPrefixed).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Operator surface pin test — full browser guard (OAuth + allowlist + session)
+// ---------------------------------------------------------------------------
+
+describe('gateway operator ingress surface (gateway-net) — full browser guard', () => {
+  it('is exactly the expected set when OAuth, allowlist, csrfSecret, and sessionStore are all provided', () => {
+    // #given — build the Hono app with full browser guard deps
+    const app = buildOperatorApp(makeBrowserGuardStubDeps(), {
+      ...makeOperatorStubConfig(),
+      githubOAuth: makeOAuthStubConfig(),
+    })
+
+    // #when — extract the registered user-defined routes as unique (method, path) pairs.
+    const actualRoutes = extractRoutes(app)
+
+    // #then — the inventory must match the pinned full-browser-guard set exactly.
+    // Adding a privileged route without updating this pin fails the test, requiring
+    // a security review of the new operator endpoint.
+    expect(actualRoutes).toEqual(EXPECTED_OPERATOR_ROUTES_WITH_BROWSER_GUARD)
+  })
+
+  it('contains no announce routes when full browser guard is enabled — surfaces remain disjoint', () => {
+    // #given
+    const operatorApp = buildOperatorApp(makeBrowserGuardStubDeps(), {
+      ...makeOperatorStubConfig(),
+      githubOAuth: makeOAuthStubConfig(),
+    })
+    const operatorRoutes = extractRoutes(operatorApp)
+    const announcePaths = new Set(EXPECTED_ANNOUNCE_ROUTES.map(r => r.path))
+
+    // #when — check for overlap
+    const overlap = operatorRoutes.filter(r => announcePaths.has(r.path))
+
+    // #then — no announce route appears in the operator surface
+    expect(overlap).toEqual([])
   })
 })
 

--- a/packages/gateway/src/web/auth/session-info-route.test.ts
+++ b/packages/gateway/src/web/auth/session-info-route.test.ts
@@ -19,8 +19,14 @@ import {Hono} from 'hono'
 import {describe, expect, it, vi} from 'vitest'
 import {setOperatorRouteGuard} from '../operator-route.js'
 import {loadAllowlistFromText} from './allowlist.js'
+import {applyBrowserGuard} from './csrf.js'
 import {buildSessionInfoRoute} from './session-info-route.js'
-import {SESSION_ABSOLUTE_TTL_MS, SESSION_IDLE_TTL_MS} from './session.js'
+import {
+  createInMemorySessionStore,
+  SESSION_ABSOLUTE_TTL_MS,
+  SESSION_COOKIE_NAME,
+  SESSION_IDLE_TTL_MS,
+} from './session.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -316,5 +322,82 @@ describe('buildSessionInfoRoute — response headers', () => {
     // #then
     expect(res.status).toBe(200)
     expect(res.headers.get('Vary')).toBe('Origin, Sec-Fetch-Site, Sec-Fetch-Mode, Sec-Fetch-Dest')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration — real session store + real browser guard (touch→recompute path)
+// ---------------------------------------------------------------------------
+
+describe('buildSessionInfoRoute — integration: real guard touch updates expiresAt', () => {
+  it('expiresAt reflects the idle window refreshed by the guard touch, not the pre-request lastAccessedAt', async () => {
+    // #given — real in-memory session store and a controlled clock
+    //
+    // Timeline:
+    //   issuedAt  = nowMs - 1_000  (session is 1 second old)
+    //   nowMs     = the moment the request arrives (guard runs touch at this time)
+    //
+    // We choose issuedAt such that the absolute expiry (issuedAt + 8h) is far in
+    // the future, so the idle bound (nowMs + 30min) is always the sooner one.
+    // This lets us assert expiresAt === nowMs + SESSION_IDLE_TTL_MS precisely.
+    const nowMs = 5_000_000
+    const issuedAt = nowMs - 1_000 // absolute expires at nowMs - 1000 + 8h (far future)
+
+    const sessionStore = createInMemorySessionStore()
+    const sessionId = sessionStore.create({githubUserId: 42, login: 'octocat'}, issuedAt)
+    if (sessionId === undefined) throw new Error('expected session to be created')
+
+    // Advance the store's internal lastAccessedAt to issuedAt (create sets it to issuedAt).
+    // The guard will call touch(sessionId, nowMs) which sets lastAccessedAt = nowMs.
+    // The handler then reads lastAccessedAt = nowMs → idleExpiry = nowMs + SESSION_IDLE_TTL_MS.
+
+    const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+    const browserGuardDeps: BrowserGuardDeps = {
+      logger,
+      auditLogger: {info: vi.fn(), warn: vi.fn()},
+      sessionStore,
+      allowlist: loadAllowlistFromText('42\n', logger),
+      csrfSecret: 'stub-csrf-secret-base64url-32bytes-ok',
+      publicOrigin: 'https://operator.example.com',
+      // Fixed clock: guard and handler both see nowMs — touch sets lastAccessedAt = nowMs
+      clock: () => nowMs,
+    }
+
+    // Build a real Hono app with the REAL browser guard installed exactly as server.ts does
+    const app = new Hono()
+    const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+    setOperatorRouteGuard(app, async (c, method, _path) => {
+      const requireCsrf = SAFE_METHODS.has(method.toUpperCase()) === false
+      return applyBrowserGuard(c, browserGuardDeps, false, requireCsrf)
+    })
+    buildSessionInfoRoute(app, browserGuardDeps)
+
+    // #when — GET /operator/session with a valid session cookie and matching Origin
+    // (GET is a safe method: no CSRF token required; Origin must match publicOrigin)
+    const req = new Request('https://operator.example.com/operator/session', {
+      method: 'GET',
+      headers: {
+        cookie: `${SESSION_COOKIE_NAME}=${sessionId}`,
+        origin: 'https://operator.example.com',
+      },
+    })
+    const res = await app.fetch(req)
+
+    // #then — 200 and expiresAt === nowMs + SESSION_IDLE_TTL_MS
+    // This proves the guard's touch(sessionId, nowMs) updated lastAccessedAt to nowMs
+    // and the handler recomputed idleExpiry from the refreshed value — the production contract.
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {operatorId: number; login: string; expiresAt: number}
+    expect(body.operatorId).toBe(42)
+    expect(body.login).toBe('octocat')
+
+    // Verify idle bound is sooner than absolute bound (precondition for the assertion)
+    const absoluteExpiry = issuedAt + SESSION_ABSOLUTE_TTL_MS
+    const expectedIdleExpiry = nowMs + SESSION_IDLE_TTL_MS
+    expect(expectedIdleExpiry).toBeLessThan(absoluteExpiry)
+
+    // The key assertion: expiresAt reflects the guard-refreshed lastAccessedAt (= nowMs),
+    // not the original issuedAt-based lastAccessedAt that was set at session creation.
+    expect(body.expiresAt).toBe(expectedIdleExpiry)
   })
 })

--- a/packages/gateway/src/web/auth/session-info-route.test.ts
+++ b/packages/gateway/src/web/auth/session-info-route.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Tests for the GET /operator/session route.
+ *
+ * Covers:
+ *   - Happy path: valid session → 200 with operatorId, login, expiresAt.
+ *   - Expiry math: min(absolute, idle) — both idle-bound and absolute-bound cases.
+ *   - Error path: store.get returns undefined (expired/revoked/missing) → coarse 401.
+ *   - Error path: getOperatorAuthContext undefined (guard not installed) → 401.
+ *   - Headers: Cache-Control: no-store, private and Vary header set on 200.
+ *
+ * Uses BDD comments (#given, #when, #then).
+ * Mirrors the structure of csrf-route tests and session.test.ts.
+ */
+
+import type {BrowserGuardDeps} from './csrf.js'
+import type {SessionEntry, SessionStore} from './session.js'
+
+import {Hono} from 'hono'
+import {describe, expect, it, vi} from 'vitest'
+import {setOperatorRouteGuard} from '../operator-route.js'
+import {loadAllowlistFromText} from './allowlist.js'
+import {buildSessionInfoRoute} from './session-info-route.js'
+import {SESSION_ABSOLUTE_TTL_MS, SESSION_IDLE_TTL_MS} from './session.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+}
+
+function makeStubSessionStore(entry?: Readonly<SessionEntry>): SessionStore {
+  return {
+    create: vi.fn(() => 'stub-session-id'),
+    get: vi.fn((_sessionId: string, _nowMs: number) => entry),
+    touch: vi.fn(),
+    delete: vi.fn(),
+    onRevoke: vi.fn(),
+    scavenge: vi.fn(),
+    size: vi.fn(() => 0),
+  }
+}
+
+function makeStubBrowserGuardDeps(overrides?: Partial<BrowserGuardDeps>): BrowserGuardDeps {
+  const logger = makeLogger()
+  return {
+    logger,
+    auditLogger: {info: vi.fn(), warn: vi.fn()},
+    sessionStore: makeStubSessionStore(),
+    allowlist: loadAllowlistFromText('12345', logger),
+    csrfSecret: 'stub-csrf-secret-base64url-32bytes-ok',
+    publicOrigin: 'https://operator.example.com',
+    clock: () => 1_000_000,
+    ...overrides,
+  }
+}
+
+/**
+ * Build a minimal Hono test app with a stub guard that sets the auth context,
+ * then registers the session-info route.
+ *
+ * When guardInstalled=false, no guard is installed (simulates guard-not-installed path).
+ */
+function buildTestApp(
+  deps: BrowserGuardDeps,
+  opts?: {guardInstalled?: boolean; sessionId?: string; githubUserId?: number},
+): Hono {
+  const app = new Hono()
+  const guardInstalled = opts?.guardInstalled !== false
+  const sessionId = opts?.sessionId ?? 'stub-session-id'
+  const githubUserId = opts?.githubUserId ?? 12345
+
+  if (guardInstalled) {
+    setOperatorRouteGuard(app, async (_c, _method, _path) => {
+      return {ok: true, githubUserId, sessionId}
+    })
+  }
+
+  buildSessionInfoRoute(app, deps)
+  return app
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe('buildSessionInfoRoute — happy path', () => {
+  it('returns 200 with operatorId, login, and expiresAt for a valid session', async () => {
+    // #given
+    const nowMs = 1_000_000
+    const issuedAt = nowMs - 1000
+    const lastAccessedAt = nowMs - 500
+
+    const entry: SessionEntry = {
+      githubUserId: 42,
+      login: 'octocat',
+      issuedAt,
+      lastAccessedAt,
+      revoked: false,
+    }
+
+    const sessionStore = makeStubSessionStore(entry)
+    const deps = makeStubBrowserGuardDeps({
+      sessionStore,
+      clock: () => nowMs,
+    })
+    const app = buildTestApp(deps, {githubUserId: 42, sessionId: 'test-session-id'})
+
+    // #when
+    const req = new Request('http://localhost/operator/session', {method: 'GET'})
+    const res = await app.fetch(req)
+
+    // #then
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {operatorId: number; login: string; expiresAt: number}
+    expect(body.operatorId).toBe(42)
+    expect(body.login).toBe('octocat')
+
+    // expiresAt = min(issuedAt + ABSOLUTE_TTL, lastAccessedAt + IDLE_TTL)
+    const absoluteExpiry = issuedAt + SESSION_ABSOLUTE_TTL_MS
+    const idleExpiry = lastAccessedAt + SESSION_IDLE_TTL_MS
+    expect(body.expiresAt).toBe(Math.min(absoluteExpiry, idleExpiry))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Expiry math — idle-bound vs absolute-bound
+// ---------------------------------------------------------------------------
+
+describe('buildSessionInfoRoute — expiry math', () => {
+  it('uses idle expiry when idle TTL bounds sooner than absolute TTL', async () => {
+    // #given — session was just issued but last accessed long ago (idle expires first)
+    const nowMs = 1_000_000
+    // issuedAt is recent → absolute expiry is far in the future
+    const issuedAt = nowMs - 1000 // absolute expires at nowMs - 1000 + 8h (far future)
+    // lastAccessedAt is old → idle expires soon
+    const lastAccessedAt = nowMs - SESSION_IDLE_TTL_MS + 60_000 // idle expires in 60s
+
+    const entry: SessionEntry = {
+      githubUserId: 99,
+      login: 'idle-user',
+      issuedAt,
+      lastAccessedAt,
+      revoked: false,
+    }
+
+    const sessionStore = makeStubSessionStore(entry)
+    const deps = makeStubBrowserGuardDeps({sessionStore, clock: () => nowMs})
+    const app = buildTestApp(deps)
+
+    // #when
+    const req = new Request('http://localhost/operator/session', {method: 'GET'})
+    const res = await app.fetch(req)
+
+    // #then
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {expiresAt: number}
+    const absoluteExpiry = issuedAt + SESSION_ABSOLUTE_TTL_MS
+    const idleExpiry = lastAccessedAt + SESSION_IDLE_TTL_MS
+    // idle expires sooner
+    expect(idleExpiry).toBeLessThan(absoluteExpiry)
+    expect(body.expiresAt).toBe(idleExpiry)
+  })
+
+  it('uses absolute expiry when absolute TTL bounds sooner than idle TTL', async () => {
+    // #given — session is near its absolute limit but was recently accessed
+    const nowMs = 1_000_000
+    // issuedAt is old → absolute expires soon
+    const issuedAt = nowMs - SESSION_ABSOLUTE_TTL_MS + 60_000 // absolute expires in 60s
+    // lastAccessedAt is recent → idle expires far in the future
+    const lastAccessedAt = nowMs - 1000 // idle expires at nowMs - 1000 + 30min (far future)
+
+    const entry: SessionEntry = {
+      githubUserId: 77,
+      login: 'absolute-user',
+      issuedAt,
+      lastAccessedAt,
+      revoked: false,
+    }
+
+    const sessionStore = makeStubSessionStore(entry)
+    const deps = makeStubBrowserGuardDeps({sessionStore, clock: () => nowMs})
+    const app = buildTestApp(deps)
+
+    // #when
+    const req = new Request('http://localhost/operator/session', {method: 'GET'})
+    const res = await app.fetch(req)
+
+    // #then
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {expiresAt: number}
+    const absoluteExpiry = issuedAt + SESSION_ABSOLUTE_TTL_MS
+    const idleExpiry = lastAccessedAt + SESSION_IDLE_TTL_MS
+    // absolute expires sooner
+    expect(absoluteExpiry).toBeLessThan(idleExpiry)
+    expect(body.expiresAt).toBe(absoluteExpiry)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error path — store.get returns undefined
+// ---------------------------------------------------------------------------
+
+describe('buildSessionInfoRoute — store.get returns undefined', () => {
+  it('returns coarse 401 with {error: "unauthorized"} when session is expired/revoked/missing', async () => {
+    // #given — store.get returns undefined (raced revocation/expiry)
+    const sessionStore = makeStubSessionStore(undefined)
+    const deps = makeStubBrowserGuardDeps({sessionStore})
+    const app = buildTestApp(deps)
+
+    // #when
+    const req = new Request('http://localhost/operator/session', {method: 'GET'})
+    const res = await app.fetch(req)
+
+    // #then
+    expect(res.status).toBe(401)
+    const body = (await res.json()) as {error: string}
+    expect(body).toEqual({error: 'unauthorized'})
+  })
+
+  it('returns the same coarse 401 body as the guard-not-installed case (no detail leak)', async () => {
+    // #given — two apps: one with missing session, one with guard not installed
+    const sessionStore = makeStubSessionStore(undefined)
+    const deps = makeStubBrowserGuardDeps({sessionStore})
+    const appMissingSession = buildTestApp(deps)
+    const appNoGuard = buildTestApp(deps, {guardInstalled: false})
+
+    // #when
+    const req1 = new Request('http://localhost/operator/session', {method: 'GET'})
+    const req2 = new Request('http://localhost/operator/session', {method: 'GET'})
+    const [res1, res2] = await Promise.all([appMissingSession.fetch(req1), appNoGuard.fetch(req2)])
+
+    // #then — both return 401 with identical body
+    expect(res1.status).toBe(401)
+    expect(res2.status).toBe(401)
+    const [body1, body2] = await Promise.all([res1.json(), res2.json()])
+    expect(body1).toEqual({error: 'unauthorized'})
+    expect(body2).toEqual({error: 'unauthorized'})
+    expect(body1).toEqual(body2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error path — guard not installed
+// ---------------------------------------------------------------------------
+
+describe('buildSessionInfoRoute — guard not installed', () => {
+  it('returns 401 when getOperatorAuthContext returns undefined (guard not installed)', async () => {
+    // #given — no guard installed on the app
+    const deps = makeStubBrowserGuardDeps()
+    const app = buildTestApp(deps, {guardInstalled: false})
+
+    // #when
+    const req = new Request('http://localhost/operator/session', {method: 'GET'})
+    const res = await app.fetch(req)
+
+    // #then
+    expect(res.status).toBe(401)
+    const body = (await res.json()) as {error: string}
+    expect(body).toEqual({error: 'unauthorized'})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Headers
+// ---------------------------------------------------------------------------
+
+describe('buildSessionInfoRoute — response headers', () => {
+  it('sets Cache-Control: no-store, private on a 200 response', async () => {
+    // #given
+    const nowMs = 2_000_000
+    const entry: SessionEntry = {
+      githubUserId: 1,
+      login: 'headeruser',
+      issuedAt: nowMs - 1000,
+      lastAccessedAt: nowMs - 500,
+      revoked: false,
+    }
+    const sessionStore = makeStubSessionStore(entry)
+    const deps = makeStubBrowserGuardDeps({sessionStore, clock: () => nowMs})
+    const app = buildTestApp(deps)
+
+    // #when
+    const req = new Request('http://localhost/operator/session', {method: 'GET'})
+    const res = await app.fetch(req)
+
+    // #then
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Cache-Control')).toBe('no-store, private')
+  })
+
+  it('sets Vary: Origin, Sec-Fetch-Site, Sec-Fetch-Mode, Sec-Fetch-Dest on a 200 response', async () => {
+    // #given
+    const nowMs = 2_000_000
+    const entry: SessionEntry = {
+      githubUserId: 1,
+      login: 'varyuser',
+      issuedAt: nowMs - 1000,
+      lastAccessedAt: nowMs - 500,
+      revoked: false,
+    }
+    const sessionStore = makeStubSessionStore(entry)
+    const deps = makeStubBrowserGuardDeps({sessionStore, clock: () => nowMs})
+    const app = buildTestApp(deps)
+
+    // #when
+    const req = new Request('http://localhost/operator/session', {method: 'GET'})
+    const res = await app.fetch(req)
+
+    // #then
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Vary')).toBe('Origin, Sec-Fetch-Site, Sec-Fetch-Mode, Sec-Fetch-Dest')
+  })
+})

--- a/packages/gateway/src/web/auth/session-info-route.ts
+++ b/packages/gateway/src/web/auth/session-info-route.ts
@@ -1,0 +1,90 @@
+/**
+ * Session info endpoint for the operator web surface.
+ *
+ * GET /operator/session
+ *
+ * Returns current session info for an authenticated, allowlisted operator.
+ * The response includes the operator's numeric GitHub user ID, display login,
+ * and the computed session expiry timestamp.
+ *
+ * Security invariants:
+ *   - Requires a valid session cookie (authenticated session).
+ *   - Requires the session's GitHub user ID to be in the operator allowlist.
+ *   - Origin and Fetch Metadata checks are applied before returning session info.
+ *   - No CSRF token required (safe GET method).
+ *   - Response is no-store, private — never cached.
+ *   - No session ID, secret, or internal detail is included in the response.
+ *
+ * The browser guard is applied automatically by the privileged-route guard seam
+ * installed in server.ts (via setOperatorRouteGuard). The handler reads the
+ * authenticated context (githubUserId, sessionId) from the Hono context variables
+ * set by the guard wrapper — no double session lookup.
+ */
+
+import type {Hono} from 'hono'
+import type {BrowserGuardDeps} from './csrf.js'
+import {getOperatorAuthContext, registerOperatorRoute} from '../operator-route.js'
+import {SESSION_ABSOLUTE_TTL_MS, SESSION_IDLE_TTL_MS} from './session.js'
+
+/**
+ * Register the GET /operator/session route on the given Hono app.
+ *
+ * Registered as a privileged operator route (requires session + allowlist).
+ * The browser guard is applied automatically by the privileged-route guard seam
+ * (setOperatorRouteGuard in server.ts). No CSRF token is required to GET session
+ * info (safe method — guard uses requireCsrf=false for GET).
+ *
+ * The handler reads the authenticated context from Hono context variables set
+ * by the guard wrapper, avoiding a double session lookup.
+ *
+ * Response body: { operatorId: number, login: string, expiresAt: number }
+ *   - operatorId: stable GitHub numeric user ID
+ *   - login: GitHub display login (mutable, for display only)
+ *   - expiresAt: ms-since-epoch timestamp of the sooner of absolute or idle expiry
+ */
+export function buildSessionInfoRoute(app: Hono, deps: BrowserGuardDeps): void {
+  registerOperatorRoute(app, 'GET', '/operator/session', c => {
+    // The browser guard has already run (via the privileged-route guard seam).
+    // Read the authenticated context stored by the guard wrapper.
+    const authCtx = getOperatorAuthContext(c)
+    if (authCtx === undefined) {
+      // Guard not installed. This path is unreachable in production — buildSessionInfoRoute
+      // is only called when browserGuardDeps is present, which also installs the guard.
+      // Return 401 as a safe fallback.
+      return c.json({error: 'unauthorized'}, 401)
+    }
+
+    const {sessionId} = authCtx
+    const nowMs = deps.clock()
+
+    // Look up the session entry to get identity and timestamps.
+    // The guard already validated the session, but a race (revocation/expiry between
+    // guard and handler) can produce undefined here. Treat it as a coarse 401 —
+    // same body as the guard-not-installed fallback to avoid distinguishing detail.
+    const entry = deps.sessionStore.get(sessionId, nowMs)
+    if (entry === undefined) {
+      return c.json({error: 'unauthorized'}, 401)
+    }
+
+    // Compute the effective expiry: the sooner of absolute TTL and idle TTL.
+    const absoluteExpiry = entry.issuedAt + SESSION_ABSOLUTE_TTL_MS
+    const idleExpiry = entry.lastAccessedAt + SESSION_IDLE_TTL_MS
+    const expiresAt = Math.min(absoluteExpiry, idleExpiry)
+
+    // Prevent caching of session info — it is session-bound and must not be
+    // served from any cache (browser, CDN, or proxy).
+    c.header('Cache-Control', 'no-store, private')
+    // Vary on the headers the browser guard inspects so intermediaries cannot
+    // serve a cached response to a different origin or fetch context.
+    c.header('Vary', 'Origin, Sec-Fetch-Site, Sec-Fetch-Mode, Sec-Fetch-Dest')
+
+    return c.json(
+      {
+        operatorId: entry.githubUserId,
+        login: entry.login,
+        expiresAt,
+      },
+      200,
+    )
+  })
+}

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -26,6 +26,7 @@ import type {AuditLogger} from './audit.js'
 import type {OperatorAllowlist} from './auth/allowlist.js'
 import type {GitHubOAuthConfig, GitHubOAuthDeps} from './auth/github.js'
 import type {SessionDeps, SessionStore} from './auth/session.js'
+
 import {serve} from '@hono/node-server'
 import {getConnInfo} from '@hono/node-server/conninfo'
 import {Hono} from 'hono'
@@ -34,6 +35,7 @@ import {createRateLimiter} from '../http/rate-limit.js'
 import {buildCsrfRoute} from './auth/csrf-route.js'
 import {applyBrowserGuard} from './auth/csrf.js'
 import {buildGitHubOAuthRoutes} from './auth/github.js'
+import {buildSessionInfoRoute} from './auth/session-info-route.js'
 import {buildLogoutRoutes} from './auth/session.js'
 import {assertAllPrivilegedRoutesWrapped, registerPublicRoute, setOperatorRouteGuard} from './operator-route.js'
 import {
@@ -464,6 +466,15 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
   // Returns a fresh signed CSRF token for the authenticated session.
   if (browserGuardDeps !== undefined) {
     buildCsrfRoute(app, browserGuardDeps)
+  }
+
+  // ── Session info endpoint ───────────────────────────────────────────────────
+  //
+  // Registered only when the browser guard is present (same condition as CSRF endpoint).
+  // Route: GET /operator/session — privileged (requires session + allowlist).
+  // Returns current session info (operatorId, login, expiresAt) for the authenticated session.
+  if (browserGuardDeps !== undefined) {
+    buildSessionInfoRoute(app, browserGuardDeps)
   }
 
   // ── Catch-all ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What this adds

`GET /operator/session` — the operator web surface's current-session endpoint. An authenticated, allowlisted operator gets back their GitHub user id, display login, and the effective session expiry (the sooner of the absolute and idle TTLs). Invalid, expired, or revoked sessions get a coarse `401` with no distinguishing detail.

It's a safe `GET` behind the existing operator browser guard (session + allowlist + origin), so the guard seam applies automatically and the handler reads the authenticated context rather than doing a second session lookup — the same shape as the CSRF endpoint. The response sets `Cache-Control: no-store, private` and the matching `Vary` header, and never exposes the session id or any secret.

The deploy guide now documents the operator OAuth callback URL, the required secrets, and the distinction between the OAuth client id/secret (operator login) and the GitHub App id/private key (installation auth).

## Notes

The session logout and CSRF-token routes already shipped earlier in the operator-surface work, so this change is just the remaining session-info route plus its wiring and docs. The route is added to the privileged-route inventory pin so it can't drift out of guard coverage unnoticed.

## Verification

New tests cover the happy path, both expiry bounds (idle-bound and absolute-bound), the coarse-401 paths (raced/expired session and missing guard context with identical bodies), and the cache/Vary headers. Gateway type-check, lint, and the full gateway test suite pass.
