### PR TITLE
feat(gateway): stream run status to operators over an inert SSE core

### DIFF
--- a/docs/plans/2026-06-19-003-feat-sse-run-observation-core-plan.md
+++ b/docs/plans/2026-06-19-003-feat-sse-run-observation-core-plan.md
@@ -1,0 +1,269 @@
+---
+title: "feat: Inert SSE run-observation core (Unit 4a)"
+type: feat
+status: active
+date: 2026-06-19
+deepened: 2026-06-19
+origin: docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
+---
+
+# Inert SSE run-observation core (Unit 4a)
+
+## Overview
+
+Build the **lean inert core** that will let authenticated operators observe gateway runs through a bounded, redacted, status-only stream — **without exposing any HTTP route**. This is Unit 4a of the operator web-surface plan (`docs/plans/2026-06-15-002`). After a design review (5 reviewers, 2026-06-19), 4a was scoped down to the minimum safe substrate: a run-status projection (consuming the operator contract via the redaction bridge), a registry scope-pending accessor, a minimal backpressure-safe pub/sub manager with a latest-state snapshot cache and heartbeat, and a run-lifecycle observer push source.
+
+**Deliberately deferred to Unit 4b** (where a real route, operator identity, and measurable reconnect churn exist to justify and test them): the replay buffer + Last-Event-ID, the heartbeat-derived staleness detector, and the per-operator stream cap. Reconnect in 4a is `reset` → snapshot-read. This reverses the parent plan's Fork 1 (keep-replay) with reviewer-grounded rationale: for a status-only, zero-subscriber inert core, replay/staleness/cap are machinery without payoff and are cleaner to build against the 4b route.
+
+Landing 4a lean de-risks the genuinely load-bearing parts now — the safe-field projection, the observer-only invariant, and non-blocking backpressure — behind tests, before any route can leak.
+
+## Problem Frame
+
+The operator web surface needs a live view of run status. The prerequisites now exist on `main`: the operator contract (`packages/gateway/src/operator-contract/`) with `toOperatorRunStatus`, the redaction surface gate (`packages/gateway/src/redaction/surface-gate.ts` `projectRunStatus`), and the run index (Unit 3i). What's missing is the *streaming substrate*: a projection that maps a `RunState` to a safe `OperatorWebStatus`, a manager that fans run-status events to subscribers without ever stalling on a slow consumer, and a push source wired into the run lifecycle. The design review established that this core must be observer-only (never touching run lifecycle/locks/heartbeat) and status-only (a closed allowlist DTO — no raw output/tool args/paths/`details`).
+
+## Requirements Trace
+
+- R1. A `RunState` projects to a safe `OperatorRunStatus` via the gateway redaction bridge; a denylisted/keyless repo yields **no record** (`null`), and a `null` projection is dropped before any buffering/emit.
+- R2. The projected base status is overlaid with the one endpoint-only `OperatorWebStatus` value that has a real source on `main`: `waiting_for_approval` (the run's approval scope has an open/claimed entry). The result is always a valid `OperatorWebStatus`. (`blocked` is **not** in v1 — no source exists; see Open Questions.)
+- R3. The approval registry exposes `hasPendingForScope(approvalScopeId)` returning true only when an open/claimed entry exists for that scope (no requestID guessing / cross-run leak).
+- R4. A run-lifecycle observer hook in gateway `run.ts` pushes the post-transition safe `RunState` to the manager at each `transitionRun` call site where the new state is in hand; runtime is untouched and the run is never affected by observation (best-effort, contained).
+- R5. The manager is backpressure-safe: the publisher serializes once and enqueues per subscriber and **never awaits** a subscriber write; per-subscriber enqueue is strictly non-blocking and a subscriber past its 64 KB queue cap is dropped locally (its stream closed) without affecting publish or peers. Per-subscriber resource use is bounded; the manager holds only a small latest-status cache per run, not an unbounded history.
+- R6. Reconnect (or any subscribe) delivers the run's **latest** projected status immediately from the snapshot cache (no replay buffer, no Last-Event-ID in v1), then live frames; if no snapshot exists, a `reset` (`{runId, reason}`) is emitted. Snapshot-on-subscribe is the contract.
+- R7. The stream carries only an explicit closed-DTO `OperatorRunStatus`, `reset`, and heartbeat/connection frames — **never** raw output, prompts, tool args/titles, workspace paths, approval details, internal URLs, or any `RunState.details` passthrough. Enforced structurally (field-by-field DTO, never spread), with a serialization test.
+- R8. The manager is **observer-only**: it never mutates run lifecycle, lock, or heartbeat state; disconnect/abort removes only the subscription + its timers/queue. EOF before a terminal status is an observation failure, not run success.
+- R9. 4a exposes **no public SSE route** — it is inert and safe to land.
+
+## Scope Boundaries
+
+- No HTTP route, no `web/server.ts` change, no socket-timeout fix (all Unit 4b).
+- No `checkRepoAuthz` call, no operator-token use, no continuous-authz lease (Unit 4b).
+- No owner-scoped visibility logic (the repo-scoped authz model is enforced at the 4b route).
+- No web-launch approval-scope registration (`approvalScopeId = runId` for web runs is Unit 6); 4a's overlay correlates Discord runs via `thread_id → approvalScopeId` and is written so a web run's `runId` scope works once Unit 6 registers it.
+- No progress/token streaming — status-only. Coarse progress is a future contract type.
+- **No `blocked` status overlay** — no readable pre-execution-rejection source exists on `main` (see Open Questions). v1 overlays only `waiting_for_approval`.
+
+### Deferred to Separate Tasks
+
+- **Replay buffer + Last-Event-ID** (`${runId}:${seq}` monotonic sequence, count/byte/TTL-bounded history, in-window replay, gap `reset`): Unit 4b/later. v1 uses snapshot-on-subscribe. Reason: over-built for a status-only, zero-subscriber inert core; cleaner to size and test against a real route and measured reconnect churn. *(Reverses parent Fork 1 per the 2026-06-19 design review.)*
+- **Heartbeat-derived staleness detector** (snapshot-reconcile a live-but-stuck run into a terminal/stale frame): Unit 4b/later. Reason: nothing observes the inert core, so there is no stuck-stream to reconcile yet; it also needs an exported canonical snapshot-read helper that does not exist on `main`.
+- **Per-operator stream cap** (5 concurrent streams per operator): Unit 4b. Reason: 4a has no authenticated operator identity, so the cap would be synthetic/vacuous here; it becomes real when 4b supplies the operator id at the route.
+- Authenticated route + authz + redaction-at-route + continuous-authz lease: Unit 4b (`docs/plans/2026-06-15-002`).
+- OAuth scope broadening (`read:user` → repo-read) for the 4b authz path: tracked in project memory; belongs with 4b.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/gateway/src/redaction/surface-gate.ts` — `projectRunStatus(runState, {nowMs, staleThresholdMs, bindingsLookup, isRepoDenied})` is the async bridge the projection consumes; it resolves run→binding→deny-keys and calls `toOperatorRunStatus` internally, returning `OperatorRunStatus | null`. **Do not call `toOperatorRunStatus` directly.**
+- `packages/gateway/src/operator-contract/` — `OperatorRunStatus`, `OperatorWebStatus` (canonical 7-value set), `OPERATOR_CONTRACT_VERSION`. The base mapping covers `queued|running|succeeded|failed|cancelled`; `waiting_for_approval` and `blocked` are endpoint overlays.
+- `packages/gateway/src/approvals/registry.ts` — `RegistryEntry` carries `approvalScopeId` (L209) and `state: 'open'|'claimed'|'confirmed'`; `pending()` (L425) returns requestIDs. Add `hasPendingForScope` by filtering the entries map by scope + `open|claimed`.
+- `packages/runtime/src/coordination/types.ts` — `RunState` (`run_id`, `surface`, `thread_id`, `entity_ref`, `phase`, `started_at`, `last_heartbeat`, `holder_id`, `details`); `RunPhase` (`PENDING|ACKNOWLEDGED|EXECUTING|COMPLETED|FAILED|CANCELLED`).
+- `packages/gateway/src/execute/run.ts` — drives transitions via `transitionRunEffect` (gateway Effect wrapper, `runtime-effect.ts`). The observer hook fires after each successful transition with the new `RunState`.
+- `packages/gateway/src/discord/status-message.ts` — `createStatusController` is the lifecycle/cleanup pattern to mirror: debounced updates, fail-soft `safePost`/`safeEdit`, `settle()`, terminal-edit discipline, `dispose()` clears timers. Mirror its discipline, not its Discord specifics.
+- `packages/gateway/src/execute/run-index.ts` — bounded-map cap/TTL/eviction style to mirror for the manager's per-subscriber bounds and latest-status cache.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/gateway-control-surface-spine-2026-06-15.md` — server-owned run resolution; the projection must never trust client input (4a has no client; 4b enforces).
+- `docs/solutions/best-practices/atomic-serial-channel-queue-handoff-2026-06-09.md` and the mention-loop terminal-correctness doc — terminal-signal discipline and dual-finally cleanup; EOF/abort is observation failure, not run success.
+- `docs/solutions/best-practices/centralize-s3-key-identity-construction-2026-06-09.md` — the staleness snapshot read must use the shared run-state key builder/identity, not an inline key.
+
+### External References
+
+- None — this is internal substrate following established gateway patterns.
+
+## Key Technical Decisions
+
+- **Consume the contract via the gateway bridge, not directly.** `projection.ts` calls `surface-gate.ts`'s `projectRunStatus` so binding resolution + denylist live in one owner; the projection only layers the single `waiting_for_approval` overlay on the returned base, then builds a **closed DTO** field-by-field.
+- **Closed-DTO safe-field allowlist (structural, not documented).** The projection never spreads `RunState` or `RunState.details`; it constructs the output by copying only the explicit contract fields. A denied/keyless repo (`projectRunStatus` → `null`) is dropped before any cache/emit. A serialization test asserts no unsafe field can appear.
+- **Observer push, not polling.** The hook fires at each `run.ts` `transitionRun` call site where the new `{state}` is in hand. There is no polling in 4a (staleness is deferred to 4b).
+- **`hasPendingForScope` derives the approval overlay from the run's scope, not requestIDs.** Discord runs map `thread_id → approvalScopeId`; web runs (Unit 6) will use `runId`. Never infer via requestID guessing.
+- **Publisher never awaits a subscriber write.** One bounded queue + one writer task per subscription; serialize the event once, enqueue per subscriber. Enqueue is strictly non-blocking; a subscriber past its 64 KB queue cap is dropped locally (stream closed) without affecting publish or peers — proven by an all-subscribers-slow test where `observe()` still completes in bounded time.
+- **Snapshot-on-subscribe, not replay.** The manager keeps only the **latest** projected status per active run (a small cache, not a history). A new subscription receives the latest snapshot immediately, then live frames; with no snapshot it gets `reset`. No `${runId}:${seq}` sequence, no Last-Event-ID, no replay buffer in v1 (deferred).
+- **Manager is observer-only.** Disconnect/abort removes only the subscription + its timers/queue; it must never touch the run timeout signal, coordinator, lock, or heartbeat — proven by a mutation-guard test with read-only-typed deps.
+
+## Bounds (v1)
+
+| Bound | Value |
+|------|-------|
+| Per-subscriber buffered-write cap | 64 KB (drop subscriber past cap) |
+| Heartbeat interval | 15 seconds |
+| Max stream duration | 30 minutes |
+| Latest-status cache | one projected frame per active run; entry cleared on terminal/cleanup |
+
+All bounds are named constants in `manager.ts`, injectable for tests. *(Replay count/byte/TTL bounds, the staleness grace, and the per-operator cap are deferred to 4b — see Scope Boundaries.)*
+
+## Implementation Units
+
+- [ ] **Unit 1: Run-status projection (consumes the contract bridge)**
+
+  **Goal:** Map a safe `RunState` to an `OperatorRunStatus` (closed DTO) with the `waiting_for_approval` overlay, via the redaction bridge.
+
+  **Requirements:** R1, R2, R7
+
+  **Dependencies:** None (all consumed surfaces are on `main`).
+
+  **Files:**
+  - Create: `packages/gateway/src/web/sse/projection.ts`
+  - Create: `packages/gateway/src/web/sse/projection.test.ts`
+
+  **Approach:**
+  - Export `projectRunObservation(runState, deps)` where `deps` carries `{nowMs, staleThresholdMs, bindingsLookup, isRepoDenied, hasPendingForScope}`. The `isRepoDenied` predicate shape is `(repoKey: {readonly databaseId: number | null; readonly nodeId: string | null}) => boolean` — pass it straight through to `projectRunStatus`, which resolves the binding's repo keys internally.
+  - Call `projectRunStatus(runState, {nowMs, staleThresholdMs, bindingsLookup, isRepoDenied})` from `surface-gate.ts` to get the base `OperatorRunStatus | null`. `null` → return `null` (denied/keyless repo: contract omission; no record — the manager drops it before caching/emit).
+  - Overlay (single): if `hasPendingForScope(scopeIdFor(runState))` is true, set the status to `waiting_for_approval` (overriding the projected base, which would be `running`). Otherwise keep the projected base. The result is always a valid `OperatorWebStatus`. **No `blocked` overlay** — no source exists on `main` (see Open Questions).
+  - `scopeIdFor(runState)`: `surface === 'discord'` → `thread_id`; otherwise → `run_id` (forward-compatible with the Unit 6 web-launch scope).
+  - **Closed DTO:** build the returned object by copying only the explicit contract fields from the `projectRunStatus` result + the overlaid status. Never spread `runState`, never read `runState.details` into the output. The return type is the contract's `OperatorRunStatus` (no extra fields).
+
+  **Execution note:** Test-first — pin the phase→status mapping table and the overlay before wiring the manager.
+
+  **Patterns to follow:** `surface-gate.ts` `projectRunStatus` call shape; the contract's `OperatorWebStatus` value set.
+
+  **Test scenarios:**
+  - Happy path: each `RunPhase` maps to the expected base status (`PENDING`/`ACKNOWLEDGED`→`queued`, `EXECUTING`→`running`, `COMPLETED`→`succeeded`, `FAILED`→`failed`, `CANCELLED`→`cancelled`).
+  - Overlay: a run whose scope has a pending approval projects `waiting_for_approval` (overrides `running`).
+  - Edge: a denylisted/keyless repo (`projectRunStatus` returns `null`) yields `null` (no record).
+  - Safety: a `RunState` whose `details` carries raw output / a workspace path / tool args projects an output that contains **none** of those keys/values — assert the serialized DTO has exactly the contract fields (structural allowlist proof).
+  - Scope: `scopeIdFor` returns `thread_id` for a Discord run and `run_id` for a non-Discord run.
+
+  **Verification:** Every phase + the overlay produce a valid `OperatorWebStatus`; denied repos omit (`null`); the output is a closed DTO with no `details` passthrough.
+
+- [ ] **Unit 2: Registry scope-pending accessor**
+
+  **Goal:** Add `hasPendingForScope(approvalScopeId)` so the projection's `waiting_for_approval` overlay derives from the run's scope, not requestID guessing.
+
+  **Requirements:** R3
+
+  **Dependencies:** None.
+
+  **Files:**
+  - Modify: `packages/gateway/src/approvals/registry.ts`
+  - Test: `packages/gateway/src/approvals/registry.test.ts`
+
+  **Approach:**
+  - Add `hasPendingForScope(approvalScopeId: string): boolean` to the `ApprovalRegistry` interface and `createApprovalRegistry`.
+  - Implement by scanning the entries map for any entry whose `approvalScopeId` matches AND whose `state` is `open` or `claimed` (not `confirmed`). Return on first match.
+  - Do not expose entry contents — boolean only (no oracle on request details).
+
+  **Execution note:** Test-first.
+
+  **Patterns to follow:** existing `pending()` / `has()` accessors in `registry.ts`.
+
+  **Test scenarios:**
+  - Happy path: returns true when an `open` entry exists for the scope; true for a `claimed` entry.
+  - Edge: returns false when only a `confirmed` entry exists for the scope.
+  - Edge: returns false for a scope with no entries; false after the entry settles/disposes.
+  - Isolation: an entry for a *different* scope does not satisfy the query (no cross-scope match).
+
+  **Verification:** `hasPendingForScope` is true iff an open/claimed entry exists for exactly that scope.
+
+- [ ] **Unit 3: Lean backpressure-safe pub/sub manager (snapshot-on-subscribe)**
+
+  **Goal:** The observer-only manager that fans run-status frames to subscribers without ever stalling on a slow consumer, serves the latest snapshot on subscribe, and heartbeats — with no replay buffer, no staleness detector, and no per-operator cap (all deferred to 4b).
+
+  **Requirements:** R5, R6, R7, R8, R9
+
+  **Dependencies:** Unit 1 (projection).
+
+  **Files:**
+  - Create: `packages/gateway/src/web/sse/manager.ts`
+  - Create: `packages/gateway/src/web/sse/manager.test.ts`
+
+  **Approach:**
+  - `createRunObservationManager(deps)` returns `{ observe(runState), subscribe(runId, {onEvent, onClose}), shutdown() }` (names directional). Pure in-memory substrate; no route.
+  - **Publish path:** `observe(runState)` projects via Unit 1. A `null` projection (denied/keyless repo) is **dropped immediately** — never cached, never emitted, no side effect. A non-null projection updates the run's **latest-status cache** (one frame per run) and is enqueued to each current subscriber of that run. The publisher serializes the frame once and enqueues per subscriber; it **never awaits** a write. On a terminal status, the cache entry is cleared after fan-out and subscribers are closed cleanly.
+  - **Subscriber:** one bounded queue + one writer task draining to `onEvent`. Enqueue is strictly non-blocking: if appending would exceed the 64 KB queue cap, the subscriber is dropped locally (`onClose('overflow')`, queue/timers cleared) and removed from the run's subscriber set — without touching publish or peers. Dropping a subscriber mid-fan-out must not corrupt the publish iteration (iterate over a snapshot of the subscriber set, or guard removal).
+  - **Subscribe / snapshot:** on `subscribe(runId, ...)`, if a latest-status cache entry exists, deliver it immediately as the first frame, then live frames. If none exists, emit a single `reset` (`{runId, reason}`) — the subscriber (4b's route) is expected to snapshot-read canonical state. There is **no** Last-Event-ID, sequence, or replay in v1.
+  - **Heartbeat:** a 15 s keepalive frame per active subscription; **max duration** 30 min then close. Both are named injectable constants.
+  - **Lifecycle separation (observer-only):** stream disconnect / `onAbort` removes only the subscription + its timers/queue; it must NEVER touch the run timeout signal, coordinator, lock, or heartbeat. The manager has no reference to any mutating run API (enforced by read-only-typed deps). EOF before a terminal status fires `onClose('observation-failed')`, never treated as run success.
+  - `shutdown()` closes all subscriptions and clears all caches/timers.
+
+  **Execution note:** Test-first — the load-bearing risk is non-blocking backpressure and the observer-only invariant; prove both before wiring the hook.
+
+  **Patterns to follow:** `status-message.ts` fail-soft + `settle`/`dispose` cleanup discipline; `run-index.ts` bounded-map style; the mention-loop terminal-correctness solution doc.
+
+  **Test scenarios:**
+  - Happy path: observing queued→running→terminal pushes ordered frames to a subscriber; the terminal status closes the stream cleanly and clears the cache entry.
+  - Snapshot-on-subscribe: subscribing to a run with a cached latest status delivers that status first, then live frames; subscribing to a run with no cache emits `reset`.
+  - Backpressure (the load-bearing one): a slow subscriber exceeding its 64 KB queue cap is dropped (`onClose('overflow')`) without blocking publish or a fast peer; with **all** subscribers slow, `observe()` still completes in bounded time (no await on any write; the latest-cache update stays O(1) per run).
+  - Bounds: a subscriber past the 30-min max duration is closed; the 15 s heartbeat frame is emitted on an idle subscription.
+  - Denied-repo omission: observing a run whose `projectRunObservation` returns `null` produces no cache entry, no enqueued frame, no heartbeat/reset side effect (assert nothing buffered).
+  - Observer-only invariant: a mutation-guard test wires mocked lifecycle/lock/heartbeat deps and asserts `observe`/`subscribe`/`shutdown`/disconnect never call any mutating run API.
+  - Cleanup: an aborted connection removes its subscription, timers, and queued bytes; rapid connect/disconnect does not leak listeners or timers.
+  - Error path: a writer failure on one subscriber is contained (does not crash the manager or other subscribers); EOF before terminal status fires `onClose('observation-failed')`, not success.
+  - Safety: only the closed-DTO `OperatorRunStatus` / `reset` / heartbeat frames are ever enqueued — assert no raw output/tool/path frame can appear.
+
+  **Verification:** The manager is non-blocking-backpressure-safe, snapshot-on-subscribe, redacted (denied omitted before cache), observer-only, and fully tested — no replay/staleness/cap, no route exposed.
+
+- [ ] **Unit 4: Run-lifecycle observer hook (push source)**
+
+  **Goal:** Wire the manager's `observe` into the gateway run lifecycle so transitions push safe `RunState` snapshots; instantiate the manager in the composition root.
+
+  **Requirements:** R4, R9
+
+  **Dependencies:** Units 1-3.
+
+  **Files:**
+  - Modify: `packages/gateway/src/execute/run.ts` (push after each successful transition)
+  - Modify: `packages/gateway/src/program.ts` (instantiate manager, thread into run deps)
+  - Test: `packages/gateway/src/execute/run.test.ts`
+
+  **Approach:**
+  - Add an optional `runObserver?` dep to the run path (mirroring how `runIndex` is optional in `RunMentionDeps`). `run.ts` calls runtime `transitionRun(...)` **directly** (not `transitionRunEffect`) and the call returns `{etag, state}` on success. At each successful `transitionRun` call site (the PENDING→ACKNOWLEDGED, ACKNOWLEDGED→EXECUTING, and EXECUTING→terminal points), call `runObserver?.observe(result.state)` with the post-transition `RunState` that is already in hand — best-effort, wrapped so an observer error never aborts or alters the run (try/catch + `logger.warn`). Do **not** refactor `run.ts` onto `transitionRunEffect`; attach at the existing direct call sites.
+  - In `program.ts`, instantiate `createRunObservationManager(...)` once and thread it as `runObserver`. No route registration (4a is inert) — the manager exists and is fed, but nothing subscribes yet.
+  - Confirm runtime is untouched (the hook lives in gateway `run.ts`, not runtime `transitionRun`).
+
+  **Execution note:** Test-first on the wiring — assert `observe` is called with the post-transition state and that observer failure is contained.
+
+  **Patterns to follow:** the optional-`runIndex` dep + try/catch best-effort `register` wiring already in `run.ts` (3i); the direct `transitionRun(...)` call sites in `run.ts`.
+
+  **Test scenarios:**
+  - Happy path: a run transitioning PENDING→ACKNOWLEDGED→EXECUTING→terminal calls `runObserver.observe` with the correct post-transition `RunState` at each step.
+  - Best-effort: an `observe` that throws is caught and logged; the run continues and completes normally (no abort, no lifecycle change).
+  - Inert: omitting `runObserver` is safe (no crash); `program.ts` wires a manager but exposes no subscribe route.
+  - Integration: creating a run end-to-end drives observed transitions in order (mock manager records the sequence).
+
+  **Verification:** Transitions push safe state to the manager, observer failure is contained, runtime is untouched, and no public route exists.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should `blocked` be a v1 overlay?** No. `RunState` has no pre-execution-rejection field and `toOperatorRunStatus` does not emit `blocked`; there is no readable source on `main`. v1 overlays only `waiting_for_approval` (which has a real source via `hasPendingForScope`). The contract still *defines* `blocked` as a valid `OperatorWebStatus`; 4a simply never produces it.
+- **Where does the observer hook attach?** At the direct `transitionRun(...)` call sites in `run.ts` (it returns `{state}`), not `transitionRunEffect` — `run.ts` does not use the Effect wrapper.
+- **Replay vs snapshot-on-subscribe?** Snapshot-on-subscribe for v1 (latest-status cache); replay buffer + Last-Event-ID deferred to 4b (reverses parent Fork 1 per the design review).
+
+### Deferred to Implementation
+
+- Exact latest-status cache eviction on run completion vs a short grace (so a subscriber connecting right after terminal still gets the final status) — decide against real `run.ts` terminal timing during implementation.
+- The precise `blocked` source, if/when a pre-execution-rejection signal is added to `RunState` or surfaced via `details` — a future contract/runtime change, out of scope here.
+
+## System-Wide Impact
+
+- **Interaction graph:** the observer hook is additive at the direct `transitionRun(...)` call sites in `run.ts`; `program.ts` gains one instantiation. Nothing subscribes until 4b.
+- **Error propagation:** observer errors are caught at the hook and never propagate to the run; manager writer errors are contained per-subscriber.
+- **State lifecycle risks:** the manager must never mutate run/lock/heartbeat state — observer-only is the invariant (no snapshot/reconcile path in v1, so no read-then-write risk either).
+- **API surface parity:** none exposed in 4a; the `subscribe`/`reset`/heartbeat/snapshot-frame shapes become the contract 4b's route serves.
+- **Integration coverage:** the run.ts→manager push is the cross-layer behavior unit tests must prove (mock manager records the transition sequence).
+- **Unchanged invariants:** runtime `transitionRun`/coordination is untouched; the run lifecycle, locks, and heartbeat behave identically with or without an observer.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Backpressure bug stalls publish/run | Publisher never awaits subscriber writes; strictly non-blocking enqueue + local drop past 64 KB; explicit all-subscribers-slow test proving `observe()` completes in bounded time. |
+| Observer error affects the run | Best-effort try/catch at the hook; run-continues test; catch covers both sync throw and async rejection. |
+| Status frames leak unsafe fields | Closed-DTO allowlist (never spread `RunState`/`details`); serialization test asserts no raw/tool/path/`details` field can appear. |
+| Denied repo frame buffered/leaked | `null` projection dropped before any cache/emit; omission test asserts no buffered frame. |
+| Drop-subscriber-mid-fan-out corrupts publish loop | Iterate over a snapshot of the subscriber set (or guard removal); cleanup/leak test. |
+| Scope overlay wrong for web runs (Unit 6 not built) | `scopeIdFor` returns `run_id` for non-Discord; documented forward-compat; Discord path fully tested now. |
+
+## Documentation / Operational Notes
+
+- After 4b lands the route, document the operator stream contract (`subscribe`, `reset`, heartbeat, status-only fields) in the gateway operator docs. 4a adds no operator-facing docs (inert).
+- Update `docs/plans/2026-06-15-002` Unit 4a checkbox on completion.
+
+## Sources & References
+
+- **Origin plan:** `docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md` (Unit 4a section, reshaped 2026-06-19).
+- Related code: `packages/gateway/src/redaction/surface-gate.ts`, `packages/gateway/src/operator-contract/`, `packages/gateway/src/approvals/registry.ts`, `packages/gateway/src/execute/run.ts`, `packages/gateway/src/discord/status-message.ts`, `packages/runtime/src/coordination/types.ts`.
+- Related issue: #907 (operator web surface umbrella).

--- a/docs/plans/2026-06-19-003-feat-sse-run-observation-core-plan.md
+++ b/docs/plans/2026-06-19-003-feat-sse-run-observation-core-plan.md
@@ -119,7 +119,7 @@ All bounds are named constants in `manager.ts`, injectable for tests. *(Replay c
   **Patterns to follow:** `surface-gate.ts` `projectRunStatus` call shape; the contract's `OperatorWebStatus` value set.
 
   **Test scenarios:**
-  - Happy path: each `RunPhase` maps to the expected base status (`PENDING`/`ACKNOWLEDGED`→`queued`, `EXECUTING`→`running`, `COMPLETED`→`succeeded`, `FAILED`→`failed`, `CANCELLED`→`cancelled`).
+  - Happy path: each `RunPhase` maps to the expected base status per the contract's `PHASE_TO_WEB_STATUS` (`PENDING`→`queued`, `ACKNOWLEDGED`/`EXECUTING`→`running`, `COMPLETED`→`succeeded`, `FAILED`→`failed`, `CANCELLED`→`cancelled`).
   - Overlay: a run whose scope has a pending approval projects `waiting_for_approval` (overrides `running`).
   - Edge: a denylisted/keyless repo (`projectRunStatus` returns `null`) yields `null` (no record).
   - Safety: a `RunState` whose `details` carries raw output / a workspace path / tool args projects an output that contains **none** of those keys/values — assert the serialized DTO has exactly the contract fields (structural allowlist proof).

--- a/docs/plans/2026-06-19-003-feat-sse-run-observation-core-plan.md
+++ b/docs/plans/2026-06-19-003-feat-sse-run-observation-core-plan.md
@@ -1,9 +1,10 @@
 ---
 title: "feat: Inert SSE run-observation core (Unit 4a)"
 type: feat
-status: active
+status: completed
 date: 2026-06-19
 deepened: 2026-06-19
+completed: 2026-06-19
 origin: docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
 ---
 
@@ -95,7 +96,7 @@ All bounds are named constants in `manager.ts`, injectable for tests. *(Replay c
 
 ## Implementation Units
 
-- [ ] **Unit 1: Run-status projection (consumes the contract bridge)**
+- [x] **Unit 1: Run-status projection (consumes the contract bridge)**
 
   **Goal:** Map a safe `RunState` to an `OperatorRunStatus` (closed DTO) with the `waiting_for_approval` overlay, via the redaction bridge.
 
@@ -127,7 +128,7 @@ All bounds are named constants in `manager.ts`, injectable for tests. *(Replay c
 
   **Verification:** Every phase + the overlay produce a valid `OperatorWebStatus`; denied repos omit (`null`); the output is a closed DTO with no `details` passthrough.
 
-- [ ] **Unit 2: Registry scope-pending accessor**
+- [x] **Unit 2: Registry scope-pending accessor**
 
   **Goal:** Add `hasPendingForScope(approvalScopeId)` so the projection's `waiting_for_approval` overlay derives from the run's scope, not requestID guessing.
 
@@ -156,7 +157,7 @@ All bounds are named constants in `manager.ts`, injectable for tests. *(Replay c
 
   **Verification:** `hasPendingForScope` is true iff an open/claimed entry exists for exactly that scope.
 
-- [ ] **Unit 3: Lean backpressure-safe pub/sub manager (snapshot-on-subscribe)**
+- [x] **Unit 3: Lean backpressure-safe pub/sub manager (snapshot-on-subscribe)**
 
   **Goal:** The observer-only manager that fans run-status frames to subscribers without ever stalling on a slow consumer, serves the latest snapshot on subscribe, and heartbeats — with no replay buffer, no staleness detector, and no per-operator cap (all deferred to 4b).
 
@@ -194,7 +195,7 @@ All bounds are named constants in `manager.ts`, injectable for tests. *(Replay c
 
   **Verification:** The manager is non-blocking-backpressure-safe, snapshot-on-subscribe, redacted (denied omitted before cache), observer-only, and fully tested — no replay/staleness/cap, no route exposed.
 
-- [ ] **Unit 4: Run-lifecycle observer hook (push source)**
+- [x] **Unit 4: Run-lifecycle observer hook (push source)**
 
   **Goal:** Wire the manager's `observe` into the gateway run lifecycle so transitions push safe `RunState` snapshots; instantiate the manager in the composition root.
 

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -231,6 +231,8 @@ When the workspace OpenCode config sets any tool to `ask` (rather than the defau
 
 - **`heartbeat.stop()` failure can leave a run stuck.** If `heartbeat.stop()` returns an error, the gateway logs a warning and proceeds with last-known etags, but the run may remain in EXECUTING with the lock held until the lease expires. The next startup recovery sweep will detect and heal the stale run automatically.
 
+- **Run-observation cache leak on failed transitions.** If a run's state transition fails after the PENDING observe is sent (so the run never reaches a terminal status), its latest-status cache entry in the run-observation manager is never cleared. A future subscriber for that run would receive the stale cached status rather than a reset frame. The entry is cleared on process restart. A future staleness/reconcile path will evict these entries proactively.
+
 ## Build
 
 ```bash

--- a/packages/gateway/src/approvals/registry.test.ts
+++ b/packages/gateway/src/approvals/registry.test.ts
@@ -945,3 +945,153 @@ describe('P2 — confirmReply sessionID mismatch guard', () => {
     expect(renderFn).toHaveBeenCalledOnce()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Unit 2: hasPendingForScope
+// ---------------------------------------------------------------------------
+
+describe('hasPendingForScope', () => {
+  // Happy: open entry for scope → true
+  it('returns true when an open entry exists for the scope', () => {
+    // #given a registry with one open entry for scope_A
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    registry.register(makeParams({approvalScopeId: 'scope_A'}))
+
+    // #when queried for scope_A
+    const result = registry.hasPendingForScope('scope_A')
+
+    // #then true (open entry matches)
+    expect(result).toBe(true)
+  })
+
+  // Happy: claimed entry for scope → true
+  it('returns true when a claimed entry exists for the scope', async () => {
+    // #given a registry with an entry that is in-flight (claimed)
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    let resolveReply!: (v: {ok: boolean}) => void
+    const replyPromise = new Promise<{ok: boolean}>(res => {
+      resolveReply = res
+    })
+    const effects = makeEffects({postReply: vi.fn().mockReturnValue(replyPromise)})
+    registry.register(makeParams({approvalScopeId: 'scope_A', effects}))
+
+    // Transition to claimed (postReply in-flight, not yet resolved)
+    const clickPromise = registry.handleDecision({
+      requestID: 'per_1',
+      approvalScopeId: 'scope_A',
+      decision: 'once',
+      actor: makeActor(),
+    })
+
+    // #when queried while entry is claimed
+    const result = registry.hasPendingForScope('scope_A')
+
+    // #then true (claimed entry matches)
+    expect(result).toBe(true)
+
+    // Cleanup: resolve the in-flight reply so no dangling promise
+    resolveReply({ok: true})
+    await clickPromise
+  })
+
+  // Edge: only a confirmed (settled/deleted) entry existed → false
+  it('returns false after the matching entry is settled via applySettlement', async () => {
+    // #given a registry with one open entry for scope_A
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    registry.register(makeParams({approvalScopeId: 'scope_A'}))
+
+    // #when the entry is settled (applySettlement deletes it)
+    await registry.applySettlement({requestID: 'per_1', decision: 'reject', reason: 'deadline'})
+
+    // #then false (entry is gone — confirmed state is transient and entry is deleted)
+    const result = registry.hasPendingForScope('scope_A')
+    expect(result).toBe(false)
+  })
+
+  // Edge: no entries for scope → false
+  it('returns false for a scope with no entries', () => {
+    // #given an empty registry
+    const registry = createApprovalRegistry({logger: makeLogger()})
+
+    // #when queried for a scope that was never registered
+    const result = registry.hasPendingForScope('scope_NONE')
+
+    // #then false
+    expect(result).toBe(false)
+  })
+
+  // Edge: false after entry is disposed
+  it('returns false after the matching entry is disposed via disposeRun', async () => {
+    // #given a registry with one open entry for scope_A
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    registry.register(
+      makeParams({
+        approvalScopeId: 'scope_A',
+        sessionID: 'ses_1',
+        request: makeRequest({requestID: 'per_1', sessionID: 'ses_1'}),
+      }),
+    )
+
+    // #when the run is disposed
+    await registry.disposeRun('ses_1', 'run ended')
+
+    // #then false (entry is gone)
+    const result = registry.hasPendingForScope('scope_A')
+    expect(result).toBe(false)
+  })
+
+  // Isolation: different scope does not satisfy the query
+  it('returns false when only an entry for a DIFFERENT scope exists', () => {
+    // #given a registry with an open entry for scope_B
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    registry.register(makeParams({approvalScopeId: 'scope_B'}))
+
+    // #when queried for scope_A
+    const result = registry.hasPendingForScope('scope_A')
+
+    // #then false (no cross-scope match)
+    expect(result).toBe(false)
+  })
+
+  // Isolation: multiple scopes — only the matching scope returns true
+  it('returns true only for the scope that has an open entry, false for others', () => {
+    // #given two entries in different scopes
+    const registry = createApprovalRegistry({logger: makeLogger()})
+    registry.register(
+      makeParams({
+        requestID: 'per_1',
+        sessionID: 'ses_1',
+        approvalScopeId: 'scope_A',
+        request: makeRequest({requestID: 'per_1', sessionID: 'ses_1'}),
+      }),
+    )
+    registry.register(
+      makeParams({
+        requestID: 'per_2',
+        sessionID: 'ses_2',
+        approvalScopeId: 'scope_B',
+        request: makeRequest({requestID: 'per_2', sessionID: 'ses_2'}),
+      }),
+    )
+
+    // #when queried for each scope
+    const resultA = registry.hasPendingForScope('scope_A')
+    const resultB = registry.hasPendingForScope('scope_B')
+    const resultC = registry.hasPendingForScope('scope_C')
+
+    // #then only the matching scope returns true
+    expect(resultA).toBe(true)
+    expect(resultB).toBe(true)
+    expect(resultC).toBe(false)
+  })
+
+  // Type safety: return value is always a boolean (never throws)
+  it('never throws and always returns a boolean', () => {
+    // #given an empty registry
+    const registry = createApprovalRegistry({logger: makeLogger()})
+
+    // #when called with various inputs #then it returns a boolean and never throws
+    expect(typeof registry.hasPendingForScope('')).toBe('boolean')
+    expect(typeof registry.hasPendingForScope('any-scope')).toBe('boolean')
+  })
+})

--- a/packages/gateway/src/approvals/registry.ts
+++ b/packages/gateway/src/approvals/registry.ts
@@ -162,6 +162,16 @@ export interface ApprovalRegistry {
   has: (requestID: string) => boolean
   pending: () => readonly string[]
   /**
+   * Returns true if any entry for the given `approvalScopeId` is in an
+   * `open` or `claimed` state (i.e. the run is waiting for approval).
+   *
+   * Returns false when no entry exists for the scope, or when the only
+   * matching entry is `confirmed` (already settled and about to be deleted).
+   *
+   * Boolean only — does not expose entry contents.
+   */
+  hasPendingForScope: (approvalScopeId: string) => boolean
+  /**
    * Transport-neutral decision intake: enforce scope binding, single-winner
    * claim, POST reply. Does NOT edit the embed/notification.
    *
@@ -426,6 +436,15 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
     return Array.from(entries.keys())
   }
 
+  function hasPendingForScope(approvalScopeId: string): boolean {
+    for (const entry of entries.values()) {
+      if (entry.approvalScopeId === approvalScopeId && (entry.state === 'open' || entry.state === 'claimed')) {
+        return true
+      }
+    }
+    return false
+  }
+
   // -------------------------------------------------------------------------
   // handleDecision (transport-neutral decision intake)
   // -------------------------------------------------------------------------
@@ -688,6 +707,7 @@ export function createApprovalRegistry(deps: {readonly logger: GatewayLogger}): 
     markMessagePostFailed,
     has,
     pending,
+    hasPendingForScope,
     handleDecision,
     confirmReply,
     applySettlement,

--- a/packages/gateway/src/discord/mentions.test.ts
+++ b/packages/gateway/src/discord/mentions.test.ts
@@ -145,6 +145,7 @@ function makeRunMentionDeps(): MentionDeps['run'] {
       register: vi.fn(),
       has: vi.fn().mockReturnValue(false),
       pending: vi.fn().mockReturnValue([]),
+      hasPendingForScope: vi.fn().mockReturnValue(false),
       handleDecision: vi.fn().mockResolvedValue('ok'),
       applySettlement: vi.fn(),
       attachMessage: vi.fn(),

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -2742,6 +2742,156 @@ describe('runMention', () => {
     })
   })
 
+  // ── Run observer hook ───────────────────────────────────────────────────
+
+  describe('run observer hook', () => {
+    it('happy path: observe called with correct RunState at each transition (PENDING→ACKNOWLEDGED→EXECUTING→COMPLETED)', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+
+      const ackState = {run_id: 'r1', phase: 'ACKNOWLEDGED'} as unknown as import('@fro-bot/runtime').RunState
+      const execState = {run_id: 'r1', phase: 'EXECUTING'} as unknown as import('@fro-bot/runtime').RunState
+      const completedState = {run_id: 'r1', phase: 'COMPLETED'} as unknown as import('@fro-bot/runtime').RunState
+
+      mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'run-etag-v1'}})
+      mockRuntime.acquireLock.mockResolvedValue({
+        success: true as const,
+        data: {acquired: true as const, etag: 'lock-etag-v1', holder: null},
+      })
+      mockRuntime.releaseLock.mockResolvedValue({success: true as const, data: undefined})
+      mockRuntime.transitionRun
+        .mockResolvedValueOnce({success: true as const, data: {etag: 'ack-etag', state: ackState}})
+        .mockResolvedValueOnce({success: true as const, data: {etag: 'exec-etag', state: execState}})
+        .mockResolvedValueOnce({success: true as const, data: {etag: 'done-etag', state: completedState}})
+      mockRuntime.createHeartbeatController.mockReturnValue({
+        start: vi.fn(),
+        stop: vi.fn().mockResolvedValue({
+          success: true,
+          data: {runEtag: 'r-etag', lockEtag: 'l-etag', runState: completedState},
+        }),
+        isRunning: false,
+      })
+      mockRunOpenCodeCore.mockResolvedValue(undefined)
+      vi.mocked(attachModule.attachOpencode).mockReturnValue({
+        server: {url: 'http://workspace:9200'},
+        session: {create: vi.fn(), prompt: vi.fn()},
+      } as unknown as ReturnType<typeof attachModule.attachOpencode>)
+      vi.mocked(promptModule.buildDiscordPrompt).mockReturnValue('Repository: acme/widget\n\ndo the thing')
+
+      const observeFn = vi.fn().mockResolvedValue(undefined)
+      const runObserver = {observe: observeFn}
+      const deps = makeDeps({runObserver})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — observe called for PENDING (createRun), ACKNOWLEDGED, EXECUTING, COMPLETED
+      expect(observeFn).toHaveBeenCalledTimes(4)
+      const phases = observeFn.mock.calls.map((c: unknown[]) => (c[0] as {phase?: string}).phase)
+      expect(phases).toContain('PENDING')
+      expect(phases).toContain('ACKNOWLEDGED')
+      expect(phases).toContain('EXECUTING')
+      expect(phases).toContain('COMPLETED')
+    })
+
+    it('failure path: observe called with FAILED state on error', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      const failedState = {run_id: 'r1', phase: 'FAILED'} as unknown as import('@fro-bot/runtime').RunState
+      const ackState = {run_id: 'r1', phase: 'ACKNOWLEDGED'} as unknown as import('@fro-bot/runtime').RunState
+      const execState = {run_id: 'r1', phase: 'EXECUTING'} as unknown as import('@fro-bot/runtime').RunState
+
+      mockRuntime.acquireLock.mockResolvedValue({
+        success: true as const,
+        data: {acquired: true as const, etag: 'lock-etag-v1', holder: null},
+      })
+      mockRuntime.releaseLock.mockResolvedValue({success: true as const, data: undefined})
+      mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'run-etag-v1'}})
+      mockRuntime.transitionRun
+        .mockResolvedValueOnce({success: true as const, data: {etag: 'ack-etag', state: ackState}})
+        .mockResolvedValueOnce({success: true as const, data: {etag: 'exec-etag', state: execState}})
+        .mockResolvedValueOnce({success: true as const, data: {etag: 'fail-etag', state: failedState}})
+      mockRuntime.createHeartbeatController.mockReturnValue({
+        start: vi.fn(),
+        stop: vi.fn().mockResolvedValue({
+          success: true,
+          data: {runEtag: 'r-etag', lockEtag: 'l-etag', runState: failedState},
+        }),
+        isRunning: false,
+      })
+      mockRunOpenCodeCore.mockRejectedValue(new Error('boom'))
+      vi.mocked(attachModule.attachOpencode).mockReturnValue({
+        server: {url: 'http://workspace:9200'},
+        session: {create: vi.fn(), prompt: vi.fn()},
+      } as unknown as ReturnType<typeof attachModule.attachOpencode>)
+      vi.mocked(promptModule.buildDiscordPrompt).mockReturnValue('Repository: acme/widget\n\ndo the thing')
+
+      const observeFn = vi.fn().mockResolvedValue(undefined)
+      const deps = makeDeps({runObserver: {observe: observeFn}})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — observe called with FAILED state
+      const phases = observeFn.mock.calls.map((c: unknown[]) => (c[0] as {phase?: string}).phase)
+      expect(phases).toContain('FAILED')
+    })
+
+    it('best-effort sync: observe that throws synchronously does not abort the run', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const observeFn = vi.fn().mockImplementation(() => {
+        throw new Error('observe threw synchronously')
+      })
+      const deps = makeDeps({runObserver: {observe: observeFn}})
+      const message = makeMessage()
+
+      // #when — must not throw
+      await expect(runMention(message, makeBinding(), deps)).resolves.toBeUndefined()
+
+      // #then — run completed normally (COMPLETED transition happened)
+      const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+      expect(transitionPhases).toContain('COMPLETED')
+    })
+
+    it('best-effort async: observe that rejects does not abort the run and does not surface as unhandled rejection', async () => {
+      // #given
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const observeFn = vi.fn().mockRejectedValue(new Error('observe rejected'))
+      const deps = makeDeps({runObserver: {observe: observeFn}})
+      const message = makeMessage()
+
+      // #when — must not throw; rejection must be contained
+      await expect(runMention(message, makeBinding(), deps)).resolves.toBeUndefined()
+
+      // #then — run completed normally
+      const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+      expect(transitionPhases).toContain('COMPLETED')
+    })
+
+    it('inert: omitting runObserver (undefined) is safe — run completes normally', async () => {
+      // #given — no runObserver in deps
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const deps = makeDeps() // runObserver absent
+      const message = makeMessage()
+
+      // #when — must not throw
+      await expect(runMention(message, makeBinding(), deps)).resolves.toBeUndefined()
+
+      // #then — run completed normally
+      const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+      expect(transitionPhases).toContain('COMPLETED')
+    })
+  })
+
   // ── Status controller wiring ─────────────────────────────────────────────
 
   describe('status controller wiring', () => {

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -184,6 +184,7 @@ function makeApprovalRegistry(): ApprovalRegistry {
     register: vi.fn(),
     has: vi.fn().mockReturnValue(false),
     pending: vi.fn().mockReturnValue([]),
+    hasPendingForScope: vi.fn().mockReturnValue(false),
     handleDecision: vi.fn().mockResolvedValue('ok'),
     applySettlement: vi.fn().mockResolvedValue(undefined),
     attachMessage: vi.fn(),

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -2786,13 +2786,10 @@ describe('runMention', () => {
       // #when
       await runMention(message, makeBinding(), deps)
 
-      // #then — observe called for PENDING (createRun), ACKNOWLEDGED, EXECUTING, COMPLETED
+      // #then — observe called for PENDING (createRun), ACKNOWLEDGED, EXECUTING, COMPLETED in exact order
       expect(observeFn).toHaveBeenCalledTimes(4)
       const phases = observeFn.mock.calls.map((c: unknown[]) => (c[0] as {phase?: string}).phase)
-      expect(phases).toContain('PENDING')
-      expect(phases).toContain('ACKNOWLEDGED')
-      expect(phases).toContain('EXECUTING')
-      expect(phases).toContain('COMPLETED')
+      expect(phases).toEqual(['PENDING', 'ACKNOWLEDGED', 'EXECUTING', 'COMPLETED'])
     })
 
     it('failure path: observe called with FAILED state on error', async () => {
@@ -2834,9 +2831,9 @@ describe('runMention', () => {
       // #when
       await runMention(message, makeBinding(), deps)
 
-      // #then — observe called with FAILED state
+      // #then — observe called with PENDING, ACKNOWLEDGED, EXECUTING, FAILED in exact order
       const phases = observeFn.mock.calls.map((c: unknown[]) => (c[0] as {phase?: string}).phase)
-      expect(phases).toContain('FAILED')
+      expect(phases).toEqual(['PENDING', 'ACKNOWLEDGED', 'EXECUTING', 'FAILED'])
     })
 
     it('best-effort sync: observe that throws synchronously does not abort the run', async () => {

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -85,6 +85,18 @@ export interface RunMentionDeps {
    */
   readonly runIndex?: RunIndex
   /**
+   * Run-state observer for the SSE observation pipeline.
+   *
+   * Called best-effort after each successful run-state transition so the
+   * observation manager can project and fan out the new state to subscribers.
+   * Optional — when absent, observation is skipped (e.g. in tests that do
+   * not exercise the SSE pipeline).
+   *
+   * Narrow interface: only `observe` is exposed here so run.ts cannot call
+   * subscribe, shutdown, or abortSubscription on the manager.
+   */
+  readonly runObserver?: {readonly observe: (runState: import('@fro-bot/runtime').RunState) => Promise<void>}
+  /**
    * Ensure the workspace checkout exists for the given owner/repo.
    * Called after the concurrency gate acquires a slot, before readyz/execution.
    * Injected so tests can stub it without live GitHub/workspace calls.
@@ -382,6 +394,16 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       )
     }
 
+    // Push the initial PENDING state to the observation pipeline.
+    // Fire-and-forget: neither a sync throw nor an async rejection must abort the run.
+    try {
+      deps.runObserver
+        ?.observe(initialRunState)
+        .catch((error: unknown) => logger.warn({repo, runId, err: String(error)}, 'run: runObserver.observe failed'))
+    } catch (observeError: unknown) {
+      logger.warn({repo, runId, err: String(observeError)}, 'run: runObserver.observe threw — continuing (best-effort)')
+    }
+
     let runEtag = createResult.data.etag
 
     const ackResult = await transitionRun(
@@ -400,6 +422,15 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       return
     }
     runEtag = ackResult.data.etag
+
+    // Push the ACKNOWLEDGED state to the observation pipeline (best-effort, fire-and-forget).
+    try {
+      deps.runObserver
+        ?.observe(ackResult.data.state)
+        .catch((error: unknown) => logger.warn({repo, runId, err: String(error)}, 'run: runObserver.observe failed'))
+    } catch (observeError: unknown) {
+      logger.warn({repo, runId, err: String(observeError)}, 'run: runObserver.observe threw — continuing (best-effort)')
+    }
 
     const heartbeat = createHeartbeatController(coordinationConfig, identity, repo, runId, lockEtag, coordLogger)
     heartbeat.start()
@@ -422,6 +453,18 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
         throw new Error(`transitionRun EXECUTING failed: ${execResult.error.message}`)
       }
       runEtag = execResult.data.etag
+
+      // Push the EXECUTING state to the observation pipeline (best-effort, fire-and-forget).
+      try {
+        deps.runObserver
+          ?.observe(execResult.data.state)
+          .catch((error: unknown) => logger.warn({repo, runId, err: String(error)}, 'run: runObserver.observe failed'))
+      } catch (observeError: unknown) {
+        logger.warn(
+          {repo, runId, err: String(observeError)},
+          'run: runObserver.observe threw — continuing (best-effort)',
+        )
+      }
 
       // ── Working reaction — best-effort, fire-and-forget ───────────────────────────────────────────────────────────────────
       statusSink.setReaction('working')
@@ -592,6 +635,20 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       if (completedResult.success === false) {
         logger.error({repo, runId, err: completedResult.error.message}, 'run: transitionRun COMPLETED failed')
         // Non-fatal: continue to flush sink and release resources
+      } else {
+        // Push the COMPLETED state to the observation pipeline (best-effort, fire-and-forget).
+        try {
+          deps.runObserver
+            ?.observe(completedResult.data.state)
+            .catch((error: unknown) =>
+              logger.warn({repo, runId, err: String(error)}, 'run: runObserver.observe failed'),
+            )
+        } catch (observeError: unknown) {
+          logger.warn(
+            {repo, runId, err: String(observeError)},
+            'run: runObserver.observe threw — continuing (best-effort)',
+          )
+        }
       }
 
       // ── Status controller final-answer transition ─────────────────────────────────────────────
@@ -655,6 +712,20 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       )
       if (failedResult.success === false) {
         logger.error({repo, runId, err: failedResult.error.message}, 'run: transitionRun FAILED failed')
+      } else {
+        // Push the FAILED state to the observation pipeline (best-effort, fire-and-forget).
+        try {
+          deps.runObserver
+            ?.observe(failedResult.data.state)
+            .catch((error: unknown) =>
+              logger.warn({repo, runId, err: String(error)}, 'run: runObserver.observe failed'),
+            )
+        } catch (observeError: unknown) {
+          logger.warn(
+            {repo, runId, err: String(observeError)},
+            'run: runObserver.observe threw — continuing (best-effort)',
+          )
+        }
       }
 
       // Flush partial output (best-effort) so the user sees whatever streamed before the failure.

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -394,15 +394,24 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       )
     }
 
-    // Push the initial PENDING state to the observation pipeline.
+    // Notify the observation pipeline of a run-state transition.
     // Fire-and-forget: neither a sync throw nor an async rejection must abort the run.
-    try {
-      deps.runObserver
-        ?.observe(initialRunState)
-        .catch((error: unknown) => logger.warn({repo, runId, err: String(error)}, 'run: runObserver.observe failed'))
-    } catch (observeError: unknown) {
-      logger.warn({repo, runId, err: String(observeError)}, 'run: runObserver.observe threw — continuing (best-effort)')
+    // Optional-chaining the .catch() ensures undefined-observer is a clean no-op (no TypeError).
+    function notifyObserver(state: import('@fro-bot/runtime').RunState): void {
+      try {
+        deps.runObserver?.observe(state)?.catch((error: unknown) => {
+          logger.warn({repo, runId, err: String(error)}, 'run: runObserver.observe failed')
+        })
+      } catch (observeError: unknown) {
+        logger.warn(
+          {repo, runId, err: String(observeError)},
+          'run: runObserver.observe threw — continuing (best-effort)',
+        )
+      }
     }
+
+    // Push the initial PENDING state to the observation pipeline.
+    notifyObserver(initialRunState)
 
     let runEtag = createResult.data.etag
 
@@ -424,13 +433,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
     runEtag = ackResult.data.etag
 
     // Push the ACKNOWLEDGED state to the observation pipeline (best-effort, fire-and-forget).
-    try {
-      deps.runObserver
-        ?.observe(ackResult.data.state)
-        .catch((error: unknown) => logger.warn({repo, runId, err: String(error)}, 'run: runObserver.observe failed'))
-    } catch (observeError: unknown) {
-      logger.warn({repo, runId, err: String(observeError)}, 'run: runObserver.observe threw — continuing (best-effort)')
-    }
+    notifyObserver(ackResult.data.state)
 
     const heartbeat = createHeartbeatController(coordinationConfig, identity, repo, runId, lockEtag, coordLogger)
     heartbeat.start()
@@ -455,16 +458,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       runEtag = execResult.data.etag
 
       // Push the EXECUTING state to the observation pipeline (best-effort, fire-and-forget).
-      try {
-        deps.runObserver
-          ?.observe(execResult.data.state)
-          .catch((error: unknown) => logger.warn({repo, runId, err: String(error)}, 'run: runObserver.observe failed'))
-      } catch (observeError: unknown) {
-        logger.warn(
-          {repo, runId, err: String(observeError)},
-          'run: runObserver.observe threw — continuing (best-effort)',
-        )
-      }
+      notifyObserver(execResult.data.state)
 
       // ── Working reaction — best-effort, fire-and-forget ───────────────────────────────────────────────────────────────────
       statusSink.setReaction('working')
@@ -637,18 +631,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
         // Non-fatal: continue to flush sink and release resources
       } else {
         // Push the COMPLETED state to the observation pipeline (best-effort, fire-and-forget).
-        try {
-          deps.runObserver
-            ?.observe(completedResult.data.state)
-            .catch((error: unknown) =>
-              logger.warn({repo, runId, err: String(error)}, 'run: runObserver.observe failed'),
-            )
-        } catch (observeError: unknown) {
-          logger.warn(
-            {repo, runId, err: String(observeError)},
-            'run: runObserver.observe threw — continuing (best-effort)',
-          )
-        }
+        notifyObserver(completedResult.data.state)
       }
 
       // ── Status controller final-answer transition ─────────────────────────────────────────────
@@ -714,18 +697,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
         logger.error({repo, runId, err: failedResult.error.message}, 'run: transitionRun FAILED failed')
       } else {
         // Push the FAILED state to the observation pipeline (best-effort, fire-and-forget).
-        try {
-          deps.runObserver
-            ?.observe(failedResult.data.state)
-            .catch((error: unknown) =>
-              logger.warn({repo, runId, err: String(error)}, 'run: runObserver.observe failed'),
-            )
-        } catch (observeError: unknown) {
-          logger.warn(
-            {repo, runId, err: String(observeError)},
-            'run: runObserver.observe threw — continuing (best-effort)',
-          )
-        }
+        notifyObserver(failedResult.data.state)
       }
 
       // Flush partial output (best-effort) so the user sees whatever streamed before the failure.

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -74,6 +74,18 @@ vi.mock('./workspace-api/ensure-clone.js', async importOriginal => {
   }
 })
 
+// Stub createDenylistCache so program tests can assert startup priming without real GitHub App calls.
+vi.mock('./redaction/denylist.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./redaction/denylist.js')>()
+  return {
+    ...actual,
+    createDenylistCache: vi.fn().mockReturnValue({
+      getDenylistState: vi.fn().mockResolvedValue(undefined),
+      isRepoDenied: vi.fn().mockReturnValue(false),
+    }),
+  }
+})
+
 const {makeDiscordClientFromConfig, makeGatewayProgram} = await import('./program.js')
 const {createDiscordClient} = await import('./discord/client.js')
 const createDiscordClientSpy = vi.mocked(createDiscordClient)
@@ -1183,6 +1195,71 @@ describe('button interaction handler (approval flow)', () => {
     expect(serverDeps.allowlist?.isAuthorized(99)).toBe(false)
     expect(serverDeps.csrfSecret).toBe('dGVzdC1jc3JmLXNlY3JldC0zMi1ieXRlcy1sb25nISE')
     expect(serverDeps.auditLogger).toBeDefined()
+  })
+
+  it('denylist: getDenylistState is called once at startup to prime the cache', async () => {
+    // #given — the denylist cache mock is already set up via vi.mock above
+    const {createDenylistCache} = await import('./redaction/denylist.js')
+    const createDenylistCacheMock = vi.mocked(createDenylistCache)
+
+    const fakeConfig = makeFakeConfig({announce: undefined})
+    const fakeClient = makeFakeClient()
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: vi.fn(),
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    // #when
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then — createDenylistCache was called (the cache was created)
+    expect(createDenylistCacheMock).toHaveBeenCalledOnce()
+
+    // #and — getDenylistState was called at startup to prime the cache
+    const fakeCacheInstance = createDenylistCacheMock.mock.results[0]?.value as {
+      getDenylistState: ReturnType<typeof vi.fn>
+    }
+    expect(fakeCacheInstance).toBeDefined()
+    expect(fakeCacheInstance.getDenylistState).toHaveBeenCalledOnce()
+  })
+
+  it('denylist: startup prime failure is logged and does not crash boot', async () => {
+    // #given — getDenylistState rejects on the first call (prime failure)
+    const {createDenylistCache} = await import('./redaction/denylist.js')
+    const createDenylistCacheMock = vi.mocked(createDenylistCache)
+    createDenylistCacheMock.mockReturnValueOnce({
+      getDenylistState: vi.fn().mockRejectedValue(new Error('prime failed — network error')),
+      isRepoDenied: vi.fn().mockReturnValue(true), // stays deny-all
+    })
+
+    const fakeConfig = makeFakeConfig({announce: undefined})
+    const fakeClient = makeFakeClient()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: vi.fn(),
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    try {
+      // #when — boot must NOT throw even though prime failed
+      await expect(Effect.runPromise(makeGatewayProgram(deps, fakeConfig))).resolves.toBeUndefined()
+
+      // #then — a warn was logged about the prime failure
+      const warnMessages = warnSpy.mock.calls.map(args => String(args[0]))
+      expect(warnMessages.some(m => m.includes('startup prime failed'))).toBe(true)
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   it('shutdown → approvalRegistry.disposeAll called', async () => {

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -639,6 +639,7 @@ describe('button interaction handler (approval flow)', () => {
       register: vi.fn(),
       has: vi.fn().mockReturnValue(false),
       pending: vi.fn().mockReturnValue([]),
+      hasPendingForScope: vi.fn().mockReturnValue(false),
       handleDecision: vi.fn().mockResolvedValue('ok'),
       applySettlement: vi.fn().mockResolvedValue(undefined),
       attachMessage: vi.fn(),

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -225,9 +225,10 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
     // Run-observation manager: projects run states and fans them to SSE subscribers.
     // It is fed by the run lifecycle hook and holds a latest-status cache per active run.
     // No HTTP route consumes it yet, so nothing subscribes.
+    const DENYLIST_TTL_MS = 5 * 60_000 // 5-minute TTL — also used as the background refresh cadence
     const denylistCache = createDenylistCache({
       reader: createAppClientMetadataReader(appClient),
-      ttlMs: 5 * 60_000, // 5-minute TTL
+      ttlMs: DENYLIST_TTL_MS,
       graceMs: 30 * 60_000, // 30-minute grace window
       now: () => Date.now(),
       logger,
@@ -248,6 +249,31 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
       clearTimeout: id => clearTimeout(id),
       now: () => Date.now(),
     })
+
+    // Prime the denylist cache once at startup so isRepoDenied reads primed state
+    // rather than deny-all. A prime failure is logged but must not crash startup —
+    // the cache stays fail-closed (deny-all) until a later refresh succeeds.
+    yield* Effect.tryPromise({
+      try: async () => {
+        try {
+          await denylistCache.getDenylistState()
+        } catch (primeError: unknown) {
+          logger.warn(
+            {err: String(primeError)},
+            'denylist: startup prime failed — cache stays deny-all until next refresh',
+          )
+        }
+      },
+      catch: error => (error instanceof Error ? error : new Error(String(error))),
+    })
+
+    // Background refresh: keep the denylist warm on the same cadence as the TTL.
+    // Errors are logged by the cache internally; the interval catch is a final safety net.
+    const denylistRefreshInterval = setInterval(() => {
+      denylistCache.getDenylistState().catch((error: unknown) => {
+        logger.warn({err: String(error)}, 'denylist: background refresh failed')
+      })
+    }, DENYLIST_TTL_MS)
 
     // e. Register slash commands
     yield* Effect.tryPromise({
@@ -530,6 +556,12 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           }
 
     installShutdownHandlers(client, logger, undefined, compositeServerHandle, async () => {
+      // Stop the denylist background refresh — no new refreshes after shutdown starts.
+      clearInterval(denylistRefreshInterval)
+
+      // Shut down the run-observation manager — closes all SSE subscriptions and clears timers.
+      runObservationManager.shutdown()
+
       // Dispose pending approvals before draining runs — ensures pending permissions
       // fail-closed so in-flight runs don't hang waiting for a button that will never come.
       //

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -30,10 +30,14 @@ import {recoverStaleRuns} from './execute/recovery.js'
 import {createRunIndex} from './execute/run-index.js'
 import {createAppClient} from './github/app-client.js'
 import {createRateLimiter} from './http/rate-limit.js'
+import {createDenylistCache} from './redaction/denylist.js'
+import {createAppClientMetadataReader} from './redaction/reader-app-client.js'
 import {forceReleaseStaleLockEffect} from './runtime-effect.js'
 import {installShutdownHandlers, isShuttingDown} from './shutdown.js'
 import {buildGitHubOAuthDeps} from './web/auth/github.js'
 import {createInMemorySessionStore} from './web/auth/session.js'
+import {createRunObservationManager} from './web/sse/manager.js'
+import {projectRunObservation} from './web/sse/projection.js'
 import {createWorkspaceClient} from './workspace-api/client.js'
 import {ensureWorkspaceClone} from './workspace-api/ensure-clone.js'
 
@@ -218,6 +222,33 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
     // Program-scoped approval registry — shared between the button handler and shutdown drain.
     const approvalRegistry = createApprovalRegistry({logger})
 
+    // Run-observation manager: projects run states and fans them to SSE subscribers.
+    // It is fed by the run lifecycle hook and holds a latest-status cache per active run.
+    // No HTTP route consumes it yet, so nothing subscribes.
+    const denylistCache = createDenylistCache({
+      reader: createAppClientMetadataReader(appClient),
+      ttlMs: 5 * 60_000, // 5-minute TTL
+      graceMs: 30 * 60_000, // 30-minute grace window
+      now: () => Date.now(),
+      logger,
+    })
+    const runObservationManager = createRunObservationManager({
+      projectRunObservation: async runState =>
+        projectRunObservation(runState, {
+          nowMs: Date.now(),
+          staleThresholdMs: DEFAULT_STALE_THRESHOLD_MS,
+          bindingsLookup: bindingsStore,
+          isRepoDenied: denylistCache.isRepoDenied,
+          hasPendingForScope: scopeId => approvalRegistry.hasPendingForScope(scopeId),
+        }),
+      logger,
+      setInterval: (cb, ms) => setInterval(cb, ms),
+      clearInterval: id => clearInterval(id),
+      setTimeout: (cb, ms) => setTimeout(cb, ms),
+      clearTimeout: id => clearTimeout(id),
+      now: () => Date.now(),
+    })
+
     // e. Register slash commands
     yield* Effect.tryPromise({
       try: async () =>
@@ -346,6 +377,8 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           isShuttingDown,
           // Server-owned run index: populated at run creation for privileged route authz.
           runIndex,
+          // Feeds the run-observation manager at each lifecycle transition.
+          runObserver: runObservationManager,
         },
         logger,
       }

--- a/packages/gateway/src/web/sse/manager.test.ts
+++ b/packages/gateway/src/web/sse/manager.test.ts
@@ -1,0 +1,1142 @@
+/**
+ * manager.test.ts — Tests for the run-observation pub/sub manager (Unit 3).
+ *
+ * Test-first (RED→GREEN). The load-bearing risks are:
+ *   1. Non-blocking backpressure: observe() must never await a subscriber write.
+ *   2. Observer-only invariant: the manager must never call any mutating run API.
+ *
+ * BDD comments: #given / #when / #then.
+ *
+ * Timer seam: all tests use injectable fake timers (setInterval/clearInterval/
+ * setTimeout/clearTimeout/now) so heartbeat and max-duration tests are synchronous.
+ */
+
+import type {RunState} from '@fro-bot/runtime'
+import type {OperatorRunStatus} from '../../operator-contract/index.js'
+import type {ObservationFrame, RunObservationManager, RunObservationManagerDeps} from './manager.js'
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createRunObservationManager} from './manager.js'
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeRunState(overrides: Partial<RunState> = {}): RunState {
+  return {
+    run_id: 'run-001',
+    surface: 'github',
+    thread_id: 'thread-001',
+    entity_ref: 'acme/widget#1',
+    phase: 'EXECUTING',
+    started_at: '2024-01-01T00:00:00.000Z',
+    last_heartbeat: new Date(1_000_000).toISOString(),
+    holder_id: 'holder-001',
+    details: {},
+    ...overrides,
+  }
+}
+
+function makeOperatorRunStatus(overrides: Partial<OperatorRunStatus> = {}): OperatorRunStatus {
+  return {
+    runId: 'run-001',
+    entityRef: 'acme/widget#1',
+    surface: 'github',
+    phase: 'EXECUTING',
+    status: 'running',
+    startedAt: '2024-01-01T00:00:00.000Z',
+    stale: false,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fake timer infrastructure
+// ---------------------------------------------------------------------------
+
+interface FakeTimerEntry {
+  readonly id: number
+  readonly intervalMs: number
+  readonly callback: () => void
+  readonly isInterval: boolean
+  /** Absolute time (from startMs) at which this timer next fires. */
+  nextFireAt: number
+}
+
+interface FakeTimerSystem {
+  readonly setInterval: (cb: () => void, ms: number) => ReturnType<typeof setInterval>
+  readonly clearInterval: (id: ReturnType<typeof setInterval> | undefined) => void
+  readonly setTimeout: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>
+  readonly clearTimeout: (id: ReturnType<typeof setTimeout> | undefined) => void
+  readonly now: () => number
+  /** Advance the fake clock by `ms` milliseconds, firing all due timers in order. */
+  readonly advance: (ms: number) => void
+  readonly activeTimerCount: () => number
+}
+
+function makeFakeTimerSystem(startMs = 0): FakeTimerSystem {
+  let currentTime = startMs
+  let nextId = 1
+  const timers = new Map<number, FakeTimerEntry>()
+
+  const setInterval = (cb: () => void, ms: number): ReturnType<typeof globalThis.setInterval> => {
+    const id = nextId++
+    timers.set(id, {id, intervalMs: ms, callback: cb, isInterval: true, nextFireAt: currentTime + ms})
+    return id as unknown as ReturnType<typeof globalThis.setInterval>
+  }
+
+  const clearInterval = (id: ReturnType<typeof globalThis.setInterval> | undefined): void => {
+    if (id !== undefined) {
+      timers.delete(id as unknown as number)
+    }
+  }
+
+  const setTimeout = (cb: () => void, ms: number): ReturnType<typeof globalThis.setTimeout> => {
+    const id = nextId++
+    timers.set(id, {id, intervalMs: ms, callback: cb, isInterval: false, nextFireAt: currentTime + ms})
+    return id as unknown as ReturnType<typeof globalThis.setTimeout>
+  }
+
+  const clearTimeout = (id: ReturnType<typeof globalThis.setTimeout> | undefined): void => {
+    if (id !== undefined) {
+      timers.delete(id as unknown as number)
+    }
+  }
+
+  const now = (): number => currentTime
+
+  const advance = (ms: number): void => {
+    const targetTime = currentTime + ms
+    // Fire timers in chronological order until we reach targetTime
+    let safetyLimit = 100_000
+    while (safetyLimit-- > 0) {
+      // Find the earliest timer that fires at or before targetTime
+      let earliest: FakeTimerEntry | undefined
+      for (const timer of timers.values()) {
+        if (timer.nextFireAt <= targetTime && (earliest === undefined || timer.nextFireAt < earliest.nextFireAt)) {
+          earliest = timer
+        }
+      }
+      if (earliest === undefined) {
+        break
+      }
+      // Advance clock to the fire time
+      currentTime = earliest.nextFireAt
+      // Fire the callback
+      earliest.callback()
+      if (earliest.isInterval === true) {
+        // Reschedule: update nextFireAt in place
+        earliest.nextFireAt = currentTime + earliest.intervalMs
+      } else {
+        // One-shot: remove
+        timers.delete(earliest.id)
+      }
+    }
+    currentTime = targetTime
+  }
+
+  const activeTimerCount = (): number => timers.size
+
+  return {setInterval, clearInterval, setTimeout, clearTimeout, now, advance, activeTimerCount}
+}
+
+// ---------------------------------------------------------------------------
+// Manager factory helper
+// ---------------------------------------------------------------------------
+
+type ProjectFn = RunObservationManagerDeps['projectRunObservation']
+
+function makeManager(
+  projectFn: ProjectFn,
+  overrides: Partial<RunObservationManagerDeps> = {},
+  fakeTimers?: FakeTimerSystem,
+): {manager: RunObservationManager; timers: FakeTimerSystem} {
+  const timers = fakeTimers ?? makeFakeTimerSystem()
+  const manager = createRunObservationManager({
+    projectRunObservation: projectFn,
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    setInterval: timers.setInterval,
+    clearInterval: timers.clearInterval,
+    setTimeout: timers.setTimeout,
+    clearTimeout: timers.clearTimeout,
+    now: timers.now,
+    ...overrides,
+  })
+  return {manager, timers}
+}
+
+// ---------------------------------------------------------------------------
+// Collected frames helper
+// ---------------------------------------------------------------------------
+
+function collectFrames(
+  manager: RunObservationManager,
+  runId: string,
+): {frames: ObservationFrame[]; closes: string[]; unsubscribe: () => void} {
+  const frames: ObservationFrame[] = []
+  const closes: string[] = []
+  const unsubscribe = manager.subscribe(runId, {
+    onEvent: frame => {
+      frames.push(frame)
+    },
+    onClose: reason => {
+      closes.push(reason)
+    },
+  })
+  return {frames, closes, unsubscribe}
+}
+
+// ---------------------------------------------------------------------------
+// Drain helper: flush the microtask queue so async writer tasks run
+// ---------------------------------------------------------------------------
+
+async function drain(): Promise<void> {
+  // Multiple rounds to let chained microtasks settle
+  for (let i = 0; i < 20; i++) {
+    await Promise.resolve()
+  }
+}
+
+// ===========================================================================
+// 1. Happy path: ordered frames + terminal close + cache clear
+// ===========================================================================
+
+describe('happy path — ordered frames, terminal close, cache clear', () => {
+  it('pushes ordered frames to a subscriber and closes cleanly on terminal status', async () => {
+    // #given a manager with a project function that returns status frames in sequence
+    const statuses: OperatorRunStatus[] = [
+      makeOperatorRunStatus({phase: 'PENDING', status: 'queued'}),
+      makeOperatorRunStatus({phase: 'EXECUTING', status: 'running'}),
+      makeOperatorRunStatus({phase: 'COMPLETED', status: 'succeeded'}),
+    ]
+    let callCount = 0
+    const projectFn: ProjectFn = async () => statuses[callCount++] ?? null
+
+    const {manager} = makeManager(projectFn)
+    const {frames, closes, unsubscribe} = collectFrames(manager, 'run-001')
+
+    // #when observing three transitions
+    await manager.observe(makeRunState({phase: 'PENDING'}))
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await manager.observe(makeRunState({phase: 'COMPLETED', run_id: 'run-001'}))
+    await drain()
+
+    // #then frames arrive in order
+    const statusFrames = frames.filter(f => f.type === 'status')
+    expect(statusFrames).toHaveLength(3)
+    expect(statusFrames[0]).toMatchObject({type: 'status', data: {status: 'queued'}})
+    expect(statusFrames[1]).toMatchObject({type: 'status', data: {status: 'running'}})
+    expect(statusFrames[2]).toMatchObject({type: 'status', data: {status: 'succeeded'}})
+
+    // #then the stream is closed after the terminal status
+    expect(closes).toHaveLength(1)
+    expect(closes[0]).toBe('terminal')
+
+    // #then subscribing again after terminal emits reset (cache cleared)
+    const {frames: frames2} = collectFrames(manager, 'run-001')
+    await drain()
+    expect(frames2.filter(f => f.type === 'reset')).toHaveLength(1)
+
+    unsubscribe()
+    manager.shutdown()
+  })
+
+  it('clears the cache entry after terminal fan-out', async () => {
+    // #given a manager that projects a terminal status
+    const terminalStatus = makeOperatorRunStatus({phase: 'COMPLETED', status: 'succeeded'})
+    const projectFn: ProjectFn = async () => terminalStatus
+
+    const {manager} = makeManager(projectFn)
+
+    // #when observing a terminal transition
+    await manager.observe(makeRunState({phase: 'COMPLETED'}))
+    await drain()
+
+    // #then subscribing after terminal gets reset (no cached entry)
+    const {frames} = collectFrames(manager, 'run-001')
+    await drain()
+    expect(frames.some(f => f.type === 'reset')).toBe(true)
+    expect(frames.some(f => f.type === 'status')).toBe(false)
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 2. Snapshot-on-subscribe
+// ===========================================================================
+
+describe('snapshot-on-subscribe', () => {
+  it('delivers the cached latest status immediately on subscribe, then live frames', async () => {
+    // #given a manager with a cached status for run-001
+    const cachedStatus = makeOperatorRunStatus({status: 'running'})
+    const liveStatus = makeOperatorRunStatus({status: 'succeeded', phase: 'COMPLETED'})
+    let callCount = 0
+    const projectFn: ProjectFn = async () => (callCount++ === 0 ? cachedStatus : liveStatus)
+
+    const {manager} = makeManager(projectFn)
+
+    // Seed the cache by observing first
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #when subscribing after the cache is populated
+    const {frames, closes} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #then the snapshot is delivered immediately (before any new observe)
+    const statusFrames = frames.filter(f => f.type === 'status')
+    expect(statusFrames.length).toBeGreaterThanOrEqual(1)
+    expect(statusFrames[0]).toMatchObject({type: 'status', data: {status: 'running'}})
+
+    // #when a live frame arrives
+    await manager.observe(makeRunState({phase: 'COMPLETED'}))
+    await drain()
+
+    // #then the live frame is also delivered
+    const allStatusFrames = frames.filter(f => f.type === 'status')
+    expect(allStatusFrames.length).toBeGreaterThanOrEqual(2)
+    expect(allStatusFrames.at(-1)).toMatchObject({type: 'status', data: {status: 'succeeded'}})
+
+    // #then the stream closes on terminal
+    expect(closes).toContain('terminal')
+
+    manager.shutdown()
+  })
+
+  it('emits a reset frame when no cached status exists for the run', async () => {
+    // #given a manager with no cached status for run-999
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const {manager} = makeManager(projectFn)
+
+    // #when subscribing to a run with no cache
+    const {frames} = collectFrames(manager, 'run-999')
+    await drain()
+
+    // #then a reset frame is emitted
+    const resetFrames = frames.filter(f => f.type === 'reset')
+    expect(resetFrames).toHaveLength(1)
+    expect(resetFrames[0]).toMatchObject({type: 'reset', runId: 'run-999'})
+
+    manager.shutdown()
+  })
+
+  it('does NOT emit reset when a cached status exists', async () => {
+    // #given a manager with a cached status
+    const cachedStatus = makeOperatorRunStatus({status: 'running'})
+    const projectFn: ProjectFn = async () => cachedStatus
+    const {manager} = makeManager(projectFn)
+
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #when subscribing
+    const {frames} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #then no reset frame is emitted
+    expect(frames.some(f => f.type === 'reset')).toBe(false)
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 3. Backpressure (LOAD-BEARING)
+// ===========================================================================
+
+describe('backpressure — LOAD-BEARING', () => {
+  it('drops a slow subscriber (overflow) without blocking publish or a fast peer', async () => {
+    // #given a manager with a queue cap sized for exactly one status frame
+    // We need the slow subscriber to overflow when a SECOND frame arrives (queue full),
+    // while the fast subscriber drains immediately and never overflows.
+    //
+    // Strategy: use a cap that fits one frame. The slow subscriber gets the snapshot
+    // frame (fills the queue) and then never drains. When the second observe() arrives,
+    // the slow subscriber's queue is full → overflow. The fast subscriber drains
+    // immediately so its queue is always empty → no overflow.
+    const status = makeOperatorRunStatus({status: 'running'})
+    const projectFn: ProjectFn = async () => status
+
+    // Estimate one frame's byte size so we can set the cap to exactly that
+    const oneFrameBytes = JSON.stringify({type: 'status', data: status}).length
+    // Cap = one frame: the slow subscriber fills up after the snapshot, overflows on the next
+    const {manager} = makeManager(projectFn, {subscriberQueueCapBytes: oneFrameBytes})
+
+    // Seed the cache so both subscribers get a snapshot frame on subscribe
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #given a slow subscriber that never drains (simulated by blocking onEvent)
+    const slowCloses: string[] = []
+    manager.subscribe('run-001', {
+      onEvent: async () => {
+        // Simulate a slow consumer: never resolves during the test
+        await new Promise<void>(() => {
+          // intentionally never resolves
+        })
+      },
+      onClose: reason => {
+        slowCloses.push(reason)
+      },
+    })
+
+    // #given a fast subscriber
+    const fastFrames: ObservationFrame[] = []
+    const fastCloses: string[] = []
+    manager.subscribe('run-001', {
+      onEvent: frame => {
+        fastFrames.push(frame)
+      },
+      onClose: reason => {
+        fastCloses.push(reason)
+      },
+    })
+
+    // Both subscribers got the snapshot frame. The slow subscriber's queue is now full
+    // (one frame = cap). The fast subscriber drained immediately (queue empty).
+
+    // #when observing again (second frame — slow subscriber queue is full → overflow)
+    const observeStart = Date.now()
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    const observeElapsed = Date.now() - observeStart
+
+    // #then observe() completes in bounded time (not blocked by slow subscriber)
+    // The key invariant: observe() must return without awaiting any subscriber write
+    expect(observeElapsed).toBeLessThan(100) // well under any real I/O timeout
+
+    await drain()
+
+    // #then the slow subscriber is dropped with 'overflow'
+    expect(slowCloses).toContain('overflow')
+
+    // #then the fast subscriber still receives frames (snapshot + live)
+    expect(fastFrames.filter(f => f.type === 'status').length).toBeGreaterThanOrEqual(1)
+    expect(fastCloses).not.toContain('overflow')
+
+    manager.shutdown()
+  })
+
+  it('observe() completes in bounded time with ALL subscribers slow (no await on any write)', async () => {
+    // #given a manager with a tiny cap to force all subscribers to overflow
+    const status = makeOperatorRunStatus({status: 'running'})
+    const projectFn: ProjectFn = async () => status
+    const {manager} = makeManager(projectFn, {subscriberQueueCapBytes: 1})
+
+    // #given multiple slow subscribers
+    const closes: string[] = []
+    for (let i = 0; i < 5; i++) {
+      manager.subscribe('run-001', {
+        onEvent: async () => {
+          // Never resolves — simulates a completely stuck consumer
+          await new Promise<void>(() => {
+            // intentionally never resolves
+          })
+        },
+        onClose: reason => {
+          closes.push(reason)
+        },
+      })
+    }
+
+    // #when observing with all subscribers slow
+    const start = Date.now()
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    const elapsed = Date.now() - start
+
+    // #then observe() returns in bounded time — it NEVER awaits subscriber writes
+    // This is the critical invariant: the publisher is non-blocking
+    expect(elapsed).toBeLessThan(100)
+
+    // #then the latest-status cache is updated (O(1) operation)
+    // Verify by subscribing a new fast subscriber and getting the snapshot
+    await drain()
+
+    // All slow subscribers should have been dropped due to overflow
+    // The cache may or may not have been updated depending on whether the
+    // enqueue happened before the overflow check — but observe() must have returned
+    expect(elapsed).toBeLessThan(100) // re-assert the key invariant
+
+    manager.shutdown()
+  })
+
+  it('dropping a subscriber mid-fan-out does not corrupt the publish iteration', async () => {
+    // #given a manager with a tiny cap
+    const statuses = [
+      makeOperatorRunStatus({status: 'running'}),
+      makeOperatorRunStatus({status: 'succeeded', phase: 'COMPLETED'}),
+    ]
+    let callCount = 0
+    const projectFn: ProjectFn = async () => statuses[callCount++ % statuses.length] ?? null
+    const {manager} = makeManager(projectFn, {subscriberQueueCapBytes: 1})
+
+    // #given a mix of subscribers (some will overflow, some won't)
+    const results: {frames: ObservationFrame[]; closes: string[]}[] = []
+    for (let i = 0; i < 3; i++) {
+      const frames: ObservationFrame[] = []
+      const closes: string[] = []
+      results.push({frames, closes})
+      manager.subscribe('run-001', {
+        onEvent: frame => {
+          frames.push(frame)
+        },
+        onClose: reason => {
+          closes.push(reason)
+        },
+      })
+    }
+
+    // #when observing multiple times (some subscribers will overflow)
+    // This must not throw or corrupt the iteration
+    await expect(
+      (async () => {
+        await manager.observe(makeRunState({phase: 'EXECUTING'}))
+        await manager.observe(makeRunState({phase: 'COMPLETED'}))
+        await drain()
+      })(),
+    ).resolves.not.toThrow()
+
+    // #then the results array is still intact (no corruption)
+    expect(results).toHaveLength(3)
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 4. Bounds: heartbeat and max duration
+// ===========================================================================
+
+describe('bounds — heartbeat and max duration', () => {
+  it('emits a heartbeat frame after the heartbeat interval', async () => {
+    // #given a manager with injectable fake timers
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const fakeTimers = makeFakeTimerSystem(0)
+    const {manager} = makeManager(projectFn, {heartbeatIntervalMs: 15_000}, fakeTimers)
+
+    // #given a subscriber
+    const {frames} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #when advancing time past the heartbeat interval
+    fakeTimers.advance(15_001)
+    await drain()
+
+    // #then a heartbeat frame was emitted
+    const heartbeats = frames.filter(f => f.type === 'heartbeat')
+    expect(heartbeats.length).toBeGreaterThanOrEqual(1)
+
+    manager.shutdown()
+  })
+
+  it('does NOT emit a heartbeat before the interval elapses', async () => {
+    // #given a manager with injectable fake timers
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const fakeTimers = makeFakeTimerSystem(0)
+    const {manager} = makeManager(projectFn, {heartbeatIntervalMs: 15_000}, fakeTimers)
+
+    // #given a subscriber
+    const {frames} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #when advancing time to just before the heartbeat interval
+    fakeTimers.advance(14_999)
+    await drain()
+
+    // #then no heartbeat frame was emitted
+    const heartbeats = frames.filter(f => f.type === 'heartbeat')
+    expect(heartbeats).toHaveLength(0)
+
+    manager.shutdown()
+  })
+
+  it('closes a subscriber after the max stream duration', async () => {
+    // #given a manager with injectable fake timers and the default max duration
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const fakeTimers = makeFakeTimerSystem(0)
+    const {manager} = makeManager(
+      projectFn,
+      {heartbeatIntervalMs: 15_000, maxStreamDurationMs: 30 * 60 * 1000},
+      fakeTimers,
+    )
+
+    // #given a subscriber
+    const {closes} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #when advancing time past the max stream duration (30 minutes)
+    fakeTimers.advance(30 * 60 * 1000 + 1)
+    await drain()
+
+    // #then the subscriber is closed with 'max-duration'
+    expect(closes).toContain('max-duration')
+
+    manager.shutdown()
+  })
+
+  it('emits multiple heartbeats over multiple intervals', async () => {
+    // #given a manager with injectable fake timers
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const fakeTimers = makeFakeTimerSystem(0)
+    const {manager} = makeManager(projectFn, {heartbeatIntervalMs: 15_000}, fakeTimers)
+
+    // #given a subscriber
+    const {frames} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #when advancing time past 3 heartbeat intervals
+    fakeTimers.advance(45_001)
+    await drain()
+
+    // #then at least 3 heartbeat frames were emitted
+    const heartbeats = frames.filter(f => f.type === 'heartbeat')
+    expect(heartbeats.length).toBeGreaterThanOrEqual(3)
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 5. Denied-repo omission
+// ===========================================================================
+
+describe('denied-repo omission', () => {
+  it('produces no cache entry, no enqueued frame, no side effect when projection returns null', async () => {
+    // #given a manager whose project function always returns null (denied repo)
+    const projectFn: ProjectFn = async () => null
+    const {manager} = makeManager(projectFn)
+
+    // #given a subscriber before the observe
+    const {frames, closes} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // The initial subscribe with no cache emits reset — that's expected
+    const initialResetCount = frames.filter(f => f.type === 'reset').length
+
+    // #when observing a denied run
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #then no new status frame was enqueued
+    const statusFrames = frames.filter(f => f.type === 'status')
+    expect(statusFrames).toHaveLength(0)
+
+    // #then no new reset was triggered by the denied observe (only the initial one)
+    const resetFrames = frames.filter(f => f.type === 'reset')
+    expect(resetFrames).toHaveLength(initialResetCount)
+
+    // #then no close was triggered by the denied observe
+    expect(closes).toHaveLength(0)
+
+    // #then subscribing again still gets reset (no cache entry was created)
+    const {frames: frames2} = collectFrames(manager, 'run-001')
+    await drain()
+    expect(frames2.some(f => f.type === 'reset')).toBe(true)
+    expect(frames2.some(f => f.type === 'status')).toBe(false)
+
+    manager.shutdown()
+  })
+
+  it('does not update the latest-status cache when projection returns null', async () => {
+    // #given a manager that first returns a real status, then null
+    const realStatus = makeOperatorRunStatus({status: 'running'})
+    let callCount = 0
+    const projectFn: ProjectFn = async () => (callCount++ === 0 ? realStatus : null)
+    const {manager} = makeManager(projectFn)
+
+    // Seed the cache
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #when observing a denied run (null projection)
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #then the cache still holds the previous real status (null didn't overwrite it)
+    const {frames} = collectFrames(manager, 'run-001')
+    await drain()
+    const statusFrames = frames.filter(f => f.type === 'status')
+    // Should get the cached real status, not a reset
+    expect(statusFrames.length).toBeGreaterThanOrEqual(1)
+    expect(statusFrames[0]).toMatchObject({type: 'status', data: {status: 'running'}})
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 6. Observer-only invariant (LOAD-BEARING)
+// ===========================================================================
+
+describe('observer-only invariant — LOAD-BEARING', () => {
+  it('deps type has no mutating run API — observer-only by construction', () => {
+    // #given the RunObservationManagerDeps type
+    // This is a structural/compile-time test: we verify that the deps object
+    // we pass to createRunObservationManager has NO mutating run API fields.
+    // The type system enforces this — if the type had lock/coordinator/heartbeat
+    // mutators, TypeScript would require them and this test would fail to compile.
+
+    const deps: RunObservationManagerDeps = {
+      projectRunObservation: async () => null,
+      logger: {info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn()},
+      setInterval: globalThis.setInterval.bind(globalThis),
+      clearInterval: globalThis.clearInterval.bind(globalThis),
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+      clearTimeout: globalThis.clearTimeout.bind(globalThis),
+      now: Date.now.bind(Date),
+    }
+
+    // #then the deps object has ONLY the expected read-only/observer fields
+    const depKeys = new Set(Object.keys(deps))
+
+    // No mutating run API keys are present
+    const mutatingKeys = ['transitionRun', 'acquireLock', 'releaseLock', 'heartbeat', 'coordinator', 'runLock']
+    for (const key of mutatingKeys) {
+      expect(depKeys.has(key)).toBe(false)
+    }
+
+    // All present keys are in the allowed set
+    const allowedKeys = new Set([
+      'projectRunObservation',
+      'logger',
+      'setInterval',
+      'clearInterval',
+      'setTimeout',
+      'clearTimeout',
+      'now',
+      'heartbeatIntervalMs',
+      'maxStreamDurationMs',
+      'subscriberQueueCapBytes',
+    ])
+    for (const key of depKeys) {
+      expect(allowedKeys.has(key)).toBe(true)
+    }
+  })
+
+  it('observe/subscribe/shutdown never call any mutating run API (behavioral)', async () => {
+    // #given spy objects for anything mutating-adjacent
+    const mutatingSpies = {
+      transitionRun: vi.fn(),
+      acquireLock: vi.fn(),
+      releaseLock: vi.fn(),
+      heartbeat: vi.fn(),
+      coordinator: {transition: vi.fn(), lock: vi.fn()},
+    }
+
+    // #given a manager that does NOT receive any mutating deps
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const {manager} = makeManager(projectFn)
+
+    // #when calling all manager operations
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    const unsubscribe = manager.subscribe('run-001', {
+      onEvent: vi.fn(),
+      onClose: vi.fn(),
+    })
+    await drain()
+    unsubscribe()
+    manager.shutdown()
+
+    // #then no mutating spy was ever called (they were never passed to the manager)
+    expect(mutatingSpies.transitionRun).not.toHaveBeenCalled()
+    expect(mutatingSpies.acquireLock).not.toHaveBeenCalled()
+    expect(mutatingSpies.releaseLock).not.toHaveBeenCalled()
+    expect(mutatingSpies.heartbeat).not.toHaveBeenCalled()
+    expect(mutatingSpies.coordinator.transition).not.toHaveBeenCalled()
+    expect(mutatingSpies.coordinator.lock).not.toHaveBeenCalled()
+  })
+
+  it('disconnect/abort removes only the subscription — never touches run lifecycle', async () => {
+    // #given a manager with a subscriber
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const {manager} = makeManager(projectFn)
+
+    // Seed the cache
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    const {frames, closes, unsubscribe} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #when disconnecting (unsubscribing)
+    unsubscribe()
+    await drain()
+
+    // #then the subscription is removed (no more frames after disconnect)
+    const frameCountAtDisconnect = frames.length
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+    expect(frames.length).toBe(frameCountAtDisconnect) // no new frames
+
+    // #then no close reason was emitted (clean disconnect, not an error)
+    // Note: unsubscribe() is a clean disconnect — no onClose is called
+    expect(closes).toHaveLength(0)
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 7. Cleanup: no leaks on abort/rapid connect-disconnect
+// ===========================================================================
+
+describe('cleanup — no leaks', () => {
+  it('aborted connection removes subscription, timers, and queued bytes', async () => {
+    // #given a manager with fake timers
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const fakeTimers = makeFakeTimerSystem(0)
+    const {manager} = makeManager(projectFn, {heartbeatIntervalMs: 15_000}, fakeTimers)
+
+    // Seed the cache
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #given a subscriber
+    const {unsubscribe} = collectFrames(manager, 'run-001')
+    await drain()
+
+    const timerCountWithSubscriber = fakeTimers.activeTimerCount()
+    expect(timerCountWithSubscriber).toBeGreaterThan(0)
+
+    // #when aborting (unsubscribing)
+    unsubscribe()
+    await drain()
+
+    // #then timers are cleared (fewer active timers)
+    const timerCountAfterAbort = fakeTimers.activeTimerCount()
+    expect(timerCountAfterAbort).toBeLessThan(timerCountWithSubscriber)
+
+    manager.shutdown()
+  })
+
+  it('rapid connect/disconnect does not leak listeners or timers', async () => {
+    // #given a manager with fake timers
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const fakeTimers = makeFakeTimerSystem(0)
+    const {manager} = makeManager(projectFn, {heartbeatIntervalMs: 15_000}, fakeTimers)
+
+    // #when rapidly connecting and disconnecting many subscribers
+    const unsubscribers: (() => void)[] = []
+    for (let i = 0; i < 20; i++) {
+      const unsub = manager.subscribe('run-001', {
+        onEvent: vi.fn(),
+        onClose: vi.fn(),
+      })
+      unsubscribers.push(unsub)
+    }
+
+    // Disconnect all
+    for (const unsub of unsubscribers) {
+      unsub()
+    }
+    await drain()
+
+    // #then active subscription count returns to 0 (no leaks)
+    // Verify by checking that a new observe doesn't deliver to any subscriber
+    const frames: ObservationFrame[] = []
+    const newUnsub = manager.subscribe('run-001', {
+      onEvent: frame => {
+        frames.push(frame)
+      },
+      onClose: vi.fn(),
+    })
+    await drain()
+    // Only the reset frame (no cached status) should appear — no leaked frames from old subs
+    const statusFrames = frames.filter(f => f.type === 'status')
+    expect(statusFrames).toHaveLength(0)
+
+    newUnsub()
+
+    // #then timers are cleared (no leaked timers from disconnected subscribers)
+    // After all unsubscribes, only manager-level timers (if any) remain
+    const timerCount = fakeTimers.activeTimerCount()
+    expect(timerCount).toBeLessThanOrEqual(1) // at most 1 manager-level timer
+
+    manager.shutdown()
+  })
+
+  it('shutdown closes all subscriptions and clears all caches/timers', async () => {
+    // #given a manager with multiple subscribers
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const fakeTimers = makeFakeTimerSystem(0)
+    const {manager} = makeManager(projectFn, {heartbeatIntervalMs: 15_000}, fakeTimers)
+
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    const closes1: string[] = []
+    const closes2: string[] = []
+    manager.subscribe('run-001', {onEvent: vi.fn(), onClose: r => closes1.push(r)})
+    manager.subscribe('run-001', {onEvent: vi.fn(), onClose: r => closes2.push(r)})
+    await drain()
+
+    // #when shutting down
+    manager.shutdown()
+    await drain()
+
+    // #then all subscribers are closed
+    expect(closes1).toContain('shutdown')
+    expect(closes2).toContain('shutdown')
+
+    // #then all timers are cleared
+    expect(fakeTimers.activeTimerCount()).toBe(0)
+  })
+})
+
+// ===========================================================================
+// 8. Error path: writer failure containment + EOF observation-failed
+// ===========================================================================
+
+describe('error path — writer failure containment', () => {
+  it('a writer failure on one subscriber does not crash the manager or other subscribers', async () => {
+    // #given a manager with a throwing subscriber and a healthy subscriber
+    const status = makeOperatorRunStatus({status: 'running'})
+    const projectFn: ProjectFn = async () => status
+    const {manager} = makeManager(projectFn)
+
+    // Seed the cache
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    const throwingCloses: string[] = []
+    manager.subscribe('run-001', {
+      onEvent: () => {
+        throw new Error('simulated writer failure')
+      },
+      onClose: reason => {
+        throwingCloses.push(reason)
+      },
+    })
+
+    const healthyFrames: ObservationFrame[] = []
+    const healthyCloses: string[] = []
+    manager.subscribe('run-001', {
+      onEvent: frame => {
+        healthyFrames.push(frame)
+      },
+      onClose: reason => {
+        healthyCloses.push(reason)
+      },
+    })
+
+    // #when observing (the throwing subscriber will fail)
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #then the manager did not crash (test is still running)
+    expect(true).toBe(true)
+
+    // #then the healthy subscriber still received frames
+    expect(healthyFrames.filter(f => f.type === 'status').length).toBeGreaterThanOrEqual(1)
+
+    // #then the throwing subscriber was dropped (writer-error close)
+    expect(throwingCloses.length).toBeGreaterThanOrEqual(1)
+
+    manager.shutdown()
+  })
+
+  it('eOF before terminal status fires onClose("observation-failed"), not success', async () => {
+    // #given a manager with a subscriber
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus({status: 'running'})
+    const {manager} = makeManager(projectFn)
+
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    const closes: string[] = []
+    const unsubscribe = manager.subscribe('run-001', {
+      onEvent: vi.fn(),
+      onClose: reason => {
+        closes.push(reason)
+      },
+    })
+
+    await drain()
+
+    // #when the connection is aborted (EOF) before a terminal status
+    // We simulate EOF by calling abort on the subscription handle
+    // The unsubscribe function returned by subscribe() is the clean-disconnect path.
+    // For EOF (connection drop), the caller signals via the abort callback.
+    // We test this by calling the returned unsubscribe with an 'eof' signal.
+    // Since the plan says "EOF before terminal fires onClose('observation-failed')",
+    // we need the manager to expose an abort path distinct from clean unsubscribe.
+    // The manager's subscribe returns an unsubscribe fn; EOF is signaled via
+    // manager.signalEof(subscriptionHandle) or similar.
+    // For testability, we use the manager's abortSubscription method.
+    manager.abortSubscription('run-001', 'observation-failed')
+    await drain()
+
+    // #then onClose is called with 'observation-failed'
+    expect(closes).toContain('observation-failed')
+
+    // #then it was NOT called with 'terminal' or 'succeeded'
+    expect(closes).not.toContain('terminal')
+    expect(closes).not.toContain('succeeded')
+
+    unsubscribe()
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 9. Safety: only closed-DTO frames are ever enqueued
+// ===========================================================================
+
+describe('safety — only closed-DTO frames are enqueued', () => {
+  it('only OperatorRunStatus / reset / heartbeat frames are ever enqueued', async () => {
+    // #given a run state with sensitive details
+    const runStateWithDetails = makeRunState({
+      details: {
+        rawOutput: 'secret tool output',
+        workspacePath: '/home/runner/workspace',
+        toolArgs: ['--token', 'ghp_secret'],
+        internalUrl: 'http://internal.corp/api',
+      },
+    })
+
+    // #given a project function that returns a clean OperatorRunStatus
+    const cleanStatus = makeOperatorRunStatus({status: 'running'})
+    const projectFn: ProjectFn = async () => cleanStatus
+    const {manager} = makeManager(projectFn)
+
+    // #given a subscriber that collects all frames
+    const {frames} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #when observing a run with sensitive details
+    await manager.observe(runStateWithDetails)
+    await drain()
+
+    // #then all frames are of the allowed types only
+    for (const frame of frames) {
+      expect(['status', 'reset', 'heartbeat']).toContain(frame.type)
+    }
+
+    // #then no frame contains any sensitive field
+    const serialized = JSON.stringify(frames)
+    expect(serialized).not.toContain('rawOutput')
+    expect(serialized).not.toContain('secret tool output')
+    expect(serialized).not.toContain('workspacePath')
+    expect(serialized).not.toContain('/home/runner/workspace')
+    expect(serialized).not.toContain('toolArgs')
+    expect(serialized).not.toContain('ghp_secret')
+    expect(serialized).not.toContain('internalUrl')
+    expect(serialized).not.toContain('http://internal.corp')
+    expect(serialized).not.toContain('details')
+    expect(serialized).not.toContain('holder_id')
+    expect(serialized).not.toContain('thread_id')
+
+    // #then status frames contain ONLY the contract fields
+    const statusFrames = frames.filter(f => f.type === 'status')
+    const contractFields = new Set(['runId', 'entityRef', 'surface', 'phase', 'status', 'startedAt', 'stale'])
+    for (const frame of statusFrames) {
+      // frame is already narrowed to StatusFrame by the filter above
+      const dataKeys = new Set(Object.keys(frame.data))
+      expect(dataKeys).toEqual(contractFields)
+    }
+
+    manager.shutdown()
+  })
+
+  it('reset frames contain only runId and reason — no run state fields', async () => {
+    // #given a manager with no cached status
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const {manager} = makeManager(projectFn)
+
+    // #when subscribing to a run with no cache
+    const {frames} = collectFrames(manager, 'run-999')
+    await drain()
+
+    // #then the reset frame has only runId and reason
+    const resetFrames = frames.filter(f => f.type === 'reset')
+    expect(resetFrames).toHaveLength(1)
+    // resetFrames[0] is guaranteed by the length assertion above
+    const resetFrame = resetFrames[0] as Extract<ObservationFrame, {type: 'reset'}>
+    const resetKeys = new Set(Object.keys(resetFrame))
+    expect(resetKeys.has('type')).toBe(true)
+    expect(resetKeys.has('runId')).toBe(true)
+    expect(resetKeys.has('reason')).toBe(true)
+    // No extra fields
+    expect(resetKeys.size).toBe(3)
+
+    manager.shutdown()
+  })
+
+  it('heartbeat frames contain only the type field', async () => {
+    // #given a manager with fake timers
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const fakeTimers = makeFakeTimerSystem(0)
+    const {manager} = makeManager(projectFn, {heartbeatIntervalMs: 15_000}, fakeTimers)
+
+    // #given a subscriber
+    const {frames} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #when advancing time to trigger a heartbeat
+    fakeTimers.advance(15_001)
+    await drain()
+
+    // #then heartbeat frames contain only the type field
+    const heartbeats = frames.filter(f => f.type === 'heartbeat')
+    for (const hb of heartbeats) {
+      const keys = new Set(Object.keys(hb))
+      expect(keys).toEqual(new Set(['type']))
+    }
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 10. Multiple runs: isolation between run IDs
+// ===========================================================================
+
+describe('run isolation', () => {
+  it('frames for run-A do not appear in run-B subscriber', async () => {
+    // #given a manager
+    const statusA = makeOperatorRunStatus({runId: 'run-A', status: 'running'})
+    const statusB = makeOperatorRunStatus({runId: 'run-B', status: 'queued', phase: 'PENDING'})
+    const projectFn: ProjectFn = async runState =>
+      runState.run_id === 'run-A' ? statusA : runState.run_id === 'run-B' ? statusB : null
+    const {manager} = makeManager(projectFn)
+
+    // #given subscribers for two different runs
+    const {frames: framesA} = collectFrames(manager, 'run-A')
+    const {frames: framesB} = collectFrames(manager, 'run-B')
+    await drain()
+
+    // #when observing run-A
+    await manager.observe(makeRunState({run_id: 'run-A', phase: 'EXECUTING'}))
+    await drain()
+
+    // #then run-A subscriber gets the frame
+    expect(framesA.filter(f => f.type === 'status').length).toBeGreaterThanOrEqual(1)
+
+    // #then run-B subscriber does NOT get run-A's frame
+    const runBStatusFrames = framesB.filter(f => f.type === 'status')
+    for (const frame of runBStatusFrames) {
+      // frame is already narrowed to StatusFrame by the filter above
+      expect(frame.data.runId).toBe('run-B')
+    }
+
+    manager.shutdown()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cleanup: ensure no real timers leak between tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})

--- a/packages/gateway/src/web/sse/manager.test.ts
+++ b/packages/gateway/src/web/sse/manager.test.ts
@@ -1129,6 +1129,129 @@ describe('run isolation', () => {
   })
 })
 
+// ===========================================================================
+// 11. Error path: throwing projectFn is caught, logged, no cache/frame
+// ===========================================================================
+
+describe('error path — throwing projectRunObservation', () => {
+  it('a rejecting projectFn is caught, logged, and produces no cache entry and no frame', async () => {
+    // #given a manager whose projectRunObservation always rejects
+    const projectFn: ProjectFn = async () => {
+      throw new Error('projection exploded')
+    }
+    const warnSpy = vi.fn()
+    const {manager} = makeManager(projectFn, {
+      logger: {info: vi.fn(), warn: warnSpy, error: vi.fn(), debug: vi.fn()},
+    })
+
+    // #given a subscriber before the observe
+    const {frames, closes} = collectFrames(manager, 'run-001')
+    await drain()
+    const initialFrameCount = frames.length
+
+    // #when observing with a throwing projectFn
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #then no new status frame was produced
+    const statusFrames = frames.filter(f => f.type === 'status')
+    expect(statusFrames).toHaveLength(0)
+
+    // #then no close was triggered (the subscriber is still open)
+    expect(closes).toHaveLength(0)
+
+    // #then the warn logger was called (error was logged)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({runId: 'run-001'}),
+      expect.stringContaining('projectRunObservation threw'),
+    )
+
+    // #then no cache entry was created (subscribing again gets reset)
+    const {frames: frames2} = collectFrames(manager, 'run-001')
+    await drain()
+    expect(frames2.some(f => f.type === 'reset')).toBe(true)
+    expect(frames2.some(f => f.type === 'status')).toBe(false)
+
+    // #then total frame count did not increase beyond the initial reset
+    expect(frames.length).toBe(initialFrameCount)
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 12. Post-shutdown behavior: subscribe and observe after shutdown
+// ===========================================================================
+
+describe('post-shutdown behavior', () => {
+  it('subscribe after shutdown immediately calls onClose("shutdown") and returns a no-op unsubscribe', async () => {
+    // #given a manager that has been shut down
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const {manager} = makeManager(projectFn)
+    manager.shutdown()
+
+    // #when subscribing after shutdown
+    const closes: string[] = []
+    const frames: ObservationFrame[] = []
+    const unsubscribe = manager.subscribe('run-001', {
+      onEvent: frame => {
+        frames.push(frame)
+      },
+      onClose: reason => {
+        closes.push(reason)
+      },
+    })
+    await drain()
+
+    // #then onClose is called immediately with 'shutdown'
+    expect(closes).toContain('shutdown')
+
+    // #then no frames were delivered
+    expect(frames).toHaveLength(0)
+
+    // #then the returned unsubscribe is a no-op (does not throw)
+    expect(() => unsubscribe()).not.toThrow()
+  })
+
+  it('observe after shutdown returns early — no cache entry, no frame delivered', async () => {
+    // #given a manager with a subscriber, then shut down
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus({status: 'running'})
+    const {manager} = makeManager(projectFn)
+
+    // Subscribe before shutdown to verify no frames arrive after
+    const frames: ObservationFrame[] = []
+    manager.subscribe('run-001', {
+      onEvent: frame => {
+        frames.push(frame)
+      },
+      onClose: vi.fn(),
+    })
+    await drain()
+
+    manager.shutdown()
+    const frameCountAtShutdown = frames.length
+
+    // #when observing after shutdown
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #then no new frames were delivered (observe returned early)
+    expect(frames.length).toBe(frameCountAtShutdown)
+
+    // #then no cache entry was created (a new subscribe gets reset)
+    const frames2: ObservationFrame[] = []
+    manager.subscribe('run-001', {
+      onEvent: frame => {
+        frames2.push(frame)
+      },
+      onClose: vi.fn(),
+    })
+    await drain()
+    // After shutdown, subscribe immediately calls onClose — no frames expected
+    expect(frames2.filter(f => f.type === 'status')).toHaveLength(0)
+  })
+})
+
 // ---------------------------------------------------------------------------
 // Cleanup: ensure no real timers leak between tests
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/web/sse/manager.test.ts
+++ b/packages/gateway/src/web/sse/manager.test.ts
@@ -668,6 +668,46 @@ describe('denied-repo omission', () => {
 
     manager.shutdown()
   })
+
+  it('cold-start deny-all: null projection at manager boundary yields no cache entry and no emitted frame', async () => {
+    // Pins the fail-closed posture at the manager boundary: when the denylist cache is
+    // unprimed (cold start), projectRunObservation returns null (deny-all). The manager
+    // must produce no observable output — no cache write, no frame to any subscriber.
+
+    // #given a manager whose projection always returns null (unprimed denylist → deny-all)
+    const projectFn: ProjectFn = async () => null
+    const {manager} = makeManager(projectFn)
+
+    // #when observing before any subscriber exists (cold path — no subscribers yet)
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #then subscribing after the denied observe yields reset (no cache entry was written)
+    const {frames: framesAfter, closes: closesAfter} = collectFrames(manager, 'run-001')
+    await drain()
+
+    expect(framesAfter.filter(f => f.type === 'status')).toHaveLength(0)
+    expect(framesAfter.filter(f => f.type === 'reset')).toHaveLength(1)
+    expect(closesAfter).toHaveLength(0)
+
+    // #when a subscriber is present during a cold-start denied observe
+    const {frames: framesDuring, closes: closesDuring} = collectFrames(manager, 'run-002')
+    await drain()
+    // Initial subscribe with no cache → reset (expected)
+    const resetsBefore = framesDuring.filter(f => f.type === 'reset').length
+
+    await manager.observe(makeRunState({run_id: 'run-002', phase: 'EXECUTING'}))
+    await drain()
+
+    // #then no status frame was emitted to the subscriber
+    expect(framesDuring.filter(f => f.type === 'status')).toHaveLength(0)
+    // #then no additional reset was triggered by the denied observe
+    expect(framesDuring.filter(f => f.type === 'reset')).toHaveLength(resetsBefore)
+    // #then no close was triggered
+    expect(closesDuring).toHaveLength(0)
+
+    manager.shutdown()
+  })
 })
 
 // ===========================================================================

--- a/packages/gateway/src/web/sse/manager.ts
+++ b/packages/gateway/src/web/sse/manager.ts
@@ -224,7 +224,11 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
   // State
   // ---------------------------------------------------------------------------
 
-  /** Latest projected status per run (one frame per active run). */
+  // Latest projected status per run (one frame per active run).
+  // A run that never reaches a terminal status (e.g. because a transition fails after
+  // PENDING is observed) leaves its entry here until process restart. A future
+  // staleness/reconcile path will evict these entries; for now the leak is bounded
+  // by the number of active runs and is cleared on process restart.
   const latestStatusCache = new Map<string, OperatorRunStatus>()
 
   /** Active subscribers per run. Map<runId, Map<subId, SubscriberState>>. */
@@ -266,12 +270,17 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
       }
     }
 
-    // Notify the caller
-    try {
-      sub.callbacks.onClose(reason)
-    } catch (error) {
-      logger.warn({subId: sub.id, runId: sub.runId, err: String(error)}, 'manager: onClose threw — ignoring')
-    }
+    // Schedule onClose via queueMicrotask so a slow or synchronous onClose callback
+    // cannot block observe() from returning. The terminal-status path calls dropSubscriber
+    // synchronously inside observe(); without this deferral, a slow onClose would hold
+    // the observe() promise open until onClose completes.
+    queueMicrotask(() => {
+      try {
+        sub.callbacks.onClose(reason)
+      } catch (error) {
+        logger.warn({subId: sub.id, runId: sub.runId, err: String(error)}, 'manager: onClose threw — ignoring')
+      }
+    })
   }
 
   // ---------------------------------------------------------------------------
@@ -328,7 +337,10 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
       try {
         await sub.callbacks.onEvent(frame)
       } catch (error) {
-        // Writer failure: contain the error, drop the subscriber
+        // Writer failure: contain the error, drop the subscriber.
+        // Reset writerRunning before returning so the invariant holds even though
+        // dropSubscriber does not clear it (it only clears timers and the queue).
+        sub.writerRunning = false
         logger.warn(
           {subId: sub.id, runId: sub.runId, err: String(error)},
           'manager: onEvent threw — dropping subscriber',

--- a/packages/gateway/src/web/sse/manager.ts
+++ b/packages/gateway/src/web/sse/manager.ts
@@ -201,21 +201,22 @@ function estimateFrameBytes(frame: ObservationFrame): number {
 }
 
 // ---------------------------------------------------------------------------
-// ID generation
-// ---------------------------------------------------------------------------
-
-let subIdCounter = 0
-function nextSubId(): string {
-  subIdCounter++
-  return `sub-${subIdCounter}`
-}
-
-// ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
 
 export function createRunObservationManager(deps: RunObservationManagerDeps): RunObservationManager {
   const {logger} = deps
+
+  // ---------------------------------------------------------------------------
+  // ID generation — per-factory counter so two managers never share sub IDs
+  // ---------------------------------------------------------------------------
+
+  let subIdCounter = 0
+  function nextSubId(): string {
+    subIdCounter++
+    return `sub-${subIdCounter}`
+  }
+
   const heartbeatIntervalMs = deps.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS
   const maxStreamDurationMs = deps.maxStreamDurationMs ?? DEFAULT_MAX_STREAM_DURATION_MS
   const subscriberQueueCapBytes = deps.subscriberQueueCapBytes ?? DEFAULT_SUBSCRIBER_QUEUE_CAP_BYTES
@@ -484,7 +485,14 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
     // Fan out to all current subscribers (non-blocking — never awaits writes)
     fanOut(runId, frame)
 
-    // On terminal status: clear the cache entry AFTER fan-out and close subscribers
+    // On terminal status: clear the cache entry AFTER fan-out and close subscribers.
+    // Order matters: fanOut() above calls enqueueFrame() → drainQueue() fire-and-forget.
+    // drainQueue() captures `frame` in a local variable and calls onEvent(frame) before
+    // its first `await` suspends — so the terminal frame is already in-flight when
+    // closeRunSubscribers() runs synchronously below and clears each subscriber's queue.
+    // The queue clear does NOT drop the in-flight frame because drainQueue() holds a
+    // direct reference to it; reordering fanOut and closeRunSubscribers would silently
+    // discard the terminal frame for any subscriber whose writer task hadn't started yet.
     if (isTerminal(projected.status) === true) {
       latestStatusCache.delete(runId)
       closeRunSubscribers(runId, 'terminal')

--- a/packages/gateway/src/web/sse/manager.ts
+++ b/packages/gateway/src/web/sse/manager.ts
@@ -1,0 +1,580 @@
+/**
+ * In-memory pub/sub for run-status observation.
+ *
+ * `observe(runState)` projects the run through the redaction bridge, caches the
+ * latest status per run, and fans it to that run's subscribers. A denied/keyless
+ * projection (null) is dropped — never cached, never emitted. Fan-out serializes
+ * once and enqueues per subscriber; it never awaits a write, so a slow consumer
+ * cannot stall publishing. A subscriber whose queue exceeds the byte cap is
+ * dropped locally without affecting peers, and fan-out iterates a snapshot of the
+ * subscriber set so mid-fan-out removal is safe.
+ *
+ * `subscribe(runId)` delivers the cached latest status first (or a `reset` frame
+ * if none exists), then live frames, plus a keepalive heartbeat; subscriptions
+ * close at the max-duration cap. Only three frame shapes are ever enqueued —
+ * status (the closed-DTO contract type), reset, and heartbeat — so RunState and
+ * its details never reach a subscriber.
+ *
+ * This is observer-only: the deps carry no mutating run API, and teardown touches
+ * only the subscription's own timers and queue, never the run, lock, or heartbeat.
+ * EOF before a terminal status closes as an observation failure, not run success.
+ */
+
+import type {RunState} from '@fro-bot/runtime'
+import type {OperatorRunStatus} from '../../operator-contract/index.js'
+
+// ---------------------------------------------------------------------------
+// Constants (injectable for tests)
+// ---------------------------------------------------------------------------
+
+/** Default heartbeat interval (15 seconds). */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000
+
+/** Default max stream duration (30 minutes). */
+export const DEFAULT_MAX_STREAM_DURATION_MS = 30 * 60 * 1000
+
+/** Default per-subscriber queue cap in bytes (64 KB). */
+export const DEFAULT_SUBSCRIBER_QUEUE_CAP_BYTES = 64 * 1024
+
+// ---------------------------------------------------------------------------
+// Terminal statuses
+// ---------------------------------------------------------------------------
+
+const TERMINAL_STATUSES = new Set<OperatorRunStatus['status']>(['succeeded', 'failed', 'cancelled'])
+
+function isTerminal(status: OperatorRunStatus['status']): boolean {
+  return TERMINAL_STATUSES.has(status)
+}
+
+// ---------------------------------------------------------------------------
+// Frame types (closed union — only these three types are ever enqueued)
+// ---------------------------------------------------------------------------
+
+/** A status frame carrying the closed-DTO OperatorRunStatus. */
+export interface StatusFrame {
+  readonly type: 'status'
+  readonly data: OperatorRunStatus
+}
+
+/** A reset frame emitted when no snapshot exists for a run. */
+export interface ResetFrame {
+  readonly type: 'reset'
+  readonly runId: string
+  readonly reason: string
+}
+
+/** A heartbeat keepalive frame. */
+export interface HeartbeatFrame {
+  readonly type: 'heartbeat'
+}
+
+/** The closed union of all frame types the manager can emit. */
+export type ObservationFrame = StatusFrame | ResetFrame | HeartbeatFrame
+
+// ---------------------------------------------------------------------------
+// Subscriber callbacks
+// ---------------------------------------------------------------------------
+
+export interface SubscriberCallbacks {
+  /** Called synchronously (or async) when a frame is ready. May throw — errors are contained. */
+  readonly onEvent: (frame: ObservationFrame) => void | Promise<void>
+  /** Called when the subscription is closed for any reason. */
+  readonly onClose: (reason: string) => void
+}
+
+// ---------------------------------------------------------------------------
+// Logger interface (minimal — matches GatewayLogger shape)
+// ---------------------------------------------------------------------------
+
+export interface ObservationManagerLogger {
+  readonly info: (obj: Record<string, unknown>, msg: string) => void
+  readonly warn: (obj: Record<string, unknown>, msg: string) => void
+  readonly error: (obj: Record<string, unknown>, msg: string) => void
+  readonly debug: (obj: Record<string, unknown>, msg: string) => void
+}
+
+// ---------------------------------------------------------------------------
+// Deps interface — observer-only by construction (NO mutating run API)
+// ---------------------------------------------------------------------------
+
+/**
+ * Dependencies for createRunObservationManager.
+ *
+ * Observer-only by construction: this interface has NO mutating run API.
+ * There is no transitionRun, acquireLock, releaseLock, heartbeat, or coordinator.
+ * The manager cannot mutate run lifecycle even if it wanted to.
+ */
+export interface RunObservationManagerDeps {
+  /**
+   * Project a RunState to an OperatorRunStatus (or null for denied/keyless repos).
+   * Injected so the manager test doesn't need a real bindings store.
+   * In production, wire to projectRunObservation from projection.ts.
+   */
+  readonly projectRunObservation: (runState: RunState) => Promise<OperatorRunStatus | null>
+
+  /** Logger with redaction. */
+  readonly logger: ObservationManagerLogger
+
+  // Timer seams — injectable for deterministic tests
+  readonly setInterval: (cb: () => void, ms: number) => ReturnType<typeof globalThis.setInterval>
+  readonly clearInterval: (id: ReturnType<typeof globalThis.setInterval> | undefined) => void
+  readonly setTimeout: (cb: () => void, ms: number) => ReturnType<typeof globalThis.setTimeout>
+  readonly clearTimeout: (id: ReturnType<typeof globalThis.setTimeout> | undefined) => void
+  readonly now: () => number
+
+  // Optional injectable bounds (defaults to named constants above)
+  readonly heartbeatIntervalMs?: number
+  readonly maxStreamDurationMs?: number
+  readonly subscriberQueueCapBytes?: number
+}
+
+// ---------------------------------------------------------------------------
+// Public manager interface
+// ---------------------------------------------------------------------------
+
+export interface RunObservationManager {
+  /**
+   * Observe a run state transition. Projects via the injected function.
+   * A null projection is dropped immediately (no cache, no emit, no side effect).
+   * A non-null projection updates the latest-status cache and fans out to subscribers.
+   * On a terminal status, clears the cache entry and closes subscribers cleanly.
+   * NEVER awaits a subscriber write — strictly non-blocking.
+   */
+  readonly observe: (runState: RunState) => Promise<void>
+
+  /**
+   * Subscribe to run-status frames for a given runId.
+   * If a latest-status cache entry exists, delivers it immediately as the first frame.
+   * If none exists, emits a single `reset` frame.
+   * Returns an unsubscribe function for clean disconnect (no onClose called).
+   */
+  readonly subscribe: (runId: string, callbacks: SubscriberCallbacks) => () => void
+
+  /**
+   * Abort a subscription with a given reason (e.g., 'observation-failed' for EOF).
+   * Calls onClose(reason) and removes the subscription + its timers/queue.
+   * Used by the route layer to signal connection drops before a terminal status.
+   * Aborts ALL subscriptions for the given runId with the given reason.
+   */
+  readonly abortSubscription: (runId: string, reason: string) => void
+
+  /**
+   * Shut down the manager: close all subscriptions with 'shutdown', clear all caches/timers.
+   * Idempotent.
+   */
+  readonly shutdown: () => void
+}
+
+// ---------------------------------------------------------------------------
+// Internal subscriber state
+// ---------------------------------------------------------------------------
+
+interface SubscriberState {
+  readonly id: string
+  readonly runId: string
+  readonly callbacks: SubscriberCallbacks
+  /** Pending frames waiting to be drained to onEvent. */
+  readonly queue: ObservationFrame[]
+  /** Current estimated byte size of the queue. */
+  queueBytes: number
+  /** Whether the writer task is currently running. */
+  writerRunning: boolean
+  /** Whether this subscriber has been dropped (overflow, error, close, etc.). */
+  dropped: boolean
+  /** Heartbeat interval timer ID. */
+  heartbeatTimer: ReturnType<typeof globalThis.setInterval> | undefined
+  /** Max-duration timeout timer ID. */
+  maxDurationTimer: ReturnType<typeof globalThis.setTimeout> | undefined
+}
+
+// ---------------------------------------------------------------------------
+// Byte estimation for queue cap
+// ---------------------------------------------------------------------------
+
+/**
+ * Estimate the serialized byte size of a frame.
+ * Uses JSON.stringify length as a conservative estimate.
+ * This is O(frame size) but frames are small closed DTOs.
+ */
+function estimateFrameBytes(frame: ObservationFrame): number {
+  return JSON.stringify(frame).length
+}
+
+// ---------------------------------------------------------------------------
+// ID generation
+// ---------------------------------------------------------------------------
+
+let subIdCounter = 0
+function nextSubId(): string {
+  subIdCounter++
+  return `sub-${subIdCounter}`
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createRunObservationManager(deps: RunObservationManagerDeps): RunObservationManager {
+  const {logger} = deps
+  const heartbeatIntervalMs = deps.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS
+  const maxStreamDurationMs = deps.maxStreamDurationMs ?? DEFAULT_MAX_STREAM_DURATION_MS
+  const subscriberQueueCapBytes = deps.subscriberQueueCapBytes ?? DEFAULT_SUBSCRIBER_QUEUE_CAP_BYTES
+
+  // ---------------------------------------------------------------------------
+  // State
+  // ---------------------------------------------------------------------------
+
+  /** Latest projected status per run (one frame per active run). */
+  const latestStatusCache = new Map<string, OperatorRunStatus>()
+
+  /** Active subscribers per run. Map<runId, Map<subId, SubscriberState>>. */
+  const runSubscribers = new Map<string, Map<string, SubscriberState>>()
+
+  /** Whether the manager has been shut down. */
+  let isShutdown = false
+
+  // ---------------------------------------------------------------------------
+  // Internal: drop a subscriber (overflow, error, close, shutdown)
+  // ---------------------------------------------------------------------------
+
+  function dropSubscriber(sub: SubscriberState, reason: string): void {
+    if (sub.dropped === true) {
+      return
+    }
+    sub.dropped = true
+
+    // Clear timers
+    if (sub.heartbeatTimer !== undefined) {
+      deps.clearInterval(sub.heartbeatTimer)
+      sub.heartbeatTimer = undefined
+    }
+    if (sub.maxDurationTimer !== undefined) {
+      deps.clearTimeout(sub.maxDurationTimer)
+      sub.maxDurationTimer = undefined
+    }
+
+    // Clear queue
+    sub.queue.length = 0
+    sub.queueBytes = 0
+
+    // Remove from the run's subscriber set
+    const subs = runSubscribers.get(sub.runId)
+    if (subs !== undefined) {
+      subs.delete(sub.id)
+      if (subs.size === 0) {
+        runSubscribers.delete(sub.runId)
+      }
+    }
+
+    // Notify the caller
+    try {
+      sub.callbacks.onClose(reason)
+    } catch (error) {
+      logger.warn({subId: sub.id, runId: sub.runId, err: String(error)}, 'manager: onClose threw — ignoring')
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal: enqueue a frame to a subscriber (strictly non-blocking)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Enqueue a frame to a subscriber's queue.
+   * If the queue would exceed the cap, drop the subscriber locally (overflow).
+   * NEVER awaits the writer task — strictly non-blocking.
+   * Returns true if enqueued, false if the subscriber was dropped.
+   */
+  function enqueueFrame(sub: SubscriberState, frame: ObservationFrame): boolean {
+    if (sub.dropped === true) {
+      return false
+    }
+
+    const frameBytes = estimateFrameBytes(frame)
+    if (sub.queueBytes + frameBytes > subscriberQueueCapBytes) {
+      // Overflow: drop the subscriber locally
+      logger.warn(
+        {subId: sub.id, runId: sub.runId, queueBytes: sub.queueBytes, frameBytes},
+        'manager: subscriber queue overflow — dropping subscriber',
+      )
+      dropSubscriber(sub, 'overflow')
+      return false
+    }
+
+    sub.queue.push(frame)
+    sub.queueBytes += frameBytes
+
+    // Start the writer task if not already running
+    if (sub.writerRunning === false) {
+      sub.writerRunning = true
+      // Fire-and-forget: the writer task drains the queue asynchronously.
+      // Never awaited — a slow or erroring drain must not stall the publisher.
+      drainQueue(sub).catch(() => {})
+    }
+
+    return true
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal: async writer task — drains the queue to onEvent
+  // ---------------------------------------------------------------------------
+
+  async function drainQueue(sub: SubscriberState): Promise<void> {
+    while (sub.dropped === false && sub.queue.length > 0) {
+      const frame = sub.queue[0]
+      if (frame === undefined) {
+        break
+      }
+
+      try {
+        await sub.callbacks.onEvent(frame)
+      } catch (error) {
+        // Writer failure: contain the error, drop the subscriber
+        logger.warn(
+          {subId: sub.id, runId: sub.runId, err: String(error)},
+          'manager: onEvent threw — dropping subscriber',
+        )
+        dropSubscriber(sub, 'writer-error')
+        return
+      }
+
+      // Re-check dropped: dropSubscriber may have been called from another path
+      // (e.g., heartbeat timer) while onEvent was awaited.
+      // TypeScript's control flow doesn't track mutations through function calls,
+      // so we use a local re-read via the queue length as the guard.
+      if (sub.queue.length === 0 || sub.dropped !== false) {
+        sub.writerRunning = false
+        return
+      }
+
+      // Remove the delivered frame from the queue
+      sub.queue.shift()
+      const frameBytes = estimateFrameBytes(frame)
+      sub.queueBytes = Math.max(0, sub.queueBytes - frameBytes)
+    }
+
+    sub.writerRunning = false
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal: create a subscriber with heartbeat + max-duration timers
+  // ---------------------------------------------------------------------------
+
+  function createSubscriber(runId: string, callbacks: SubscriberCallbacks): SubscriberState {
+    const id = nextSubId()
+    const sub: SubscriberState = {
+      id,
+      runId,
+      callbacks,
+      queue: [],
+      queueBytes: 0,
+      writerRunning: false,
+      dropped: false,
+      heartbeatTimer: undefined,
+      maxDurationTimer: undefined,
+    }
+
+    // Heartbeat timer: emit a heartbeat frame every heartbeatIntervalMs
+    sub.heartbeatTimer = deps.setInterval(() => {
+      if (sub.dropped === true) {
+        return
+      }
+      const heartbeat: HeartbeatFrame = {type: 'heartbeat'}
+      enqueueFrame(sub, heartbeat)
+    }, heartbeatIntervalMs)
+
+    // Max-duration timer: close the subscriber after maxStreamDurationMs
+    sub.maxDurationTimer = deps.setTimeout(() => {
+      if (sub.dropped === true) {
+        return
+      }
+      logger.info({subId: id, runId}, 'manager: subscriber reached max stream duration — closing')
+      dropSubscriber(sub, 'max-duration')
+    }, maxStreamDurationMs)
+
+    return sub
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal: fan-out a frame to all subscribers of a run
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Fan out a frame to all current subscribers of a run.
+   * Iterates over a SNAPSHOT of the subscriber set so mid-fan-out removal
+   * cannot corrupt the iteration.
+   * NEVER awaits any subscriber write — strictly non-blocking.
+   */
+  function fanOut(runId: string, frame: ObservationFrame): void {
+    const subs = runSubscribers.get(runId)
+    if (subs === undefined || subs.size === 0) {
+      return
+    }
+
+    // Snapshot the subscriber set before iterating
+    const snapshot = Array.from(subs.values())
+    for (const sub of snapshot) {
+      enqueueFrame(sub, frame)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal: close all subscribers of a run with a given reason
+  // ---------------------------------------------------------------------------
+
+  function closeRunSubscribers(runId: string, reason: string): void {
+    const subs = runSubscribers.get(runId)
+    if (subs === undefined || subs.size === 0) {
+      return
+    }
+
+    // Snapshot before iterating (dropSubscriber modifies the map)
+    const snapshot = Array.from(subs.values())
+    for (const sub of snapshot) {
+      dropSubscriber(sub, reason)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // observe
+  // ---------------------------------------------------------------------------
+
+  const observe = async (runState: RunState): Promise<void> => {
+    if (isShutdown === true) {
+      return
+    }
+
+    // Project the run state — may return null for denied/keyless repos
+    let projected: OperatorRunStatus | null
+    try {
+      projected = await deps.projectRunObservation(runState)
+    } catch (error) {
+      logger.warn(
+        {runId: runState.run_id, err: String(error)},
+        'manager: projectRunObservation threw — dropping observation',
+      )
+      return
+    }
+
+    // Null projection: denied/keyless repo — drop immediately, no cache, no emit
+    if (projected === null) {
+      return
+    }
+
+    const runId = runState.run_id
+
+    // Build the status frame (closed DTO — only the contract fields)
+    // The projection already returns a closed OperatorRunStatus; we wrap it in a frame.
+    const frame: StatusFrame = {type: 'status', data: projected}
+
+    // Update the latest-status cache BEFORE fan-out
+    latestStatusCache.set(runId, projected)
+
+    // Fan out to all current subscribers (non-blocking — never awaits writes)
+    fanOut(runId, frame)
+
+    // On terminal status: clear the cache entry AFTER fan-out and close subscribers
+    if (isTerminal(projected.status) === true) {
+      latestStatusCache.delete(runId)
+      closeRunSubscribers(runId, 'terminal')
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // subscribe
+  // ---------------------------------------------------------------------------
+
+  const subscribe = (runId: string, callbacks: SubscriberCallbacks): (() => void) => {
+    if (isShutdown === true) {
+      // Manager is shut down — immediately close
+      try {
+        callbacks.onClose('shutdown')
+      } catch {
+        // ignore
+      }
+      return () => {
+        // no-op
+      }
+    }
+
+    // Create the subscriber with heartbeat + max-duration timers
+    const sub = createSubscriber(runId, callbacks)
+
+    // Register in the run's subscriber set
+    let subs = runSubscribers.get(runId)
+    if (subs === undefined) {
+      subs = new Map()
+      runSubscribers.set(runId, subs)
+    }
+    subs.set(sub.id, sub)
+
+    // Snapshot-on-subscribe: deliver the latest cached status immediately,
+    // or emit a reset frame if no snapshot exists.
+    const cached = latestStatusCache.get(runId)
+    if (cached === undefined) {
+      const resetFrame: ResetFrame = {type: 'reset', runId, reason: 'no-snapshot'}
+      enqueueFrame(sub, resetFrame)
+    } else {
+      const snapshotFrame: StatusFrame = {type: 'status', data: cached}
+      enqueueFrame(sub, snapshotFrame)
+    }
+
+    // Return a clean-disconnect function (no onClose called)
+    return () => {
+      if (sub.dropped === true) {
+        return
+      }
+      // Clean disconnect: remove timers/queue but do NOT call onClose
+      sub.dropped = true
+
+      if (sub.heartbeatTimer !== undefined) {
+        deps.clearInterval(sub.heartbeatTimer)
+        sub.heartbeatTimer = undefined
+      }
+      if (sub.maxDurationTimer !== undefined) {
+        deps.clearTimeout(sub.maxDurationTimer)
+        sub.maxDurationTimer = undefined
+      }
+
+      sub.queue.length = 0
+      sub.queueBytes = 0
+
+      const runSubs = runSubscribers.get(runId)
+      if (runSubs !== undefined) {
+        runSubs.delete(sub.id)
+        if (runSubs.size === 0) {
+          runSubscribers.delete(runId)
+        }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // abortSubscription
+  // ---------------------------------------------------------------------------
+
+  const abortSubscription = (runId: string, reason: string): void => {
+    closeRunSubscribers(runId, reason)
+  }
+
+  // ---------------------------------------------------------------------------
+  // shutdown
+  // ---------------------------------------------------------------------------
+
+  const shutdown = (): void => {
+    if (isShutdown === true) {
+      return
+    }
+    isShutdown = true
+
+    // Close all subscriptions across all runs
+    const allRunIds = Array.from(runSubscribers.keys())
+    for (const runId of allRunIds) {
+      closeRunSubscribers(runId, 'shutdown')
+    }
+
+    // Clear the latest-status cache
+    latestStatusCache.clear()
+  }
+
+  return {observe, subscribe, abortSubscription, shutdown}
+}

--- a/packages/gateway/src/web/sse/projection.test.ts
+++ b/packages/gateway/src/web/sse/projection.test.ts
@@ -206,6 +206,53 @@ describe('projectRunObservation — waiting_for_approval overlay', () => {
     // #then blocked is never produced
     expect(result?.status).not.toBe('blocked')
   })
+
+  it('does NOT override a terminal succeeded status even when hasPendingForScope is true', async () => {
+    // #given a run that has already completed (base status = succeeded) but a stale
+    // approval entry still reports pending for the scope
+    const runState = makeRunState({phase: 'COMPLETED', surface: 'github', run_id: 'run-terminal-1'})
+    const baseStatus = makeBaseStatus({phase: 'COMPLETED', status: 'succeeded'})
+    // hasPendingForScope returns true — simulates a stale approval entry
+    const deps = makeDeps(baseStatus, () => true)
+
+    // #when projecting
+    const result = await projectRunObservation(runState, deps)
+
+    // #then the terminal status is preserved — overlay does NOT apply
+    expect(result).not.toBeNull()
+    expect(result?.status).toBe('succeeded')
+    expect(result?.status).not.toBe('waiting_for_approval')
+  })
+
+  it('does NOT override a terminal failed status even when hasPendingForScope is true', async () => {
+    // #given a run that has failed (base status = failed) but a stale approval entry lingers
+    const runState = makeRunState({phase: 'FAILED', surface: 'github', run_id: 'run-terminal-2'})
+    const baseStatus = makeBaseStatus({phase: 'FAILED', status: 'failed'})
+    const deps = makeDeps(baseStatus, () => true)
+
+    // #when projecting
+    const result = await projectRunObservation(runState, deps)
+
+    // #then the terminal status is preserved
+    expect(result).not.toBeNull()
+    expect(result?.status).toBe('failed')
+    expect(result?.status).not.toBe('waiting_for_approval')
+  })
+
+  it('does NOT override a queued status (waiting_for_approval only applies to running)', async () => {
+    // #given a run in PENDING phase (queued) with a pending approval scope
+    const runState = makeRunState({phase: 'PENDING', surface: 'github', run_id: 'run-queued-1'})
+    const baseStatus = makeBaseStatus({phase: 'PENDING', status: 'queued'})
+    const deps = makeDeps(baseStatus, () => true)
+
+    // #when projecting
+    const result = await projectRunObservation(runState, deps)
+
+    // #then queued status is preserved — overlay only applies to running
+    expect(result).not.toBeNull()
+    expect(result?.status).toBe('queued')
+    expect(result?.status).not.toBe('waiting_for_approval')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/web/sse/projection.test.ts
+++ b/packages/gateway/src/web/sse/projection.test.ts
@@ -1,0 +1,332 @@
+/**
+ * projection.test.ts — Tests for the run-status projection (Unit 1).
+ *
+ * Covers:
+ * 1. Happy path: each RunPhase maps to the expected base OperatorWebStatus.
+ * 2. Overlay: waiting_for_approval overrides 'running' when hasPendingForScope → true.
+ * 3. Edge: denied/keyless repo (projectRunStatus → null) yields null.
+ * 4. Safety: the closed DTO contains ONLY the contract fields — no details passthrough.
+ * 5. Scope: scopeIdFor returns thread_id for discord, run_id for non-discord.
+ *
+ * Test seam: projectRunStatus is injected via the deps object so tests can drive
+ * it without needing a real binding store or denylist. This avoids the async I/O
+ * of the real bridge while still testing the projection logic in full.
+ *
+ * BDD comments: #given / #when / #then.
+ */
+
+import type {RunState} from '@fro-bot/runtime'
+import type {OperatorRunStatus, OperatorWebStatus} from '../../operator-contract/index.js'
+import type {ProjectRunObservationDeps} from './projection.js'
+
+import {describe, expect, it} from 'vitest'
+
+import {projectRunObservation, scopeIdFor} from './projection.js'
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+const BASE_NOW_MS = 2_000_000
+const STALE_THRESHOLD_MS = 60_000
+
+function makeRunState(overrides: Partial<RunState> = {}): RunState {
+  return {
+    run_id: 'run-001',
+    surface: 'github',
+    thread_id: 'thread-001',
+    entity_ref: 'acme/widget#1',
+    phase: 'EXECUTING',
+    started_at: '2024-01-01T00:00:00.000Z',
+    last_heartbeat: new Date(BASE_NOW_MS - 1000).toISOString(),
+    holder_id: 'holder-001',
+    details: {},
+    ...overrides,
+  }
+}
+
+function makeBaseStatus(overrides: Partial<OperatorRunStatus> = {}): OperatorRunStatus {
+  return {
+    runId: 'run-001',
+    entityRef: 'acme/widget#1',
+    surface: 'github',
+    phase: 'EXECUTING',
+    status: 'running',
+    startedAt: '2024-01-01T00:00:00.000Z',
+    stale: false,
+    ...overrides,
+  }
+}
+
+/**
+ * Build a deps object with a stubbed projectRunStatus that returns the given value.
+ * hasPendingForScope defaults to always-false (no pending approval).
+ */
+function makeDeps(
+  baseStatus: OperatorRunStatus | null,
+  hasPendingForScope: (scopeId: string) => boolean = () => false,
+): ProjectRunObservationDeps {
+  return {
+    nowMs: BASE_NOW_MS,
+    staleThresholdMs: STALE_THRESHOLD_MS,
+    bindingsLookup: {getBindingByRepo: async () => ({success: true, data: null})},
+    isRepoDenied: () => false,
+    hasPendingForScope,
+    // Inject a stub so tests don't need a real binding store
+    _projectRunStatus: async () => baseStatus,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// scopeIdFor
+// ---------------------------------------------------------------------------
+
+describe('scopeIdFor', () => {
+  it('returns thread_id for a discord run', () => {
+    // #given a discord run with a thread_id
+    const runState = makeRunState({surface: 'discord', thread_id: 'thread-discord-42'})
+
+    // #when computing the scope id
+    const scopeId = scopeIdFor(runState)
+
+    // #then thread_id is returned
+    expect(scopeId).toBe('thread-discord-42')
+  })
+
+  it('returns run_id for a github run', () => {
+    // #given a github run
+    const runState = makeRunState({surface: 'github', run_id: 'run-github-99'})
+
+    // #when computing the scope id
+    const scopeId = scopeIdFor(runState)
+
+    // #then run_id is returned
+    expect(scopeId).toBe('run-github-99')
+  })
+
+  it('returns run_id for a web run (forward-compat with Unit 6)', () => {
+    // #given a web run
+    const runState = makeRunState({surface: 'web', run_id: 'run-web-77'})
+
+    // #when computing the scope id
+    const scopeId = scopeIdFor(runState)
+
+    // #then run_id is returned (web runs use runId scope, registered by Unit 6)
+    expect(scopeId).toBe('run-web-77')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Happy path: RunPhase → base OperatorWebStatus
+// ---------------------------------------------------------------------------
+
+describe('projectRunObservation — phase → base status mapping', () => {
+  const phases: {phase: RunState['phase']; expectedStatus: OperatorWebStatus}[] = [
+    {phase: 'PENDING', expectedStatus: 'queued'},
+    {phase: 'ACKNOWLEDGED', expectedStatus: 'running'},
+    {phase: 'EXECUTING', expectedStatus: 'running'},
+    {phase: 'COMPLETED', expectedStatus: 'succeeded'},
+    {phase: 'FAILED', expectedStatus: 'failed'},
+    {phase: 'CANCELLED', expectedStatus: 'cancelled'},
+  ]
+
+  for (const {phase, expectedStatus} of phases) {
+    it(`maps ${phase} → ${expectedStatus}`, async () => {
+      // #given a run in the given phase and a base status from the bridge
+      const runState = makeRunState({phase})
+      const baseStatus = makeBaseStatus({phase, status: expectedStatus})
+      const deps = makeDeps(baseStatus)
+
+      // #when projecting
+      const result = await projectRunObservation(runState, deps)
+
+      // #then the status matches the expected base
+      expect(result).not.toBeNull()
+      expect(result?.status).toBe(expectedStatus)
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Overlay: waiting_for_approval
+// ---------------------------------------------------------------------------
+
+describe('projectRunObservation — waiting_for_approval overlay', () => {
+  it('overrides running → waiting_for_approval when hasPendingForScope is true', async () => {
+    // #given a running run whose scope has a pending approval
+    const runState = makeRunState({phase: 'EXECUTING', surface: 'github', run_id: 'run-001'})
+    const baseStatus = makeBaseStatus({phase: 'EXECUTING', status: 'running'})
+    const deps = makeDeps(baseStatus, scopeId => scopeId === 'run-001')
+
+    // #when projecting
+    const result = await projectRunObservation(runState, deps)
+
+    // #then status is overridden to waiting_for_approval
+    expect(result).not.toBeNull()
+    expect(result?.status).toBe('waiting_for_approval')
+  })
+
+  it('uses thread_id as scope for discord runs when checking pending approval', async () => {
+    // #given a discord run whose thread_id scope has a pending approval
+    const runState = makeRunState({surface: 'discord', thread_id: 'thread-discord-42', run_id: 'run-001'})
+    const baseStatus = makeBaseStatus({surface: 'discord', status: 'running'})
+    // Only the thread_id scope triggers the overlay
+    const deps = makeDeps(baseStatus, scopeId => scopeId === 'thread-discord-42')
+
+    // #when projecting
+    const result = await projectRunObservation(runState, deps)
+
+    // #then status is overridden to waiting_for_approval (via thread_id scope)
+    expect(result).not.toBeNull()
+    expect(result?.status).toBe('waiting_for_approval')
+  })
+
+  it('does NOT override when hasPendingForScope is false', async () => {
+    // #given a running run with no pending approval
+    const runState = makeRunState({phase: 'EXECUTING'})
+    const baseStatus = makeBaseStatus({phase: 'EXECUTING', status: 'running'})
+    const deps = makeDeps(baseStatus, () => false)
+
+    // #when projecting
+    const result = await projectRunObservation(runState, deps)
+
+    // #then status remains running (no overlay)
+    expect(result?.status).toBe('running')
+  })
+
+  it('does NOT produce blocked — no source exists in v1', async () => {
+    // #given any run state
+    const runState = makeRunState()
+    const baseStatus = makeBaseStatus()
+    const deps = makeDeps(baseStatus, () => false)
+
+    // #when projecting
+    const result = await projectRunObservation(runState, deps)
+
+    // #then blocked is never produced
+    expect(result?.status).not.toBe('blocked')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Edge: denied / keyless repo → null
+// ---------------------------------------------------------------------------
+
+describe('projectRunObservation — denied/keyless repo', () => {
+  it('returns null when the bridge returns null (denied repo)', async () => {
+    // #given a run whose repo is on the denylist (bridge returns null)
+    const runState = makeRunState()
+    const deps = makeDeps(null)
+
+    // #when projecting
+    const result = await projectRunObservation(runState, deps)
+
+    // #then null is returned (contract omission — no record)
+    expect(result).toBeNull()
+  })
+
+  it('does not call hasPendingForScope when the bridge returns null', async () => {
+    // #given a denied run
+    const runState = makeRunState()
+    let pendingCalled = false
+    const deps = makeDeps(null, () => {
+      pendingCalled = true
+      return true
+    })
+
+    // #when projecting
+    await projectRunObservation(runState, deps)
+
+    // #then hasPendingForScope was never called (short-circuit on null)
+    expect(pendingCalled).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Safety: closed DTO — no details passthrough
+// ---------------------------------------------------------------------------
+
+describe('projectRunObservation — closed DTO safety', () => {
+  it('output contains ONLY the contract fields — no details passthrough', async () => {
+    // #given a run whose details carry sensitive internal data
+    const runState = makeRunState({
+      details: {
+        rawOutput: 'secret tool output',
+        workspacePath: '/home/runner/workspace/acme/widget',
+        toolArgs: ['--token', 'ghp_supersecret'],
+        internalUrl: 'http://internal.corp/api',
+        holder_id: 'should-not-leak',
+      },
+    })
+    const baseStatus = makeBaseStatus()
+    const deps = makeDeps(baseStatus)
+
+    // #when projecting
+    const result = await projectRunObservation(runState, deps)
+
+    // #then the result is non-null
+    expect(result).not.toBeNull()
+
+    // #then the serialized DTO contains NONE of the sensitive values
+    const serialized = JSON.stringify(result)
+    expect(serialized).not.toContain('rawOutput')
+    expect(serialized).not.toContain('secret tool output')
+    expect(serialized).not.toContain('workspacePath')
+    expect(serialized).not.toContain('/home/runner/workspace')
+    expect(serialized).not.toContain('toolArgs')
+    expect(serialized).not.toContain('ghp_supersecret')
+    expect(serialized).not.toContain('internalUrl')
+    expect(serialized).not.toContain('http://internal.corp')
+    expect(serialized).not.toContain('details')
+
+    // #then the result has EXACTLY the contract fields (structural allowlist proof)
+    const contractFields = new Set(['runId', 'entityRef', 'surface', 'phase', 'status', 'startedAt', 'stale'])
+    const resultKeys = new Set(Object.keys(result as object))
+    expect(resultKeys).toEqual(contractFields)
+  })
+
+  it('does not spread runState — holder_id and thread_id are absent from output', async () => {
+    // #given a run with holder_id and thread_id
+    const runState = makeRunState({holder_id: 'holder-secret', thread_id: 'thread-secret'})
+    const baseStatus = makeBaseStatus()
+    const deps = makeDeps(baseStatus)
+
+    // #when projecting
+    const result = await projectRunObservation(runState, deps)
+
+    // #then holder_id and thread_id are not in the output
+    expect(result).not.toBeNull()
+    const serialized = JSON.stringify(result)
+    expect(serialized).not.toContain('holder_id')
+    expect(serialized).not.toContain('holder-secret')
+    expect(serialized).not.toContain('thread_id')
+    expect(serialized).not.toContain('thread-secret')
+  })
+
+  it('copies only the explicit OperatorRunStatus fields from the bridge result', async () => {
+    // #given a base status with all contract fields populated
+    const baseStatus: OperatorRunStatus = {
+      runId: 'run-closed-dto',
+      entityRef: 'org/repo#5',
+      surface: 'github',
+      phase: 'COMPLETED',
+      status: 'succeeded',
+      startedAt: '2024-06-01T12:00:00.000Z',
+      stale: false,
+    }
+    const runState = makeRunState({run_id: 'run-closed-dto', phase: 'COMPLETED'})
+    const deps = makeDeps(baseStatus)
+
+    // #when projecting
+    const result = await projectRunObservation(runState, deps)
+
+    // #then each contract field is copied exactly
+    expect(result?.runId).toBe('run-closed-dto')
+    expect(result?.entityRef).toBe('org/repo#5')
+    expect(result?.surface).toBe('github')
+    expect(result?.phase).toBe('COMPLETED')
+    expect(result?.status).toBe('succeeded')
+    expect(result?.startedAt).toBe('2024-06-01T12:00:00.000Z')
+    expect(result?.stale).toBe(false)
+  })
+})

--- a/packages/gateway/src/web/sse/projection.ts
+++ b/packages/gateway/src/web/sse/projection.ts
@@ -1,0 +1,96 @@
+/**
+ * Projects a run's coordination state into an operator-safe run status.
+ *
+ * Goes through the redaction bridge (projectRunStatus) so a denied or keyless
+ * repo yields null and is never surfaced. The result is a closed DTO that copies
+ * only the operator-contract fields — RunState and its free-form details never
+ * reach the output. When the run's approval scope has a pending decision, the
+ * status is overlaid with waiting_for_approval.
+ */
+
+import type {RunState} from '@fro-bot/runtime'
+import type {OperatorRunStatus} from '../../operator-contract/index.js'
+import type {BindingsLookup} from '../../redaction/surface-gate.js'
+
+import {projectRunStatus} from '../../redaction/surface-gate.js'
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Carries the redaction-bridge options plus the approval-overlay predicate.
+ * `_projectRunStatus` is an injectable override for the bridge call so tests
+ * avoid binding-store I/O; production callers omit it.
+ */
+export interface ProjectRunObservationDeps {
+  readonly nowMs: number
+  readonly staleThresholdMs: number
+  readonly bindingsLookup: BindingsLookup
+  readonly isRepoDenied: (repoKey: {readonly databaseId: number | null; readonly nodeId: string | null}) => boolean
+  readonly hasPendingForScope: (approvalScopeId: string) => boolean
+  readonly _projectRunStatus?: (
+    runState: RunState,
+    deps: ProjectRunObservationDeps,
+  ) => Promise<OperatorRunStatus | null>
+}
+
+// ---------------------------------------------------------------------------
+// scopeIdFor — derive the approval scope id from a run
+// ---------------------------------------------------------------------------
+
+/**
+ * Derives the approval scope id for a run. Discord runs are thread-scoped
+ * (the approval flow keys on the thread); other surfaces key on the run id.
+ */
+export function scopeIdFor(runState: RunState): string {
+  if (runState.surface === 'discord') {
+    return runState.thread_id
+  }
+  return runState.run_id
+}
+
+// ---------------------------------------------------------------------------
+// projectRunObservation — main projection entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns null for a denied or keyless repo (the caller omits it), otherwise a
+ * closed DTO carrying only operator-contract fields with the approval overlay
+ * applied.
+ */
+export async function projectRunObservation(
+  runState: RunState,
+  deps: ProjectRunObservationDeps,
+): Promise<OperatorRunStatus | null> {
+  const bridgeFn = deps._projectRunStatus ?? callRealBridge
+  const base = await bridgeFn(runState, deps)
+  if (base === null) {
+    return null
+  }
+
+  const scopeId = scopeIdFor(runState)
+  const overlaidStatus = deps.hasPendingForScope(scopeId) === true ? 'waiting_for_approval' : base.status
+
+  // Copy only the contract fields; never spread runState or read its details.
+  const result: OperatorRunStatus = {
+    runId: base.runId,
+    entityRef: base.entityRef,
+    surface: base.surface,
+    phase: base.phase,
+    status: overlaidStatus,
+    startedAt: base.startedAt,
+    stale: base.stale,
+  }
+
+  return result
+}
+
+async function callRealBridge(runState: RunState, deps: ProjectRunObservationDeps): Promise<OperatorRunStatus | null> {
+  return projectRunStatus(runState, {
+    nowMs: deps.nowMs,
+    staleThresholdMs: deps.staleThresholdMs,
+    bindingsLookup: deps.bindingsLookup,
+    isRepoDenied: deps.isRepoDenied,
+  })
+}

--- a/packages/gateway/src/web/sse/projection.ts
+++ b/packages/gateway/src/web/sse/projection.ts
@@ -70,7 +70,11 @@ export async function projectRunObservation(
   }
 
   const scopeId = scopeIdFor(runState)
-  const overlaidStatus = deps.hasPendingForScope(scopeId) === true ? 'waiting_for_approval' : base.status
+  // Only overlay waiting_for_approval when the run is actively running — a stale approval
+  // entry must not override a terminal status (succeeded/failed/cancelled) that has already
+  // been reached. The overlay is meaningless once the run has left the running state.
+  const overlaidStatus =
+    base.status === 'running' && deps.hasPendingForScope(scopeId) === true ? 'waiting_for_approval' : base.status
 
   // Copy only the contract fields; never spread runState or read its details.
   const result: OperatorRunStatus = {


### PR DESCRIPTION
Adds the in-memory substrate that will let authenticated operators observe gateway runs over SSE — a status-only, redacted, backpressure-safe stream — without exposing any HTTP route yet. The authenticated route, repository authorization, and route-level redaction wiring come in a follow-up; this lands the core behind tests so the load-bearing parts are proven before anything can serve them.

## What's here

- **Projection.** A run's coordination state is projected into an operator-safe status through the redaction bridge, so a denied or keyless repository yields no record. The projection builds a closed object of only the operator-contract fields — the raw run state and its free-form details can never reach a client — and overlays "waiting for approval" only while the run is actually running.
- **Approval-scope check.** The approval registry can now answer whether a given scope has a pending decision (open or claimed), as a boolean with no request detail exposed.
- **Manager.** An in-memory pub/sub that caches the latest status per run and fans it to subscribers. Publishing never awaits a subscriber write, so a slow consumer cannot stall it; a subscriber whose buffer exceeds its cap is dropped on its own without affecting peers. A new subscription gets the cached latest status first (or a reset if none), then live frames and a keepalive, and closes at a maximum duration. The manager holds no mutating run API, so it cannot touch run lifecycle, locks, or heartbeats.
- **Lifecycle hook.** Each successful run-state transition pushes the new state to the manager, best-effort, so neither a synchronous throw nor an async rejection can affect the run. The composition root wires the manager and feeds it; nothing subscribes yet.

## Operational notes

- The repository denylist that the projection depends on is primed at startup and refreshed on a background interval, and both that interval and the manager are torn down on shutdown.
- A run that never reaches a terminal status leaves its cached status in memory until the process restarts; a future reconciliation path will evict it. This is documented in the gateway notes.

## Scope

Status-only by design — no raw output, prompts, tool arguments, or paths are ever streamed. There is no public route in this change. Replay/resume, a staleness reconciler for stuck runs, per-operator stream caps, and the authenticated route with repository authorization are intentionally deferred to the route unit.

Verified: the full gateway suite passes (2201 tests), with type checks and lint clean. The backpressure, observer-only, denied-repo-omission, and closed-output invariants are each covered by direct tests.
