### PR TITLE
feat(gateway): authenticated SSE run-stream route

### DIFF
--- a/docs/plans/2026-06-20-001-feat-authenticated-sse-run-stream-route-plan.md
+++ b/docs/plans/2026-06-20-001-feat-authenticated-sse-run-stream-route-plan.md
@@ -1,0 +1,299 @@
+---
+title: "feat: Authenticated SSE run-stream route (Unit 4b)"
+type: feat
+status: active
+date: 2026-06-20
+deepened: 2026-06-20
+origin: docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
+---
+
+# Authenticated SSE run-stream route (Unit 4b)
+
+## Overview
+
+Expose the inert run-observation core (Unit 4a) through a single authenticated, repo-scoped, fail-closed SSE route: `GET /operator/runs/:runId/stream`. An operator with repository access streams a run's redacted, status-only updates; everyone else gets an indistinguishable generic not-found. This is the security-critical unit — authorization and redaction happen **before any byte is written**, the resolved repository is **never** taken from the client, and access lost mid-stream terminates the connection.
+
+This plan was Oracle-reviewed against current `main` (`48ff4e6`) before writing; the review corrected real drift (route file path, replay assumptions, redaction placement) and footguns (run-wide `abortSubscription`). It is split into three sub-units because the surface is security-dense.
+
+## Problem Frame
+
+Unit 4a shipped the observation manager (`packages/gateway/src/web/sse/manager.ts`) with no public route. The prerequisites are all live on `main`: operator session + token retention (3h, `getOperatorToken`), server-owned run resolution (3i, `RunIndex.lookup`), repository authorization (3f, `checkRepoAuthz`), the redaction gate (#950, `projectRunStatus`/`isRepoDenied`, already primed in `program.ts`), and the privileged-route wrapper (`registerOperatorRoute`). What is missing is the HTTP surface that ties them together with a correct gate ordering and a streaming lifecycle. Because a single missed gate leaks repo-scoped run status (or a run-existence oracle), the route's ordering and teardown are the whole point.
+
+## Requirements Trace
+
+- R0. The operator app deps (`OperatorServerDeps` / `buildOperatorApp`) are extended to carry the `denylistCache`, `bindingsLookup`, and the run-observation `manager` instances created in `program.ts` so the route can reach them. (Today they are threaded only into the observation manager, not the operator app — a verified feasibility prerequisite.)
+- R1. `GET /operator/runs/:runId/stream` is registered through `registerOperatorRoute` so the browser/session/allowlist/CSRF guard runs first; `assertAllPrivilegedRoutesWrapped` still passes.
+- R2. Gate ordering before any SSE byte (and before any distinguishable success response): (1) guard; (2) resolve session + OAuth token by `sessionId`; (3) `runId → repo` via `RunIndex.lookup` (server-owned, never client-supplied); (4) split `owner/repo`; (5) explicit redaction check (denylist, fail-closed); (6) `checkRepoAuthz`; (7) acquire a stream slot; (8) only then open the SSE stream. Any failure at 2-7 returns the **same** generic not-found. **There is no authorized non-stream response** — a successful gate transitions directly into the SSE stream, so a 200 can never act as a run-resolved/authorized oracle.
+- R3. Visibility is **repo-scoped**: any allowlisted operator with repo access to the run's repo may observe it, regardless of who launched it. Authorization is purely `checkRepoAuthz` on the resolved repo — no run-owner comparison.
+- R4. The route performs an **explicit pre-subscribe redaction check** (not relying on the manager's publish-time projection), because `subscribe()` emits the latest cached status immediately and that cache could be a stale-allowed status for a now-denylisted repo.
+- R5. No run-existence oracle: unknown `runId`, missing/keyless binding, binding-store error, denylisted repo, and unauthorized all return the identical generic `not-found` shape. The accepted residual is timing only (unknown `runId` may incur the ~8s `RunIndex` fallback vs a fast denial); acceptable because run ids are UUIDs and the response shape is identical (documented residual, not a blocker).
+- R6. Reconnect model is **snapshot-on-subscribe** — the first frame is the cached latest status, or a `reset` if none. No `Last-Event-ID`, no replay (4a deferred replay; the manager has none). The route relies only on the manager's documented contract: a subscriber receives the cached snapshot (or reset) then future frames; a frame fanned out concurrently with `subscribe` may race (the route does not assume stronger ordering).
+- R7. SSE frames are mapped to Hono `streamSSE`; the teardown paths (client abort, manager `onClose` for shutdown/max-duration, lease failure) all converge on **one synchronous, locally-guarded `cleanup()`** (a route-local `cleaned` boolean) that runs exactly once, using the **per-connection `unsubscribe()`** returned by `subscribe` (never run-wide `abortSubscription`), clears the lease timer, releases the stream slot, and ends the stream.
+- R8. Per-connection socket timeout is raised above the 15s heartbeat for the stream connection only, in a `try/finally` so it is restored/closed on every exit path (never leaked to a reused keep-alive socket); the global 10s pre-auth server timeout is unchanged. **(Spike-gated — see Unit 1 / Open Questions: if the per-connection node socket is not reachable from the route, fall back to lowering the heartbeat below 10s.)**
+- R9. A **continuous-authz lease** re-checks session + token + redaction + `checkRepoAuthz` on a bounded interval for the life of the stream; on failure it closes that connection (per-connection `unsubscribe`, not run-wide). Each tick checks a `closed`/generation flag before acting on its async result, so a slow `checkRepoAuthz` resolving after the connection has been torn down is a no-op. Revocation detection is bounded by `checkRepoAuthz`'s positive cache TTL **plus its 10% jitter (≈5m30s) plus the lease interval** — documented, not bypassed.
+- R10. A **per-operator** (keyed on the numeric `operatorId`/`githubUserId`, never the session) concurrent active-stream cap is enforced; the slot is acquired before opening the stream and released **synchronously** in `cleanup()` so a reconnect storm cannot transiently exceed the cap.
+
+## Scope Boundaries
+
+- Repo-scoped visibility only — no owner/launcher comparison, no per-run ACLs.
+- No replay / `Last-Event-ID` (deferred with the 4a replay deferral). Reconnect = snapshot-or-reset.
+- No staleness reconciler for stuck runs (deferred from 4a) — a run that never reaches terminal still streams its last cached status until max-duration; out of scope here.
+- No cache-bypass on the authz lease — TTL-bounded revocation detection is accepted for v1.
+- No new OAuth scope work beyond what R2's token read needs; the `read:user`-insufficiency for private-repo authz is tracked separately (memory 5806) and must be resolved for private repos to authorize, but is not this unit's code.
+
+### Deferred to Separate Tasks
+
+- Replay / `Last-Event-ID`: future unit, only if measured reconnect churn justifies it.
+- Staleness reconciler (evict/seal a stuck run's cached status): future unit (also closes the 4a accepted cache-leak).
+- OAuth scope broadening for private-repo authz (memory 5806): prerequisite for private repos, tracked separately.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/gateway/src/web/operator-route.ts` — `registerOperatorRoute(app, method, path, handler)` wraps the handler with the installed guard; `getOperatorAuthContext(c)` returns `{githubUserId, sessionId}`; `assertAllPrivilegedRoutesWrapped` enforces wrapping.
+- `packages/gateway/src/web/auth/session-info-route.ts` `buildSessionInfoRoute(app, deps)` + `csrf-route.ts` `buildCsrfRoute` — the exact builder + registration pattern to mirror.
+- `packages/gateway/src/web/auth/session.ts` — `getOperatorToken(sessionId, nowMs)` (checks live/non-revoked/non-expired; returns `undefined` when dropped → re-auth needed); `get(sessionId, nowMs)` for session validity.
+- `packages/gateway/src/execute/run-index.ts` — `RunIndex.lookup(runId): Promise<RunLocation | undefined>`; `RunLocation.repo` is an `owner/repo` **string** (split it), plus `surface`. Fallback can take up to ~8s; unknown → `undefined`.
+- `packages/gateway/src/web/auth/repo-authz.ts` — `checkRepoAuthz(operatorId: number, owner: string, repo: string, userOAuthToken: string, deps): Promise<RepoAuthzResult>`. Allowlist + cache (positive 5m, negative 30s, 10% jitter) + audit built in.
+- `packages/gateway/src/redaction/denylist.ts` + `surface-gate.ts` — `denylistCache.getDenylistState()` / `isRepoDenied(repoKey)`; `projectRunStatus` resolves binding keys and returns null when denied. The cache is already created + primed + background-refreshed in `program.ts`.
+- `packages/gateway/src/web/sse/manager.ts` — `subscribe(runId, callbacks): () => void` (returns **unsubscribe**; clean unsubscribe does NOT call `onClose`), `abortSubscription(runId, reason)` (**run-wide — do not use for per-connection teardown**), `SubscriberCallbacks` (`onEvent(frame)`, `onClose(reason)`), `ObservationFrame` = status | reset | heartbeat.
+- `packages/gateway/src/web/server.ts` `buildOperatorApp` (~229-491); the global `server.setTimeout(10_000)` (~510) bounds idle pre-auth connections — do not raise it.
+- `packages/gateway/src/http/safe-response.ts` `notFoundResponse(c)` → `{error: 'not-found'}` — the single generic shape for every denied path.
+- `packages/gateway/src/http/ingress-pin.test.ts` (~113-120) — the guarded-route allowlist; adding the route intentionally breaks it and must be updated.
+- `@hono/node-server` `HttpBindings` (`incoming`/`outgoing`) — for the per-connection socket-timeout adjustment; Hono `streamSSE` for the stream.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/gateway-control-surface-spine-2026-06-15.md` — server-owned resolution; never trust client-supplied repo.
+- `docs/solutions/best-practices/centralize-s3-key-identity-construction-2026-06-09.md` — verify identity end-to-end; reuse shared key builders for binding/deny-key resolution.
+- The 4a manager doc and mention-loop terminal-correctness doc — terminal/teardown discipline; EOF is observation failure not success.
+
+### External References
+
+- Hono `streamSSE` helper (`onAbort`, manual write) — does not implement replay; the route owns lifecycle.
+
+## Key Technical Decisions
+
+- **No authorized non-stream response.** A passing gate transitions directly into `streamSSE`; there is no intermediate authorized 200/marker. A distinguishable success response would itself be a run-resolved/authorized oracle, so the gate and the stream are one unit of work.
+- **Token before run work.** After the guard, resolve session + `getOperatorToken(sessionId)` first. A missing token → generic not-found independent of `runId`, so a re-auth need never becomes a run-existence timing signal.
+- **Explicit pre-subscribe redaction (P0).** The route resolves the binding's deny-keys and calls `isRepoDenied` before subscribing, returning the generic not-found on deny. Manager-level redaction is publish-time defense-in-depth, not the subscribe gate — `subscribe()` would otherwise emit a stale-allowed cached status for a newly denylisted repo.
+- **Per-connection teardown via `unsubscribe()`, single synchronous cleanup.** `abortSubscription` is run-wide and would kill every operator's stream for that run on one tab disconnect — never use it for per-connection teardown. All exit paths converge on one `cleanup()` guarded by a route-local `cleaned` boolean so it runs once even under concurrent abort/lease-failure/manager-close; it calls `unsubscribe()`, clears the lease timer, releases the stream slot (synchronously), and ends the stream.
+- **TTL-bounded continuous authz with a generation guard.** The lease re-checks through `checkRepoAuthz`'s cache; revocation is detected no later than positive-cache TTL + 10% jitter (≈5m30s) + lease interval. Accepted for v1; documented. No cache-bypass (avoids GitHub API pressure). Each tick re-checks the `cleaned`/`closed` flag before acting on its async result, so a slow check resolving after teardown is a no-op.
+- **Per-connection socket timeout, not global, `try/finally`.** Raise only this connection's Node socket timeout above the heartbeat via the Hono node bindings, in a `try/finally` so it is restored/closed on every exit and never leaks to a reused keep-alive socket. The global 10s stays to bound idle pre-auth sockets. Spike-gated: if the route cannot reach the connection socket, fall back to a heartbeat below 10s.
+- **Stream cap keyed on `operatorId`.** The concurrent-stream cap is keyed on the numeric GitHub user id, not the session — a session key is bypassable by opening multiple sessions. Slot acquired before the stream opens, released synchronously in `cleanup()`.
+- **One generic denial shape.** `notFoundResponse(c)` for unknown runId / missing-keyless binding / store error / denied / unauthorized. Timing is UUID-keyed; accept the ~8s-fallback-vs-fast divergence for v1 (no coarse timing normalization unless leaked run IDs become a concern).
+- **Status-only DTO (the revocation window is only safe because of this).** The streamed `OperatorRunStatus` carries exactly: `runId`, `entityRef`, `surface`, `phase`, `status`, `startedAt`, `stale` — no launcher identity, actor name, prompt, tool args, file path, or token. The TTL-bounded revocation window (R9) is acceptable precisely because these fields are low-sensitivity status only; any future richer field would force re-evaluating the lease/cache window.
+
+## Gate Ordering (the load-bearing flow)
+
+> *Directional — illustrates the required ordering for review, not implementation code.*
+
+```
+GET /operator/runs/:runId/stream
+  └─ registerOperatorRoute guard (browser/session/allowlist/CSRF)  ── fail → guard's own response
+  └─ getOperatorAuthContext(c) → { githubUserId, sessionId }
+  └─ token = sessionStore.getOperatorToken(sessionId, now)         ── undefined → notFound (re-auth)
+  └─ location = runIndex.lookup(runId)                             ── undefined → notFound
+  └─ { owner, repo } = split(location.repo)                       ── malformed → notFound
+  └─ denyKeys = resolve binding keys; await getDenylistState()
+     if isRepoDenied(denyKeys)                                    ── denied → notFound
+  └─ authz = checkRepoAuthz(githubUserId, owner, repo, token)     ── !authorized → notFound
+  └─ acquire per-operator stream slot (key = githubUserId)        ── over cap → 429 (operator already authorized; honest backpressure, not a run oracle)
+  └─ streamSSE: subscribe(runId) → snapshot/reset → live frames + heartbeat
+        lease timer: re-check session+token+redaction+authz       ── fail → cleanup() (unsubscribe + clear timer + release slot)
+        onAbort / onClose / max-duration                          ── → clear timer + unsubscribe
+```
+
+## Implementation Units
+
+- [ ] **Unit 0: Thread the denylist, bindings, and manager into the operator app deps**
+
+  **Goal:** Make the redaction cache, bindings lookup, and observation manager reachable from operator routes — they exist in `program.ts` today but are not in `OperatorServerDeps`.
+
+  **Requirements:** R0
+
+  **Dependencies:** None (pure wiring on `main`).
+
+  **Files:**
+  - Modify: `packages/gateway/src/web/server.ts` (extend `OperatorServerDeps` + thread through `buildOperatorApp`)
+  - Modify: `packages/gateway/src/program.ts` (pass the existing `denylistCache`, `bindingsStore`/lookup, and `runObservationManager` into `buildOperatorApp`)
+  - Test: `packages/gateway/src/web/server.test.ts` (deps wiring)
+
+  **Approach:**
+  - Add `denylistCache`, `bindingsLookup`, and `manager` (the run-observation manager) to `OperatorServerDeps` (readonly). Thread them where `buildOperatorApp` constructs/wires routes.
+  - In `program.ts`, pass the already-created instances (created for the observation manager) into `buildOperatorApp` — do not create second instances (one denylist cache, one manager per process).
+  - No behavior change yet; this is the seam Unit 1 consumes.
+
+  **Execution note:** Pure wiring — keep it minimal; the route units depend on it.
+
+  **Patterns to follow:** how existing deps (`sessionStore`, `allowlist`, rate limiter) are threaded into `OperatorServerDeps` / `buildOperatorApp`.
+
+  **Test scenarios:**
+  - Wiring: `buildOperatorApp` accepts and retains the new deps; existing server tests still pass with the extended deps shape.
+
+  **Verification:** The operator app can reach the denylist cache, bindings lookup, and observation manager; no second instance is created; no behavior change.
+
+- [ ] **Unit 1: Gate + authorized SSE open (no standalone success response)**
+
+  **Goal:** The authenticated, server-owned, fail-closed gate that resolves the run, enforces redaction + repo authz, and — on success — transitions **directly into the SSE stream**. Every denial is the one generic not-found; there is **no** authorized non-stream response (no oracle).
+
+  **Requirements:** R1, R2, R3, R4, R5, R6 (snapshot frame), R10 (slot acquire)
+
+  **Dependencies:** Unit 0; 4a (manager), 3h, 3i, 3f, #950.
+
+  **Files:**
+  - Create: `packages/gateway/src/web/sse/run-stream-route.ts` (`buildRunStreamRoute(app, deps)`)
+  - Create: `packages/gateway/src/web/sse/run-stream-route.test.ts`
+  - Modify: `packages/gateway/src/web/server.ts` (register the route in `buildOperatorApp` after the guard is installed, before `notFound`/`assertAllPrivilegedRoutesWrapped`)
+  - Modify: `packages/gateway/src/http/ingress-pin.test.ts` (add the new guarded route to the pinned list)
+
+  **Approach:**
+  - `buildRunStreamRoute(app, deps)` registers `GET /operator/runs/:runId/stream` via `registerOperatorRoute`. Deps come from Unit 0 plus `{sessionStore, runIndex, repoAuthzDeps, logger, now}`.
+  - Handler runs the gate in the flow's exact order: `getOperatorAuthContext(c)` → `getOperatorToken(sessionId)` → `runIndex.lookup(runId)` → split `owner/repo` → resolve binding deny-keys + `getDenylistState()` + `isRepoDenied` → `checkRepoAuthz(githubUserId, owner, repo, token, repoAuthzDeps)` → acquire the per-`operatorId` stream slot (over cap → `429`).
+  - **Every failure at any gate step returns `notFoundResponse(c)` before opening any stream** — there is no authorized 200/marker. On full success, the handler calls `streamSSE(c, ...)` and immediately delivers the manager's snapshot/reset as the first frame. (The live-frame loop, heartbeat, socket timeout, teardown, and lease are Units 2-3; Unit 1 lands the gate + stream-open + first snapshot frame so success is never observable as a non-stream response.)
+  - Resolve the binding's deny-keys reusing the same binding/deny-key resolution `surface-gate.ts` uses (`bindingsLookup` + the shared key builder) — do not reinvent key construction.
+  - Slot acquired here so an over-cap operator never opens a stream; released by the Unit 2 `cleanup()` (in Unit 1, release on the immediate stream end).
+
+  **Execution note:** Test-first — the load-bearing assertion is that **no stream is opened and no distinguishable success response exists** unless all gates pass, and all denials share one shape.
+
+  **Patterns to follow:** `buildSessionInfoRoute`/`buildCsrfRoute` registration; `checkRepoAuthz` fail-closed posture; `notFoundResponse`; Hono `streamSSE`.
+
+  **Test scenarios:**
+  - Security: missing token (dropped session) → not-found, identical whether `runId` exists or not; no stream opened.
+  - Security: unknown `runId` (`lookup → undefined`) → not-found; no authz/redaction call after the miss; no stream.
+  - Security: client cannot influence the resolved repo — only `runIndex.lookup` determines owner/repo (no query/body/header repo read).
+  - Security: denylisted repo → not-found; `checkRepoAuthz` NOT reached (denylist before authz); no stream.
+  - Security: `checkRepoAuthz` denies → not-found; byte-identical shape to unknown/denied; no stream.
+  - Security: success is observable ONLY as an SSE stream (content-type `text/event-stream` + first snapshot/reset frame) — there is no 200 JSON/marker body that a prober could distinguish from not-found.
+  - Cap: an over-cap operator (by `githubUserId`) gets `429`, not a stream.
+  - Integration: `assertAllPrivilegedRoutesWrapped` passes; ingress-pin lists the new guarded route.
+
+  **Verification:** No stream and no distinguishable success response unless token + lookup + redaction + authz + slot all pass; every denial is the one generic shape; resolved repo is server-owned; route is guard-wrapped and pinned.
+
+- [ ] **Unit 2: SSE live bridge + socket timeout + single cleanup**
+
+  **Goal:** Turn Unit 1's stream-open into a full live stream — live frames, heartbeat, a spike-verified per-connection socket timeout, and one synchronous guarded cleanup that all teardown paths converge on.
+
+  **Requirements:** R6, R7, R8
+
+  **Dependencies:** Unit 1.
+
+  **Files:**
+  - Modify: `packages/gateway/src/web/sse/run-stream-route.ts`
+  - Modify: `packages/gateway/src/web/sse/run-stream-route.test.ts`
+
+  **Approach:**
+  - **Socket-timeout spike FIRST (R8):** before building on it, verify the per-connection Node socket is reachable from the route and supports `setTimeout`. The plan's assumption (`c.env.outgoing`/`incoming` from `@hono/node-server` `HttpBindings`) is **unverified against current source** — confirm it exposes a Node socket with `setTimeout`, or fall back to lowering the manager heartbeat below the global 10s timeout (a config change, no socket access). Pick the working path and note it.
+  - If the socket path works: raise this connection's socket timeout above the heartbeat (e.g. 60s) inside a `try/finally`, capturing the prior value and **always** restoring/closing it on exit so it never leaks to a reused keep-alive socket. Do not touch the global server timeout.
+  - `const unsubscribe = manager.subscribe(runId, { onEvent: frame => writeFrame(stream, frame), onClose: reason => endStream(reason) })`. Map `ObservationFrame` → SSE: `status` → `event: status` + JSON data; `reset` → `event: reset` + `{runId, reason}`; `heartbeat` → SSE comment/keepalive. Never serialize anything outside the frame union.
+  - **Single synchronous cleanup (R7):** one `cleanup()` guarded by a route-local `let cleaned = false` so it runs exactly once even under concurrent invocation. It: calls `unsubscribe()`, clears the lease timer (Unit 3), releases the stream slot synchronously, restores the socket timeout, and ends the stream. All paths call it: `stream.onAbort(cleanup)`, manager `onClose(reason)` → `cleanup`, max-duration → `onClose('max-duration')` → `cleanup`. **Never** `abortSubscription`. Stream finalization is a one-way edge owned only by `cleanup`.
+  - EOF before terminal is an observation failure (manager closes with a reason), not success — surface as a clean stream end, not a completion.
+
+  **Execution note:** Test-first on cleanup idempotency under concurrent teardown and the socket-timeout restore-on-every-exit property; these are the leak/race risks.
+
+  **Patterns to follow:** the 4a manager's `onClose`/unsubscribe contract; `status-message.ts` cleanup discipline.
+
+  **Test scenarios:**
+  - Happy: stream delivers snapshot/reset first, then live status frames, then a clean terminal close; heartbeats on idle.
+  - Teardown idempotency (load-bearing): concurrent client-abort + manager-`onClose` both invoke `cleanup`, which runs exactly once — `unsubscribe` once, slot released once, timer cleared once, no double stream-end.
+  - Reliability: with the socket path, the per-connection timeout is raised above the heartbeat and **restored on every exit path** (including early error) — assert the underlying socket timeout returns to baseline after cleanup; the global timeout is untouched. (If the spike chose the heartbeat-lowering fallback, assert the heartbeat is below the global timeout instead.)
+  - Isolation: one connection's teardown does not affect other subscribers of the same run (proves `unsubscribe`, not `abortSubscription`).
+  - Safety: only `status`/`reset`/`heartbeat` SSE events are ever written — no raw output/tool/path bytes.
+
+  **Verification:** Live frames stream with snapshot-on-subscribe semantics; one synchronous guarded cleanup handles every teardown path; the socket-timeout mechanism is spike-verified and never leaks.
+
+- [ ] **Unit 3: Continuous-authz lease + per-operator stream cap**
+
+  **Goal:** Keep a live stream honest — periodically re-verify session, token, redaction, and repo authz with a generation guard, terminate on loss, and bound concurrent streams per operator id.
+
+  **Requirements:** R9, R10
+
+  **Dependencies:** Units 1-2.
+
+  **Files:**
+  - Modify: `packages/gateway/src/web/sse/run-stream-route.ts`
+  - Modify: `packages/gateway/src/web/sse/run-stream-route.test.ts`
+
+  **Approach:**
+  - Start a route-owned lease timer when the stream opens (interval = heartbeat or a small multiple; named injectable constant). On each tick, re-run: `sessionStore.get(sessionId)` (live?), `getOperatorToken(sessionId)` (present?), `getDenylistState()` + `isRepoDenied` (still allowed?), `checkRepoAuthz(...)` (still authorized?). Any failure → `cleanup()` (closes this connection only).
+  - **Generation guard:** each tick checks the `cleaned` flag *after* its async work resolves and before acting, so a slow `checkRepoAuthz` (which can wait on an in-flight request) that resolves after the connection is already torn down is a no-op — no acting on a dead socket, no late close.
+  - The lease goes through `checkRepoAuthz`'s cache; document that revocation detection is bounded by **positive-cache TTL + its 10% jitter (≈5m30s worst case) + the lease interval**, and denylist detection by the denylist refresh TTL + lease interval. No cache-bypass (accepted for v1, status-only data).
+  - **Per-operator cap (R10):** track active streams keyed on the numeric `githubUserId` (never the session — a session key is bypassable). The slot is acquired in Unit 1 before the stream opens (over cap → `429`, honest backpressure for an already-authorized operator, not a run oracle) and released **synchronously** in `cleanup()` so a rapid connect/disconnect storm cannot transiently exceed the cap.
+  - Do **not** call `dropOperatorToken()` on a generic `github_denied` from `checkRepoAuthz` — that result cannot distinguish a revoked token from a denied repo. Only drop the token on a token-specific signal.
+
+  **Execution note:** Test-first on the lease-failure → per-connection-close path, the late-resolving-check no-op (generation guard), and synchronous cap release.
+
+  **Patterns to follow:** the existing per-route rate-limit/resource-bound convention in `server.ts`; `checkRepoAuthz` cache semantics.
+
+  **Test scenarios:**
+  - Security (lease): repo access revoked mid-stream → on the next tick after authz cache expiry (test clock) the stream is closed via `cleanup`; status stops flowing.
+  - Security (lease): repo denylisted mid-stream → next tick closes the stream.
+  - Security (lease): token dropped / session expired mid-stream → next tick closes the stream.
+  - Generation guard: a lease tick whose `checkRepoAuthz` resolves *after* the connection is torn down does nothing (no close on a dead socket, no throw, no log spam).
+  - Isolation: a lease failure on one connection closes only that connection, not other subscribers of the run.
+  - Cap: the (N+1)th concurrent stream for one `githubUserId` gets `429`; closing one frees a slot synchronously; a rapid reconnect storm cannot exceed the cap; multiple sessions for the same operator share one cap.
+  - No false drop: a still-authorized stream survives lease ticks; no `dropOperatorToken` on a generic repo denial.
+
+  **Verification:** A stream is terminated within (≈5m30s + lease interval) of access loss via per-connection teardown; a late-resolving check is a no-op; concurrent streams are bounded per operator id with synchronous slot release; token is not dropped on ambiguous denials.
+
+## System-Wide Impact
+
+- **Interaction graph:** new guarded route in `buildOperatorApp`; consumes 3h/3i/3f/#950/4a. `ingress-pin.test.ts` and `assertAllPrivilegedRoutesWrapped` are the structural guards.
+- **Error propagation:** every gate failure collapses to one `notFoundResponse`; lease failures close the connection without touching the run.
+- **State lifecycle risks:** per-connection teardown must be idempotent and use `unsubscribe` (not run-wide `abortSubscription`); the socket-timeout change must be restored/closed; the stream-cap slot must release on every path.
+- **API surface parity:** this is the first SSE route; its frame shapes (status/reset/heartbeat) become the operator stream contract.
+- **Integration coverage:** the gate-ordering security tests and the lease-revocation tests are the cross-layer proofs unit mocks alone can't give.
+- **Unchanged invariants:** the manager stays observer-only and untouched; the global 10s server timeout stays; runtime/coordination untouched.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Authorized non-stream response acts as a run-resolved/authorized oracle | No placeholder/marker — a passing gate transitions directly into `streamSSE`; success is observable only as a stream (test: no distinguishable 200 body). |
+| Deps not reachable from the route (`denylistCache`/`bindingsLookup` not in `OperatorServerDeps`) | Unit 0 threads them from `program.ts` into `buildOperatorApp` before any route work. |
+| Per-connection socket-timeout mechanism unverified against source | Unit 2 spikes it first; falls back to lowering the heartbeat below the global 10s if the connection socket is unreachable. |
+| Manager-only redaction serves a stale-allowed cached status on subscribe | Explicit pre-subscribe `isRepoDenied` gate in the route (R4); test a newly-denylisted repo returns not-found and never subscribes. |
+| `abortSubscription` (run-wide) used for per-connection teardown kills all operators' streams | Use the `unsubscribe()` return; isolation test proves one teardown doesn't affect peers. |
+| Idle SSE socket killed by the 10s global timeout | Per-connection socket timeout raised above heartbeat in `try/finally` (restored on every exit, no keep-alive leak); global untouched. |
+| Revoked GitHub access keeps streaming status | Lease re-check; documented worst case ≈5m30s (positive TTL + 10% jitter) + lease interval; accepted for v1 because frames are status-only; lease test uses a controlled clock. |
+| Late-resolving lease check acts on a torn-down connection | Generation/`cleaned` guard: each tick re-checks the flag after its async work before acting. |
+| Run-existence oracle via differing denial shapes/timing | Single `notFoundResponse` for all denials; UUID run ids; timing divergence accepted/noted. |
+| Token revoked vs repo denied indistinguishable → wrong `dropOperatorToken` | Do not drop token on generic `github_denied`; only on a token-specific signal. |
+| Teardown double-close / leaked timer / double slot-release | One synchronous `cleanup()` guarded by a `cleaned` boolean for all paths; idempotency test under concurrent teardown. |
+| Stream-cap bypass via multiple sessions or reconnect storm | Cap keyed on `githubUserId` (not session); slot released synchronously in `cleanup()`; reconnect-storm test. |
+| Stale-cached status on a never-terminal run (4a accepted leak) gives a subscriber a believable stale snapshot then only heartbeats | Bounded by max-duration; documented v1 limitation; the deferred staleness reconciler (4a) is the real fix. |
+
+## Documentation / Operational Notes
+
+- Document the operator stream contract (`GET /operator/runs/:runId/stream`, status/reset/heartbeat frames, snapshot-on-subscribe, TTL-bounded revocation) in the gateway operator docs after Unit 3.
+- Note the accepted v1 limitations (no replay, TTL-bounded authz, no staleness reconciler) where operators will read them.
+- Update `docs/plans/2026-06-15-002` Unit 4b checkbox on completion.
+
+## Open Questions
+
+### Resolved During Planning (Oracle + document review)
+
+- Route file/shape: `web/sse/run-stream-route.ts` + `buildRunStreamRoute` via `registerOperatorRoute` (plan's `web/routes/run-stream.ts` was drift).
+- **No placeholder/authorized-marker response** — a passing gate transitions directly into the stream (no 200 oracle). Gate + stream-open land together in Unit 1.
+- **Deps threading is a real prerequisite** — `denylistCache`/`bindingsLookup`/`manager` are not in `OperatorServerDeps` today; Unit 0 adds them.
+- Replay: none — snapshot-on-subscribe (4a deferred replay).
+- Redaction placement: explicit pre-subscribe route check, not manager-implicit.
+- Teardown: one synchronous `cleaned`-guarded `cleanup()` using per-connection `unsubscribe()`, never run-wide `abortSubscription`.
+- Socket timeout: per-connection in `try/finally` (spike-gated), not the global server timeout.
+- Continuous authz: **kept in v1**; cache-TTL-bounded (≈5m30s + lease interval worst case), generation-guarded, no bypass.
+- Stream cap: **kept in v1**, keyed on `githubUserId`; over-cap → `429` (honest backpressure for an already-authorized operator, not a run oracle).
+
+### Deferred to Implementation
+
+- Exact lease interval (heartbeat vs small multiple) — pick against the heartbeat constant during implementation.
+- The socket-timeout spike outcome (per-connection socket vs heartbeat-lowering fallback) — decided in Unit 2 against the verified binding behavior.
+- Coarse timing normalization for the unknown-runId 8s-fallback vs fast-denial divergence — only if leaked run ids prove a concern (likely not, UUIDs).
+
+## Sources & References
+
+- **Origin plan:** `docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md` (Unit 4b section).
+- Oracle design review (2026-06-20) against `main` `48ff4e6` — file:line-cited findings on route path, token retrieval, redaction placement, lease cache semantics, socket timeout, teardown footgun, unit split.
+- Document review (2026-06-20, 5 reviewers) — found the placeholder-200 oracle (P0), the `OperatorServerDeps` deps-threading gap and unverified socket-timeout binding (feasibility P1s), the operatorId cap key, the ≈5m30s jitter bound, the synchronous-cleanup/generation-guard robustness, and the status-only DTO enumeration. Forks resolved by Marcus: keep the continuous-authz lease and the stream cap in v1.
+- Related code: `packages/gateway/src/web/operator-route.ts`, `web/auth/session.ts`, `web/auth/repo-authz.ts`, `execute/run-index.ts`, `redaction/denylist.ts`, `web/sse/manager.ts`, `web/server.ts`, `http/safe-response.ts`, `http/ingress-pin.test.ts`.
+- Related issue: #907 (operator web surface umbrella).

--- a/docs/plans/2026-06-20-001-feat-authenticated-sse-run-stream-route-plan.md
+++ b/docs/plans/2026-06-20-001-feat-authenticated-sse-run-stream-route-plan.md
@@ -1,9 +1,10 @@
 ---
 title: "feat: Authenticated SSE run-stream route (Unit 4b)"
 type: feat
-status: active
+status: completed
 date: 2026-06-20
 deepened: 2026-06-20
+completed: 2026-06-20
 origin: docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
 ---
 
@@ -107,7 +108,7 @@ GET /operator/runs/:runId/stream
 
 ## Implementation Units
 
-- [ ] **Unit 0: Thread the denylist, bindings, and manager into the operator app deps**
+- [x] **Unit 0: Thread the denylist, bindings, and manager into the operator app deps**
 
   **Goal:** Make the redaction cache, bindings lookup, and observation manager reachable from operator routes — they exist in `program.ts` today but are not in `OperatorServerDeps`.
 
@@ -134,7 +135,7 @@ GET /operator/runs/:runId/stream
 
   **Verification:** The operator app can reach the denylist cache, bindings lookup, and observation manager; no second instance is created; no behavior change.
 
-- [ ] **Unit 1: Gate + authorized SSE open (no standalone success response)**
+- [x] **Unit 1: Gate + authorized SSE open (no standalone success response)**
 
   **Goal:** The authenticated, server-owned, fail-closed gate that resolves the run, enforces redaction + repo authz, and — on success — transitions **directly into the SSE stream**. Every denial is the one generic not-found; there is **no** authorized non-stream response (no oracle).
 
@@ -171,7 +172,7 @@ GET /operator/runs/:runId/stream
 
   **Verification:** No stream and no distinguishable success response unless token + lookup + redaction + authz + slot all pass; every denial is the one generic shape; resolved repo is server-owned; route is guard-wrapped and pinned.
 
-- [ ] **Unit 2: SSE live bridge + socket timeout + single cleanup**
+- [x] **Unit 2: SSE live bridge + socket timeout + single cleanup**
 
   **Goal:** Turn Unit 1's stream-open into a full live stream — live frames, heartbeat, a spike-verified per-connection socket timeout, and one synchronous guarded cleanup that all teardown paths converge on.
 
@@ -203,7 +204,7 @@ GET /operator/runs/:runId/stream
 
   **Verification:** Live frames stream with snapshot-on-subscribe semantics; one synchronous guarded cleanup handles every teardown path; the socket-timeout mechanism is spike-verified and never leaks.
 
-- [ ] **Unit 3: Continuous-authz lease + per-operator stream cap**
+- [x] **Unit 3: Continuous-authz lease + per-operator stream cap**
 
   **Goal:** Keep a live stream honest — periodically re-verify session, token, redaction, and repo authz with a generation guard, terminate on loss, and bound concurrent streams per operator id.
 

--- a/packages/gateway/src/http/ingress-pin.test.ts
+++ b/packages/gateway/src/http/ingress-pin.test.ts
@@ -105,7 +105,8 @@ const EXPECTED_OPERATOR_ROUTES_WITH_OAUTH: readonly {method: string; path: strin
  * when the full browser guard is configured (OAuth + allowlist + csrfSecret + sessionStore).
  *
  * This is the production-ready surface: OAuth routes (public), logout (privileged, CSRF-gated),
- * CSRF token endpoint (privileged, safe GET), and session info endpoint (privileged, safe GET).
+ * CSRF token endpoint (privileged, safe GET), session info endpoint (privileged, safe GET),
+ * and the authenticated SSE run-stream endpoint (privileged, safe GET).
  *
  * SECURITY: All privileged routes are wrapped by the browser guard (session + allowlist +
  * origin + Fetch Metadata). Adding a route here requires a deliberate security review.
@@ -117,6 +118,7 @@ const EXPECTED_OPERATOR_ROUTES_WITH_BROWSER_GUARD: readonly {method: string; pat
   {method: 'POST', path: '/operator/auth/logout'},
   {method: 'GET', path: '/operator/session/csrf'},
   {method: 'GET', path: '/operator/session'},
+  {method: 'GET', path: '/operator/runs/:runId/stream'},
 ]
 
 // ---------------------------------------------------------------------------
@@ -204,6 +206,23 @@ function makeBrowserGuardStubDeps(): OperatorServerDeps {
     allowlist: loadAllowlistFromText('12345', logger),
     csrfSecret: 'stub-csrf-secret-base64url-32bytes-ok',
     auditLogger: {info: vi.fn(), warn: vi.fn()},
+    // Provide the run-stream route deps so the route is registered in the pinned inventory.
+    denylistCache: {
+      getDenylistState: vi.fn(async () => undefined),
+      isRepoDenied: vi.fn(() => false),
+    },
+    bindingsLookup: {
+      getBindingByRepo: vi.fn(async () => ({success: true as const, data: null})),
+    },
+    runObservationManager: {
+      observe: vi.fn(async () => undefined),
+      subscribe: vi.fn(() => () => undefined),
+      abortSubscription: vi.fn(),
+      shutdown: vi.fn(),
+    },
+    runIndex: {
+      lookup: vi.fn(async () => undefined),
+    },
   }
 }
 

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -504,6 +504,11 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           allowlist: config.operatorWeb.allowlist,
           csrfSecret: config.operatorWeb.csrfSecret,
           auditLogger: logger,
+          // Wire the existing program-scoped instances so the run-stream route
+          // can reach them without creating second copies.
+          denylistCache,
+          bindingsLookup: bindingsStore,
+          runObservationManager,
         },
         {
           bindHost: config.operatorWeb.bindHost,

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -509,6 +509,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           denylistCache,
           bindingsLookup: bindingsStore,
           runObservationManager,
+          runIndex,
         },
         {
           bindHost: config.operatorWeb.bindHost,

--- a/packages/gateway/src/redaction/surface-gate.ts
+++ b/packages/gateway/src/redaction/surface-gate.ts
@@ -56,6 +56,50 @@ export interface BindingsLookup {
 }
 
 // ---------------------------------------------------------------------------
+// resolveBindingDenyKeys — shared fail-closed binding → deny-key resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve deny-keys for a repo by calling getBindingByRepo directly.
+ *
+ * Fail-closed: returns {databaseId: null, nodeId: null} on store error,
+ * missing binding, or missing keys. Try/catch is internal — callers never
+ * see a thrown error from this function.
+ *
+ * Used by both resolveRunRepoKey (entity_ref path) and the run-stream route
+ * (owner/repo already resolved from RunIndex) so the fail-closed logic lives
+ * in exactly one place.
+ */
+export async function resolveBindingDenyKeys(
+  owner: string,
+  repo: string,
+  bindingsLookup: BindingsLookup,
+): Promise<RunStatusRepoKey> {
+  const NULL_KEY: RunStatusRepoKey = {databaseId: null, nodeId: null}
+
+  let result: Awaited<ReturnType<BindingsLookup['getBindingByRepo']>>
+  try {
+    result = await bindingsLookup.getBindingByRepo(owner, repo)
+  } catch {
+    return NULL_KEY
+  }
+
+  if (result.success === false) {
+    return NULL_KEY
+  }
+
+  if (result.data === null) {
+    return NULL_KEY
+  }
+
+  const binding = result.data
+  const databaseId = typeof binding.databaseId === 'number' ? binding.databaseId : null
+  const nodeId = typeof binding.nodeId === 'string' ? binding.nodeId : null
+
+  return {databaseId, nodeId}
+}
+
+// ---------------------------------------------------------------------------
 // resolveRunRepoKey — resolve a run's entity_ref to its binding deny keys
 // ---------------------------------------------------------------------------
 
@@ -108,23 +152,7 @@ export async function resolveRunRepoKey(runState: RunState, bindingsLookup: Bind
   }
 
   const {owner, repo} = parsed
-  const result = await bindingsLookup.getBindingByRepo(owner, repo)
-
-  if (result.success === false) {
-    // Store error — fail closed
-    return NULL_KEY
-  }
-
-  if (result.data === null) {
-    // Binding not found — fail closed
-    return NULL_KEY
-  }
-
-  const binding = result.data
-  const databaseId = typeof binding.databaseId === 'number' ? binding.databaseId : null
-  const nodeId = typeof binding.nodeId === 'string' ? binding.nodeId : null
-
-  return {databaseId, nodeId}
+  return resolveBindingDenyKeys(owner, repo, bindingsLookup)
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/web/server.test.ts
+++ b/packages/gateway/src/web/server.test.ts
@@ -1618,3 +1618,55 @@ describe('GET /operator/session/csrf — Cache-Control and Vary headers (Fix 7)'
     expect(vary).toContain('Origin')
   })
 })
+
+// ---------------------------------------------------------------------------
+// OperatorServerDeps — optional streaming deps wiring
+// ---------------------------------------------------------------------------
+
+describe('buildOperatorApp — optional streaming deps accepted without error', () => {
+  it('accepts denylistCache, bindingsLookup, and runObservationManager without registering new routes', () => {
+    // #given — stub implementations of the three optional streaming deps
+    const stubDenylistCache: import('./server.js').OperatorServerDeps['denylistCache'] = {
+      getDenylistState: async () => undefined,
+      isRepoDenied: () => false,
+    }
+    const stubBindingsLookup: import('./server.js').OperatorServerDeps['bindingsLookup'] = {
+      getBindingByRepo: async () => ({success: true, data: null}),
+    }
+    const stubRunObservationManager: import('./server.js').OperatorServerDeps['runObservationManager'] = {
+      observe: async () => undefined,
+      subscribe: () => () => undefined,
+      abortSubscription: () => undefined,
+      shutdown: () => undefined,
+    }
+
+    // #when — build the app with all three optional deps present
+    const app = buildOperatorApp(
+      makeStubDeps({
+        denylistCache: stubDenylistCache,
+        bindingsLookup: stubBindingsLookup,
+        runObservationManager: stubRunObservationManager,
+      }),
+      makeStubConfig(),
+    )
+
+    // #then — no error thrown; route inventory is unchanged (no new route registered yet)
+    const seen = new Set<string>()
+    const routes = app.routes
+      .map((route: RouteEntry) => ({method: route.method, path: route.path}))
+      .filter((route: RouteEntry) => {
+        if (route.method === 'ALL' && route.path === '/*') return false
+        const key = `${route.method}:${route.path}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+    expect(routes).toEqual([{method: 'GET', path: '/operator/health'}])
+  })
+
+  it('accepts buildOperatorApp without the optional streaming deps (backward-compatible)', () => {
+    // #given — no streaming deps (omitted entirely)
+    // #when / #then — no error; existing call sites that omit the new deps still compile and run
+    expect(() => buildOperatorApp(makeStubDeps(), makeStubConfig())).not.toThrow()
+  })
+})

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -22,10 +22,13 @@
  */
 
 import type {ServerType} from '@hono/node-server'
+import type {DenylistCache} from '../redaction/denylist.js'
+import type {BindingsLookup} from '../redaction/surface-gate.js'
 import type {AuditLogger} from './audit.js'
 import type {OperatorAllowlist} from './auth/allowlist.js'
 import type {GitHubOAuthConfig, GitHubOAuthDeps} from './auth/github.js'
 import type {SessionDeps, SessionStore} from './auth/session.js'
+import type {RunObservationManager} from './sse/manager.js'
 
 import {serve} from '@hono/node-server'
 import {getConnInfo} from '@hono/node-server/conninfo'
@@ -125,6 +128,25 @@ export interface OperatorServerDeps {
    * Required when allowlist is present; ignored otherwise.
    */
   readonly auditLogger?: AuditLogger
+  /**
+   * Denylist cache for the run-stream route's pre-subscribe redaction check.
+   * Consumed by the run-stream route to verify a repo is not denied before
+   * opening the SSE stream. Optional — omit in tests that don't exercise streaming.
+   */
+  readonly denylistCache?: DenylistCache
+  /**
+   * Bindings lookup for the run-stream route's repo-key resolution.
+   * Used to resolve a run's entity_ref to its binding deny keys before
+   * the pre-subscribe redaction check. Optional — omit in tests that don't exercise streaming.
+   */
+  readonly bindingsLookup?: BindingsLookup
+  /**
+   * Run-observation manager for the run-stream route's SSE subscription.
+   * Provides subscribe/unsubscribe for per-connection streaming; the route
+   * calls subscribe() after all gates pass and unsubscribe() on every exit path.
+   * Optional — omit in tests that don't exercise streaming.
+   */
+  readonly runObservationManager?: RunObservationManager
 }
 
 export interface OperatorServerConfig {

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -22,6 +22,7 @@
  */
 
 import type {ServerType} from '@hono/node-server'
+import type {RunIndex} from '../execute/run-index.js'
 import type {DenylistCache} from '../redaction/denylist.js'
 import type {BindingsLookup} from '../redaction/surface-gate.js'
 import type {AuditLogger} from './audit.js'
@@ -30,8 +31,6 @@ import type {GitHubOAuthConfig, GitHubOAuthDeps} from './auth/github.js'
 import type {RepoAuthzCache} from './auth/repo-authz.js'
 import type {SessionDeps, SessionStore} from './auth/session.js'
 import type {RunObservationManager} from './sse/manager.js'
-import type {RunIndex} from './sse/run-stream-route.js'
-
 import {serve} from '@hono/node-server'
 import {getConnInfo} from '@hono/node-server/conninfo'
 import {Hono} from 'hono'
@@ -157,7 +156,7 @@ export interface OperatorServerDeps {
    * trusting any client-supplied value. Optional — omit in tests that don't
    * exercise the run-stream route.
    */
-  readonly runIndex?: RunIndex
+  readonly runIndex?: Pick<RunIndex, 'lookup'>
   /**
    * Shared repo-authz cache for the run-stream route's checkRepoAuthz calls.
    * When absent, a fresh in-memory cache is created per buildOperatorApp call.

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -27,8 +27,10 @@ import type {BindingsLookup} from '../redaction/surface-gate.js'
 import type {AuditLogger} from './audit.js'
 import type {OperatorAllowlist} from './auth/allowlist.js'
 import type {GitHubOAuthConfig, GitHubOAuthDeps} from './auth/github.js'
+import type {RepoAuthzCache} from './auth/repo-authz.js'
 import type {SessionDeps, SessionStore} from './auth/session.js'
 import type {RunObservationManager} from './sse/manager.js'
+import type {RunIndex} from './sse/run-stream-route.js'
 
 import {serve} from '@hono/node-server'
 import {getConnInfo} from '@hono/node-server/conninfo'
@@ -38,6 +40,7 @@ import {createRateLimiter} from '../http/rate-limit.js'
 import {buildCsrfRoute} from './auth/csrf-route.js'
 import {applyBrowserGuard} from './auth/csrf.js'
 import {buildGitHubOAuthRoutes} from './auth/github.js'
+import {createRepoAuthzCache} from './auth/repo-authz.js'
 import {buildSessionInfoRoute} from './auth/session-info-route.js'
 import {buildLogoutRoutes} from './auth/session.js'
 import {assertAllPrivilegedRoutesWrapped, registerPublicRoute, setOperatorRouteGuard} from './operator-route.js'
@@ -49,6 +52,7 @@ import {
   rateLimitedResponse,
   unavailableResponse,
 } from './safe-response.js'
+import {buildRunStreamRoute} from './sse/run-stream-route.js'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -147,6 +151,20 @@ export interface OperatorServerDeps {
    * Optional — omit in tests that don't exercise streaming.
    */
   readonly runObservationManager?: RunObservationManager
+  /**
+   * Server-owned run index for runId → {repo, surface} resolution.
+   * Required by the run-stream route to resolve a runId to its repo without
+   * trusting any client-supplied value. Optional — omit in tests that don't
+   * exercise the run-stream route.
+   */
+  readonly runIndex?: RunIndex
+  /**
+   * Shared repo-authz cache for the run-stream route's checkRepoAuthz calls.
+   * When absent, a fresh in-memory cache is created per buildOperatorApp call.
+   * Pass a shared instance in production so positive/negative results are reused
+   * across requests and the GitHub API is not called redundantly.
+   */
+  readonly repoAuthzCache?: RepoAuthzCache
 }
 
 export interface OperatorServerConfig {
@@ -497,6 +515,55 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
   // Returns current session info (operatorId, login, expiresAt) for the authenticated session.
   if (browserGuardDeps !== undefined) {
     buildSessionInfoRoute(app, browserGuardDeps)
+  }
+
+  // ── Run-stream SSE endpoint ─────────────────────────────────────────────────
+  //
+  // Registered only when the full browser guard is present AND the run-observation
+  // deps (denylistCache, bindingsLookup, runObservationManager) are provided.
+  // Route: GET /operator/runs/:runId/stream — privileged (requires session + allowlist).
+  //
+  // Gate ordering (all must pass before any byte is written):
+  //   1. Guard (browser/session/allowlist/CSRF) — installed above
+  //   2. Session token resolution
+  //   3. RunIndex.lookup (server-owned repo resolution)
+  //   4. Denylist check (pre-subscribe redaction, fail-closed)
+  //   5. checkRepoAuthz (allowlist + GitHub repo access)
+  //   6. Per-operator stream slot acquisition
+  //   7. SSE stream open → first snapshot/reset frame
+  //
+  // Every failure at steps 2–5 returns the identical generic not-found shape.
+  // There is NO authorized non-stream response — a distinguishable success would
+  // be a run-resolved/authorized oracle.
+  if (
+    browserGuardDeps !== undefined &&
+    deps.sessionStore !== undefined &&
+    deps.denylistCache !== undefined &&
+    deps.bindingsLookup !== undefined &&
+    deps.runObservationManager !== undefined &&
+    deps.runIndex !== undefined &&
+    deps.allowlist !== undefined &&
+    deps.auditLogger !== undefined
+  ) {
+    const clock = deps.sessionDeps?.clock ?? (() => Date.now())
+    buildRunStreamRoute(app, {
+      sessionStore: deps.sessionStore,
+      runIndex: deps.runIndex,
+      denylistCache: deps.denylistCache,
+      bindingsLookup: deps.bindingsLookup,
+      repoAuthzDeps: {
+        allowlist: deps.allowlist,
+        fetch: globalThis.fetch,
+        clock,
+        random: Math.random.bind(Math),
+        auditLogger: deps.auditLogger,
+        logger: deps.logger,
+        cache: deps.repoAuthzCache ?? createRepoAuthzCache(),
+      },
+      manager: deps.runObservationManager,
+      logger: deps.logger,
+      now: clock,
+    })
   }
 
   // ── Catch-all ──────────────────────────────────────────────────────────────

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -350,6 +350,10 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
   // session ID) so that a single authenticated user cannot exhaust the
   // unauthenticated burst budget.
   //
+  // Exception: authenticated long-lived streaming routes (e.g. the run-stream route)
+  // use the per-operator stream-slot cap (gate 7, keyed on numeric githubUserId) for
+  // backpressure instead of the socket-keyed rateLimiter — stronger keying for that case.
+  //
   // Failure to call rateLimiter.allow() in a new route is a security defect.
   // The ingress-pin test (http/ingress-pin.test.ts) will catch any new route
   // added without updating the pinned inventory — use that as the review gate.

--- a/packages/gateway/src/web/sse/manager.test.ts
+++ b/packages/gateway/src/web/sse/manager.test.ts
@@ -1,9 +1,9 @@
 /**
- * manager.test.ts — Tests for the run-observation pub/sub manager (Unit 3).
+ * manager.test.ts — Tests for the run-observation pub/sub manager.
  *
- * Test-first (RED→GREEN). The load-bearing risks are:
- *   1. Non-blocking backpressure: observe() must never await a subscriber write.
- *   2. Observer-only invariant: the manager must never call any mutating run API.
+ * The load-bearing risks are:
+ *   - Non-blocking backpressure: observe() must never await a subscriber write.
+ *   - Observer-only invariant: the manager must never call any mutating run API.
  *
  * BDD comments: #given / #when / #then.
  *

--- a/packages/gateway/src/web/sse/manager.ts
+++ b/packages/gateway/src/web/sse/manager.ts
@@ -56,11 +56,17 @@ export interface StatusFrame {
   readonly data: OperatorRunStatus
 }
 
+/**
+ * Typed set of reasons a reset frame can carry.
+ * Exhaustive over all reasons emitted by the manager.
+ */
+export type ResetReason = 'no-snapshot' | 'terminal' | 'shutdown' | 'max-duration' | 'writer-error' | 'overflow'
+
 /** A reset frame emitted when no snapshot exists for a run. */
 export interface ResetFrame {
   readonly type: 'reset'
   readonly runId: string
-  readonly reason: string
+  readonly reason: ResetReason
 }
 
 /** A heartbeat keepalive frame. */

--- a/packages/gateway/src/web/sse/projection.test.ts
+++ b/packages/gateway/src/web/sse/projection.test.ts
@@ -1,12 +1,12 @@
 /**
- * projection.test.ts — Tests for the run-status projection (Unit 1).
+ * projection.test.ts — Tests for the run-status projection.
  *
  * Covers:
- * 1. Happy path: each RunPhase maps to the expected base OperatorWebStatus.
- * 2. Overlay: waiting_for_approval overrides 'running' when hasPendingForScope → true.
- * 3. Edge: denied/keyless repo (projectRunStatus → null) yields null.
- * 4. Safety: the closed DTO contains ONLY the contract fields — no details passthrough.
- * 5. Scope: scopeIdFor returns thread_id for discord, run_id for non-discord.
+ * - Happy path: each RunPhase maps to the expected base OperatorWebStatus.
+ * - Overlay: waiting_for_approval overrides 'running' when hasPendingForScope → true.
+ * - Edge: denied/keyless repo (projectRunStatus → null) yields null.
+ * - Safety: the closed DTO contains ONLY the contract fields — no details passthrough.
+ * - Scope: scopeIdFor returns thread_id for discord, run_id for non-discord.
  *
  * Test seam: projectRunStatus is injected via the deps object so tests can drive
  * it without needing a real binding store or denylist. This avoids the async I/O
@@ -104,14 +104,14 @@ describe('scopeIdFor', () => {
     expect(scopeId).toBe('run-github-99')
   })
 
-  it('returns run_id for a web run (forward-compat with Unit 6)', () => {
+  it('returns run_id for a web run (forward-compat for non-discord surfaces)', () => {
     // #given a web run
     const runState = makeRunState({surface: 'web', run_id: 'run-web-77'})
 
     // #when computing the scope id
     const scopeId = scopeIdFor(runState)
 
-    // #then run_id is returned (web runs use runId scope, registered by Unit 6)
+    // #then run_id is returned (web runs use runId scope)
     expect(scopeId).toBe('run-web-77')
   })
 })

--- a/packages/gateway/src/web/sse/run-stream-route.test.ts
+++ b/packages/gateway/src/web/sse/run-stream-route.test.ts
@@ -374,6 +374,62 @@ describe('GET /operator/runs/:runId/stream — server-owned repo resolution', ()
 })
 
 // ---------------------------------------------------------------------------
+// NBC-4: #-suffix strip — fragment in location.repo must not bleed into repo name
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — #-suffix strip in resolved repo', () => {
+  it('strips a trailing #runNumber from location.repo before resolving owner/repo', async () => {
+    // #given — runIndex returns a repo string with a #-suffix fragment
+    const runIndex = makeRunIndex('owner/repo#42')
+    const bindingsLookup = makeBindingsLookup(42, 'node-id-1')
+    const deps = makeDeps({runIndex, bindingsLookup})
+    const app = buildTestApp(deps)
+
+    // #when
+    await fetchStream(app, 'run-abc')
+
+    // #then — downstream calls use 'repo', not 'repo#42'
+    expect(bindingsLookup.getBindingByRepo).toHaveBeenCalledWith('owner', 'repo')
+    expect(bindingsLookup.getBindingByRepo).not.toHaveBeenCalledWith('owner', 'repo#42')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Security: 429 over-cap path — no SSE frame written, no stream entered
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — 429 over-cap: no SSE frame emitted', () => {
+  it('returns 429 with no ready frame and no data frame when the per-operator cap is exceeded', async () => {
+    // #given — cap of 1; first stream holds the slot open
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => () => undefined),
+    })
+    const deps = makeDeps({manager, maxStreamsPerOperator: 1})
+    const app = buildTestApp(deps)
+
+    // First request acquires the slot; do not await the body so the stream stays open
+    const res1Promise = fetchStream(app, 'run-abc')
+    await new Promise<void>(resolve => setTimeout(resolve, 10))
+
+    // #when — second request from the same operator (same githubUserId=99)
+    const res2 = await fetchStream(app, 'run-def')
+
+    // #then — 429 response; subscribe was never called for the second request
+    expect(res2.status).toBe(429)
+    const body2 = await res2.json()
+    expect(body2).toEqual({error: 'rate limited'})
+    // subscribe called exactly once (only for the first, slot-holding request)
+    expect(manager.subscribe).toHaveBeenCalledTimes(1)
+    // response is not text/event-stream — no SSE stream was entered
+    const contentType = res2.headers.get('content-type') ?? ''
+    expect(contentType).not.toContain('text/event-stream')
+
+    const res1 = await res1Promise
+    await res1.body?.cancel()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Security: denylisted repo → not-found, checkRepoAuthz NOT reached
 // ---------------------------------------------------------------------------
 

--- a/packages/gateway/src/web/sse/run-stream-route.test.ts
+++ b/packages/gateway/src/web/sse/run-stream-route.test.ts
@@ -1965,6 +1965,120 @@ describe('GET /operator/runs/:runId/stream — lease: unexpected throw closes st
 })
 
 // ---------------------------------------------------------------------------
+// Route-owned max-duration timer: defense-in-depth hard cap
+// ---------------------------------------------------------------------------
+
+/**
+ * A minimal fake setTimeout/clearTimeout pair that lets tests fire the one-shot
+ * timer manually without real wall-clock delays.
+ */
+function makeFakeOneShotTimer(): {
+  readonly setTimeout: (fn: () => void, _ms: number) => ReturnType<typeof globalThis.setTimeout>
+  readonly clearTimeout: (handle: ReturnType<typeof globalThis.setTimeout> | undefined) => void
+  readonly fire: () => Promise<void>
+  readonly cleared: () => boolean
+  readonly scheduled: () => boolean
+} {
+  let callback: (() => void) | undefined
+  let isCleared = false
+
+  return {
+    setTimeout: (fn: () => void, _ms: number): ReturnType<typeof globalThis.setTimeout> => {
+      callback = fn
+      return 1 as unknown as ReturnType<typeof globalThis.setTimeout>
+    },
+    clearTimeout: (_handle: ReturnType<typeof globalThis.setTimeout> | undefined): void => {
+      isCleared = true
+      callback = undefined
+    },
+    fire: async (): Promise<void> => {
+      if (callback !== undefined) {
+        callback()
+        await new Promise<void>(resolve => setTimeout(resolve, 0))
+      }
+    },
+    cleared: () => isCleared,
+    scheduled: () => callback !== undefined,
+  }
+}
+
+describe('GET /operator/runs/:runId/stream — route-owned max-duration timer', () => {
+  it('firing the max-duration timer triggers cleanup: unsubscribe called once, slot released, stream resolves', async () => {
+    // #given — stream opens with a fake one-shot timer; manager holds the stream open
+    let unsubscribeCalls = 0
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => {
+        return () => {
+          unsubscribeCalls++
+        }
+      }),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const fakeOneShot = makeFakeOneShotTimer()
+    const deps = makeDeps({
+      manager,
+      maxStreamsPerOperator: 1,
+      setInterval: fakeTimer.setInterval,
+      clearInterval: fakeTimer.clearInterval,
+      setTimeout: fakeOneShot.setTimeout,
+      clearTimeout: fakeOneShot.clearTimeout,
+    })
+    const app = buildTestApp(deps)
+
+    // #when — stream opens
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+    expect(fakeOneShot.scheduled()).toBe(true)
+
+    // Fire the max-duration timer
+    await fakeOneShot.fire()
+
+    // #then — cleanup ran: unsubscribe called once
+    expect(unsubscribeCalls).toBe(1)
+
+    // Slot must be released: a new stream from the same operator should succeed
+    const res2 = await fetchStream(app, 'run-def')
+    expect(res2.status).toBe(200)
+    await res2.body?.cancel()
+    await res.body?.cancel()
+  })
+
+  it('max-duration timer is cleared on a normal teardown path (no leak)', async () => {
+    // #given — stream opens with a fake one-shot timer; manager closes the stream normally
+    let capturedCallbacks: SubscriberCallbacks | undefined
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        capturedCallbacks = callbacks
+        return () => undefined
+      }),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const fakeOneShot = makeFakeOneShotTimer()
+    const deps = makeDeps({
+      manager,
+      setInterval: fakeTimer.setInterval,
+      clearInterval: fakeTimer.clearInterval,
+      setTimeout: fakeOneShot.setTimeout,
+      clearTimeout: fakeOneShot.clearTimeout,
+    })
+    const app = buildTestApp(deps)
+
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+    expect(fakeOneShot.scheduled()).toBe(true)
+
+    // #when — stream ends via manager onClose (normal teardown)
+    capturedCallbacks?.onClose('terminal')
+    await res.body?.cancel()
+
+    // #then — clearTimeout was called (timer cleared in cleanup, no leak)
+    expect(fakeOneShot.cleared()).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // FIX-D: contract version ready frame emitted as first SSE frame on success
 // ---------------------------------------------------------------------------
 

--- a/packages/gateway/src/web/sse/run-stream-route.test.ts
+++ b/packages/gateway/src/web/sse/run-stream-route.test.ts
@@ -1,0 +1,735 @@
+/**
+ * Tests for the authenticated SSE run-stream route.
+ *
+ * Security properties are the load-bearing assertions:
+ *   - Every denial path returns the identical generic not-found shape.
+ *   - No stream is opened unless all gates pass.
+ *   - Success is observable ONLY as text/event-stream + first frame.
+ *   - The resolved repo comes exclusively from runIndex.lookup — never from the client.
+ *   - Denylist check runs before checkRepoAuthz (no authz call on denied repos).
+ *
+ * BDD comments: #given / #when / #then.
+ */
+
+import type {DenylistCache, RepoKey} from '../../redaction/denylist.js'
+import type {BindingsLookup} from '../../redaction/surface-gate.js'
+import type {RepoAuthzCache, RepoAuthzDeps} from '../auth/repo-authz.js'
+import type {SessionStore} from '../auth/session.js'
+import type {RunObservationManager, SubscriberCallbacks} from './manager.js'
+import type {RunStreamRouteDeps} from './run-stream-route.js'
+
+import {Hono} from 'hono'
+import {describe, expect, it, vi} from 'vitest'
+import {setOperatorRouteGuard} from '../operator-route.js'
+import {buildRunStreamRoute} from './run-stream-route.js'
+
+// ---------------------------------------------------------------------------
+// Stub factories
+// ---------------------------------------------------------------------------
+
+function makeLogger(): RunStreamRouteDeps['logger'] {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+}
+
+function makeSessionStore(overrides?: Partial<SessionStore>): SessionStore {
+  return {
+    create: vi.fn(() => 'session-id'),
+    get: vi.fn(() => undefined),
+    touch: vi.fn(),
+    delete: vi.fn(),
+    onRevoke: vi.fn(),
+    scavenge: vi.fn(),
+    size: vi.fn(() => 0),
+    getOperatorToken: vi.fn(() => 'stub-oauth-token'),
+    dropOperatorToken: vi.fn(),
+    ...overrides,
+  }
+}
+
+function makeRunIndex(repo?: string): RunStreamRouteDeps['runIndex'] {
+  return {
+    lookup: vi.fn(async () => (repo === undefined ? undefined : {repo, surface: 'github' as const})),
+  }
+}
+
+function makeDenylistCache(denied = false): DenylistCache {
+  return {
+    getDenylistState: vi.fn(async () => undefined),
+    isRepoDenied: vi.fn(() => denied),
+  }
+}
+
+function makeBindingsLookup(databaseId?: number, nodeId?: string): BindingsLookup {
+  const data = databaseId !== undefined || nodeId !== undefined ? {databaseId, nodeId} : null
+  return {
+    getBindingByRepo: vi.fn(async () => ({success: true as const, data})),
+  }
+}
+
+function makeRepoAuthzCache(authorized: boolean): RepoAuthzCache {
+  return {
+    get: vi.fn(() =>
+      authorized
+        ? {authorized: true as const, expiresAt: Number.MAX_SAFE_INTEGER}
+        : {authorized: false as const, reason: 'github_denied' as const, expiresAt: Number.MAX_SAFE_INTEGER},
+    ),
+    set: vi.fn(),
+    getInFlight: vi.fn(() => undefined),
+    setInFlight: vi.fn(),
+    deleteInFlight: vi.fn(),
+    tokenIdentityFor: vi.fn(() => 'stub-token-id'),
+  }
+}
+
+function makeRepoAuthzDeps(authorized = true): RepoAuthzDeps {
+  return {
+    allowlist: {isAuthorized: vi.fn(() => true), size: 1},
+    fetch: vi.fn(async () => new Response('{}', {status: authorized ? 200 : 403})),
+    clock: () => 0,
+    random: () => 0,
+    auditLogger: {info: vi.fn(), warn: vi.fn()},
+    logger: {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()},
+    cache: makeRepoAuthzCache(authorized),
+  }
+}
+
+function makeManager(overrides?: Partial<RunObservationManager>): RunObservationManager {
+  return {
+    observe: vi.fn(async () => undefined),
+    subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => () => undefined),
+    abortSubscription: vi.fn(),
+    shutdown: vi.fn(),
+    ...overrides,
+  }
+}
+
+function makeDeps(overrides?: Partial<RunStreamRouteDeps>): RunStreamRouteDeps {
+  return {
+    sessionStore: makeSessionStore(),
+    runIndex: makeRunIndex('acme/widget'),
+    denylistCache: makeDenylistCache(false),
+    bindingsLookup: makeBindingsLookup(42, 'node-id-1'),
+    repoAuthzDeps: makeRepoAuthzDeps(true),
+    manager: makeManager(),
+    logger: makeLogger(),
+    now: () => 0,
+    ...overrides,
+  }
+}
+
+/**
+ * Build a Hono app with the guard installed and the run-stream route registered.
+ * The guard sets githubUserId and sessionId on the context.
+ */
+function buildTestApp(
+  deps: RunStreamRouteDeps,
+  guardUserId = 99,
+  guardSessionId = 'test-session-id',
+  installGuard = true,
+): Hono {
+  const app = new Hono()
+
+  if (installGuard) {
+    setOperatorRouteGuard(app, async (_c, _method, _path) => ({
+      ok: true as const,
+      githubUserId: guardUserId,
+      sessionId: guardSessionId,
+    }))
+  }
+
+  buildRunStreamRoute(app, deps)
+  return app
+}
+
+/**
+ * Make a GET request to the run-stream route.
+ */
+async function fetchStream(app: Hono, runId: string): Promise<Response> {
+  const req = new Request(`http://localhost/operator/runs/${runId}/stream`)
+  return app.fetch(req)
+}
+
+// ---------------------------------------------------------------------------
+// Security: missing token → not-found, no stream
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — missing token', () => {
+  it('returns not-found when getOperatorToken returns undefined, regardless of runId', async () => {
+    // #given — session store returns no token
+    const sessionStore = makeSessionStore({getOperatorToken: vi.fn(() => undefined)})
+    const runIndex = makeRunIndex('acme/widget')
+    const manager = makeManager()
+    const deps = makeDeps({sessionStore, runIndex, manager})
+    const app = buildTestApp(deps)
+
+    // #when — request with a valid runId but no token
+    const res = await fetchStream(app, 'run-abc-123')
+    const body = await res.json()
+
+    // #then — generic not-found, no stream opened
+    expect(res.status).toBe(404)
+    expect(body).toEqual({error: 'not-found'})
+    expect(manager.subscribe).not.toHaveBeenCalled()
+  })
+
+  it('returns the same not-found shape when runId does not exist and token is missing', async () => {
+    // #given — no token, no run
+    const sessionStore = makeSessionStore({getOperatorToken: vi.fn(() => undefined)})
+    const runIndex = makeRunIndex(undefined)
+    const deps = makeDeps({sessionStore, runIndex})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'nonexistent-run')
+    const body = await res.json()
+
+    // #then — identical shape regardless of run existence
+    expect(res.status).toBe(404)
+    expect(body).toEqual({error: 'not-found'})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Security: unknown runId → not-found, no authz/redaction call
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — unknown runId', () => {
+  it('returns not-found when lookup returns undefined', async () => {
+    // #given — run does not exist
+    const runIndex = makeRunIndex(undefined)
+    const denylistCache = makeDenylistCache(false)
+    const repoAuthzDeps = makeRepoAuthzDeps(true)
+    const manager = makeManager()
+    const deps = makeDeps({runIndex, denylistCache, repoAuthzDeps, manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'unknown-run-id')
+    const body = await res.json()
+
+    // #then — not-found, no downstream calls
+    expect(res.status).toBe(404)
+    expect(body).toEqual({error: 'not-found'})
+    expect(denylistCache.isRepoDenied).not.toHaveBeenCalled()
+    expect(manager.subscribe).not.toHaveBeenCalled()
+  })
+
+  it('does not call checkRepoAuthz after a run lookup miss', async () => {
+    // #given — run does not exist; authz fetch should never be called
+    const runIndex = makeRunIndex(undefined)
+    const fetchFn = vi.fn() as typeof globalThis.fetch
+    const repoAuthzDeps: RepoAuthzDeps = {...makeRepoAuthzDeps(true), fetch: fetchFn}
+    const deps = makeDeps({runIndex, repoAuthzDeps})
+    const app = buildTestApp(deps)
+
+    // #when
+    await fetchStream(app, 'unknown-run-id')
+
+    // #then — no GitHub API call was made
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Security: client cannot influence resolved repo
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — server-owned repo resolution', () => {
+  it('uses only runIndex.lookup to determine owner/repo, ignoring any query params', async () => {
+    // #given — run resolves to acme/widget; query param tries to inject a different repo
+    const runIndex = makeRunIndex('acme/widget')
+    const bindingsLookup = makeBindingsLookup(42, 'node-id-1')
+    const deps = makeDeps({runIndex, bindingsLookup})
+    const app = buildTestApp(deps)
+
+    // #when — request includes a query param attempting to override the repo
+    const req = new Request('http://localhost/operator/runs/run-abc/stream?repo=evil/repo&owner=evil')
+    await app.fetch(req)
+
+    // #then — getBindingByRepo was called with the server-resolved owner/repo, not the query param
+    expect(bindingsLookup.getBindingByRepo).toHaveBeenCalledWith('acme', 'widget')
+    expect(bindingsLookup.getBindingByRepo).not.toHaveBeenCalledWith('evil', 'repo')
+  })
+
+  it('returns not-found for a malformed repo string (no slash)', async () => {
+    // #given — run resolves to a malformed repo string
+    const runIndex = makeRunIndex('noslash')
+    const manager = makeManager()
+    const deps = makeDeps({runIndex, manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    const body = await res.json()
+
+    // #then — malformed repo → not-found, no stream
+    expect(res.status).toBe(404)
+    expect(body).toEqual({error: 'not-found'})
+    expect(manager.subscribe).not.toHaveBeenCalled()
+  })
+
+  it('returns not-found for a repo string with empty owner', async () => {
+    // #given — repo string starts with slash (empty owner)
+    const runIndex = makeRunIndex('/widget')
+    const manager = makeManager()
+    const deps = makeDeps({runIndex, manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    const body = await res.json()
+
+    // #then
+    expect(res.status).toBe(404)
+    expect(body).toEqual({error: 'not-found'})
+    expect(manager.subscribe).not.toHaveBeenCalled()
+  })
+
+  it('returns not-found for a repo string with empty repo name', async () => {
+    // #given — repo string ends with slash (empty repo name)
+    const runIndex = makeRunIndex('acme/')
+    const manager = makeManager()
+    const deps = makeDeps({runIndex, manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    const body = await res.json()
+
+    // #then
+    expect(res.status).toBe(404)
+    expect(body).toEqual({error: 'not-found'})
+    expect(manager.subscribe).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Security: denylisted repo → not-found, checkRepoAuthz NOT reached
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — denylisted repo', () => {
+  it('returns not-found when repo is denied, without calling checkRepoAuthz', async () => {
+    // #given — repo is on the denylist
+    const denylistCache = makeDenylistCache(true)
+    const authzFetch = vi.fn() as typeof globalThis.fetch
+    const repoAuthzDeps: RepoAuthzDeps = {...makeRepoAuthzDeps(true), fetch: authzFetch}
+    const manager = makeManager()
+    const deps = makeDeps({denylistCache, repoAuthzDeps, manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    const body = await res.json()
+
+    // #then — not-found, no authz call, no stream
+    expect(res.status).toBe(404)
+    expect(body).toEqual({error: 'not-found'})
+    expect(authzFetch).not.toHaveBeenCalled()
+    expect(manager.subscribe).not.toHaveBeenCalled()
+  })
+
+  it('calls getDenylistState before isRepoDenied', async () => {
+    // #given — track call order
+    const callOrder: string[] = []
+    const denylistCache: DenylistCache = {
+      getDenylistState: vi.fn(async () => {
+        callOrder.push('getDenylistState')
+      }),
+      isRepoDenied: vi.fn(() => {
+        callOrder.push('isRepoDenied')
+        return false
+      }),
+    }
+    const deps = makeDeps({denylistCache})
+    const app = buildTestApp(deps)
+
+    // #when
+    await fetchStream(app, 'run-abc')
+
+    // #then — getDenylistState called before isRepoDenied
+    expect(callOrder.indexOf('getDenylistState')).toBeLessThan(callOrder.indexOf('isRepoDenied'))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Security: checkRepoAuthz denies → not-found, byte-identical to other denials
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — checkRepoAuthz denies', () => {
+  it('returns not-found when checkRepoAuthz denies, same shape as unknown/denied', async () => {
+    // #given — authz cache returns denied
+    const repoAuthzDeps = makeRepoAuthzDeps(false)
+    const manager = makeManager()
+    const deps = makeDeps({repoAuthzDeps, manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    const body = await res.json()
+
+    // #then — identical shape to all other denials
+    expect(res.status).toBe(404)
+    expect(body).toEqual({error: 'not-found'})
+    expect(manager.subscribe).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Security (THE no-oracle test): success is ONLY observable as SSE stream
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — no-oracle: success is stream-only', () => {
+  it('returns text/event-stream content-type on success, not a JSON body', async () => {
+    // #given — all gates pass; manager delivers a status frame
+    const statusFrame = {
+      type: 'status' as const,
+      data: {
+        runId: 'run-abc',
+        entityRef: 'acme/widget#1',
+        surface: 'github' as const,
+        phase: 'EXECUTING' as const,
+        status: 'running' as const,
+        startedAt: '2024-01-01T00:00:00.000Z',
+        stale: false,
+      },
+    }
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        // Deliver the first frame synchronously (simulates snapshot-on-subscribe)
+        queueMicrotask(() => {
+          Promise.resolve(callbacks.onEvent(statusFrame)).catch(() => {})
+        })
+        return () => undefined
+      }),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+
+    // #then — content-type is text/event-stream, not application/json
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/event-stream')
+
+    // Consume the body to avoid resource leaks
+    await res.body?.cancel()
+  })
+
+  it('does not return a JSON body on success — no 200 JSON marker', async () => {
+    // #given — all gates pass
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => () => undefined),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+
+    // #then — response is NOT application/json (no oracle marker)
+    const contentType = res.headers.get('content-type') ?? ''
+    expect(contentType).not.toContain('application/json')
+
+    await res.body?.cancel()
+  })
+
+  it('calls manager.subscribe exactly once on success', async () => {
+    // #given — all gates pass
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => () => undefined),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+
+    // #then — subscribe called once with the correct runId
+    expect(manager.subscribe).toHaveBeenCalledTimes(1)
+    expect(manager.subscribe).toHaveBeenCalledWith('run-abc', expect.any(Object))
+
+    await res.body?.cancel()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cap: over-cap operator → 429, no stream
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — per-operator stream cap', () => {
+  it('returns 429 when the operator is at the stream cap', async () => {
+    // #given — cap of 1, operator already has 1 active stream
+    // The first stream stays open (never calls onClose) to hold the slot.
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => () => undefined),
+    })
+    const deps = makeDeps({manager, maxStreamsPerOperator: 1})
+    const app = buildTestApp(deps)
+
+    // First request acquires the slot. We do NOT await the body — the stream stays open.
+    // fetchStream returns the Response (headers) immediately; the body is a live stream.
+    const res1Promise = fetchStream(app, 'run-abc')
+    // Give the first request time to acquire the slot before the second request arrives.
+    await new Promise<void>(resolve => setTimeout(resolve, 10))
+
+    // #when — second request from the same operator (same githubUserId=99)
+    const res2 = await fetchStream(app, 'run-def')
+    const body2 = await res2.json()
+
+    // #then — 429 (honest backpressure for an already-authorized operator)
+    expect(res2.status).toBe(429)
+    expect(body2).toEqual({error: 'too many streams'})
+    // subscribe was only called once (for the first request)
+    expect(manager.subscribe).toHaveBeenCalledTimes(1)
+
+    // Clean up: cancel the first stream body to avoid resource leaks
+    const res1 = await res1Promise
+    await res1.body?.cancel()
+  })
+
+  it('allows a stream when under the cap', async () => {
+    // #given — cap of 2, operator has 0 active streams
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => () => undefined),
+    })
+    const deps = makeDeps({manager, maxStreamsPerOperator: 2})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+
+    // #then — stream opened
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/event-stream')
+
+    await res.body?.cancel()
+  })
+
+  it('releases the slot when the stream ends, allowing a new stream', async () => {
+    // #given — cap of 1; first stream ends via onClose
+    let capturedCallbacks: SubscriberCallbacks | undefined
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        capturedCallbacks = callbacks
+        return () => undefined
+      }),
+    })
+    const deps = makeDeps({manager, maxStreamsPerOperator: 1})
+    const app = buildTestApp(deps)
+
+    // First stream opens
+    const res1 = await fetchStream(app, 'run-abc')
+    expect(res1.status).toBe(200)
+
+    // Close the first stream via manager onClose
+    capturedCallbacks?.onClose('terminal')
+    await res1.body?.cancel()
+
+    // #when — second request after slot is released
+    const res2 = await fetchStream(app, 'run-def')
+
+    // #then — slot was released; new stream is allowed
+    expect(res2.status).toBe(200)
+    await res2.body?.cancel()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Deny-key resolution: fail-closed on store error
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — deny-key resolution', () => {
+  it('treats a binding store error as fail-closed (null/null keys → denied)', async () => {
+    // #given — binding store returns an error
+    const bindingsLookup: BindingsLookup = {
+      getBindingByRepo: vi.fn(async () => ({success: false as const, error: new Error('store error')})),
+    }
+    // Denylist treats null/null as denied
+    const denylistCache: DenylistCache = {
+      getDenylistState: vi.fn(async () => undefined),
+      isRepoDenied: vi.fn((repoKey: RepoKey) => repoKey.databaseId === null && repoKey.nodeId === null),
+    }
+    const manager = makeManager()
+    const deps = makeDeps({bindingsLookup, denylistCache, manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    const body = await res.json()
+
+    // #then — fail-closed: store error → null/null keys → denied → not-found
+    expect(res.status).toBe(404)
+    expect(body).toEqual({error: 'not-found'})
+    expect(manager.subscribe).not.toHaveBeenCalled()
+  })
+
+  it('treats a missing binding (data=null) as fail-closed (null/null keys → denied)', async () => {
+    // #given — binding not found
+    const bindingsLookup: BindingsLookup = {
+      getBindingByRepo: vi.fn(async () => ({success: true as const, data: null})),
+    }
+    const denylistCache: DenylistCache = {
+      getDenylistState: vi.fn(async () => undefined),
+      isRepoDenied: vi.fn((repoKey: RepoKey) => repoKey.databaseId === null && repoKey.nodeId === null),
+    }
+    const manager = makeManager()
+    const deps = makeDeps({bindingsLookup, denylistCache, manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    const body = await res.json()
+
+    // #then — fail-closed: missing binding → null/null keys → denied → not-found
+    expect(res.status).toBe(404)
+    expect(body).toEqual({error: 'not-found'})
+    expect(manager.subscribe).not.toHaveBeenCalled()
+  })
+
+  it('passes correct deny keys to isRepoDenied when binding has both keys', async () => {
+    // #given — binding has both databaseId and nodeId
+    const bindingsLookup = makeBindingsLookup(42, 'node-id-1')
+    const isRepoDenied = vi.fn(() => false)
+    const denylistCache: DenylistCache = {
+      getDenylistState: vi.fn(async () => undefined),
+      isRepoDenied,
+    }
+    const deps = makeDeps({bindingsLookup, denylistCache})
+    const app = buildTestApp(deps)
+
+    // #when
+    await fetchStream(app, 'run-abc')
+
+    // #then — isRepoDenied called with the correct keys
+    expect(isRepoDenied).toHaveBeenCalledWith({databaseId: 42, nodeId: 'node-id-1'})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integration: assertAllPrivilegedRoutesWrapped passes
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — route registration', () => {
+  it('is registered as a privileged route (guard-wrapped)', () => {
+    // #given — build app with guard installed
+    const deps = makeDeps()
+    const app = buildTestApp(deps)
+
+    // #when — inspect the route registry
+    const routes = (app.routes as {method: string; path: string}[]).filter(
+      r => r.method !== 'ALL' && r.path === '/operator/runs/:runId/stream',
+    )
+
+    // #then — route is registered
+    expect(routes.length).toBeGreaterThan(0)
+    expect(routes[0]?.method).toBe('GET')
+  })
+
+  it('returns not-found when no guard is installed (guard-not-installed fallback)', async () => {
+    // #given — no guard installed; route falls back to coarse not-found
+    const deps = makeDeps()
+    const app = new Hono()
+    buildRunStreamRoute(app, deps)
+
+    // #when — request without guard context
+    const res = await fetchStream(app, 'run-abc')
+    const body = await res.json()
+
+    // #then — coarse not-found (guard not installed → authCtx undefined)
+    expect(res.status).toBe(404)
+    expect(body).toEqual({error: 'not-found'})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Happy path: all gates pass → SSE stream with first frame
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — happy path', () => {
+  it('delivers the first snapshot frame as an SSE event on success', async () => {
+    // #given — all gates pass; manager delivers a status frame
+    const statusData = {
+      runId: 'run-abc',
+      entityRef: 'acme/widget#1',
+      surface: 'github' as const,
+      phase: 'EXECUTING' as const,
+      status: 'running' as const,
+      startedAt: '2024-01-01T00:00:00.000Z',
+      stale: false,
+    }
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        // Deliver the snapshot frame immediately
+        Promise.resolve(callbacks.onEvent({type: 'status', data: statusData})).catch(() => {})
+        return () => undefined
+      }),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+
+    // #then — SSE stream with status event
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/event-stream')
+
+    // Read the first chunk of the SSE stream
+    const reader = res.body?.getReader()
+    if (reader === undefined) {
+      throw new Error('Expected a readable body')
+    }
+    const decoder = new TextDecoder()
+    let text = ''
+    // Read until we have the status event or exhaust the stream
+    for (let i = 0; i < 10; i++) {
+      const result = await reader.read()
+      if (result.done === true) break
+      text += decoder.decode(result.value as Uint8Array, {stream: true})
+      if (text.includes('event: status')) break
+    }
+    await reader.cancel()
+
+    expect(text).toContain('event: status')
+    expect(text).toContain('"runId":"run-abc"')
+  })
+
+  it('delivers a reset frame when no snapshot exists', async () => {
+    // #given — manager delivers a reset frame (no cached snapshot)
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        Promise.resolve(callbacks.onEvent({type: 'reset', runId: 'run-abc', reason: 'no-snapshot'})).catch(() => {})
+        return () => undefined
+      }),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+
+    // #then — SSE stream with reset event
+    expect(res.status).toBe(200)
+
+    const reader = res.body?.getReader()
+    if (reader === undefined) throw new Error('Expected a readable body')
+    const decoder = new TextDecoder()
+    let text = ''
+    for (let i = 0; i < 10; i++) {
+      const result = await reader.read()
+      if (result.done === true) break
+      text += decoder.decode(result.value as Uint8Array, {stream: true})
+      if (text.includes('event: reset')) break
+    }
+    await reader.cancel()
+
+    expect(text).toContain('event: reset')
+    expect(text).toContain('"runId":"run-abc"')
+  })
+})

--- a/packages/gateway/src/web/sse/run-stream-route.test.ts
+++ b/packages/gateway/src/web/sse/run-stream-route.test.ts
@@ -733,3 +733,349 @@ describe('GET /operator/runs/:runId/stream — happy path', () => {
     expect(text).toContain('"runId":"run-abc"')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Socket timeout: per-connection timeout raised on stream open, restored on cleanup
+// ---------------------------------------------------------------------------
+
+/** Build a mock socket with a controllable setTimeout. */
+function makeMockSocket(initialTimeout = 10_000): {
+  readonly socket: {setTimeout: ReturnType<typeof vi.fn>; timeout: number}
+  readonly setTimeoutCalls: number[]
+} {
+  const setTimeoutCalls: number[] = []
+  const socket = {
+    setTimeout: vi.fn((ms: number) => {
+      setTimeoutCalls.push(ms)
+      socket.timeout = ms
+    }),
+    timeout: initialTimeout,
+  }
+  return {socket, setTimeoutCalls}
+}
+
+/** Build a mock HttpBindings env with a controllable socket. */
+function makeMockEnv(socket: {setTimeout: ReturnType<typeof vi.fn>; timeout: number}): {
+  incoming: {socket: typeof socket}
+  outgoing: Record<string, never>
+} {
+  return {incoming: {socket}, outgoing: {}}
+}
+
+/** Fetch the stream route with a mock env (simulates @hono/node-server bindings). */
+async function fetchStreamWithEnv(app: Hono, runId: string, env: Record<string, unknown>): Promise<Response> {
+  const req = new Request(`http://localhost/operator/runs/${runId}/stream`)
+  return app.fetch(req, env)
+}
+
+describe('GET /operator/runs/:runId/stream — socket timeout', () => {
+  it('calls socket.setTimeout(60_000) on stream open (above the 15s heartbeat)', async () => {
+    // #given — all gates pass; mock socket with initial timeout of 10_000
+    const {socket, setTimeoutCalls} = makeMockSocket(10_000)
+    const env = makeMockEnv(socket)
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => () => undefined),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    // #when — stream opens with mock env
+    const res = await fetchStreamWithEnv(app, 'run-abc', env)
+
+    // #then — socket.setTimeout called with 60_000 (> 15_000 heartbeat)
+    expect(setTimeoutCalls).toContain(60_000)
+    expect(60_000).toBeGreaterThan(15_000)
+
+    await res.body?.cancel()
+  })
+
+  it('restores the prior socket timeout on cleanup (onClose path)', async () => {
+    // #given — mock socket with initial timeout of 10_000; manager closes the stream
+    const {socket, setTimeoutCalls} = makeMockSocket(10_000)
+    const env = makeMockEnv(socket)
+    let capturedCallbacks: SubscriberCallbacks | undefined
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        capturedCallbacks = callbacks
+        return () => undefined
+      }),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    // #when — stream opens, then manager closes it
+    const res = await fetchStreamWithEnv(app, 'run-abc', env)
+    capturedCallbacks?.onClose('terminal')
+    await res.body?.cancel()
+
+    // #then — setTimeout called with 60_000 (raise), then 10_000 (restore)
+    expect(setTimeoutCalls[0]).toBe(60_000)
+    expect(setTimeoutCalls.at(-1)).toBe(10_000)
+  })
+
+  it('restores the prior socket timeout on the write-failure path', async () => {
+    // #given — mock socket; onEvent write throws to simulate a broken connection
+    const {socket, setTimeoutCalls} = makeMockSocket(10_000)
+    const env = makeMockEnv(socket)
+    let capturedCallbacks: SubscriberCallbacks | undefined
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        capturedCallbacks = callbacks
+        return () => undefined
+      }),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    const res = await fetchStreamWithEnv(app, 'run-abc', env)
+
+    // Trigger a write failure by calling onEvent after the stream body is cancelled
+    await res.body?.cancel()
+    // Deliver a frame after cancel — writeFrame will throw; cleanup must still restore
+    if (capturedCallbacks !== undefined) {
+      const result = capturedCallbacks.onEvent({type: 'heartbeat'})
+      if (result instanceof Promise) {
+        await result.catch(() => {})
+      }
+    }
+
+    // #then — restore call must have happened (last setTimeout call = prior timeout)
+    expect(setTimeoutCalls[0]).toBe(60_000)
+    expect(setTimeoutCalls.at(-1)).toBe(10_000)
+  })
+
+  it('does not crash when socket is undefined (graceful degrade)', async () => {
+    // #given — env with no socket (c.env.incoming.socket is undefined)
+    const envNoSocket = {incoming: {socket: undefined}, outgoing: {}}
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => () => undefined),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    // #when — stream opens without a socket
+    const res = await fetchStreamWithEnv(app, 'run-abc', envNoSocket)
+
+    // #then — stream still opens normally (no crash)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/event-stream')
+
+    await res.body?.cancel()
+  })
+
+  it('does not crash when c.env is undefined (test harness / non-node-server path)', async () => {
+    // #given — no env passed (c.env is undefined, as in plain Hono test harness)
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => () => undefined),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    // #when — plain fetch with no env
+    const res = await fetchStream(app, 'run-abc')
+
+    // #then — stream still opens normally
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/event-stream')
+
+    await res.body?.cancel()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cleanup idempotency: concurrent onAbort + onClose run cleanup exactly once
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — cleanup idempotency', () => {
+  it('concurrent onAbort + onClose: unsubscribe called once, slot released once', async () => {
+    // #given — cap of 1; track unsubscribe calls
+    let unsubscribeCalls = 0
+    let capturedCallbacks: SubscriberCallbacks | undefined
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        capturedCallbacks = callbacks
+        return () => {
+          unsubscribeCalls++
+        }
+      }),
+    })
+    const deps = makeDeps({manager, maxStreamsPerOperator: 1})
+    const app = buildTestApp(deps)
+
+    // First stream opens and holds the slot
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    // #when — fire both onAbort (via body cancel) and onClose concurrently
+    // onAbort fires when the body is cancelled; onClose fires from the manager
+    const abortPromise = res.body?.cancel()
+    capturedCallbacks?.onClose('terminal')
+    await abortPromise
+
+    // #then — unsubscribe called exactly once (idempotent cleanup)
+    expect(unsubscribeCalls).toBe(1)
+
+    // Slot must be released: a new stream from the same operator should succeed
+    const res2 = await fetchStream(app, 'run-def')
+    expect(res2.status).toBe(200)
+    await res2.body?.cancel()
+  })
+
+  it('concurrent onAbort + onClose with socket: socket restored exactly once', async () => {
+    // #given — mock socket; both teardown paths fire
+    const {socket, setTimeoutCalls} = makeMockSocket(10_000)
+    const env = makeMockEnv(socket)
+    let capturedCallbacks: SubscriberCallbacks | undefined
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        capturedCallbacks = callbacks
+        return () => undefined
+      }),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    const res = await fetchStreamWithEnv(app, 'run-abc', env)
+
+    // #when — fire both teardown paths
+    const abortPromise = res.body?.cancel()
+    capturedCallbacks?.onClose('terminal')
+    await abortPromise
+
+    // #then — restore call (10_000) appears exactly once after the raise (60_000)
+    const restoreCalls = setTimeoutCalls.filter(ms => ms === 10_000)
+    expect(restoreCalls).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// EOF / observation-failed: clean stream end, not an error
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — EOF / observation-failed', () => {
+  it('ends the stream cleanly when manager closes with observation-failed', async () => {
+    // #given — manager closes with observation-failed (EOF before terminal)
+    let capturedCallbacks: SubscriberCallbacks | undefined
+    let unsubscribeCalls = 0
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        capturedCallbacks = callbacks
+        return () => {
+          unsubscribeCalls++
+        }
+      }),
+    })
+    const deps = makeDeps({manager, maxStreamsPerOperator: 1})
+    const app = buildTestApp(deps)
+
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    // #when — manager signals EOF (observation failure, not run success)
+    capturedCallbacks?.onClose('observation-failed')
+    await res.body?.cancel()
+
+    // #then — cleanup ran (unsubscribe called, slot released)
+    expect(unsubscribeCalls).toBe(1)
+
+    // Slot released: new stream allowed
+    const res2 = await fetchStream(app, 'run-def')
+    expect(res2.status).toBe(200)
+    await res2.body?.cancel()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Isolation: one connection's teardown does not affect other subscribers
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — isolation', () => {
+  it('unsubscribes only the per-connection subscriber, not the run-wide abortSubscription', async () => {
+    // #given — two connections to the same run; each gets its own unsubscribe
+    let sub1Unsubscribed = false
+    let sub2Unsubscribed = false
+    let sub1Callbacks: SubscriberCallbacks | undefined
+    let callCount = 0
+
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        callCount++
+        if (callCount === 1) {
+          sub1Callbacks = callbacks
+          return () => {
+            sub1Unsubscribed = true
+          }
+        }
+        return () => {
+          sub2Unsubscribed = true
+        }
+      }),
+    })
+    const deps = makeDeps({manager, maxStreamsPerOperator: 5})
+    // Two separate apps (different operator user IDs) to avoid cap collision
+    const app1 = buildTestApp(deps, 1, 'session-1')
+    const app2 = buildTestApp(deps, 2, 'session-2')
+
+    const res1 = await fetchStream(app1, 'run-abc')
+    const res2 = await fetchStream(app2, 'run-abc')
+    expect(res1.status).toBe(200)
+    expect(res2.status).toBe(200)
+
+    // #when — close only connection 1 via manager onClose
+    sub1Callbacks?.onClose('terminal')
+    await res1.body?.cancel()
+
+    // #then — only sub1 was unsubscribed; sub2 is unaffected
+    expect(sub1Unsubscribed).toBe(true)
+    expect(sub2Unsubscribed).toBe(false)
+    // abortSubscription was never called (run-wide teardown)
+    expect(manager.abortSubscription).not.toHaveBeenCalled()
+
+    await res2.body?.cancel()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Heartbeat: heartbeat frames flow through writeFrame
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — heartbeat', () => {
+  it('writes a heartbeat frame as an SSE comment line', async () => {
+    // #given — manager delivers a heartbeat frame
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        Promise.resolve(callbacks.onEvent({type: 'heartbeat'})).catch(() => {})
+        return () => undefined
+      }),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    const reader = res.body?.getReader()
+    if (reader === undefined) throw new Error('Expected a readable body')
+    const decoder = new TextDecoder()
+    let text = ''
+    for (let i = 0; i < 10; i++) {
+      const result = await reader.read()
+      if (result.done === true) break
+      text += decoder.decode(result.value as Uint8Array, {stream: true})
+      if (text.includes(': heartbeat')) break
+    }
+    await reader.cancel()
+
+    // #then — heartbeat written as SSE comment (keepalive, not a named event)
+    expect(text).toContain(': heartbeat')
+  })
+
+  it('socket timeout (60_000) exceeds the manager heartbeat interval (15_000)', () => {
+    // #given / #then — structural invariant: the socket timeout must exceed the heartbeat
+    // so an idle-but-heartbeating stream is not killed by the socket timeout.
+    const SOCKET_TIMEOUT_MS = 60_000
+    const HEARTBEAT_INTERVAL_MS = 15_000
+    expect(SOCKET_TIMEOUT_MS).toBeGreaterThan(HEARTBEAT_INTERVAL_MS)
+  })
+})

--- a/packages/gateway/src/web/sse/run-stream-route.test.ts
+++ b/packages/gateway/src/web/sse/run-stream-route.test.ts
@@ -549,7 +549,7 @@ describe('GET /operator/runs/:runId/stream — per-operator stream cap', () => {
 
     // #then — 429 (honest backpressure for an already-authorized operator)
     expect(res2.status).toBe(429)
-    expect(body2).toEqual({error: 'too many streams'})
+    expect(body2).toEqual({error: 'rate limited'})
     // subscribe was only called once (for the first request)
     expect(manager.subscribe).toHaveBeenCalledTimes(1)
 
@@ -1696,7 +1696,7 @@ describe('GET /operator/runs/:runId/stream — cap: multi-session same operator'
 
     // #then — 429: cap is keyed on githubUserId, not sessionId
     expect(res2.status).toBe(429)
-    expect(body2).toEqual({error: 'too many streams'})
+    expect(body2).toEqual({error: 'rate limited'})
 
     await res1.body?.cancel()
   })
@@ -1727,9 +1727,290 @@ describe('GET /operator/runs/:runId/stream — cap: multi-session same operator'
 
     // #then — 429
     expect(res3.status).toBe(429)
-    expect(body3).toEqual({error: 'too many streams'})
+    expect(body3).toEqual({error: 'rate limited'})
 
     await res1.body?.cancel()
     await res2.body?.cancel()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FIX-2: synchronous onClose during subscribe — no TDZ, slot released, timer cleared
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — synchronous onClose during subscribe', () => {
+  it('synchronous onClose("shutdown") during subscribe does not throw and releases the slot', async () => {
+    // #given — manager fires onClose synchronously during subscribe (simulates shutdown)
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        // Fire onClose synchronously before subscribe returns
+        callbacks.onClose('shutdown')
+        return () => undefined
+      }),
+    })
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {manager, maxStreamsPerOperator: 1})
+    const app = buildTestApp(deps)
+
+    // #when — request that triggers synchronous onClose during subscribe
+    // This must not throw a TDZ ReferenceError (unsubscribe was undefined at onClose time)
+    let res: Response | undefined
+    await expect(
+      (async () => {
+        res = await fetchStream(app, 'run-abc')
+      })(),
+    ).resolves.not.toThrow()
+
+    // #then — slot was released (new stream from same operator succeeds)
+    const res2 = await fetchStream(app, 'run-def')
+    expect(res2.status).toBe(200)
+    await res2.body?.cancel()
+    await res?.body?.cancel()
+  })
+
+  it('synchronous onClose during subscribe clears the lease timer', async () => {
+    // #given — manager fires onClose synchronously during subscribe
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        callbacks.onClose('shutdown')
+        return () => undefined
+      }),
+    })
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+
+    // #then — clearInterval was called (timer cleared even though it was set after subscribe)
+    expect(fakeTimer.cleared()).toBe(true)
+
+    await res?.body?.cancel()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FIX-2: socket.setTimeout throw does not skip slot release
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — socket.setTimeout throw resilience', () => {
+  it('slot is released even when restoreSocketTimeout throws (ERR_SOCKET_DESTROYED)', async () => {
+    // #given — a mock socket whose setTimeout throws on the restore call
+    let setTimeoutCallCount = 0
+    const socket = {
+      setTimeout: vi.fn((ms: number) => {
+        setTimeoutCallCount++
+        // First call (raise) succeeds; second call (restore) throws
+        if (setTimeoutCallCount >= 2) {
+          throw new Error('ERR_SOCKET_DESTROYED')
+        }
+        socket.timeout = ms
+      }),
+      timeout: 10_000,
+    }
+    const env = makeMockEnv(socket)
+
+    let capturedCallbacks: SubscriberCallbacks | undefined
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        capturedCallbacks = callbacks
+        return () => undefined
+      }),
+    })
+    const deps = makeDeps({manager, maxStreamsPerOperator: 1})
+    const app = buildTestApp(deps)
+
+    const res = await fetchStreamWithEnv(app, 'run-abc', env)
+    expect(res.status).toBe(200)
+
+    // #when — close the stream (triggers restoreSocketTimeout which throws)
+    capturedCallbacks?.onClose('terminal')
+    await res.body?.cancel()
+
+    // #then — slot was released despite the socket throw (new stream succeeds)
+    const res2 = await fetchStream(app, 'run-def')
+    expect(res2.status).toBe(200)
+    await res2.body?.cancel()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FIX-3: gate throws → 404 (no-oracle preserved)
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — gate throws → 404', () => {
+  it('returns 404 when getOperatorToken throws (no 500, no stream)', async () => {
+    // #given — session store throws on getOperatorToken
+    const sessionStore = makeSessionStore({
+      getOperatorToken: vi.fn(() => {
+        throw new Error('store unavailable')
+      }),
+    })
+    const manager = makeManager()
+    const deps = makeDeps({sessionStore, manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    const body = await res.json()
+
+    // #then — 404 (not 500), no stream opened
+    expect(res.status).toBe(404)
+    expect(body).toEqual({error: 'not-found'})
+    expect(manager.subscribe).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when runIndex.lookup throws (no 500, no stream)', async () => {
+    // #given — runIndex throws
+    const runIndex: RunStreamRouteDeps['runIndex'] = {
+      lookup: vi.fn(async () => {
+        throw new Error('index unavailable')
+      }),
+    }
+    const manager = makeManager()
+    const deps = makeDeps({runIndex, manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    const body = await res.json()
+
+    // #then — 404 (not 500), no stream opened
+    expect(res.status).toBe(404)
+    expect(body).toEqual({error: 'not-found'})
+    expect(manager.subscribe).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when getDenylistState throws (no 500, no stream)', async () => {
+    // #given — denylist cache throws on getDenylistState
+    const denylistCache: DenylistCache = {
+      getDenylistState: vi.fn(async () => {
+        throw new Error('denylist unavailable')
+      }),
+      isRepoDenied: vi.fn(() => false),
+    }
+    const manager = makeManager()
+    const deps = makeDeps({denylistCache, manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    const body = await res.json()
+
+    // #then — 404 (not 500), no stream opened
+    expect(res.status).toBe(404)
+    expect(body).toEqual({error: 'not-found'})
+    expect(manager.subscribe).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FIX-5: lease check throws → stream closed (fail-closed)
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — lease: unexpected throw closes stream', () => {
+  it('closes the stream when checkRepoAuthz throws inside a lease tick', async () => {
+    // #given — gate passes (cache hit); lease tick's checkRepoAuthz throws unexpectedly
+    // The cache returns authorized on the first call (gate), then undefined (cache miss)
+    // on subsequent calls so the lease tick goes to fetch — which throws.
+    let cacheCallCount = 0
+    const repoAuthzDeps: RepoAuthzDeps = {
+      ...makeRepoAuthzDeps(true),
+      cache: {
+        get: vi.fn(() => {
+          cacheCallCount++
+          if (cacheCallCount === 1) {
+            // Gate call: authorized (cache hit)
+            return {authorized: true as const, expiresAt: Number.MAX_SAFE_INTEGER}
+          }
+          // Lease tick: cache miss → goes to fetch
+          return undefined
+        }),
+        set: vi.fn(),
+        getInFlight: vi.fn(() => undefined),
+        setInFlight: vi.fn(),
+        deleteInFlight: vi.fn(),
+        tokenIdentityFor: vi.fn(() => 'stub-token-id'),
+      },
+      fetch: vi.fn(async () => {
+        throw new Error('network error')
+      }),
+    }
+
+    let unsubscribeCalls = 0
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => {
+        return () => {
+          unsubscribeCalls++
+        }
+      }),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {repoAuthzDeps, manager, maxStreamsPerOperator: 1})
+    const app = buildTestApp(deps)
+
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    // #when — fire a lease tick where checkRepoAuthz throws
+    await fakeTimer.tick()
+
+    // #then — stream was closed (fail-closed on unexpected lease error)
+    expect(unsubscribeCalls).toBe(1)
+
+    await res.body?.cancel()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FIX-D: contract version ready frame emitted as first SSE frame on success
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — contract version ready frame', () => {
+  it('emits a ready frame with contractVersion as the first SSE event on success', async () => {
+    // #given — all gates pass; manager holds the stream open
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => () => undefined),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    // #then — first SSE event is 'ready' with contractVersion
+    const reader = res.body?.getReader()
+    if (reader === undefined) throw new Error('Expected a readable body')
+    const decoder = new TextDecoder()
+    let text = ''
+    for (let i = 0; i < 10; i++) {
+      const result = await reader.read()
+      if (result.done === true) break
+      text += decoder.decode(result.value as Uint8Array, {stream: true})
+      if (text.includes('event: ready')) break
+    }
+    await reader.cancel()
+
+    expect(text).toContain('event: ready')
+    expect(text).toContain('"contractVersion"')
+  })
+
+  it('does NOT emit a ready frame on denial paths (no-oracle preserved)', async () => {
+    // #given — runIndex returns undefined (run not found)
+    const runIndex = makeRunIndex(undefined)
+    const deps = makeDeps({runIndex})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    const body = await res.json()
+
+    // #then — 404 JSON response, no SSE stream, no ready frame
+    expect(res.status).toBe(404)
+    expect(body).toEqual({error: 'not-found'})
+    expect(res.headers.get('content-type')).not.toContain('text/event-stream')
   })
 })

--- a/packages/gateway/src/web/sse/run-stream-route.test.ts
+++ b/packages/gateway/src/web/sse/run-stream-route.test.ts
@@ -24,6 +24,48 @@ import {setOperatorRouteGuard} from '../operator-route.js'
 import {buildRunStreamRoute} from './run-stream-route.js'
 
 // ---------------------------------------------------------------------------
+// Fake timer seam for lease tests
+// ---------------------------------------------------------------------------
+
+/**
+ * A minimal fake setInterval/clearInterval pair that lets tests drive ticks
+ * manually without real timers.
+ */
+function makeFakeTimer(): {
+  readonly setInterval: (fn: () => void, _ms: number) => ReturnType<typeof globalThis.setInterval>
+  readonly clearInterval: (id: ReturnType<typeof globalThis.setInterval> | undefined) => void
+  readonly tick: () => Promise<void>
+  readonly tickCount: () => number
+  readonly cleared: () => boolean
+} {
+  let callback: (() => void) | undefined
+  let ticks = 0
+  let isCleared = false
+  let nextId = 1
+
+  return {
+    setInterval: (fn: () => void, _ms: number): ReturnType<typeof globalThis.setInterval> => {
+      callback = fn
+      return nextId++ as unknown as ReturnType<typeof globalThis.setInterval>
+    },
+    clearInterval: (_id: ReturnType<typeof globalThis.setInterval> | undefined): void => {
+      isCleared = true
+      callback = undefined
+    },
+    tick: async (): Promise<void> => {
+      if (callback !== undefined) {
+        ticks++
+        callback()
+        // Yield to let async work inside the tick settle
+        await new Promise<void>(resolve => setTimeout(resolve, 0))
+      }
+    },
+    tickCount: () => ticks,
+    cleared: () => isCleared,
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Stub factories
 // ---------------------------------------------------------------------------
 
@@ -36,10 +78,19 @@ function makeLogger(): RunStreamRouteDeps['logger'] {
   }
 }
 
+/** A valid session entry returned by the default stub session store. */
+const STUB_SESSION = {
+  githubUserId: 99,
+  login: 'testuser',
+  issuedAt: 0,
+  lastAccessedAt: 0,
+  revoked: false,
+} as const
+
 function makeSessionStore(overrides?: Partial<SessionStore>): SessionStore {
   return {
     create: vi.fn(() => 'session-id'),
-    get: vi.fn(() => undefined),
+    get: vi.fn(() => STUB_SESSION),
     touch: vi.fn(),
     delete: vi.fn(),
     onRevoke: vi.fn(),
@@ -120,6 +171,20 @@ function makeDeps(overrides?: Partial<RunStreamRouteDeps>): RunStreamRouteDeps {
     now: () => 0,
     ...overrides,
   }
+}
+
+/**
+ * Build deps with a fake timer injected for lease tests.
+ */
+function makeDepsWithFakeTimer(
+  fakeTimer: ReturnType<typeof makeFakeTimer>,
+  overrides?: Partial<RunStreamRouteDeps>,
+): RunStreamRouteDeps {
+  return makeDeps({
+    setInterval: fakeTimer.setInterval,
+    clearInterval: fakeTimer.clearInterval,
+    ...overrides,
+  })
 }
 
 /**
@@ -1077,5 +1142,594 @@ describe('GET /operator/runs/:runId/stream — heartbeat', () => {
     const SOCKET_TIMEOUT_MS = 60_000
     const HEARTBEAT_INTERVAL_MS = 15_000
     expect(SOCKET_TIMEOUT_MS).toBeGreaterThan(HEARTBEAT_INTERVAL_MS)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Continuous-authz lease: repo access revoked mid-stream
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — lease: repo access revoked mid-stream', () => {
+  it('closes the stream on the next tick when checkRepoAuthz starts returning authorized:false', async () => {
+    // #given — stream opens with authz passing; after first tick authz is revoked
+    let authzAuthorized = true
+    const repoAuthzDeps: RepoAuthzDeps = {
+      ...makeRepoAuthzDeps(true),
+      cache: {
+        get: vi.fn(() =>
+          authzAuthorized
+            ? {authorized: true as const, expiresAt: Number.MAX_SAFE_INTEGER}
+            : {authorized: false as const, reason: 'github_denied' as const, expiresAt: Number.MAX_SAFE_INTEGER},
+        ),
+        set: vi.fn(),
+        getInFlight: vi.fn(() => undefined),
+        setInFlight: vi.fn(),
+        deleteInFlight: vi.fn(),
+        tokenIdentityFor: vi.fn(() => 'stub-token-id'),
+      },
+    }
+
+    let unsubscribeCalls = 0
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => {
+        return () => {
+          unsubscribeCalls++
+        }
+      }),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {repoAuthzDeps, manager, maxStreamsPerOperator: 1})
+    const app = buildTestApp(deps)
+
+    // #when — stream opens (authz passes)
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    // Revoke access, then fire a lease tick
+    authzAuthorized = false
+    await fakeTimer.tick()
+
+    // #then — cleanup ran: unsubscribe called once (connection closed)
+    expect(unsubscribeCalls).toBe(1)
+
+    // Restore authz and verify the slot was released (new stream succeeds)
+    authzAuthorized = true
+    const res2 = await fetchStream(app, 'run-def')
+    expect(res2.status).toBe(200)
+    await res2.body?.cancel()
+    await res.body?.cancel()
+  })
+
+  it('does not call dropOperatorToken when checkRepoAuthz returns github_denied', async () => {
+    // #given — gate passes (authorized); lease tick sees github_denied
+    // The cache returns authorized on the first call (gate), denied on subsequent calls (lease)
+    let callCount = 0
+    const repoAuthzDeps: RepoAuthzDeps = {
+      ...makeRepoAuthzDeps(true),
+      cache: {
+        get: vi.fn(() => {
+          callCount++
+          if (callCount === 1) {
+            return {authorized: true as const, expiresAt: Number.MAX_SAFE_INTEGER}
+          }
+          return {authorized: false as const, reason: 'github_denied' as const, expiresAt: Number.MAX_SAFE_INTEGER}
+        }),
+        set: vi.fn(),
+        getInFlight: vi.fn(() => undefined),
+        setInFlight: vi.fn(),
+        deleteInFlight: vi.fn(),
+        tokenIdentityFor: vi.fn(() => 'stub-token-id'),
+      },
+    }
+
+    const dropOperatorToken = vi.fn()
+    const sessionStore = makeSessionStore({dropOperatorToken})
+
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => () => undefined),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {repoAuthzDeps, sessionStore, manager})
+    const app = buildTestApp(deps)
+
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    // #when — lease tick fires with github_denied
+    await fakeTimer.tick()
+
+    // #then — dropOperatorToken was NOT called (cannot distinguish revoked token from denied repo)
+    expect(dropOperatorToken).not.toHaveBeenCalled()
+
+    await res.body?.cancel()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Continuous-authz lease: repo denylisted mid-stream
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — lease: repo denylisted mid-stream', () => {
+  it('closes the stream on the next tick when isRepoDenied flips to true', async () => {
+    // #given — stream opens with repo allowed; denylist flips to denied
+    let isDenied = false
+    const denylistCache: DenylistCache = {
+      getDenylistState: vi.fn(async () => undefined),
+      isRepoDenied: vi.fn(() => isDenied),
+    }
+
+    let unsubscribeCalls = 0
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => {
+        return () => {
+          unsubscribeCalls++
+        }
+      }),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {denylistCache, manager, maxStreamsPerOperator: 1})
+    const app = buildTestApp(deps)
+
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    // Flip denylist, then fire a lease tick
+    isDenied = true
+    await fakeTimer.tick()
+
+    // #then — cleanup ran: unsubscribe called once (connection closed)
+    expect(unsubscribeCalls).toBe(1)
+
+    // Restore denylist and verify the slot was released (new stream succeeds)
+    isDenied = false
+    const res2 = await fetchStream(app, 'run-def')
+    expect(res2.status).toBe(200)
+    await res2.body?.cancel()
+    await res.body?.cancel()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Continuous-authz lease: token dropped / session expired mid-stream
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — lease: token/session loss mid-stream', () => {
+  it('closes the stream on the next tick when getOperatorToken returns undefined', async () => {
+    // #given — token is present at open time; dropped before the lease tick
+    let tokenPresent = true
+    const sessionStore = makeSessionStore({
+      getOperatorToken: vi.fn(() => (tokenPresent ? 'stub-oauth-token' : undefined)),
+    })
+
+    let unsubscribeCalls = 0
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => {
+        return () => {
+          unsubscribeCalls++
+        }
+      }),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {sessionStore, manager, maxStreamsPerOperator: 1})
+    const app = buildTestApp(deps)
+
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    // Drop the token, then fire a lease tick
+    tokenPresent = false
+    await fakeTimer.tick()
+
+    // #then — cleanup ran: unsubscribe called once (connection closed)
+    expect(unsubscribeCalls).toBe(1)
+
+    // Restore token and verify the slot was released (new stream succeeds)
+    tokenPresent = true
+    const res2 = await fetchStream(app, 'run-def')
+    expect(res2.status).toBe(200)
+    await res2.body?.cancel()
+    await res.body?.cancel()
+  })
+
+  it('closes the stream on the next tick when session.get returns undefined', async () => {
+    // #given — session is valid at open time; expires before the lease tick
+    let sessionValid = true
+    const sessionStore = makeSessionStore({
+      get: vi.fn(() => (sessionValid ? STUB_SESSION : undefined)),
+    })
+
+    let unsubscribeCalls = 0
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => {
+        return () => {
+          unsubscribeCalls++
+        }
+      }),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {sessionStore, manager, maxStreamsPerOperator: 1})
+    const app = buildTestApp(deps)
+
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    // Expire the session, then fire a lease tick
+    sessionValid = false
+    await fakeTimer.tick()
+
+    // #then — cleanup ran
+    expect(unsubscribeCalls).toBe(1)
+
+    // Slot released
+    const res2 = await fetchStream(app, 'run-def')
+    expect(res2.status).toBe(200)
+    await res2.body?.cancel()
+    await res.body?.cancel()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Continuous-authz lease: generation guard (late-resolving check is a no-op)
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — lease: generation guard', () => {
+  it('a lease tick whose checkRepoAuthz resolves after teardown does nothing (no double cleanup)', async () => {
+    // #given — a slow checkRepoAuthz that we can resolve manually after teardown
+    let resolveAuthz!: (result: {authorized: false; reason: 'github_denied'}) => void
+    const slowAuthzPromise = new Promise<{authorized: false; reason: 'github_denied'}>(resolve => {
+      resolveAuthz = resolve
+    })
+
+    // First call (gate): returns authorized immediately via cache
+    // Subsequent calls (lease tick): returns the slow promise
+    let callCount = 0
+    const repoAuthzDeps: RepoAuthzDeps = {
+      ...makeRepoAuthzDeps(true),
+      cache: {
+        get: vi.fn(() => {
+          callCount++
+          if (callCount === 1) {
+            // Gate call: authorized
+            return {authorized: true as const, expiresAt: Number.MAX_SAFE_INTEGER}
+          }
+          // Lease tick call: cache miss → will go to fetch (which we control via slowAuthzPromise)
+          return undefined
+        }),
+        set: vi.fn(),
+        getInFlight: vi.fn(() => undefined),
+        setInFlight: vi.fn(),
+        deleteInFlight: vi.fn(),
+        tokenIdentityFor: vi.fn(() => 'stub-token-id'),
+      },
+      fetch: vi.fn(async () => {
+        // Block until we manually resolve
+        const result = await slowAuthzPromise
+        return new Response('{}', {status: result.authorized === false ? 403 : 200})
+      }),
+    }
+
+    let unsubscribeCalls = 0
+    let capturedCallbacks: SubscriberCallbacks | undefined
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        capturedCallbacks = callbacks
+        return () => {
+          unsubscribeCalls++
+        }
+      }),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {repoAuthzDeps, manager, maxStreamsPerOperator: 1})
+    const app = buildTestApp(deps)
+
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+    expect(capturedCallbacks).toBeDefined()
+
+    // Start a lease tick — checkRepoAuthz is now in-flight (blocked on slowAuthzPromise)
+    // We do NOT await tick() yet — it's pending
+    const tickPromise = fakeTimer.tick()
+
+    // Tear down the connection via manager onClose BEFORE the tick resolves
+    capturedCallbacks?.onClose('terminal')
+    await res.body?.cancel()
+
+    // #then — unsubscribe called once (from onClose teardown)
+    expect(unsubscribeCalls).toBe(1)
+
+    // Now resolve the slow authz check (returns denied)
+    resolveAuthz({authorized: false, reason: 'github_denied'})
+    await tickPromise
+
+    // #then — unsubscribe still called exactly once (generation guard prevented double cleanup)
+    expect(unsubscribeCalls).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Continuous-authz lease: timer cleared on teardown
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — lease: timer cleared on teardown', () => {
+  it('clears the lease timer when the stream ends via manager onClose', async () => {
+    // #given — stream opens with a fake timer
+    let capturedCallbacks: SubscriberCallbacks | undefined
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        capturedCallbacks = callbacks
+        return () => undefined
+      }),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {manager})
+    const app = buildTestApp(deps)
+
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    // #when — stream ends via manager onClose
+    capturedCallbacks?.onClose('terminal')
+    await res.body?.cancel()
+
+    // #then — clearInterval was called (timer cleared in cleanup)
+    expect(fakeTimer.cleared()).toBe(true)
+  })
+
+  it('does not fire further ticks after cleanup (advancing timer is a no-op)', async () => {
+    // #given — stream opens; we track how many times the lease check runs after teardown
+    let leaseCheckCount = 0
+    const repoAuthzDeps: RepoAuthzDeps = {
+      ...makeRepoAuthzDeps(true),
+      cache: {
+        get: vi.fn(() => {
+          leaseCheckCount++
+          return {authorized: true as const, expiresAt: Number.MAX_SAFE_INTEGER}
+        }),
+        set: vi.fn(),
+        getInFlight: vi.fn(() => undefined),
+        setInFlight: vi.fn(),
+        deleteInFlight: vi.fn(),
+        tokenIdentityFor: vi.fn(() => 'stub-token-id'),
+      },
+    }
+
+    let capturedCallbacks: SubscriberCallbacks | undefined
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        capturedCallbacks = callbacks
+        return () => undefined
+      }),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {repoAuthzDeps, manager})
+    const app = buildTestApp(deps)
+
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    // Close the stream
+    capturedCallbacks?.onClose('terminal')
+    await res.body?.cancel()
+
+    // Reset the counter after teardown so we only count post-teardown ticks
+    leaseCheckCount = 0
+
+    // #when — advance the timer after teardown (should be a no-op)
+    await fakeTimer.tick()
+    await fakeTimer.tick()
+
+    // #then — no further lease checks fired after teardown
+    expect(leaseCheckCount).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Continuous-authz lease: no false drop (still-authorized stream survives ticks)
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — lease: no false drop', () => {
+  it('a still-authorized stream survives multiple lease ticks without cleanup', async () => {
+    // #given — authz always passes; stream stays open
+    let unsubscribeCalls = 0
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => {
+        return () => {
+          unsubscribeCalls++
+        }
+      }),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {manager})
+    const app = buildTestApp(deps)
+
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    // #when — fire multiple lease ticks with authz still passing
+    await fakeTimer.tick()
+    await fakeTimer.tick()
+    await fakeTimer.tick()
+
+    // #then — no cleanup fired; stream still open
+    expect(unsubscribeCalls).toBe(0)
+
+    await res.body?.cancel()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cap hardening: reconnect storm
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — cap: reconnect storm', () => {
+  it('active count never exceeds maxStreams during rapid open+close cycles', async () => {
+    // #given — cap of 2; track active count via subscribe/unsubscribe
+    let activeCount = 0
+    let maxObservedCount = 0
+    const callbacks: SubscriberCallbacks[] = []
+
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, cb: SubscriberCallbacks) => {
+        activeCount++
+        if (activeCount > maxObservedCount) maxObservedCount = activeCount
+        callbacks.push(cb)
+        return () => {
+          activeCount--
+        }
+      }),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {manager, maxStreamsPerOperator: 2})
+    const app = buildTestApp(deps)
+
+    // Open 2 streams (at cap)
+    const res1 = await fetchStream(app, 'run-1')
+    const res2 = await fetchStream(app, 'run-2')
+    expect(res1.status).toBe(200)
+    expect(res2.status).toBe(200)
+
+    // Third should be 429
+    const res3 = await fetchStream(app, 'run-3')
+    expect(res3.status).toBe(429)
+    await res3.json()
+
+    // Close stream 1 via onClose (synchronous slot release)
+    callbacks[0]?.onClose('terminal')
+    await res1.body?.cancel()
+
+    // Now a new stream should succeed (slot was released synchronously)
+    const res4 = await fetchStream(app, 'run-4')
+    expect(res4.status).toBe(200)
+
+    // #then — active count never exceeded maxStreams
+    expect(maxObservedCount).toBeLessThanOrEqual(2)
+
+    await res2.body?.cancel()
+    await res4.body?.cancel()
+  })
+
+  it('each close frees exactly one slot (synchronous release in cleanup)', async () => {
+    // #given — cap of 1; open, close, open again — should always succeed
+    let capturedCallbacks: SubscriberCallbacks | undefined
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        capturedCallbacks = callbacks
+        return () => undefined
+      }),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {manager, maxStreamsPerOperator: 1})
+    const app = buildTestApp(deps)
+
+    for (let i = 0; i < 5; i++) {
+      const res = await fetchStream(app, `run-${i}`)
+      expect(res.status).toBe(200)
+      // Close via onClose (synchronous slot release)
+      capturedCallbacks?.onClose('terminal')
+      await res.body?.cancel()
+    }
+
+    // After all cycles, a new stream should still succeed
+    const finalRes = await fetchStream(app, 'run-final')
+    expect(finalRes.status).toBe(200)
+    await finalRes.body?.cancel()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cap hardening: multi-session same operator shares one cap
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Hono app where the guard's sessionId is controlled by a mutable ref.
+ * This lets a single app simulate multiple sessions from the same operator.
+ */
+function buildTestAppWithMutableSession(
+  deps: RunStreamRouteDeps,
+  guardUserId: number,
+  sessionIdRef: {current: string},
+): Hono {
+  const app = new Hono()
+  setOperatorRouteGuard(app, async (_c, _method, _path) => ({
+    ok: true as const,
+    githubUserId: guardUserId,
+    sessionId: sessionIdRef.current,
+  }))
+  buildRunStreamRoute(app, deps)
+  return app
+}
+
+describe('GET /operator/runs/:runId/stream — cap: multi-session same operator', () => {
+  it('two streams from the same githubUserId but different sessionIds share one cap', async () => {
+    // #given — cap of 1; same githubUserId (99) with two different sessionIds
+    // A single app with a mutable sessionId ref so both requests share the same activeStreams map
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => () => undefined),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {manager, maxStreamsPerOperator: 1})
+
+    const sessionIdRef = {current: 'session-A'}
+    const app = buildTestAppWithMutableSession(deps, 99, sessionIdRef)
+
+    // First stream from session-A (githubUserId=99)
+    sessionIdRef.current = 'session-A'
+    const res1 = await app.fetch(new Request('http://localhost/operator/runs/run-1/stream'))
+    expect(res1.status).toBe(200)
+
+    // #when — second stream from session-B (same githubUserId=99, different session)
+    sessionIdRef.current = 'session-B'
+    const res2 = await app.fetch(new Request('http://localhost/operator/runs/run-2/stream'))
+    const body2 = await res2.json()
+
+    // #then — 429: cap is keyed on githubUserId, not sessionId
+    expect(res2.status).toBe(429)
+    expect(body2).toEqual({error: 'too many streams'})
+
+    await res1.body?.cancel()
+  })
+
+  it('the (maxStreams+1)th stream from the same githubUserId is 429 regardless of session', async () => {
+    // #given — cap of 2; open 2 streams from different sessions, 3rd is 429
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => () => undefined),
+    })
+
+    const fakeTimer = makeFakeTimer()
+    const deps = makeDepsWithFakeTimer(fakeTimer, {manager, maxStreamsPerOperator: 2})
+
+    const sessionIdRef = {current: 'session-A'}
+    const app = buildTestAppWithMutableSession(deps, 99, sessionIdRef)
+
+    sessionIdRef.current = 'session-A'
+    const res1 = await app.fetch(new Request('http://localhost/operator/runs/run-1/stream'))
+    sessionIdRef.current = 'session-B'
+    const res2 = await app.fetch(new Request('http://localhost/operator/runs/run-2/stream'))
+    expect(res1.status).toBe(200)
+    expect(res2.status).toBe(200)
+
+    // #when — third stream from a third session (same githubUserId)
+    sessionIdRef.current = 'session-C'
+    const res3 = await app.fetch(new Request('http://localhost/operator/runs/run-3/stream'))
+    const body3 = await res3.json()
+
+    // #then — 429
+    expect(res3.status).toBe(429)
+    expect(body3).toEqual({error: 'too many streams'})
+
+    await res1.body?.cancel()
+    await res2.body?.cancel()
   })
 })

--- a/packages/gateway/src/web/sse/run-stream-route.ts
+++ b/packages/gateway/src/web/sse/run-stream-route.ts
@@ -9,7 +9,7 @@
  *   5. Resolve binding deny-keys; prime denylist; check isRepoDenied
  *   6. checkRepoAuthz (allowlist + GitHub repo access)
  *   7. Acquire per-operator stream slot (keyed on numeric githubUserId)
- *   8. Open SSE stream → deliver first snapshot/reset frame
+ *   8. Open SSE stream → deliver ready frame (contract version) + first snapshot/reset frame
  *
  * Every failure at steps 2–6 returns the identical generic not-found shape.
  * Step 7 failure returns 429 (honest backpressure for an already-authorized operator).
@@ -28,9 +28,11 @@ import type {OperatorLogger} from '../server.js'
 import type {ObservationFrame, RunObservationManager} from './manager.js'
 
 import {streamSSE, type SSEStreamingApi} from 'hono/streaming'
+import {OPERATOR_CONTRACT_VERSION} from '../../operator-contract/index.js'
+import {resolveBindingDenyKeys} from '../../redaction/surface-gate.js'
 import {checkRepoAuthz} from '../auth/repo-authz.js'
 import {getOperatorAuthContext, registerOperatorRoute} from '../operator-route.js'
-import {notFoundResponse} from '../safe-response.js'
+import {notFoundResponse, rateLimitedResponse} from '../safe-response.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -144,43 +146,14 @@ function restoreSocketTimeout(socket: Socket | undefined, priorTimeout: number):
 }
 
 // ---------------------------------------------------------------------------
-// Deny-key resolution (mirrors resolveRunRepoKey logic from surface-gate.ts,
-// but takes owner/repo strings directly since we already have them from RunIndex)
+// Reset-reason type
 // ---------------------------------------------------------------------------
 
-interface RepoKey {
-  readonly databaseId: number | null
-  readonly nodeId: string | null
-}
-
 /**
- * Resolve deny-keys for a repo by calling getBindingByRepo directly.
- * Fail-closed: returns {null, null} on store error, missing binding, or missing keys.
+ * Typed set of reasons a reset frame can carry.
+ * Exhaustive over all reasons emitted by the manager and route layer.
  */
-async function resolveRepoDenyKeys(owner: string, repo: string, bindingsLookup: BindingsLookup): Promise<RepoKey> {
-  const NULL_KEY: RepoKey = {databaseId: null, nodeId: null}
-
-  let result: Awaited<ReturnType<BindingsLookup['getBindingByRepo']>>
-  try {
-    result = await bindingsLookup.getBindingByRepo(owner, repo)
-  } catch {
-    return NULL_KEY
-  }
-
-  if (result.success === false) {
-    return NULL_KEY
-  }
-
-  if (result.data === null) {
-    return NULL_KEY
-  }
-
-  const binding = result.data
-  const databaseId = typeof binding.databaseId === 'number' ? binding.databaseId : null
-  const nodeId = typeof binding.nodeId === 'string' ? binding.nodeId : null
-
-  return {databaseId, nodeId}
-}
+export type ResetReason = 'no-snapshot' | 'terminal' | 'shutdown' | 'max-duration' | 'writer-error' | 'overflow'
 
 // ---------------------------------------------------------------------------
 // SSE frame writer
@@ -198,6 +171,10 @@ async function writeFrame(stream: SSEStreamingApi, frame: ObservationFrame): Pro
   } else if (frame.type === 'heartbeat') {
     // SSE comment line — keepalive, not a named event
     await stream.write(': heartbeat\n\n')
+  } else {
+    // Exhaustiveness guard: a new ObservationFrame variant must be handled above.
+    const EXHAUSTIVE_CHECK: never = frame
+    throw new Error(`run-stream: unhandled frame type: ${JSON.stringify(EXHAUSTIVE_CHECK)}`)
   }
 }
 
@@ -219,6 +196,7 @@ async function writeFrame(stream: SSEStreamingApi, frame: ObservationFrame): Pro
 async function runLeaseCheck(
   githubUserId: number,
   sessionId: string,
+  runId: string,
   owner: string,
   repo: string,
   deps: RunStreamRouteDeps,
@@ -231,6 +209,7 @@ async function runLeaseCheck(
   const session = deps.sessionStore.get(sessionId, nowMs)
   if (isCleaned() === true) return
   if (session === undefined) {
+    deps.logger.warn({githubUserId, runId}, 'run-stream: lease closed — session expired')
     onFail()
     return
   }
@@ -239,16 +218,18 @@ async function runLeaseCheck(
   const freshToken = deps.sessionStore.getOperatorToken(sessionId, nowMs)
   if (isCleaned() === true) return
   if (freshToken === undefined) {
+    deps.logger.warn({githubUserId, runId}, 'run-stream: lease closed — token missing')
     onFail()
     return
   }
 
   // ── Check 3: Repo still not denylisted ───────────────────────────────────
-  const denyKeys = await resolveRepoDenyKeys(owner, repo, deps.bindingsLookup)
+  const denyKeys = await resolveBindingDenyKeys(owner, repo, deps.bindingsLookup)
   if (isCleaned() === true) return
   await deps.denylistCache.getDenylistState()
   if (isCleaned() === true) return
   if (deps.denylistCache.isRepoDenied(denyKeys) === true) {
+    deps.logger.warn({githubUserId, runId, owner, repo}, 'run-stream: lease closed — repo denylisted')
     onFail()
     return
   }
@@ -262,6 +243,7 @@ async function runLeaseCheck(
   if (authzResult.authorized === false) {
     // Do NOT call dropOperatorToken here — github_denied cannot distinguish
     // a revoked token from a denied repo. Only drop on a token-specific signal.
+    deps.logger.warn({githubUserId, runId, owner, repo}, 'run-stream: lease closed — authz denied')
     onFail()
   }
 }
@@ -291,53 +273,75 @@ export function buildRunStreamRoute(app: Hono, deps: RunStreamRouteDeps): void {
     // Return not-found as a safe fallback (no oracle — same shape as all denials).
     const authCtx = getOperatorAuthContext(c)
     if (authCtx === undefined) {
+      deps.logger.warn({gate: 'no-auth-ctx'}, 'run-stream: denied')
       return notFoundResponse(c)
     }
 
     const {githubUserId, sessionId} = authCtx
 
-    // ── Gate 2: Resolve OAuth token ──────────────────────────────────────────
-    // A missing token means the session is dropped/expired/revoked and re-auth is needed.
-    // Return not-found independent of runId so a re-auth need never becomes a
-    // run-existence timing signal.
-    const token = deps.sessionStore.getOperatorToken(sessionId, nowMs)
-    if (token === undefined) {
-      return notFoundResponse(c)
-    }
+    // ── Gate 2–6: Pre-stream authorization gates ─────────────────────────────
+    // Wrapped in try/catch so any unexpected throw returns the uniform not-found
+    // shape rather than propagating to Hono as a 500 (which would be distinguishable
+    // from the 404 and break the no-oracle property).
+    let token: string
+    let runId: string
+    let owner: string
+    let repo: string
 
-    // ── Gate 3: Resolve runId → repo (server-owned) ──────────────────────────
-    // The repo is NEVER taken from the client. RunIndex.lookup is the sole authority.
-    const runId = c.req.param('runId') ?? ''
-    const location = await deps.runIndex.lookup(runId)
-    if (location === undefined) {
-      return notFoundResponse(c)
-    }
+    try {
+      // ── Gate 2: Resolve OAuth token ────────────────────────────────────────
+      // A missing token means the session is dropped/expired/revoked and re-auth is needed.
+      // Return not-found independent of runId so a re-auth need never becomes a
+      // run-existence timing signal.
+      const resolvedToken = deps.sessionStore.getOperatorToken(sessionId, nowMs)
+      if (resolvedToken === undefined) {
+        deps.logger.warn({githubUserId, gate: 'no-token'}, 'run-stream: denied')
+        return notFoundResponse(c)
+      }
+      token = resolvedToken
 
-    // ── Gate 4: Split owner/repo ─────────────────────────────────────────────
-    const slashIdx = location.repo.indexOf('/')
-    if (slashIdx === -1) {
-      return notFoundResponse(c)
-    }
-    const owner = location.repo.slice(0, slashIdx)
-    const repo = location.repo.slice(slashIdx + 1)
-    if (owner.length === 0 || repo.length === 0) {
-      return notFoundResponse(c)
-    }
+      // ── Gate 3: Resolve runId → repo (server-owned) ────────────────────────
+      // The repo is NEVER taken from the client. RunIndex.lookup is the sole authority.
+      runId = c.req.param('runId') ?? ''
+      const location = await deps.runIndex.lookup(runId)
+      if (location === undefined) {
+        deps.logger.warn({githubUserId, runId, gate: 'runIndex-miss'}, 'run-stream: denied')
+        return notFoundResponse(c)
+      }
 
-    // ── Gate 5: Redaction check (explicit pre-subscribe, fail-closed) ─────────
-    // Resolve deny-keys from the binding store (fail-closed on error/missing).
-    // Prime/refresh the denylist cache, then check synchronously.
-    // This runs BEFORE checkRepoAuthz so a denylisted repo never triggers a GitHub call.
-    const denyKeys = await resolveRepoDenyKeys(owner, repo, deps.bindingsLookup)
-    await deps.denylistCache.getDenylistState()
-    if (deps.denylistCache.isRepoDenied(denyKeys) === true) {
-      return notFoundResponse(c)
-    }
+      // ── Gate 4: Split owner/repo ───────────────────────────────────────────
+      const slashIdx = location.repo.indexOf('/')
+      if (slashIdx === -1) {
+        deps.logger.warn({githubUserId, runId, gate: 'malformed-repo'}, 'run-stream: denied')
+        return notFoundResponse(c)
+      }
+      owner = location.repo.slice(0, slashIdx)
+      repo = location.repo.slice(slashIdx + 1)
+      if (owner.length === 0 || repo.length === 0) {
+        deps.logger.warn({githubUserId, runId, gate: 'malformed-repo'}, 'run-stream: denied')
+        return notFoundResponse(c)
+      }
 
-    // ── Gate 6: Repo authorization ───────────────────────────────────────────
-    // Allowlist + GitHub repo access check. Fail-closed on any error.
-    const authzResult = await checkRepoAuthz(githubUserId, owner, repo, token, deps.repoAuthzDeps)
-    if (authzResult.authorized === false) {
+      // ── Gate 5: Redaction check (explicit pre-subscribe, fail-closed) ──────
+      // Resolve deny-keys from the binding store (fail-closed on error/missing).
+      // Prime/refresh the denylist cache, then check synchronously.
+      // This runs BEFORE checkRepoAuthz so a denylisted repo never triggers a GitHub call.
+      const denyKeys = await resolveBindingDenyKeys(owner, repo, deps.bindingsLookup)
+      await deps.denylistCache.getDenylistState()
+      if (deps.denylistCache.isRepoDenied(denyKeys) === true) {
+        deps.logger.warn({githubUserId, runId, gate: 'denylisted'}, 'run-stream: denied')
+        return notFoundResponse(c)
+      }
+
+      // ── Gate 6: Repo authorization ─────────────────────────────────────────
+      // Allowlist + GitHub repo access check. Fail-closed on any error.
+      const authzResult = await checkRepoAuthz(githubUserId, owner, repo, token, deps.repoAuthzDeps)
+      if (authzResult.authorized === false) {
+        deps.logger.warn({githubUserId, runId, gate: 'authz-denied'}, 'run-stream: denied')
+        return notFoundResponse(c)
+      }
+    } catch (error: unknown) {
+      deps.logger.warn({runId: c.req.param('runId') ?? '', githubUserId, error}, 'run-stream: gate threw — denying')
       return notFoundResponse(c)
     }
 
@@ -347,9 +351,23 @@ export function buildRunStreamRoute(app: Hono, deps: RunStreamRouteDeps): void {
     // already-authorized operator; not a run oracle since authz already passed).
     const currentCount = activeStreams.get(githubUserId) ?? 0
     if (currentCount >= maxStreams) {
-      return c.json({error: 'too many streams'}, 429)
+      deps.logger.warn({githubUserId, activeCount: currentCount, maxStreams}, 'run-stream: over cap')
+      return rateLimitedResponse(c)
     }
     activeStreams.set(githubUserId, currentCount + 1)
+
+    // Idempotent slot-release helper — safe to call multiple times.
+    let slotReleased = false
+    const releaseSlot = (): void => {
+      if (slotReleased === true) return
+      slotReleased = true
+      const count = activeStreams.get(githubUserId) ?? 0
+      if (count <= 1) {
+        activeStreams.delete(githubUserId)
+      } else {
+        activeStreams.set(githubUserId, count - 1)
+      }
+    }
 
     // ── Gate 8: Open SSE stream ──────────────────────────────────────────────
     // All gates passed. Transition directly into the SSE stream.
@@ -365,53 +383,75 @@ export function buildRunStreamRoute(app: Hono, deps: RunStreamRouteDeps): void {
     const leaseIntervalMs = deps.leaseIntervalMs ?? DEFAULT_LEASE_INTERVAL_MS
 
     let cleaned = false
-    // Declared before cleanup so cleanup can clear it; assigned when the stream opens.
+    // Declared before subscribe so a synchronous onClose('shutdown') during subscribe
+    // can safely call unsubscribe?.() without hitting a TDZ ReferenceError.
+    let unsubscribe: (() => void) | undefined
+    // Declared before subscribe so a synchronous onClose can clear it.
     let leaseTimer: ReturnType<typeof globalThis.setInterval> | undefined
 
-    const cleanup = (unsubscribe: () => void): void => {
+    const cleanup = (closeReason: string): void => {
       if (cleaned === true) return
       cleaned = true
       // Clear the lease timer before unsubscribing so no tick fires during teardown.
       clearIntervalFn(leaseTimer)
-      unsubscribe()
-      // Restore the socket timeout to its pre-stream value so it never leaks
-      // to a reused keep-alive socket.
-      restoreSocketTimeout(socket, priorSocketTimeout)
+      // unsubscribe may be undefined if onClose fired synchronously during subscribe.
+      unsubscribe?.()
       // Release the slot synchronously so a rapid reconnect storm cannot
       // transiently exceed the cap.
-      const count = activeStreams.get(githubUserId) ?? 0
-      if (count <= 1) {
-        activeStreams.delete(githubUserId)
-      } else {
-        activeStreams.set(githubUserId, count - 1)
+      releaseSlot()
+      // Restore the socket timeout to its pre-stream value so it never leaks
+      // to a reused keep-alive socket. Wrapped in try/catch so a destroyed-socket
+      // error does not skip the slot release above.
+      try {
+        restoreSocketTimeout(socket, priorSocketTimeout)
+      } catch {
+        // Socket already destroyed — timeout restore is a no-op; slot already released.
       }
+      deps.logger.info({githubUserId, runId, reason: closeReason}, 'run-stream: closed')
     }
+
+    deps.logger.info({githubUserId, runId, owner, repo}, 'run-stream: opened')
 
     return streamSSE(c, async stream => {
       // Promise that resolves when the stream should end (manager closes or client aborts).
       // The streamSSE callback must stay alive (not return) while the stream is open.
       try {
         await new Promise<void>(resolve => {
-          const unsubscribe = deps.manager.subscribe(runId, {
+          // Emit the ready frame (contract version) as the very first SSE frame.
+          // Sent only after all gates pass — never on a denial path.
+          // Fire-and-forget: if the write fails the stream is broken and the
+          // abort/onClose path will clean up.
+          stream
+            .writeSSE({event: 'ready', data: JSON.stringify({contractVersion: OPERATOR_CONTRACT_VERSION})})
+            .catch(() => {})
+
+          unsubscribe = deps.manager.subscribe(runId, {
             onEvent: async (frame: ObservationFrame) => {
               if (cleaned === true) return
               try {
                 await writeFrame(stream, frame)
               } catch {
                 // Write failure — stream is likely closed; cleanup will handle it
-                cleanup(unsubscribe)
+                cleanup('writer-error')
                 resolve()
               }
             },
-            onClose: (_reason: string) => {
-              cleanup(unsubscribe)
+            onClose: (reason: string) => {
+              cleanup(reason)
               resolve()
             },
           })
 
+          // If onClose fired synchronously during subscribe (e.g. 'shutdown'),
+          // cleaned is already true — no further setup needed.
+          if (cleaned === true) {
+            resolve()
+            return
+          }
+
           // Register abort handler so client disconnect releases the slot
           stream.onAbort(() => {
-            cleanup(unsubscribe)
+            cleanup('client-abort')
             resolve()
           })
 
@@ -419,29 +459,39 @@ export function buildRunStreamRoute(app: Hono, deps: RunStreamRouteDeps): void {
           // Re-verifies session, token, redaction, and repo authz on each tick.
           // On any failure, closes this connection only (not run-wide).
           leaseTimer = setIntervalFn((): void => {
-            // runLeaseCheck is async; fire-and-forget with a no-op error handler
-            // (errors inside are handled by the generation guard + cleanup path).
+            // runLeaseCheck is async; fail-closed on unexpected error.
             runLeaseCheck(
               githubUserId,
               sessionId,
+              runId,
               owner,
               repo,
               deps,
               () => cleaned,
               () => {
-                cleanup(unsubscribe)
+                cleanup('lease-failed')
                 resolve()
               },
-            ).catch(() => {})
+            ).catch((error: unknown) => {
+              deps.logger.warn({runId, githubUserId, error}, 'run-stream: lease check threw — closing stream')
+              cleanup('lease-error')
+              resolve()
+            })
           }, leaseIntervalMs)
         })
       } finally {
-        // Safety net: restore the socket timeout if cleanup() was never called
-        // (e.g. an unexpected throw before any teardown path fired).
+        // Safety net: ensure the slot is always released even if an unexpected
+        // throw bypassed all cleanup paths (e.g. streamSSE internal error).
+        releaseSlot()
+        // Restore the socket timeout if cleanup() was never called.
         // cleanup() sets cleaned=true before restoring, so this is a no-op when
         // cleanup already ran — avoids a double-restore on a reused keep-alive socket.
         if (cleaned === false) {
-          restoreSocketTimeout(socket, priorSocketTimeout)
+          try {
+            restoreSocketTimeout(socket, priorSocketTimeout)
+          } catch {
+            // Socket already destroyed — no-op.
+          }
         }
       }
     })

--- a/packages/gateway/src/web/sse/run-stream-route.ts
+++ b/packages/gateway/src/web/sse/run-stream-route.ts
@@ -64,6 +64,21 @@ export interface RunStreamRouteDeps {
    * Defaults to 5 when omitted.
    */
   readonly maxStreamsPerOperator?: number
+  /**
+   * How often (ms) to re-verify session, token, redaction, and repo authz for a live stream.
+   * Defaults to DEFAULT_LEASE_INTERVAL_MS when omitted.
+   */
+  readonly leaseIntervalMs?: number
+  /**
+   * Injectable setInterval — defaults to globalThis.setInterval.
+   * Injected in tests to drive lease ticks manually without real timers.
+   */
+  readonly setInterval?: (fn: () => void, ms: number) => ReturnType<typeof globalThis.setInterval>
+  /**
+   * Injectable clearInterval — defaults to globalThis.clearInterval.
+   * Injected in tests to verify the timer is cleared on teardown.
+   */
+  readonly clearInterval?: (id: ReturnType<typeof globalThis.setInterval> | undefined) => void
 }
 
 // ---------------------------------------------------------------------------
@@ -80,6 +95,13 @@ const DEFAULT_MAX_STREAMS_PER_OPERATOR = 5
  * bounds idle pre-auth sockets and is intentionally left unchanged.
  */
 const SOCKET_TIMEOUT_MS = 60_000
+
+/**
+ * How often to re-verify session, token, redaction, and repo authz for a live stream.
+ * A small multiple of the 15s heartbeat interval. Revocation detection is bounded by
+ * checkRepoAuthz's positive cache TTL (~5m + 10% jitter) plus this interval.
+ */
+const DEFAULT_LEASE_INTERVAL_MS = 30_000
 
 // ---------------------------------------------------------------------------
 // Socket timeout helpers
@@ -180,6 +202,71 @@ async function writeFrame(stream: SSEStreamingApi, frame: ObservationFrame): Pro
 }
 
 // ---------------------------------------------------------------------------
+// Continuous-authz lease check
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-verify session, token, redaction, and repo authz for a live stream.
+ *
+ * Called on each lease tick. On any failure, invokes onFail() to close this
+ * connection. Each await point is followed by a generation guard: if the
+ * connection was already torn down (isCleaned() === true) before the async
+ * work resolved, the tick is a no-op — no double cleanup, no late close.
+ *
+ * Does NOT call dropOperatorToken() on a generic github_denied result because
+ * that result cannot distinguish a revoked token from a denied repo.
+ */
+async function runLeaseCheck(
+  githubUserId: number,
+  sessionId: string,
+  owner: string,
+  repo: string,
+  deps: RunStreamRouteDeps,
+  isCleaned: () => boolean,
+  onFail: () => void,
+): Promise<void> {
+  const nowMs = deps.now()
+
+  // ── Check 1: Session still valid ─────────────────────────────────────────
+  const session = deps.sessionStore.get(sessionId, nowMs)
+  if (isCleaned() === true) return
+  if (session === undefined) {
+    onFail()
+    return
+  }
+
+  // ── Check 2: OAuth token still present ───────────────────────────────────
+  const freshToken = deps.sessionStore.getOperatorToken(sessionId, nowMs)
+  if (isCleaned() === true) return
+  if (freshToken === undefined) {
+    onFail()
+    return
+  }
+
+  // ── Check 3: Repo still not denylisted ───────────────────────────────────
+  const denyKeys = await resolveRepoDenyKeys(owner, repo, deps.bindingsLookup)
+  if (isCleaned() === true) return
+  await deps.denylistCache.getDenylistState()
+  if (isCleaned() === true) return
+  if (deps.denylistCache.isRepoDenied(denyKeys) === true) {
+    onFail()
+    return
+  }
+
+  // ── Check 4: Repo authz still passes ─────────────────────────────────────
+  // Goes through checkRepoAuthz's cache; revocation detection is bounded by
+  // the positive cache TTL (~5m + 10% jitter) plus the lease interval.
+  // No cache-bypass — accepted for v1 (status-only data).
+  const authzResult = await checkRepoAuthz(githubUserId, owner, repo, freshToken, deps.repoAuthzDeps)
+  if (isCleaned() === true) return
+  if (authzResult.authorized === false) {
+    // Do NOT call dropOperatorToken here — github_denied cannot distinguish
+    // a revoked token from a denied repo. Only drop on a token-specific signal.
+    onFail()
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Route builder
 // ---------------------------------------------------------------------------
 
@@ -273,11 +360,19 @@ export function buildRunStreamRoute(app: Hono, deps: RunStreamRouteDeps): void {
     const socket = getConnectionSocket(c)
     const priorSocketTimeout = raiseSocketTimeout(socket)
 
+    const setIntervalFn = deps.setInterval ?? globalThis.setInterval.bind(globalThis)
+    const clearIntervalFn = deps.clearInterval ?? globalThis.clearInterval.bind(globalThis)
+    const leaseIntervalMs = deps.leaseIntervalMs ?? DEFAULT_LEASE_INTERVAL_MS
+
     let cleaned = false
+    // Declared before cleanup so cleanup can clear it; assigned when the stream opens.
+    let leaseTimer: ReturnType<typeof globalThis.setInterval> | undefined
 
     const cleanup = (unsubscribe: () => void): void => {
       if (cleaned === true) return
       cleaned = true
+      // Clear the lease timer before unsubscribing so no tick fires during teardown.
+      clearIntervalFn(leaseTimer)
       unsubscribe()
       // Restore the socket timeout to its pre-stream value so it never leaks
       // to a reused keep-alive socket.
@@ -319,6 +414,26 @@ export function buildRunStreamRoute(app: Hono, deps: RunStreamRouteDeps): void {
             cleanup(unsubscribe)
             resolve()
           })
+
+          // Start the continuous-authz lease timer.
+          // Re-verifies session, token, redaction, and repo authz on each tick.
+          // On any failure, closes this connection only (not run-wide).
+          leaseTimer = setIntervalFn((): void => {
+            // runLeaseCheck is async; fire-and-forget with a no-op error handler
+            // (errors inside are handled by the generation guard + cleanup path).
+            runLeaseCheck(
+              githubUserId,
+              sessionId,
+              owner,
+              repo,
+              deps,
+              () => cleaned,
+              () => {
+                cleanup(unsubscribe)
+                resolve()
+              },
+            ).catch(() => {})
+          }, leaseIntervalMs)
         })
       } finally {
         // Safety net: restore the socket timeout if cleanup() was never called

--- a/packages/gateway/src/web/sse/run-stream-route.ts
+++ b/packages/gateway/src/web/sse/run-stream-route.ts
@@ -322,13 +322,16 @@ export function buildRunStreamRoute(app: Hono, deps: RunStreamRouteDeps): void {
       }
 
       // ── Gate 4: Split owner/repo ───────────────────────────────────────────
-      const slashIdx = location.repo.indexOf('/')
+      // Strip any trailing `#...` suffix (e.g. `#runNumber`) before splitting so
+      // future entity_ref formats with a fragment do not bleed into the repo name.
+      const repoPath = location.repo.split('#')[0] ?? location.repo
+      const slashIdx = repoPath.indexOf('/')
       if (slashIdx === -1) {
         deps.logger.warn({githubUserId, runId, gate: 'malformed-repo'}, 'run-stream: denied')
         return notFoundResponse(c)
       }
-      owner = location.repo.slice(0, slashIdx)
-      repo = location.repo.slice(slashIdx + 1)
+      owner = repoPath.slice(0, slashIdx)
+      repo = repoPath.slice(slashIdx + 1)
       if (owner.length === 0 || repo.length === 0) {
         deps.logger.warn({githubUserId, runId, gate: 'malformed-repo'}, 'run-stream: denied')
         return notFoundResponse(c)

--- a/packages/gateway/src/web/sse/run-stream-route.ts
+++ b/packages/gateway/src/web/sse/run-stream-route.ts
@@ -17,6 +17,8 @@
  * a run-resolved/authorized oracle.
  */
 
+import type {Socket} from 'node:net'
+import type {HttpBindings} from '@hono/node-server'
 import type {Context, Hono} from 'hono'
 import type {DenylistCache} from '../../redaction/denylist.js'
 import type {BindingsLookup} from '../../redaction/surface-gate.js'
@@ -70,6 +72,54 @@ export interface RunStreamRouteDeps {
 
 /** Default maximum concurrent SSE streams per operator. */
 const DEFAULT_MAX_STREAMS_PER_OPERATOR = 5
+
+/**
+ * Per-connection socket timeout for SSE streams.
+ * Must exceed the manager's 15s heartbeat interval so an idle-but-heartbeating
+ * stream is not killed by the socket timeout. The global server timeout (10s)
+ * bounds idle pre-auth sockets and is intentionally left unchanged.
+ */
+const SOCKET_TIMEOUT_MS = 60_000
+
+// ---------------------------------------------------------------------------
+// Socket timeout helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the Node socket from the Hono context's HttpBindings env, if present.
+ * Returns undefined when running outside @hono/node-server (e.g. test harness
+ * with plain app.fetch()) or when the socket has not yet been assigned.
+ */
+function getConnectionSocket(c: Context): Socket | undefined {
+  const env = c.env as HttpBindings | undefined
+  const socket = env?.incoming?.socket
+  // IncomingMessage.socket is typed as Socket | null in Node's types
+  return socket ?? undefined
+}
+
+/**
+ * Raise the per-connection socket timeout above the heartbeat interval.
+ * Returns the prior timeout value so it can be restored on every exit path.
+ * Safe to call when socket is undefined — returns 0 (no-op restore).
+ */
+function raiseSocketTimeout(socket: Socket | undefined): number {
+  if (socket === undefined) return 0
+  // socket.timeout is number | undefined in Node's types; treat undefined as 0
+  const prior = socket.timeout ?? 0
+  socket.setTimeout(SOCKET_TIMEOUT_MS)
+  return prior
+}
+
+/**
+ * Restore the socket timeout to the value captured before the stream opened.
+ * Must run on every exit path (normal close, error, abort) to avoid leaking
+ * the raised timeout to a reused keep-alive socket.
+ * Safe to call when socket is undefined — no-op.
+ */
+function restoreSocketTimeout(socket: Socket | undefined, priorTimeout: number): void {
+  if (socket === undefined) return
+  socket.setTimeout(priorTimeout)
+}
 
 // ---------------------------------------------------------------------------
 // Deny-key resolution (mirrors resolveRunRepoKey logic from surface-gate.ts,
@@ -217,12 +267,21 @@ export function buildRunStreamRoute(app: Hono, deps: RunStreamRouteDeps): void {
     // ── Gate 8: Open SSE stream ──────────────────────────────────────────────
     // All gates passed. Transition directly into the SSE stream.
     // There is NO intermediate authorized response — the stream IS the success.
+
+    // Capture the connection socket before entering streamSSE so we can raise
+    // and restore its timeout. Undefined when not running under @hono/node-server.
+    const socket = getConnectionSocket(c)
+    const priorSocketTimeout = raiseSocketTimeout(socket)
+
     let cleaned = false
 
     const cleanup = (unsubscribe: () => void): void => {
       if (cleaned === true) return
       cleaned = true
       unsubscribe()
+      // Restore the socket timeout to its pre-stream value so it never leaks
+      // to a reused keep-alive socket.
+      restoreSocketTimeout(socket, priorSocketTimeout)
       // Release the slot synchronously so a rapid reconnect storm cannot
       // transiently exceed the cap.
       const count = activeStreams.get(githubUserId) ?? 0
@@ -236,30 +295,40 @@ export function buildRunStreamRoute(app: Hono, deps: RunStreamRouteDeps): void {
     return streamSSE(c, async stream => {
       // Promise that resolves when the stream should end (manager closes or client aborts).
       // The streamSSE callback must stay alive (not return) while the stream is open.
-      await new Promise<void>(resolve => {
-        const unsubscribe = deps.manager.subscribe(runId, {
-          onEvent: async (frame: ObservationFrame) => {
-            if (cleaned === true) return
-            try {
-              await writeFrame(stream, frame)
-            } catch {
-              // Write failure — stream is likely closed; cleanup will handle it
+      try {
+        await new Promise<void>(resolve => {
+          const unsubscribe = deps.manager.subscribe(runId, {
+            onEvent: async (frame: ObservationFrame) => {
+              if (cleaned === true) return
+              try {
+                await writeFrame(stream, frame)
+              } catch {
+                // Write failure — stream is likely closed; cleanup will handle it
+                cleanup(unsubscribe)
+                resolve()
+              }
+            },
+            onClose: (_reason: string) => {
               cleanup(unsubscribe)
               resolve()
-            }
-          },
-          onClose: (_reason: string) => {
+            },
+          })
+
+          // Register abort handler so client disconnect releases the slot
+          stream.onAbort(() => {
             cleanup(unsubscribe)
             resolve()
-          },
+          })
         })
-
-        // Register abort handler so client disconnect releases the slot
-        stream.onAbort(() => {
-          cleanup(unsubscribe)
-          resolve()
-        })
-      })
+      } finally {
+        // Safety net: restore the socket timeout if cleanup() was never called
+        // (e.g. an unexpected throw before any teardown path fired).
+        // cleanup() sets cleaned=true before restoring, so this is a no-op when
+        // cleanup already ran — avoids a double-restore on a reused keep-alive socket.
+        if (cleaned === false) {
+          restoreSocketTimeout(socket, priorSocketTimeout)
+        }
+      }
     })
   })
 }

--- a/packages/gateway/src/web/sse/run-stream-route.ts
+++ b/packages/gateway/src/web/sse/run-stream-route.ts
@@ -1,0 +1,265 @@
+/**
+ * Authenticated SSE route: GET /operator/runs/:runId/stream
+ *
+ * Gate ordering (all must pass before any byte is written):
+ *   1. Guard (browser/session/allowlist/CSRF) — installed by buildOperatorApp
+ *   2. Resolve session + OAuth token by sessionId
+ *   3. Resolve runId → repo via RunIndex (server-owned; never client-supplied)
+ *   4. Split owner/repo from the resolved location
+ *   5. Resolve binding deny-keys; prime denylist; check isRepoDenied
+ *   6. checkRepoAuthz (allowlist + GitHub repo access)
+ *   7. Acquire per-operator stream slot (keyed on numeric githubUserId)
+ *   8. Open SSE stream → deliver first snapshot/reset frame
+ *
+ * Every failure at steps 2–6 returns the identical generic not-found shape.
+ * Step 7 failure returns 429 (honest backpressure for an already-authorized operator).
+ * There is NO authorized non-stream response — a distinguishable success would be
+ * a run-resolved/authorized oracle.
+ */
+
+import type {Context, Hono} from 'hono'
+import type {DenylistCache} from '../../redaction/denylist.js'
+import type {BindingsLookup} from '../../redaction/surface-gate.js'
+import type {RepoAuthzDeps} from '../auth/repo-authz.js'
+import type {SessionStore} from '../auth/session.js'
+import type {OperatorLogger} from '../server.js'
+import type {ObservationFrame, RunObservationManager} from './manager.js'
+
+import {streamSSE, type SSEStreamingApi} from 'hono/streaming'
+import {checkRepoAuthz} from '../auth/repo-authz.js'
+import {getOperatorAuthContext, registerOperatorRoute} from '../operator-route.js'
+import {notFoundResponse} from '../safe-response.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Minimal run-index interface required by this route. */
+export interface RunIndex {
+  readonly lookup: (runId: string) => Promise<{readonly repo: string; readonly surface: string} | undefined>
+}
+
+/** Dependencies for the run-stream route. */
+export interface RunStreamRouteDeps {
+  /** Session store for token retrieval. */
+  readonly sessionStore: SessionStore
+  /** Server-owned run index for runId → repo resolution. */
+  readonly runIndex: RunIndex
+  /** Denylist cache for pre-subscribe redaction check. */
+  readonly denylistCache: DenylistCache
+  /** Bindings lookup for deny-key resolution. */
+  readonly bindingsLookup: BindingsLookup
+  /** Repo authorization dependencies. */
+  readonly repoAuthzDeps: RepoAuthzDeps
+  /** Run-observation manager for SSE subscription. */
+  readonly manager: RunObservationManager
+  /** Structured logger. */
+  readonly logger: OperatorLogger
+  /** Injectable clock. */
+  readonly now: () => number
+  /**
+   * Maximum concurrent SSE streams per operator (keyed on numeric githubUserId).
+   * Defaults to 5 when omitted.
+   */
+  readonly maxStreamsPerOperator?: number
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default maximum concurrent SSE streams per operator. */
+const DEFAULT_MAX_STREAMS_PER_OPERATOR = 5
+
+// ---------------------------------------------------------------------------
+// Deny-key resolution (mirrors resolveRunRepoKey logic from surface-gate.ts,
+// but takes owner/repo strings directly since we already have them from RunIndex)
+// ---------------------------------------------------------------------------
+
+interface RepoKey {
+  readonly databaseId: number | null
+  readonly nodeId: string | null
+}
+
+/**
+ * Resolve deny-keys for a repo by calling getBindingByRepo directly.
+ * Fail-closed: returns {null, null} on store error, missing binding, or missing keys.
+ */
+async function resolveRepoDenyKeys(owner: string, repo: string, bindingsLookup: BindingsLookup): Promise<RepoKey> {
+  const NULL_KEY: RepoKey = {databaseId: null, nodeId: null}
+
+  let result: Awaited<ReturnType<BindingsLookup['getBindingByRepo']>>
+  try {
+    result = await bindingsLookup.getBindingByRepo(owner, repo)
+  } catch {
+    return NULL_KEY
+  }
+
+  if (result.success === false) {
+    return NULL_KEY
+  }
+
+  if (result.data === null) {
+    return NULL_KEY
+  }
+
+  const binding = result.data
+  const databaseId = typeof binding.databaseId === 'number' ? binding.databaseId : null
+  const nodeId = typeof binding.nodeId === 'string' ? binding.nodeId : null
+
+  return {databaseId, nodeId}
+}
+
+// ---------------------------------------------------------------------------
+// SSE frame writer
+// ---------------------------------------------------------------------------
+
+/**
+ * Write an observation frame to the SSE stream.
+ * Only status, reset, and heartbeat frames are ever written — no raw run data.
+ */
+async function writeFrame(stream: SSEStreamingApi, frame: ObservationFrame): Promise<void> {
+  if (frame.type === 'status') {
+    await stream.writeSSE({event: 'status', data: JSON.stringify(frame.data)})
+  } else if (frame.type === 'reset') {
+    await stream.writeSSE({event: 'reset', data: JSON.stringify({runId: frame.runId, reason: frame.reason})})
+  } else if (frame.type === 'heartbeat') {
+    // SSE comment line — keepalive, not a named event
+    await stream.write(': heartbeat\n\n')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Register GET /operator/runs/:runId/stream on the given Hono app.
+ *
+ * Must be called after setOperatorRouteGuard is installed in buildOperatorApp.
+ * The guard runs first (browser/session/allowlist/CSRF); this handler runs only
+ * if the guard allows the request.
+ */
+export function buildRunStreamRoute(app: Hono, deps: RunStreamRouteDeps): void {
+  // Per-operator active stream count, keyed on numeric githubUserId.
+  // Acquired before opening the stream; released synchronously when the stream ends.
+  const activeStreams = new Map<number, number>()
+  const maxStreams = deps.maxStreamsPerOperator ?? DEFAULT_MAX_STREAMS_PER_OPERATOR
+
+  registerOperatorRoute(app, 'GET', '/operator/runs/:runId/stream', async (c: Context): Promise<Response> => {
+    const nowMs = deps.now()
+
+    // ── Gate 1: Read authenticated context set by the guard ──────────────────
+    // In production the guard always sets this; undefined is unreachable.
+    // Return not-found as a safe fallback (no oracle — same shape as all denials).
+    const authCtx = getOperatorAuthContext(c)
+    if (authCtx === undefined) {
+      return notFoundResponse(c)
+    }
+
+    const {githubUserId, sessionId} = authCtx
+
+    // ── Gate 2: Resolve OAuth token ──────────────────────────────────────────
+    // A missing token means the session is dropped/expired/revoked and re-auth is needed.
+    // Return not-found independent of runId so a re-auth need never becomes a
+    // run-existence timing signal.
+    const token = deps.sessionStore.getOperatorToken(sessionId, nowMs)
+    if (token === undefined) {
+      return notFoundResponse(c)
+    }
+
+    // ── Gate 3: Resolve runId → repo (server-owned) ──────────────────────────
+    // The repo is NEVER taken from the client. RunIndex.lookup is the sole authority.
+    const runId = c.req.param('runId') ?? ''
+    const location = await deps.runIndex.lookup(runId)
+    if (location === undefined) {
+      return notFoundResponse(c)
+    }
+
+    // ── Gate 4: Split owner/repo ─────────────────────────────────────────────
+    const slashIdx = location.repo.indexOf('/')
+    if (slashIdx === -1) {
+      return notFoundResponse(c)
+    }
+    const owner = location.repo.slice(0, slashIdx)
+    const repo = location.repo.slice(slashIdx + 1)
+    if (owner.length === 0 || repo.length === 0) {
+      return notFoundResponse(c)
+    }
+
+    // ── Gate 5: Redaction check (explicit pre-subscribe, fail-closed) ─────────
+    // Resolve deny-keys from the binding store (fail-closed on error/missing).
+    // Prime/refresh the denylist cache, then check synchronously.
+    // This runs BEFORE checkRepoAuthz so a denylisted repo never triggers a GitHub call.
+    const denyKeys = await resolveRepoDenyKeys(owner, repo, deps.bindingsLookup)
+    await deps.denylistCache.getDenylistState()
+    if (deps.denylistCache.isRepoDenied(denyKeys) === true) {
+      return notFoundResponse(c)
+    }
+
+    // ── Gate 6: Repo authorization ───────────────────────────────────────────
+    // Allowlist + GitHub repo access check. Fail-closed on any error.
+    const authzResult = await checkRepoAuthz(githubUserId, owner, repo, token, deps.repoAuthzDeps)
+    if (authzResult.authorized === false) {
+      return notFoundResponse(c)
+    }
+
+    // ── Gate 7: Acquire per-operator stream slot ─────────────────────────────
+    // Keyed on numeric githubUserId (not session — a session key is bypassable
+    // by opening multiple sessions). Over cap → 429 (honest backpressure for an
+    // already-authorized operator; not a run oracle since authz already passed).
+    const currentCount = activeStreams.get(githubUserId) ?? 0
+    if (currentCount >= maxStreams) {
+      return c.json({error: 'too many streams'}, 429)
+    }
+    activeStreams.set(githubUserId, currentCount + 1)
+
+    // ── Gate 8: Open SSE stream ──────────────────────────────────────────────
+    // All gates passed. Transition directly into the SSE stream.
+    // There is NO intermediate authorized response — the stream IS the success.
+    let cleaned = false
+
+    const cleanup = (unsubscribe: () => void): void => {
+      if (cleaned === true) return
+      cleaned = true
+      unsubscribe()
+      // Release the slot synchronously so a rapid reconnect storm cannot
+      // transiently exceed the cap.
+      const count = activeStreams.get(githubUserId) ?? 0
+      if (count <= 1) {
+        activeStreams.delete(githubUserId)
+      } else {
+        activeStreams.set(githubUserId, count - 1)
+      }
+    }
+
+    return streamSSE(c, async stream => {
+      // Promise that resolves when the stream should end (manager closes or client aborts).
+      // The streamSSE callback must stay alive (not return) while the stream is open.
+      await new Promise<void>(resolve => {
+        const unsubscribe = deps.manager.subscribe(runId, {
+          onEvent: async (frame: ObservationFrame) => {
+            if (cleaned === true) return
+            try {
+              await writeFrame(stream, frame)
+            } catch {
+              // Write failure — stream is likely closed; cleanup will handle it
+              cleanup(unsubscribe)
+              resolve()
+            }
+          },
+          onClose: (_reason: string) => {
+            cleanup(unsubscribe)
+            resolve()
+          },
+        })
+
+        // Register abort handler so client disconnect releases the slot
+        stream.onAbort(() => {
+          cleanup(unsubscribe)
+          resolve()
+        })
+      })
+    })
+  })
+}

--- a/packages/gateway/src/web/sse/run-stream-route.ts
+++ b/packages/gateway/src/web/sse/run-stream-route.ts
@@ -20,35 +20,31 @@
 import type {Socket} from 'node:net'
 import type {HttpBindings} from '@hono/node-server'
 import type {Context, Hono} from 'hono'
+import type {RunIndex as FullRunIndex} from '../../execute/run-index.js'
 import type {DenylistCache} from '../../redaction/denylist.js'
 import type {BindingsLookup} from '../../redaction/surface-gate.js'
 import type {RepoAuthzDeps} from '../auth/repo-authz.js'
 import type {SessionStore} from '../auth/session.js'
 import type {OperatorLogger} from '../server.js'
 import type {ObservationFrame, RunObservationManager} from './manager.js'
-
 import {streamSSE, type SSEStreamingApi} from 'hono/streaming'
 import {OPERATOR_CONTRACT_VERSION} from '../../operator-contract/index.js'
 import {resolveBindingDenyKeys} from '../../redaction/surface-gate.js'
 import {checkRepoAuthz} from '../auth/repo-authz.js'
 import {getOperatorAuthContext, registerOperatorRoute} from '../operator-route.js'
 import {notFoundResponse, rateLimitedResponse} from '../safe-response.js'
+import {DEFAULT_MAX_STREAM_DURATION_MS} from './manager.js'
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-/** Minimal run-index interface required by this route. */
-export interface RunIndex {
-  readonly lookup: (runId: string) => Promise<{readonly repo: string; readonly surface: string} | undefined>
-}
 
 /** Dependencies for the run-stream route. */
 export interface RunStreamRouteDeps {
   /** Session store for token retrieval. */
   readonly sessionStore: SessionStore
   /** Server-owned run index for runId → repo resolution. */
-  readonly runIndex: RunIndex
+  readonly runIndex: Pick<FullRunIndex, 'lookup'>
   /** Denylist cache for pre-subscribe redaction check. */
   readonly denylistCache: DenylistCache
   /** Bindings lookup for deny-key resolution. */
@@ -81,6 +77,22 @@ export interface RunStreamRouteDeps {
    * Injected in tests to verify the timer is cleared on teardown.
    */
   readonly clearInterval?: (id: ReturnType<typeof globalThis.setInterval> | undefined) => void
+  /**
+   * Route-owned hard max-duration for a single SSE connection (defense-in-depth).
+   * Defaults to DEFAULT_MAX_STREAM_DURATION_MS (same 30-minute value as the manager).
+   * Injected in tests to drive the timer without real wall-clock delays.
+   */
+  readonly maxStreamDurationMs?: number
+  /**
+   * Injectable setTimeout — defaults to globalThis.setTimeout.
+   * Injected in tests to drive the max-duration timer manually.
+   */
+  readonly setTimeout?: (fn: () => void, ms: number) => ReturnType<typeof globalThis.setTimeout>
+  /**
+   * Injectable clearTimeout — defaults to globalThis.clearTimeout.
+   * Injected in tests to verify the timer is cleared on teardown.
+   */
+  readonly clearTimeout?: (handle: ReturnType<typeof globalThis.setTimeout> | undefined) => void
 }
 
 // ---------------------------------------------------------------------------
@@ -380,7 +392,10 @@ export function buildRunStreamRoute(app: Hono, deps: RunStreamRouteDeps): void {
 
     const setIntervalFn = deps.setInterval ?? globalThis.setInterval.bind(globalThis)
     const clearIntervalFn = deps.clearInterval ?? globalThis.clearInterval.bind(globalThis)
+    const setTimeoutFn = deps.setTimeout ?? globalThis.setTimeout.bind(globalThis)
+    const clearTimeoutFn = deps.clearTimeout ?? globalThis.clearTimeout.bind(globalThis)
     const leaseIntervalMs = deps.leaseIntervalMs ?? DEFAULT_LEASE_INTERVAL_MS
+    const routeMaxDurationMs = deps.maxStreamDurationMs ?? DEFAULT_MAX_STREAM_DURATION_MS
 
     let cleaned = false
     // Declared before subscribe so a synchronous onClose('shutdown') during subscribe
@@ -388,12 +403,16 @@ export function buildRunStreamRoute(app: Hono, deps: RunStreamRouteDeps): void {
     let unsubscribe: (() => void) | undefined
     // Declared before subscribe so a synchronous onClose can clear it.
     let leaseTimer: ReturnType<typeof globalThis.setInterval> | undefined
+    // Declared before subscribe so a synchronous onClose can clear it safely
+    // (clearTimeout(undefined) is a no-op).
+    let maxDurationTimer: ReturnType<typeof globalThis.setTimeout> | undefined
 
     const cleanup = (closeReason: string): void => {
       if (cleaned === true) return
       cleaned = true
-      // Clear the lease timer before unsubscribing so no tick fires during teardown.
+      // Clear both timers before unsubscribing so no tick or fire occurs during teardown.
       clearIntervalFn(leaseTimer)
+      clearTimeoutFn(maxDurationTimer)
       // unsubscribe may be undefined if onClose fired synchronously during subscribe.
       unsubscribe?.()
       // Release the slot synchronously so a rapid reconnect storm cannot
@@ -454,6 +473,13 @@ export function buildRunStreamRoute(app: Hono, deps: RunStreamRouteDeps): void {
             cleanup('client-abort')
             resolve()
           })
+
+          // Route-owned hard max-duration timer (defense-in-depth).
+          // Closes the connection if the manager's own max-duration timer fails to fire.
+          maxDurationTimer = setTimeoutFn(() => {
+            cleanup('route-max-duration')
+            resolve()
+          }, routeMaxDurationMs)
 
           // Start the continuous-authz lease timer.
           // Re-verifies session, token, redaction, and repo authz on each tick.


### PR DESCRIPTION
## Authenticated SSE run-stream route

Adds `GET /operator/runs/:runId/stream`, the authenticated server-sent-events route that streams repo-scoped run status to the operator web surface. This consumes the inert observation core from #961 (advances #907).

### Authorization model

Success is observable **only as an SSE stream** — there is no authorized non-stream response, so a prober can't tell "run resolved + you're authorized" apart from "no such run." Every denial returns the identical not-found shape. The gates run in a fixed order:

1. Browser/session/allowlist/CSRF guard (the operator-route wrapper)
2. Resolve the session OAuth token
3. Resolve `runId → repo` via the **server-owned** run index (never client-supplied)
4. **Redaction check before authorization** — a denylisted repo never triggers a GitHub call
5. Repo authorization (allowlist + GitHub access)
6. Acquire a per-operator stream slot (keyed on the numeric operator id; over-cap is rate-limited backpressure, reached only after authorization)

A continuous-authz **lease** then re-checks the session, token, denylist, and repo access on an interval and closes the connection the moment access is lost, so a revocation stops the stream within the cache window rather than at stream end.

### Lifecycle

The stream emits a `ready` frame carrying the operator contract version, then live `status` frames (the closed status DTO — no raw output, tool, or path data), `reset` on a snapshot gap, and SSE-comment heartbeats. Teardown is single-path and idempotent: the per-operator slot is released on any exit, the lease and a route-owned hard max-duration timer are cleared, and the connection's socket timeout is restored without leaking to a reused keep-alive socket. The route owns its own max-duration bound as defense-in-depth so a stuck subscription can't hang a connection.

### Scope

This is the route on top of the inert core. The replay buffer / Last-Event-ID, the staleness reconciler, and the cross-operator concurrency tuning remain deferred to later Phase B work; v1 is status-only with snapshot-on-subscribe.

### Verification

Gateway suite green (2263 tests), type-check and lint clean, no dist drift. The route was reviewed for the no-oracle property, redaction-before-authz ordering, server-owned resolution, fail-closed teardown, and lease behavior.
