### PR TITLE
feat(harness): squash carries into one fingerprint commit, list them in release notes

### DIFF
--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -51,6 +51,7 @@ jobs:
       base_version: ${{ steps.render.outputs.base_version }}
       rendered_prompt: ${{ steps.render.outputs.rendered_prompt }}
       has_refs: ${{ steps.render.outputs.has_refs }}
+      carries: ${{ steps.render.outputs.carries }}
 
     steps:
       - name: Checkout harness repo
@@ -149,6 +150,16 @@ jobs:
           fi
           echo "has_refs=${HAS_REFS}" >> "$GITHUB_OUTPUT"
           echo "has_refs: ${HAS_REFS}"
+
+          # --- Emit carries: the comma-joined carry labels for the release notes ---
+          # Same set `harness patches` reports (the integrationRefs labels), e.g.
+          # "anomalyco/opencode#19961, anomalyco/opencode#31859, anomalyco/opencode#31638".
+          {
+            echo "carries<<EOF_CARRIES"
+            printf '%s\n' "${BRANCHES}"
+            echo "EOF_CARRIES"
+          } >> "$GITHUB_OUTPUT"
+          echo "carries: ${BRANCHES}"
 
           # --- Render the prompt template ---
           PROMPT_TPL=$(cat packages/harness/prompt.txt)
@@ -736,6 +747,8 @@ jobs:
           RELEASE_TAG: ${{ steps.params.outputs.release_tag }}
           BASE_VERSION: ${{ steps.params.outputs.base_version }}
           SHORT_SHA: ${{ steps.params.outputs.short_sha }}
+          # Comma-joined carry labels (the same set `harness patches` reports).
+          CARRIES: ${{ needs.prepare-integrate.outputs.carries }}
         run: |
           set -euo pipefail
           cd /tmp/harness-release-assets
@@ -756,11 +769,30 @@ jobs:
               --clobber
             echo "Assets re-uploaded (clobber) for: ${RELEASE_TAG}"
           else
+            # Build the release notes: a summary line plus a bulleted list of the
+            # carried upstream refs (one per comma-separated label).
+            NOTES_FILE="$(mktemp)"
+            {
+              printf '%s\n\n' "Harness build of OpenCode ${BASE_VERSION} (integration ${SHORT_SHA})."
+              if [ -n "${CARRIES:-}" ]; then
+                printf '%s\n' "### Carries"
+                IFS=','
+                for CARRY in ${CARRIES}; do
+                  TRIMMED="$(echo "${CARRY}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+                  [ -n "${TRIMMED}" ] && printf -- '- %s\n' "${TRIMMED}"
+                done
+                unset IFS
+              fi
+            } > "${NOTES_FILE}"
+
             # Quote the tag — it contains '+' which some shells/tools misinterpret.
+            # --latest=false: a harness release must never take GitHub's "latest"
+            # pointer from the product agent releases.
             echo "Creating GitHub Release: ${RELEASE_TAG}"
             gh release create "${RELEASE_TAG}" \
               --title "${RELEASE_TAG}" \
-              --notes "Harness build of OpenCode ${BASE_VERSION} (integration ${SHORT_SHA})." \
+              --notes-file "${NOTES_FILE}" \
+              --latest=false \
               opencode-linux-x64.tar.gz \
               opencode-linux-arm64.tar.gz \
               opencode-darwin-x64.zip \

--- a/docs/plans/2026-06-21-002-feat-harness-release-carry-fingerprint-plan.md
+++ b/docs/plans/2026-06-21-002-feat-harness-release-carry-fingerprint-plan.md
@@ -1,0 +1,150 @@
+---
+title: 'feat: harness release carry fingerprint, notes, and non-latest'
+type: feat
+status: active
+date: 2026-06-21
+---
+
+# Harness release carry fingerprint, notes, and non-latest
+
+## Overview
+
+Three improvements to the `@fro.bot/harness` release pipeline so a harness build's identity, provenance, and release ranking are correct:
+
+1. **Squash all carried refs into one integration commit** so the integration SHA is a true fingerprint — its diff against the base tag is the combined diff of every carry, viewable as a single diff. Today the LLM merge produces N `--no-ff` merge commits and the SHA is just the *last* merge.
+2. **List the carried PRs in the harness GitHub Release notes** (the same set `harness patches` reports), so a release at `1.17.6+harness.<short8>` documents exactly which upstream PRs it carries.
+3. **Mark harness releases `--latest=false`** so a harness release never takes GitHub's "latest" pointer from the product `agent` releases.
+
+## Problem Frame
+
+The harness release flow: `prepare-integrate` renders a merge prompt → `integrate` (Fro Bot LLM merge) clones the base tag, `git merge --no-ff` each carry ref in order, pushes `refs/harness-integrate/<base_version>` → `build` fetches that ref and resolves `integration_commit = HEAD` → `release-binaries` creates the GitHub Release tagged `<base_version>+harness.<short8>`.
+
+- The integration commit is the **last** `--no-ff` merge, so "view the carries as one diff" isn't possible and the SHA fingerprint understates what's carried.
+- The release notes are a fixed one-liner (`Harness build of OpenCode <base> (integration <short8>)`) with no carry list.
+- `gh release create` does not pass `--latest`, so GitHub's auto-latest could rank a harness tag (`1.17.6+...`) above a product tag (`v0.74.0`). Today `/releases/latest` resolves to the product release, but that is incidental, not enforced.
+
+## Requirements Trace
+
+- R1. The pushed integration ref is a **single commit** on top of the base tag whose tree equals all carries merged in order (conflicts resolved), so `git diff <base_tag>..<integration_commit>` is the combined carry diff.
+- R2. The single integration commit's message names the carried refs.
+- R3. The harness GitHub Release notes list the carried PRs (same labels as `harness patches` / the `integrationRefs`).
+- R4. `gh release create` for harness releases passes `--latest=false`.
+- R5. Existing gates still pass: the binary still self-reports `<base>+harness.<short8>`, the build/verify/libc/checksum steps are unaffected (they operate on the resulting tree/binary, not on history shape).
+
+## Scope Boundaries
+
+- Not changing which refs are carried (that's `harness.config.json`).
+- Not changing the npm publish flow or the non-`v` tag scheme.
+- Not changing how `integration_commit` / `short8` is derived (still `git rev-parse HEAD` of the pushed ref — now a single commit).
+
+### Deferred to Separate Tasks
+
+- Embedding the carry list into the binary `provenance.json` notes (already carried there structurally; release-notes is the gap this addresses).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/harness/prompt.txt` — the LLM merge procedure (step 2 merges each ref `--no-ff`; step 5 pushes `refs/harness-integrate/<version>`; step 6 returns the integration SHA). This is where the squash is added.
+- `.github/workflows/harness-release.yaml`:
+  - `prepare-integrate` (lines ~61-178) — computes `BRANCHES` (comma-joined carry labels like `anomalyco/opencode#19961, #31859, #31638`) from `integrationRefs`; renders the prompt. Add a `carries` output here.
+  - `release-binaries` → `Create GitHub Release` step (lines ~726-772) — the `gh release create` with `--notes` and no `--latest`. Add the carry list to notes + `--latest=false`.
+- `packages/harness/src/cli.ts` `cmdPatches()` (lines ~45-62) — the `harness patches` output shape (lists `integrationRefs`); the release notes should convey the same set.
+- `packages/harness/harness.config.json` — `integrationRefs` (the 3 PR URLs).
+
+### Institutional Learnings
+
+- `docs/solutions/build-errors/` harness docs: the integration commit is the build/provenance anchor; any change to how it's produced must keep the binary version-identity verification intact (the existing `verify-binary.ts` + the release-binaries version gate).
+
+## Key Technical Decisions
+
+- **Squash via merge-then-soft-reset** (chosen): keep the per-ref `git merge --no-ff` sequence so the LLM resolves conflicts naturally ref-by-ref, then `git reset --soft {{tag}} && git commit` to collapse to one commit. The tree is identical to the multi-merge result; only history is flattened. Build, version verification, and the pushed-ref consumer are unaffected because they read the tree/HEAD, not the history shape.
+- **Single source for the carry list**: the carry labels already computed as `BRANCHES` in `prepare-integrate` feed BOTH the squash commit message (via the prompt's `{{branches}}`) and the release notes (via a new `carries` output). No new data source.
+- **`--latest=false` is defensive-explicit**: enforce non-latest regardless of how GitHub's auto-latest would rank the tag.
+
+## Open Questions
+
+### Resolved During Planning
+
+- How to squash without breaking conflict resolution? → merge-then-soft-reset (conflicts handled during the merges; squash is purely a history flatten afterward).
+- Does the squash break the version fingerprint / build? → No; the build and `verify-binary.ts` read the tree and the binary `--version`, not git history; `git rev-parse HEAD` still yields a single SHA.
+- Where does the carry list come from for the notes? → the existing `BRANCHES` labels in `prepare-integrate`, plumbed as a `carries` output.
+
+### Deferred to Implementation
+
+- Exact commit-message format for the squash (e.g. `harness: integrate <base_version> carrying <labels>`) — finalize during prompt edit so it reads well and is deterministic.
+- Whether the release notes render the carries as a bullet list or comma-joined — finalize when editing the `--notes` (bullet list is more readable for the GitHub Release body).
+
+## Implementation Units
+
+- [x] **Unit 1: Squash the integration into one fingerprint commit (prompt.txt)**
+
+**Goal:** The pushed `refs/harness-integrate/<version>` is a single commit on top of the base tag containing all carries.
+
+**Requirements:** R1, R2, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/harness/prompt.txt`
+
+**Approach:**
+- After step 2's per-ref `git merge --no-ff` sequence (and conflict resolution), add a squash step: `git reset --soft {{tag}}` then `git commit -m "<message naming the carries>"`. The message should name the carried refs (use the `{{branches}}` template var, already the comma-joined labels). Keep step 3 (build), step 4 (verify `--version` == `{{version}}`), and step 5 (push the ref) unchanged — they operate on the resulting tree/HEAD. Step 6 still returns `git rev-parse HEAD` (now the single squash commit).
+- Update the procedure's prose/requirements so the agent knows the end state is ONE commit (not N merge commits) — explicitly: "After merging all refs and resolving conflicts, collapse the integration into a single commit with `git reset --soft {{tag}}` followed by `git commit`."
+- Preserve the empty-carry path semantics: this job only runs when `has_refs == true` (the integrate job is skipped for empty carry sets), so the squash always has at least one carry. No empty-carry handling needed in the prompt.
+
+**Execution note:** This is a prompt/runbook change validated end-to-end by a dry-run release, not by a unit test.
+
+**Patterns to follow:** the existing exact-command style in `prompt.txt`; keep column-0 heredoc discipline.
+
+**Test scenarios:** Test expectation: none — prompt/runbook change. Validated by a dry-run harness-release that produces a single-commit integration ref whose `git diff <tag>..HEAD` shows all carries.
+
+**Verification:** A dry-run integration ref has exactly one commit above the base tag; `git diff <base_tag>..<integration_commit>` contains all three carries' changes; the built binary still reports `<base>+harness.<short8>`.
+
+- [x] **Unit 2: Plumb the carry list to the release job and into the notes (harness-release.yaml)**
+
+**Goal:** The harness GitHub Release notes list the carried PRs, and the release is marked non-latest.
+
+**Requirements:** R3, R4
+
+**Dependencies:** None (independent of Unit 1; the carry labels already exist in `prepare-integrate`)
+
+**Files:**
+- Modify: `.github/workflows/harness-release.yaml`
+
+**Approach:**
+- In `prepare-integrate`, add a `carries` output carrying the human-readable carry labels (reuse the `BRANCHES` value, or emit the `integrationRefs` as a newline/comma list). Thread it through the job `outputs`.
+- The `release-binaries` job needs the carry list. Since `release-binaries` already consumes `prepare-integrate` outputs indirectly, add `carries` to its available inputs (via `needs.prepare-integrate.outputs.carries`).
+- In the `Create GitHub Release` step, extend `--notes` to include the carried PRs (a `### Carries` section listing each ref/PR), and add `--latest=false` to the `gh release create` call. Apply the carries-in-notes to the create path; the clobber/idempotent-repair path (`gh release upload`) doesn't set notes, which is fine (notes are set on creation).
+- Keep the existing one-line summary plus the carry list. Format the carry list as a markdown bullet list for readability in the GitHub Release body.
+
+**Execution note:** CI/workflow change validated by `actionlint` + a dry-run/real release; no unit-test surface.
+
+**Patterns to follow:** the existing `>> "$GITHUB_OUTPUT"` heredoc pattern in `prepare-integrate`; the existing `gh release create` flag style.
+
+**Test scenarios:** Test expectation: none — workflow change. Validated by `actionlint` and a release run whose notes show the carry list and whose release is not marked latest.
+
+**Verification:** `actionlint` clean; a release run's GitHub Release body contains the three carried PRs; `gh api repos/fro-bot/agent/releases/latest` still resolves to the product release after a harness release publishes; the harness release shows `--latest=false` behavior (not flagged latest).
+
+## System-Wide Impact
+
+- **Interaction graph:** `prompt.txt` (consumed by the Fro Bot integrate job) → the pushed integration ref → `build`/`release-binaries`/`publish`. Squashing changes only the history shape of the pushed ref; all consumers read HEAD/tree/binary.
+- **Unchanged invariants:** the binary version identity (`<base>+harness.<short8>`), the build/verify/libc/checksum gates, the npm publish flow, the non-`v` tag scheme, and `integration_commit`/`short8` derivation (still `git rev-parse HEAD`, now a single commit).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| The soft-reset squash loses conflict resolutions or changes the tree | `git reset --soft` preserves the index/tree exactly; only commit history is discarded. The tree after the merges == the tree after the squash commit. Verify via dry-run `git diff <tag>..HEAD`. |
+| The squash commit message is non-deterministic, breaking byte-stability expectations | The integration commit SHA is already non-deterministic across runs (LLM merge); nothing downstream pins it except per-run derivation. A stable message format is preferred but not required for correctness. |
+| `--latest=false` interacts badly with the clobber/repair path | `--latest` is a create-time flag; the repair path uses `gh release upload` (no latest change), so a repaired release retains its non-latest status. |
+| Carry list formatting breaks the heredoc/`--notes` quoting | Build the notes via a heredoc or a `--notes-file`, mirroring the existing safe-quoting patterns; validate with `actionlint`. |
+
+## Documentation / Operational Notes
+
+- No runtime/deploy impact. The next real harness release (next OpenCode bump) exercises all three changes; a dry-run can validate Unit 1's single-commit shape and Unit 2's notes/latest before a real publish.
+
+## Sources & References
+
+- Related code: `packages/harness/prompt.txt`, `.github/workflows/harness-release.yaml` (`prepare-integrate`, `release-binaries`), `packages/harness/src/cli.ts` (`cmdPatches`), `packages/harness/harness.config.json`.
+- Trigger: maintainer request — squash carries into one fingerprint commit, list carries in release notes, keep harness releases non-latest.

--- a/packages/harness/prompt.txt
+++ b/packages/harness/prompt.txt
@@ -37,7 +37,23 @@ git checkout -b {{branch}} refs/tags/{{tag}}
    Use the local ref name (the part after the colon in the fetch command) as the merge target.
    If there are merge conflicts, resolve them completely before proceeding.
 
-3. Build the host CLI. Run from the repo root ({{repo}}) — build.ts does its own chdir into packages/opencode:
+3. Collapse the integration into a SINGLE commit on top of {{tag}}.
+
+   After all refs are merged and every conflict is resolved, flatten the merge
+   history into one commit so the integration SHA is a fingerprint whose diff
+   against {{tag}} is the combined diff of all carried refs:
+
+```bash
+git reset --soft {{tag}}
+git commit -m "harness: integrate OpenCode {{version}} carrying {{branches}}"
+```
+
+   `git reset --soft` keeps the merged working tree and index exactly as-is and
+   only discards the intermediate merge commits, so this does not change any
+   file content — it only flattens history. After this, {{branch}} has exactly
+   one commit above {{tag}}, and `git diff {{tag}}..HEAD` shows all carries.
+
+4. Build the host CLI. Run from the repo root ({{repo}}) — build.ts does its own chdir into packages/opencode:
 
    First install workspace dependencies:
    bun install
@@ -45,7 +61,7 @@ git checkout -b {{branch}} refs/tags/{{tag}}
    Then run the upstream build script with release identity:
    OPENCODE_CHANNEL=latest OPENCODE_VERSION={{version}} bun ./packages/opencode/script/build.ts --single
 
-4. Verify the built binary exists and reports the correct version:
+5. Verify the built binary exists and reports the correct version:
 
 ```bash
 artifact="$(find packages/opencode/dist -path '*/bin/opencode' -type f -print -quit)"
@@ -55,7 +71,7 @@ test -n "$artifact" || { echo "ERROR: built binary not found under packages/open
 
    The `--version` output must be exactly `{{version}}`.
 
-5. Push the integrated branch to the throwaway ref in the harness repo. Do not push to `origin`; `origin` is upstream OpenCode. Run this exact non-interactive pattern (the heredoc terminator and the helper body must stay at column 0):
+6. Push the integrated branch to the throwaway ref in the harness repo. Do not push to `origin`; `origin` is upstream OpenCode. Run this exact non-interactive pattern (the heredoc terminator and the helper body must stay at column 0):
 
 ```bash
 test -n "${GH_TOKEN:-}" || { echo "GH_TOKEN is required for harness push"; exit 1; }
@@ -80,9 +96,9 @@ HUSKY=0 GIT_TERMINAL_PROMPT=0 GIT_ASKPASS="$askpass" \
 
    `--force` is required so re-runs overwrite the throwaway ref. `--no-verify` is required so local hooks do not run.
 
-6. Return a concise plain-text final assistant message only — no GitHub posting — with:
+7. Return a concise plain-text final assistant message only — no GitHub posting — with:
    - pushed ref: `refs/harness-integrate/{{version}}`
-   - integration commit SHA: output of `git rev-parse HEAD`
+   - integration commit SHA: output of `git rev-parse HEAD` (the single squash commit)
    - built artifact path(s) under `packages/opencode/dist/`
 </procedure>
 
@@ -103,6 +119,7 @@ Requirements:
 - Name the branch {{branch}}.
 - Merge refs {{merges}} into {{branch}} in order.
 - If there are merge conflicts, resolve them completely.
+- After merging and resolving conflicts, collapse the integration into a single commit on top of {{tag}} with `git reset --soft {{tag}}` then `git commit`. The pushed ref must have exactly one commit above {{tag}}; `git diff {{tag}}..HEAD` must contain all carried refs.
 - Build the host CLI.
 - The CLI must be compiled with stable release identity: OPENCODE_CHANNEL=latest and OPENCODE_VERSION={{version}}.
 - In this automation clone, `origin` is the upstream OpenCode repo ({{release_repo}}), not `fro-bot/agent`. Do not push to `origin`.


### PR DESCRIPTION
Three improvements to the `@fro.bot/harness` release pipeline so a harness build's identity, provenance, and release ranking are correct.

## What changed

- **Squash all carried refs into one integration commit.** The LLM merge previously produced N `--no-ff` merge commits and the integration SHA was just the *last* merge, so a harness release's identity understated what it carried and the carries couldn't be viewed as a single diff. The merge prompt now collapses the integration into one commit on top of the base tag (`git reset --soft <tag>` + commit) after merging and resolving conflicts. The soft reset keeps the merged tree exactly, so the build, version-identity verification, and ref consumers are unaffected — only history is flattened.
- **List the carried PRs in the harness GitHub Release notes** (the same set `harness patches` reports), plumbed from the carry labels `prepare-integrate` already computes, rendered as a bulleted `### Carries` section via `--notes-file`.
- **Mark harness releases `--latest=false`** so a harness release never takes GitHub's "latest" pointer from the product `agent` releases. (Today `/releases/latest` resolves to the product release, but that's incidental, not enforced.)

## Validation

Dry-run release run on this branch passed every job (prepare-integrate, integrate/LLM-merge, all six platform builds, Release Binaries assembly, publish). Inspecting the actual pushed integration ref proved the squash:

- The integration ref is a **single commit** (`harness: integrate OpenCode 1.17.6 carrying anomalyco/opencode#19961, #31859, #31638`) sitting exactly one commit above the base tag `release: v1.17.6`.
- Its diff against the base tag is **370 files** — the combined diff of all three carries.
- All six platform binaries built from that squashed tree and self-reported `1.17.6+harness.<short8>`.

The notes/`--latest` behavior is simulation-verified and `actionlint`-clean (a dry-run skips the actual `gh release create`); the real GitHub-Release proof lands on the next real harness release.

Prompt + workflow only; no source or `dist` impact.