### PR TITLE
fix(build): scrub and verify dist hidden unicode independent of the bundler

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -165,7 +165,9 @@
     },
   ],
   postUpgradeTasks: {
-    commands: ['pnpm install', 'pnpm run build', 'pnpm run fix'],
+    // `build` escapes dist hidden Unicode as its final step, so a rebuilt dist on
+    // update branches stays free of characters Renovate would otherwise flag.
+    commands: ['pnpm install', 'pnpm run fix', 'pnpm run build'],
     executionMode: 'branch',
   },
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,7 @@ jobs:
               - added|modified: *config
               - added|modified: *dist-changed
               - added|modified: *src-changed
+              - scripts/** # Build changes to CI scripts trigger build+test (scripts tests run in Test job)
 
   lint:
     if: ${{ needs.setup.outputs.should-lint == 'true' }}
@@ -93,6 +94,8 @@ jobs:
         uses: ./.github/actions/setup
       - name: Rebuild the dist/ directory
         run: pnpm build
+      - name: Check dist/ for hidden Unicode characters
+        run: pnpm run dist:check-hidden-unicode
       - name: Compare the expected and actual dist/ directories
         run: |
           if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,12 +178,15 @@ post.ts → harness/post.ts
 ## COMMANDS
 
 ```bash
-pnpm install        # Install dependencies
-pnpm test           # Run all tests (vitest)
-pnpm lint           # ESLint check
-pnpm fix            # ESLint auto-fix
-pnpm check-types    # TypeScript type check (tsc --noEmit)
-pnpm build          # Type check + bundle to dist/ (must stay in sync)
+pnpm install                          # Install dependencies
+pnpm test                             # Run workspace + scripts/ tests (vitest from repo root)
+pnpm run test:scripts                 # Run only scripts/ tests
+pnpm lint                             # ESLint check (also checks the committed dist/ for hidden Unicode)
+pnpm fix                              # ESLint auto-fix
+pnpm check-types                      # TypeScript type check (tsc --noEmit)
+pnpm build                            # Type check + bundle to dist/ (also scrubs dist/ hidden Unicode)
+pnpm run dist:escape-hidden-unicode   # Scrub hidden Unicode from dist/ (run by build)
+pnpm run dist:check-hidden-unicode    # Verify dist/ has no raw hidden Unicode (lint checks committed dist/; the CI Build job checks freshly built dist/)
 ```
 
 ## NOTES

--- a/apps/action/package.json
+++ b/apps/action/package.json
@@ -6,7 +6,7 @@
   "main": "dist/main.js",
   "module": "dist/main.js",
   "scripts": {
-    "build": "pnpm --dir ../.. exec tsc --noEmit && pnpm --dir ../.. exec tsdown -c apps/action/tsdown.config.ts",
+    "build": "pnpm --dir ../.. exec tsc --noEmit && pnpm --dir ../.. exec tsdown -c tsdown.config.ts",
     "check-types": "pnpm --dir ../.. exec tsc --noEmit",
     "fix": "pnpm --dir ../.. exec eslint --fix src tsdown.config.ts eslint.config.ts",
     "lint": "pnpm --dir ../.. exec eslint src tsdown.config.ts eslint.config.ts",

--- a/apps/action/tsconfig.json
+++ b/apps/action/tsconfig.json
@@ -4,9 +4,10 @@
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.cache/tsconfig.tsbuildinfo",
     "rootDir": "../../src",
+    "allowImportingTsExtensions": true,
     "noEmit": true
   },
   "references": [{"path": "../../packages/runtime"}],
-  "include": ["../../src/**/*.ts", "../../tsdown.config.ts", "../../eslint.config.ts"],
+  "include": ["../../src/**/*.ts", "../../tsdown.config.ts", "../../eslint.config.ts", "../../scripts/**/*.ts"],
   "exclude": ["../../dist", "../../node_modules"]
 }

--- a/package.json
+++ b/package.json
@@ -21,12 +21,15 @@
   ],
   "scripts": {
     "bootstrap": "SKIP_INSTALL_SIMPLE_GIT_HOOKS=1 pnpm install --no-strict-peer-dependencies --prefer-offline --loglevel warn",
-    "build": "pnpm --filter @fro-bot/runtime build && pnpm --filter @fro-bot/action build && pnpm --filter @fro.bot/harness build",
+    "build": "pnpm --filter @fro-bot/runtime build && pnpm --filter @fro-bot/action build && pnpm --filter @fro.bot/harness build && pnpm run dist:escape-hidden-unicode",
     "check-types": "pnpm --filter @fro-bot/runtime check-types && pnpm --filter @fro-bot/action check-types && pnpm --filter @fro.bot/harness check-types",
+    "dist:check-hidden-unicode": "node --experimental-strip-types scripts/check-dist-hidden-unicode.ts",
+    "dist:escape-hidden-unicode": "node --experimental-strip-types scripts/escape-dist-hidden-unicode.ts",
     "fix": "pnpm --filter @fro-bot/runtime fix && pnpm --filter @fro-bot/action fix && pnpm --filter @fro.bot/harness fix",
     "postinstall": "simple-git-hooks",
-    "lint": "pnpm --filter @fro-bot/runtime lint && pnpm --filter @fro-bot/action lint && pnpm --filter @fro.bot/harness lint",
-    "test": "pnpm --filter @fro-bot/runtime test && pnpm --filter @fro-bot/action test && pnpm --filter @fro.bot/harness test"
+    "lint": "pnpm --filter @fro-bot/runtime lint && pnpm --filter @fro-bot/action lint && pnpm --filter @fro.bot/harness lint && pnpm run dist:check-hidden-unicode",
+    "test": "pnpm --filter @fro-bot/runtime test && pnpm --filter @fro-bot/action test && pnpm --filter @fro.bot/harness test",
+    "test:scripts": "vitest run scripts/"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm exec lint-staged",

--- a/scripts/check-dist-hidden-unicode.ts
+++ b/scripts/check-dist-hidden-unicode.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+// Check dist/ files for raw hidden Unicode characters. Exits non-zero if any
+// are found. Run via: node --experimental-strip-types scripts/check-dist-hidden-unicode.ts
+//
+// This file uses .ts imports because it runs directly under Node's
+// --experimental-strip-types. The test file uses .js imports for Vitest.
+
+import process from 'node:process'
+import {checkDistHiddenUnicode} from './dist-hidden-unicode.ts'
+
+async function main(): Promise<void> {
+  const dir = process.argv[2] ?? 'dist'
+  const violations = await checkDistHiddenUnicode(dir)
+
+  if (violations.length === 0) {
+    console.log(`[dist:check-hidden-unicode] ${dir}/ is clean — no hidden Unicode found`)
+    return
+  }
+
+  for (const {file, line, codepoint} of violations) {
+    process.stderr.write(`[dist:check-hidden-unicode] FAIL ${file}:${line} — raw ${codepoint}\n`)
+  }
+
+  process.stderr.write(
+    `[dist:check-hidden-unicode] found ${violations.length} hidden Unicode character(s) in ${dir}/\n`,
+  )
+  process.stderr.write(`[dist:check-hidden-unicode] run 'pnpm run dist:escape-hidden-unicode' to fix\n`)
+  process.exitCode = 1
+}
+
+try {
+  await main()
+} catch (error: unknown) {
+  const message = error instanceof Error ? error.message : String(error)
+  process.stderr.write(`[dist:check-hidden-unicode] error: ${message}\n`)
+  process.exitCode = 1
+}

--- a/scripts/dist-hidden-unicode.test.ts
+++ b/scripts/dist-hidden-unicode.test.ts
@@ -1,0 +1,421 @@
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+import {
+  BINARY_EXTENSIONS,
+  checkDistHiddenUnicode,
+  escapeDistHiddenUnicode,
+  HIDDEN_UNICODE_TEST_RE,
+} from './dist-hidden-unicode.js'
+
+// Renovate's exact codepoints (from renovatebot/renovate lib/util/unicode.ts)
+const RENOVATE_CODEPOINTS = [
+  0x00a0, // NO-BREAK SPACE
+  0x00ad, // SOFT HYPHEN
+  0x1680, // OGHAM SPACE MARK
+  // \u2000-\u200A range
+  0x2000,
+  0x2001,
+  0x2002,
+  0x2003,
+  0x2004,
+  0x2005,
+  0x2006,
+  0x2007,
+  0x2008,
+  0x2009,
+  0x200a,
+  0x200b, // ZERO WIDTH SPACE
+  0x200c, // ZERO WIDTH NON-JOINER
+  0x200e, // LEFT-TO-RIGHT MARK
+  0x200f, // RIGHT-TO-LEFT MARK
+  0x2028, // LINE SEPARATOR
+  0x2029, // PARAGRAPH SEPARATOR
+  // \u202A-\u202E range
+  0x202a,
+  0x202b,
+  0x202c,
+  0x202d,
+  0x202e,
+  0x202f, // NARROW NO-BREAK SPACE
+  0x205f, // MEDIUM MATHEMATICAL SPACE
+  0x3000, // IDEOGRAPHIC SPACE
+  0xfeff, // ZERO WIDTH NO-BREAK SPACE (BOM)
+]
+
+describe('HIDDEN_UNICODE_TEST_RE superset coverage', () => {
+  it('matches every codepoint in Renovate hidden-Unicode set', () => {
+    // #given — every codepoint Renovate flags
+    // #when / #then — our regex must match each one
+    for (const cp of RENOVATE_CODEPOINTS) {
+      const char = String.fromCodePoint(cp)
+      expect(HIDDEN_UNICODE_TEST_RE.test(char), `U+${cp.toString(16).toUpperCase().padStart(4, '0')} not matched`).toBe(
+        true,
+      )
+    }
+  })
+
+  it('does not match normal ASCII characters', () => {
+    // #given
+    const normal = 'Hello, world! 123 \t\n'
+
+    // #when / #then
+    expect(HIDDEN_UNICODE_TEST_RE.test(normal)).toBe(false)
+  })
+
+  it('does not match regular Unicode letters and symbols', () => {
+    // #given — emoji, CJK, accented letters are NOT hidden unicode
+    const normal = '日本語 café résumé 🎉'
+
+    // #when / #then
+    expect(HIDDEN_UNICODE_TEST_RE.test(normal)).toBe(false)
+  })
+
+  it('does not match U+200D (ZWJ) — key design exclusion, used in emoji sequences', () => {
+    // #given — ZWJ is intentionally excluded from the regex; it is NOT in Renovate's set
+    // and appears legitimately in multi-codepoint emoji (e.g. 👨‍👩‍👧)
+    const zwj = '\u200D'
+
+    // #when / #then — must NOT be matched
+    expect(HIDDEN_UNICODE_TEST_RE.test(zwj)).toBe(false)
+  })
+})
+
+describe('BINARY_EXTENSIONS', () => {
+  it('includes expected binary extensions', () => {
+    expect(BINARY_EXTENSIONS.has('png')).toBe(true)
+    expect(BINARY_EXTENSIONS.has('jpg')).toBe(true)
+    expect(BINARY_EXTENSIONS.has('woff2')).toBe(true)
+  })
+
+  it('does not include .map (source maps are text/JSON, not binary)', () => {
+    // Source maps are JSON — they must be scanned for hidden unicode, not skipped.
+    expect(BINARY_EXTENSIONS.has('map')).toBe(false)
+  })
+
+  it('does not include text extensions', () => {
+    expect(BINARY_EXTENSIONS.has('js')).toBe(false)
+    expect(BINARY_EXTENSIONS.has('ts')).toBe(false)
+    expect(BINARY_EXTENSIONS.has('txt')).toBe(false)
+  })
+})
+
+describe('escapeDistHiddenUnicode', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'dist-unicode-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, {recursive: true, force: true})
+  })
+
+  it('escapes a raw U+200C (zero-width non-joiner) in a JS file', async () => {
+    // #given — file with a raw hidden unicode char
+    const filePath = join(tmpDir, 'main.js')
+    await writeFile(filePath, 'const x = "\u200C"', 'utf8')
+
+    // #when
+    const results = await escapeDistHiddenUnicode(tmpDir)
+
+    // #then
+    expect(results).toHaveLength(1)
+    expect(results[0]?.file).toBe(filePath)
+    expect(results[0]?.replacements).toBe(1)
+
+    // File content must now have the escaped form, not the raw char
+    const {readFile} = await import('node:fs/promises')
+    const content = await readFile(filePath, 'utf8')
+    expect(content).toBe(String.raw`const x = "\u200C"`)
+    expect(content).not.toContain('\u200C')
+  })
+
+  it('escapes all Renovate-flaggable codepoints', async () => {
+    // #given — one file with every Renovate codepoint
+    const raw = RENOVATE_CODEPOINTS.map(cp => String.fromCodePoint(cp)).join('')
+    const filePath = join(tmpDir, 'bundle.js')
+    await writeFile(filePath, `var s = "${raw}"`, 'utf8')
+
+    // #when
+    const results = await escapeDistHiddenUnicode(tmpDir)
+
+    // #then — all chars replaced
+    expect(results).toHaveLength(1)
+    expect(results[0]?.replacements).toBe(RENOVATE_CODEPOINTS.length)
+
+    const {readFile} = await import('node:fs/promises')
+    const content = await readFile(filePath, 'utf8')
+    for (const cp of RENOVATE_CODEPOINTS) {
+      expect(content).not.toContain(String.fromCodePoint(cp))
+    }
+  })
+
+  it('returns empty array when no hidden unicode is present', async () => {
+    // #given
+    const filePath = join(tmpDir, 'clean.js')
+    await writeFile(filePath, 'const x = "hello world"', 'utf8')
+
+    // #when
+    const results = await escapeDistHiddenUnicode(tmpDir)
+
+    // #then
+    expect(results).toHaveLength(0)
+  })
+
+  it('skips binary extensions', async () => {
+    // #given — a .png file with hidden unicode bytes (should be skipped)
+    const filePath = join(tmpDir, 'image.png')
+    await writeFile(filePath, `\u200C\uFEFF`, 'utf8')
+
+    // #when
+    const results = await escapeDistHiddenUnicode(tmpDir)
+
+    // #then — binary file not touched
+    expect(results).toHaveLength(0)
+  })
+
+  it('recurses into subdirectories', async () => {
+    // #given — file in a nested subdir
+    const subDir = join(tmpDir, 'chunks')
+    await mkdir(subDir, {recursive: true})
+    const filePath = join(subDir, 'vendor.js')
+    await writeFile(filePath, 'var x = "\uFEFF"', 'utf8')
+
+    // #when
+    const results = await escapeDistHiddenUnicode(tmpDir)
+
+    // #then
+    expect(results).toHaveLength(1)
+    expect(results[0]?.file).toBe(filePath)
+  })
+
+  it('does not modify files that already contain escaped unicode sequences', async () => {
+    // #given — content with the literal backslash-u escape (already safe, 6 ASCII chars)
+    const filePath = join(tmpDir, 'escaped.js')
+    const alreadyEscaped = String.raw`var x = "\u200C"`
+    await writeFile(filePath, alreadyEscaped, 'utf8')
+
+    // #when
+    const results = await escapeDistHiddenUnicode(tmpDir)
+
+    // #then — no changes needed
+    expect(results).toHaveLength(0)
+  })
+})
+
+describe('escapeDistHiddenUnicode — ZWJ exclusion', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'dist-unicode-zwj-'))
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, {recursive: true, force: true})
+  })
+
+  it('leaves U+200D (ZWJ) unchanged — not a hidden unicode violation', async () => {
+    // #given — file containing only a ZWJ (should be untouched)
+    const filePath = join(tmpDir, 'emoji.js')
+    await writeFile(filePath, 'var e = "\u200D"', 'utf8')
+
+    // #when
+    const results = await escapeDistHiddenUnicode(tmpDir)
+
+    // #then — no modifications
+    expect(results).toHaveLength(0)
+
+    const {readFile} = await import('node:fs/promises')
+    const content = await readFile(filePath, 'utf8')
+    expect(content).toContain('\u200D')
+  })
+})
+
+describe('checkDistHiddenUnicode — ZWJ exclusion', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'dist-unicode-zwj-check-'))
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, {recursive: true, force: true})
+  })
+
+  it('reports NO violation for U+200D (ZWJ)', async () => {
+    // #given — file with only a ZWJ
+    const filePath = join(tmpDir, 'emoji.js')
+    await writeFile(filePath, 'var e = "\u200D"', 'utf8')
+
+    // #when
+    const violations = await checkDistHiddenUnicode(tmpDir)
+
+    // #then — ZWJ is not a violation
+    expect(violations).toHaveLength(0)
+  })
+})
+
+describe('checkDistHiddenUnicode — multi-violation', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'dist-unicode-multi-'))
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, {recursive: true, force: true})
+  })
+
+  it('reports all violations in a single file with multiple hidden chars on same and different lines', async () => {
+    // #given — file with 2 chars on line 1 and 1 char on line 2
+    const filePath = join(tmpDir, 'multi.js')
+    await writeFile(filePath, '\u200Bfoo\u200C\nbar\u200E', 'utf8')
+
+    // #when
+    const violations = await checkDistHiddenUnicode(tmpDir)
+
+    // #then — all 3 violations reported
+    expect(violations).toHaveLength(3)
+    const codepoints = violations.map(v => v.codepoint).sort()
+    expect(codepoints).toEqual(['U+200B', 'U+200C', 'U+200E'])
+    // line numbers: line 1 has U+200B and U+200C, line 2 has U+200E
+    const line1Violations = violations.filter(v => v.line === 1)
+    const line2Violations = violations.filter(v => v.line === 2)
+    expect(line1Violations).toHaveLength(2)
+    expect(line2Violations).toHaveLength(1)
+  })
+
+  it('scrubber escapes all violations in a multi-violation file', async () => {
+    // #given — file with 3 hidden chars across 2 lines
+    const filePath = join(tmpDir, 'multi.js')
+    await writeFile(filePath, '\u200Bfoo\u200C\nbar\u200E', 'utf8')
+
+    // #when
+    const results = await escapeDistHiddenUnicode(tmpDir)
+
+    // #then — all 3 replaced
+    expect(results).toHaveLength(1)
+    expect(results[0]?.replacements).toBe(3)
+
+    const {readFile} = await import('node:fs/promises')
+    const content = await readFile(filePath, 'utf8')
+    expect(content).not.toContain('\u200B')
+    expect(content).not.toContain('\u200C')
+    expect(content).not.toContain('\u200E')
+    expect(content).toContain(String.raw`\u200B`)
+    expect(content).toContain(String.raw`\u200C`)
+    expect(content).toContain(String.raw`\u200E`)
+  })
+})
+
+describe('checkDistHiddenUnicode', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'dist-unicode-check-'))
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, {recursive: true, force: true})
+  })
+
+  it('returns violations for a file with raw hidden unicode', async () => {
+    // #given
+    const filePath = join(tmpDir, 'main.js')
+    await writeFile(filePath, 'line1\nline with \u200C here\nline3', 'utf8')
+
+    // #when
+    const violations = await checkDistHiddenUnicode(tmpDir)
+
+    // #then
+    expect(violations).toHaveLength(1)
+    expect(violations[0]?.file).toBe(filePath)
+    expect(violations[0]?.line).toBe(2)
+    expect(violations[0]?.codepoint).toBe('U+200C')
+  })
+
+  it('returns empty array for clean content', async () => {
+    // #given
+    const filePath = join(tmpDir, 'clean.js')
+    await writeFile(filePath, 'const x = "hello"', 'utf8')
+
+    // #when
+    const violations = await checkDistHiddenUnicode(tmpDir)
+
+    // #then
+    expect(violations).toHaveLength(0)
+  })
+
+  it('returns empty array for already-escaped content', async () => {
+    // #given — the literal \u200C escape sequence (6 ASCII chars, not the raw char)
+    const filePath = join(tmpDir, 'escaped.js')
+    await writeFile(filePath, String.raw`var x = "\u200C"`, 'utf8')
+
+    // #when
+    const violations = await checkDistHiddenUnicode(tmpDir)
+
+    // #then — escaped form is clean
+    expect(violations).toHaveLength(0)
+  })
+
+  it('skips binary extensions', async () => {
+    // #given
+    const filePath = join(tmpDir, 'font.woff2')
+    await writeFile(filePath, '\u200C\uFEFF', 'utf8')
+
+    // #when
+    const violations = await checkDistHiddenUnicode(tmpDir)
+
+    // #then
+    expect(violations).toHaveLength(0)
+  })
+
+  it('recurses into subdirectories', async () => {
+    // #given
+    const subDir = join(tmpDir, 'assets')
+    await mkdir(subDir, {recursive: true})
+    const filePath = join(subDir, 'chunk.js')
+    await writeFile(filePath, '\uFEFF', 'utf8')
+
+    // #when
+    const violations = await checkDistHiddenUnicode(tmpDir)
+
+    // #then
+    expect(violations).toHaveLength(1)
+    expect(violations[0]?.file).toBe(filePath)
+    expect(violations[0]?.codepoint).toBe('U+FEFF')
+  })
+
+  it('reports multiple violations across multiple files', async () => {
+    // #given
+    await writeFile(join(tmpDir, 'a.js'), '\u200B', 'utf8')
+    await writeFile(join(tmpDir, 'b.js'), '\u00AD', 'utf8')
+
+    // #when
+    const violations = await checkDistHiddenUnicode(tmpDir)
+
+    // #then
+    expect(violations).toHaveLength(2)
+    const codepoints = violations.map(v => v.codepoint).sort()
+    expect(codepoints).toEqual(['U+00AD', 'U+200B'])
+  })
+
+  it('scrubber → checker round-trip: inject raw char, scrub, check passes', async () => {
+    // #given — inject a raw U+200C
+    const filePath = join(tmpDir, 'bundle.js')
+    await writeFile(filePath, 'var x = "\u200C"', 'utf8')
+
+    // #when — checker must fail first
+    const before = await checkDistHiddenUnicode(tmpDir)
+    expect(before).toHaveLength(1)
+
+    // #when — scrub
+    await escapeDistHiddenUnicode(tmpDir)
+
+    // #then — checker must pass after scrub
+    const after = await checkDistHiddenUnicode(tmpDir)
+    expect(after).toHaveLength(0)
+  })
+})

--- a/scripts/dist-hidden-unicode.ts
+++ b/scripts/dist-hidden-unicode.ts
@@ -1,0 +1,158 @@
+/**
+ * Shared utilities for scrubbing and checking hidden Unicode characters in dist/.
+ *
+ * The regex is a superset of Renovate's hidden-Unicode detector
+ * (renovatebot/renovate lib/util/unicode.ts). It covers every codepoint
+ * Renovate flags without matching legitimate chars like U+200D (ZWJ used in
+ * emoji sequences).
+ *
+ * Renovate's set: \u00A0 \u00AD \u1680 \u2000-\u200A \u200B \u200C \u200E \u200F
+ *                 \u2028 \u2029 \u202A-\u202E \u202F \u205F \u3000 \uFEFF
+ *
+ * Superset used here: \u00A0 \u00AD \u1680 \u2000-\u200C \u200E \u200F
+ *                     \u2028 \u2029 \u202A-\u202F \u205F \u3000 \uFEFF
+ *
+ * The range \u2000-\u200C covers \u2000-\u200A (Renovate) plus \u200B \u200C.
+ * \u200D (ZWJ) is intentionally excluded — it is NOT in Renovate's set and
+ * appears legitimately in emoji sequences. \u200E \u200F are listed explicitly.
+ * The range \u202A-\u202F covers \u202A-\u202E (Renovate) plus \u202F (narrow
+ * no-break space, also in Renovate's explicit list). Every Renovate codepoint
+ * is contained in this superset.
+ *
+ * Two instances are required: a stateless test regex (no /g flag) for the
+ * per-file guard, and a /g-flagged replace regex. Stateful /g regexes leak
+ * lastIndex across concurrent Promise.all iterations and silently skip matches.
+ */
+
+import {readdir, readFile, writeFile} from 'node:fs/promises'
+import {extname, join} from 'node:path'
+
+// Stateless test — safe for concurrent use
+export const HIDDEN_UNICODE_TEST_RE =
+  /[\u00A0\u00AD\u1680\u2000-\u200C\u200E\u200F\u2028\u2029\u202A-\u202F\u205F\u3000\uFEFF]/
+
+// /g-flagged replace — must NOT be shared across concurrent calls (lastIndex is stateful)
+export const HIDDEN_UNICODE_REPLACE_RE =
+  /[\u00A0\u00AD\u1680\u2000-\u200C\u200E\u200F\u2028\u2029\u202A-\u202F\u205F\u3000\uFEFF]/g
+
+export const BINARY_EXTENSIONS: ReadonlySet<string> = new Set([
+  'br',
+  'gif',
+  'gz',
+  'ico',
+  'jpeg',
+  'jpg',
+  'otf',
+  'pdf',
+  'png',
+  'tar',
+  'ttf',
+  'woff',
+  'woff2',
+  'zip',
+])
+
+export interface FileViolation {
+  readonly file: string
+  readonly line: number
+  readonly codepoint: string
+  readonly char: string
+}
+
+export interface ScrubResult {
+  readonly file: string
+  readonly replacements: number
+}
+
+function isBinary(filePath: string): boolean {
+  const ext = extname(filePath).replace(/^\./, '').toLowerCase()
+  return BINARY_EXTENSIONS.has(ext)
+}
+
+function escapeChar(char: string): string {
+  const code = char.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0')
+  return String.raw`\u${code}`
+}
+
+async function collectFiles(dir: string): Promise<readonly string[]> {
+  const entries = await readdir(dir, {recursive: true, withFileTypes: true})
+  const results: string[] = []
+  for (const entry of entries) {
+    if (!entry.isFile()) continue
+    const filePath = join(entry.parentPath, entry.name)
+    if (!isBinary(filePath)) {
+      results.push(filePath)
+    }
+  }
+  return results
+}
+
+/**
+ * Scrub all hidden Unicode characters from files under `dir`, replacing each
+ * with its `\uXXXX` escape. Returns the list of files that were modified.
+ */
+export async function escapeDistHiddenUnicode(dir = 'dist'): Promise<readonly ScrubResult[]> {
+  const files = await collectFiles(dir)
+  const results: ScrubResult[] = []
+
+  await Promise.all(
+    files.map(async filePath => {
+      const content = await readFile(filePath, 'utf8')
+      if (!HIDDEN_UNICODE_TEST_RE.test(content)) return
+
+      // Create a fresh /g regex per file to avoid lastIndex leakage
+      const re = new RegExp(HIDDEN_UNICODE_REPLACE_RE.source, 'g')
+      let count = 0
+      const fixed = content.replaceAll(re, char => {
+        count++
+        return escapeChar(char)
+      })
+
+      await writeFile(filePath, fixed, 'utf8')
+      results.push({file: filePath, replacements: count})
+    }),
+  )
+
+  return results
+}
+
+/**
+ * Check all files under `dir` for raw hidden Unicode characters.
+ * Returns violations (file + line + codepoint). Empty array means clean.
+ */
+export async function checkDistHiddenUnicode(dir = 'dist'): Promise<readonly FileViolation[]> {
+  const files = await collectFiles(dir)
+  const allViolations: FileViolation[] = []
+
+  await Promise.all(
+    files.map(async filePath => {
+      const content = await readFile(filePath, 'utf8')
+      if (!HIDDEN_UNICODE_TEST_RE.test(content)) return
+
+      const lines = content.split('\n')
+      const violations: FileViolation[] = []
+
+      for (const [lineIndex, line] of lines.entries()) {
+        if (line === undefined) continue
+
+        // Fresh /g regex per line to avoid lastIndex leakage
+        const re = new RegExp(HIDDEN_UNICODE_REPLACE_RE.source, 'g')
+        let match = re.exec(line)
+        while (match !== null) {
+          const char = match[0]
+          violations.push({
+            file: filePath,
+            line: lineIndex + 1,
+            codepoint: `U+${char.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0')}`,
+            char,
+          })
+          match = re.exec(line)
+        }
+      }
+
+      allViolations.push(...violations)
+    }),
+  )
+
+  return allViolations
+}

--- a/scripts/escape-dist-hidden-unicode.ts
+++ b/scripts/escape-dist-hidden-unicode.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+// Scrub hidden Unicode characters from dist/ files, replacing each with its
+// \uXXXX escape. Run via: node --experimental-strip-types scripts/escape-dist-hidden-unicode.ts
+//
+// This file uses .ts imports because it runs directly under Node's
+// --experimental-strip-types. The test file uses .js imports for Vitest.
+
+import process from 'node:process'
+import {escapeDistHiddenUnicode} from './dist-hidden-unicode.ts'
+
+async function main(): Promise<void> {
+  const dir = process.argv[2] ?? 'dist'
+  const results = await escapeDistHiddenUnicode(dir)
+
+  if (results.length === 0) {
+    console.log(`[dist:escape-hidden-unicode] ${dir}/ is clean — no hidden Unicode found`)
+    return
+  }
+
+  for (const {file, replacements} of results) {
+    console.log(`[dist:escape-hidden-unicode] scrubbed ${replacements} char(s) in ${file}`)
+  }
+
+  console.log(`[dist:escape-hidden-unicode] done — ${results.length} file(s) modified`)
+}
+
+try {
+  await main()
+} catch (error: unknown) {
+  const message = error instanceof Error ? error.message : String(error)
+  process.stderr.write(`[dist:escape-hidden-unicode] error: ${message}\n`)
+  process.exitCode = 1
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,9 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "rootDir": ".",
+    "allowImportingTsExtensions": true,
     "noEmit": true
   },
   "include": ["**/*.ts"],
-  "exclude": ["dist", "node_modules", "scripts"]
+  "exclude": ["dist", "node_modules"]
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,6 +5,7 @@ import {join} from 'node:path'
 import {promisify} from 'node:util'
 import {getProjectLicenses} from 'generate-license-file'
 import {defineConfig} from 'tsdown'
+import {BINARY_EXTENSIONS, HIDDEN_UNICODE_REPLACE_RE, HIDDEN_UNICODE_TEST_RE} from './scripts/dist-hidden-unicode.ts'
 
 function parsePackageName(dep: string): string {
   const name = dep.split('@').find(Boolean) ?? ''
@@ -123,31 +124,6 @@ function buildLicenseTypeMap(entries: PnpmLicensesJson): Map<string, string> {
   return map
 }
 
-// Character class mirrors renovatebot/renovate's `lib/util/unicode.ts`. The
-// `/g`-flagged instance is for `.replaceAll`; the unflagged one is for the
-// per-file guard, since stateful regexes leak `lastIndex` across concurrent
-// `Promise.all` iterations and silently skip matches.
-const HIDDEN_UNICODE_TEST_RE =
-  /[\u00A0\u00AD\u1680\u2000-\u200C\u200E\u200F\u2028\u2029\u202A-\u202F\u205F\u3000\uFEFF]/
-const HIDDEN_UNICODE_RE = /[\u00A0\u00AD\u1680\u2000-\u200C\u200E\u200F\u2028\u2029\u202A-\u202F\u205F\u3000\uFEFF]/g
-
-const BINARY_EXTENSIONS = new Set([
-  'br',
-  'gif',
-  'gz',
-  'ico',
-  'jpeg',
-  'jpg',
-  'otf',
-  'pdf',
-  'png',
-  'tar',
-  'ttf',
-  'woff',
-  'woff2',
-  'zip',
-])
-
 function escapeHiddenUnicodePlugin(): Plugin {
   return {
     name: 'escape-hidden-unicode',
@@ -163,7 +139,9 @@ function escapeHiddenUnicodePlugin(): Plugin {
           const path = join(dir, entry.name)
           const content = await readFile(path, 'utf8')
           if (!HIDDEN_UNICODE_TEST_RE.test(content)) return
-          const fixed = content.replaceAll(HIDDEN_UNICODE_RE, char => {
+          // Fresh /g regex per file to avoid lastIndex leakage across concurrent Promise.all iterations
+          const re = new RegExp(HIDDEN_UNICODE_REPLACE_RE.source, 'g')
+          const fixed = content.replaceAll(re, char => {
             const code = char.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0')
             return String.raw`\u${code}`
           })


### PR DESCRIPTION
Renovate update branches kept committing a `dist/` that carried raw hidden-unicode characters (and dropped the third-party-notices file), which tripped Renovate's "hidden Unicode characters discovered" warning on every dependency PR. The bundler's in-build escape hook only re-processed chunks it re-emitted, so a Renovate rebuild could leave a stale chunk untouched — the warning has survived three previous attempts (ignorePaths, the escape plugin, disabling sourcemaps) because each stayed coupled to the bundler lifecycle.

This decouples the guarantee from the bundler.

## What changed

- **Standalone scrub + check.** New `scripts/dist-hidden-unicode.ts` recursively walks `dist/`, escaping (or, in check mode, failing on) the exact set of characters Renovate flags. The zero-width joiner (U+200D) is deliberately excluded — it's a legitimate emoji-sequence character and not in Renovate's set.
- **Wired into the build the Renovate action already runs.** `build` runs the scrub as its final step and `lint` runs the verify, so a rebuilt `dist/` on an update branch stays clean using only the commands the Renovate action allowlists. A CI step runs the same check so a raw character fails the build directly instead of surfacing only on the Renovate dashboard.
- **Single source of truth.** The bundler plugin now imports the regex and binary-extension set from the shared module instead of carrying its own copy (the two had already drifted). Source maps are treated as the text they are.
- **Real config path.** The action build pointed at a nonexistent config path and silently fell back to the root config; it now references the real one.
- **`scripts/` changes trigger their tests.** Added `scripts/**` to the build paths filter so a scripts-only change runs the test job, and added a `test:scripts` command for running them directly.

The `dist/` output is byte-identical (the dedup is refactor-only). The stale Renovate branch clears once Renovate re-runs its post-upgrade build against this config.