### PR TITLE
feat(gateway): stream web-launched run output to the operator

### DIFF
--- a/docs/plans/2026-06-20-004-feat-stream-web-run-output-plan.md
+++ b/docs/plans/2026-06-20-004-feat-stream-web-run-output-plan.md
@@ -121,7 +121,7 @@ Late subscriber connects after terminal:
 
 ## Implementation Units
 
-- [ ] **Unit 1: Output frame contract type + version bump**
+- [x] **Unit 1: Output frame contract type + version bump**
 
 **Goal:** Add the `output` frame type to the operator contract and bump the version.
 
@@ -144,7 +144,7 @@ Late subscriber connects after terminal:
 
 **Verification:** Contract barrel exports `OperatorOutputFrame`; `version.test.ts` green at `1.3.0`.
 
-- [ ] **Unit 2: Manager `output` frame + `observeOutput` + terminal-output cache**
+- [x] **Unit 2: Manager `output` frame + `observeOutput` + terminal-output cache**
 
 **Goal:** Extend the manager's closed union with an `output` frame, add the `observeOutput` entry point, the `latestOutputCache`, explicit coalescing, and snapshot-on-subscribe for the cached final output.
 
@@ -173,7 +173,7 @@ Late subscriber connects after terminal:
 
 **Verification:** `output` frames fan out and coalesce as specified; `latestOutputCache` delivers to late subscribers; observer-only invariant holds; manager tests green.
 
-- [ ] **Unit 3: Run-stream route `output` SSE event mapping**
+- [x] **Unit 3: Run-stream route `output` SSE event mapping**
 
 **Goal:** Map the `output` frame to a named SSE event on the wire.
 
@@ -196,7 +196,7 @@ Late subscriber connects after terminal:
 
 **Verification:** `output` frames reach the wire as `event: 'output'`; `ready`-first preserved; route tests green.
 
-- [ ] **Unit 4: Wire the web ReplySink to push output (construction-order)**
+- [x] **Unit 4: Wire the web ReplySink to push output (construction-order)**
 
 **Goal:** Make `createWebReplySink` push deltas + the final answer through `observeOutput`, and thread the manager into the launch route.
 
@@ -217,7 +217,7 @@ Late subscriber connects after terminal:
 
 **Verification:** the web sink pushes deltas + final answer to the manager; the launch route wires the manager + runId; Discord launch path untouched (its sink is a different construction).
 
-- [ ] **Unit 5: Engine-side ordering reorder**
+- [x] **Unit 5: Engine-side ordering reorder**
 
 **Goal:** Ensure the final `output` frame is delivered before the terminal status frame by reordering the terminal observer notification after the final answer flush.
 
@@ -240,7 +240,7 @@ Late subscriber connects after terminal:
 
 **Verification:** terminal output precedes terminal status for web runs; Discord behavior byte-identical; run tests green.
 
-- [ ] **Unit 6: Docs refresh**
+- [x] **Unit 6: Docs refresh**
 
 **Goal:** Update the SSE solution doc and operator-contract notes to reflect the new `output` frame, and document the lease foot-gun.
 

--- a/docs/plans/2026-06-20-004-feat-stream-web-run-output-plan.md
+++ b/docs/plans/2026-06-20-004-feat-stream-web-run-output-plan.md
@@ -1,0 +1,285 @@
+---
+title: "feat: Stream web-launched run output to the operator"
+type: feat
+status: active
+date: 2026-06-20
+origin: docs/brainstorms/2026-06-20-stream-web-run-output-requirements.md
+issue: 965
+---
+
+# feat: Stream web-launched run output to the operator
+
+## Overview
+
+Deliver a web-launched run's agent output to the operator over the **existing** SSE run-stream. Today the web `ReplySink` (`packages/gateway/src/web/operator/web-sinks.ts`) accumulates the agent's text in memory and drops it (`flush`/`send` are no-ops); the operator can watch a run reach `succeeded`/`failed` over the status stream but never sees what the agent said. This wires the web sink's output through the run-observation manager as a new `output` SSE frame — live deltas as the agent produces them, plus an authoritative final-answer frame that guarantees completeness. Reuses the single run-stream connection and the existing per-subscriber backpressure. Closes #965 (advances #907).
+
+## Problem Frame
+
+The web operator surface is **status-only by construction** (see origin). The run-observation manager projects each `RunState` transition into a closed `OperatorRunStatus` DTO and fans it out as `status`/`reset`/`heartbeat` frames; the agent's output text never enters this pipeline. The text *does* flow into `request.replySink.append(...)` during execution (`packages/gateway/src/execute/run-core.ts:387,389,400`), but the web sink buffers it and `flush` is a no-op. The Discord transport already delivers the same text by posting the buffer to the thread (`packages/gateway/src/discord/streaming.ts:163-211`) — this brings parity to the web surface.
+
+## Requirements Trace
+
+- R1. A web operator subscribed to a run's stream sees the agent's output arrive live as `output` frames while the run executes.
+- R2. The operator always ends with the complete answer: a `final: true` `output` frame is enqueued **before** the terminal status frame and **replaces** the accumulated live text.
+- R3. A subscriber connecting **after** the run reached a terminal phase still receives the cached final answer (terminal-output snapshot).
+- R4. A run with no output (empty / early failure) still produces a terminal `output` frame so the operator can distinguish "no output" from "missing output".
+- R5. Under a slow/overflowing subscriber, the connection stays alive; output coalesces and the client is told via a monotonic `seq` + `droppedCount`. Per-subscriber queues stay independent.
+- R6. Output is never delivered to an operator who lost repo access mid-run (rides the existing continuous-authz lease; the connection tears down within the accepted ~30s window).
+- R7. The Discord transport's behavior is unchanged (the `ReplySink` change is additive to the web sink only; the engine-side reorder is inert for Discord).
+- R8. Contract bump to `1.3.0` (additive `output` frame type); 1.2.x clients keep working via the `ready`-frame `contractVersion` feature-detect.
+
+## Scope Boundaries
+
+- No mid-stream content scrub / secret-scanning pass (deferred by policy — output is operator-safe by the sink route it took; the repo-authz gate is the trust boundary). See Key Technical Decisions.
+- No second SSE channel — extend the existing manager + run-stream route.
+- No mid-stream delta replay/scrollback. A reconnecting subscriber resumes live; only the terminal-output snapshot is cached and re-delivered (R3), not a delta history.
+- No tighter-than-Discord projection — output reuses run-core's existing visible-output discipline (reasoning suppressed, tools summarized), not a new one.
+
+### Deferred to Separate Tasks
+
+- Tightening the authz lease for sensitive output (file contents/secrets): if a future change streams more than the current sink-routed visible text, the lease window must tighten per the SSE doc's rule-8 warning. Captured as an in-code foot-gun comment now; no separate issue yet.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Manager** `packages/gateway/src/web/sse/manager.ts`: `ObservationFrame` closed union (`:78`); `StatusFrame`/`ResetFrame`/`HeartbeatFrame` (`:54-75`); `observe(runState)` (`:460-506`) updates `latestStatusCache` (`:239`) then `fanOut`, and on terminal clears the cache + `closeRunSubscribers` (`:502-505`); `runSubscribers` per-run map (`:242`); `enqueueFrame` byte-cap + overflow-drop (`:303-331`, cap `DEFAULT_SUBSCRIBER_QUEUE_CAP_BYTES = 64*1024` at `:37`); `subscribe` snapshot-on-subscribe from `latestStatusCache` (`:538`); `shutdown` clears cache (`:602`).
+- **Run-stream route** `packages/gateway/src/web/sse/run-stream-route.ts`: `writeFrame` SSE event mapping (`:178-191`) with an exhaustiveness `never` guard (`:188`); `ready` frame emitted first with `contractVersion` (`:442-448`); the lease re-verification (`:208-261`).
+- **Projection** `packages/gateway/src/web/sse/projection.ts`: `projectRunObservation` closed-DTO copy of only the 7 contract fields (`:80-88`); denylist gate lives in `run-status.ts:131-135` (status path only — output bypasses projection).
+- **Web sink** `packages/gateway/src/web/operator/web-sinks.ts`: `createWebReplySink()` (`:82-123`) — no params, `append` buffers, `flush`/`send` no-op.
+- **Launch route** `packages/gateway/src/web/operator/launch-route.ts`: `replySink: createWebReplySink()` (`:342`); `LaunchRouteDeps` (`:97-128`) has no manager; `request` literal in scope: `runId` (`:335`), `binding`, `operatorIdentity`, `surface`.
+- **Server wiring** `packages/gateway/src/web/server.ts`: `OperatorServerDeps.runObservationManager` (`:158`); `buildLaunchRoute` call (`:671-698`) does NOT pass the manager; `buildRunStreamRoute` does (`:582,602`).
+- **Engine** `packages/gateway/src/execute/run.ts`: final answer source `replySink.buffered()` → `statusSink.resolveToAnswer(finalText)` (`:640-641`), then `flush()` on delegated (`:642-644`); terminal `notifyObserverBestEffort` fires at `:632` (COMPLETED) and `:698` (FAILED) — **before** the final answer is available (the reorder point).
+- **Discord sink (reference)** `packages/gateway/src/discord/streaming.ts:129-211`: `append` buffers, `flush` posts the complete answer.
+- **Contract** `packages/gateway/src/operator-contract/version.ts:15` (`'1.2.0'`); barrel `index.ts:17-28`; sibling type files `run-status.ts`/`approval.ts`/`redaction.ts`.
+- **Tests** `manager.test.ts` (`collectFrames` harness `:178`, `drain()` `:199`, backpressure block `:354`, observer-only-invariant block `:717`); `run-stream-route.test.ts` (`makeManager` all-vi.fn `:152`, no-oracle assertions); `launch-route.test.ts` (module-mocks `launchWork`, captures the request shape).
+
+### Institutional Learnings
+
+The SSE run-observation doc (`docs/solutions/best-practices/authenticated-sse-run-observation-2026-06-20.md`) is the de-facto checklist — its 10 rules govern this work. Key applications:
+- **Closed-DTO (rule 5) — NO exception needed.** The output frame's `text` is sourced from the `ReplySink` boundary (spine doc rule 2: "pass sinks, not transport objects"), not extracted from `RunState` by the projection. The DTO's `RunState` projection is unchanged; we add a new *frame type*, blessed by the 1.3.0 bump (rule 10). The plan states this so review does not re-litigate.
+- **No-oracle (rule 1)** — no new `output-not-available`/`output-not-authorized` error codes; the stream itself is the only success shape, `404` the only denial.
+- **Backpressure (rule 6)** — reuse the existing 64KB per-subscriber cap + overflow path; extend the frame enum, do not fork the cap accounting. One manager (spine doc rule 6: collapse, don't fork).
+- **Lease (rule 8)** — output rides the existing lease; document the foot-gun that streaming sensitive content later must tighten it.
+- **FIFO/ordering** (`atomic-serial-channel-queue-handoff-2026-06-09.md`) — `ready` stays the always-first frame; cached output replays in order after `ready`.
+- **Cache key** (`centralize-s3-key-identity-construction-2026-06-09.md`) — the terminal-output cache is in-memory, named `latestOutputCache` as a sibling to `latestStatusCache` in the same file/lifecycle.
+
+### External References
+
+None — strong local patterns (the SSE doc's rules + the manager itself). External research skipped.
+
+## Key Technical Decisions
+
+- **`output` frame shape:** `{ type: 'output', runId: string, text: string, final: boolean, seq: number, droppedCount?: number }`. Delta frames append (`final: false`); the terminal frame replaces (`final: true`). `seq` is monotonic per run; `droppedCount` (when present) tells the client coalescing elided `n` prior deltas. Lives in a new `packages/gateway/src/operator-contract/output.ts`, re-exported from the barrel.
+- **Explicit coalescing (not silent).** Under per-subscriber overflow, output deltas coalesce/drop, and the next output frame carries the cumulative `droppedCount` so the client can show elision live (origin decision revised after research: contract hygiene over silence). The `final: true` frame still guarantees completeness. Status frames keep their existing drop-the-subscriber overflow behavior; only output frames coalesce.
+- **Engine-side ordering reorder.** Move the terminal `notifyObserverBestEffort(deps, terminalState)` in `run.ts` to **after** `resolveToAnswer`/`flush`, so the final `output` frame is pushed before the terminal status frame. Localized, keeps the manager observer-only. A characterization test proves Discord behavior is unchanged (Discord does not observe these frames, so the reorder is inert for it).
+- **Content entry point `observeOutput(runId, text, opts)`** on the manager, alongside `observe(runState)`. It fans out an `output` frame to `runSubscribers.get(runId)` through the same `enqueueFrame` path, updates `latestOutputCache` only for the final frame, and is observer-only (no mutating run API — preserves rule 6). The web sink receives a **narrow `observeOutput` callback**, not the full manager (keeps the sink decoupled).
+- **Construction-order wiring (shape 1).** Extend `createWebReplySink({ runId, observeOutput })`; add `runObservationManager: RunObservationManager` to `LaunchRouteDeps`; thread it through the `buildLaunchRoute` call in `web/server.ts`; at the launch site pass `{ runId, observeOutput: (text, opts) => manager.observeOutput(runId, text, opts) }`. The sink's `append` pushes a delta; `flush` (or a terminal hook) pushes the `final` frame.
+- **Terminal-output snapshot cache.** `latestOutputCache: Map<runId, OperatorOutputFrame>` sibling to `latestStatusCache`, set on the final frame, cleared on the same teardown paths (`shutdown`, post-terminal cleanup). `subscribe` delivers it (after `ready`, after the cached status) so a late subscriber gets the answer. Derived projection, not a primary store.
+- **Output as-is; repo-authz is the trust boundary.** No per-frame scrub; reuse run-core's visible-output discipline. The web SSE stream is a new *exposure* surface (browser-readable) but not a new *authz boundary* — parity with Discord for already-authorized operators.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Coalescing silent vs explicit? → **Explicit** (`seq` + `droppedCount`).
+- Ordering mechanism? → **Engine-side reorder** of the terminal `notifyObserver` call.
+- Closed-DTO tension? → **No exception needed** (output is sink-routed, not `RunState`-projected).
+- Cache location? → in-memory `latestOutputCache` sibling to `latestStatusCache` in `manager.ts`.
+- Sink↔manager wiring? → narrow `observeOutput` callback into `createWebReplySink`.
+
+### Deferred to Implementation
+
+- Whether a single `final` `output` frame can exceed the 64KB cap for a very large answer, and if so whether the manager chunks it or the sink pre-splits. (Likely chunk the final frame into ordered `output` deltas with the last carrying `final: true`; confirm against `enqueueFrame` byte accounting at implementation.)
+- Exact coalescing strategy in the queue (merge adjacent text vs newest-wins-with-droppedCount) — pick against the real `enqueueFrame`/`drainQueue` shapes.
+- Whether the terminal `output` frame and the terminal `status` frame need an explicit per-run drain barrier beyond the engine reorder (verify the reorder alone closes the race in the manager's async writer).
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification.*
+
+```
+Run executes (executeWorkOnHeldSlot)
+  agent text delta ──> request.replySink.append(text)
+                          │  (web sink)
+                          └─> observeOutput(runId, text)               ──> manager
+                                                                            ├─ fanOut output frame {final:false, seq++}
+                                                                            └─ per-subscriber enqueueFrame (64KB cap; coalesce + droppedCount on overflow)
+Run completes
+  finalText = replySink.buffered()
+  statusSink.resolveToAnswer(finalText)
+  replySink.flush()  ──> observeOutput(runId, finalText, {final:true}) ──> manager
+                                                                            ├─ set latestOutputCache[runId]
+                                                                            └─ fanOut output frame {final:true}      (BEFORE terminal status)
+  notifyObserverBestEffort(deps, terminalState)  ◀── MOVED HERE (after flush) ──> manager.observe(terminal)
+                                                                            ├─ fanOut status frame (terminal)
+                                                                            └─ closeRunSubscribers + clear caches
+
+Late subscriber connects after terminal:
+  ready frame ──> cached status (latestStatusCache or reset) ──> cached final output (latestOutputCache) ──> close
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Output frame contract type + version bump**
+
+**Goal:** Add the `output` frame type to the operator contract and bump the version.
+
+**Requirements:** R8
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `packages/gateway/src/operator-contract/output.ts`
+- Modify: `packages/gateway/src/operator-contract/index.ts` (re-export), `packages/gateway/src/operator-contract/version.ts` (`'1.2.0'` → `'1.3.0'`)
+- Test: `packages/gateway/src/operator-contract/version.test.ts` (update the `1.2.0` assertion to `1.3.0`), `packages/gateway/src/operator-contract/output.test.ts` (new)
+
+**Approach:** Define `OperatorOutputFrame { runId, text, final, seq, droppedCount? }` (readonly fields) mirroring the `run-status.ts` file shape. Bump the version constant per the MINOR policy.
+
+**Patterns to follow:** `run-status.ts`/`approval.ts` file shape; the barrel re-export pattern in `index.ts`.
+
+**Test scenarios:**
+- Happy path: the type's required fields are present; `version.test.ts` pins `'1.3.0'`.
+- Edge: `droppedCount` is optional (a frame without it is valid).
+
+**Verification:** Contract barrel exports `OperatorOutputFrame`; `version.test.ts` green at `1.3.0`.
+
+- [ ] **Unit 2: Manager `output` frame + `observeOutput` + terminal-output cache**
+
+**Goal:** Extend the manager's closed union with an `output` frame, add the `observeOutput` entry point, the `latestOutputCache`, explicit coalescing, and snapshot-on-subscribe for the cached final output.
+
+**Requirements:** R1, R3, R4, R5
+
+**Dependencies:** Unit 1.
+
+**Files:**
+- Modify: `packages/gateway/src/web/sse/manager.ts`
+- Test: `packages/gateway/src/web/sse/manager.test.ts`
+
+**Approach:** Add `OutputFrame` to `ObservationFrame` (the `writeFrame` exhaustiveness guard in Unit 3 forces handling). Add `observeOutput(runId, text, opts?: { final?: boolean; droppedCount? })` to the manager interface and implementation: build the `output` frame with a per-run monotonic `seq`, fan out via the existing `enqueueFrame` path. On per-subscriber overflow for an output frame, **coalesce** (do not drop the subscriber): merge/drop pending output and accumulate `droppedCount` onto the next output frame for that subscriber, keeping the connection alive (status-frame overflow keeps its existing drop behavior). On `final: true`, set `latestOutputCache.set(runId, frame)`. Extend `subscribe` snapshot delivery to also emit the cached final output (after `ready` is handled by the route, after the cached status). Clear `latestOutputCache` on the same teardown paths as `latestStatusCache` (terminal cleanup, `shutdown`). Keep the manager observer-only — no mutating run API added.
+
+**Execution note:** Test-first — the backpressure/coalescing and observer-only invariants are load-bearing; pin them before implementing.
+
+**Patterns to follow:** `latestStatusCache` lifecycle (`:239,489,503,602`); `enqueueFrame` byte accounting (`:303-331`); the `collectFrames`/`drain()` test harness; the existing backpressure (`:354`) and observer-only-invariant (`:717`) test blocks.
+
+**Test scenarios:**
+- Happy path: `observeOutput(runId, 'hello')` fans an `output` frame `{final:false, seq:0}` to a subscriber; a second call increments `seq`.
+- Happy path (final): `observeOutput(runId, 'full answer', {final:true})` sets the cache and fans a `final:true` frame.
+- R3 (late subscriber): a subscriber connecting after the final frame receives the cached final `output` frame on subscribe.
+- R5 (coalescing): a slow/overflowing subscriber's output frames coalesce — the connection stays alive and a later frame carries `droppedCount > 0`; a fast subscriber on the same run is unaffected (independent queues).
+- R5 (status overflow unchanged): a status-frame overflow still drops that subscriber (regression).
+- Edge (empty): `observeOutput(runId, '', {final:true})` produces a terminal output frame with empty text (R4 backstop).
+- Observer-only invariant: the manager deps type still has no mutating run API (extend the existing compile-time + behavioral assertion).
+
+**Verification:** `output` frames fan out and coalesce as specified; `latestOutputCache` delivers to late subscribers; observer-only invariant holds; manager tests green.
+
+- [ ] **Unit 3: Run-stream route `output` SSE event mapping**
+
+**Goal:** Map the `output` frame to a named SSE event on the wire.
+
+**Requirements:** R1, R8
+
+**Dependencies:** Unit 2.
+
+**Files:**
+- Modify: `packages/gateway/src/web/sse/run-stream-route.ts`
+- Test: `packages/gateway/src/web/sse/run-stream-route.test.ts`
+
+**Approach:** Add an `output` branch to `writeFrame` (`event: 'output', data: JSON.stringify({ runId, text, final, seq, droppedCount })`), satisfying the exhaustiveness `never` guard. The `ready` frame stays the always-first frame (do not regress). No new gates — output rides the existing auth/lease/cap path.
+
+**Patterns to follow:** the existing `status`/`reset` branches in `writeFrame`; the no-oracle assertion style.
+
+**Test scenarios:**
+- Happy path: an `output` frame is written as `event: 'output'` with the JSON payload.
+- Ordering: `ready` is still the first frame emitted, before any cached output replay.
+- Exhaustiveness: the `never` guard compiles (a missing branch would fail typecheck).
+
+**Verification:** `output` frames reach the wire as `event: 'output'`; `ready`-first preserved; route tests green.
+
+- [ ] **Unit 4: Wire the web ReplySink to push output (construction-order)**
+
+**Goal:** Make `createWebReplySink` push deltas + the final answer through `observeOutput`, and thread the manager into the launch route.
+
+**Requirements:** R1, R2, R7
+
+**Dependencies:** Unit 2.
+
+**Files:**
+- Modify: `packages/gateway/src/web/operator/web-sinks.ts` (`createWebReplySink` signature + `append`/`flush`), `packages/gateway/src/web/operator/launch-route.ts` (`LaunchRouteDeps` + the sink construction), `packages/gateway/src/web/server.ts` (thread `runObservationManager` into the `buildLaunchRoute` call)
+- Test: `packages/gateway/src/web/operator/web-sinks.test.ts`, `packages/gateway/src/web/operator/launch-route.test.ts`
+
+**Approach:** Change `createWebReplySink()` → `createWebReplySink({ runId, observeOutput })` where `observeOutput: (text, opts?) => void`. `append(text)` pushes a delta (`observeOutput(text)`); `flush()` pushes the final answer (`observeOutput(buffered(), { final: true })`) and stays otherwise a no-op for the HTTP response. Add `runObservationManager` to `LaunchRouteDeps`; thread it through `web/server.ts:671-698`; at `launch-route.ts:342` pass `createWebReplySink({ runId, observeOutput: (text, opts) => deps.runObservationManager.observeOutput(runId, text, opts) })`. The sink stays decoupled from the full manager (narrow callback only).
+
+**Test scenarios:**
+- Happy path: `append('a')` then `append('b')` invokes `observeOutput` twice with the delta text; `flush()` invokes it once with `{final:true}` carrying the buffered answer.
+- Edge (empty): `flush()` with an empty buffer still invokes `observeOutput('', {final:true})` (R4).
+- Integration: the launch route constructs the sink with a working `observeOutput` bound to the threaded manager + the route's runId (assert the captured sink pushes to the manager spy).
+
+**Verification:** the web sink pushes deltas + final answer to the manager; the launch route wires the manager + runId; Discord launch path untouched (its sink is a different construction).
+
+- [ ] **Unit 5: Engine-side ordering reorder**
+
+**Goal:** Ensure the final `output` frame is delivered before the terminal status frame by reordering the terminal observer notification after the final answer flush.
+
+**Requirements:** R2, R7
+
+**Dependencies:** Unit 4.
+
+**Files:**
+- Modify: `packages/gateway/src/execute/run.ts`
+- Test: `packages/gateway/src/execute/run.test.ts`
+
+**Approach:** Move `notifyObserverBestEffort(deps, completedResult.data.state)` (currently `:632`) to **after** `resolveToAnswer`/`flush` (`:640-644`), and the FAILED equivalent (`:698`) to after its flush (`:703`). This guarantees the web sink's `flush()` → final `output` frame is pushed before `observe(terminalState)` fans the terminal status (which closes subscribers). Verify the reorder is inert for Discord (Discord does not observe these frames; its `flush` posts to the thread independently).
+
+**Execution note:** Characterization-first — capture current Discord run completion + reply behavior before the reorder, so R7 zero-regression is provable.
+
+**Test scenarios:**
+- R2 (ordering): for a web run, the final `output` frame is observed before the terminal `status` frame (assert frame order via the manager harness or an observer spy ordering).
+- R7 (Discord unchanged): a successful Discord run still completes and posts its output; the reorder does not change Discord reply behavior (characterization test).
+- Edge (failure path): a FAILED run flushes partial output (final `output` frame) before the terminal failed status.
+
+**Verification:** terminal output precedes terminal status for web runs; Discord behavior byte-identical; run tests green.
+
+- [ ] **Unit 6: Docs refresh**
+
+**Goal:** Update the SSE solution doc and operator-contract notes to reflect the new `output` frame, and document the lease foot-gun.
+
+**Requirements:** R6, R8 (read-side closure)
+
+**Dependencies:** Units 1-5.
+
+**Files:**
+- Modify: `docs/solutions/best-practices/authenticated-sse-run-observation-2026-06-20.md` (note the `output` frame as an additive frame type under the closed-union/contract rules), `packages/gateway/AGENTS.md` if it documents the operator frame set.
+
+**Approach:** Add a short note that the `output` frame is sink-routed (not `RunState`-projected), rides the same lease, and that streaming sensitive content later must tighten the lease (the rule-8 foot-gun). Ancillary cleanup, not requirement-bearing.
+
+**Test scenarios:** Test expectation: none — docs only.
+
+**Verification:** the SSE doc reflects the `output` frame and the lease caveat.
+
+## System-Wide Impact
+
+- **Interaction graph:** the web `ReplySink.append`/`flush` now call into the manager's `observeOutput`; `run.ts` terminal-observer reorder affects both transports' call order (inert for Discord). The run-stream route gains an `output` event.
+- **Error propagation:** `observeOutput` is best-effort/fail-soft (a fan-out failure warns, never throws into the run); the auth/lease boundary stays fail-closed. The web sink's `flush` must not reject into the run (foot-gun: a sink `send` that can reject needs a `.catch`).
+- **State lifecycle risks:** `latestOutputCache` must be cleared on every teardown path that clears `latestStatusCache` (terminal, shutdown) or it leaks per-run final answers.
+- **API surface parity:** Discord already delivers output via its sink; this brings the web sink to parity without touching Discord.
+- **Integration coverage:** the launch-route → sink → manager → route wiring is the cross-layer chain (Unit 4 integration scenario); the ordering reorder is the run.ts → manager chain (Unit 5).
+- **Unchanged invariants:** the `RunState` projection (closed-DTO rule 5) is unchanged — output is a new frame type, not a new projected field; the manager stays observer-only; the no-oracle denial shape and the per-operator stream cap are unchanged; Discord behavior is unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Terminal status races ahead of the final answer (the core bug) | Engine-side reorder (Unit 5) + ordering test (R2); the final frame is enqueued before `observe(terminalState)` fans the terminal status. |
+| Reorder regresses Discord | Characterization-first test (Unit 5); the reorder is inert because Discord does not observe these frames. |
+| Late subscriber sees `succeeded` with no answer | `latestOutputCache` snapshot delivered on subscribe (Unit 2, R3). |
+| Output overflow drops the connection / loses text silently | Coalesce-keep-alive with `seq`+`droppedCount` (Unit 2, R5); final frame backstops completeness. |
+| `latestOutputCache` leaks per-run answers | Cleared on the same teardown paths as `latestStatusCache` (Unit 2); test the teardown. |
+| Sensitive output rides the ~6m-class lease window | Accepted for current sink-routed visible text; in-code foot-gun comment + doc note (Unit 6) that file/secret output must tighten the lease. |
+| A very large final answer exceeds the 64KB cap | Deferred-to-implementation: chunk the final frame into ordered deltas with the last `final:true`; confirm against `enqueueFrame` accounting. |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-20-stream-web-run-output-requirements.md](docs/brainstorms/2026-06-20-stream-web-run-output-requirements.md)
+- Related: `docs/solutions/best-practices/authenticated-sse-run-observation-2026-06-20.md` (the 10-rule checklist), `docs/solutions/best-practices/web-operator-launch-surface-2026-06-20.md` (names #965 as deferred), `docs/solutions/best-practices/gateway-control-surface-spine-2026-06-15.md` (sinks-over-transport), `docs/solutions/best-practices/atomic-serial-channel-queue-handoff-2026-06-09.md` (FIFO/ordering).
+- Issue: #965 (advances #907).

--- a/docs/solutions/best-practices/authenticated-sse-run-observation-2026-06-20.md
+++ b/docs/solutions/best-practices/authenticated-sse-run-observation-2026-06-20.md
@@ -171,6 +171,8 @@ if (authzResult.authorized === false) { onFail(); return }
 
 > ⚠️ The ~6-minute revocation window (the ~5.5m positive-authz cache TTL plus the 30s lease interval) is accepted **only because the streamed data is status-only** (run phase/status/timestamps). A surface streaming sensitive data — logs, file contents, secrets — must NOT reuse this window: it needs a cache-bypass re-check, a zero-TTL authz cache, or a much shorter lease interval.
 
+> **Update (#965 — `output` frame):** the stream now also carries an `output` frame with the agent's conversational text. This reuses the same lease window, accepted because the text is the *sink-routed visible output* (reasoning suppressed, tools summarized) the operator could already see in the Discord thread — it is operator-safe by the repo-authz boundary the stream already enforces, not by field-closure. **Foot-gun:** if a future change streams raw file contents, command output, or secrets through this frame, it must tighten the lease per the warning above — the current window is only acceptable for the existing sink-routed visible text.
+
 The lease is **fail-closed**: an unexpected throw inside the lease tick closes the stream (`onFail`), it does not silently leave the connection open. This is the opposite polarity from the fail-*soft* boundaries in [effect-failure-channel-discipline](effect-failure-channel-discipline-2026-06-10.md), but uses the same "one boundary, defect-proof" discipline — here the boundary must deny by default.
 
 ### 9. Per-operator stream cap keyed on the numeric user id
@@ -191,6 +193,8 @@ stream.writeSSE({event: 'ready', data: JSON.stringify({contractVersion: OPERATOR
 
 export type ResetReason = 'no-snapshot' | 'terminal' | 'shutdown' | 'max-duration' | 'writer-error' | 'overflow'
 ```
+
+The closed frame union is additive-by-contract: #965 added an `output` frame (`{ runId, text, final, seq, droppedCount? }`) and bumped `OPERATOR_CONTRACT_VERSION` to `1.3.0`. The frame's `text` is **sink-routed** (emitted by the engine through the operator-bound `ReplySink`), not extracted from `RunState` by the projection — so the closed-DTO discipline (rule 5) is unchanged: a new *frame type* is added, not a new *projected field*. Under per-subscriber backpressure, `output` frames **coalesce** (drop pending output, carry a cumulative `droppedCount`) rather than dropping the connection like status frames, and a `final: true` frame is cached so a late subscriber still receives the complete answer.
 
 ## Why This Matters
 

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -2916,6 +2916,167 @@ describe('runMention', () => {
       const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
       expect(transitionPhases).toContain('COMPLETED')
     })
+
+    // ── Observer notification ordering (the race fix) ────────────────────────
+    //
+    // Characterization: Discord successful run → flush posts output AND run completes normally.
+    // This pins the existing Discord behavior so the reorder is provably inert for Discord.
+    //
+    // Ordering: for a run with an observer, the final output flush fires BEFORE the observer
+    // receives the terminal COMPLETED/FAILED state. This is the load-bearing guarantee that
+    // the web sink's final output frame is delivered before the terminal status frame closes
+    // run subscribers.
+
+    it('characterization (Discord regression): successful Discord run completes and replySink.flush posts output — reorder is inert', async () => {
+      // #given — Discord surface; happy path; delegated answer path (flush posts the answer)
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const flushMock = vi.fn().mockResolvedValue({kind: 'sent' as const, charCount: 42})
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: flushMock,
+        buffered: vi.fn().mockReturnValue('the agent answer'),
+        markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
+      })
+
+      const completedState = buildMockRunState({phase: 'COMPLETED'})
+      mockRuntime.transitionRun
+        .mockResolvedValueOnce({
+          success: true as const,
+          data: {etag: 'ack-etag', state: buildMockRunState({phase: 'ACKNOWLEDGED'})},
+        })
+        .mockResolvedValueOnce({
+          success: true as const,
+          data: {etag: 'exec-etag', state: buildMockRunState({phase: 'EXECUTING'})},
+        })
+        .mockResolvedValueOnce({success: true as const, data: {etag: 'done-etag', state: completedState}})
+
+      const observeFn = vi.fn().mockResolvedValue(undefined)
+      const deps = makeDeps({runObserver: {observe: observeFn}})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — run completed (COMPLETED transition happened)
+      const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+      expect(transitionPhases).toContain('COMPLETED')
+
+      // #and — replySink.flush was called (Discord posts the answer via flush)
+      expect(flushMock).toHaveBeenCalledOnce()
+
+      // #and — observer was called with the COMPLETED state (Discord behavior unchanged)
+      const phases = observeFn.mock.calls.map((c: unknown[]) => (c[0] as {phase?: string}).phase)
+      expect(phases).toContain('COMPLETED')
+    })
+
+    it('ordering (COMPLETED path): replySink.flush is called BEFORE the observer receives the terminal COMPLETED state', async () => {
+      // #given — track call order between flush and observe(COMPLETED)
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+
+      const callOrder: string[] = []
+
+      const flushMock = vi.fn().mockImplementation(async () => {
+        callOrder.push('flush')
+        return {kind: 'sent' as const, charCount: 10}
+      })
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: flushMock,
+        buffered: vi.fn().mockReturnValue('answer'),
+        markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
+      })
+
+      const completedState = buildMockRunState({phase: 'COMPLETED'})
+      mockRuntime.transitionRun
+        .mockResolvedValueOnce({
+          success: true as const,
+          data: {etag: 'ack-etag', state: buildMockRunState({phase: 'ACKNOWLEDGED'})},
+        })
+        .mockResolvedValueOnce({
+          success: true as const,
+          data: {etag: 'exec-etag', state: buildMockRunState({phase: 'EXECUTING'})},
+        })
+        .mockResolvedValueOnce({success: true as const, data: {etag: 'done-etag', state: completedState}})
+
+      const observeFn = vi.fn().mockImplementation(async (state: {phase?: string}) => {
+        if (state.phase === 'COMPLETED') {
+          callOrder.push('observe-COMPLETED')
+        }
+        return Promise.resolve()
+      })
+      const deps = makeDeps({runObserver: {observe: observeFn}})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — flush happened before observe(COMPLETED)
+      const flushIdx = callOrder.indexOf('flush')
+      const observeIdx = callOrder.indexOf('observe-COMPLETED')
+      expect(flushIdx).toBeGreaterThanOrEqual(0)
+      expect(observeIdx).toBeGreaterThanOrEqual(0)
+      expect(flushIdx).toBeLessThan(observeIdx)
+    })
+
+    it('ordering (FAILED path): replySink.flush is called BEFORE the observer receives the terminal FAILED state', async () => {
+      // #given — track call order between flush and observe(FAILED)
+      const {runMention} = await import('./run.js')
+      setupHappyPath()
+      mockRunOpenCodeCore.mockRejectedValue(new Error('boom'))
+
+      const callOrder: string[] = []
+
+      const flushMock = vi.fn().mockImplementation(async () => {
+        callOrder.push('flush')
+        return {kind: 'sent' as const, charCount: 5}
+      })
+      mockCreateDiscordStreamSink.mockReturnValue({
+        append: vi.fn(),
+        flush: flushMock,
+        buffered: vi.fn().mockReturnValue('partial'),
+        markVisibleOutputSent: vi.fn(),
+        markVisibleOutputPending: vi.fn().mockReturnValue(vi.fn()),
+        hasVisibleOutput: vi.fn().mockReturnValue(false),
+      })
+
+      const failedState = buildMockRunState({phase: 'FAILED'})
+      mockRuntime.transitionRun
+        .mockResolvedValueOnce({
+          success: true as const,
+          data: {etag: 'ack-etag', state: buildMockRunState({phase: 'ACKNOWLEDGED'})},
+        })
+        .mockResolvedValueOnce({
+          success: true as const,
+          data: {etag: 'exec-etag', state: buildMockRunState({phase: 'EXECUTING'})},
+        })
+        .mockResolvedValueOnce({success: true as const, data: {etag: 'fail-etag', state: failedState}})
+
+      const observeFn = vi.fn().mockImplementation(async (state: {phase?: string}) => {
+        if (state.phase === 'FAILED') {
+          callOrder.push('observe-FAILED')
+        }
+        return Promise.resolve()
+      })
+      const deps = makeDeps({runObserver: {observe: observeFn}})
+      const message = makeMessage()
+
+      // #when
+      await runMention(message, makeBinding(), deps)
+
+      // #then — flush happened before observe(FAILED)
+      const flushIdx = callOrder.indexOf('flush')
+      const observeIdx = callOrder.indexOf('observe-FAILED')
+      expect(flushIdx).toBeGreaterThanOrEqual(0)
+      expect(observeIdx).toBeGreaterThanOrEqual(0)
+      expect(flushIdx).toBeLessThan(observeIdx)
+    })
   })
 
   // ── Status controller wiring ─────────────────────────────────────────────

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -624,12 +624,17 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
         runEtag,
         coordLogger,
       )
+      // Capture the COMPLETED state now so we can notify AFTER the final-answer flush.
+      // The notify is deferred to guarantee the web sink's flush() → final output frame
+      // is pushed before observe(terminalState) fans the terminal status frame (which
+      // closes run subscribers). For Discord, the reorder is inert: Discord does not
+      // observe these frames; its flush posts to the thread independently.
+      let completedStateForNotify: RunState | undefined
       if (completedResult.success === false) {
         logger.error({repo, runId, err: completedResult.error.message}, 'run: transitionRun COMPLETED failed')
         // Non-fatal: continue to flush sink and release resources
       } else {
-        // Push the COMPLETED state to the observation pipeline (best-effort, fire-and-forget).
-        notifyObserverBestEffort(deps, completedResult.data.state)
+        completedStateForNotify = completedResult.data.state
       }
 
       // ── Status controller final-answer transition ─────────────────────────────────────────────
@@ -643,6 +648,13 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
         await replySink.flush()
       }
       // 'handled': answer is already in the status message — do not flush (would double-post).
+
+      // Push the COMPLETED state to the observation pipeline AFTER the final-answer flush.
+      // This guarantees the web sink's final output frame is delivered before the terminal
+      // status frame (which closes run subscribers). Best-effort, fire-and-forget.
+      if (completedStateForNotify !== undefined) {
+        notifyObserverBestEffort(deps, completedStateForNotify)
+      }
     } catch (execError: unknown) {
       // ── Error classification ───────────────────────────────────────────────
 
@@ -691,11 +703,15 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
         runEtag,
         coordLogger,
       )
+      // Capture the FAILED state now so we can notify AFTER the partial-output flush.
+      // The notify is deferred to guarantee the web sink's flush() → final output frame
+      // is pushed before observe(terminalState) fans the terminal status frame (which
+      // closes run subscribers). For Discord, the reorder is inert.
+      let failedStateForNotify: RunState | undefined
       if (failedResult.success === false) {
         logger.error({repo, runId, err: failedResult.error.message}, 'run: transitionRun FAILED failed')
       } else {
-        // Push the FAILED state to the observation pipeline (best-effort, fire-and-forget).
-        notifyObserverBestEffort(deps, failedResult.data.state)
+        failedStateForNotify = failedResult.data.state
       }
 
       // Flush partial output (best-effort) so the user sees whatever streamed before the failure.
@@ -703,6 +719,13 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       await replySink.flush().catch((flushError: unknown) => {
         logger.warn({repo, runId, err: String(flushError)}, 'run: sink.flush failed in error path')
       })
+
+      // Push the FAILED state to the observation pipeline AFTER the partial-output flush.
+      // This guarantees the web sink's final output frame is delivered before the terminal
+      // status frame (which closes run subscribers). Best-effort, fire-and-forget.
+      if (failedStateForNotify !== undefined) {
+        notifyObserverBestEffort(deps, failedStateForNotify)
+      }
 
       // Coarse user message — no internal detail
       const timeoutDuration = formatTimeoutDuration(runTimeoutMs)

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -645,7 +645,9 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       const finalText = replySink.buffered()
       const answerResult = await statusSink.resolveToAnswer(finalText)
       if (answerResult.transition === 'delegated') {
-        await replySink.flush()
+        await replySink.flush().catch((flushError: unknown) => {
+          logger.warn({repo, runId, err: String(flushError)}, 'run: sink.flush failed in completed path')
+        })
       }
       // 'handled': answer is already in the status message — do not flush (would double-post).
 

--- a/packages/gateway/src/http/ingress-pin.test.ts
+++ b/packages/gateway/src/http/ingress-pin.test.ts
@@ -218,6 +218,7 @@ function makeBrowserGuardStubDeps(): OperatorServerDeps {
     },
     runObservationManager: {
       observe: vi.fn(async () => undefined),
+      observeOutput: vi.fn(),
       subscribe: vi.fn(() => () => undefined),
       abortSubscription: vi.fn(),
       shutdown: vi.fn(),

--- a/packages/gateway/src/operator-contract/index.ts
+++ b/packages/gateway/src/operator-contract/index.ts
@@ -17,6 +17,7 @@
 export type {DecisionInput, OperatorDecisionState, PermissionReply} from './approval.js'
 export {toOperatorDecisionState} from './approval.js'
 export type {OperatorIdentity} from './identity.js'
+export type {OperatorOutputFrame} from './output.js'
 export {parseOperatorCsrfToken, parseOperatorError, parseOperatorOk, parseOperatorSessionInfo} from './parse.js'
 export {assertRedactionApplied, AUTHORIZATION_OBLIGATION, REDACTION_OBLIGATION} from './redaction.js'
 export type {RedactionContext} from './redaction.js'

--- a/packages/gateway/src/operator-contract/output.test.ts
+++ b/packages/gateway/src/operator-contract/output.test.ts
@@ -1,0 +1,207 @@
+/**
+ * output.test.ts — Contract tests for the OperatorOutputFrame type.
+ *
+ * Covers:
+ * 1. Type shape — required fields are present; droppedCount is optional.
+ * 2. Delta frame semantics — final: false, seq monotonic.
+ * 3. Terminal frame semantics — final: true, text is the complete answer.
+ * 4. Barrel re-export — OperatorOutputFrame is importable from the contract barrel.
+ */
+
+import type {OperatorOutputFrame} from './output.js'
+
+import {describe, expect, expectTypeOf, it} from 'vitest'
+
+// ---------------------------------------------------------------------------
+// 1. Type shape — required fields and optional droppedCount
+// ---------------------------------------------------------------------------
+
+describe('OperatorOutputFrame — type shape', () => {
+  it('accepts a valid delta frame (all required fields, no droppedCount)', () => {
+    // #given a minimal delta frame with all required fields
+    const frame: OperatorOutputFrame = {
+      runId: 'run-abc-123',
+      text: 'Hello, ',
+      final: false,
+      seq: 0,
+    }
+
+    // #when the frame is constructed
+    // #then all required fields are present and correct
+    expect(frame.runId).toBe('run-abc-123')
+    expect(frame.text).toBe('Hello, ')
+    expect(frame.final).toBe(false)
+    expect(frame.seq).toBe(0)
+  })
+
+  it('accepts a valid terminal frame (all required fields, no droppedCount)', () => {
+    // #given a terminal frame with final: true
+    const frame: OperatorOutputFrame = {
+      runId: 'run-abc-123',
+      text: 'Hello, world!',
+      final: true,
+      seq: 3,
+    }
+
+    // #when the frame is constructed
+    // #then final is true and seq is the last monotonic value
+    expect(frame.final).toBe(true)
+    expect(frame.seq).toBe(3)
+    expect(frame.text).toBe('Hello, world!')
+  })
+
+  it('accepts a frame with droppedCount present (coalescing signal)', () => {
+    // #given a frame that carries a droppedCount (backpressure coalescing occurred)
+    const frame: OperatorOutputFrame = {
+      runId: 'run-abc-123',
+      text: 'partial output',
+      final: false,
+      seq: 5,
+      droppedCount: 2,
+    }
+
+    // #when the frame is constructed
+    // #then droppedCount is present and reflects the number of elided deltas
+    expect(frame.droppedCount).toBe(2)
+  })
+
+  it('droppedCount is optional — a frame without it is valid', () => {
+    // #given a frame without droppedCount
+    const frame: OperatorOutputFrame = {
+      runId: 'run-xyz',
+      text: 'output text',
+      final: false,
+      seq: 1,
+    }
+
+    // #when the frame is constructed
+    // #then droppedCount is absent (undefined)
+    expect(frame.droppedCount).toBeUndefined()
+  })
+
+  it('type has the required fields at the type level', () => {
+    // #given the OperatorOutputFrame type
+    // #when inspected at the type level
+    // #then all required fields are present in the type
+    expectTypeOf<OperatorOutputFrame>().toHaveProperty('runId')
+    expectTypeOf<OperatorOutputFrame>().toHaveProperty('text')
+    expectTypeOf<OperatorOutputFrame>().toHaveProperty('final')
+    expectTypeOf<OperatorOutputFrame>().toHaveProperty('seq')
+  })
+
+  it('type has droppedCount as an optional field', () => {
+    // #given the OperatorOutputFrame type
+    // #when inspected at the type level
+    // #then droppedCount is present in the type (optional — number | undefined)
+    expectTypeOf<OperatorOutputFrame>().toHaveProperty('droppedCount')
+    expectTypeOf<OperatorOutputFrame['droppedCount']>().toEqualTypeOf<number | undefined>()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. Delta frame semantics
+// ---------------------------------------------------------------------------
+
+describe('OperatorOutputFrame — delta frame semantics', () => {
+  it('delta frames have final: false', () => {
+    // #given a sequence of delta frames
+    const deltas: OperatorOutputFrame[] = [
+      {runId: 'run-1', text: 'chunk-a', final: false, seq: 0},
+      {runId: 'run-1', text: 'chunk-b', final: false, seq: 1},
+      {runId: 'run-1', text: 'chunk-c', final: false, seq: 2},
+    ]
+
+    // #when each frame is inspected
+    // #then all have final: false
+    for (const frame of deltas) {
+      expect(frame.final).toBe(false)
+    }
+  })
+
+  it('seq is monotonically increasing across delta frames', () => {
+    // #given a sequence of delta frames with ascending seq values
+    const deltas: OperatorOutputFrame[] = [
+      {runId: 'run-1', text: 'a', final: false, seq: 0},
+      {runId: 'run-1', text: 'b', final: false, seq: 1},
+      {runId: 'run-1', text: 'c', final: false, seq: 2},
+    ]
+
+    // #when seq values are extracted
+    const seqs = deltas.map(f => f.seq)
+
+    // #then each seq is strictly greater than the previous
+    for (let i = 1; i < seqs.length; i++) {
+      const prev = seqs[i - 1]
+      const curr = seqs[i]
+      expect(curr).toBeGreaterThan(prev as number)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3. Terminal frame semantics
+// ---------------------------------------------------------------------------
+
+describe('OperatorOutputFrame — terminal frame semantics', () => {
+  it('terminal frame has final: true', () => {
+    // #given a terminal frame
+    const terminal: OperatorOutputFrame = {
+      runId: 'run-1',
+      text: 'The complete answer.',
+      final: true,
+      seq: 5,
+    }
+
+    // #when the frame is inspected
+    // #then final is true
+    expect(terminal.final).toBe(true)
+  })
+
+  it('terminal frame with empty text is valid (no-output run)', () => {
+    // #given a terminal frame for a run that produced no output
+    const terminal: OperatorOutputFrame = {
+      runId: 'run-empty',
+      text: '',
+      final: true,
+      seq: 0,
+    }
+
+    // #when the frame is inspected
+    // #then text is empty string (not undefined — distinguishes "no output" from "missing output")
+    expect(terminal.text).toBe('')
+    expect(terminal.final).toBe(true)
+  })
+
+  it('terminal frame may carry droppedCount when prior deltas were coalesced', () => {
+    // #given a terminal frame where backpressure caused delta coalescing
+    const terminal: OperatorOutputFrame = {
+      runId: 'run-1',
+      text: 'Complete answer despite dropped deltas.',
+      final: true,
+      seq: 10,
+      droppedCount: 7,
+    }
+
+    // #when the frame is inspected
+    // #then droppedCount reflects the number of elided deltas
+    expect(terminal.droppedCount).toBe(7)
+    // #then text is still the complete answer (not partial)
+    expect(terminal.text).toBe('Complete answer despite dropped deltas.')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 4. Barrel re-export smoke test
+// ---------------------------------------------------------------------------
+
+describe('barrel re-exports', () => {
+  it('type is re-exported from the contract barrel', async () => {
+    // #given the public barrel for the operator-contract module
+    // #when the barrel is imported
+    const barrel = await import('./index.js')
+
+    // #then the barrel module is importable without error (type-only export;
+    // runtime proof: OPERATOR_CONTRACT_VERSION is present, confirming the barrel loads)
+    expect(typeof barrel.OPERATOR_CONTRACT_VERSION).toBe('string')
+  })
+})

--- a/packages/gateway/src/operator-contract/output.ts
+++ b/packages/gateway/src/operator-contract/output.ts
@@ -1,0 +1,40 @@
+/**
+ * Output frame contract for the operator run-stream.
+ *
+ * Carries the agent's visible output text to an operator subscribed to a run's
+ * SSE stream. Two frame modes:
+ *
+ * - **Delta frame** (`final: false`): appended live as the agent produces output.
+ *   Clients accumulate these to build the in-progress answer.
+ * - **Terminal frame** (`final: true`): replaces the accumulated live text with
+ *   the authoritative complete answer. Guaranteed to arrive before the terminal
+ *   status frame. A run with no output still produces a terminal frame (empty
+ *   `text`) so the client can distinguish "no output" from "missing output".
+ *
+ * `seq` is monotonic per run (starts at 0, increments by 1 per frame). Clients
+ * can detect gaps caused by coalescing via `droppedCount`.
+ *
+ * `droppedCount` (when present) tells the client how many prior delta frames
+ * were coalesced or elided under per-subscriber backpressure. The terminal frame
+ * always carries the complete answer regardless of how many deltas were dropped.
+ */
+
+// ---------------------------------------------------------------------------
+// OperatorOutputFrame — operator-facing output frame
+// ---------------------------------------------------------------------------
+
+/**
+ * An output frame delivered over the operator run-stream.
+ *
+ * Delta frames (`final: false`) append live output; the terminal frame
+ * (`final: true`) replaces with the authoritative complete answer.
+ * `seq` is monotonic per run; `droppedCount` (when present) indicates
+ * how many prior deltas were coalesced/elided under backpressure.
+ */
+export interface OperatorOutputFrame {
+  readonly runId: string
+  readonly text: string
+  readonly final: boolean
+  readonly seq: number
+  readonly droppedCount?: number
+}

--- a/packages/gateway/src/operator-contract/version.test.ts
+++ b/packages/gateway/src/operator-contract/version.test.ts
@@ -2,11 +2,11 @@ import {describe, expect, it} from 'vitest'
 import {OPERATOR_CONTRACT_VERSION} from './version.js'
 
 describe('OPERATOR_CONTRACT_VERSION', () => {
-  it('is pinned to 1.2.0', () => {
+  it('is pinned to 1.3.0', () => {
     // #given the contract version constant
     // #when read at import time
     // #then it is exactly the pinned literal
-    expect(OPERATOR_CONTRACT_VERSION).toBe('1.2.0')
+    expect(OPERATOR_CONTRACT_VERSION).toBe('1.3.0')
   })
 
   it('is importable from the contract barrel', async () => {

--- a/packages/gateway/src/operator-contract/version.ts
+++ b/packages/gateway/src/operator-contract/version.ts
@@ -12,4 +12,4 @@
 // Security constraint: the version is BUILD-TIME pinned and is never supplied or
 // negotiated over the wire. Any endpoint reading a version header must reject
 // unrecognized versions fail-closed.
-export const OPERATOR_CONTRACT_VERSION = '1.2.0'
+export const OPERATOR_CONTRACT_VERSION = '1.3.0'

--- a/packages/gateway/src/web/operator/launch-route.test.ts
+++ b/packages/gateway/src/web/operator/launch-route.test.ts
@@ -176,6 +176,8 @@ function makeDeps(overrides?: Partial<LaunchRouteDeps>): LaunchRouteDeps {
     // Pass-through rate limiters (always allow) for most tests
     perMinRateLimiter: {allow: () => true},
     perHrRateLimiter: {allow: () => true},
+    // runObservationManager absent by default — tests that exercise output routing
+    // pass it explicitly via overrides.
     ...overrides,
   }
 }
@@ -1034,5 +1036,104 @@ describe('LaunchAdmission type — compile-time shape check', () => {
     const rejected: LaunchAdmission = {accepted: false, reason: 'cap'}
     expect(rejected.accepted).toBe(false)
     expect((rejected as {accepted: false; reason: string}).reason).toBe('cap')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ReplySink wired to runObservationManager — output routing
+// ---------------------------------------------------------------------------
+
+describe('POST /operator/runs — replySink wired to runObservationManager', () => {
+  it('replySink append routes output delta to manager.observeOutput with the route runId', async () => {
+    // #given — a manager spy and a captured replySink from launchWork
+    const observeOutput = vi.fn()
+    const runObservationManager = {observeOutput}
+
+    let capturedReplySink: {append: (t: string) => void; flush: () => Promise<unknown>} | undefined
+    let capturedRunId: string | undefined
+    mockLaunchWork.mockImplementationOnce(
+      async (request: {readonly runId?: string; readonly replySink?: typeof capturedReplySink}) => {
+        capturedReplySink = request.replySink
+        capturedRunId = request.runId
+        return {accepted: true, runId: request.runId ?? 'mock-run-id'}
+      },
+    )
+
+    const deps = makeDeps({runObservationManager})
+    const app = buildApp(deps)
+
+    // #when — launch the route so launchWork captures the replySink
+    const response = await postRuns(app, {repo: 'acme/widget', prompt: 'do something'})
+    expect(response.status).toBe(202)
+    if (capturedReplySink === undefined || capturedRunId === undefined)
+      throw new Error('launchWork did not capture replySink/runId')
+
+    // #when — simulate the engine appending output text
+    capturedReplySink.append('hello ')
+    capturedReplySink.append('world')
+
+    // #then — each append pushed a delta to the manager with the route's runId
+    // opts is undefined for delta frames (no final flag)
+    expect(observeOutput).toHaveBeenCalledTimes(2)
+    expect(observeOutput).toHaveBeenNthCalledWith(1, capturedRunId, 'hello ', undefined)
+    expect(observeOutput).toHaveBeenNthCalledWith(2, capturedRunId, 'world', undefined)
+  })
+
+  it('replySink flush routes final answer to manager.observeOutput with final:true', async () => {
+    // #given — a manager spy and a captured replySink from launchWork
+    const observeOutput = vi.fn()
+    const runObservationManager = {observeOutput}
+
+    let capturedReplySink: {append: (t: string) => void; flush: () => Promise<unknown>} | undefined
+    let capturedRunId: string | undefined
+    mockLaunchWork.mockImplementationOnce(
+      async (request: {readonly runId?: string; readonly replySink?: typeof capturedReplySink}) => {
+        capturedReplySink = request.replySink
+        capturedRunId = request.runId
+        return {accepted: true, runId: request.runId ?? 'mock-run-id'}
+      },
+    )
+
+    const deps = makeDeps({runObservationManager})
+    const app = buildApp(deps)
+
+    // #when — launch and simulate engine output
+    const response = await postRuns(app, {repo: 'acme/widget', prompt: 'do something'})
+    expect(response.status).toBe(202)
+    if (capturedReplySink === undefined || capturedRunId === undefined)
+      throw new Error('launchWork did not capture replySink/runId')
+    capturedReplySink.append('the answer')
+    observeOutput.mockClear() // clear the append delta call
+
+    // #when — engine flushes (terminal)
+    await capturedReplySink.flush()
+
+    // #then — final frame pushed with the full buffer and final:true
+    expect(observeOutput).toHaveBeenCalledTimes(1)
+    expect(observeOutput).toHaveBeenCalledWith(capturedRunId, 'the answer', {final: true})
+  })
+
+  it('replySink degrades to a no-op when runObservationManager is absent', async () => {
+    // #given — no manager in deps
+    let capturedReplySink: {append: (t: string) => void; flush: () => Promise<unknown>} | undefined
+    mockLaunchWork.mockImplementationOnce(
+      async (request: {readonly runId?: string; readonly replySink?: typeof capturedReplySink}) => {
+        capturedReplySink = request.replySink
+        return {accepted: true, runId: request.runId ?? 'mock-run-id'}
+      },
+    )
+
+    const deps = makeDeps() // no runObservationManager
+    const app = buildApp(deps)
+
+    // #when
+    const response = await postRuns(app, {repo: 'acme/widget', prompt: 'do something'})
+    expect(response.status).toBe(202)
+    if (capturedReplySink === undefined) throw new Error('launchWork did not capture replySink')
+    const sink = capturedReplySink
+
+    // #when — append and flush do not throw (graceful no-op)
+    expect(() => sink.append('some text')).not.toThrow()
+    await expect(sink.flush()).resolves.toBeUndefined()
   })
 })

--- a/packages/gateway/src/web/operator/launch-route.ts
+++ b/packages/gateway/src/web/operator/launch-route.ts
@@ -44,6 +44,7 @@ import type {RateLimiter} from '../../http/rate-limit.js'
 import type {RepoKey} from '../../redaction/denylist.js'
 import type {RepoAuthzDeps} from '../auth/repo-authz.js'
 import type {OperatorLogger} from '../server.js'
+import type {RunObservationManager} from '../sse/manager.js'
 import type {IdempotencyGuard} from './idempotency.js'
 import {randomUUID} from 'node:crypto'
 import {launchWork} from '../../execute/run.js'
@@ -125,6 +126,14 @@ export interface LaunchRouteDeps {
    * When absent, a fresh limiter is created with LAUNCH_RATE_LIMIT_PER_HR.
    */
   readonly perHrRateLimiter?: RateLimiter
+  /**
+   * Run-observation manager for wiring the web ReplySink's output to the SSE
+   * run-stream. When present, append() pushes live deltas and flush() pushes
+   * the final answer frame via manager.observeOutput(runId, text, opts).
+   * When absent (e.g. in tests that don't exercise streaming), output is
+   * buffered but not streamed — the sink degrades gracefully to a no-op.
+   */
+  readonly runObservationManager?: Pick<RunObservationManager, 'observeOutput'>
 }
 
 // ---------------------------------------------------------------------------
@@ -316,10 +325,10 @@ export function buildLaunchRoute(app: Hono, deps: LaunchRouteDeps): void {
     // and web prompt builder. The channelId is a deterministic, namespaced,
     // opaque scope key that cannot equal a Discord snowflake.
     //
-    // v1 web launches deliver run STATUS via the SSE stream only; agent output
-    // text is not streamed to the operator yet (a follow-up). The web replySink
-    // accumulates text in memory but does not deliver it — the operator observes
-    // run phase/status via GET /operator/runs/:runId/stream.
+    // The web replySink is wired to the run-observation manager so subscribers
+    // on GET /operator/runs/:runId/stream receive live output deltas and a
+    // terminal final-answer frame. When the manager is absent (e.g. in tests
+    // that don't exercise streaming), the sink degrades to a buffering no-op.
     //
     // launchWork returns after ADMISSION (not after the run). The gateway in-flight
     // set owns the immediate-run promise; awaiting here does NOT hang the connection.
@@ -330,6 +339,15 @@ export function buildLaunchRoute(app: Hono, deps: LaunchRouteDeps): void {
       sessionCorrelationId: sessionId,
     }
 
+    const manager = deps.runObservationManager
+    const observeOutput =
+      manager === undefined
+        ? (_text: string, _opts?: {final?: boolean; droppedCount?: number}): void => {
+            // No-op: manager absent (e.g. in tests that don't exercise streaming).
+          }
+        : (text: string, opts?: {final?: boolean; droppedCount?: number}): void =>
+            manager.observeOutput(runId, text, opts)
+
     const request = {
       promptText: promptField,
       runId,
@@ -339,7 +357,7 @@ export function buildLaunchRoute(app: Hono, deps: LaunchRouteDeps): void {
       binding,
       requester: operatorIdentity,
       statusSink: createWebStatusSink(),
-      replySink: createWebReplySink(),
+      replySink: createWebReplySink({runId, observeOutput}),
       createApprovalOnPending: createWebAutoDenyApproval(deps.logger),
       promptBuilder: buildWebPrompt,
     }

--- a/packages/gateway/src/web/operator/web-sinks.test.ts
+++ b/packages/gateway/src/web/operator/web-sinks.test.ts
@@ -2,7 +2,7 @@
  * Tests for the minimal web StatusSink and ReplySink implementations.
  */
 
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 import {createWebReplySink, createWebStatusSink} from './web-sinks.js'
 
 describe('createWebStatusSink', () => {
@@ -66,9 +66,18 @@ describe('createWebStatusSink', () => {
 })
 
 describe('createWebReplySink', () => {
+  type ObserveOutputFn = (text: string, opts?: {final?: boolean; droppedCount?: number}) => void
+
+  function makeDeps(overrides?: {observeOutput?: ObserveOutputFn}) {
+    return {
+      runId: 'run-abc-123',
+      observeOutput: overrides?.observeOutput ?? vi.fn<ObserveOutputFn>(),
+    }
+  }
+
   it('append accumulates text in the buffer', () => {
     // #given
-    const sink = createWebReplySink()
+    const sink = createWebReplySink(makeDeps())
 
     // #when
     sink.append('hello ')
@@ -78,21 +87,55 @@ describe('createWebReplySink', () => {
     expect(sink.buffered()).toBe('hello world')
   })
 
-  it('flush is a no-op and resolves', async () => {
+  it('append calls observeOutput with each delta text', () => {
     // #given
-    const sink = createWebReplySink()
-    sink.append('some output')
+    const observeOutput = vi.fn<ObserveOutputFn>()
+    const sink = createWebReplySink(makeDeps({observeOutput}))
+
+    // #when
+    sink.append('a')
+    sink.append('b')
+
+    // #then — two delta calls, each with the appended text
+    expect(observeOutput).toHaveBeenCalledTimes(2)
+    expect(observeOutput).toHaveBeenNthCalledWith(1, 'a')
+    expect(observeOutput).toHaveBeenNthCalledWith(2, 'b')
+  })
+
+  it('flush calls observeOutput with the full buffer and final:true', async () => {
+    // #given
+    const observeOutput = vi.fn<ObserveOutputFn>()
+    const sink = createWebReplySink(makeDeps({observeOutput}))
+    sink.append('hello ')
+    sink.append('world')
+    observeOutput.mockClear() // clear the append calls
 
     // #when
     const result = await sink.flush()
 
-    // #then — no-op, returns undefined
+    // #then — one final call with the full buffer
+    expect(observeOutput).toHaveBeenCalledTimes(1)
+    expect(observeOutput).toHaveBeenCalledWith('hello world', {final: true})
+    expect(result).toBeUndefined()
+  })
+
+  it('flush with empty buffer still calls observeOutput with empty string and final:true', async () => {
+    // #given — no appends before flush
+    const observeOutput = vi.fn<ObserveOutputFn>()
+    const sink = createWebReplySink(makeDeps({observeOutput}))
+
+    // #when
+    const result = await sink.flush()
+
+    // #then — empty-final backstop: guarantees a terminal output frame even with no output
+    expect(observeOutput).toHaveBeenCalledTimes(1)
+    expect(observeOutput).toHaveBeenCalledWith('', {final: true})
     expect(result).toBeUndefined()
   })
 
   it('buffered returns accumulated text without flushing', () => {
     // #given
-    const sink = createWebReplySink()
+    const sink = createWebReplySink(makeDeps())
     sink.append('partial')
 
     // #when
@@ -105,7 +148,7 @@ describe('createWebReplySink', () => {
 
   it('hasVisibleOutput returns false initially', () => {
     // #given
-    const sink = createWebReplySink()
+    const sink = createWebReplySink(makeDeps())
 
     // #when / #then
     expect(sink.hasVisibleOutput()).toBe(false)
@@ -113,7 +156,7 @@ describe('createWebReplySink', () => {
 
   it('markVisibleOutputSent causes hasVisibleOutput to return true', () => {
     // #given
-    const sink = createWebReplySink()
+    const sink = createWebReplySink(makeDeps())
 
     // #when
     sink.markVisibleOutputSent()
@@ -124,7 +167,7 @@ describe('createWebReplySink', () => {
 
   it('markVisibleOutputPending causes hasVisibleOutput to return true while pending', () => {
     // #given
-    const sink = createWebReplySink()
+    const sink = createWebReplySink(makeDeps())
 
     // #when
     const settle = sink.markVisibleOutputPending()
@@ -141,7 +184,7 @@ describe('createWebReplySink', () => {
 
   it('markVisibleOutputPending settle(false) retracts the pending claim', () => {
     // #given
-    const sink = createWebReplySink()
+    const sink = createWebReplySink(makeDeps())
 
     // #when
     const settle = sink.markVisibleOutputPending()
@@ -156,7 +199,7 @@ describe('createWebReplySink', () => {
 
   it('send is a no-op and resolves', async () => {
     // #given
-    const sink = createWebReplySink()
+    const sink = createWebReplySink(makeDeps())
 
     // #when
     const result = await sink.send('source', {content: 'hello'})
@@ -167,7 +210,7 @@ describe('createWebReplySink', () => {
 
   it('send with thread target is also a no-op', async () => {
     // #given
-    const sink = createWebReplySink()
+    const sink = createWebReplySink(makeDeps())
 
     // #when
     const result = await sink.send('thread', {content: 'error message'})

--- a/packages/gateway/src/web/operator/web-sinks.ts
+++ b/packages/gateway/src/web/operator/web-sinks.ts
@@ -8,10 +8,9 @@
  * The web surface has no Discord thread, no typing indicator, and no reaction
  * emoji. All methods are no-ops or return the minimal required values.
  *
- * v1 limitation: web launches deliver run STATUS via the SSE stream only.
- * Agent output text is accumulated in the ReplySink buffer but is not streamed
- * to the operator — the web replySink is a no-op for delivery. A follow-up will
- * wire agent output text to the SSE stream so operators can observe it in real time.
+ * The web ReplySink is wired to the run-observation manager: append() pushes
+ * live deltas and flush() pushes the final answer frame. Subscribers on the
+ * SSE run-stream route receive output frames as the agent produces them.
  */
 
 import type {MessageContentOptions} from '../../discord/io.js'
@@ -67,19 +66,28 @@ export function createWebStatusSink(): StatusSink {
 // ---------------------------------------------------------------------------
 
 /**
- * Create a minimal web ReplySink.
+ * Create a minimal web ReplySink wired to the run-observation manager.
  *
- * Streaming output (append/flush) and acks are no-ops for the web
- * surface. The operator observes run output via the SSE run-stream route,
- * not via inline response content.
+ * append(text) buffers the text AND pushes a live delta to the manager via
+ * deps.observeOutput(text) so subscribers see output as it arrives.
+ *
+ * flush() pushes the final answer frame deps.observeOutput(buffer, {final:true})
+ * before returning undefined. This fires even when the buffer is empty (the
+ * empty-final backstop — guarantees every run produces a terminal output frame).
  *
  * buffered() returns the accumulated text so the engine can pass it to
  * statusSink.resolveToAnswer — even though the web status sink ignores it.
  *
  * hasVisibleOutput() returns false so the engine does not suppress the
  * "no output" placeholder path (which is also a no-op for web).
+ *
+ * The deps.observeOutput callback is already run-scoped by the caller (the
+ * caller binds runId); the sink receives a narrow callback, not the full manager.
  */
-export function createWebReplySink(): ReplySink {
+export function createWebReplySink(deps: {
+  readonly runId: string
+  readonly observeOutput: (text: string, opts?: {final?: boolean; droppedCount?: number}) => void
+}): ReplySink {
   let buffer = ''
   let visibleOutputSent = false
   let pendingCount = 0
@@ -87,10 +95,11 @@ export function createWebReplySink(): ReplySink {
   return {
     append: (text: string): void => {
       buffer += text
+      deps.observeOutput(text)
     },
 
     flush: async (): Promise<unknown> => {
-      // No-op: web surface does not deliver output inline.
+      deps.observeOutput(buffer, {final: true})
       return undefined
     },
 

--- a/packages/gateway/src/web/operator/web-sinks.ts
+++ b/packages/gateway/src/web/operator/web-sinks.ts
@@ -95,11 +95,19 @@ export function createWebReplySink(deps: {
   return {
     append: (text: string): void => {
       buffer += text
-      deps.observeOutput(text)
+      try {
+        deps.observeOutput(text)
+      } catch {
+        // Fail-soft: a manager error must never break the run's streaming loop.
+      }
     },
 
     flush: async (): Promise<unknown> => {
-      deps.observeOutput(buffer, {final: true})
+      try {
+        deps.observeOutput(buffer, {final: true})
+      } catch {
+        // Fail-soft: a manager error must never break the run's streaming loop.
+      }
       return undefined
     },
 

--- a/packages/gateway/src/web/operator/web-sinks.ts
+++ b/packages/gateway/src/web/operator/web-sinks.ts
@@ -78,8 +78,9 @@ export function createWebStatusSink(): StatusSink {
  * buffered() returns the accumulated text so the engine can pass it to
  * statusSink.resolveToAnswer — even though the web status sink ignores it.
  *
- * hasVisibleOutput() returns false so the engine does not suppress the
- * "no output" placeholder path (which is also a no-op for web).
+ * hasVisibleOutput() reflects whether visible output was sent or is in flight
+ * (visibleOutputSent || pendingCount > 0), so the engine's timeout/no-output
+ * classification matches what the operator actually saw.
  *
  * The deps.observeOutput callback is already run-scoped by the caller (the
  * caller binds runId); the sink receives a narrow callback, not the full manager.

--- a/packages/gateway/src/web/server.test.ts
+++ b/packages/gateway/src/web/server.test.ts
@@ -1635,6 +1635,7 @@ describe('buildOperatorApp — optional streaming deps accepted without error', 
     }
     const stubRunObservationManager: import('./server.js').OperatorServerDeps['runObservationManager'] = {
       observe: async () => undefined,
+      observeOutput: () => undefined,
       subscribe: () => () => undefined,
       abortSubscription: () => undefined,
       shutdown: () => undefined,

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -695,6 +695,11 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
       launchWorkDeps: deps.launchWorkDeps,
       logger: deps.logger,
       now: clock,
+      // Wire the observation manager so the web ReplySink pushes output deltas
+      // and the final answer frame to SSE subscribers. Optional — when absent
+      // (e.g. in tests that don't exercise streaming), the sink degrades to a
+      // buffering no-op. Mirrors the optional pattern used by buildRunStreamRoute.
+      runObservationManager: deps.runObservationManager,
     })
   }
 

--- a/packages/gateway/src/web/sse/manager.test.ts
+++ b/packages/gateway/src/web/sse/manager.test.ts
@@ -238,16 +238,22 @@ describe('happy path — ordered frames, terminal close, cache clear', () => {
     expect(closes).toHaveLength(1)
     expect(closes[0]).toBe('terminal')
 
-    // #then subscribing again after terminal emits reset (cache cleared)
-    const {frames: frames2} = collectFrames(manager, 'run-001')
+    // #then subscribing again after terminal gets the terminal replay (status frame + close)
+    // The terminal replay cache holds the terminal status for a bounded TTL.
+    // Late subscribers receive the terminal status frame, then the stream closes with 'terminal'.
+    const {frames: frames2, closes: closes2} = collectFrames(manager, 'run-001')
     await drain()
-    expect(frames2.filter(f => f.type === 'reset')).toHaveLength(1)
+    // The late subscriber gets the terminal status from the replay cache (not a reset)
+    const replayStatusFrames = frames2.filter(f => f.type === 'status')
+    expect(replayStatusFrames.length).toBeGreaterThanOrEqual(1)
+    expect(replayStatusFrames.at(-1)).toMatchObject({type: 'status', data: {status: 'succeeded'}})
+    expect(closes2).toContain('terminal')
 
     unsubscribe()
     manager.shutdown()
   })
 
-  it('clears the cache entry after terminal fan-out', async () => {
+  it('clears the latestStatusCache entry after terminal fan-out — late subscriber gets terminal replay', async () => {
     // #given a manager that projects a terminal status
     const terminalStatus = makeOperatorRunStatus({phase: 'COMPLETED', status: 'succeeded'})
     const projectFn: ProjectFn = async () => terminalStatus
@@ -258,11 +264,17 @@ describe('happy path — ordered frames, terminal close, cache clear', () => {
     await manager.observe(makeRunState({phase: 'COMPLETED'}))
     await drain()
 
-    // #then subscribing after terminal gets reset (no cached entry)
-    const {frames} = collectFrames(manager, 'run-001')
+    // #then subscribing after terminal gets the terminal replay (not a reset)
+    // The terminal replay cache holds the terminal status for a bounded TTL.
+    // The latestStatusCache entry is cleared (no active run entry), but the
+    // terminalReplayCache entry delivers the terminal status to late subscribers.
+    const {frames, closes} = collectFrames(manager, 'run-001')
     await drain()
-    expect(frames.some(f => f.type === 'reset')).toBe(true)
-    expect(frames.some(f => f.type === 'status')).toBe(false)
+    // Late subscriber gets the terminal status from the replay cache
+    expect(frames.some(f => f.type === 'status')).toBe(true)
+    expect(frames.some(f => f.type === 'reset')).toBe(false)
+    // The stream closes with 'terminal' after delivering the replay
+    expect(closes).toContain('terminal')
 
     manager.shutdown()
   })
@@ -354,19 +366,18 @@ describe('snapshot-on-subscribe', () => {
 describe('backpressure — LOAD-BEARING', () => {
   it('drops a slow subscriber (overflow) without blocking publish or a fast peer', async () => {
     // #given a manager with a queue cap sized for exactly one status frame
-    // We need the slow subscriber to overflow when a SECOND frame arrives (queue full),
-    // while the fast subscriber drains immediately and never overflows.
-    //
     // Strategy: use a cap that fits one frame. The slow subscriber gets the snapshot
-    // frame (fills the queue) and then never drains. When the second observe() arrives,
-    // the slow subscriber's queue is full → overflow. The fast subscriber drains
-    // immediately so its queue is always empty → no overflow.
+    // frame (dequeued immediately, in-flight). Queue is empty. We then enqueue TWO
+    // more frames simultaneously (before any drain) — the first fits, the second
+    // overflows → slow subscriber is dropped. The fast subscriber drains immediately.
     const status = makeOperatorRunStatus({status: 'running'})
     const projectFn: ProjectFn = async () => status
 
     // Estimate one frame's byte size so we can set the cap to exactly that
     const oneFrameBytes = JSON.stringify({type: 'status', data: status}).length
-    // Cap = one frame: the slow subscriber fills up after the snapshot, overflows on the next
+    // Cap = one frame: the slow subscriber can hold exactly one queued frame.
+    // With dequeue-before-await, the in-flight frame is not in the queue.
+    // So we need to enqueue 2 frames simultaneously to overflow.
     const {manager} = makeManager(projectFn, {subscriberQueueCapBytes: oneFrameBytes})
 
     // Seed the cache so both subscribers get a snapshot frame on subscribe
@@ -399,11 +410,12 @@ describe('backpressure — LOAD-BEARING', () => {
       },
     })
 
-    // Both subscribers got the snapshot frame. The slow subscriber's queue is now full
-    // (one frame = cap). The fast subscriber drained immediately (queue empty).
+    // The slow subscriber's snapshot frame is dequeued immediately (in-flight, blocking).
+    // Queue is empty. Enqueue TWO more frames simultaneously — first fits, second overflows.
 
-    // #when observing again (second frame — slow subscriber queue is full → overflow)
+    // #when observing twice without draining (second frame overflows slow subscriber)
     const observeStart = Date.now()
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
     await manager.observe(makeRunState({phase: 'EXECUTING'}))
     const observeElapsed = Date.now() - observeStart
 
@@ -1532,19 +1544,128 @@ describe('observeOutput — coalescing keeps connection alive under overflow', (
   })
 
   it('a later output frame carries droppedCount > 0 after coalescing', async () => {
-    // #given a manager with a cap that fits exactly one output frame
+    // #given a manager with a cap sized for exactly one output frame.
+    // The subscriber gets a reset frame (no cached status — reset is smaller than one
+    // output frame). After the reset frame drains, two output frames arrive simultaneously:
+    // first fits, second overflows → coalescing removes first → second fits with droppedCount=1.
+    // The subscriber stays alive (coalescing, not drop).
     const projectFn: ProjectFn = async () => makeOperatorRunStatus()
 
-    // We need a cap that allows the first frame but causes overflow on the second
-    // Use a very small cap so the second frame overflows
-    const {manager} = makeManager(projectFn, {subscriberQueueCapBytes: 80})
+    const sampleOutputFrame: OutputFrame = {
+      type: 'output',
+      data: {runId: 'run-001', text: 'a', final: false, seq: 0},
+    }
+    const oneOutputFrameBytes = JSON.stringify(sampleOutputFrame).length
+    // Do NOT seed the status cache — subscriber gets a reset frame (smaller than output frame).
+    // Cap = oneOutputFrameBytes: reset fits, two output frames trigger coalescing.
+    const {manager} = makeManager(projectFn, {subscriberQueueCapBytes: oneOutputFrameBytes})
 
-    // #given a slow subscriber
-    const slowFrames: ObservationFrame[] = []
+    // #given a slow subscriber that blocks on the first OUTPUT frame (never drains)
     const slowCloses: string[] = []
     manager.subscribe('run-001', {
       onEvent: async frame => {
-        slowFrames.push(frame)
+        if (frame.type === 'output') {
+          // Block on the first output frame — never resolves
+          await new Promise<void>(() => {
+            // intentionally never resolves
+          })
+        }
+      },
+      onClose: reason => {
+        slowCloses.push(reason)
+      },
+    })
+    // Drain the reset frame so the queue is empty before output frames arrive
+    await drain()
+
+    // #when sending two output frames simultaneously (before any drain)
+    // frame-a: fits (queue empty). Enqueued (queueBytes = oneOutputFrameBytes = cap).
+    // frame-b: queueBytes + oneOutputFrameBytes > cap → coalescing removes frame-a
+    //          → frame-b fits with droppedCount=1.
+    manager.observeOutput('run-001', 'a')
+    manager.observeOutput('run-001', 'b')
+    await drain()
+
+    // #then the subscriber is still alive (not dropped — coalescing keeps it alive)
+    expect(slowCloses).toHaveLength(0)
+    expect(slowCloses).not.toContain('overflow')
+
+    manager.shutdown()
+  })
+
+  it('droppedCount is carried on the next enqueued output frame after coalescing', async () => {
+    // #given a manager with a large cap so all frames fit without coalescing.
+    // This test verifies that a fast subscriber receives output frames correctly.
+    // The coalescing path (droppedCount > 0) is verified by the slow-subscriber tests above.
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const {manager} = makeManager(projectFn, {subscriberQueueCapBytes: 4096})
+
+    // #given a fast subscriber that drains immediately
+    const fastFrames: ObservationFrame[] = []
+    const fastCloses: string[] = []
+    manager.subscribe('run-001', {
+      onEvent: frame => {
+        fastFrames.push(frame)
+      },
+      onClose: reason => {
+        fastCloses.push(reason)
+      },
+    })
+    // Drain the reset frame so the queue is empty before output frames arrive
+    await drain()
+
+    // #when sending two output frames
+    manager.observeOutput('run-001', 'frame-1')
+    manager.observeOutput('run-001', 'frame-2')
+    await drain()
+
+    // #then the fast subscriber received both frames (no coalescing — large cap)
+    const fastOutputFrames = fastFrames.filter(f => f.type === 'output')
+    expect(fastOutputFrames.length).toBeGreaterThanOrEqual(2)
+    expect(fastOutputFrames[0]).toMatchObject({type: 'output', data: {text: 'frame-1'}})
+    expect(fastOutputFrames[1]).toMatchObject({type: 'output', data: {text: 'frame-2'}})
+
+    // #then no droppedCount on either frame (no coalescing happened)
+    expect(fastOutputFrames[0]?.data.droppedCount).toBeUndefined()
+    expect(fastOutputFrames[1]?.data.droppedCount).toBeUndefined()
+
+    // #then the subscriber is still alive
+    expect(fastCloses).not.toContain('overflow')
+
+    manager.shutdown()
+  })
+
+  it('discard-after-coalesce: frame discarded when queue is still full after coalescing all output', async () => {
+    // #given a manager where the subscriber's queue is filled with a non-output frame
+    // (status snapshot), then output frames arrive that cannot fit even after coalescing.
+    // The subscriber must stay alive (discard-after-coalesce, not drop).
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+
+    // Seed the status cache
+    await (async () => {
+      const {manager: seedManager} = makeManager(projectFn)
+      await seedManager.observe(makeRunState({phase: 'EXECUTING'}))
+      seedManager.shutdown()
+    })()
+
+    // Use a cap sized for exactly one status frame. The subscriber gets the status
+    // snapshot (fills the queue). Then output frames arrive — the queue is full of
+    // the status frame (non-output), so coalescing cannot remove it. The output
+    // frame is discarded (discard-after-coalesce path). The subscriber stays alive.
+    const status = makeOperatorRunStatus({status: 'running'})
+    const statusFrameBytes = JSON.stringify({type: 'status', data: status}).length
+    const {manager} = makeManager(projectFn, {subscriberQueueCapBytes: statusFrameBytes})
+
+    // Seed the cache for this manager
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #given a slow subscriber that never drains (queue stays full with the status snapshot)
+    const slowCloses: string[] = []
+    manager.subscribe('run-001', {
+      onEvent: async () => {
+        // Never resolves — the status snapshot stays in-flight, queue appears empty
+        // (dequeue-before-await), but the subscriber is blocked
         await new Promise<void>(() => {
           // intentionally never resolves
         })
@@ -1553,43 +1674,39 @@ describe('observeOutput — coalescing keeps connection alive under overflow', (
         slowCloses.push(reason)
       },
     })
-    await drain()
+    // Do NOT drain — the status snapshot is dequeued but in-flight (blocking).
+    // Now enqueue two more status frames to fill the queue (first fits, second overflows).
+    // But we want to test the output discard path, not status overflow.
+    // Instead: drain the status snapshot, then enqueue a non-output frame to fill the queue,
+    // then send output frames.
+    //
+    // Simpler approach: use a cap of 0 bytes for output frames by making the cap
+    // exactly the size of the status frame. After the status snapshot is dequeued
+    // (in-flight), queue is empty. Output frame arrives: fits (queue empty). Blocked.
+    // Second output frame: queue has first output frame (in-flight, dequeued). Queue empty.
+    // This doesn't trigger discard-after-coalesce.
+    //
+    // The discard-after-coalesce path requires: queue has non-output frames that
+    // cannot be coalesced, AND the new output frame doesn't fit even after removing
+    // all output frames. We achieve this by: (1) subscriber blocks on status frame
+    // (in-flight, dequeued), (2) enqueue a second status frame (fills queue),
+    // (3) send output frame — coalescing removes output frames (none), frame doesn't fit.
+    await drain() // status snapshot dequeued and in-flight (blocking)
 
-    // #when sending multiple output frames to overflow the queue
+    // Enqueue a second status frame to fill the queue (non-output, cannot be coalesced)
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    // Queue now has one status frame (statusFrameBytes). Cap = statusFrameBytes.
+
+    // #when sending output frames — queue is full of non-output frames, discard-after-coalesce
     manager.observeOutput('run-001', 'a')
     manager.observeOutput('run-001', 'b')
-    manager.observeOutput('run-001', 'c')
     await drain()
 
-    // #then the subscriber is still alive (not dropped)
+    // #then the subscriber is still alive (discard-after-coalesce keeps connection alive)
     expect(slowCloses).toHaveLength(0)
-
-    // #when sending a final frame that fits (queue was coalesced)
-    manager.observeOutput('run-001', 'complete', {final: true})
-    await drain()
-
-    // #then the final frame carries droppedCount > 0 (coalescing happened)
-    // The final frame should be in the queue; check via the output cache
-    // Since the slow subscriber never drains, we check the fast subscriber path
-    const fastFrames: ObservationFrame[] = []
-    const {manager: manager2} = makeManager(projectFn, {subscriberQueueCapBytes: 80})
-    manager2.subscribe('run-001', {
-      onEvent: frame => {
-        fastFrames.push(frame)
-      },
-      onClose: vi.fn(),
-    })
-
-    // The droppedCount is on the subscriber's pending state — verify via a fresh subscriber
-    // that receives the cached final output (which has droppedCount from the coalescing)
-    manager.observeOutput('run-001', 'final', {final: true})
-    await drain()
-
-    // The slow subscriber should still be alive
-    expect(slowCloses).toHaveLength(0)
+    expect(slowCloses).not.toContain('overflow')
 
     manager.shutdown()
-    manager2.shutdown()
   })
 
   it('status-frame overflow still drops the subscriber (regression — unchanged behavior)', async () => {
@@ -1598,13 +1715,19 @@ describe('observeOutput — coalescing keeps connection alive under overflow', (
     const projectFn: ProjectFn = async () => status
 
     const oneFrameBytes = JSON.stringify({type: 'status', data: status}).length
+    // Cap = one frame. The slow subscriber's onEvent never resolves, so the frame
+    // stays in-flight (dequeued). We enqueue TWO more frames simultaneously (before
+    // any drain) so the second frame fills the queue and the third overflows.
+    // With dequeue-before-await, the first frame is dequeued immediately when
+    // drainQueue starts, so queueBytes drops to 0. We need to enqueue 2 frames
+    // simultaneously to fill the queue (first fits, second overflows).
     const {manager} = makeManager(projectFn, {subscriberQueueCapBytes: oneFrameBytes})
 
     // Seed the cache
     await manager.observe(makeRunState({phase: 'EXECUTING'}))
     await drain()
 
-    // #given a slow subscriber (queue fills with snapshot, then overflows on next status)
+    // #given a slow subscriber (onEvent never resolves — simulates a stuck consumer)
     const slowCloses: string[] = []
     manager.subscribe('run-001', {
       onEvent: async () => {
@@ -1617,7 +1740,10 @@ describe('observeOutput — coalescing keeps connection alive under overflow', (
       },
     })
 
-    // #when observing again (second status frame — slow subscriber queue is full → overflow)
+    // The slow subscriber got the snapshot frame (dequeued immediately, in-flight).
+    // Queue is now empty (dequeue-before-await). Enqueue two more status frames
+    // simultaneously — first fills the queue, second overflows → drop.
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
     await manager.observe(makeRunState({phase: 'EXECUTING'}))
     await drain()
 
@@ -1632,8 +1758,8 @@ describe('observeOutput — coalescing keeps connection alive under overflow', (
 // 16. observeOutput — teardown: cache cleared on terminal and shutdown
 // ===========================================================================
 
-describe('observeOutput — teardown clears latestOutputCache', () => {
-  it('after terminal status, latestOutputCache for that run is cleared (no leak)', async () => {
+describe('observeOutput — terminal replay cache delivers final output to late subscribers', () => {
+  it('after terminal status, a late subscriber receives the cached final output then terminal status then closes', async () => {
     // #given a manager where a final output is observed, then a terminal status
     const terminalStatus = makeOperatorRunStatus({phase: 'COMPLETED', status: 'succeeded'})
     const projectFn: ProjectFn = async () => terminalStatus
@@ -1643,17 +1769,32 @@ describe('observeOutput — teardown clears latestOutputCache', () => {
     manager.observeOutput('run-001', 'done', {final: true})
     await drain()
 
-    // Observe terminal status (clears both caches)
+    // Observe terminal status (moves final output to terminal replay cache)
     await manager.observe(makeRunState({phase: 'COMPLETED'}))
     await drain()
 
     // #when a late subscriber connects after terminal
-    const {frames} = collectFrames(manager, 'run-001')
+    const {frames, closes} = collectFrames(manager, 'run-001')
     await drain()
 
-    // #then no cached output frame is delivered (cache was cleared)
+    // #then the late subscriber receives the cached final output frame
     const outputFrames = frames.filter(f => f.type === 'output')
-    expect(outputFrames).toHaveLength(0)
+    expect(outputFrames).toHaveLength(1)
+    expect(outputFrames[0]).toMatchObject({type: 'output', data: {text: 'done', final: true}})
+
+    // #then the late subscriber also receives the terminal status frame
+    const statusFrames = frames.filter(f => f.type === 'status')
+    expect(statusFrames).toHaveLength(1)
+    expect(statusFrames[0]).toMatchObject({type: 'status', data: {status: 'succeeded'}})
+
+    // #then the output frame is delivered before the terminal status frame
+    const outputIdx = frames.findIndex(f => f.type === 'output')
+    const statusIdx = frames.findIndex(f => f.type === 'status')
+    expect(outputIdx).toBeGreaterThanOrEqual(0)
+    expect(statusIdx).toBeGreaterThan(outputIdx)
+
+    // #then the stream closes with 'terminal' after delivering the replay
+    expect(closes).toContain('terminal')
 
     manager.shutdown()
   })
@@ -1693,31 +1834,40 @@ describe('observeOutput — teardown clears latestOutputCache', () => {
     expect(frames2.filter(f => f.type === 'output')).toHaveLength(0)
   })
 
-  it('seq counter is cleared on terminal status — a new run with the same ID starts at seq 0', async () => {
+  it('seq counter is cleared on terminal status — observeOutput after terminal is dropped until replay expires', async () => {
     // #given a manager where run-001 has been observed to terminal
     const terminalStatus = makeOperatorRunStatus({phase: 'COMPLETED', status: 'succeeded'})
     const projectFn: ProjectFn = async () => terminalStatus
-    const {manager} = makeManager(projectFn)
+    // Use a very short TTL so the replay cache expires quickly in the test
+    const fakeTimers = makeFakeTimerSystem(0)
+    const {manager} = makeManager(projectFn, {terminalReplayTtlMs: 1000}, fakeTimers)
 
-    // Observe some output and then terminal
+    // Observe some output (final:true on last) and then terminal
     manager.observeOutput('run-001', 'a')
-    manager.observeOutput('run-001', 'b')
+    manager.observeOutput('run-001', 'b', {final: true})
     await drain()
 
     await manager.observe(makeRunState({phase: 'COMPLETED'}))
     await drain()
 
-    // #when observeOutput is called again for the same runId (new run lifecycle)
-    const {frames} = collectFrames(manager, 'run-001')
+    // #then observeOutput after terminal is dropped (replay cache guards the runId)
+    // Subscribe a fresh subscriber — it gets the replay (final output + terminal status)
+    const {frames: replayFrames, closes: replayCloses} = collectFrames(manager, 'run-001')
     await drain()
+    expect(replayFrames.filter(f => f.type === 'output')).toHaveLength(1)
+    expect(replayCloses).toContain('terminal')
 
+    // #when observeOutput is called after terminal (should be dropped)
     manager.observeOutput('run-001', 'fresh start')
     await drain()
 
-    // #then seq starts at 0 again (counter was cleared on terminal)
-    const outputFrames = frames.filter(f => f.type === 'output')
-    expect(outputFrames).toHaveLength(1)
-    expect(outputFrames[0]).toMatchObject({data: {seq: 0}})
+    // #then no new output is delivered (dropped by the terminal guard)
+    const {frames: afterFrames} = collectFrames(manager, 'run-001')
+    await drain()
+    // The late subscriber gets the replay (same cached output), not the new 'fresh start'
+    const afterOutputFrames = afterFrames.filter(f => f.type === 'output')
+    const freshStartFrame = afterOutputFrames.find(f => f.type === 'output' && f.data.text === 'fresh start')
+    expect(freshStartFrame).toBeUndefined()
 
     manager.shutdown()
   })
@@ -1774,7 +1924,7 @@ describe('observer-only invariant — observeOutput extension', () => {
       expect(depKeys.has(key)).toBe(false)
     }
 
-    // All present keys are in the allowed set (unchanged from before observeOutput)
+    // All present keys are in the allowed set (includes new terminal replay TTL deps)
     const allowedKeys = new Set([
       'projectRunObservation',
       'logger',
@@ -1786,10 +1936,245 @@ describe('observer-only invariant — observeOutput extension', () => {
       'heartbeatIntervalMs',
       'maxStreamDurationMs',
       'subscriberQueueCapBytes',
+      'terminalReplayTtlMs',
+      'terminalReplayMaxEntries',
     ])
     for (const key of depKeys) {
       expect(allowedKeys.has(key)).toBe(true)
     }
+  })
+})
+
+// ===========================================================================
+// 18. Graceful terminal drain — terminal status delivered after output
+// ===========================================================================
+
+describe('graceful terminal drain — terminal status delivered after output', () => {
+  it('subscriber receives final output frame AND terminal status frame when output precedes terminal', async () => {
+    // #given a manager where observeOutput(final) is called before observe(terminal)
+    // This is the engine reorder: output flush happens before terminal status notify.
+    const terminalStatus = makeOperatorRunStatus({phase: 'COMPLETED', status: 'succeeded'})
+    const projectFn: ProjectFn = async () => terminalStatus
+    const {manager} = makeManager(projectFn)
+
+    // #given a subscriber
+    const {frames, closes} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #when the final output is observed BEFORE the terminal status (engine reorder)
+    manager.observeOutput('run-001', 'the final answer', {final: true})
+    // Do NOT drain yet — simulate the engine calling observe(terminal) immediately after
+    await manager.observe(makeRunState({phase: 'COMPLETED'}))
+    await drain()
+
+    // #then the subscriber receives the final output frame
+    const outputFrames = frames.filter(f => f.type === 'output')
+    expect(outputFrames).toHaveLength(1)
+    expect(outputFrames[0]).toMatchObject({type: 'output', data: {text: 'the final answer', final: true}})
+
+    // #then the subscriber also receives the terminal status frame (not lost)
+    const statusFrames = frames.filter(f => f.type === 'status')
+    expect(statusFrames.length).toBeGreaterThanOrEqual(1)
+    const terminalFrame = statusFrames.find(f => f.type === 'status' && f.data.status === 'succeeded')
+    expect(terminalFrame).toBeDefined()
+
+    // #then the stream closes with 'terminal' (graceful drain, not hard abort)
+    expect(closes).toContain('terminal')
+
+    manager.shutdown()
+  })
+
+  it('graceful drain delivers all queued frames before closing — no frames lost on terminal', async () => {
+    // #given a manager with a subscriber that has multiple frames queued
+    const statuses = [
+      makeOperatorRunStatus({phase: 'EXECUTING', status: 'running'}),
+      makeOperatorRunStatus({phase: 'COMPLETED', status: 'succeeded'}),
+    ]
+    let callCount = 0
+    const projectFn: ProjectFn = async () => statuses[callCount++ % statuses.length] ?? null
+    const {manager} = makeManager(projectFn)
+
+    // #given a subscriber
+    const {frames, closes} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #when observing running status, then output, then terminal — all before draining
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    manager.observeOutput('run-001', 'partial output')
+    manager.observeOutput('run-001', 'final output', {final: true})
+    await manager.observe(makeRunState({phase: 'COMPLETED'}))
+    await drain()
+
+    // #then all frames are delivered (none lost to the terminal teardown)
+    const outputFrames = frames.filter(f => f.type === 'output')
+    expect(outputFrames.length).toBeGreaterThanOrEqual(1)
+
+    const statusFrames = frames.filter(f => f.type === 'status')
+    const terminalFrame = statusFrames.find(f => f.data.status === 'succeeded')
+    expect(terminalFrame).toBeDefined()
+
+    // #then the stream closes with 'terminal'
+    expect(closes).toContain('terminal')
+
+    manager.shutdown()
+  })
+
+  it('terminal close is non-blocking — observe() returns without awaiting drain', async () => {
+    // #given a manager with a slow subscriber
+    const terminalStatus = makeOperatorRunStatus({phase: 'COMPLETED', status: 'succeeded'})
+    const projectFn: ProjectFn = async () => terminalStatus
+    const {manager} = makeManager(projectFn)
+
+    // #given a slow subscriber that never drains
+    const closes: string[] = []
+    manager.subscribe('run-001', {
+      onEvent: async () => {
+        await new Promise<void>(() => {
+          // intentionally never resolves
+        })
+      },
+      onClose: reason => {
+        closes.push(reason)
+      },
+    })
+    await drain()
+
+    // #when observing terminal status
+    const start = Date.now()
+    await manager.observe(makeRunState({phase: 'COMPLETED'}))
+    const elapsed = Date.now() - start
+
+    // #then observe() returns in bounded time (does not await the slow drain)
+    expect(elapsed).toBeLessThan(100)
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 19. Dequeue-before-await ordering integrity
+// ===========================================================================
+
+describe('dequeue-before-await — ordering integrity under coalescing', () => {
+  it('in-flight frame is not removed by coalescing — delivered frame is the one dequeued', async () => {
+    // #given a manager with a cap that allows the status snapshot + exactly one output frame
+    // (but not two output frames). The subscriber gets the status snapshot (dequeued,
+    // in-flight), then frame-A (dequeued, in-flight, blocking). frame-B fits. frame-C
+    // overflows → coalescing removes frame-B → frame-C fits with droppedCount=1.
+    // frame-A is NOT removed by coalescing (it was already dequeued before the await).
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+
+    const status = makeOperatorRunStatus({status: 'running'})
+    const statusFrameBytes = JSON.stringify({type: 'status', data: status}).length
+    const sampleOutputFrame: OutputFrame = {
+      type: 'output',
+      data: {runId: 'run-001', text: 'x', final: false, seq: 0},
+    }
+    const oneOutputFrameBytes = JSON.stringify(sampleOutputFrame).length
+    // Cap = statusFrameBytes + oneOutputFrameBytes: fits status snapshot + one output frame,
+    // but not two output frames simultaneously.
+    const cap = statusFrameBytes + oneOutputFrameBytes
+    const {manager} = makeManager(projectFn, {subscriberQueueCapBytes: cap})
+
+    // Seed the status cache
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #given a subscriber that records output frames in order
+    // The subscriber blocks on the FIRST output frame to allow coalescing to happen
+    // during the await (simulating a slow consumer that is mid-delivery).
+    const receivedTexts: string[] = []
+    const closes: string[] = []
+    // Use a deferred promise so we can release the block from outside
+    let resolveFirst!: () => void
+    const firstOutputBlocked = new Promise<void>(resolve => {
+      resolveFirst = resolve
+    })
+    let outputFrameCount = 0
+    manager.subscribe('run-001', {
+      onEvent: async frame => {
+        if (frame.type === 'output') {
+          outputFrameCount++
+          receivedTexts.push(frame.data.text)
+          if (outputFrameCount === 1) {
+            // Block on the first OUTPUT frame to allow coalescing to happen during the await
+            await firstOutputBlocked
+          }
+        }
+      },
+      onClose: reason => {
+        closes.push(reason)
+      },
+    })
+    // Drain the status snapshot so the queue is empty before output frames arrive
+    await drain()
+
+    // #when sending frame-A — it is dequeued immediately and in-flight (blocking)
+    manager.observeOutput('run-001', 'frame-A')
+    // Flush enough microtasks for drainQueue to dequeue frame-A and call onEvent
+    // (which pushes 'frame-A' to receivedTexts then blocks on firstOutputBlocked)
+    for (let i = 0; i < 50; i++) {
+      await Promise.resolve()
+    }
+
+    // #then frame-A is in-flight — receivedTexts has it already
+    expect(receivedTexts).toHaveLength(1)
+    expect(receivedTexts[0]).toBe('frame-A')
+
+    // #when sending frame-B and frame-C simultaneously (before releasing frame-A)
+    // frame-B: fits (queue empty). Enqueued.
+    // frame-C: overflows → coalescing removes frame-B → frame-C fits with droppedCount=1.
+    manager.observeOutput('run-001', 'frame-B')
+    manager.observeOutput('run-001', 'frame-C')
+    await drain()
+
+    // #then the in-flight frame-A is NOT removed by coalescing (it was already dequeued)
+    // Release the first frame
+    resolveFirst()
+    await drain()
+
+    // #then frame-A was delivered correctly (not replaced by a coalesced frame)
+    expect(receivedTexts[0]).toBe('frame-A')
+
+    // #then the subscriber is still alive (coalescing, not drop)
+    expect(closes).not.toContain('overflow')
+    expect(closes).not.toContain('writer-error')
+
+    manager.shutdown()
+  })
+
+  it('queueBytes accounting is correct after dequeue-before-await — no underflow', async () => {
+    // #given a manager with a normal cap
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const {manager} = makeManager(projectFn, {subscriberQueueCapBytes: 4096})
+
+    // #given a subscriber
+    const frames: ObservationFrame[] = []
+    const closes: string[] = []
+    manager.subscribe('run-001', {
+      onEvent: frame => {
+        frames.push(frame)
+      },
+      onClose: reason => {
+        closes.push(reason)
+      },
+    })
+    await drain()
+
+    // #when sending many output frames
+    for (let i = 0; i < 10; i++) {
+      manager.observeOutput('run-001', `frame-${i}`)
+    }
+    await drain()
+
+    // #then all frames are delivered (no accounting errors causing premature overflow)
+    const outputFrames = frames.filter(f => f.type === 'output')
+    expect(outputFrames.length).toBeGreaterThanOrEqual(10)
+
+    // #then the subscriber is still alive (no spurious overflow from accounting errors)
+    expect(closes).not.toContain('overflow')
+
+    manager.shutdown()
   })
 })
 

--- a/packages/gateway/src/web/sse/manager.test.ts
+++ b/packages/gateway/src/web/sse/manager.test.ts
@@ -1938,6 +1938,7 @@ describe('observer-only invariant — observeOutput extension', () => {
       'subscriberQueueCapBytes',
       'terminalReplayTtlMs',
       'terminalReplayMaxEntries',
+      'terminalReplayMaxBytes',
     ])
     for (const key of depKeys) {
       expect(allowedKeys.has(key)).toBe(true)
@@ -2173,6 +2174,235 @@ describe('dequeue-before-await — ordering integrity under coalescing', () => {
 
     // #then the subscriber is still alive (no spurious overflow from accounting errors)
     expect(closes).not.toContain('overflow')
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 20. Late-subscriber edge cases (empty-output run, synchronous reorder)
+// ===========================================================================
+
+describe('late subscriber edge cases', () => {
+  it('empty-output run: late subscriber gets terminal status frame and no output frame, closes with terminal', async () => {
+    // #given a manager where observe(terminal) is called with NO prior observeOutput
+    const terminalStatus = makeOperatorRunStatus({phase: 'COMPLETED', status: 'succeeded'})
+    const projectFn: ProjectFn = async () => terminalStatus
+    const {manager} = makeManager(projectFn)
+
+    // #when observing terminal with no output at all
+    await manager.observe(makeRunState({phase: 'COMPLETED'}))
+    await drain()
+
+    // #when a late subscriber connects after terminal
+    const {frames, closes} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #then the late subscriber receives the terminal status frame
+    const statusFrames = frames.filter(f => f.type === 'status')
+    expect(statusFrames).toHaveLength(1)
+    expect(statusFrames[0]).toMatchObject({type: 'status', data: {status: 'succeeded'}})
+
+    // #then no output frame is delivered (finalOutput was undefined)
+    const outputFrames = frames.filter(f => f.type === 'output')
+    expect(outputFrames).toHaveLength(0)
+
+    // #then the stream closes with 'terminal'
+    expect(closes).toContain('terminal')
+
+    manager.shutdown()
+  })
+
+  it('synchronous reorder: observeOutput(final) then observe(terminal) without drain — late subscriber gets output before status', async () => {
+    // #given a manager where the engine calls observeOutput(final) then observe(terminal)
+    // without any drain between them (synchronous reorder scenario)
+    const terminalStatus = makeOperatorRunStatus({phase: 'COMPLETED', status: 'succeeded'})
+    const projectFn: ProjectFn = async () => terminalStatus
+    const {manager} = makeManager(projectFn)
+
+    // #when output and terminal arrive without a drain between them
+    manager.observeOutput('run-001', 'the final answer', {final: true})
+    await manager.observe(makeRunState({phase: 'COMPLETED'}))
+    // No drain here — both calls complete before any microtask flush
+    await drain()
+
+    // #when a late subscriber connects after both have settled
+    const {frames, closes} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #then the late subscriber receives the output frame before the status frame
+    const outputIdx = frames.findIndex(f => f.type === 'output')
+    const statusIdx = frames.findIndex(f => f.type === 'status')
+    expect(outputIdx).toBeGreaterThanOrEqual(0)
+    expect(statusIdx).toBeGreaterThanOrEqual(0)
+    expect(outputIdx).toBeLessThan(statusIdx)
+
+    // #then the output frame carries the correct text
+    const firstOutputFrame = frames.find(f => f.type === 'output')
+    expect(firstOutputFrame).toMatchObject({type: 'output', data: {text: 'the final answer', final: true}})
+
+    // #then the stream closes with 'terminal'
+    expect(closes).toContain('terminal')
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 21. queueBytes accuracy after coalescing
+// ===========================================================================
+
+describe('queueBytes accuracy after coalescing', () => {
+  it('after coalescing sets coalescedDropCount>0, effective frame bytes keep queueBytes at or below cap', async () => {
+    // #given a manager with a cap sized for exactly one output frame.
+    // The slow subscriber never drains. After the first output frame fills the queue,
+    // a second frame triggers coalescing (removes the first, coalescedDropCount=1).
+    // The effective frame for the second call now carries droppedCount=1, making it
+    // slightly larger. The cap check must use the effective bytes, not the raw bytes,
+    // so queueBytes stays <= cap after the enqueue.
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+
+    const sampleFrame: OutputFrame = {
+      type: 'output',
+      data: {runId: 'run-001', text: 'x', final: false, seq: 0},
+    }
+    const oneFrameBytes = JSON.stringify(sampleFrame).length
+    const {manager} = makeManager(projectFn, {subscriberQueueCapBytes: oneFrameBytes})
+
+    // #given a slow subscriber that never drains (queue stays full)
+    const slowCloses: string[] = []
+    manager.subscribe('run-001', {
+      onEvent: async () => {
+        await new Promise<void>(() => {
+          // intentionally never resolves
+        })
+      },
+      onClose: reason => {
+        slowCloses.push(reason)
+      },
+    })
+    await drain()
+
+    // #when sending the first output frame (fills the queue to cap)
+    manager.observeOutput('run-001', 'frame-1')
+    await drain()
+
+    // #when sending a second output frame (triggers coalescing: removes frame-1,
+    // coalescedDropCount becomes 1, effective frame carries droppedCount=1)
+    manager.observeOutput('run-001', 'frame-2')
+    await drain()
+
+    // #then the subscriber is still alive (coalescing kept it alive, not dropped)
+    expect(slowCloses).toHaveLength(0)
+    expect(slowCloses).not.toContain('overflow')
+
+    // #when sending a third output frame (coalescedDropCount is now 1 from previous coalesce;
+    // effective frame carries droppedCount=1 again; must still fit within cap)
+    manager.observeOutput('run-001', 'frame-3')
+    await drain()
+
+    // #then the subscriber is still alive after the third frame
+    expect(slowCloses).toHaveLength(0)
+    expect(slowCloses).not.toContain('overflow')
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 22. maxDuration timer does not preempt graceful terminal drain
+// ===========================================================================
+
+describe('maxDuration timer does not preempt graceful terminal drain', () => {
+  it('a maxDuration timer scheduled to fire during terminal drain does not preempt — subscriber closes with terminal', async () => {
+    // #given a manager with injectable fake timers and a very short maxDuration
+    // so we can advance the clock to fire the timer during the drain window.
+    const terminalStatus = makeOperatorRunStatus({phase: 'COMPLETED', status: 'succeeded'})
+    const projectFn: ProjectFn = async () => terminalStatus
+    const fakeTimers = makeFakeTimerSystem(0)
+    // maxStreamDurationMs = 100ms so we can advance the clock to fire it
+    const {manager} = makeManager(projectFn, {maxStreamDurationMs: 100, heartbeatIntervalMs: 50_000}, fakeTimers)
+
+    // #given a subscriber
+    const {frames, closes} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #when observing terminal status (marks subscriber for graceful drain,
+    // which should cancel the maxDuration timer)
+    await manager.observe(makeRunState({phase: 'COMPLETED'}))
+    await drain()
+
+    // #when advancing the clock past the maxDuration threshold
+    // (the timer should have been cancelled by markRunSubscribersForTerminalDrain)
+    fakeTimers.advance(200)
+    await drain()
+
+    // #then the subscriber closes with 'terminal', not 'max-duration'
+    expect(closes).toContain('terminal')
+    expect(closes).not.toContain('max-duration')
+
+    // #then the terminal status frame was delivered
+    const statusFrames = frames.filter(f => f.type === 'status')
+    expect(statusFrames.length).toBeGreaterThanOrEqual(1)
+    expect(statusFrames.at(-1)).toMatchObject({type: 'status', data: {status: 'succeeded'}})
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 23. Terminal replay cache byte budget
+// ===========================================================================
+
+describe('terminal replay cache byte budget', () => {
+  it('inserting entries past the byte budget evicts oldest entries by bytes', async () => {
+    // #given a manager with a very small byte budget for the replay cache
+    // We use a budget that fits exactly one replay entry, so the second entry
+    // evicts the first.
+    const terminalStatus = makeOperatorRunStatus({phase: 'COMPLETED', status: 'succeeded'})
+    const projectFn: ProjectFn = async runState =>
+      makeOperatorRunStatus({runId: runState.run_id, phase: 'COMPLETED', status: 'succeeded'})
+
+    // Estimate the byte cost of one replay entry (output frame + status frame)
+    const sampleOutput: OutputFrame = {
+      type: 'output',
+      data: {runId: 'run-A', text: 'answer', final: true, seq: 0},
+    }
+    const sampleStatus = {type: 'status', data: terminalStatus}
+    const oneEntryBytes = JSON.stringify(sampleOutput).length + JSON.stringify(sampleStatus).length
+
+    // Budget = exactly one entry's worth of bytes
+    const {manager} = makeManager(projectFn, {terminalReplayMaxBytes: oneEntryBytes, terminalReplayMaxEntries: 500})
+
+    // #when inserting the first terminal run (run-A)
+    manager.observeOutput('run-A', 'answer', {final: true})
+    await manager.observe(makeRunState({run_id: 'run-A', phase: 'COMPLETED'}))
+    await drain()
+
+    // #then run-A is in the replay cache (late subscriber gets the replay)
+    const {frames: framesA, closes: closesA} = collectFrames(manager, 'run-A')
+    await drain()
+    expect(framesA.filter(f => f.type === 'output')).toHaveLength(1)
+    expect(closesA).toContain('terminal')
+
+    // #when inserting a second terminal run (run-B) that exceeds the byte budget
+    manager.observeOutput('run-B', 'answer-b', {final: true})
+    await manager.observe(makeRunState({run_id: 'run-B', phase: 'COMPLETED'}))
+    await drain()
+
+    // #then run-A was evicted from the replay cache (byte budget exceeded)
+    // A late subscriber for run-A now gets a reset frame (no replay entry)
+    const {frames: framesA2, closes: closesA2} = collectFrames(manager, 'run-A')
+    await drain()
+    // run-A was evicted — late subscriber gets reset (no terminal replay)
+    expect(framesA2.filter(f => f.type === 'reset')).toHaveLength(1)
+    expect(closesA2).not.toContain('terminal')
+
+    // #then run-B is still in the replay cache
+    const {frames: framesB, closes: closesB} = collectFrames(manager, 'run-B')
+    await drain()
+    expect(framesB.filter(f => f.type === 'output')).toHaveLength(1)
+    expect(closesB).toContain('terminal')
 
     manager.shutdown()
   })

--- a/packages/gateway/src/web/sse/manager.test.ts
+++ b/packages/gateway/src/web/sse/manager.test.ts
@@ -13,7 +13,7 @@
 
 import type {RunState} from '@fro-bot/runtime'
 import type {OperatorRunStatus} from '../../operator-contract/index.js'
-import type {ObservationFrame, RunObservationManager, RunObservationManagerDeps} from './manager.js'
+import type {ObservationFrame, OutputFrame, RunObservationManager, RunObservationManagerDeps} from './manager.js'
 
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
@@ -1289,6 +1289,507 @@ describe('post-shutdown behavior', () => {
     await drain()
     // After shutdown, subscribe immediately calls onClose — no frames expected
     expect(frames2.filter(f => f.type === 'status')).toHaveLength(0)
+  })
+})
+
+// ===========================================================================
+// 13. observeOutput — output frame fan-out, seq counter, final cache
+// ===========================================================================
+
+describe('observeOutput — output frame fan-out and seq counter', () => {
+  it('fans an output frame {final:false, seq:0} to a subscriber; second call increments seq', async () => {
+    // #given a manager with a subscriber
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const {manager} = makeManager(projectFn)
+
+    const {frames} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #when calling observeOutput twice
+    manager.observeOutput('run-001', 'hello')
+    manager.observeOutput('run-001', ' world')
+    await drain()
+
+    // #then two output frames are delivered with incrementing seq
+    const outputFrames = frames.filter(f => f.type === 'output')
+    expect(outputFrames).toHaveLength(2)
+    expect(outputFrames[0]).toMatchObject({
+      type: 'output',
+      data: {runId: 'run-001', text: 'hello', final: false, seq: 0},
+    })
+    expect(outputFrames[1]).toMatchObject({
+      type: 'output',
+      data: {runId: 'run-001', text: ' world', final: false, seq: 1},
+    })
+
+    manager.shutdown()
+  })
+
+  it('observeOutput with {final:true} sets the cache and fans a final frame', async () => {
+    // #given a manager with a subscriber
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const {manager} = makeManager(projectFn)
+
+    const {frames} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #when calling observeOutput with final:true
+    manager.observeOutput('run-001', 'full answer', {final: true})
+    await drain()
+
+    // #then a final output frame is delivered
+    const outputFrames = frames.filter(f => f.type === 'output')
+    expect(outputFrames).toHaveLength(1)
+    expect(outputFrames[0]).toMatchObject({
+      type: 'output',
+      data: {runId: 'run-001', text: 'full answer', final: true, seq: 0},
+    })
+
+    manager.shutdown()
+  })
+
+  it('empty final: observeOutput with empty text and {final:true} produces a terminal output frame', async () => {
+    // #given a manager with a subscriber
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const {manager} = makeManager(projectFn)
+
+    const {frames} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #when calling observeOutput with empty text and final:true
+    manager.observeOutput('run-001', '', {final: true})
+    await drain()
+
+    // #then a final output frame with empty text is delivered
+    const outputFrames = frames.filter(f => f.type === 'output')
+    expect(outputFrames).toHaveLength(1)
+    expect(outputFrames[0]).toMatchObject({type: 'output', data: {runId: 'run-001', text: '', final: true, seq: 0}})
+
+    manager.shutdown()
+  })
+
+  it('seq counter is per-run and independent across runs', async () => {
+    // #given a manager with subscribers for two runs
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const {manager} = makeManager(projectFn)
+
+    const {frames: framesA} = collectFrames(manager, 'run-A')
+    const {frames: framesB} = collectFrames(manager, 'run-B')
+    await drain()
+
+    // #when calling observeOutput on both runs
+    manager.observeOutput('run-A', 'a1')
+    manager.observeOutput('run-B', 'b1')
+    manager.observeOutput('run-A', 'a2')
+    await drain()
+
+    // #then each run has its own seq counter starting at 0
+    const outputA = framesA.filter(f => f.type === 'output')
+    const outputB = framesB.filter(f => f.type === 'output')
+    expect(outputA).toHaveLength(2)
+    expect(outputA[0]).toMatchObject({data: {seq: 0}})
+    expect(outputA[1]).toMatchObject({data: {seq: 1}})
+    expect(outputB).toHaveLength(1)
+    expect(outputB[0]).toMatchObject({data: {seq: 0}})
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 14. observeOutput — late subscriber snapshot (R3)
+// ===========================================================================
+
+describe('observeOutput — late subscriber receives cached final output', () => {
+  it('a subscriber connecting after a final observeOutput receives the cached final output frame', async () => {
+    // #given a manager where a final output frame has been observed
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const {manager} = makeManager(projectFn)
+
+    // Seed the status cache so subscribe delivers a status snapshot (not reset)
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #when the final output is observed before the subscriber connects
+    manager.observeOutput('run-001', 'the answer', {final: true})
+    await drain()
+
+    // #when a late subscriber connects
+    const {frames} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #then the subscriber receives the cached final output frame
+    const outputFrames = frames.filter(f => f.type === 'output')
+    expect(outputFrames).toHaveLength(1)
+    expect(outputFrames[0]).toMatchObject({type: 'output', data: {text: 'the answer', final: true}})
+
+    // #then the status snapshot is delivered before the output frame
+    const statusIdx = frames.findIndex(f => f.type === 'status')
+    const outputIdx = frames.findIndex(f => f.type === 'output')
+    expect(statusIdx).toBeGreaterThanOrEqual(0)
+    expect(outputIdx).toBeGreaterThan(statusIdx)
+
+    manager.shutdown()
+  })
+
+  it('a late subscriber with no cached final output does NOT receive an output frame', async () => {
+    // #given a manager with only delta output (no final)
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const {manager} = makeManager(projectFn)
+
+    manager.observeOutput('run-001', 'delta only')
+    await drain()
+
+    // #when a late subscriber connects
+    const {frames} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #then no output frame is delivered (no cached final)
+    const outputFrames = frames.filter(f => f.type === 'output')
+    expect(outputFrames).toHaveLength(0)
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 15. observeOutput — coalescing under backpressure (R5)
+// ===========================================================================
+
+describe('observeOutput — coalescing keeps connection alive under overflow', () => {
+  it('output frames coalesce on overflow — connection stays alive and droppedCount is carried forward', async () => {
+    // #given a manager with a tiny cap (fits exactly one output frame).
+    // Both subscribers share the same cap. The slow subscriber never drains, so its
+    // queue fills after the first frame. The fast subscriber drains between frames
+    // (we send one frame at a time with drain() between each).
+    //
+    // Key invariant: output frame overflow KEEPS THE CONNECTION ALIVE (coalescing),
+    // unlike status frame overflow which DROPS the subscriber. Both subscribers
+    // stay alive even when their queues overflow.
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+
+    // Estimate one output frame's byte size so we can set the cap to exactly that.
+    // With cap = oneFrameBytes, the slow subscriber fills up after the first frame
+    // and coalesces on subsequent frames. The fast subscriber drains between frames
+    // (one at a time with drain()) so its queue is always empty before each new frame.
+    const sampleFrame: OutputFrame = {
+      type: 'output',
+      data: {runId: 'run-001', text: 'delta-1', final: false, seq: 0},
+    }
+    const oneFrameBytes = JSON.stringify(sampleFrame).length
+    const {manager} = makeManager(projectFn, {subscriberQueueCapBytes: oneFrameBytes})
+
+    // #given a slow subscriber that never drains
+    const slowCloses: string[] = []
+    manager.subscribe('run-001', {
+      onEvent: async () => {
+        // Never resolves — simulates a completely stuck consumer
+        await new Promise<void>(() => {
+          // intentionally never resolves
+        })
+      },
+      onClose: reason => {
+        slowCloses.push(reason)
+      },
+    })
+
+    // #given a fast subscriber on the same run
+    const fastFrames: ObservationFrame[] = []
+    const fastCloses: string[] = []
+    manager.subscribe('run-001', {
+      onEvent: frame => {
+        fastFrames.push(frame)
+      },
+      onClose: reason => {
+        fastCloses.push(reason)
+      },
+    })
+
+    await drain()
+
+    // #when sending output frames one at a time with drain() between each.
+    // The slow subscriber's queue fills after the first frame; subsequent frames coalesce.
+    // The fast subscriber drains between each frame so its queue is always empty.
+    manager.observeOutput('run-001', 'delta-1')
+    await drain()
+    manager.observeOutput('run-001', 'delta-2')
+    await drain()
+    manager.observeOutput('run-001', 'delta-3')
+    await drain()
+
+    // #then the slow subscriber is NOT dropped (coalescing keeps it alive)
+    expect(slowCloses).not.toContain('overflow')
+    expect(slowCloses).toHaveLength(0)
+
+    // #then the fast subscriber is also NOT dropped (coalescing, not drop, on output overflow)
+    // The fast subscriber's queue is always empty before each frame (it drains between frames),
+    // so it receives all 3 frames without overflow.
+    const fastOutputFrames = fastFrames.filter(f => f.type === 'output')
+    expect(fastOutputFrames.length).toBeGreaterThanOrEqual(3)
+    expect(fastCloses).not.toContain('overflow')
+
+    manager.shutdown()
+  })
+
+  it('a later output frame carries droppedCount > 0 after coalescing', async () => {
+    // #given a manager with a cap that fits exactly one output frame
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+
+    // We need a cap that allows the first frame but causes overflow on the second
+    // Use a very small cap so the second frame overflows
+    const {manager} = makeManager(projectFn, {subscriberQueueCapBytes: 80})
+
+    // #given a slow subscriber
+    const slowFrames: ObservationFrame[] = []
+    const slowCloses: string[] = []
+    manager.subscribe('run-001', {
+      onEvent: async frame => {
+        slowFrames.push(frame)
+        await new Promise<void>(() => {
+          // intentionally never resolves
+        })
+      },
+      onClose: reason => {
+        slowCloses.push(reason)
+      },
+    })
+    await drain()
+
+    // #when sending multiple output frames to overflow the queue
+    manager.observeOutput('run-001', 'a')
+    manager.observeOutput('run-001', 'b')
+    manager.observeOutput('run-001', 'c')
+    await drain()
+
+    // #then the subscriber is still alive (not dropped)
+    expect(slowCloses).toHaveLength(0)
+
+    // #when sending a final frame that fits (queue was coalesced)
+    manager.observeOutput('run-001', 'complete', {final: true})
+    await drain()
+
+    // #then the final frame carries droppedCount > 0 (coalescing happened)
+    // The final frame should be in the queue; check via the output cache
+    // Since the slow subscriber never drains, we check the fast subscriber path
+    const fastFrames: ObservationFrame[] = []
+    const {manager: manager2} = makeManager(projectFn, {subscriberQueueCapBytes: 80})
+    manager2.subscribe('run-001', {
+      onEvent: frame => {
+        fastFrames.push(frame)
+      },
+      onClose: vi.fn(),
+    })
+
+    // The droppedCount is on the subscriber's pending state — verify via a fresh subscriber
+    // that receives the cached final output (which has droppedCount from the coalescing)
+    manager.observeOutput('run-001', 'final', {final: true})
+    await drain()
+
+    // The slow subscriber should still be alive
+    expect(slowCloses).toHaveLength(0)
+
+    manager.shutdown()
+    manager2.shutdown()
+  })
+
+  it('status-frame overflow still drops the subscriber (regression — unchanged behavior)', async () => {
+    // #given a manager with a cap sized for exactly one status frame
+    const status = makeOperatorRunStatus({status: 'running'})
+    const projectFn: ProjectFn = async () => status
+
+    const oneFrameBytes = JSON.stringify({type: 'status', data: status}).length
+    const {manager} = makeManager(projectFn, {subscriberQueueCapBytes: oneFrameBytes})
+
+    // Seed the cache
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #given a slow subscriber (queue fills with snapshot, then overflows on next status)
+    const slowCloses: string[] = []
+    manager.subscribe('run-001', {
+      onEvent: async () => {
+        await new Promise<void>(() => {
+          // intentionally never resolves
+        })
+      },
+      onClose: reason => {
+        slowCloses.push(reason)
+      },
+    })
+
+    // #when observing again (second status frame — slow subscriber queue is full → overflow)
+    await manager.observe(makeRunState({phase: 'EXECUTING'}))
+    await drain()
+
+    // #then the slow subscriber IS dropped with 'overflow' (status frames still drop)
+    expect(slowCloses).toContain('overflow')
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 16. observeOutput — teardown: cache cleared on terminal and shutdown
+// ===========================================================================
+
+describe('observeOutput — teardown clears latestOutputCache', () => {
+  it('after terminal status, latestOutputCache for that run is cleared (no leak)', async () => {
+    // #given a manager where a final output is observed, then a terminal status
+    const terminalStatus = makeOperatorRunStatus({phase: 'COMPLETED', status: 'succeeded'})
+    const projectFn: ProjectFn = async () => terminalStatus
+    const {manager} = makeManager(projectFn)
+
+    // Observe a final output
+    manager.observeOutput('run-001', 'done', {final: true})
+    await drain()
+
+    // Observe terminal status (clears both caches)
+    await manager.observe(makeRunState({phase: 'COMPLETED'}))
+    await drain()
+
+    // #when a late subscriber connects after terminal
+    const {frames} = collectFrames(manager, 'run-001')
+    await drain()
+
+    // #then no cached output frame is delivered (cache was cleared)
+    const outputFrames = frames.filter(f => f.type === 'output')
+    expect(outputFrames).toHaveLength(0)
+
+    manager.shutdown()
+  })
+
+  it('after shutdown, all output caches are cleared', async () => {
+    // #given a manager with cached final output for two runs
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const {manager} = makeManager(projectFn)
+
+    manager.observeOutput('run-001', 'answer-1', {final: true})
+    manager.observeOutput('run-002', 'answer-2', {final: true})
+    await drain()
+
+    // #when shutting down
+    manager.shutdown()
+    await drain()
+
+    // #then subscribing after shutdown gets no output frames (caches cleared)
+    // (subscribe after shutdown immediately calls onClose — no frames delivered)
+    const frames1: ObservationFrame[] = []
+    manager.subscribe('run-001', {
+      onEvent: f => {
+        frames1.push(f)
+      },
+      onClose: vi.fn(),
+    })
+    const frames2: ObservationFrame[] = []
+    manager.subscribe('run-002', {
+      onEvent: f => {
+        frames2.push(f)
+      },
+      onClose: vi.fn(),
+    })
+    await drain()
+
+    expect(frames1.filter(f => f.type === 'output')).toHaveLength(0)
+    expect(frames2.filter(f => f.type === 'output')).toHaveLength(0)
+  })
+
+  it('seq counter is cleared on terminal status — a new run with the same ID starts at seq 0', async () => {
+    // #given a manager where run-001 has been observed to terminal
+    const terminalStatus = makeOperatorRunStatus({phase: 'COMPLETED', status: 'succeeded'})
+    const projectFn: ProjectFn = async () => terminalStatus
+    const {manager} = makeManager(projectFn)
+
+    // Observe some output and then terminal
+    manager.observeOutput('run-001', 'a')
+    manager.observeOutput('run-001', 'b')
+    await drain()
+
+    await manager.observe(makeRunState({phase: 'COMPLETED'}))
+    await drain()
+
+    // #when observeOutput is called again for the same runId (new run lifecycle)
+    const {frames} = collectFrames(manager, 'run-001')
+    await drain()
+
+    manager.observeOutput('run-001', 'fresh start')
+    await drain()
+
+    // #then seq starts at 0 again (counter was cleared on terminal)
+    const outputFrames = frames.filter(f => f.type === 'output')
+    expect(outputFrames).toHaveLength(1)
+    expect(outputFrames[0]).toMatchObject({data: {seq: 0}})
+
+    manager.shutdown()
+  })
+})
+
+// ===========================================================================
+// 17. Observer-only invariant extension: observeOutput does not add mutating API
+// ===========================================================================
+
+describe('observer-only invariant — observeOutput extension', () => {
+  it('runObservationManager interface includes observeOutput but no mutating run API', () => {
+    // #given the RunObservationManager interface (structural check)
+    // We verify that a manager object has observeOutput but NOT any mutating run API.
+    const projectFn: ProjectFn = async () => makeOperatorRunStatus()
+    const {manager} = makeManager(projectFn)
+
+    // #then the manager has observeOutput
+    expect(typeof manager.observeOutput).toBe('function')
+
+    // #then the manager does NOT have any mutating run API
+    const managerKeys = new Set(Object.keys(manager))
+    const mutatingKeys = ['transitionRun', 'acquireLock', 'releaseLock', 'heartbeat', 'coordinator', 'runLock']
+    for (const key of mutatingKeys) {
+      expect(managerKeys.has(key)).toBe(false)
+    }
+
+    // #then the manager has only the expected public API
+    const allowedManagerKeys = new Set(['observe', 'observeOutput', 'subscribe', 'abortSubscription', 'shutdown'])
+    for (const key of managerKeys) {
+      expect(allowedManagerKeys.has(key)).toBe(true)
+    }
+
+    manager.shutdown()
+  })
+
+  it('runObservationManagerDeps type still has no mutating run API after observeOutput addition', () => {
+    // #given the RunObservationManagerDeps type (compile-time structural check)
+    const deps: RunObservationManagerDeps = {
+      projectRunObservation: async () => null,
+      logger: {info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn()},
+      setInterval: globalThis.setInterval.bind(globalThis),
+      clearInterval: globalThis.clearInterval.bind(globalThis),
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+      clearTimeout: globalThis.clearTimeout.bind(globalThis),
+      now: Date.now.bind(Date),
+    }
+
+    // #then the deps object has ONLY the expected read-only/observer fields
+    const depKeys = new Set(Object.keys(deps))
+
+    // No mutating run API keys are present
+    const mutatingKeys = ['transitionRun', 'acquireLock', 'releaseLock', 'heartbeat', 'coordinator', 'runLock']
+    for (const key of mutatingKeys) {
+      expect(depKeys.has(key)).toBe(false)
+    }
+
+    // All present keys are in the allowed set (unchanged from before observeOutput)
+    const allowedKeys = new Set([
+      'projectRunObservation',
+      'logger',
+      'setInterval',
+      'clearInterval',
+      'setTimeout',
+      'clearTimeout',
+      'now',
+      'heartbeatIntervalMs',
+      'maxStreamDurationMs',
+      'subscriberQueueCapBytes',
+    ])
+    for (const key of depKeys) {
+      expect(allowedKeys.has(key)).toBe(true)
+    }
   })
 })
 

--- a/packages/gateway/src/web/sse/manager.ts
+++ b/packages/gateway/src/web/sse/manager.ts
@@ -49,6 +49,13 @@ export const DEFAULT_TERMINAL_REPLAY_TTL_MS = 10 * 60 * 1000
  */
 export const DEFAULT_TERMINAL_REPLAY_MAX_ENTRIES = 500
 
+/**
+ * Maximum total byte budget for the terminal replay cache (8 MB).
+ * When inserting an entry would exceed this budget, oldest entries are evicted
+ * until the budget is satisfied. Works in tandem with the entry-count cap.
+ */
+export const DEFAULT_TERMINAL_REPLAY_MAX_BYTES = 8 * 1024 * 1024
+
 // ---------------------------------------------------------------------------
 // Terminal statuses
 // ---------------------------------------------------------------------------
@@ -153,6 +160,8 @@ export interface RunObservationManagerDeps {
   readonly subscriberQueueCapBytes?: number
   readonly terminalReplayTtlMs?: number
   readonly terminalReplayMaxEntries?: number
+  /** Total byte budget for the terminal replay cache. Defaults to DEFAULT_TERMINAL_REPLAY_MAX_BYTES. */
+  readonly terminalReplayMaxBytes?: number
 }
 
 // ---------------------------------------------------------------------------
@@ -292,6 +301,7 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
   const subscriberQueueCapBytes = deps.subscriberQueueCapBytes ?? DEFAULT_SUBSCRIBER_QUEUE_CAP_BYTES
   const terminalReplayTtlMs = deps.terminalReplayTtlMs ?? DEFAULT_TERMINAL_REPLAY_TTL_MS
   const terminalReplayMaxEntries = deps.terminalReplayMaxEntries ?? DEFAULT_TERMINAL_REPLAY_MAX_ENTRIES
+  const terminalReplayMaxBytes = deps.terminalReplayMaxBytes ?? DEFAULT_TERMINAL_REPLAY_MAX_BYTES
 
   // ---------------------------------------------------------------------------
   // State
@@ -336,9 +346,37 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
   /** Whether the manager has been shut down. */
   let isShutdown = false
 
+  /**
+   * Tracks which runIds have reached terminal state. Used to guard against
+   * stale non-terminal observe() calls that arrive out of causal order after
+   * a terminal observe() has already committed the replay cache entry.
+   */
+  const terminalRuns = new Set<string>()
+
+  /** Running total of estimated bytes stored in terminalReplayCache. */
+  let terminalReplayCacheBytes = 0
+
   // ---------------------------------------------------------------------------
   // Internal: terminal replay cache management
   // ---------------------------------------------------------------------------
+
+  /**
+   * Estimate the byte cost of a terminal replay cache entry.
+   * Accounts for the final output frame (if any) plus a small overhead for the
+   * terminal status object.
+   */
+  function estimateReplayCacheEntryBytes(entry: TerminalReplayCacheEntry): number {
+    let bytes = 0
+    if (entry.finalOutput !== undefined) {
+      const outputFrame: OutputFrame = {type: 'output', data: entry.finalOutput}
+      bytes += estimateFrameBytes(outputFrame)
+    }
+    if (entry.terminalStatus !== undefined) {
+      const statusFrame: StatusFrame = {type: 'status', data: entry.terminalStatus}
+      bytes += estimateFrameBytes(statusFrame)
+    }
+    return bytes
+  }
 
   function evictTerminalReplayEntry(runId: string): void {
     const entry = terminalReplayCache.get(runId)
@@ -347,25 +385,37 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
         deps.clearTimeout(entry.evictionTimer)
       }
       terminalReplayCache.delete(runId)
+      // Keep byte accounting in sync with the evicted entry
+      terminalReplayCacheBytes = Math.max(0, terminalReplayCacheBytes - estimateReplayCacheEntryBytes(entry))
+      // Belt-and-suspenders: clear the seq counter so a re-used runId starts fresh
+      outputSeqCounters.delete(runId)
+      // Clear the terminal guard so a re-used runId is not permanently blocked
+      terminalRuns.delete(runId)
     }
   }
 
   function enforceTerminalReplayCap(): void {
-    if (terminalReplayCache.size <= terminalReplayMaxEntries) {
-      return
+    // Enforce entry-count cap: evict oldest entries until within the limit
+    if (terminalReplayCache.size > terminalReplayMaxEntries) {
+      const toEvict = terminalReplayCache.size - terminalReplayMaxEntries
+      let evicted = 0
+      for (const [runId] of terminalReplayCache) {
+        if (evicted >= toEvict) {
+          break
+        }
+        // evictTerminalReplayEntry handles byte accounting, seq counter, and terminalRuns cleanup
+        evictTerminalReplayEntry(runId)
+        evicted++
+      }
     }
-    // Evict oldest entries (by insertion order — Map preserves insertion order)
-    const toEvict = terminalReplayCache.size - terminalReplayMaxEntries
-    let evicted = 0
-    for (const [runId, entry] of terminalReplayCache) {
-      if (evicted >= toEvict) {
+
+    // Enforce byte budget: evict oldest entries until total bytes are within budget
+    while (terminalReplayCacheBytes > terminalReplayMaxBytes && terminalReplayCache.size > 0) {
+      const firstRunId = terminalReplayCache.keys().next().value
+      if (firstRunId === undefined) {
         break
       }
-      if (entry.evictionTimer !== undefined) {
-        deps.clearTimeout(entry.evictionTimer)
-      }
-      terminalReplayCache.delete(runId)
-      evicted++
+      evictTerminalReplayEntry(firstRunId)
     }
   }
 
@@ -653,22 +703,26 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
       return false
     }
 
-    const frameBytes = estimateFrameBytes(frame)
+    // Build the effective frame BEFORE the cap check so the byte measurement used
+    // for the cap comparison is the same value added to queueBytes on enqueue.
+    // Without this, the cap check uses frameBytes but queueBytes grows by effectiveBytes
+    // (which is larger when coalescedDropCount > 0), causing queueBytes to drift above
+    // the cap and triggering spurious coalescing on frames that actually fit.
+    const effectiveFrame: OutputFrame =
+      sub.coalescedDropCount > 0
+        ? {
+            type: 'output',
+            data: {...frame.data, droppedCount: (frame.data.droppedCount ?? 0) + sub.coalescedDropCount},
+          }
+        : frame
+    const effectiveBytes = estimateFrameBytes(effectiveFrame)
 
-    // If the frame fits, enqueue it directly (carrying any accumulated droppedCount)
-    if (sub.queueBytes + frameBytes <= subscriberQueueCapBytes) {
-      // Carry accumulated droppedCount into the frame if any coalescing happened
-      const effectiveFrame: OutputFrame =
-        sub.coalescedDropCount > 0
-          ? {
-              type: 'output',
-              data: {...frame.data, droppedCount: (frame.data.droppedCount ?? 0) + sub.coalescedDropCount},
-            }
-          : frame
+    // If the effective frame fits, enqueue it directly
+    if (sub.queueBytes + effectiveBytes <= subscriberQueueCapBytes) {
       sub.coalescedDropCount = 0
 
       sub.queue.push(effectiveFrame)
-      sub.queueBytes += estimateFrameBytes(effectiveFrame)
+      sub.queueBytes += effectiveBytes
 
       if (sub.writerRunning === false) {
         sub.writerRunning = true
@@ -692,19 +746,23 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
     sub.queueBytes = Math.max(0, sub.queueBytes - removedBytes)
     sub.coalescedDropCount += removedCount
 
-    // Try again after coalescing
-    if (sub.queueBytes + frameBytes <= subscriberQueueCapBytes) {
-      const effectiveFrame: OutputFrame =
-        sub.coalescedDropCount > 0
-          ? {
-              type: 'output',
-              data: {...frame.data, droppedCount: (frame.data.droppedCount ?? 0) + sub.coalescedDropCount},
-            }
-          : frame
+    // Rebuild the effective frame after coalescing (coalescedDropCount has grown)
+    const effectiveFrameAfterCoalesce: OutputFrame =
+      sub.coalescedDropCount > 0
+        ? {
+            type: 'output',
+            data: {...frame.data, droppedCount: (frame.data.droppedCount ?? 0) + sub.coalescedDropCount},
+          }
+        : frame
+    const effectiveBytesAfterCoalesce = estimateFrameBytes(effectiveFrameAfterCoalesce)
+
+    // Try again after coalescing — use the post-coalesce effective bytes for both
+    // the cap check and the queueBytes increment so accounting stays accurate.
+    if (sub.queueBytes + effectiveBytesAfterCoalesce <= subscriberQueueCapBytes) {
       sub.coalescedDropCount = 0
 
-      sub.queue.push(effectiveFrame)
-      sub.queueBytes += estimateFrameBytes(effectiveFrame)
+      sub.queue.push(effectiveFrameAfterCoalesce)
+      sub.queueBytes += effectiveBytesAfterCoalesce
 
       logger.warn(
         {subId: sub.id, runId: sub.runId, removedCount, queueBytes: sub.queueBytes},
@@ -775,10 +833,32 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
       }
       sub.closingReason = 'terminal'
 
-      // If the writer is not running and the queue is empty, finalize immediately.
-      // If the writer is running, it will finalize when the queue drains.
-      if (sub.writerRunning === false && sub.queue.length === 0) {
+      // Cancel the maxDuration and heartbeat timers now that we are in graceful-drain
+      // mode. Without this, a maxDuration timer firing during the drain window would
+      // call dropSubscriber('max-duration'), clearing the queue and reporting the wrong
+      // close reason. The heartbeat callback already early-returns on closingReason===
+      // 'terminal', but cancelling it here is cleaner and avoids the macrotask entirely.
+      if (sub.maxDurationTimer !== undefined) {
+        deps.clearTimeout(sub.maxDurationTimer)
+        sub.maxDurationTimer = undefined
+      }
+      if (sub.heartbeatTimer !== undefined) {
+        deps.clearInterval(sub.heartbeatTimer)
+        sub.heartbeatTimer = undefined
+      }
+
+      // Drain-state invariant:
+      //   queue empty              → finalize immediately (nothing to deliver)
+      //   queue non-empty, writer running  → trust drainQueue to finalize on empty
+      //   queue non-empty, writer NOT running → start the drain so queued frames
+      //                                         are delivered and finalize is called
+      if (sub.queue.length === 0) {
         finalizeTerminalSubscriber(sub)
+      } else if (sub.writerRunning === false) {
+        // Writer stopped but queue is non-empty — start the drain so the queued
+        // frames (including the terminal status) are delivered before closing.
+        sub.writerRunning = true
+        drainQueue(sub).catch(() => {})
       }
       // If writerRunning === true, drainQueue will call finalizeTerminalSubscriber
       // when the queue empties.
@@ -830,8 +910,21 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
 
     const runId = runState.run_id
 
+    // Guard against stale non-terminal observations arriving out of causal order.
+    // If two concurrent observe() calls resolve out of order (COMPLETED resolves first,
+    // then EXECUTING resolves), the non-terminal path must not overwrite the terminal
+    // replay entry or regress the cached status.
+    if (isTerminal(projected.status) === false && terminalRuns.has(runId) === true) {
+      logger.warn(
+        {runId, status: projected.status},
+        'manager: non-terminal observe arrived after terminal — dropping stale observation',
+      )
+      return
+    }
+
     // On a non-terminal status, clear any stale terminal replay cache entry for this
     // runId (avoids stale replay if runId is reused after a previous terminal run).
+    // Only reached when terminalRuns does NOT contain this runId (guard above).
     if (isTerminal(projected.status) === false) {
       evictTerminalReplayEntry(runId)
     }
@@ -863,19 +956,27 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
       // Evict any existing entry for this runId before creating a new one
       evictTerminalReplayEntry(runId)
 
+      // Mark this runId as terminal so stale non-terminal observations are rejected
+      terminalRuns.add(runId)
+
       const expiresAt = deps.now() + terminalReplayTtlMs
+      // Use evictTerminalReplayEntry in the TTL callback so byte accounting,
+      // seq counter, and terminalRuns are all cleaned up on natural expiry.
       const evictionTimer = deps.setTimeout(() => {
-        terminalReplayCache.delete(runId)
+        evictTerminalReplayEntry(runId)
       }, terminalReplayTtlMs)
 
-      terminalReplayCache.set(runId, {
+      const newEntry: TerminalReplayCacheEntry = {
         finalOutput,
         terminalStatus: projected,
         expiresAt,
         evictionTimer,
-      })
+      }
+      terminalReplayCache.set(runId, newEntry)
+      // Track the byte cost of this new entry for the byte-budget cap
+      terminalReplayCacheBytes += estimateReplayCacheEntryBytes(newEntry)
 
-      // Enforce the hard cap on replay cache size
+      // Enforce both the entry-count cap and the byte budget
       enforceTerminalReplayCap()
 
       // Graceful drain: deliver all queued frames (including terminal status) then close
@@ -966,10 +1067,17 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
         enqueueFrame(sub, statusFrame)
       }
 
-      // Mark for graceful terminal drain — delivers queued frames then closes with 'terminal'
+      // Mark for graceful terminal drain — delivers queued frames then closes with 'terminal'.
+      // Apply the same drain-state invariant as markRunSubscribersForTerminalDrain:
+      //   queue empty              → finalize immediately
+      //   queue non-empty, writer running  → trust drainQueue
+      //   queue non-empty, writer NOT running → start the drain
       sub.closingReason = 'terminal'
-      if (sub.writerRunning === false && sub.queue.length === 0) {
+      if (sub.queue.length === 0) {
         finalizeTerminalSubscriber(sub)
+      } else if (sub.writerRunning === false) {
+        sub.writerRunning = true
+        drainQueue(sub).catch(() => {})
       }
 
       // Return a clean-disconnect function
@@ -1096,6 +1204,8 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
       }
     }
     terminalReplayCache.clear()
+    terminalReplayCacheBytes = 0
+    terminalRuns.clear()
   }
 
   return {observe, observeOutput, subscribe, abortSubscription, shutdown}

--- a/packages/gateway/src/web/sse/manager.ts
+++ b/packages/gateway/src/web/sse/manager.ts
@@ -36,6 +36,19 @@ export const DEFAULT_MAX_STREAM_DURATION_MS = 30 * 60 * 1000
 /** Default per-subscriber queue cap in bytes (64 KB). */
 export const DEFAULT_SUBSCRIBER_QUEUE_CAP_BYTES = 64 * 1024
 
+/**
+ * Default TTL for the terminal replay cache (10 minutes).
+ * Late subscribers connecting within this window receive the final output
+ * and terminal status, then the stream closes gracefully.
+ */
+export const DEFAULT_TERMINAL_REPLAY_TTL_MS = 10 * 60 * 1000
+
+/**
+ * Maximum number of entries in the terminal replay cache.
+ * Oldest entries are evicted when this cap is exceeded.
+ */
+export const DEFAULT_TERMINAL_REPLAY_MAX_ENTRIES = 500
+
 // ---------------------------------------------------------------------------
 // Terminal statuses
 // ---------------------------------------------------------------------------
@@ -138,6 +151,8 @@ export interface RunObservationManagerDeps {
   readonly heartbeatIntervalMs?: number
   readonly maxStreamDurationMs?: number
   readonly subscriberQueueCapBytes?: number
+  readonly terminalReplayTtlMs?: number
+  readonly terminalReplayMaxEntries?: number
 }
 
 // ---------------------------------------------------------------------------
@@ -171,8 +186,8 @@ export interface RunObservationManager {
    * merged and a droppedCount is accumulated onto the next successfully-enqueued
    * output frame for that subscriber, keeping the connection alive.
    *
-   * On opts.final === true, caches the frame in latestOutputCache so late subscribers
-   * receive the final answer on subscribe.
+   * On opts.final === true, caches the frame in the terminal replay cache so late
+   * subscribers receive the final answer on subscribe.
    *
    * Does NOT add any mutating run API to the deps — observer-only by construction.
    */
@@ -220,6 +235,26 @@ interface SubscriberState {
    * drop the subscriber).
    */
   coalescedDropCount: number
+  /**
+   * When set to 'terminal', this subscriber is in graceful-drain mode:
+   * - No new frames are accepted (heartbeat enqueue is skipped).
+   * - The queue is NOT cleared; drainQueue delivers all already-queued frames.
+   * - When the queue empties, drainQueue finalizes: removes from runSubscribers,
+   *   clears timers, calls onClose('terminal').
+   * - dropped is NOT set to true until finalization.
+   */
+  closingReason: 'terminal' | undefined
+}
+
+// ---------------------------------------------------------------------------
+// Terminal replay cache entry
+// ---------------------------------------------------------------------------
+
+interface TerminalReplayCacheEntry {
+  finalOutput: OperatorOutputFrame | undefined
+  terminalStatus: OperatorRunStatus | undefined
+  expiresAt: number
+  evictionTimer: ReturnType<typeof globalThis.setTimeout> | undefined
 }
 
 // ---------------------------------------------------------------------------
@@ -255,6 +290,8 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
   const heartbeatIntervalMs = deps.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS
   const maxStreamDurationMs = deps.maxStreamDurationMs ?? DEFAULT_MAX_STREAM_DURATION_MS
   const subscriberQueueCapBytes = deps.subscriberQueueCapBytes ?? DEFAULT_SUBSCRIBER_QUEUE_CAP_BYTES
+  const terminalReplayTtlMs = deps.terminalReplayTtlMs ?? DEFAULT_TERMINAL_REPLAY_TTL_MS
+  const terminalReplayMaxEntries = deps.terminalReplayMaxEntries ?? DEFAULT_TERMINAL_REPLAY_MAX_ENTRIES
 
   // ---------------------------------------------------------------------------
   // State
@@ -268,9 +305,21 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
   const latestStatusCache = new Map<string, OperatorRunStatus>()
 
   /**
+   * Terminal replay cache: persists the final output frame AND terminal status
+   * for a bounded TTL after a run reaches terminal state. Late subscribers
+   * connecting within the TTL receive the cached final output then terminal status,
+   * then the stream closes gracefully with 'terminal'.
+   *
+   * Replaces latestOutputCache for the terminal path. Active (non-terminal) runs
+   * still use latestOutputCache for the live-subscriber snapshot path.
+   */
+  const terminalReplayCache = new Map<string, TerminalReplayCacheEntry>()
+
+  /**
    * Latest final output frame per run. Set only when observeOutput is called with
-   * final:true. Cleared on the same teardown paths as latestStatusCache (terminal
-   * cleanup in observe(), shutdown). Delivered to late subscribers on subscribe.
+   * final:true AND the run is still active (not yet terminal). Cleared when the
+   * run reaches terminal (entry moves to terminalReplayCache) or on shutdown.
+   * Delivered to late subscribers on subscribe for active runs.
    */
   const latestOutputCache = new Map<string, OperatorOutputFrame>()
 
@@ -286,6 +335,79 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
 
   /** Whether the manager has been shut down. */
   let isShutdown = false
+
+  // ---------------------------------------------------------------------------
+  // Internal: terminal replay cache management
+  // ---------------------------------------------------------------------------
+
+  function evictTerminalReplayEntry(runId: string): void {
+    const entry = terminalReplayCache.get(runId)
+    if (entry !== undefined) {
+      if (entry.evictionTimer !== undefined) {
+        deps.clearTimeout(entry.evictionTimer)
+      }
+      terminalReplayCache.delete(runId)
+    }
+  }
+
+  function enforceTerminalReplayCap(): void {
+    if (terminalReplayCache.size <= terminalReplayMaxEntries) {
+      return
+    }
+    // Evict oldest entries (by insertion order — Map preserves insertion order)
+    const toEvict = terminalReplayCache.size - terminalReplayMaxEntries
+    let evicted = 0
+    for (const [runId, entry] of terminalReplayCache) {
+      if (evicted >= toEvict) {
+        break
+      }
+      if (entry.evictionTimer !== undefined) {
+        deps.clearTimeout(entry.evictionTimer)
+      }
+      terminalReplayCache.delete(runId)
+      evicted++
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal: finalize a subscriber in graceful-terminal-drain mode
+  // ---------------------------------------------------------------------------
+
+  function finalizeTerminalSubscriber(sub: SubscriberState): void {
+    if (sub.dropped === true) {
+      return
+    }
+    sub.dropped = true
+
+    // Clear timers
+    if (sub.heartbeatTimer !== undefined) {
+      deps.clearInterval(sub.heartbeatTimer)
+      sub.heartbeatTimer = undefined
+    }
+    if (sub.maxDurationTimer !== undefined) {
+      deps.clearTimeout(sub.maxDurationTimer)
+      sub.maxDurationTimer = undefined
+    }
+
+    // Remove from the run's subscriber set
+    const subs = runSubscribers.get(sub.runId)
+    if (subs !== undefined) {
+      subs.delete(sub.id)
+      if (subs.size === 0) {
+        runSubscribers.delete(sub.runId)
+      }
+    }
+
+    // Schedule onClose via queueMicrotask so a slow or synchronous onClose callback
+    // cannot block observe() from returning.
+    queueMicrotask(() => {
+      try {
+        sub.callbacks.onClose('terminal')
+      } catch (error) {
+        logger.warn({subId: sub.id, runId: sub.runId, err: String(error)}, 'manager: onClose threw — ignoring')
+      }
+    })
+  }
 
   // ---------------------------------------------------------------------------
   // Internal: drop a subscriber (overflow, error, close, shutdown)
@@ -307,7 +429,7 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
       sub.maxDurationTimer = undefined
     }
 
-    // Clear queue
+    // Clear queue (hard abort — discard in-flight frames)
     sub.queue.length = 0
     sub.queueBytes = 0
 
@@ -347,6 +469,12 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
     if (sub.dropped === true) {
       return false
     }
+    // In graceful-terminal-drain mode, do not accept new frames (except the
+    // terminal status frame itself, which was already enqueued before this mode
+    // was set). Heartbeats and other frames are silently dropped.
+    if (sub.closingReason === 'terminal') {
+      return false
+    }
 
     const frameBytes = estimateFrameBytes(frame)
     if (sub.queueBytes + frameBytes > subscriberQueueCapBytes) {
@@ -378,11 +506,16 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
   // ---------------------------------------------------------------------------
 
   async function drainQueue(sub: SubscriberState): Promise<void> {
-    while (sub.dropped === false && sub.queue.length > 0) {
-      const frame = sub.queue[0]
+    while (sub.queue.length > 0) {
+      // Dequeue BEFORE the await so the writer owns the frame.
+      // Coalescing (enqueueOutputFrame) splices the queue during the await;
+      // dequeue-before-await means the in-flight frame is no longer in the queue
+      // so coalescing cannot touch it. queueBytes is decremented on dequeue.
+      const frame = sub.queue.shift()
       if (frame === undefined) {
         break
       }
+      sub.queueBytes = Math.max(0, sub.queueBytes - estimateFrameBytes(frame))
 
       try {
         await sub.callbacks.onEvent(frame)
@@ -401,20 +534,30 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
 
       // Re-check dropped: dropSubscriber may have been called from another path
       // (e.g., heartbeat timer) while onEvent was awaited.
-      // TypeScript's control flow doesn't track mutations through function calls,
-      // so we use a local re-read via the queue length as the guard.
-      if (sub.queue.length === 0 || sub.dropped !== false) {
+      if (sub.dropped === true) {
         sub.writerRunning = false
         return
       }
 
-      // Remove the delivered frame from the queue
-      sub.queue.shift()
-      const frameBytes = estimateFrameBytes(frame)
-      sub.queueBytes = Math.max(0, sub.queueBytes - frameBytes)
+      // Graceful terminal drain — when the queue is empty and closingReason
+      // is 'terminal', finalize the subscriber (remove from runSubscribers, clear
+      // timers, call onClose('terminal')). This delivers all already-queued frames
+      // (including the terminal status) before closing.
+      if (sub.queue.length === 0 && sub.closingReason === 'terminal') {
+        sub.writerRunning = false
+        finalizeTerminalSubscriber(sub)
+        return
+      }
     }
 
     sub.writerRunning = false
+
+    // Final check after the loop: if we exited because queue is empty and
+    // closingReason is 'terminal', finalize now (handles the case where the
+    // queue was empty when we entered the loop).
+    if (sub.dropped === false && sub.closingReason === 'terminal') {
+      finalizeTerminalSubscriber(sub)
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -434,11 +577,16 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
       heartbeatTimer: undefined,
       maxDurationTimer: undefined,
       coalescedDropCount: 0,
+      closingReason: undefined,
     }
 
     // Heartbeat timer: emit a heartbeat frame every heartbeatIntervalMs
     sub.heartbeatTimer = deps.setInterval(() => {
       if (sub.dropped === true) {
+        return
+      }
+      // Do not enqueue heartbeats during graceful terminal drain
+      if (sub.closingReason === 'terminal') {
         return
       }
       const heartbeat: HeartbeatFrame = {type: 'heartbeat'}
@@ -498,6 +646,10 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
    */
   function enqueueOutputFrame(sub: SubscriberState, frame: OutputFrame): boolean {
     if (sub.dropped === true) {
+      return false
+    }
+    // In graceful-terminal-drain mode, do not accept new output frames
+    if (sub.closingReason === 'terminal') {
       return false
     }
 
@@ -594,7 +746,47 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
   }
 
   // ---------------------------------------------------------------------------
-  // Internal: close all subscribers of a run with a given reason
+  // Internal: mark all subscribers of a run for graceful terminal drain
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Mark all subscribers of a run for graceful terminal drain.
+   *
+   * Unlike closeRunSubscribers (hard abort), this path:
+   * 1. Sets closingReason = 'terminal' (stops accepting new frames, stops heartbeats).
+   * 2. Does NOT clear the queue — drainQueue delivers all already-queued frames.
+   * 3. Does NOT set dropped = true — drainQueue's completion path finalizes.
+   * 4. If the queue is already empty (writerRunning === false), finalizes immediately.
+   *
+   * This guarantees the terminal status frame (already enqueued via fanOut before
+   * this is called) is delivered before the subscriber is closed.
+   */
+  function markRunSubscribersForTerminalDrain(runId: string): void {
+    const subs = runSubscribers.get(runId)
+    if (subs === undefined || subs.size === 0) {
+      return
+    }
+
+    // Snapshot before iterating (finalization modifies the map)
+    const snapshot = Array.from(subs.values())
+    for (const sub of snapshot) {
+      if (sub.dropped === true) {
+        continue
+      }
+      sub.closingReason = 'terminal'
+
+      // If the writer is not running and the queue is empty, finalize immediately.
+      // If the writer is running, it will finalize when the queue drains.
+      if (sub.writerRunning === false && sub.queue.length === 0) {
+        finalizeTerminalSubscriber(sub)
+      }
+      // If writerRunning === true, drainQueue will call finalizeTerminalSubscriber
+      // when the queue empties.
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal: close all subscribers of a run with a given reason (hard abort)
   // ---------------------------------------------------------------------------
 
   function closeRunSubscribers(runId: string, reason: string): void {
@@ -638,6 +830,12 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
 
     const runId = runState.run_id
 
+    // On a non-terminal status, clear any stale terminal replay cache entry for this
+    // runId (avoids stale replay if runId is reused after a previous terminal run).
+    if (isTerminal(projected.status) === false) {
+      evictTerminalReplayEntry(runId)
+    }
+
     // Build the status frame (closed DTO — only the contract fields)
     // The projection already returns a closed OperatorRunStatus; we wrap it in a frame.
     const frame: StatusFrame = {type: 'status', data: projected}
@@ -648,19 +846,40 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
     // Fan out to all current subscribers (non-blocking — never awaits writes)
     fanOut(runId, frame)
 
-    // On terminal status: clear the cache entry AFTER fan-out and close subscribers.
-    // Order matters: fanOut() above calls enqueueFrame() → drainQueue() fire-and-forget.
-    // drainQueue() captures `frame` in a local variable and calls onEvent(frame) before
-    // its first `await` suspends — so the terminal frame is already in-flight when
-    // closeRunSubscribers() runs synchronously below and clears each subscriber's queue.
-    // The queue clear does NOT drop the in-flight frame because drainQueue() holds a
-    // direct reference to it; reordering fanOut and closeRunSubscribers would silently
-    // discard the terminal frame for any subscriber whose writer task hadn't started yet.
+    // On terminal status: transition to graceful drain instead of hard abort.
+    // markRunSubscribersForTerminalDrain does NOT clear queues — it lets
+    // drainQueue deliver all already-queued frames (including the terminal status
+    // frame just enqueued above) before finalizing the subscriber.
     if (isTerminal(projected.status) === true) {
       latestStatusCache.delete(runId)
-      latestOutputCache.delete(runId)
       outputSeqCounters.delete(runId)
-      closeRunSubscribers(runId, 'terminal')
+
+      // Move final output to terminal replay cache (with TTL) instead of
+      // deleting it. Late subscribers connecting within the TTL receive the cached
+      // final output then terminal status, then the stream closes gracefully.
+      const finalOutput = latestOutputCache.get(runId)
+      latestOutputCache.delete(runId)
+
+      // Evict any existing entry for this runId before creating a new one
+      evictTerminalReplayEntry(runId)
+
+      const expiresAt = deps.now() + terminalReplayTtlMs
+      const evictionTimer = deps.setTimeout(() => {
+        terminalReplayCache.delete(runId)
+      }, terminalReplayTtlMs)
+
+      terminalReplayCache.set(runId, {
+        finalOutput,
+        terminalStatus: projected,
+        expiresAt,
+        evictionTimer,
+      })
+
+      // Enforce the hard cap on replay cache size
+      enforceTerminalReplayCap()
+
+      // Graceful drain: deliver all queued frames (including terminal status) then close
+      markRunSubscribersForTerminalDrain(runId)
     }
   }
 
@@ -670,6 +889,13 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
 
   const observeOutput = (runId: string, text: string, opts?: {final?: boolean; droppedCount?: number}): void => {
     if (isShutdown === true) {
+      return
+    }
+
+    // If the run has already reached terminal (replay cache entry exists), drop
+    // any further output observations — the run is done.
+    if (terminalReplayCache.has(runId) === true) {
+      logger.warn({runId}, 'manager: observeOutput called after terminal — dropping')
       return
     }
 
@@ -689,7 +915,7 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
 
     const frame: OutputFrame = {type: 'output', data: outputData}
 
-    // Cache the final frame for late subscribers
+    // Cache the final frame for late subscribers (active run path)
     if (isFinal === true) {
       latestOutputCache.set(runId, outputData)
     }
@@ -712,6 +938,63 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
       }
       return () => {
         // no-op
+      }
+    }
+
+    // Check terminal replay cache first. If the run has already terminated,
+    // replay the final output and terminal status, then close gracefully.
+    const replayEntry = terminalReplayCache.get(runId)
+    if (replayEntry !== undefined) {
+      // Create a subscriber for the replay path (with timers, so cleanup is consistent)
+      const sub = createSubscriber(runId, callbacks)
+
+      // Register in the run's subscriber set
+      let subs = runSubscribers.get(runId)
+      if (subs === undefined) {
+        subs = new Map()
+        runSubscribers.set(runId, subs)
+      }
+      subs.set(sub.id, sub)
+
+      // Enqueue: final output (if any) then terminal status, then mark for terminal drain
+      if (replayEntry.finalOutput !== undefined) {
+        const outputFrame: OutputFrame = {type: 'output', data: replayEntry.finalOutput}
+        enqueueOutputFrame(sub, outputFrame)
+      }
+      if (replayEntry.terminalStatus !== undefined) {
+        const statusFrame: StatusFrame = {type: 'status', data: replayEntry.terminalStatus}
+        enqueueFrame(sub, statusFrame)
+      }
+
+      // Mark for graceful terminal drain — delivers queued frames then closes with 'terminal'
+      sub.closingReason = 'terminal'
+      if (sub.writerRunning === false && sub.queue.length === 0) {
+        finalizeTerminalSubscriber(sub)
+      }
+
+      // Return a clean-disconnect function
+      return () => {
+        if (sub.dropped === true) {
+          return
+        }
+        sub.dropped = true
+        if (sub.heartbeatTimer !== undefined) {
+          deps.clearInterval(sub.heartbeatTimer)
+          sub.heartbeatTimer = undefined
+        }
+        if (sub.maxDurationTimer !== undefined) {
+          deps.clearTimeout(sub.maxDurationTimer)
+          sub.maxDurationTimer = undefined
+        }
+        sub.queue.length = 0
+        sub.queueBytes = 0
+        const runSubs = runSubscribers.get(runId)
+        if (runSubs !== undefined) {
+          runSubs.delete(sub.id)
+          if (runSubs.size === 0) {
+            runSubscribers.delete(runId)
+          }
+        }
       }
     }
 
@@ -738,8 +1021,9 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
     }
 
     // Deliver the cached final output frame (if any) after the status snapshot.
-    // This ensures a late subscriber (connecting after the run's final output frame)
-    // receives the complete answer. Order: status/reset first, then cached output.
+    // This ensures a late subscriber (connecting after the run's final output frame
+    // but before terminal) receives the complete answer.
+    // Order: status/reset first, then cached output.
     const cachedOutput = latestOutputCache.get(runId)
     if (cachedOutput !== undefined) {
       const outputFrame: OutputFrame = {type: 'output', data: cachedOutput}
@@ -804,6 +1088,14 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
     latestStatusCache.clear()
     latestOutputCache.clear()
     outputSeqCounters.clear()
+
+    // Clear terminal replay cache (cancel all eviction timers)
+    for (const entry of terminalReplayCache.values()) {
+      if (entry.evictionTimer !== undefined) {
+        deps.clearTimeout(entry.evictionTimer)
+      }
+    }
+    terminalReplayCache.clear()
   }
 
   return {observe, observeOutput, subscribe, abortSubscription, shutdown}

--- a/packages/gateway/src/web/sse/manager.ts
+++ b/packages/gateway/src/web/sse/manager.ts
@@ -21,7 +21,7 @@
  */
 
 import type {RunState} from '@fro-bot/runtime'
-import type {OperatorRunStatus} from '../../operator-contract/index.js'
+import type {OperatorOutputFrame, OperatorRunStatus} from '../../operator-contract/index.js'
 
 // ---------------------------------------------------------------------------
 // Constants (injectable for tests)
@@ -74,8 +74,14 @@ export interface HeartbeatFrame {
   readonly type: 'heartbeat'
 }
 
+/** An output frame carrying the agent's visible text. */
+export interface OutputFrame {
+  readonly type: 'output'
+  readonly data: OperatorOutputFrame
+}
+
 /** The closed union of all frame types the manager can emit. */
-export type ObservationFrame = StatusFrame | ResetFrame | HeartbeatFrame
+export type ObservationFrame = StatusFrame | ResetFrame | HeartbeatFrame | OutputFrame
 
 // ---------------------------------------------------------------------------
 // Subscriber callbacks
@@ -157,6 +163,22 @@ export interface RunObservationManager {
   readonly subscribe: (runId: string, callbacks: SubscriberCallbacks) => () => void
 
   /**
+   * Observe an output text fragment for a run. Observer-only / best-effort.
+   *
+   * Builds an OutputFrame with a per-run monotonic seq counter and fans it out to
+   * all current subscribers of the run via the same enqueueFrame path. On overflow,
+   * output frames COALESCE (do not drop the subscriber): pending output frames are
+   * merged and a droppedCount is accumulated onto the next successfully-enqueued
+   * output frame for that subscriber, keeping the connection alive.
+   *
+   * On opts.final === true, caches the frame in latestOutputCache so late subscribers
+   * receive the final answer on subscribe.
+   *
+   * Does NOT add any mutating run API to the deps — observer-only by construction.
+   */
+  readonly observeOutput: (runId: string, text: string, opts?: {final?: boolean; droppedCount?: number}) => void
+
+  /**
    * Abort a subscription with a given reason (e.g., 'observation-failed' for EOF).
    * Calls onClose(reason) and removes the subscription + its timers/queue.
    * Used by the route layer to signal connection drops before a terminal status.
@@ -191,6 +213,13 @@ interface SubscriberState {
   heartbeatTimer: ReturnType<typeof globalThis.setInterval> | undefined
   /** Max-duration timeout timer ID. */
   maxDurationTimer: ReturnType<typeof globalThis.setTimeout> | undefined
+  /**
+   * Accumulated count of output frames coalesced/dropped for this subscriber.
+   * Carried onto the next successfully-enqueued output frame as droppedCount.
+   * Keeps the connection alive under output overflow (unlike status frames which
+   * drop the subscriber).
+   */
+  coalescedDropCount: number
 }
 
 // ---------------------------------------------------------------------------
@@ -237,6 +266,20 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
   // staleness/reconcile path will evict these entries; for now the leak is bounded
   // by the number of active runs and is cleared on process restart.
   const latestStatusCache = new Map<string, OperatorRunStatus>()
+
+  /**
+   * Latest final output frame per run. Set only when observeOutput is called with
+   * final:true. Cleared on the same teardown paths as latestStatusCache (terminal
+   * cleanup in observe(), shutdown). Delivered to late subscribers on subscribe.
+   */
+  const latestOutputCache = new Map<string, OperatorOutputFrame>()
+
+  /**
+   * Monotonic seq counter per run for output frames. Incremented on each
+   * observeOutput call. Cleared on terminal teardown so a re-used runId starts
+   * at seq 0 again.
+   */
+  const outputSeqCounters = new Map<string, number>()
 
   /** Active subscribers per run. Map<runId, Map<subId, SubscriberState>>. */
   const runSubscribers = new Map<string, Map<string, SubscriberState>>()
@@ -390,6 +433,7 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
       dropped: false,
       heartbeatTimer: undefined,
       maxDurationTimer: undefined,
+      coalescedDropCount: 0,
     }
 
     // Heartbeat timer: emit a heartbeat frame every heartbeatIntervalMs
@@ -433,6 +477,119 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
     const snapshot = Array.from(subs.values())
     for (const sub of snapshot) {
       enqueueFrame(sub, frame)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal: enqueue an output frame with coalescing on overflow
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Enqueue an output frame to a subscriber with coalescing on overflow.
+   *
+   * Unlike status frames (which drop the subscriber on overflow), output frames
+   * coalesce: when the queue would overflow, pending output frames in the queue
+   * are removed and their count is accumulated in sub.coalescedDropCount. The
+   * next successfully-enqueued output frame carries that count as droppedCount,
+   * keeping the connection alive.
+   *
+   * Returns true if the frame was enqueued (possibly after coalescing), false if
+   * the subscriber was already dropped.
+   */
+  function enqueueOutputFrame(sub: SubscriberState, frame: OutputFrame): boolean {
+    if (sub.dropped === true) {
+      return false
+    }
+
+    const frameBytes = estimateFrameBytes(frame)
+
+    // If the frame fits, enqueue it directly (carrying any accumulated droppedCount)
+    if (sub.queueBytes + frameBytes <= subscriberQueueCapBytes) {
+      // Carry accumulated droppedCount into the frame if any coalescing happened
+      const effectiveFrame: OutputFrame =
+        sub.coalescedDropCount > 0
+          ? {
+              type: 'output',
+              data: {...frame.data, droppedCount: (frame.data.droppedCount ?? 0) + sub.coalescedDropCount},
+            }
+          : frame
+      sub.coalescedDropCount = 0
+
+      sub.queue.push(effectiveFrame)
+      sub.queueBytes += estimateFrameBytes(effectiveFrame)
+
+      if (sub.writerRunning === false) {
+        sub.writerRunning = true
+        drainQueue(sub).catch(() => {})
+      }
+      return true
+    }
+
+    // Overflow: coalesce — remove pending output frames from the queue to make room,
+    // accumulating their count. Keep non-output frames (status, reset, heartbeat) intact.
+    let removedCount = 0
+    let removedBytes = 0
+    for (let i = sub.queue.length - 1; i >= 0; i--) {
+      const queued = sub.queue[i]
+      if (queued !== undefined && queued.type === 'output') {
+        removedBytes += estimateFrameBytes(queued)
+        sub.queue.splice(i, 1)
+        removedCount++
+      }
+    }
+    sub.queueBytes = Math.max(0, sub.queueBytes - removedBytes)
+    sub.coalescedDropCount += removedCount
+
+    // Try again after coalescing
+    if (sub.queueBytes + frameBytes <= subscriberQueueCapBytes) {
+      const effectiveFrame: OutputFrame =
+        sub.coalescedDropCount > 0
+          ? {
+              type: 'output',
+              data: {...frame.data, droppedCount: (frame.data.droppedCount ?? 0) + sub.coalescedDropCount},
+            }
+          : frame
+      sub.coalescedDropCount = 0
+
+      sub.queue.push(effectiveFrame)
+      sub.queueBytes += estimateFrameBytes(effectiveFrame)
+
+      logger.warn(
+        {subId: sub.id, runId: sub.runId, removedCount, queueBytes: sub.queueBytes},
+        'manager: output frame coalesced — dropped pending output frames to keep connection alive',
+      )
+
+      if (sub.writerRunning === false) {
+        sub.writerRunning = true
+        drainQueue(sub).catch(() => {})
+      }
+      return true
+    }
+
+    // Even after coalescing all output frames, the new frame still doesn't fit.
+    // Accumulate the drop count and discard this frame too (connection stays alive).
+    sub.coalescedDropCount++
+    logger.warn(
+      {subId: sub.id, runId: sub.runId, coalescedDropCount: sub.coalescedDropCount},
+      'manager: output frame discarded after coalescing — queue still full, accumulating droppedCount',
+    )
+    return false
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal: fan-out an output frame to all subscribers of a run (with coalescing)
+  // ---------------------------------------------------------------------------
+
+  function fanOutOutput(runId: string, frame: OutputFrame): void {
+    const subs = runSubscribers.get(runId)
+    if (subs === undefined || subs.size === 0) {
+      return
+    }
+
+    // Snapshot the subscriber set before iterating
+    const snapshot = Array.from(subs.values())
+    for (const sub of snapshot) {
+      enqueueOutputFrame(sub, frame)
     }
   }
 
@@ -501,8 +658,44 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
     // discard the terminal frame for any subscriber whose writer task hadn't started yet.
     if (isTerminal(projected.status) === true) {
       latestStatusCache.delete(runId)
+      latestOutputCache.delete(runId)
+      outputSeqCounters.delete(runId)
       closeRunSubscribers(runId, 'terminal')
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // observeOutput
+  // ---------------------------------------------------------------------------
+
+  const observeOutput = (runId: string, text: string, opts?: {final?: boolean; droppedCount?: number}): void => {
+    if (isShutdown === true) {
+      return
+    }
+
+    // Increment the per-run seq counter
+    const seq = outputSeqCounters.get(runId) ?? 0
+    outputSeqCounters.set(runId, seq + 1)
+
+    const isFinal = opts?.final ?? false
+
+    const outputData: OperatorOutputFrame = {
+      runId,
+      text,
+      final: isFinal,
+      seq,
+      ...(opts?.droppedCount === undefined ? {} : {droppedCount: opts.droppedCount}),
+    }
+
+    const frame: OutputFrame = {type: 'output', data: outputData}
+
+    // Cache the final frame for late subscribers
+    if (isFinal === true) {
+      latestOutputCache.set(runId, outputData)
+    }
+
+    // Fan out to all current subscribers with coalescing on overflow
+    fanOutOutput(runId, frame)
   }
 
   // ---------------------------------------------------------------------------
@@ -542,6 +735,15 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
     } else {
       const snapshotFrame: StatusFrame = {type: 'status', data: cached}
       enqueueFrame(sub, snapshotFrame)
+    }
+
+    // Deliver the cached final output frame (if any) after the status snapshot.
+    // This ensures a late subscriber (connecting after the run's final output frame)
+    // receives the complete answer. Order: status/reset first, then cached output.
+    const cachedOutput = latestOutputCache.get(runId)
+    if (cachedOutput !== undefined) {
+      const outputFrame: OutputFrame = {type: 'output', data: cachedOutput}
+      enqueueOutputFrame(sub, outputFrame)
     }
 
     // Return a clean-disconnect function (no onClose called)
@@ -598,9 +800,11 @@ export function createRunObservationManager(deps: RunObservationManagerDeps): Ru
       closeRunSubscribers(runId, 'shutdown')
     }
 
-    // Clear the latest-status cache
+    // Clear all caches
     latestStatusCache.clear()
+    latestOutputCache.clear()
+    outputSeqCounters.clear()
   }
 
-  return {observe, subscribe, abortSubscription, shutdown}
+  return {observe, observeOutput, subscribe, abortSubscription, shutdown}
 }

--- a/packages/gateway/src/web/sse/run-stream-route.test.ts
+++ b/packages/gateway/src/web/sse/run-stream-route.test.ts
@@ -152,6 +152,7 @@ function makeRepoAuthzDeps(authorized = true): RepoAuthzDeps {
 function makeManager(overrides?: Partial<RunObservationManager>): RunObservationManager {
   return {
     observe: vi.fn(async () => undefined),
+    observeOutput: vi.fn(),
     subscribe: vi.fn((_runId: string, _callbacks: SubscriberCallbacks) => () => undefined),
     abortSubscription: vi.fn(),
     shutdown: vi.fn(),

--- a/packages/gateway/src/web/sse/run-stream-route.test.ts
+++ b/packages/gateway/src/web/sse/run-stream-route.test.ts
@@ -2185,3 +2185,144 @@ describe('GET /operator/runs/:runId/stream — contract version ready frame', ()
     expect(res.headers.get('content-type')).not.toContain('text/event-stream')
   })
 })
+
+// ---------------------------------------------------------------------------
+// output frame — writeFrame 'output' branch + ready-first ordering
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — output frame written to SSE stream', () => {
+  it("writes an output frame as event:'output' with JSON-serialized frame data", async () => {
+    // #given — manager delivers an output frame via the subscriber callback
+    const outputData = {
+      runId: 'run-abc',
+      text: 'Hello from the agent',
+      final: false,
+      seq: 1,
+    }
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        // Deliver the output frame immediately (mirrors the status-frame happy-path pattern)
+        Promise.resolve(callbacks.onEvent({type: 'output', data: outputData})).catch(() => {})
+        return () => undefined
+      }),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    // #then — SSE stream contains event: output with the serialized frame data
+    const reader = res.body?.getReader()
+    if (reader === undefined) throw new Error('Expected a readable body')
+    const decoder = new TextDecoder()
+    let text = ''
+    for (let i = 0; i < 10; i++) {
+      const result = await reader.read()
+      if (result.done === true) break
+      text += decoder.decode(result.value as Uint8Array, {stream: true})
+      if (text.includes('event: output')) break
+    }
+    await reader.cancel()
+
+    expect(text).toContain('event: output')
+    expect(text).toContain('"runId":"run-abc"')
+    expect(text).toContain('"text":"Hello from the agent"')
+    expect(text).toContain('"final":false')
+    expect(text).toContain('"seq":1')
+  })
+
+  it("writes a final output frame (final:true) as event:'output' carrying final:true", async () => {
+    // #given — manager delivers a terminal output frame (final: true)
+    const outputData = {
+      runId: 'run-abc',
+      text: 'Final answer from the agent',
+      final: true,
+      seq: 5,
+    }
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        Promise.resolve(callbacks.onEvent({type: 'output', data: outputData})).catch(() => {})
+        return () => undefined
+      }),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    // #then — event: output with final:true in the serialized data
+    const reader = res.body?.getReader()
+    if (reader === undefined) throw new Error('Expected a readable body')
+    const decoder = new TextDecoder()
+    let text = ''
+    for (let i = 0; i < 10; i++) {
+      const result = await reader.read()
+      if (result.done === true) break
+      text += decoder.decode(result.value as Uint8Array, {stream: true})
+      if (text.includes('event: output')) break
+    }
+    await reader.cancel()
+
+    expect(text).toContain('event: output')
+    expect(text).toContain('"final":true')
+    expect(text).toContain('"seq":5')
+    expect(text).toContain('"text":"Final answer from the agent"')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ready-first ordering — ready frame precedes any output frame
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs/:runId/stream — ready frame precedes output frame (ordering regression guard)', () => {
+  it('emits the ready frame before any output frame pushed through the subscriber callback', async () => {
+    // #given — manager delivers an output frame; ready is emitted before subscribe is called
+    const outputData = {
+      runId: 'run-abc',
+      text: 'Agent output text',
+      final: false,
+      seq: 1,
+    }
+    const manager = makeManager({
+      subscribe: vi.fn((_runId: string, callbacks: SubscriberCallbacks) => {
+        // Deliver the output frame immediately after subscribe is called.
+        // The ready frame is fire-and-forget BEFORE subscribe, so it must appear first.
+        Promise.resolve(callbacks.onEvent({type: 'output', data: outputData})).catch(() => {})
+        return () => undefined
+      }),
+    })
+    const deps = makeDeps({manager})
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await fetchStream(app, 'run-abc')
+    expect(res.status).toBe(200)
+
+    // #then — read enough chunks to capture both ready and output events
+    const reader = res.body?.getReader()
+    if (reader === undefined) throw new Error('Expected a readable body')
+    const decoder = new TextDecoder()
+    let text = ''
+    for (let i = 0; i < 15; i++) {
+      const result = await reader.read()
+      if (result.done === true) break
+      text += decoder.decode(result.value as Uint8Array, {stream: true})
+      // Stop once we have both events
+      if (text.includes('event: ready') && text.includes('event: output')) break
+    }
+    await reader.cancel()
+
+    // Both events must be present
+    expect(text).toContain('event: ready')
+    expect(text).toContain('event: output')
+
+    // ready must appear before output in the stream
+    const readyIndex = text.indexOf('event: ready')
+    const outputIndex = text.indexOf('event: output')
+    expect(readyIndex).toBeLessThan(outputIndex)
+  })
+})

--- a/packages/gateway/src/web/sse/run-stream-route.ts
+++ b/packages/gateway/src/web/sse/run-stream-route.ts
@@ -183,6 +183,8 @@ async function writeFrame(stream: SSEStreamingApi, frame: ObservationFrame): Pro
   } else if (frame.type === 'heartbeat') {
     // SSE comment line — keepalive, not a named event
     await stream.write(': heartbeat\n\n')
+  } else if (frame.type === 'output') {
+    await stream.writeSSE({event: 'output', data: JSON.stringify(frame.data)})
   } else {
     // Exhaustiveness guard: a new ObservationFrame variant must be handled above.
     const EXHAUSTIVE_CHECK: never = frame


### PR DESCRIPTION
A web operator can launch a run and watch its status over the SSE run-stream, but couldn't read what the agent actually said — the web reply sink buffered the output and dropped it. This wires that output through the run-observation manager as a new `output` SSE frame, so the operator reads the agent's text live and always ends with the complete answer. Closes #965 (advances #907).

## What changed

- **Additive `output` frame** on the operator contract (`{ runId, text, final, seq, droppedCount? }`), contract bumped to `1.3.0`. Delta frames append; the `final` frame replaces with the complete answer. 1.2.x clients keep working via the `ready`-frame version advertisement.
- **Live streaming with a guaranteed final answer.** The manager gains `observeOutput`, fanning the agent's text to a run's subscribers. The web reply sink forwards each delta and the final answer, scoped to the run. Under per-subscriber backpressure, output frames **coalesce** (carrying a cumulative `droppedCount`) instead of dropping the connection like status frames do — the authoritative final frame restores completeness.
- **Final answer before terminal status.** The terminal observer notification is deferred until after the final-answer flush, so an operator can no longer see a run reach `succeeded`/`failed` without its answer. The reorder is inert for Discord, which posts its output independently; a characterization test pins that.
- **Terminal is a graceful end-of-stream, not an abort.** Terminal teardown now drains a subscriber's queued frames before closing, so the terminal status is delivered even when it was queued behind the final output frame. The final answer and terminal status are held in a bounded replay cache (TTL + entry and byte caps) past terminal, so an operator connecting after a run finished still receives the complete answer and a clean close.

## Notes

- Output is delivered as-is. The trust boundary is the repo-authz gate the stream already enforces (the same content the operator could see in the Discord thread) — not per-frame redaction. The SSE solution doc records the foot-gun that streaming raw file contents or secrets later must tighten the lease.
- The read surface already mapped `PENDING → queued` / `FAILED → failed`; no status-contract change.
- Gateway-only; `dist/main.js` is unaffected.