### PR TITLE
feat(gateway): own and freeze the operator API contract

### DIFF
--- a/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
+++ b/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
@@ -13,6 +13,8 @@ deepened: 2026-06-15
 
 Add the Gateway-side API surface that Phase A made possible: GitHub-authenticated allowlisted operators can launch work, observe run state, and approve or reject tool requests through the same execution and approval spine Discord already uses. The surface is browser-only in v1, uses server-side opaque sessions, preserves the gateway ingress/egress boundary, and leaves scoped read-only binding data as an optional Phase B.1 follow-up.
 
+> **Operator-surface types are now owned by `packages/gateway/src/operator-contract/` (the frozen contract at `OPERATOR_CONTRACT_VERSION = '1.0.0'`).** Consuming units in this plan (launch, run-state, approvals) MUST import operator-surface types from that module, not re-declare them. The dashboard's `operator-client.ts` is a non-canonical downstream fixture; the contract barrel is the import authority.
+
 ## Problem Frame
 
 The Gateway currently has two proven control paths: Discord commands/mentions for launching work and Discord buttons for OpenCode approvals. Phase A extracted `launchWork`, transport-neutral sinks, and the generalized approval registry so another transport can use the same queue, concurrency cap, shutdown handoff, and fail-closed approval gate.

--- a/docs/plans/2026-06-19-001-feat-operator-api-contract-plan.md
+++ b/docs/plans/2026-06-19-001-feat-operator-api-contract-plan.md
@@ -1,0 +1,332 @@
+---
+title: "feat: Own and freeze the canonical operator API contract (S1 surface)"
+type: feat
+status: active
+date: 2026-06-19
+deepened: 2026-06-19
+origin: https://github.com/fro-bot/agent/issues/949 (Fro Bot triage comment as requirements)
+---
+
+# Own and freeze the canonical operator API contract (S1 surface)
+
+## Overview
+
+Make this repo the single source of truth for the operator API contract. Add a dedicated `packages/gateway/src/operator-contract/` module that consolidates the operator-facing shapes that exist today but are scattered and internal — run-state lifecycle, approval-decision semantics, and operator authorization identity — and exports them as transport-stable plain TS types plus a runtime validator, behind an explicit contract version. Embed the authorization and `metadata/repos.yaml` redaction (#950) obligations as first-class normative clauses. The dashboard's mock client becomes a conformant downstream fixture; the gateway owns the real contract.
+
+Net-new command/mission shapes (launch/query/stream a unit of work) are **deferred** — they are designed and frozen alongside the endpoints that implement them in Units 4–6 of the web-operator surface plan, not here.
+
+## Problem Frame
+
+The gateway is gaining an inbound operator control surface (S1/S2, umbrella #907). As that surface takes shape, the gateway must be the authority any client validates against — not the dashboard, which already carries a typed *mock* operator client (`fro-bot/dashboard` `src/gateway/operator-client.ts`). Today no canonical, versioned, exported operator contract exists: the relevant shapes live as runtime coordination internals, gateway approval internals, and inline HTTP response literals. Until the contract is frozen, downstream interactive UI work stays behind mocks (per #949's gating rule).
+
+## Requirements Trace
+
+- R1. The operator command/state/approval/authz contract is documented and exported from one stable location in this repo.
+- R2. Consumers have a referenceable, pinned contract **version** to validate against.
+- R3. The contract is transport-stable: exported types are plain TS and validation returns `Result<T, E>`; Effect `Schema` is never part of the exported surface.
+- R4. The contract is the **sole definer** of its types; existing scattered definitions re-import from it rather than duplicating (collapse, don't fork).
+- R5. The contract surfaces only operator-safe fields; internal coordination fields are excluded by construction.
+- R6. The contract embeds the authorization obligation (operator→repo access) and the `metadata/repos.yaml` redaction obligation (#950) as normative clauses.
+- R7. The contract encodes approval-decision semantics so a web transport cannot become a higher-privilege bypass of the fail-closed gate.
+
+## Scope Boundaries
+
+- This plan does **not** implement the redaction gate itself (denylist-before-query against `metadata/repos.yaml`). It binds the contract to that obligation so the first repo-data endpoint cannot skip it; the gate ships with the endpoint that needs it.
+- This plan does **not** change any runtime behavior of existing routes, approvals, or the engine. It is a types-consolidation + versioning + obligation-documentation change.
+- No cross-repo coupling: `fro-bot/dashboard` is a downstream consumer; this contract has no source dependency on it, and this plan touches only `fro-bot/agent`.
+
+### Deferred to Separate Tasks
+
+- Net-new operator **command/mission shapes** (`POST /operator/runs`, `GET /operator/runs/:id`, stream, approvals decision body): designed + frozen with their endpoints in the web-operator surface plan (`docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md`, Units 4–6).
+- The **redaction gate implementation** (#950): a follow-up that implements denylist-before-query; this plan only freezes the obligation.
+- A **compound solutions doc** capturing "centralize-key pattern applied to type families": after this lands (no existing types-ownership doc exists).
+- A **dashboard-side conformance check** (type-assignability CI gate or assertion test that the dashboard mock conforms to the frozen contract version): lives in `fro-bot/dashboard`, out of scope here, but the contract's value depends on it — flagged so the contract doesn't silently drift from the mock.
+- Promoting `PermissionRequest`/`PermissionReplyEvent`/`SettlementReason` and the OAuth-callback / route-guard response shapes into the contract: a later v1.1 MINOR (kept out of v1 to bound the fan-out).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Run-state lifecycle** — `packages/runtime/src/coordination/types.ts`: `RunPhase` (`PENDING|ACKNOWLEDGED|EXECUTING|COMPLETED|FAILED|CANCELLED`), `Surface` (`github|discord|web`), `RunState` (carries internal `holder_id`, `thread_id`, `details`). Exported via `packages/runtime/src/coordination/index.ts` → `packages/runtime/src/index.ts`. NOT re-declared in the gateway — imported.
+- **Run-state parser precedent** — `packages/runtime/src/coordination/run-state.ts` `parseRunState(data): Result<RunState, Error>` + `hasValidRunStateShape` type-guard. The canonical validator pattern to mirror.
+- **Approval semantics** — `packages/gateway/src/approvals/coordinator.ts`: `PermissionReply` (`once|always|reject`, declared here — gateway-owned), `PermissionRequest`, `PermissionReplyEvent`, `SettlementReason`. `packages/gateway/src/approvals/registry.ts`: `WebOperatorActor`, `ApprovalActor` union, `DecisionOutcome`.
+- **Identity duplication (consolidation target)** — structurally overlapping `OperatorAuthContext` (`packages/gateway/src/web/operator-route.ts`), `SessionIdentity` (`packages/gateway/src/web/auth/session.ts`), `WebOperatorIdentity` (`packages/gateway/src/execute/launch-types.ts`), `WebOperatorActor` (`packages/gateway/src/approvals/registry.ts`).
+- **Operator HTTP response shapes (inline literals to name)** — `session-info-route.ts` `{operatorId, login, expiresAt}`; `csrf-route.ts` `{csrfToken}`; `safe-response.ts` `{ok}` / `{error}`.
+- **Version-constant precedent** — `OPENCODE_SQLITE_VERSION` (`packages/runtime/src/session/version.ts`) + colocated `version.test.ts` pin; `STORAGE_VERSION = 1` (`packages/runtime/src/shared/constants.ts`, "increment on breaking changes").
+- **Effect/Result boundary** — `packages/gateway/AGENTS.md`: gateway is the only `effect` user; exported surface must be plain TS + `Result<T,E>` from `@bfra.me/es/result`; Effect `Schema` confined to `packages/gateway/src/http/announce-schema.ts`.
+- **Module convention** — gateway submodules are flat, file-per-concept, no `index.ts` barrel (the dominant pattern across `approvals/`, `web/`, `execute/`, `http/`, `bindings/`); the runtime package uses a barrel for its cross-package public API.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/centralize-s3-key-identity-construction-2026-06-09.md` — one owner per type/identity family; consumers import, never re-declare; thread identity as a required param; pin literal values in regression tests; a "must stay in sync" comment is a drift bug.
+- `docs/solutions/best-practices/effect-failure-channel-discipline-2026-06-10.md` — Effect Schema stays internal; across the boundary types are plain TS and validation returns `Result`; document the error-channel convention at the seam.
+- `docs/solutions/best-practices/versioned-tool-config-plugin-pattern-2026-03-29.md` — version flows from one constant through a typed pipeline; no second copy; track the constant via Renovate.
+- `docs/solutions/best-practices/gateway-control-surface-spine-2026-06-15.md` — `ApprovalActor` as a discriminated union (not `string`); scope-equivalence asserted not assumed; characterize-before-cut; collapse-don't-fork (verify zero live references to removed symbols).
+- `docs/solutions/best-practices/signed-webhook-ingress-hardening-2026-05-29.md` — no-oracle parse errors: the validator must not echo rejected input values into error reasons.
+
+### External References
+
+- None. The work mirrors strong local patterns (runtime `parseRunState`, `OPENCODE_SQLITE_VERSION`, gateway module layout); no external research needed.
+
+## Key Technical Decisions
+
+- **Contract home: a gateway module, not a published package.** `packages/gateway/src/operator-contract/`. The dashboard references the contract by version; no new publishable `@fro-bot/operator-contract` package yet. (Per #949 scope decision.)
+- **Consolidate-only freeze.** Freeze what exists today (lifecycle, approval-decision, authz identity) + version + redaction clause. Net-new command/mission shapes are deferred to their implementing units.
+- **Run-state is projected, not re-exported raw — and the projection is redaction-aware.** Define `OperatorRunStatus` exposing only operator-safe fields (`runId`, `entityRef`, `surface`, `phase`, `startedAt`, and a derived `stale: boolean`). Exclude `holder_id`, `thread_id`, `details` by construction (R5, Phase B R12). Re-export `RunPhase`/`Surface` as-is. **Critical (security review):** `entity_ref` is the repo slug `owner/repo#123`; exposing it for a repo redacted in `metadata/repos.yaml` reintroduces the exact leak #950 closes — and the redaction obligation is a *pre-query* gate, so it does not retroactively scrub an already-stored run's status. Therefore `toOperatorRunStatus(runState, opts)` must accept a redaction signal and, for a denylisted repo, return `null` (omit the record) rather than a populated status. `OperatorRunStatus` is documented as a redaction-aware projection, and Unit 6's redaction clause explicitly states the gate applies to status projections, not only to repo-data queries. The `stale` derivation takes an explicit `staleThresholdMs` (no hidden coupling to the runtime default) — the projection is pure over its inputs.
+- **The redaction obligation ships a fail-closed structural stub, not just prose (security review).** A documented `REDACTION_OBLIGATION` constant is not an enforceable control. Unit 6 additionally exports a fail-closed `assertRedactionApplied`-style guard that throws by default (`REDACTION_GATE_NOT_IMPLEMENTED`), so the first repo-data endpoint cannot ship a response path that surfaces repo data without either implementing the gate or visibly removing the call (which fails review). This makes the obligation grepable and unskippable while keeping the gate implementation itself deferred. The contract binds redaction to run *alongside* `checkRepoAuthz` (`web/auth/repo-authz.ts`) — both must pass — so the two cannot silently diverge.
+- **Canonical `OperatorIdentity` for the genuine duplicate only.** Deepening (architecture review) corrected the over-broad "four sites collapse" framing: only `WebOperatorActor` (`approvals/registry.ts`) and `WebOperatorIdentity` (`execute/launch-types.ts`) are byte-for-byte identical (`kind:'web-operator'`, `githubUserId`, `login`, `sessionCorrelationId`) — those two collapse onto one canonical `OperatorIdentity`. `OperatorAuthContext` (`{githubUserId, sessionId}` — a Hono-context guard result) and `SessionIdentity` (`{githubUserId, login}` — a session-store record) are **semantically distinct** and do NOT belong in the identity union; they only reference the canonical field types (e.g. `OperatorIdentity['githubUserId']`) for consistency. The `ApprovalActor` union stays the transport-variant consumer. This collapse shape is resolved here, not deferred.
+- **Decision-state canonicalizes the operator-facing set (corrected mapping).** Deepening (architecture review) found the first mapping wrong. The operator set is `pending | claimed | already_claimed | scope_mismatch | failed_to_settle | unavailable`. The `DecisionOutcome` (`ok | not-found | channel-mismatch | already-claimed | reply-failed`, `approvals/registry.ts`) maps: `ok→claimed`, `channel-mismatch→scope_mismatch`, `already-claimed→already_claimed` (NOT `already_settled` — the first POST is still in-flight, the entry has not settled), `reply-failed→failed_to_settle`, `not-found→unavailable`. `pending` is the implied pre-decision state (open entry, no `DecisionOutcome`). `expired` is **dropped** from the `DecisionOutcome` mapping — it is a deadline/settlement-path state (`SettlementReason 'deadline'`), not a decision outcome; if exposed at all it is derived separately from the deadline path, not from this mapping. The `never` exhaustiveness guard covers exactly the 5 `DecisionOutcome` variants. The mapping is a contract clause with a table-driven test.
+- **`PermissionReply` becomes contract-owned via re-export, not re-definition.** The contract is its sole definer; `packages/gateway/src/approvals/coordinator.ts` keeps the existing export path working with `export type { PermissionReply } from '../operator-contract/approval.js'` (re-export — NOT a second `export type PermissionReply = ...`, which would be the exact fork this plan eliminates). This keeps all 9 existing import sites valid without a 9-file change; a note flags the re-export seam as an incremental future migration. `PermissionRequest`/`PermissionReplyEvent`/`SettlementReason` stay in `coordinator.ts` for v1 (11/2/5-file fan-out respectively) with a v1.1-candidate comment. Approval semantics are encoded so a web decision must carry a transport-bound actor — the contract exports a `DecisionInput` type (`actor: ApprovalActor`, no free-form `decidedBy: string`) so the type constraint is load-bearing (R7).
+- **Validator: plain-TS + `Result`, Effect-free exported surface (R3).** `parseOperatorX(input: unknown): Result<OperatorX, Error>` with hand-rolled type-guards, mirroring `parseRunState`. No-oracle error reasons (no echo of rejected input). Effect `Schema`, if used at all, stays internal to the module and is never re-exported.
+- **Version: a single pinned constant with a breaking-change policy.** `OPERATOR_CONTRACT_VERSION = '1.0.0'` exported from the module + a colocated pin test, mirroring `OPENCODE_SQLITE_VERSION`/`STORAGE_VERSION`. Source comment documents MAJOR=breaking / MINOR=additive / PATCH=doc. Add a Renovate-trackable single source.
+- **Module layout matches the gateway's dominant pattern with one deliberate exception.** File-per-concept under `operator-contract/`, but **add a single `index.ts` barrel** as the one stable import point a downstream consumer (dashboard) pins — the contract's whole purpose is to be the import authority, which the runtime package precedent supports.
+- **Redaction (#950) is a documented obligation, not an implementation here.** Embed the verbatim invariant + the four operational rules (denylist-before-query; format-stable deny keys; fail-closed; composes alongside `checkRepoAuthz`, not instead of) as a normative clause module. The first repo-data endpoint must satisfy it.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Are `RunPhase`/`RunState` re-declared in the gateway (to delete)? — No. Verified: only imported from runtime. Only `PermissionReply` is gateway-declared, so only it changes owner. (Repo verification, 2026-06-19.)
+- Does `metadata/repos.yaml` appear anywhere in this repo today? — No (zero matches). The redaction gate is unimplemented; the contract embeds the obligation + a fail-closed structural stub only.
+- Module barrel or flat? — Flat is the gateway norm, but the contract adds a single `index.ts` because its purpose is to be the one import authority. Verified no import-cycle risk: the barrel re-exports `RunPhase`/`Surface` from `@fro-bot/runtime` and runtime cannot import back from the gateway (layer rule).
+- Identity-collapse shape — only `WebOperatorActor` + `WebOperatorIdentity` (byte-identical) collapse onto `OperatorIdentity`; `OperatorAuthContext` and `SessionIdentity` are semantically distinct and stay separate, referencing canonical field types only. (Architecture review, 2026-06-19.)
+- Do `WebOperatorActor`/`WebOperatorIdentity`/`OperatorAuthContext`/`SessionIdentity` have external consumers that the unit file-lists must cover? — No. Verified zero external by-name consumers; only the `ApprovalActor` union has 3 consumers and stays in place. `PermissionReply` has 9 import sites, all preserved via the coordinator re-export. (Repo blast-radius verification, 2026-06-19.)
+- Unit 3 posture (re-export vs migrate): v1 is **re-export only** — the contract adds the operator-facing `OperatorRunStatus` projection and re-exports `RunPhase`/`Surface`; existing direct `@fro-bot/runtime` imports are left in place (migrating them is a deferred, optional follow-up). The Unit 3 goal text is aligned to this.
+
+### Deferred to Implementation
+
+- Whether the OAuth-callback `{githubUserId, login}` shape (`web/auth/github.ts`) and the route-guard `{ok, response}` return union (`web/operator-route.ts`) should also be named in a later v1.1 MINOR — out of scope for v1's 4 named response shapes.
+- Whether to later migrate the 3 gateway files that import `RunPhase`/`Surface` directly from `@fro-bot/runtime` (`execute/launch-types.ts`, `runtime-effect.ts`, `execute/recovery.test.ts`) to import from the contract barrel — v1 leaves them as-is (see Unit 3 posture, resolved below).
+
+> Note: two questions the first draft deferred are now resolved by deepening — the identity-collapse shape (only `WebOperatorActor`+`WebOperatorIdentity` collapse; `OperatorAuthContext`/`SessionIdentity` stay distinct) and the Phase B field-name reconciliation (now a Unit 3 precondition, not deferred).
+
+## Output Structure
+
+    packages/gateway/src/operator-contract/
+      ├── version.ts            # OPERATOR_CONTRACT_VERSION + increment policy
+      ├── version.test.ts
+      ├── identity.ts           # canonical OperatorIdentity (+ ApprovalActor reference)
+      ├── identity.test.ts
+      ├── run-status.ts         # OperatorRunStatus projection; re-exports RunPhase/Surface
+      ├── run-status.test.ts
+      ├── approval.ts           # PermissionReply (sole definer), decision-state set + DecisionOutcome mapping
+      ├── approval.test.ts
+      ├── responses.ts          # named operator HTTP response types (SessionInfo, etc.)
+      ├── parse.ts              # parseOperatorX(input): Result<T, Error> validators
+      ├── parse.test.ts
+      ├── redaction.ts          # #950 redaction obligation clause (types + constants, no gate)
+      └── index.ts              # single public barrel — the import authority
+
+## Implementation Units
+
+- [ ] **Unit 1: Contract version + module skeleton**
+
+  **Goal:** Establish the module home, the pinned contract version, and the public barrel.
+
+  **Requirements:** R1, R2
+
+  **Dependencies:** None
+
+  **Files:**
+  - Create: `packages/gateway/src/operator-contract/version.ts`
+  - Create: `packages/gateway/src/operator-contract/version.test.ts`
+  - Create: `packages/gateway/src/operator-contract/index.ts`
+
+  **Approach:**
+  - `OPERATOR_CONTRACT_VERSION = '1.0.0'` with a source comment stating the increment policy (MAJOR=breaking, MINOR=additive, PATCH=doc), mirroring the `STORAGE_VERSION` comment style.
+  - `index.ts` re-exports the version now and grows as later units land (the single import authority).
+  - Add a Renovate-trackable single source for the constant (or a documented note that the version is human-bumped on breaking changes, like `STORAGE_VERSION`).
+
+  **Patterns to follow:** `packages/runtime/src/session/version.ts` + `version.test.ts`; `STORAGE_VERSION` in `packages/runtime/src/shared/constants.ts`.
+
+  **Test scenarios:**
+  - Happy path: `OPERATOR_CONTRACT_VERSION` is exactly `'1.0.0'` (literal pin, like the `OPENCODE_SQLITE_VERSION` test).
+  - Happy path: the value is importable from the module barrel `index.ts`.
+
+  **Verification:** the version constant is pinned by test and exported from the barrel; type-check and lint clean.
+
+- [ ] **Unit 2: Canonical operator identity**
+
+  **Goal:** Define one `OperatorIdentity` as the sole definer and collapse the duplicated identity sites onto it.
+
+  **Requirements:** R3, R4, R5
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Create: `packages/gateway/src/operator-contract/identity.ts`
+  - Create: `packages/gateway/src/operator-contract/identity.test.ts`
+  - Modify: `packages/gateway/src/execute/launch-types.ts` (have `WebOperatorIdentity` reference the contract type)
+  - Modify: `packages/gateway/src/approvals/registry.ts` (have `WebOperatorActor` reference the contract type)
+  - Modify: `packages/gateway/src/operator-contract/index.ts` (export identity)
+  - Test: `packages/gateway/src/execute/run.test.ts` / existing approval tests stay green (behavior unchanged)
+
+  **Approach:**
+  - Canonical `OperatorIdentity` with the `web-operator` shape (`githubUserId: number`, `login: string` (display-only), `sessionCorrelationId: string`), `readonly` throughout, discriminated by `kind` so future variants extend without forking.
+  - Collapse ONLY the genuine duplicate: `WebOperatorIdentity` (`execute/launch-types.ts`) and `WebOperatorActor` (`approvals/registry.ts`) are byte-identical — both reference the canonical `OperatorIdentity` so there is one structural definer. Keep the `ApprovalActor` union (`registry.ts`) and `RequesterIdentity` union (`launch-types.ts`) as the transport-variant consumers (unchanged export paths; their 3/0 external consumers keep working).
+  - Do NOT fold `OperatorAuthContext` (`{githubUserId, sessionId}`, Hono guard result) or `SessionIdentity` (`{githubUserId, login}`, session record) into the identity union — they are semantically distinct. At most, reference canonical field types (`OperatorIdentity['githubUserId']`) for consistency; no structural relationship, no Modify churn required for v1.
+  - Collapse-don't-fork check: no second structural declaration of the `{githubUserId, login, sessionCorrelationId}` triple remains outside the contract; the `web-operator` construct-site literals in `run.test.ts` and `approval-flow.integration.test.ts` stay assignable.
+
+  **Execution note:** characterization-first — confirm the existing approval/launch identity tests are green before the cut, and remain green after (behavior must not change).
+
+  **Patterns to follow:** `centralize-s3-key-identity-construction` (export the type, consumers import); `RequesterIdentity` discriminated-union shape in `launch-types.ts`.
+
+  **Test scenarios:**
+  - Happy path: a `web-operator` identity constructed against the contract type satisfies `WebOperatorActor` and `WebOperatorIdentity` structurally (assignability test).
+  - Edge case: `login` is documented/typed as display-only (a comment/JSDoc assertion or a type-level note) so it is never treated as an identity key.
+  - Integration: existing approval-decision and launch tests remain green after the consolidation (no behavior change).
+
+  **Verification:** one structural definer of the operator identity; dependent sites reference it; all existing approval/launch tests pass.
+
+- [ ] **Unit 3: Run-status projection + lifecycle re-export**
+
+  **Goal:** Expose an operator-safe `OperatorRunStatus` projection and make the contract the operator-facing surface for `RunPhase`/`Surface`.
+
+  **Requirements:** R3, R4, R5
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Create: `packages/gateway/src/operator-contract/run-status.ts`
+  - Create: `packages/gateway/src/operator-contract/run-status.test.ts`
+  - Modify: `packages/gateway/src/operator-contract/index.ts`
+
+  **Approach:**
+  - **Precondition:** read the Phase B status projection table (`docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md` lines 185-194) and align `OperatorRunStatus` field names + status taxonomy to it before writing, so the frozen v1.0.0 contract does not mismatch the endpoints it governs.
+  - Re-export `RunPhase` and `Surface` from `@fro-bot/runtime` through the contract barrel as the operator-facing lifecycle types. **Posture: re-export only** — do not migrate the existing gateway files that import these directly from runtime (left as a deferred follow-up).
+  - Define `OperatorRunStatus` carrying only operator-safe fields: `runId`, `entityRef`, `surface`, `phase`, `startedAt`, `stale: boolean`. Exclude `holder_id`, `thread_id`, `details`.
+  - Provide a pure, **redaction-aware** `toOperatorRunStatus(runState, opts)` projection (no I/O) where `opts` carries an explicit `staleThresholdMs` (no hidden runtime-default coupling) and a redaction signal. For a denylisted repo (`entity_ref` resolves to a repo redacted in `metadata/repos.yaml`), it returns `null` (omit the record) — never a populated status. This closes the cross-obligation leak: `entity_ref` = `owner/repo#123` would otherwise expose a redacted repo's identity/activity that the pre-query redaction gate does not retroactively scrub.
+
+  **Patterns to follow:** Phase B status mapping (`2026-06-15-002` lines 185-194); pure-projection style; the #950 redaction obligation (Unit 6).
+
+  **Test scenarios:**
+  - Happy path: `toOperatorRunStatus` maps each `RunPhase` to the expected operator status and copies operator-safe fields.
+  - Security (R5): the projection output type and result contain no `holder_id`, `thread_id`, or `details` (assert keys absent).
+  - Security (R5/R6, cross-obligation): a denylisted-repo run yields `null` (record omitted), not a populated status exposing `entityRef`.
+  - Edge case: a non-denylisted repo is NOT accidentally omitted (positive control).
+  - Edge case: `stale` derives true/false correctly from `last_heartbeat` vs `now` at the `staleThresholdMs` boundary.
+
+  **Verification:** `OperatorRunStatus` excludes internal fields by construction, omits denylisted repos, and is covered by projection tests; field names match the Phase B table; `RunPhase`/`Surface` are re-exported from the barrel.
+
+- [ ] **Unit 4: Approval-decision contract + `PermissionReply` ownership**
+
+  **Goal:** Make the contract the sole definer of `PermissionReply` and canonicalize the operator-facing decision-state set with an explicit mapping.
+
+  **Requirements:** R4, R7
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Create: `packages/gateway/src/operator-contract/approval.ts`
+  - Create: `packages/gateway/src/operator-contract/approval.test.ts`
+  - Modify: `packages/gateway/src/approvals/coordinator.ts` (re-import `PermissionReply` from the contract)
+  - Modify: `packages/gateway/src/operator-contract/index.ts`
+
+  **Approach:**
+  - Define `PermissionReply` (`once|always|reject`) in the contract as the sole definer. `coordinator.ts` MUST keep its export with a re-export — `export type { PermissionReply } from '../operator-contract/approval.js'` — NOT a second `export type PermissionReply = ...`. This preserves all 9 existing import sites (`launch-types.ts`, `registry.ts`, `discord-transport.ts`, `discord/approvals.ts`, plus 5 tests) without a 9-file change. Add a comment marking the re-export as an incremental migration seam.
+  - Keep `PermissionRequest`/`PermissionReplyEvent`/`SettlementReason` in `coordinator.ts` (11/2/5-file fan-out) with a `// v1.1 promotion candidate` note in `approval.ts` so the next consolidator sees the seam.
+  - Define the operator-facing decision-state set `pending | claimed | already_claimed | scope_mismatch | failed_to_settle | unavailable` and a mapping function from `DecisionOutcome` (`ok→claimed`, `channel-mismatch→scope_mismatch`, `already-claimed→already_claimed`, `reply-failed→failed_to_settle`, `not-found→unavailable`). `pending` is the implied pre-decision state. `expired` is NOT in this mapping (it is a deadline/settlement-path state). The `never` exhaustiveness guard is over the 5 `DecisionOutcome` variants only.
+  - Export a `DecisionInput` type (`{ requestID, approvalScopeId, decision: PermissionReply, actor: ApprovalActor }`) so a decision must carry a transport-bound actor by type — no free-form `decidedBy: string`. This makes the R7 constraint load-bearing: any new decision entry point references `DecisionInput`. Add a structural test scanning approval-related functions for a `decidedBy: string` parameter (must find none) and document in AGENTS.md that `registry.handleDecision` is the sole approval gate.
+
+  **Execution note:** characterization-first — existing coordinator/registry tests green before and after the ownership move.
+
+  **Patterns to follow:** `gateway-control-surface-spine` (one fail-closed gate, many transports; actor union not `string`; the `handleDecision` scope-binding/single-winner model is the real enforcement); `comment-only-review-blocked-approval` (verdict coupled to a transport event).
+
+  **Test scenarios:**
+  - Happy path: `PermissionReply` imported via the contract still satisfies `coordinator.ts` usage (assignability + all 9 import sites + existing tests green).
+  - Happy path: each of the 5 `DecisionOutcome` variants maps to the documented operator decision-state (table-driven test; assert `already-claimed→already_claimed`, NOT `already_settled`).
+  - Error path: the mapping is exhaustive over `DecisionOutcome` (a `never` guard fails compilation if a variant is unmapped).
+  - Security (R7): a structural test scans approval-decision functions and fails if any accepts a `decidedBy: string` instead of a transport-bound `actor: ApprovalActor`.
+
+  **Verification:** `PermissionReply` has one definer with a working re-export; the 5-variant mapping is correct and exhaustive; `DecisionInput` is exported and the no-`decidedBy` structural test passes; coordinator tests pass unchanged.
+
+- [ ] **Unit 5: Named operator response types + validators**
+
+  **Goal:** Publish named types for the already-shipped operator HTTP responses and provide Effect-free runtime validators.
+
+  **Requirements:** R1, R3
+
+  **Dependencies:** Units 1–4
+
+  **Files:**
+  - Create: `packages/gateway/src/operator-contract/responses.ts`
+  - Create: `packages/gateway/src/operator-contract/parse.ts`
+  - Create: `packages/gateway/src/operator-contract/parse.test.ts`
+  - Modify: `packages/gateway/src/web/auth/session-info-route.ts` (use the named `OperatorSessionInfo` type)
+  - Modify: `packages/gateway/src/operator-contract/index.ts`
+
+  **Approach:**
+  - Name the shipped response shapes (`OperatorSessionInfo` = `{operatorId, login, expiresAt}`, plus the csrf/ok/error shapes) as plain TS types; have `session-info-route.ts` use `OperatorSessionInfo` instead of its inline literal + JSDoc.
+  - Provide `parseOperatorX(input: unknown): Result<OperatorX, Error>` validators with hand-rolled type-guards mirroring `parseRunState`. Error reasons are no-oracle (do not echo rejected input values). Effect `Schema` is not used on the exported surface.
+
+  **Patterns to follow:** `packages/runtime/src/coordination/run-state.ts` `parseRunState` + `hasValidRunStateShape`; `signed-webhook-ingress-hardening` no-oracle errors.
+
+  **Test scenarios:**
+  - Happy path: a valid payload parses to the typed value via `Result.ok`.
+  - Edge case: missing/extra fields are rejected deterministically.
+  - Security (no-oracle): a captured-logger / collected-error test across ALL validator error paths asserts no input value substring, no token shape (`ghs_`, `ghp_`, `Bearer `), and no session secret (`sessionCorrelationId`, raw cookie value) appears in any error reason — the validator must not echo input at all, even a garbled fragment.
+  - Integration: `session-info-route.ts` compiles and its existing tests pass using the named `OperatorSessionInfo` type.
+
+  **Verification:** named response types exported; validators return `Result` with no-oracle errors proven across all error paths; the session-info route uses the contract type; existing route tests pass.
+
+- [ ] **Unit 6: Redaction + authorization obligation clauses**
+
+  **Goal:** Embed the #950 redaction obligation and the authorization obligation as normative contract clauses bound to the contract version.
+
+  **Requirements:** R6, R7
+
+  **Dependencies:** Units 1–5
+
+  **Files:**
+  - Create: `packages/gateway/src/operator-contract/redaction.ts`
+  - Modify: `packages/gateway/src/operator-contract/index.ts`
+  - Modify: `docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md` (cross-reference the frozen contract from the consuming units)
+  - Modify: AGENTS.md (note the contract module as the operator-surface authority)
+
+  **Approach:**
+  - `redaction.ts` exports the obligation as a documented `REDACTION_OBLIGATION` constant + the four operational rules as a normative comment: denylist-before-query; format-stable deny keys (node_id `MDEw…` vs `R_kgDO…` skew, derive numeric database_id); fail-closed; composes alongside `checkRepoAuthz` (both must pass). The clause explicitly states the gate applies to `OperatorRunStatus` projections (not only repo-data queries).
+  - **Fail-closed structural stub (security review):** export an `assertRedactionApplied`-style guard whose body throws (`REDACTION_GATE_NOT_IMPLEMENTED`) by default. The first repo-data endpoint must call it (and replace the body with the real gate) — a response path that surfaces repo data without it crashes at runtime, so the obligation is grepable and unskippable. The gate's real implementation stays deferred; only the fail-closed stub + its contract binding ship now. Bind it to run alongside `checkRepoAuthz` (`web/auth/repo-authz.ts`) so authz and redaction cannot diverge.
+  - State the authorization obligation: an operator decision/launch carries a transport-bound `OperatorIdentity`/`DecisionInput`; the contract cannot bypass the fail-closed approval gate. Add two documented constraints (security review): the version constant is build-time pinned and never negotiated over the wire (any endpoint reading a version header rejects unrecognized versions fail-closed); `OperatorIdentity` is always constructed server-side from the authenticated session, never deserialized from a request payload.
+  - Document, in the contract and AGENTS.md, that the gateway owns this contract, `registry.handleDecision` is the sole approval gate, and the dashboard mock is a non-canonical fixture; downstream consumers pin `OPERATOR_CONTRACT_VERSION`.
+
+  **Test scenarios:**
+  - Happy path: `REDACTION_OBLIGATION` is exported, references the four operational rules, and is wired into the barrel.
+  - Security: `assertRedactionApplied` throws by default (proves the fail-closed stub is live, not a no-op).
+  - Test expectation: the behavioral redaction-gate tests (denylisted-repo leak path, node_id skew, denylist-read-failure fail-closed) ship with the gate implementation (deferred), per #950 acceptance #3.
+
+  **Verification:** the contract exports the redaction + authorization clauses and the fail-closed stub, the barrel surfaces them, AGENTS.md records ownership + the sole-gate + the two documented constraints, and the web-operator plan cross-references the frozen contract.
+
+## System-Wide Impact
+
+- **Interaction graph:** `coordinator.ts` (PermissionReply), `registry.ts` / `launch-types.ts` (identity), `session-info-route.ts` (response type) shift to import from the contract. No control-flow change — only type ownership.
+- **Error propagation:** validators return `Result`; no new throw paths across the package boundary. Effect stays internal.
+- **State lifecycle risks:** none — no runtime state is added or changed; this is a types/version/docs consolidation.
+- **API surface parity:** the contract becomes the single definer; the collapse-don't-fork checks (zero live duplicate declarations) are the parity guarantee.
+- **Unchanged invariants:** the fail-closed approval gate, the operator browser guard, all shipped route behavior, and the runtime coordination internals are unchanged. The contract re-exports/projects them; it does not alter them.
+- **Sequencing / parallelism:** Unit 1 first (the barrel + version must exist before others export through it). Units 2, 3, 4 have disjoint create-files and disjoint domain Modify-files (`registry.ts`+`launch-types.ts` / none / `coordinator.ts`), but **all three add re-exports to `operator-contract/index.ts`** — the one serialization point. Execute Units 2/3/4 serially, OR develop their create-files in parallel and consolidate every `index.ts` re-export in a single integration step (do not let parallel workers edit `index.ts`). Unit 5's `responses.ts` + `session-info-route.ts` edits are independent of 2/3/4, but `parse.ts` depends on the types from 2/3/4. Unit 6 is last (binds the obligations + barrel + docs).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Consolidating identity types introduces a subtle behavior change in approvals/launch | Characterization-first: existing approval/launch tests green before and after; assignability tests prove structural equivalence. Only the byte-identical `WebOperatorActor`/`WebOperatorIdentity` collapse; distinct types stay separate. |
+| Operator status taxonomy drifts from the Phase B projection table | Unit 3 reconciles field names against `2026-06-15-002` lines 185-194 as a **precondition** (not a deferred note) before `v1.0.0` freezes. |
+| Freezing `v1.0.0` before command/mission shapes exist invites a premature breaking bump later | Consolidate-only scope + documented MINOR=additive policy: command shapes are additive in a later MINOR, not a breaking change to frozen types. |
+| `OperatorRunStatus.entityRef` leaks a denylisted repo's identity/activity (the #950 leak), because redaction is a pre-query gate that does not scrub stored status | **Critical.** The projection is redaction-aware: `toOperatorRunStatus` omits (`null`) a denylisted repo's record; Unit 6's clause states the gate applies to status projections; tests cover the leak path. |
+| Redaction obligation documented but gate deferred — a future endpoint could skip it | A fail-closed `assertRedactionApplied` stub throws by default, so a repo-data response path crashes without it (grepable, unskippable); bound to run alongside `checkRepoAuthz`. |
+| R7 type constraint isn't load-bearing — a new decision path could take a raw `string` actor outside the contract | Export `DecisionInput` (`actor: ApprovalActor`); a structural test fails on any `decidedBy: string` approval signature; AGENTS.md names `registry.handleDecision` the sole gate. |
+| Version-downgrade via a wire-supplied contract version | The version constant is build-time pinned, never negotiated over the wire; an endpoint reading a version header rejects unrecognized versions fail-closed (documented constraint). |
+| `OperatorIdentity` deserialized from untrusted request payload | Documented constraint (contract + AGENTS.md): `OperatorIdentity` is always constructed server-side from the authenticated session, never from a request body. |
+
+## Documentation / Operational Notes
+
+- AGENTS.md gains a one-line note: the operator contract module is the authority for operator-surface types; the dashboard client is a non-canonical fixture.
+- Consider a follow-up compound solutions doc: "centralize-key pattern applied to type families" (no existing types-ownership doc).
+
+## Sources & References
+
+- **Origin:** [fro-bot/agent#949](https://github.com/fro-bot/agent/issues/949) (Fro Bot triage comment as requirements)
+- Related issues: #907 (umbrella), #950 (redaction invariant)
+- Related plan: `docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md` (consuming web-operator units 4–6)
+- Key code: `packages/runtime/src/coordination/types.ts`, `packages/gateway/src/approvals/{coordinator,registry}.ts`, `packages/gateway/src/web/{operator-route,auth/session,auth/session-info-route}.ts`, `packages/gateway/src/execute/launch-types.ts`, `packages/runtime/src/session/version.ts`
+- Learnings: `centralize-s3-key-identity-construction`, `effect-failure-channel-discipline`, `versioned-tool-config-plugin-pattern`, `gateway-control-surface-spine`, `signed-webhook-ingress-hardening`

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -2,6 +2,15 @@
 
 The Discord-first gateway daemon. Wraps `@fro-bot/runtime` with Effect 3.x as the composition layer.
 
+## Operator API contract
+
+`packages/gateway/src/operator-contract/` is the **single authority** for operator-surface types (lifecycle, identity, approval-decision, responses) and the contract version. Import from its barrel (`index.ts`); do not re-declare these types elsewhere.
+
+- `registry.handleDecision` is the **sole approval gate** — all transports (Discord, web) settle through it; no transport may implement a parallel settlement path.
+- `OperatorIdentity` is always constructed **server-side** from the authenticated session. It is never deserialized from a request payload.
+- `OPERATOR_CONTRACT_VERSION` is **build-time pinned** and never negotiated over the wire. Any endpoint reading a version header must reject unrecognized versions fail-closed.
+- The dashboard's `operator-client.ts` is a **non-canonical downstream fixture**; it does not define the contract.
+
 ## Effect / Result<> boundary
 
 This package is the **only** place in the monorepo that uses `effect`. The Action and the runtime package stay on hand-rolled `Result<T, E>` from `@bfra.me/es`.

--- a/packages/gateway/src/approvals/coordinator.ts
+++ b/packages/gateway/src/approvals/coordinator.ts
@@ -28,13 +28,23 @@
  */
 
 import type {GatewayLogger} from '../discord/client.js'
+import type {PermissionReply} from '../operator-contract/approval.js'
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-/** Reply verbs accepted by the OpenCode permission reply endpoint. */
-export type PermissionReply = 'once' | 'always' | 'reject'
+/**
+ * Re-export seam — `PermissionReply` is now solely defined in the operator
+ * contract module. This re-export keeps the `coordinator.js` path valid for
+ * all 9 existing import sites (launch-types.ts, registry.ts, discord-transport.ts,
+ * discord/approvals.ts, and 5 test files including the `import * as coordinatorModule`
+ * namespace import in run.test.ts) without a 9-file change.
+ *
+ * Consider migrating import sites to the contract directly in a future pass:
+ *   `import type { PermissionReply } from '../operator-contract/approval.js'`
+ */
+export type {PermissionReply} from '../operator-contract/approval.js'
 
 /** Parsed `permission.asked` payload — the request awaiting a decision. */
 export interface PermissionRequest {

--- a/packages/gateway/src/approvals/registry.ts
+++ b/packages/gateway/src/approvals/registry.ts
@@ -45,6 +45,7 @@
  */
 
 import type {GatewayLogger} from '../discord/client.js'
+import type {OperatorIdentity} from '../operator-contract/identity.js'
 import type {PermissionReply, PermissionReplyEvent, PermissionRequest, SettlementReason} from './coordinator.js'
 
 // ---------------------------------------------------------------------------
@@ -67,30 +68,12 @@ export interface DiscordApprovalActor {
 /**
  * A web operator who submitted an approval decision via the control surface.
  *
- * Carries stable GitHub numeric identity for authorization and audit, plus
- * a display login for human-readable logs. The numeric ID is the authoritative
- * identity — logins are mutable and must not be used for access decisions.
+ * Type alias for the canonical {@link OperatorIdentity} defined in the
+ * operator-contract module. The structural shape is declared exactly once
+ * there; this alias keeps the existing export path valid for all consumers
+ * (discord-transport.ts, approval-flow.integration.test.ts, registry.test.ts).
  */
-export interface WebOperatorActor {
-  readonly kind: 'web-operator'
-  /**
-   * Stable GitHub numeric user ID (from the GitHub API `id` field).
-   * Used for authorization, audit, and idempotency key scoping.
-   * Prefer this over `login` for any access-control or audit decision.
-   */
-  readonly githubUserId: number
-  /**
-   * GitHub display login (e.g. `'octocat'`).
-   * Mutable — use only for human-readable logs and display metadata.
-   * Never use for authorization or audit identity.
-   */
-  readonly login: string
-  /**
-   * Opaque session correlation value for log correlation.
-   * Not used for authorization — use `githubUserId` instead.
-   */
-  readonly sessionCorrelationId: string
-}
+export type WebOperatorActor = OperatorIdentity
 
 /**
  * Transport-neutral actor identity for an approval decision.

--- a/packages/gateway/src/execute/launch-types.ts
+++ b/packages/gateway/src/execute/launch-types.ts
@@ -42,6 +42,7 @@ import type {ApprovalRegistry} from '../approvals/registry.js'
 import type {RepoBinding} from '../bindings/types.js'
 import type {MessageContentOptions} from '../discord/io.js'
 import type {TransitionResult} from '../discord/status-message.js'
+import type {OperatorIdentity} from '../operator-contract/identity.js'
 
 // ---------------------------------------------------------------------------
 // RequesterIdentity — discriminated union for transport-neutral caller identity
@@ -59,30 +60,11 @@ export interface DiscordRequesterIdentity {
 /**
  * A web operator who triggered the run via the control surface.
  *
- * Carries stable GitHub numeric identity for authorization and audit, plus
- * a display login for human-readable logs. The numeric ID is the authoritative
- * identity — logins are mutable and must not be used for access decisions.
+ * Type alias for the canonical {@link OperatorIdentity} defined in the
+ * operator-contract module. The structural shape is declared exactly once
+ * there; this alias keeps the existing export path valid for all consumers.
  */
-export interface WebOperatorIdentity {
-  readonly kind: 'web-operator'
-  /**
-   * Stable GitHub numeric user ID (from the GitHub API `id` field).
-   * Used for authorization, audit, and idempotency key scoping.
-   * Prefer this over `login` for any access-control or audit decision.
-   */
-  readonly githubUserId: number
-  /**
-   * GitHub display login (e.g. `'octocat'`).
-   * Mutable — use only for human-readable logs and display metadata.
-   * Never use for authorization or audit identity.
-   */
-  readonly login: string
-  /**
-   * Opaque session correlation value for log correlation.
-   * Not used for authorization — use `githubUserId` instead.
-   */
-  readonly sessionCorrelationId: string
-}
+export type WebOperatorIdentity = OperatorIdentity
 
 /**
  * Transport-neutral requester identity.

--- a/packages/gateway/src/operator-contract/approval.test.ts
+++ b/packages/gateway/src/operator-contract/approval.test.ts
@@ -12,7 +12,7 @@
 import type {DecisionOutcome} from '../approvals/registry.js'
 import type {DecisionInput, OperatorDecisionState, PermissionReply} from './approval.js'
 
-import {readFileSync} from 'node:fs'
+import {accessSync, constants, readFileSync} from 'node:fs'
 import path from 'node:path'
 import {fileURLToPath} from 'node:url'
 import {describe, expect, it} from 'vitest'
@@ -161,10 +161,11 @@ describe('R7 structural boundary: no decidedBy:string in approval-decision sourc
    * Pattern that would indicate a free-form string actor bypassing the
    * ApprovalActor discriminated union (the R7 anti-pattern).
    *
-   * Matches `decidedBy` followed by optional whitespace, a colon, optional
-   * whitespace, and `string` — i.e. a parameter or property typed as `string`.
+   * Matches `decidedBy` (with optional `?` for optional params) followed by
+   * optional whitespace, a colon, optional whitespace, and `string` — i.e. a
+   * parameter or property typed as `string` (required or optional).
    */
-  const DECIDED_BY_PATTERN = /decidedBy\s*:\s*string/
+  const DECIDED_BY_PATTERN = /decidedBy\??\s*:\s*string/
 
   it('no approval-decision source file contains a decidedBy: string parameter', () => {
     // #given — the approval-decision source files
@@ -172,6 +173,18 @@ describe('R7 structural boundary: no decidedBy:string in approval-decision sourc
 
     for (const relPath of SCAN_TARGETS) {
       const absPath = path.join(gatewaySrcRoot, relPath)
+
+      // Existence guard: fail loudly if a scanned file has been renamed or deleted
+      // so a rename cannot silently drop coverage.
+      try {
+        accessSync(absPath, constants.R_OK)
+      } catch {
+        throw new Error(
+          `R7 scan target no longer exists or is unreadable: ${relPath}\n` +
+            `Update SCAN_TARGETS in approval.test.ts to reflect the rename.`,
+        )
+      }
+
       const content = readFileSync(absPath, 'utf8')
       const lines = content.split('\n')
 
@@ -200,8 +213,8 @@ describe('R7 structural boundary: no decidedBy:string in approval-decision sourc
     expect(violations).toHaveLength(0)
   })
 
-  it('self-test: scanner WOULD flag a decidedBy: string parameter', () => {
-    // #given — a fixture string containing the anti-pattern
+  it('self-test: scanner WOULD flag a decidedBy: string parameter (required)', () => {
+    // #given — a fixture string containing the anti-pattern (required param)
     const fixtureContent = [
       '// some-handler.ts',
       'async function handleApproval(requestID: string, decidedBy: string, decision: string) {',
@@ -221,6 +234,27 @@ describe('R7 structural boundary: no decidedBy:string in approval-decision sourc
     // #then — the scanner must flag the anti-pattern
     expect(violations.length).toBeGreaterThan(0)
     expect(violations[0]?.text).toContain('decidedBy: string')
+  })
+
+  it('self-test: scanner WOULD flag a decidedBy?: string optional parameter', () => {
+    // #given — a fixture string containing the anti-pattern (optional param variant)
+    const fixtureContent = [
+      '// some-handler.ts',
+      'interface ApprovalOpts { requestID: string; decidedBy?: string }',
+    ].join('\n')
+
+    // #when — scan the fixture
+    const violations: {line: number; text: string}[] = []
+    for (const [i, line] of fixtureContent.split('\n').entries()) {
+      if (line.trimStart().startsWith('//')) continue
+      if (DECIDED_BY_PATTERN.test(line)) {
+        violations.push({line: i + 1, text: line.trim()})
+      }
+    }
+
+    // #then — the scanner must flag the optional variant too
+    expect(violations.length).toBeGreaterThan(0)
+    expect(violations[0]?.text).toContain('decidedBy?: string')
   })
 
   it('self-test: scanner does NOT flag a line comment or JSDoc comment containing decidedBy: string', () => {

--- a/packages/gateway/src/operator-contract/approval.test.ts
+++ b/packages/gateway/src/operator-contract/approval.test.ts
@@ -1,0 +1,251 @@
+/**
+ * approval.test.ts — Contract tests for the approval-decision module.
+ *
+ * Covers:
+ * 1. PermissionReply is the sole definer (importable from the contract).
+ * 2. DecisionOutcome → OperatorDecisionState mapping (table-driven, all 5 variants).
+ * 3. Exhaustiveness: all 5 known DecisionOutcome variants are handled.
+ * 4. Security (R7): structural scan — no `decidedBy: string` parameter in
+ *    approval-decision source files.
+ */
+
+import type {DecisionOutcome} from '../approvals/registry.js'
+import type {DecisionInput, OperatorDecisionState, PermissionReply} from './approval.js'
+
+import {readFileSync} from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {describe, expect, it} from 'vitest'
+import {toOperatorDecisionState} from './approval.js'
+
+// ---------------------------------------------------------------------------
+// 1. PermissionReply — sole definer, importable from the contract
+// ---------------------------------------------------------------------------
+
+describe('PermissionReply', () => {
+  it('is importable from the contract module', () => {
+    // #given — the contract module exports PermissionReply
+    // #when — we import it (type-level; runtime check via assignability)
+    // #then — the three valid verbs are assignable to PermissionReply
+    const once: PermissionReply = 'once'
+    const always: PermissionReply = 'always'
+    const reject: PermissionReply = 'reject'
+
+    // Runtime non-vacuousness: the values are what they say they are
+    expect(once).toBe('once')
+    expect(always).toBe('always')
+    expect(reject).toBe('reject')
+  })
+
+  it('is also importable from the contract barrel (index.ts)', async () => {
+    // #given — the barrel re-exports approval symbols
+    // #when — we import PermissionReply-related exports from the barrel
+    const barrel = await import('./index.js')
+
+    // #then — toOperatorDecisionState is exported (proves the barrel wires approval.ts)
+    expect(typeof barrel.toOperatorDecisionState).toBe('function')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. DecisionOutcome → OperatorDecisionState mapping (table-driven)
+// ---------------------------------------------------------------------------
+
+describe('toOperatorDecisionState', () => {
+  const cases: readonly {readonly outcome: DecisionOutcome; readonly expected: OperatorDecisionState}[] = [
+    {outcome: 'ok', expected: 'claimed'},
+    {outcome: 'channel-mismatch', expected: 'scope_mismatch'},
+    // CRITICAL: 'already-claimed' maps to 'already_claimed', NOT 'already_settled'.
+    // The first POST is still in-flight; the entry has NOT settled yet.
+    {outcome: 'already-claimed', expected: 'already_claimed'},
+    {outcome: 'reply-failed', expected: 'failed_to_settle'},
+    {outcome: 'not-found', expected: 'unavailable'},
+  ]
+
+  for (const {outcome, expected} of cases) {
+    it(`maps '${outcome}' → '${expected}'`, () => {
+      // #given — a DecisionOutcome from the registry
+      // #when — mapped to the operator-facing state
+      const result = toOperatorDecisionState(outcome)
+
+      // #then — the operator state matches the documented mapping
+      expect(result).toBe(expected)
+    })
+  }
+
+  it("explicitly asserts 'already-claimed' → 'already_claimed' (NOT 'already_settled')", () => {
+    // #given — the 'already-claimed' outcome (first POST still in-flight, not settled)
+    // #when — mapped
+    const result = toOperatorDecisionState('already-claimed')
+
+    // #then — must be 'already_claimed', never 'already_settled'
+    expect(result).toBe('already_claimed')
+    expect(result).not.toBe('already_settled')
+  })
+
+  it("'pending' is NOT produced by the mapping function (it is the pre-decision state)", () => {
+    // #given — all 5 DecisionOutcome variants
+    // #when — each is mapped
+    const results = cases.map(({outcome}) => toOperatorDecisionState(outcome))
+
+    // #then — none of the mapped states is 'pending' (pending has no DecisionOutcome)
+    for (const result of results) {
+      expect(result).not.toBe('pending')
+    }
+  })
+
+  it('handles all 5 known DecisionOutcome variants (exhaustiveness coverage)', () => {
+    // #given — the complete set of DecisionOutcome variants
+    const allOutcomes: readonly DecisionOutcome[] = [
+      'ok',
+      'channel-mismatch',
+      'already-claimed',
+      'reply-failed',
+      'not-found',
+    ]
+
+    // #when — each is mapped
+    // #then — no variant throws (the never guard only fires on unknown variants)
+    for (const outcome of allOutcomes) {
+      expect(() => toOperatorDecisionState(outcome)).not.toThrow()
+    }
+
+    // Non-vacuousness: all 5 variants are covered
+    expect(allOutcomes).toHaveLength(5)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3. DecisionInput — structural shape (R7 load-bearing)
+// ---------------------------------------------------------------------------
+
+describe('DecisionInput', () => {
+  it('requires an actor field (not a free-form decidedBy string)', () => {
+    // #given — a valid DecisionInput with a typed actor
+    const input: DecisionInput = {
+      requestID: 'req-123',
+      approvalScopeId: 'scope-abc',
+      decision: 'once',
+      actor: {kind: 'discord-user', userId: 'u-456'},
+    }
+
+    // #when / #then — the shape is structurally valid
+    expect(input.requestID).toBe('req-123')
+    expect(input.approvalScopeId).toBe('scope-abc')
+    expect(input.decision).toBe('once')
+    expect(input.actor).toEqual({kind: 'discord-user', userId: 'u-456'})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 4. Security (R7): structural scan — no `decidedBy: string` in approval source
+// ---------------------------------------------------------------------------
+
+describe('R7 structural boundary: no decidedBy:string in approval-decision source', () => {
+  const thisDir = path.dirname(fileURLToPath(import.meta.url))
+  // This file lives at packages/gateway/src/operator-contract/ — go up 1 to reach src/
+  const gatewaySrcRoot = path.resolve(thisDir, '..')
+
+  /**
+   * Files to scan for the `decidedBy: string` anti-pattern.
+   * Covers the approval internals and the contract module itself.
+   */
+  const SCAN_TARGETS: readonly string[] = [
+    'approvals/coordinator.ts',
+    'approvals/registry.ts',
+    'approvals/discord-transport.ts',
+    'operator-contract/approval.ts',
+  ]
+
+  /**
+   * Pattern that would indicate a free-form string actor bypassing the
+   * ApprovalActor discriminated union (the R7 anti-pattern).
+   *
+   * Matches `decidedBy` followed by optional whitespace, a colon, optional
+   * whitespace, and `string` — i.e. a parameter or property typed as `string`.
+   */
+  const DECIDED_BY_PATTERN = /decidedBy\s*:\s*string/
+
+  it('no approval-decision source file contains a decidedBy: string parameter', () => {
+    // #given — the approval-decision source files
+    const violations: {file: string; line: number; text: string}[] = []
+
+    for (const relPath of SCAN_TARGETS) {
+      const absPath = path.join(gatewaySrcRoot, relPath)
+      const content = readFileSync(absPath, 'utf8')
+      const lines = content.split('\n')
+
+      for (const [i, line] of lines.entries()) {
+        const trimmed = line.trimStart()
+        // Skip line comments and JSDoc/block comment lines
+        if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) continue
+
+        if (DECIDED_BY_PATTERN.test(line)) {
+          violations.push({file: relPath, line: i + 1, text: line.trim()})
+        }
+      }
+    }
+
+    // #when / #then — zero violations; any match means a free-form string actor
+    // has bypassed the ApprovalActor discriminated union (R7 violation)
+    if (violations.length > 0) {
+      const report = violations.map(v => `  ${v.file}:${v.line}: ${v.text}`).join('\n')
+      throw new Error(
+        `R7 violation: 'decidedBy: string' found in approval-decision source.\n` +
+          `Use 'actor: ApprovalActor' (discriminated union) instead — see DecisionInput.\n\n` +
+          `Violations:\n${report}`,
+      )
+    }
+
+    expect(violations).toHaveLength(0)
+  })
+
+  it('self-test: scanner WOULD flag a decidedBy: string parameter', () => {
+    // #given — a fixture string containing the anti-pattern
+    const fixtureContent = [
+      '// some-handler.ts',
+      'async function handleApproval(requestID: string, decidedBy: string, decision: string) {',
+      '  // ...',
+      '}',
+    ].join('\n')
+
+    // #when — scan the fixture
+    const violations: {line: number; text: string}[] = []
+    for (const [i, line] of fixtureContent.split('\n').entries()) {
+      if (line.trimStart().startsWith('//')) continue
+      if (DECIDED_BY_PATTERN.test(line)) {
+        violations.push({line: i + 1, text: line.trim()})
+      }
+    }
+
+    // #then — the scanner must flag the anti-pattern
+    expect(violations.length).toBeGreaterThan(0)
+    expect(violations[0]?.text).toContain('decidedBy: string')
+  })
+
+  it('self-test: scanner does NOT flag a line comment or JSDoc comment containing decidedBy: string', () => {
+    // #given — a fixture where the pattern only appears in comments
+    const fixtureContent = [
+      '// Previously: decidedBy: string — replaced with actor: ApprovalActor',
+      '/**',
+      ' * Use actor: ApprovalActor instead of decidedBy: string.',
+      ' */',
+      'async function handleApproval(requestID: string, actor: ApprovalActor) {',
+      '  // ...',
+      '}',
+    ].join('\n')
+
+    // #when — scan the fixture
+    const violations: {line: number; text: string}[] = []
+    for (const [i, line] of fixtureContent.split('\n').entries()) {
+      const trimmed = line.trimStart()
+      if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) continue
+      if (DECIDED_BY_PATTERN.test(line)) {
+        violations.push({line: i + 1, text: line.trim()})
+      }
+    }
+
+    // #then — comment lines are skipped; no violation
+    expect(violations).toHaveLength(0)
+  })
+})

--- a/packages/gateway/src/operator-contract/approval.test.ts
+++ b/packages/gateway/src/operator-contract/approval.test.ts
@@ -12,7 +12,7 @@
 import type {DecisionOutcome} from '../approvals/registry.js'
 import type {DecisionInput, OperatorDecisionState, PermissionReply} from './approval.js'
 
-import {accessSync, constants, readFileSync} from 'node:fs'
+import {readFileSync} from 'node:fs'
 import path from 'node:path'
 import {fileURLToPath} from 'node:url'
 import {describe, expect, it} from 'vitest'
@@ -176,16 +176,17 @@ describe('R7 structural boundary: no decidedBy:string in approval-decision sourc
 
       // Existence guard: fail loudly if a scanned file has been renamed or deleted
       // so a rename cannot silently drop coverage.
+      // Read directly and surface a missing/renamed target from the read error
+      // itself — a single read avoids a check-then-read race.
+      let content: string
       try {
-        accessSync(absPath, constants.R_OK)
+        content = readFileSync(absPath, 'utf8')
       } catch {
         throw new Error(
           `R7 scan target no longer exists or is unreadable: ${relPath}\n` +
             `Update SCAN_TARGETS in approval.test.ts to reflect the rename.`,
         )
       }
-
-      const content = readFileSync(absPath, 'utf8')
       const lines = content.split('\n')
 
       for (const [i, line] of lines.entries()) {

--- a/packages/gateway/src/operator-contract/approval.ts
+++ b/packages/gateway/src/operator-contract/approval.ts
@@ -1,0 +1,106 @@
+/**
+ * Approval-decision contract for the operator API surface.
+ *
+ * This module is the **sole definer** of `PermissionReply`.
+ * `packages/gateway/src/approvals/coordinator.ts` re-exports it from here
+ * (not re-declares it) so all 9 existing import sites continue to resolve
+ * `PermissionReply` from `coordinator.js` unchanged — a seam for incremental
+ * migration to direct contract imports in a future pass.
+ *
+ * ### v1.1 promotion candidates (kept in coordinator.ts for v1 to bound fan-out)
+ * - `PermissionRequest`    (11-file fan-out)
+ * - `PermissionReplyEvent` (2-file fan-out)
+ * - `SettlementReason`     (5-file fan-out)
+ */
+
+import type {ApprovalActor, DecisionOutcome} from '../approvals/registry.js'
+
+// ---------------------------------------------------------------------------
+// PermissionReply — sole definer (coordinator.ts re-exports from here)
+// ---------------------------------------------------------------------------
+
+/** Reply verbs accepted by the OpenCode permission reply endpoint. */
+export type PermissionReply = 'once' | 'always' | 'reject'
+
+// ---------------------------------------------------------------------------
+// OperatorDecisionState — operator-facing decision-state set
+// ---------------------------------------------------------------------------
+
+/**
+ * Operator-facing decision states for an approval entry.
+ *
+ * - `pending`         — implied pre-decision state: entry is open, no `DecisionOutcome` yet.
+ *                       NOT produced by `toOperatorDecisionState` (which maps `DecisionOutcome`
+ *                       values only); it is the state before any outcome exists.
+ * - `claimed`         — decision was accepted and the reply was POSTed successfully (`ok`).
+ * - `already_claimed` — a second decision arrived while the first POST was still in-flight;
+ *                       the entry has NOT settled yet (NOT `already_settled`).
+ * - `scope_mismatch`  — the `approvalScopeId` in the decision did not match the registered entry.
+ * - `failed_to_settle`— the reply POST failed (threw or returned `ok:false`).
+ * - `unavailable`     — no entry found for the given `requestID`.
+ *
+ * Note: `expired` is NOT in this set. It is a deadline/settlement-path state
+ * (`SettlementReason 'deadline'`), not a `DecisionOutcome`; if exposed at all
+ * it is derived separately from the deadline path, not from this mapping.
+ */
+export type OperatorDecisionState =
+  | 'pending'
+  | 'claimed'
+  | 'already_claimed'
+  | 'scope_mismatch'
+  | 'failed_to_settle'
+  | 'unavailable'
+
+/**
+ * Map a `DecisionOutcome` (registry-internal) to the operator-facing `OperatorDecisionState`.
+ *
+ * The `never` exhaustiveness guard at the bottom ensures that adding a new
+ * `DecisionOutcome` variant to `registry.ts` without updating this mapping
+ * fails compilation — the constraint is load-bearing.
+ *
+ * `pending` is NOT produced here — it is the implied pre-decision state (open
+ * entry, no `DecisionOutcome`). This function only maps the 5 post-decision outcomes.
+ */
+export function toOperatorDecisionState(outcome: DecisionOutcome): Exclude<OperatorDecisionState, 'pending'> {
+  switch (outcome) {
+    case 'ok':
+      return 'claimed'
+    case 'channel-mismatch':
+      return 'scope_mismatch'
+    case 'already-claimed':
+      // The first POST is still in-flight; the entry has NOT settled yet.
+      // This is NOT 'already_settled'.
+      return 'already_claimed'
+    case 'reply-failed':
+      return 'failed_to_settle'
+    case 'not-found':
+      return 'unavailable'
+    default: {
+      // Exhaustiveness guard: if a new DecisionOutcome variant is added to
+      // registry.ts without a case here, TypeScript will fail to compile.
+      const exhaustiveCheck: never = outcome
+      throw new Error(`toOperatorDecisionState: unhandled DecisionOutcome variant: ${String(exhaustiveCheck)}`)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DecisionInput — makes R7 load-bearing
+// ---------------------------------------------------------------------------
+
+/**
+ * The input shape for an operator approval decision.
+ *
+ * Requires a transport-bound `actor: ApprovalActor` (a discriminated union)
+ * rather than a free-form `decidedBy: string`. This makes the R7 constraint
+ * load-bearing: any new decision entry point that references `DecisionInput`
+ * cannot bypass the fail-closed gate with an untyped string actor.
+ *
+ * Mirrors the args accepted by `registry.handleDecision`.
+ */
+export interface DecisionInput {
+  readonly requestID: string
+  readonly approvalScopeId: string
+  readonly decision: PermissionReply
+  readonly actor: ApprovalActor
+}

--- a/packages/gateway/src/operator-contract/identity.test.ts
+++ b/packages/gateway/src/operator-contract/identity.test.ts
@@ -1,0 +1,70 @@
+import type {WebOperatorActor} from '../approvals/registry.js'
+import type {WebOperatorIdentity} from '../execute/launch-types.js'
+import type {OperatorIdentity} from './identity.js'
+
+import {describe, expectTypeOf, it} from 'vitest'
+
+describe('OperatorIdentity', () => {
+  // #given a concrete web-operator value built against the canonical OperatorIdentity shape
+  const webOperator: OperatorIdentity = {
+    kind: 'web-operator',
+    githubUserId: 42,
+    login: 'octocat',
+    sessionCorrelationId: 'sess-abc',
+  }
+
+  it('is structurally assignable to WebOperatorActor', () => {
+    // #when assigned to WebOperatorActor (the approvals alias)
+    // #then TypeScript accepts the assignment without error
+    expectTypeOf(webOperator).toMatchTypeOf<WebOperatorActor>()
+  })
+
+  it('is structurally assignable to WebOperatorIdentity', () => {
+    // #when assigned to WebOperatorIdentity (the launch-types alias)
+    // #then TypeScript accepts the assignment without error
+    expectTypeOf(webOperator).toMatchTypeOf<WebOperatorIdentity>()
+  })
+
+  it('webOperatorActor is assignable to OperatorIdentity (bidirectional equivalence)', () => {
+    // #given a value typed as WebOperatorActor
+    const actor: WebOperatorActor = webOperator
+    // #when checked against OperatorIdentity
+    // #then the types are structurally equivalent
+    expectTypeOf(actor).toMatchTypeOf<OperatorIdentity>()
+  })
+
+  it('webOperatorIdentity is assignable to OperatorIdentity (bidirectional equivalence)', () => {
+    // #given a value typed as WebOperatorIdentity
+    const identity: WebOperatorIdentity = webOperator
+    // #when checked against OperatorIdentity
+    // #then the types are structurally equivalent
+    expectTypeOf(identity).toMatchTypeOf<OperatorIdentity>()
+  })
+
+  it('discriminant kind narrows correctly', () => {
+    // #given a union that includes OperatorIdentity alongside a distinct variant
+    interface OtherVariant {
+      readonly kind: 'discord-user'
+      readonly userId: string
+    }
+    type IdentityUnion = OperatorIdentity | OtherVariant
+
+    const value: IdentityUnion = webOperator
+
+    if (value.kind === 'web-operator') {
+      // #when narrowed by the discriminant
+      // #then all OperatorIdentity fields are accessible
+      expectTypeOf(value).toMatchTypeOf<OperatorIdentity>()
+      expectTypeOf(value.githubUserId).toBeNumber()
+      expectTypeOf(value.login).toBeString()
+      expectTypeOf(value.sessionCorrelationId).toBeString()
+    }
+  })
+
+  it('kind literal is exactly web-operator', () => {
+    // #given the canonical identity
+    // #when the kind field is inspected
+    // #then it is the exact literal type 'web-operator'
+    expectTypeOf(webOperator.kind).toEqualTypeOf<'web-operator'>()
+  })
+})

--- a/packages/gateway/src/operator-contract/identity.ts
+++ b/packages/gateway/src/operator-contract/identity.ts
@@ -1,0 +1,33 @@
+/**
+ * Canonical operator identity for the web control surface.
+ *
+ * `OperatorIdentity` is the single structural definer of the
+ * `{kind:'web-operator', githubUserId, login, sessionCorrelationId}` shape.
+ * All other gateway types that carry this shape (`WebOperatorActor`,
+ * `WebOperatorIdentity`) are type aliases that point here — they are NOT
+ * independent declarations.
+ *
+ * Discriminated on `kind: 'web-operator'` so future operator variants
+ * (e.g. `kind: 'api-key-operator'`) can extend the union without forking
+ * the existing shape.
+ */
+export interface OperatorIdentity {
+  readonly kind: 'web-operator'
+  /**
+   * Stable GitHub numeric user ID (from the GitHub API `id` field).
+   * Used for authorization, audit, and idempotency key scoping.
+   * Prefer this over `login` for any access-control or audit decision.
+   */
+  readonly githubUserId: number
+  /**
+   * GitHub display login (e.g. `'octocat'`).
+   * Mutable — use only for human-readable logs and display metadata.
+   * Never use for authorization or audit identity.
+   */
+  readonly login: string
+  /**
+   * Opaque session correlation value for log correlation.
+   * Not used for authorization — use `githubUserId` instead.
+   */
+  readonly sessionCorrelationId: string
+}

--- a/packages/gateway/src/operator-contract/index.ts
+++ b/packages/gateway/src/operator-contract/index.ts
@@ -14,6 +14,8 @@
  * redaction modules land.
  */
 
+export type {DecisionInput, OperatorDecisionState, PermissionReply} from './approval.js'
+export {toOperatorDecisionState} from './approval.js'
 export type {OperatorIdentity} from './identity.js'
 export type {OperatorRunStatus, OperatorWebStatus, RunPhase, Surface} from './run-status.js'
 export {toOperatorRunStatus} from './run-status.js'

--- a/packages/gateway/src/operator-contract/index.ts
+++ b/packages/gateway/src/operator-contract/index.ts
@@ -17,6 +17,8 @@
 export type {DecisionInput, OperatorDecisionState, PermissionReply} from './approval.js'
 export {toOperatorDecisionState} from './approval.js'
 export type {OperatorIdentity} from './identity.js'
+export {parseOperatorCsrfToken, parseOperatorError, parseOperatorOk, parseOperatorSessionInfo} from './parse.js'
+export type {OperatorCsrfToken, OperatorError, OperatorOk, OperatorSessionInfo} from './responses.js'
 export type {OperatorRunStatus, OperatorWebStatus, RunPhase, Surface} from './run-status.js'
 export {toOperatorRunStatus} from './run-status.js'
 export {OPERATOR_CONTRACT_VERSION} from './version.js'

--- a/packages/gateway/src/operator-contract/index.ts
+++ b/packages/gateway/src/operator-contract/index.ts
@@ -18,6 +18,8 @@ export type {DecisionInput, OperatorDecisionState, PermissionReply} from './appr
 export {toOperatorDecisionState} from './approval.js'
 export type {OperatorIdentity} from './identity.js'
 export {parseOperatorCsrfToken, parseOperatorError, parseOperatorOk, parseOperatorSessionInfo} from './parse.js'
+export {assertRedactionApplied, AUTHORIZATION_OBLIGATION, REDACTION_OBLIGATION} from './redaction.js'
+export type {RedactionContext} from './redaction.js'
 export type {OperatorCsrfToken, OperatorError, OperatorOk, OperatorSessionInfo} from './responses.js'
 export type {OperatorRunStatus, OperatorWebStatus, RunPhase, Surface} from './run-status.js'
 export {toOperatorRunStatus} from './run-status.js'

--- a/packages/gateway/src/operator-contract/index.ts
+++ b/packages/gateway/src/operator-contract/index.ts
@@ -15,4 +15,6 @@
  */
 
 export type {OperatorIdentity} from './identity.js'
+export type {OperatorRunStatus, OperatorWebStatus, RunPhase, Surface} from './run-status.js'
+export {toOperatorRunStatus} from './run-status.js'
 export {OPERATOR_CONTRACT_VERSION} from './version.js'

--- a/packages/gateway/src/operator-contract/index.ts
+++ b/packages/gateway/src/operator-contract/index.ts
@@ -14,4 +14,5 @@
  * redaction modules land.
  */
 
+export type {OperatorIdentity} from './identity.js'
 export {OPERATOR_CONTRACT_VERSION} from './version.js'

--- a/packages/gateway/src/operator-contract/index.ts
+++ b/packages/gateway/src/operator-contract/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Single public import authority for the operator API contract.
+ *
+ * The gateway owns this contract. Downstream consumers (e.g. the dashboard) pin
+ * OPERATOR_CONTRACT_VERSION and import all operator-surface types from this barrel.
+ *
+ * Design constraints:
+ * - Effect Schema is never part of the exported surface (plain TS + Result only).
+ * - All exported types are transport-stable; internal coordination fields are excluded
+ *   by construction.
+ * - The contract version is build-time pinned and never negotiated over the wire.
+ *
+ * Later units will grow this barrel as identity, run-status, approval, response, and
+ * redaction modules land.
+ */
+
+export {OPERATOR_CONTRACT_VERSION} from './version.js'

--- a/packages/gateway/src/operator-contract/parse.test.ts
+++ b/packages/gateway/src/operator-contract/parse.test.ts
@@ -111,6 +111,32 @@ describe('parseOperatorSessionInfo — missing fields', () => {
   })
 })
 
+describe('parseOperatorSessionInfo — numeric guard hardening (NaN / Infinity / float)', () => {
+  it('returns err when operatorId is NaN (not a valid integer id)', () => {
+    // #given — NaN passes typeof === 'number' but is not a valid GitHub user id
+    const input = {operatorId: Number.NaN, login: 'octocat', expiresAt: 1_700_000_000_000}
+
+    // #when / #then
+    expect(parseOperatorSessionInfo(input).success).toBe(false)
+  })
+
+  it('returns err when operatorId is a float (GitHub user ids are integers)', () => {
+    // #given — 42.5 passes typeof === 'number' but is not an integer id
+    const input = {operatorId: 42.5, login: 'octocat', expiresAt: 1_700_000_000_000}
+
+    // #when / #then
+    expect(parseOperatorSessionInfo(input).success).toBe(false)
+  })
+
+  it('returns err when expiresAt is Infinity (not a finite ms timestamp)', () => {
+    // #given — Infinity passes typeof === 'number' but is not a valid timestamp
+    const input = {operatorId: 42, login: 'octocat', expiresAt: Infinity}
+
+    // #when / #then
+    expect(parseOperatorSessionInfo(input).success).toBe(false)
+  })
+})
+
 describe('parseOperatorSessionInfo — wrong-typed fields', () => {
   it('returns err when operatorId is a string instead of number', () => {
     // #given
@@ -357,6 +383,41 @@ describe('parseOperatorOk — error paths', () => {
 
   it('returns err when ok is a string', () => {
     expect(parseOperatorOk({ok: 'true'}).success).toBe(false)
+  })
+
+  it('no-oracle: error message does not echo sensitive input values', () => {
+    // #given — a crafted malicious input: ok is a wrong type embedding a sensitive value
+    const input = {ok: 'ghs_DEADBEEF_SECRET_TOKEN', extra: 'ghp_ANOTHER_SECRET'}
+
+    // #when
+    const result = parseOperatorOk(input)
+
+    // #then — must be an error (ok is not true)
+    expect(result.success).toBe(false)
+    const message = result.success === false ? result.error.message : ''
+    // The error message must NOT echo any part of the crafted input
+    expect(message).not.toContain('ghs_DEADBEEF_SECRET_TOKEN')
+    expect(message).not.toContain('ghp_ANOTHER_SECRET')
+    expect(message).not.toContain('ghs_')
+    expect(message).not.toContain('ghp_')
+    expect(message.length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Barrel re-export smoke test
+// ---------------------------------------------------------------------------
+
+describe('barrel re-exports', () => {
+  it('parse functions are importable from the contract barrel (index.ts)', async () => {
+    // #given — the public barrel for the operator-contract module
+    const barrel = await import('./index.js')
+
+    // #when / #then — all four parse functions are present and callable
+    expect(typeof barrel.parseOperatorSessionInfo).toBe('function')
+    expect(typeof barrel.parseOperatorCsrfToken).toBe('function')
+    expect(typeof barrel.parseOperatorOk).toBe('function')
+    expect(typeof barrel.parseOperatorError).toBe('function')
   })
 })
 

--- a/packages/gateway/src/operator-contract/parse.test.ts
+++ b/packages/gateway/src/operator-contract/parse.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Tests for operator response type validators (parse.ts).
+ *
+ * Covers:
+ *   - Happy path: valid payloads parse to ok(value).
+ *   - Edge: missing fields, wrong-typed fields, extra fields.
+ *   - Security NO-ORACLE: every error path is driven with crafted malicious inputs
+ *     that embed sensitive substrings. The resulting Error.message must NEVER echo
+ *     any part of the input — not field values, not token prefixes, not secrets.
+ *
+ * Extra-field policy: IGNORE extra fields (permissive structural subtyping).
+ * Rationale: mirrors parseRunState's stance — the guard checks only the required
+ * fields; unknown extra fields are silently ignored. This is safe because the
+ * parsed value is typed as the interface (extra fields are not accessible via the
+ * type) and the validator never echoes input back.
+ *
+ * Uses BDD comments (#given, #when, #then).
+ */
+
+import {describe, expect, it} from 'vitest'
+import {parseOperatorCsrfToken, parseOperatorError, parseOperatorOk, parseOperatorSessionInfo} from './parse.js'
+
+// ---------------------------------------------------------------------------
+// parseOperatorSessionInfo — happy path
+// ---------------------------------------------------------------------------
+
+describe('parseOperatorSessionInfo — happy path', () => {
+  it('returns ok(value) for a valid OperatorSessionInfo payload', () => {
+    // #given
+    const input = {operatorId: 42, login: 'octocat', expiresAt: 1_700_000_000_000}
+
+    // #when
+    const result = parseOperatorSessionInfo(input)
+
+    // #then
+    expect(result.success).toBe(true)
+    expect(result.success && result.data).toEqual({operatorId: 42, login: 'octocat', expiresAt: 1_700_000_000_000})
+  })
+
+  it('ignores extra fields (permissive structural subtyping)', () => {
+    // #given — extra field present
+    const input = {operatorId: 1, login: 'user', expiresAt: 9999, extra: 'ignored'}
+
+    // #when
+    const result = parseOperatorSessionInfo(input)
+
+    // #then — parses successfully; extra field is not in the typed result
+    expect(result.success).toBe(true)
+    expect(result.success && result.data.operatorId).toBe(1)
+    expect(result.success && result.data.login).toBe('user')
+    expect(result.success && result.data.expiresAt).toBe(9999)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseOperatorSessionInfo — missing / wrong-typed fields
+// ---------------------------------------------------------------------------
+
+describe('parseOperatorSessionInfo — missing fields', () => {
+  it('returns err when operatorId is missing', () => {
+    // #given
+    const input = {login: 'octocat', expiresAt: 1_700_000_000_000}
+
+    // #when
+    const result = parseOperatorSessionInfo(input)
+
+    // #then
+    expect(result.success).toBe(false)
+  })
+
+  it('returns err when login is missing', () => {
+    // #given
+    const input = {operatorId: 42, expiresAt: 1_700_000_000_000}
+
+    // #when
+    const result = parseOperatorSessionInfo(input)
+
+    // #then
+    expect(result.success).toBe(false)
+  })
+
+  it('returns err when expiresAt is missing', () => {
+    // #given
+    const input = {operatorId: 42, login: 'octocat'}
+
+    // #when
+    const result = parseOperatorSessionInfo(input)
+
+    // #then
+    expect(result.success).toBe(false)
+  })
+
+  it('returns err for null input', () => {
+    // #given / #when / #then
+    expect(parseOperatorSessionInfo(null).success).toBe(false)
+  })
+
+  it('returns err for non-object input (string)', () => {
+    // #given / #when / #then
+    expect(parseOperatorSessionInfo('not an object').success).toBe(false)
+  })
+
+  it('returns err for non-object input (number)', () => {
+    // #given / #when / #then
+    expect(parseOperatorSessionInfo(42).success).toBe(false)
+  })
+
+  it('returns err for array input', () => {
+    // #given / #when / #then
+    expect(parseOperatorSessionInfo([]).success).toBe(false)
+  })
+})
+
+describe('parseOperatorSessionInfo — wrong-typed fields', () => {
+  it('returns err when operatorId is a string instead of number', () => {
+    // #given
+    const input = {operatorId: '42', login: 'octocat', expiresAt: 1_700_000_000_000}
+
+    // #when / #then
+    expect(parseOperatorSessionInfo(input).success).toBe(false)
+  })
+
+  it('returns err when login is a number instead of string', () => {
+    // #given
+    const input = {operatorId: 42, login: 99, expiresAt: 1_700_000_000_000}
+
+    // #when / #then
+    expect(parseOperatorSessionInfo(input).success).toBe(false)
+  })
+
+  it('returns err when expiresAt is a string instead of number', () => {
+    // #given
+    const input = {operatorId: 42, login: 'octocat', expiresAt: '1700000000000'}
+
+    // #when / #then
+    expect(parseOperatorSessionInfo(input).success).toBe(false)
+  })
+
+  it('returns err when operatorId is null', () => {
+    // #given
+    const input = {operatorId: null, login: 'octocat', expiresAt: 1_700_000_000_000}
+
+    // #when / #then
+    expect(parseOperatorSessionInfo(input).success).toBe(false)
+  })
+
+  it('returns err when login is null', () => {
+    // #given
+    const input = {operatorId: 42, login: null, expiresAt: 1_700_000_000_000}
+
+    // #when / #then
+    expect(parseOperatorSessionInfo(input).success).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Security NO-ORACLE: error messages must NEVER echo input
+// ---------------------------------------------------------------------------
+
+describe('parseOperatorSessionInfo — no-oracle: error messages never echo input', () => {
+  /**
+   * Sensitive substrings that must NEVER appear in any error message.
+   * These simulate real secrets that could appear in crafted inputs.
+   */
+  const SENSITIVE_SUBSTRINGS = [
+    'ghs_DEADBEEF',
+    'ghp_SECRET',
+    'Bearer abc123',
+    'sessionCorrelationId-XYZ',
+    'raw-cookie-value=abc',
+    'Authorization: Bearer',
+    'X-CSRF-Token: tok123',
+  ]
+
+  /**
+   * Crafted malicious inputs — each embeds sensitive substrings in field values
+   * or as the entire input. Every error path is exercised.
+   */
+  const maliciousInputs: {label: string; input: unknown}[] = [
+    // Non-object inputs with sensitive values
+    {label: 'sensitive string as input', input: 'ghs_DEADBEEF'},
+    {label: 'sensitive string as input (ghp)', input: 'ghp_SECRET'},
+    {label: 'bearer token as input', input: 'Bearer abc123'},
+
+    // Object with wrong-typed operatorId containing sensitive value
+    {
+      label: 'operatorId is sensitive string',
+      input: {operatorId: 'ghs_DEADBEEF', login: 'octocat', expiresAt: 1_000_000},
+    },
+    {
+      label: 'operatorId is bearer token',
+      input: {operatorId: 'Bearer abc123', login: 'octocat', expiresAt: 1_000_000},
+    },
+
+    // Object with wrong-typed login containing sensitive value
+    {
+      label: 'login is sensitive number (ghp prefix in operatorId)',
+      input: {operatorId: 'ghp_SECRET', login: 42, expiresAt: 1_000_000},
+    },
+    {
+      label: 'login is null with sensitive operatorId',
+      input: {operatorId: 'sessionCorrelationId-XYZ', login: null, expiresAt: 1_000_000},
+    },
+
+    // Object with wrong-typed expiresAt containing sensitive value
+    {
+      label: 'expiresAt is sensitive string',
+      input: {operatorId: 42, login: 'octocat', expiresAt: 'raw-cookie-value=abc'},
+    },
+    {
+      label: 'expiresAt is bearer token string',
+      input: {operatorId: 42, login: 'octocat', expiresAt: 'Authorization: Bearer'},
+    },
+
+    // Missing fields with sensitive values in present fields
+    {
+      label: 'missing expiresAt, login contains sensitive value',
+      input: {operatorId: 42, login: 'X-CSRF-Token: tok123'},
+    },
+    {
+      label: 'missing login, operatorId contains sensitive string',
+      input: {operatorId: 'ghs_DEADBEEF', expiresAt: 1_000_000},
+    },
+
+    // Deeply nested sensitive values
+    {
+      label: 'all fields wrong type with sensitive values',
+      input: {operatorId: 'ghs_DEADBEEF', login: 'ghp_SECRET', expiresAt: 'Bearer abc123'},
+    },
+
+    // Sensitive value as the entire object (no valid fields)
+    {
+      label: 'object with only sensitive extra fields',
+      input: {secret: 'ghs_DEADBEEF', token: 'ghp_SECRET'},
+    },
+  ]
+
+  for (const {label, input} of maliciousInputs) {
+    it(`error message does not echo input: ${label}`, () => {
+      // #given — a crafted malicious input embedding sensitive substrings
+      // #when
+      const result = parseOperatorSessionInfo(input)
+
+      // #then — must be an error (all these inputs are invalid)
+      expect(result.success).toBe(false)
+      const message = result.success === false ? result.error.message : ''
+
+      // The error message must NOT contain any sensitive substring from the input
+      for (const sensitive of SENSITIVE_SUBSTRINGS) {
+        expect(message).not.toContain(sensitive)
+      }
+
+      // The error message must be a fixed, non-empty reason string
+      expect(message.length).toBeGreaterThan(0)
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// parseOperatorCsrfToken — happy path + error paths
+// ---------------------------------------------------------------------------
+
+describe('parseOperatorCsrfToken — happy path', () => {
+  it('returns ok(value) for a valid OperatorCsrfToken payload', () => {
+    // #given
+    const input = {csrfToken: 'tok.abc.def'}
+
+    // #when
+    const result = parseOperatorCsrfToken(input)
+
+    // #then
+    expect(result.success).toBe(true)
+    expect(result.success && result.data).toEqual({csrfToken: 'tok.abc.def'})
+  })
+
+  it('ignores extra fields', () => {
+    // #given
+    const input = {csrfToken: 'tok.abc.def', extra: 'ignored'}
+
+    // #when
+    const result = parseOperatorCsrfToken(input)
+
+    // #then
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('parseOperatorCsrfToken — error paths', () => {
+  it('returns err for null input', () => {
+    expect(parseOperatorCsrfToken(null).success).toBe(false)
+  })
+
+  it('returns err when csrfToken is missing', () => {
+    expect(parseOperatorCsrfToken({}).success).toBe(false)
+  })
+
+  it('returns err when csrfToken is a number', () => {
+    expect(parseOperatorCsrfToken({csrfToken: 42}).success).toBe(false)
+  })
+
+  it('no-oracle: error message does not echo sensitive csrfToken value', () => {
+    // #given — sensitive value in csrfToken field (wrong type to trigger error)
+    const input = {csrfToken: 42, secret: 'ghs_DEADBEEF'}
+
+    // #when
+    const result = parseOperatorCsrfToken(input)
+
+    // #then
+    expect(result.success).toBe(false)
+    const message = result.success === false ? result.error.message : ''
+    expect(message).not.toContain('ghs_DEADBEEF')
+    expect(message).not.toContain('42')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseOperatorOk — happy path + error paths
+// ---------------------------------------------------------------------------
+
+describe('parseOperatorOk — happy path', () => {
+  it('returns ok(value) for a valid OperatorOk payload', () => {
+    // #given
+    const input = {ok: true}
+
+    // #when
+    const result = parseOperatorOk(input)
+
+    // #then
+    expect(result.success).toBe(true)
+    expect(result.success && result.data).toEqual({ok: true})
+  })
+
+  it('ignores extra fields', () => {
+    // #given
+    const input = {ok: true, extra: 'ignored'}
+
+    // #when
+    const result = parseOperatorOk(input)
+
+    // #then
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('parseOperatorOk — error paths', () => {
+  it('returns err for null input', () => {
+    expect(parseOperatorOk(null).success).toBe(false)
+  })
+
+  it('returns err when ok is false', () => {
+    expect(parseOperatorOk({ok: false}).success).toBe(false)
+  })
+
+  it('returns err when ok is missing', () => {
+    expect(parseOperatorOk({}).success).toBe(false)
+  })
+
+  it('returns err when ok is a string', () => {
+    expect(parseOperatorOk({ok: 'true'}).success).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseOperatorError — happy path + error paths
+// ---------------------------------------------------------------------------
+
+describe('parseOperatorError — happy path', () => {
+  it('returns ok(value) for a valid OperatorError payload', () => {
+    // #given
+    const input = {error: 'unauthorized'}
+
+    // #when
+    const result = parseOperatorError(input)
+
+    // #then
+    expect(result.success).toBe(true)
+    expect(result.success && result.data).toEqual({error: 'unauthorized'})
+  })
+
+  it('ignores extra fields', () => {
+    // #given
+    const input = {error: 'bad request', extra: 'ignored'}
+
+    // #when
+    const result = parseOperatorError(input)
+
+    // #then
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('parseOperatorError — error paths', () => {
+  it('returns err for null input', () => {
+    expect(parseOperatorError(null).success).toBe(false)
+  })
+
+  it('returns err when error field is missing', () => {
+    expect(parseOperatorError({}).success).toBe(false)
+  })
+
+  it('returns err when error field is a number', () => {
+    expect(parseOperatorError({error: 42}).success).toBe(false)
+  })
+
+  it('no-oracle: error message does not echo sensitive error field value', () => {
+    // #given — sensitive value in error field (wrong type to trigger error)
+    const input = {error: 42, secret: 'ghp_SECRET'}
+
+    // #when
+    const result = parseOperatorError(input)
+
+    // #then
+    expect(result.success).toBe(false)
+    const message = result.success === false ? result.error.message : ''
+    expect(message).not.toContain('ghp_SECRET')
+    expect(message).not.toContain('42')
+  })
+})

--- a/packages/gateway/src/operator-contract/parse.ts
+++ b/packages/gateway/src/operator-contract/parse.ts
@@ -32,8 +32,10 @@ function hasValidOperatorSessionInfoShape(value: unknown): value is OperatorSess
   const candidate = value as Record<string, unknown>
   return (
     typeof candidate.operatorId === 'number' &&
+    Number.isInteger(candidate.operatorId) &&
     typeof candidate.login === 'string' &&
-    typeof candidate.expiresAt === 'number'
+    typeof candidate.expiresAt === 'number' &&
+    Number.isFinite(candidate.expiresAt)
   )
 }
 

--- a/packages/gateway/src/operator-contract/parse.ts
+++ b/packages/gateway/src/operator-contract/parse.ts
@@ -1,0 +1,137 @@
+/**
+ * Runtime validators for operator HTTP response types.
+ *
+ * Each validator is a hand-rolled type-guard + parse function that returns
+ * Result<T, Error>. The pattern mirrors parseRunState in
+ * packages/runtime/src/coordination/run-state.ts.
+ *
+ * Design constraints:
+ * - Effect Schema is never used here — exported surface is plain TS + Result only.
+ * - NO-ORACLE: error messages are FIXED reason strings. They never echo, interpolate,
+ *   or stringify any part of the input. Even a garbled fragment is forbidden.
+ * - Extra-field policy: IGNORE extra fields (permissive structural subtyping).
+ *   The guard checks only the required fields; unknown extra fields are silently
+ *   ignored. The parsed value is typed as the interface, so extra fields are not
+ *   accessible via the type.
+ */
+
+import type {Result} from '@fro-bot/runtime'
+import type {OperatorCsrfToken, OperatorError, OperatorOk, OperatorSessionInfo} from './responses.js'
+
+import {err, ok} from '@fro-bot/runtime'
+
+// ---------------------------------------------------------------------------
+// OperatorSessionInfo
+// ---------------------------------------------------------------------------
+
+function hasValidOperatorSessionInfoShape(value: unknown): value is OperatorSessionInfo {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const candidate = value as Record<string, unknown>
+  return (
+    typeof candidate.operatorId === 'number' &&
+    typeof candidate.login === 'string' &&
+    typeof candidate.expiresAt === 'number'
+  )
+}
+
+/**
+ * Parse an unknown value as OperatorSessionInfo.
+ *
+ * Returns ok(value) when the input has the required shape.
+ * Returns err(Error) with a FIXED reason string when validation fails —
+ * the error message never echoes any part of the input.
+ */
+export function parseOperatorSessionInfo(input: unknown): Result<OperatorSessionInfo, Error> {
+  if (hasValidOperatorSessionInfoShape(input) === false) {
+    return err(new Error('invalid operator session info shape'))
+  }
+
+  return ok(input)
+}
+
+// ---------------------------------------------------------------------------
+// OperatorCsrfToken
+// ---------------------------------------------------------------------------
+
+function hasValidOperatorCsrfTokenShape(value: unknown): value is OperatorCsrfToken {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const candidate = value as Record<string, unknown>
+  return typeof candidate.csrfToken === 'string'
+}
+
+/**
+ * Parse an unknown value as OperatorCsrfToken.
+ *
+ * Returns ok(value) when the input has the required shape.
+ * Returns err(Error) with a FIXED reason string when validation fails —
+ * the error message never echoes any part of the input.
+ */
+export function parseOperatorCsrfToken(input: unknown): Result<OperatorCsrfToken, Error> {
+  if (hasValidOperatorCsrfTokenShape(input) === false) {
+    return err(new Error('invalid operator csrf token shape'))
+  }
+
+  return ok(input)
+}
+
+// ---------------------------------------------------------------------------
+// OperatorOk
+// ---------------------------------------------------------------------------
+
+function hasValidOperatorOkShape(value: unknown): value is OperatorOk {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const candidate = value as Record<string, unknown>
+  return candidate.ok === true
+}
+
+/**
+ * Parse an unknown value as OperatorOk.
+ *
+ * Returns ok(value) when the input has the required shape ({ ok: true }).
+ * Returns err(Error) with a FIXED reason string when validation fails —
+ * the error message never echoes any part of the input.
+ */
+export function parseOperatorOk(input: unknown): Result<OperatorOk, Error> {
+  if (hasValidOperatorOkShape(input) === false) {
+    return err(new Error('invalid operator ok shape'))
+  }
+
+  return ok(input)
+}
+
+// ---------------------------------------------------------------------------
+// OperatorError
+// ---------------------------------------------------------------------------
+
+function hasValidOperatorErrorShape(value: unknown): value is OperatorError {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const candidate = value as Record<string, unknown>
+  return typeof candidate.error === 'string'
+}
+
+/**
+ * Parse an unknown value as OperatorError.
+ *
+ * Returns ok(value) when the input has the required shape.
+ * Returns err(Error) with a FIXED reason string when validation fails —
+ * the error message never echoes any part of the input.
+ */
+export function parseOperatorError(input: unknown): Result<OperatorError, Error> {
+  if (hasValidOperatorErrorShape(input) === false) {
+    return err(new Error('invalid operator error shape'))
+  }
+
+  return ok(input)
+}

--- a/packages/gateway/src/operator-contract/redaction.test.ts
+++ b/packages/gateway/src/operator-contract/redaction.test.ts
@@ -1,0 +1,138 @@
+/**
+ * redaction.test.ts — Contract tests for the redaction + authorization obligation clauses.
+ *
+ * Covers:
+ * 1. REDACTION_OBLIGATION is exported, non-empty, and references the four operational rules.
+ * 2. assertRedactionApplied throws by default (fail-closed stub is live, not a no-op).
+ * 3. AUTHORIZATION_OBLIGATION is exported and references the sole-gate + two constraints.
+ * 4. All three symbols are wired into the barrel (index.ts).
+ *
+ * Uses BDD comments (#given, #when, #then).
+ */
+
+import {describe, expect, it} from 'vitest'
+import {assertRedactionApplied, AUTHORIZATION_OBLIGATION, REDACTION_OBLIGATION} from './redaction.js'
+
+// ---------------------------------------------------------------------------
+// 1. REDACTION_OBLIGATION — exported, non-empty, references the four rules
+// ---------------------------------------------------------------------------
+
+describe('REDACTION_OBLIGATION', () => {
+  it('is exported and non-empty', () => {
+    // #given — the redaction obligation constant
+    // #when — read at import time
+    // #then — it is a non-empty string
+    expect(typeof REDACTION_OBLIGATION).toBe('string')
+    expect(REDACTION_OBLIGATION.length).toBeGreaterThan(0)
+  })
+
+  it('references the denylist-before-query rule', () => {
+    // #given — the redaction obligation constant
+    // #when — inspected for the denylist-before-query rule
+    // #then — the rule is present (case-insensitive to allow natural prose)
+    expect(REDACTION_OBLIGATION.toLowerCase()).toContain('denylist')
+  })
+
+  it('references the fail-closed rule', () => {
+    // #given — the redaction obligation constant
+    // #when — inspected for the fail-closed rule
+    // #then — the rule is present
+    expect(REDACTION_OBLIGATION.toLowerCase()).toContain('fail-closed')
+  })
+
+  it('references the format-stable / node_id rule', () => {
+    // #given — the redaction obligation constant
+    // #when — inspected for the node_id format-skew rule
+    // #then — node_id is mentioned (the format-stable deny-key rule)
+    expect(REDACTION_OBLIGATION.toLowerCase()).toContain('node_id')
+  })
+
+  it('references checkRepoAuthz (composes alongside, not instead of)', () => {
+    // #given — the redaction obligation constant
+    // #when — inspected for the checkRepoAuthz composition rule
+    // #then — checkRepoAuthz is mentioned
+    expect(REDACTION_OBLIGATION).toContain('checkRepoAuthz')
+  })
+
+  it('is importable from the contract barrel (index.ts)', async () => {
+    // #given — the public barrel for the operator-contract module
+    // #when — REDACTION_OBLIGATION is imported from the barrel
+    const barrel = await import('./index.js')
+
+    // #then — it is present and matches the direct import
+    expect(barrel.REDACTION_OBLIGATION).toBe(REDACTION_OBLIGATION)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. assertRedactionApplied — fail-closed stub throws by default
+// ---------------------------------------------------------------------------
+
+describe('assertRedactionApplied', () => {
+  it('throws by default (fail-closed stub is live, not a no-op)', () => {
+    // #given — the fail-closed redaction stub
+    // #when — called with any context
+    // #then — it throws with the REDACTION_GATE_NOT_IMPLEMENTED message
+    expect(() => assertRedactionApplied({repoRef: 'owner/repo'})).toThrow('REDACTION_GATE_NOT_IMPLEMENTED')
+  })
+
+  it('throws an Error instance (not a string throw)', () => {
+    // #given — the fail-closed redaction stub
+    // #when — called
+    // #then — the thrown value is an Error
+    expect(() => assertRedactionApplied({repoRef: 'owner/repo'})).toThrow(Error)
+  })
+
+  it('is importable from the contract barrel (index.ts)', async () => {
+    // #given — the public barrel for the operator-contract module
+    // #when — assertRedactionApplied is imported from the barrel
+    const barrel = await import('./index.js')
+
+    // #then — it is present and is a function
+    expect(typeof barrel.assertRedactionApplied).toBe('function')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3. AUTHORIZATION_OBLIGATION — exported, references sole-gate + two constraints
+// ---------------------------------------------------------------------------
+
+describe('AUTHORIZATION_OBLIGATION', () => {
+  it('is exported and non-empty', () => {
+    // #given — the authorization obligation constant
+    // #when — read at import time
+    // #then — it is a non-empty string
+    expect(typeof AUTHORIZATION_OBLIGATION).toBe('string')
+    expect(AUTHORIZATION_OBLIGATION.length).toBeGreaterThan(0)
+  })
+
+  it('references the sole approval gate (registry.handleDecision)', () => {
+    // #given — the authorization obligation constant
+    // #when — inspected for the sole-gate reference
+    // #then — handleDecision is mentioned
+    expect(AUTHORIZATION_OBLIGATION).toContain('handleDecision')
+  })
+
+  it('references the version-not-over-wire constraint', () => {
+    // #given — the authorization obligation constant
+    // #when — inspected for the version constraint
+    // #then — the wire constraint is mentioned
+    expect(AUTHORIZATION_OBLIGATION.toLowerCase()).toContain('wire')
+  })
+
+  it('references the identity-server-constructed constraint', () => {
+    // #given — the authorization obligation constant
+    // #when — inspected for the server-side identity construction constraint
+    // #then — server-side construction is mentioned
+    expect(AUTHORIZATION_OBLIGATION.toLowerCase()).toContain('server-side')
+  })
+
+  it('is importable from the contract barrel (index.ts)', async () => {
+    // #given — the public barrel for the operator-contract module
+    // #when — AUTHORIZATION_OBLIGATION is imported from the barrel
+    const barrel = await import('./index.js')
+
+    // #then — it is present and matches the direct import
+    expect(barrel.AUTHORIZATION_OBLIGATION).toBe(AUTHORIZATION_OBLIGATION)
+  })
+})

--- a/packages/gateway/src/operator-contract/redaction.test.ts
+++ b/packages/gateway/src/operator-contract/redaction.test.ts
@@ -83,6 +83,24 @@ describe('assertRedactionApplied', () => {
     expect(() => assertRedactionApplied({repoRef: 'owner/repo'})).toThrow(Error)
   })
 
+  it('(no-oracle) thrown message does NOT echo the repoRef value (stub must not leak repo identity)', () => {
+    // #given — a context with a sensitive repo reference
+    const sensitiveRepoRef = 'secret-org/secret-repo'
+
+    // #when — the stub throws
+    let thrownMessage = ''
+    try {
+      assertRedactionApplied({repoRef: sensitiveRepoRef})
+    } catch (error) {
+      thrownMessage = error instanceof Error ? error.message : String(error)
+    }
+
+    // #then — the message must not contain any part of the repo identity
+    expect(thrownMessage.length).toBeGreaterThan(0)
+    expect(thrownMessage).not.toContain('secret-org')
+    expect(thrownMessage).not.toContain('secret-repo')
+  })
+
   it('is importable from the contract barrel (index.ts)', async () => {
     // #given — the public barrel for the operator-contract module
     // #when — assertRedactionApplied is imported from the barrel
@@ -91,6 +109,11 @@ describe('assertRedactionApplied', () => {
     // #then — it is present and is a function
     expect(typeof barrel.assertRedactionApplied).toBe('function')
   })
+
+  // Deferred behavioral tests — surfaced as durable reminders for the real gate implementation
+  it.todo('omits a denylisted repo run when the real redaction gate is implemented')
+  it.todo('handles node_id format skew when deriving deny keys')
+  it.todo('fails closed when the denylist cannot be read')
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/operator-contract/redaction.ts
+++ b/packages/gateway/src/operator-contract/redaction.ts
@@ -1,7 +1,7 @@
 /**
  * Redaction and authorization obligation clauses for the operator API contract.
  *
- * This module embeds the #950 redaction obligation and the authorization obligation
+ * This module embeds the metadata/repos.yaml redaction obligation and the authorization obligation
  * as normative contract clauses bound to OPERATOR_CONTRACT_VERSION.
  *
  * It does NOT implement the redaction gate itself. The gate ships with the first
@@ -14,7 +14,7 @@
  */
 
 // ---------------------------------------------------------------------------
-// REDACTION_OBLIGATION — normative clause for the #950 redaction invariant
+// REDACTION_OBLIGATION — normative clause for the repo redaction invariant
 // ---------------------------------------------------------------------------
 
 /**
@@ -88,16 +88,16 @@ export interface RedactionContext {
  * denylist-before-query gate (bound alongside checkRepoAuthz). Until then,
  * calling this function always throws.
  *
- * The real gate implementation is deferred to the #950 follow-up task.
+ * The real gate implementation is deferred to the redaction gate follow-up.
  *
- * @param context - The repo reference being accessed.
+ * @param _context - The repo reference being accessed (unused by the stub; the real gate will use it).
  * @throws {Error} Always — until the real gate replaces this stub body.
  */
-export function assertRedactionApplied(context: RedactionContext): void {
+export function assertRedactionApplied(_context: RedactionContext): void {
   throw new Error(
-    `REDACTION_GATE_NOT_IMPLEMENTED: redaction check not yet implemented for repo '${context.repoRef}'. ` +
-      `The first repo-data endpoint must replace this stub with the real denylist-before-query gate ` +
-      `(bound alongside checkRepoAuthz). See REDACTION_OBLIGATION for the four operational rules.`,
+    'REDACTION_GATE_NOT_IMPLEMENTED: redaction check not yet implemented. ' +
+      'The first repo-data endpoint must replace this stub with the real denylist-before-query gate ' +
+      '(bound alongside checkRepoAuthz). See REDACTION_OBLIGATION for the four operational rules.',
   )
 }
 

--- a/packages/gateway/src/operator-contract/redaction.ts
+++ b/packages/gateway/src/operator-contract/redaction.ts
@@ -1,0 +1,143 @@
+/**
+ * Redaction and authorization obligation clauses for the operator API contract.
+ *
+ * This module embeds the #950 redaction obligation and the authorization obligation
+ * as normative contract clauses bound to OPERATOR_CONTRACT_VERSION.
+ *
+ * It does NOT implement the redaction gate itself. The gate ships with the first
+ * repo-data endpoint that needs it. This module provides:
+ *   - REDACTION_OBLIGATION: the normative clause stating the four operational rules.
+ *   - assertRedactionApplied: a fail-closed structural stub that throws by default,
+ *     making the obligation grepable and unskippable.
+ *   - AUTHORIZATION_OBLIGATION: the normative clause for operator decision/launch
+ *     authorization, including the two documented security constraints.
+ */
+
+// ---------------------------------------------------------------------------
+// REDACTION_OBLIGATION — normative clause for the #950 redaction invariant
+// ---------------------------------------------------------------------------
+
+/**
+ * Normative redaction obligation for the operator API contract.
+ *
+ * Any endpoint or projection that surfaces repo data or OperatorRunStatus records
+ * MUST satisfy all four operational rules stated here before exposing any result.
+ *
+ * Four operational rules:
+ *
+ * (a) denylist-before-query: exclude redacted repos BEFORE any per-repo query
+ *     (binding lookups, run-state reads, status/mission projections). Render-time
+ *     filtering is too late — the pre-query gate is the only safe enforcement point.
+ *
+ * (b) format-stable deny keys: handle node_id format skew (MDEw… vs R_kgDO…
+ *     base64 variants); derive numeric database_id for stable matching. Exact-string
+ *     matching on node_id alone is insufficient and will produce false negatives.
+ *
+ * (c) fail-closed: a redacted entry with no usable deny key, or an unreadable
+ *     denylist, MUST DENY — never return an unfiltered union. When in doubt, omit.
+ *
+ * (d) composes alongside checkRepoAuthz (packages/gateway/src/web/auth/repo-authz.ts),
+ *     NOT instead of: checkRepoAuthz proves the operator MAY see a repo; redaction
+ *     proves the repo IS NOT hidden by policy. BOTH must pass before repo data is
+ *     surfaced. The two gates cannot silently diverge.
+ *
+ * Scope: this obligation applies to OperatorRunStatus projections (the entity_ref
+ * leak path) as well as to direct repo-data queries. An OperatorRunStatus record
+ * for a denylisted repo MUST be omitted (null), not returned with a populated entityRef.
+ */
+export const REDACTION_OBLIGATION: string =
+  'Redaction obligation (operator contract v1.0.0): ' +
+  '(a) denylist-before-query — exclude redacted repos BEFORE any per-repo query ' +
+  '(binding lookups, run-state reads, OperatorRunStatus projections); render-time filtering is too late. ' +
+  '(b) format-stable deny keys — handle node_id format skew (MDEw… vs R_kgDO… base64 variants); ' +
+  'derive numeric database_id for stable matching; exact-string matching on node_id alone is insufficient. ' +
+  '(c) fail-closed — a redacted entry with no usable deny key, or an unreadable denylist, MUST DENY; ' +
+  'never return an unfiltered union. ' +
+  '(d) composes alongside checkRepoAuthz (web/auth/repo-authz.ts), NOT instead of: ' +
+  'checkRepoAuthz proves the operator MAY see a repo; redaction proves the repo IS NOT hidden by policy; ' +
+  'BOTH must pass. The two gates cannot silently diverge.'
+
+// ---------------------------------------------------------------------------
+// assertRedactionApplied — fail-closed structural stub
+// ---------------------------------------------------------------------------
+
+/**
+ * Context passed to assertRedactionApplied.
+ *
+ * The first repo-data endpoint MUST replace the stub body with the real
+ * denylist-before-query gate, accepting this context (or a superset of it)
+ * to perform the actual redaction check.
+ */
+export interface RedactionContext {
+  /** The repo reference being accessed, e.g. 'owner/repo'. */
+  readonly repoRef: string
+}
+
+/**
+ * Fail-closed redaction stub — deliberately throws by default.
+ *
+ * This is a structural enforcement point, not a no-op placeholder. Its body
+ * throws `REDACTION_GATE_NOT_IMPLEMENTED` so that any response path that
+ * surfaces repo data without calling this function (or its real replacement)
+ * crashes at runtime. This makes the redaction obligation:
+ *   - Grepable: search for `assertRedactionApplied` to find every call site.
+ *   - Unskippable: a response path that omits the call throws in production.
+ *   - Auditable: the call site is visible in code review.
+ *
+ * The first repo-data endpoint MUST replace this stub's body with the real
+ * denylist-before-query gate (bound alongside checkRepoAuthz). Until then,
+ * calling this function always throws.
+ *
+ * The real gate implementation is deferred to the #950 follow-up task.
+ *
+ * @param context - The repo reference being accessed.
+ * @throws {Error} Always — until the real gate replaces this stub body.
+ */
+export function assertRedactionApplied(context: RedactionContext): void {
+  throw new Error(
+    `REDACTION_GATE_NOT_IMPLEMENTED: redaction check not yet implemented for repo '${context.repoRef}'. ` +
+      `The first repo-data endpoint must replace this stub with the real denylist-before-query gate ` +
+      `(bound alongside checkRepoAuthz). See REDACTION_OBLIGATION for the four operational rules.`,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// AUTHORIZATION_OBLIGATION — normative clause for operator decision/launch authz
+// ---------------------------------------------------------------------------
+
+/**
+ * Normative authorization obligation for the operator API contract.
+ *
+ * Any operator decision or launch MUST satisfy all constraints stated here.
+ *
+ * Core rule: an operator decision/launch MUST carry a transport-bound OperatorIdentity
+ * and DecisionInput (no free-form decidedBy: string). The contract cannot bypass the
+ * fail-closed approval gate. registry.handleDecision is the sole approval gate — all
+ * transports (Discord, web) settle through it; no transport may implement a parallel
+ * settlement path.
+ *
+ * Two documented security constraints:
+ *
+ * (1) Version not over the wire: OPERATOR_CONTRACT_VERSION is build-time pinned and
+ *     never negotiated over the wire. Any endpoint reading a version header MUST reject
+ *     unrecognized versions fail-closed. A client cannot downgrade the contract version
+ *     by supplying a version value in a request header or body.
+ *
+ * (2) Identity server-constructed: OperatorIdentity is always constructed server-side
+ *     from the authenticated session. It is NEVER deserialized from a request payload.
+ *     A request body claiming to carry an OperatorIdentity must be rejected; the
+ *     identity is derived from the session established by the auth flow, not from
+ *     untrusted client input.
+ */
+export const AUTHORIZATION_OBLIGATION: string =
+  'Authorization obligation (operator contract v1.0.0): ' +
+  'An operator decision/launch MUST carry a transport-bound OperatorIdentity and DecisionInput ' +
+  '(no free-form decidedBy: string). The contract cannot bypass the fail-closed approval gate. ' +
+  'registry.handleDecision is the sole approval gate — all transports settle through it; ' +
+  'no transport may implement a parallel settlement path. ' +
+  'Constraint (1) version-not-over-wire: OPERATOR_CONTRACT_VERSION is build-time pinned and never ' +
+  'negotiated over the wire; any endpoint reading a version header MUST reject unrecognized versions ' +
+  'fail-closed; a client cannot downgrade the contract version via a request header or body. ' +
+  'Constraint (2) identity-server-constructed: OperatorIdentity is always constructed server-side ' +
+  'from the authenticated session and is NEVER deserialized from a request payload; ' +
+  'a request body claiming to carry an OperatorIdentity must be rejected.'

--- a/packages/gateway/src/operator-contract/responses.ts
+++ b/packages/gateway/src/operator-contract/responses.ts
@@ -1,0 +1,56 @@
+/**
+ * Named response types for the operator HTTP API surface.
+ *
+ * These are the canonical transport-stable shapes for operator endpoints.
+ * All types are plain TypeScript (no Effect Schema) and are readonly.
+ *
+ * Design constraints:
+ * - Effect Schema is never part of the exported surface (plain TS + Result only).
+ * - All types are transport-stable; internal coordination fields are excluded.
+ * - camelCase keys match the shipped JSON literals exactly.
+ */
+
+/**
+ * Canonical response shape for GET /operator/session.
+ *
+ * - `operatorId`: stable GitHub numeric user ID (from the GitHub API `id` field).
+ *   Prefer this over `login` for any access-control or audit decision.
+ * - `login`: GitHub display login (mutable, for display only).
+ * - `expiresAt`: ms-since-epoch timestamp of the sooner of absolute or idle expiry.
+ */
+export interface OperatorSessionInfo {
+  readonly operatorId: number
+  readonly login: string
+  readonly expiresAt: number
+}
+
+/**
+ * Canonical response shape for GET /operator/session/csrf.
+ *
+ * - `csrfToken`: a fresh signed CSRF token bound to the current session and operator.
+ *   Must be included in the X-CSRF-Token header for mutating requests.
+ */
+export interface OperatorCsrfToken {
+  readonly csrfToken: string
+}
+
+/**
+ * Canonical success response shape for operator routes with no meaningful body.
+ *
+ * Returned by routes that succeed but have nothing to communicate beyond the status.
+ * The `ok: true` literal is load-bearing — it is the discriminant for success.
+ */
+export interface OperatorOk {
+  readonly ok: true
+}
+
+/**
+ * Canonical error response shape for operator routes.
+ *
+ * All operator error responses use this shape. The `error` string is a coarse,
+ * no-oracle reason (e.g. 'unauthorized', 'bad request') — it never echoes input
+ * or includes internal detail.
+ */
+export interface OperatorError {
+  readonly error: string
+}

--- a/packages/gateway/src/operator-contract/run-status.test.ts
+++ b/packages/gateway/src/operator-contract/run-status.test.ts
@@ -26,7 +26,7 @@ const makeRunState = (overrides: Partial<RunState> = {}): RunState => ({
 const BASE_OPTS = {
   nowMs: BASE_NOW_MS,
   staleThresholdMs: 60_000,
-  isRepoDenylisted: false,
+  isRepoDenylisted: () => false,
 }
 
 // ---------------------------------------------------------------------------
@@ -119,8 +119,8 @@ describe('toOperatorRunStatus — redaction (r5/r6)', () => {
     // #given a run whose repo is on the denylist
     const runState = makeRunState({entity_ref: 'secret-org/secret-repo#1'})
 
-    // #when projected with isRepoDenylisted:true
-    const result = toOperatorRunStatus(runState, {...BASE_OPTS, isRepoDenylisted: true})
+    // #when projected with a predicate that always returns true
+    const result = toOperatorRunStatus(runState, {...BASE_OPTS, isRepoDenylisted: () => true})
 
     // #then the record is omitted entirely — null, not a populated status
     expect(result).toBeNull()
@@ -130,8 +130,8 @@ describe('toOperatorRunStatus — redaction (r5/r6)', () => {
     // #given a run whose repo is NOT on the denylist
     const runState = makeRunState({entity_ref: 'public-org/public-repo#5'})
 
-    // #when projected with isRepoDenylisted:false
-    const result = toOperatorRunStatus(runState, {...BASE_OPTS, isRepoDenylisted: false})
+    // #when projected with a predicate that always returns false
+    const result = toOperatorRunStatus(runState, {...BASE_OPTS, isRepoDenylisted: () => false})
 
     // #then the record is populated — not accidentally omitted
     assert(result !== null, 'expected a populated status for a non-denylisted repo')
@@ -142,11 +142,48 @@ describe('toOperatorRunStatus — redaction (r5/r6)', () => {
     // #given an actively-running denylisted run
     const runState = makeRunState({phase: 'EXECUTING', entity_ref: 'hidden/repo#99'})
 
-    // #when projected with isRepoDenylisted:true
-    const result = toOperatorRunStatus(runState, {...BASE_OPTS, isRepoDenylisted: true})
+    // #when projected with a predicate that always returns true
+    const result = toOperatorRunStatus(runState, {...BASE_OPTS, isRepoDenylisted: () => true})
 
     // #then null — the active status must not leak the repo's activity
     expect(result).toBeNull()
+  })
+
+  it('(r6) membership-based predicate gates on entity_ref — denylisted org omitted, public org surfaced', () => {
+    // #given a predicate backed by org-prefix membership (simulates metadata/repos.yaml)
+    const isRepoDenylisted = (ref: string) => ref.startsWith('secret-org/')
+
+    // #given a run in the denylisted org
+    const secretRun = makeRunState({entity_ref: 'secret-org/secret-repo#1'})
+    // #given a run in a public org
+    const publicRun = makeRunState({entity_ref: 'public-org/ok-repo#2'})
+
+    // #when projected with the membership predicate
+    const secretResult = toOperatorRunStatus(secretRun, {...BASE_OPTS, isRepoDenylisted})
+    const publicResult = toOperatorRunStatus(publicRun, {...BASE_OPTS, isRepoDenylisted})
+
+    // #then the denylisted run is omitted
+    expect(secretResult).toBeNull()
+    // #then the public run is surfaced with its entity_ref
+    assert(publicResult !== null, 'expected a populated status for a non-denylisted repo')
+    expect(publicResult.entityRef).toBe('public-org/ok-repo#2')
+  })
+
+  it('(r6) predicate receives the run entity_ref as its argument', () => {
+    // #given a spy predicate that records the argument it was called with
+    const capturedArgs: string[] = []
+    const isRepoDenylisted = (ref: string) => {
+      capturedArgs.push(ref)
+      return false
+    }
+    const runState = makeRunState({entity_ref: 'acme/widget#7'})
+
+    // #when projected
+    toOperatorRunStatus(runState, {...BASE_OPTS, isRepoDenylisted})
+
+    // #then the predicate was called with the run's entity_ref
+    expect(capturedArgs).toHaveLength(1)
+    expect(capturedArgs[0]).toBe('acme/widget#7')
   })
 })
 
@@ -207,6 +244,29 @@ describe('toOperatorRunStatus — stale derivation', () => {
     // #then stale defaults to true (fail-safe — unknown freshness = stale)
     assert(result !== null, 'expected a populated status')
     expect(result.stale).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fail-closed fallback: unknown phase → 'failed'
+// ---------------------------------------------------------------------------
+
+describe('toOperatorRunStatus — unknown phase fallback (fail-closed)', () => {
+  it("returns status 'failed' for an unrecognized phase value (defense-in-depth)", () => {
+    // #given — a RunState carrying an out-of-domain phase (data corruption or a
+    // newer-build phase this version does not know). The cast injects the runtime
+    // value the type system forbids, exercising the ?? 'failed' fallback.
+    const runState: RunState = {
+      ...makeRunState(),
+      phase: 'UNKNOWN_FUTURE_PHASE' as unknown as RunState['phase'],
+    }
+
+    // #when projected with a non-denylisted repo
+    const result = toOperatorRunStatus(runState, BASE_OPTS)
+
+    // #then status falls back to 'failed' (not undefined / not a missing key)
+    expect(result).not.toBeNull()
+    expect(result?.status).toBe('failed')
   })
 })
 

--- a/packages/gateway/src/operator-contract/run-status.test.ts
+++ b/packages/gateway/src/operator-contract/run-status.test.ts
@@ -1,0 +1,226 @@
+import type {RunState} from '@fro-bot/runtime'
+import type {OperatorRunStatus, OperatorWebStatus} from './run-status.js'
+
+import {assert, describe, expect, expectTypeOf, it} from 'vitest'
+import {toOperatorRunStatus} from './run-status.js'
+
+// ---------------------------------------------------------------------------
+// Shared fixture helpers
+// ---------------------------------------------------------------------------
+
+const BASE_NOW_MS = 1_000_000
+
+const makeRunState = (overrides: Partial<RunState> = {}): RunState => ({
+  run_id: 'run-abc-123',
+  surface: 'github',
+  thread_id: 'thread-internal-001',
+  entity_ref: 'owner/repo#42',
+  phase: 'EXECUTING',
+  started_at: '2024-01-01T00:00:00.000Z',
+  last_heartbeat: new Date(BASE_NOW_MS - 1000).toISOString(), // 1 s ago — fresh
+  holder_id: 'holder-internal-xyz',
+  details: {internal: 'secret'},
+  ...overrides,
+})
+
+const BASE_OPTS = {
+  nowMs: BASE_NOW_MS,
+  staleThresholdMs: 60_000,
+  isRepoDenylisted: false,
+}
+
+// ---------------------------------------------------------------------------
+// Phase → web-status mapping table
+// ---------------------------------------------------------------------------
+
+describe('toOperatorRunStatus — phase mapping', () => {
+  const cases: [RunState['phase'], OperatorWebStatus][] = [
+    ['PENDING', 'queued'],
+    ['ACKNOWLEDGED', 'running'],
+    ['EXECUTING', 'running'],
+    ['COMPLETED', 'succeeded'],
+    ['FAILED', 'failed'],
+    ['CANCELLED', 'cancelled'],
+  ]
+
+  for (const [phase, expectedStatus] of cases) {
+    it(`maps ${phase} → '${expectedStatus}'`, () => {
+      // #given a run in phase ${phase}
+      const runState = makeRunState({phase})
+
+      // #when projected with a non-denylisted repo
+      const result = toOperatorRunStatus(runState, BASE_OPTS)
+
+      // #then the web status is ${expectedStatus}
+      assert(result !== null, 'expected a populated status for a non-denylisted repo')
+      expect(result.status).toBe(expectedStatus)
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Operator-safe field projection
+// ---------------------------------------------------------------------------
+
+describe('toOperatorRunStatus — operator-safe fields', () => {
+  it('copies operator-safe fields from RunState', () => {
+    // #given a fully-populated RunState
+    const runState = makeRunState({
+      run_id: 'run-xyz',
+      entity_ref: 'acme/widget#7',
+      surface: 'web',
+      phase: 'EXECUTING',
+      started_at: '2024-06-01T12:00:00.000Z',
+    })
+
+    // #when projected
+    const result = toOperatorRunStatus(runState, BASE_OPTS)
+
+    // #then operator-safe fields are present and correct
+    assert(result !== null, 'expected a populated status for a non-denylisted repo')
+    expect(result.runId).toBe('run-xyz')
+    expect(result.entityRef).toBe('acme/widget#7')
+    expect(result.surface).toBe('web')
+    expect(result.phase).toBe('EXECUTING')
+    expect(result.startedAt).toBe('2024-06-01T12:00:00.000Z')
+  })
+
+  it('(r5) result object has NO holder_id, thread_id, or details keys', () => {
+    // #given a RunState with internal fields
+    const runState = makeRunState()
+
+    // #when projected
+    const result = toOperatorRunStatus(runState, BASE_OPTS)
+
+    // #then internal fields are absent from the output object
+    assert(result !== null, 'expected a populated status for a non-denylisted repo')
+    const keys = Object.keys(result)
+    expect(keys).not.toContain('holder_id')
+    expect(keys).not.toContain('thread_id')
+    expect(keys).not.toContain('details')
+  })
+
+  it('(r5) OperatorRunStatus type cannot carry holder_id, thread_id, or details', () => {
+    // #given the OperatorRunStatus type
+    // #when inspected at the type level
+    // #then it does not include internal coordination fields
+    expectTypeOf<OperatorRunStatus>().not.toHaveProperty('holder_id')
+    expectTypeOf<OperatorRunStatus>().not.toHaveProperty('thread_id')
+    expectTypeOf<OperatorRunStatus>().not.toHaveProperty('details')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Security: redaction-aware projection (R5/R6 cross-obligation)
+// ---------------------------------------------------------------------------
+
+describe('toOperatorRunStatus — redaction (r5/r6)', () => {
+  it('(r6) returns null for a denylisted repo — record is omitted, not populated', () => {
+    // #given a run whose repo is on the denylist
+    const runState = makeRunState({entity_ref: 'secret-org/secret-repo#1'})
+
+    // #when projected with isRepoDenylisted:true
+    const result = toOperatorRunStatus(runState, {...BASE_OPTS, isRepoDenylisted: true})
+
+    // #then the record is omitted entirely — null, not a populated status
+    expect(result).toBeNull()
+  })
+
+  it('(positive control) returns a populated status for a non-denylisted repo', () => {
+    // #given a run whose repo is NOT on the denylist
+    const runState = makeRunState({entity_ref: 'public-org/public-repo#5'})
+
+    // #when projected with isRepoDenylisted:false
+    const result = toOperatorRunStatus(runState, {...BASE_OPTS, isRepoDenylisted: false})
+
+    // #then the record is populated — not accidentally omitted
+    assert(result !== null, 'expected a populated status for a non-denylisted repo')
+    expect(result.entityRef).toBe('public-org/public-repo#5')
+  })
+
+  it('(r6) denylisted result is null even when phase is EXECUTING (no partial leak)', () => {
+    // #given an actively-running denylisted run
+    const runState = makeRunState({phase: 'EXECUTING', entity_ref: 'hidden/repo#99'})
+
+    // #when projected with isRepoDenylisted:true
+    const result = toOperatorRunStatus(runState, {...BASE_OPTS, isRepoDenylisted: true})
+
+    // #then null — the active status must not leak the repo's activity
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Edge: stale derivation
+// ---------------------------------------------------------------------------
+
+describe('toOperatorRunStatus — stale derivation', () => {
+  it('stale is false when last_heartbeat is within the threshold', () => {
+    // #given a heartbeat 1 ms before the stale boundary (still fresh)
+    const staleThresholdMs = 60_000
+    const lastHeartbeat = new Date(BASE_NOW_MS - staleThresholdMs + 1).toISOString()
+    const runState = makeRunState({last_heartbeat: lastHeartbeat})
+
+    // #when projected
+    const result = toOperatorRunStatus(runState, {...BASE_OPTS, staleThresholdMs})
+
+    // #then stale is false
+    assert(result !== null, 'expected a populated status')
+    expect(result.stale).toBe(false)
+  })
+
+  it('stale is true when last_heartbeat is exactly at the stale boundary', () => {
+    // #given a heartbeat exactly at the stale boundary (nowMs - staleThresholdMs)
+    const staleThresholdMs = 60_000
+    const lastHeartbeat = new Date(BASE_NOW_MS - staleThresholdMs).toISOString()
+    const runState = makeRunState({last_heartbeat: lastHeartbeat})
+
+    // #when projected
+    const result = toOperatorRunStatus(runState, {...BASE_OPTS, staleThresholdMs})
+
+    // #then stale is true (boundary is inclusive — older-than-or-equal is stale)
+    assert(result !== null, 'expected a populated status')
+    expect(result.stale).toBe(true)
+  })
+
+  it('stale is true when last_heartbeat is past the stale boundary', () => {
+    // #given a heartbeat 1 ms past the stale boundary
+    const staleThresholdMs = 60_000
+    const lastHeartbeat = new Date(BASE_NOW_MS - staleThresholdMs - 1).toISOString()
+    const runState = makeRunState({last_heartbeat: lastHeartbeat})
+
+    // #when projected
+    const result = toOperatorRunStatus(runState, {...BASE_OPTS, staleThresholdMs})
+
+    // #then stale is true
+    assert(result !== null, 'expected a populated status')
+    expect(result.stale).toBe(true)
+  })
+
+  it('stale is true (fail-safe) when last_heartbeat is unparseable', () => {
+    // #given a RunState with a garbage last_heartbeat value
+    const runState = makeRunState({last_heartbeat: 'not-a-date'})
+
+    // #when projected
+    const result = toOperatorRunStatus(runState, BASE_OPTS)
+
+    // #then stale defaults to true (fail-safe — unknown freshness = stale)
+    assert(result !== null, 'expected a populated status')
+    expect(result.stale).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Barrel re-export smoke test
+// ---------------------------------------------------------------------------
+
+describe('barrel re-exports', () => {
+  it('toOperatorRunStatus is re-exported from the contract barrel', async () => {
+    // #given the public barrel for the operator-contract module
+    const barrel = await import('./index.js')
+
+    // #when the projection function is accessed
+    // #then it is present and callable
+    expect(typeof barrel.toOperatorRunStatus).toBe('function')
+  })
+})

--- a/packages/gateway/src/operator-contract/run-status.ts
+++ b/packages/gateway/src/operator-contract/run-status.ts
@@ -1,0 +1,120 @@
+/**
+ * Operator-safe run-status projection.
+ *
+ * Re-exports the canonical lifecycle types (RunPhase, Surface) from @fro-bot/runtime
+ * so the contract barrel is the single import authority for operator-facing consumers.
+ *
+ * Posture: re-export only — existing gateway files that import RunPhase/Surface directly
+ * from @fro-bot/runtime (execute/launch-types.ts, runtime-effect.ts, execute/recovery.test.ts)
+ * are left as-is. Migrating them to the contract barrel is a deferred follow-up.
+ *
+ * Security (R5): OperatorRunStatus carries only operator-safe fields. The internal
+ * coordination fields holder_id, thread_id, and details are excluded by construction —
+ * they do not appear in the type and cannot appear in the projection output.
+ *
+ * Security (R5/R6 cross-obligation, #950): entity_ref is 'owner/repo#123'. Exposing it
+ * for a repo redacted in metadata/repos.yaml reintroduces the exact leak #950 closes.
+ * The pre-query redaction gate does NOT retroactively scrub an already-stored run's status,
+ * so toOperatorRunStatus accepts an explicit isRepoDenylisted signal and returns null
+ * (omit the record entirely) for a denylisted repo. A populated status is never returned
+ * for a denylisted repo — not even a partial one.
+ *
+ * Note: 'blocked' and 'waiting_for_approval' are NOT produced by this pure projection.
+ * They are derived by the snapshot endpoint from queue/registry state and layered on top
+ * of the web status after this function returns. This function maps RunPhase only.
+ */
+
+import type {RunPhase, RunState, Surface} from '@fro-bot/runtime'
+
+export type {RunPhase, Surface} from '@fro-bot/runtime'
+
+/**
+ * The 7-value operator-facing web status set (snake_case).
+ *
+ * 'blocked' and 'waiting_for_approval' are endpoint-layer overlays derived from
+ * queue/registry state — they are NOT produced by toOperatorRunStatus (which maps
+ * RunPhase only). The snapshot endpoint layers them on top after projection.
+ */
+export type OperatorWebStatus =
+  | 'queued'
+  | 'blocked'
+  | 'running'
+  | 'waiting_for_approval'
+  | 'succeeded'
+  | 'failed'
+  | 'cancelled'
+
+/**
+ * Operator-safe projection of a run's status.
+ *
+ * Carries only the fields safe to expose to an operator web client.
+ * Internal coordination fields (holder_id, thread_id, details) are excluded
+ * by construction — they do not appear in this type.
+ */
+export interface OperatorRunStatus {
+  readonly runId: string
+  readonly entityRef: string
+  readonly surface: Surface
+  readonly phase: RunPhase
+  readonly status: OperatorWebStatus
+  readonly startedAt: string
+  readonly stale: boolean
+}
+
+/**
+ * Maps a RunPhase to its operator-facing web status.
+ *
+ * 'blocked' and 'waiting_for_approval' are NOT in this map — they are
+ * endpoint-layer overlays, not derivable from RunPhase alone.
+ */
+const PHASE_TO_WEB_STATUS: Record<RunPhase, OperatorWebStatus> = {
+  PENDING: 'queued',
+  ACKNOWLEDGED: 'running',
+  EXECUTING: 'running',
+  COMPLETED: 'succeeded',
+  FAILED: 'failed',
+  CANCELLED: 'cancelled',
+}
+
+/**
+ * Pure, redaction-aware projection from RunState to OperatorRunStatus.
+ *
+ * Returns null when opts.isRepoDenylisted is true — the record is omitted entirely.
+ * This is the critical #950 cross-obligation fix: entity_ref would otherwise expose
+ * a denylisted repo's identity and activity that the pre-query gate cannot scrub.
+ *
+ * @param runState - The canonical run state from the coordination layer.
+ * @param opts - Projection options.
+ * @param opts.nowMs - Current time in milliseconds (explicit; no hidden clock coupling).
+ * @param opts.staleThresholdMs - Age threshold in ms beyond which a run is considered
+ *   stale. REQUIRED explicit param — no hidden coupling to any runtime default constant.
+ * @param opts.isRepoDenylisted - Whether the run's repo is on the metadata/repos.yaml
+ *   denylist. When true, returns null (record omitted) to prevent identity/activity leak.
+ */
+export const toOperatorRunStatus = (
+  runState: RunState,
+  opts: {readonly nowMs: number; readonly staleThresholdMs: number; readonly isRepoDenylisted: boolean},
+): OperatorRunStatus | null => {
+  // #given the redaction signal — check first, before touching any field
+  if (opts.isRepoDenylisted) {
+    // Omit the record entirely. A populated status must never be returned for a
+    // denylisted repo — even a partial one would leak the repo's identity/activity.
+    return null
+  }
+
+  // #given the last_heartbeat — derive stale with explicit numeric comparison
+  // Fail-safe: if last_heartbeat is unparseable, treat as stale (unknown freshness = stale).
+  const heartbeatMs = Date.parse(runState.last_heartbeat)
+  const stale = Number.isNaN(heartbeatMs) || heartbeatMs <= opts.nowMs - opts.staleThresholdMs
+
+  // #when projecting — map only operator-safe fields; internal fields are never read
+  return {
+    runId: runState.run_id,
+    entityRef: runState.entity_ref,
+    surface: runState.surface,
+    phase: runState.phase,
+    status: PHASE_TO_WEB_STATUS[runState.phase],
+    startedAt: runState.started_at,
+    stale,
+  }
+}

--- a/packages/gateway/src/operator-contract/run-status.ts
+++ b/packages/gateway/src/operator-contract/run-status.ts
@@ -12,12 +12,13 @@
  * coordination fields holder_id, thread_id, and details are excluded by construction —
  * they do not appear in the type and cannot appear in the projection output.
  *
- * Security (R5/R6 cross-obligation, #950): entity_ref is 'owner/repo#123'. Exposing it
- * for a repo redacted in metadata/repos.yaml reintroduces the exact leak #950 closes.
+ * Security (R5/R6 cross-obligation, metadata/repos.yaml redaction obligation): entity_ref is 'owner/repo#123'.
+ * Exposing it for a repo redacted in metadata/repos.yaml reintroduces the repo-redaction cross-obligation leak.
  * The pre-query redaction gate does NOT retroactively scrub an already-stored run's status,
- * so toOperatorRunStatus accepts an explicit isRepoDenylisted signal and returns null
+ * so toOperatorRunStatus requires a caller-supplied isRepoDenylisted predicate and returns null
  * (omit the record entirely) for a denylisted repo. A populated status is never returned
- * for a denylisted repo — not even a partial one.
+ * for a denylisted repo — not even a partial one. The predicate form makes the "forgot to check"
+ * state unrepresentable: the projection cannot be called without supplying a denylist mechanism.
  *
  * Note: 'blocked' and 'waiting_for_approval' are NOT produced by this pure projection.
  * They are derived by the snapshot endpoint from queue/registry state and layered on top
@@ -79,24 +80,36 @@ const PHASE_TO_WEB_STATUS: Record<RunPhase, OperatorWebStatus> = {
 /**
  * Pure, redaction-aware projection from RunState to OperatorRunStatus.
  *
- * Returns null when opts.isRepoDenylisted is true — the record is omitted entirely.
- * This is the critical #950 cross-obligation fix: entity_ref would otherwise expose
- * a denylisted repo's identity and activity that the pre-query gate cannot scrub.
+ * Returns null when opts.isRepoDenylisted(runState.entity_ref) returns true — the record
+ * is omitted entirely. This is the critical repo-redaction cross-obligation: entity_ref
+ * would otherwise expose a denylisted repo's identity and activity that the pre-query gate
+ * cannot scrub.
+ *
+ * The predicate form makes the "forgot to check" state unrepresentable: callers MUST supply
+ * a denylist mechanism (e.g. backed by metadata/repos.yaml). Passing a blanket `() => false`
+ * is an explicit opt-out, not a silent default. The predicate receives the raw entity_ref
+ * string (e.g. 'owner/repo#123'); the caller is responsible for parsing owner/repo if needed.
  *
  * @param runState - The canonical run state from the coordination layer.
  * @param opts - Projection options.
  * @param opts.nowMs - Current time in milliseconds (explicit; no hidden clock coupling).
  * @param opts.staleThresholdMs - Age threshold in ms beyond which a run is considered
  *   stale. REQUIRED explicit param — no hidden coupling to any runtime default constant.
- * @param opts.isRepoDenylisted - Whether the run's repo is on the metadata/repos.yaml
- *   denylist. When true, returns null (record omitted) to prevent identity/activity leak.
+ * @param opts.isRepoDenylisted - Predicate that receives the run's entity_ref and returns
+ *   true if that repo is on the metadata/repos.yaml denylist. When true, returns null
+ *   (record omitted) to prevent identity/activity leak. The caller supplies the denylist
+ *   mechanism; the projection cannot be called without one.
  */
 export const toOperatorRunStatus = (
   runState: RunState,
-  opts: {readonly nowMs: number; readonly staleThresholdMs: number; readonly isRepoDenylisted: boolean},
+  opts: {
+    readonly nowMs: number
+    readonly staleThresholdMs: number
+    readonly isRepoDenylisted: (entityRef: string) => boolean
+  },
 ): OperatorRunStatus | null => {
-  // #given the redaction signal — check first, before touching any field
-  if (opts.isRepoDenylisted) {
+  // #given the redaction predicate — check first, before touching any field
+  if (opts.isRepoDenylisted(runState.entity_ref) === true) {
     // Omit the record entirely. A populated status must never be returned for a
     // denylisted repo — even a partial one would leak the repo's identity/activity.
     return null
@@ -113,7 +126,9 @@ export const toOperatorRunStatus = (
     entityRef: runState.entity_ref,
     surface: runState.surface,
     phase: runState.phase,
-    status: PHASE_TO_WEB_STATUS[runState.phase],
+    // Fail-closed: an unrecognized phase (data corruption / version skew) surfaces as 'failed',
+    // not as undefined — a missing status key would silently drop the field from JSON output.
+    status: PHASE_TO_WEB_STATUS[runState.phase] ?? 'failed',
     startedAt: runState.started_at,
     stale,
   }

--- a/packages/gateway/src/operator-contract/version.test.ts
+++ b/packages/gateway/src/operator-contract/version.test.ts
@@ -1,0 +1,20 @@
+import {describe, expect, it} from 'vitest'
+import {OPERATOR_CONTRACT_VERSION} from './version.js'
+
+describe('OPERATOR_CONTRACT_VERSION', () => {
+  it('is pinned to 1.0.0', () => {
+    // #given the contract version constant
+    // #when read at import time
+    // #then it is exactly the pinned literal
+    expect(OPERATOR_CONTRACT_VERSION).toBe('1.0.0')
+  })
+
+  it('is importable from the contract barrel', async () => {
+    // #given the public barrel for the operator-contract module
+    // #when the version is imported from the barrel
+    const {OPERATOR_CONTRACT_VERSION: barrelVersion} = await import('./index.js')
+
+    // #then it equals the same constant
+    expect(barrelVersion).toBe(OPERATOR_CONTRACT_VERSION)
+  })
+})

--- a/packages/gateway/src/operator-contract/version.ts
+++ b/packages/gateway/src/operator-contract/version.ts
@@ -1,0 +1,15 @@
+// Operator API contract version — build-time pinned, never negotiated over the wire.
+//
+// Increment policy:
+//   MAJOR — breaking change to a frozen type (field removed, renamed, or type narrowed)
+//   MINOR — additive change (new optional field, new type added to the surface)
+//   PATCH — documentation or typo correction only; no structural change
+//
+// This constant is the single source of truth. Downstream consumers (e.g. the dashboard)
+// pin this value; no second copy should exist. Human-bumped on breaking changes, like
+// STORAGE_VERSION in packages/runtime/src/shared/constants.ts.
+//
+// Security constraint: the version is BUILD-TIME pinned and is never supplied or
+// negotiated over the wire. Any endpoint reading a version header must reject
+// unrecognized versions fail-closed.
+export const OPERATOR_CONTRACT_VERSION = '1.0.0'

--- a/packages/gateway/src/web/auth/session-info-route.ts
+++ b/packages/gateway/src/web/auth/session-info-route.ts
@@ -22,6 +22,7 @@
  */
 
 import type {Hono} from 'hono'
+import type {OperatorSessionInfo} from '../../operator-contract/responses.js'
 import type {BrowserGuardDeps} from './csrf.js'
 import {getOperatorAuthContext, registerOperatorRoute} from '../operator-route.js'
 import {SESSION_ABSOLUTE_TTL_MS, SESSION_IDLE_TTL_MS} from './session.js'
@@ -78,13 +79,12 @@ export function buildSessionInfoRoute(app: Hono, deps: BrowserGuardDeps): void {
     // serve a cached response to a different origin or fetch context.
     c.header('Vary', 'Origin, Sec-Fetch-Site, Sec-Fetch-Mode, Sec-Fetch-Dest')
 
-    return c.json(
-      {
-        operatorId: entry.githubUserId,
-        login: entry.login,
-        expiresAt,
-      },
-      200,
-    )
+    const responseBody: OperatorSessionInfo = {
+      operatorId: entry.githubUserId,
+      login: entry.login,
+      expiresAt,
+    }
+
+    return c.json(responseBody, 200)
   })
 }


### PR DESCRIPTION
Closes #949.

## What this adds

The gateway now owns a single, versioned source of truth for the operator API surface, under `packages/gateway/src/operator-contract/`. Until now the operator-facing shapes were scattered and internal — run-state lifecycle in the runtime coordination layer, approval-decision semantics in the gateway approvals code, operator identity duplicated across two modules — with no canonical, exported, versioned contract for a client to validate against.

This consolidates them behind one barrel (`OPERATOR_CONTRACT_VERSION = '1.0.0'`):

- **Lifecycle** — re-exports `RunPhase`/`Surface` and adds an `OperatorRunStatus` projection that carries only operator-safe fields. Internal coordination fields (holder, thread, details) are excluded by construction, and the projection omits a run entirely when its repo is redaction-denylisted, so a redacted repo's reference cannot leak through a stored run's status. The denylist check is a required predicate the caller must supply — a caller cannot forget it and silently surface a redacted repo.
- **Identity** — one canonical `OperatorIdentity`; the two byte-identical duplicates become aliases of it, so there is a single structural definer.
- **Approvals** — the contract is the sole definer of the permission reply type (the coordinator re-exports it, so existing imports are unchanged), plus an operator decision-state set with an exhaustive mapping from the internal outcome, and a decision-input type that requires a transport-bound actor so a web decision cannot bypass the fail-closed approval gate.
- **Responses** — named types for the operator HTTP responses with runtime validators that return a result and never echo input in their error reasons.
- **Obligations** — the repo-redaction and authorization obligations are embedded as normative clauses, including a fail-closed stub that throws by default so a repo-data response path cannot ship without an explicit redaction check.

The exported surface is plain TypeScript plus result-returning validators — no Effect Schema crosses the contract boundary. The dashboard's mock operator client becomes a non-canonical downstream fixture that conforms to this contract rather than defining it.

## Scope

Consolidation only. The net-new command/mission shapes and the real redaction-gate implementation are intentionally deferred to the units that build the endpoints needing them; this PR freezes what exists and binds the obligations so those units can't skip them. The contract changes are type-level and behavior-preserving — existing approval and route behavior is unchanged.

## Verification

Type-check, lint, and the full gateway suite (1940 tests) pass. The consolidation cuts were verified behavior-preserving by keeping the existing approval/route suites green before and after. New tests cover the redaction-aware omission (including a denylist-predicate membership case), the decision-state mapping exhaustiveness, the no-oracle validators, and the fail-closed redaction stub.
