### PR TITLE
fix(gateway): redirect to validated return_to after operator OAuth callback

### DIFF
--- a/packages/gateway/src/web/auth/github.test.ts
+++ b/packages/gateway/src/web/auth/github.test.ts
@@ -2330,6 +2330,192 @@ describe('GET /operator/auth/github/callback — OAuth token retention', () => {
 })
 
 // ---------------------------------------------------------------------------
+// OAuth callback — return_to redirect on session-minted success path
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/auth/github/callback — return_to redirect after session mint', () => {
+  it('redirects to allowlisted return_to path (302) with Set-Cookie on session-minted success', async () => {
+    // #given — state has a redirectTarget that is in the allowlist
+    const stateStore = createInMemoryStateStore()
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+      redirectTarget: '/operator/dashboard',
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig() // allowedReturnPaths includes '/operator/dashboard'
+    const app = buildTestAppWithSession(deps, config, sessionStore, sessionDeps)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — 302 redirect to the validated return path
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('/operator/dashboard')
+
+    // #and — session cookie is still set on the redirect response
+    const setCookieHeaders = res.headers.getSetCookie()
+    const sessionCookie = setCookieHeaders.find(h => h.startsWith(`${SESSION_COOKIE_NAME}=`))
+    expect(sessionCookie).toBeDefined()
+
+    // #and — session was minted in the store
+    expect(sessionStore.size()).toBe(1)
+  })
+
+  it('falls back to 200 JSON when state has no redirectTarget (no return_to)', async () => {
+    // #given — state has no redirectTarget
+    const stateStore = createInMemoryStateStore()
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+      // no redirectTarget
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestAppWithSession(deps, config, sessionStore, sessionDeps)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — falls back to existing 200 JSON behavior
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({githubUserId: 42, login: 'octocat'})
+
+    // #and — session cookie is still set
+    const setCookieHeaders = res.headers.getSetCookie()
+    const sessionCookie = setCookieHeaders.find(h => h.startsWith(`${SESSION_COOKIE_NAME}=`))
+    expect(sessionCookie).toBeDefined()
+  })
+
+  it('falls back to 200 JSON when redirectTarget is NOT in allowedReturnPaths (security: no unvalidated redirect)', async () => {
+    // #given — state has a redirectTarget that is NOT in the allowlist
+    const stateStore = createInMemoryStateStore()
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+      redirectTarget: '/some/unlisted/path',
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig() // allowedReturnPaths: ['/operator/dashboard', '/operator/runs']
+    const app = buildTestAppWithSession(deps, config, sessionStore, sessionDeps)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — MUST NOT redirect; falls back to 200 JSON (security-critical assertion)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({githubUserId: 42, login: 'octocat'})
+
+    // #and — session was still minted (allowlist failure only affects redirect, not session)
+    expect(sessionStore.size()).toBe(1)
+  })
+
+  it('falls back to 200 JSON when redirectTarget is an absolute URL (cross-origin attempt)', async () => {
+    // #given — state has an absolute URL as redirectTarget (should be rejected by validateReturnPath)
+    const stateStore = createInMemoryStateStore()
+    const sessionStore = createInMemorySessionStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+      redirectTarget: 'https://evil.attacker.com/steal',
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const sessionDeps = makeStubSessionDeps({clock: () => now + 1000})
+    const config = makeStubConfig()
+    const app = buildTestAppWithSession(deps, config, sessionStore, sessionDeps)
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — MUST NOT redirect to cross-origin URL; falls back to 200 JSON
+    expect(res.status).toBe(200)
+    expect(res.headers.get('location')).toBeNull()
+
+    // #and — session was still minted
+    expect(sessionStore.size()).toBe(1)
+  })
+
+  it('no-session-store path still returns 200 JSON regardless of redirectTarget', async () => {
+    // #given — no session store wired; state has a redirectTarget
+    const stateStore = createInMemoryStateStore()
+    const now = Date.now()
+    stateStore.set('valid-state-value', {
+      codeVerifier: 'test-verifier-32-bytes-long-enough-for-pkce',
+      issuedAt: now,
+      consumed: false,
+      redirectTarget: '/operator/dashboard',
+    })
+
+    const deps = makeStubDeps({
+      stateStore,
+      clock: () => now + 1000,
+      fetch: makeSuccessFetch({userId: 42, login: 'octocat'}),
+    })
+    const config = makeStubConfig()
+    const app = buildTestApp(deps, config) // no session store
+
+    // #when
+    const req = new Request(
+      'https://operator.example.com/operator/auth/github/callback?code=github-code-abc&state=valid-state-value',
+    )
+    const res = await app.fetch(req)
+
+    // #then — no-session path is unchanged: always 200 JSON
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({githubUserId: 42, login: 'octocat'})
+  })
+})
+
+// ---------------------------------------------------------------------------
 // OAuth callback — allowlist check before session creation (Fix 2)
 // ---------------------------------------------------------------------------
 

--- a/packages/gateway/src/web/auth/github.ts
+++ b/packages/gateway/src/web/auth/github.ts
@@ -666,6 +666,18 @@ export function buildGitHubOAuthRoutes(app: Hono, deps: GitHubOAuthDeps, config:
       c.header('Set-Cookie', buildSessionCookieValue(newSessionId), {append: true})
 
       deps.sessionDeps.logger.info({githubUserId}, 'oauth callback: session minted')
+
+      // Redirect to the validated return path if one was captured at flow start.
+      // Re-validate here as defense-in-depth — the allowlist config could differ
+      // from what was checked at /start, and stored targets must never be trusted
+      // unconditionally. Use the returned validated path, not the raw stored value.
+      if (stateEntry.redirectTarget !== undefined && stateEntry.redirectTarget !== '') {
+        const validatedPath = validateReturnPath(stateEntry.redirectTarget, config.allowedReturnPaths)
+        if (validatedPath !== null) {
+          return c.redirect(validatedPath, 302)
+        }
+      }
+
       return c.json({githubUserId, login}, 200)
     }
 


### PR DESCRIPTION
The operator OAuth callback minted the session cookie but always returned JSON, ignoring the `return_to` captured when the flow started — so an operator finished authenticating on a `{githubUserId, login}` JSON page instead of being returned to where they came from. Closes #973.

This is the companion to the dashboard-side fix (fro-bot/dashboard#70, shipped via fro-bot/dashboard#72), which sends operators to `/operator/auth/github/start?return_to=<path>`. Without this change the round-trip never closed: in gateway-session mode a gateway restart wipes the in-memory operator sessions, the dashboard recovers by redirecting through GitHub auth, but the operator then landed on a JSON page.

## The fix

On the session-minted success path in `packages/gateway/src/web/auth/github.ts`, after setting the `Set-Cookie` header:

```ts
if (stateEntry.redirectTarget !== undefined && stateEntry.redirectTarget !== '') {
  const validatedPath = validateReturnPath(stateEntry.redirectTarget, config.allowedReturnPaths)
  if (validatedPath !== null) return c.redirect(validatedPath, 302)
}
return c.json({githubUserId, login}, 200)
```

The `return_to` infrastructure already existed (`stateEntry.redirectTarget` captured at flow start, `validateReturnPath` for same-origin + allowlist validation, the `GATEWAY_OPERATOR_OAUTH_ALLOWED_RETURN_PATHS` config) — the callback simply never read it. The session cookie set via `c.header(...)` carries on the 302.

## Security

The return path is **re-validated at the callback** as defense-in-depth — using the value `validateReturnPath` returns, not the raw stored target — so a non-allowlisted or cross-origin target never produces a redirect even if it somehow reached the stored entry. `validateReturnPath` rejects absolute and protocol-relative URLs and requires an exact allowlist match. When no valid `return_to` is present, the response is the existing JSON, preserving prior behavior. The no-session-store path is untouched.

## Tests

Five new tests pin the behavior, including the security-critical ones: allowlisted target → 302 + `Set-Cookie` + session minted; no `return_to` → 200 JSON; **non-allowlisted target → 200 JSON, not a redirect**; cross-origin absolute URL → 200 JSON; no-session path unchanged.

Gateway-only; no `dist` impact.