### PR TITLE
fix(harness): commit install-time bin/postinstall shims

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -33,6 +33,16 @@ export default defineConfig(
     },
   },
   {
+    name: 'packages/harness/bin plain-Node-ESM overrides',
+    files: ['packages/harness/bin/**/*.mjs'],
+    rules: {
+      // bin shims are plain Node ESM — no TypeScript project reference
+      'node/prefer-global/process': 'off',
+      // import ordering is not enforced in plain-Node-ESM shims
+      'perfectionist/sort-imports': 'off',
+    },
+  },
+  {
     name: 'deploy/scripts plain-Node-ESM overrides',
     files: ['deploy/scripts/**/*.mjs'],
     rules: {

--- a/packages/harness/bin/harness.mjs
+++ b/packages/harness/bin/harness.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * bin/harness.mjs — committed install-time shim for the harness CLI.
+ *
+ * Dynamically imports dist/cli.mjs when built; degrades gracefully when absent
+ * (clean checkout / pre-build). This file is committed so `pnpm install` never
+ * hits ENOENT on the bin entry even before `pnpm build` runs.
+ *
+ * Published tarballs ship both bin/ (this shim) and dist/ (built cli.mjs), so
+ * the shim resolves correctly in both workspace-dev and installed-package layouts.
+ */
+
+import {existsSync} from 'node:fs'
+import {fileURLToPath} from 'node:url'
+import {join, dirname} from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const cliPath = join(__dirname, '..', 'dist', 'cli.mjs')
+
+if (existsSync(cliPath)) {
+  await import(cliPath)
+} else {
+  process.stderr.write(
+    '@fro.bot/harness is not built. Run: pnpm --filter @fro.bot/harness build\n',
+  )
+  process.exit(1)
+}

--- a/packages/harness/bin/postinstall.mjs
+++ b/packages/harness/bin/postinstall.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * bin/postinstall.mjs — committed install-time shim for the harness postinstall hook.
+ *
+ * Dynamically imports dist/postinstall.mjs when built; exits 0 silently when absent
+ * (clean checkout / pre-build). Never exits non-zero — postinstall must never break
+ * `pnpm install`. This shim is self-contained-non-fatal so the package.json
+ * postinstall script needs no `|| true` guard.
+ *
+ * Published tarballs ship both bin/ (this shim) and dist/ (built postinstall.mjs),
+ * so the shim resolves correctly in both workspace-dev and installed-package layouts.
+ */
+
+import {existsSync} from 'node:fs'
+import {fileURLToPath} from 'node:url'
+import {join, dirname} from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const postinstallPath = join(__dirname, '..', 'dist', 'postinstall.mjs')
+
+if (existsSync(postinstallPath)) {
+  try {
+    await import(postinstallPath)
+  } catch (err) {
+    process.stderr.write(
+      `[harness] postinstall import failed (non-fatal): ${err instanceof Error ? err.message : String(err)}\n`,
+    )
+  }
+} else {
+  process.stderr.write('[harness] dist not built yet; skipping postinstall (workspace dev)\n')
+}

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -16,11 +16,12 @@
   "author": "Fro Bot <agent@fro.bot>",
   "type": "module",
   "bin": {
-    "harness": "./dist/cli.mjs"
+    "harness": "./bin/harness.mjs"
   },
   "files": [
     "LICENSE",
     "README.md",
+    "bin",
     "dist",
     "provenance.json"
   ],
@@ -29,7 +30,7 @@
     "check-types": "pnpm exec tsc -p tsconfig.json --noEmit",
     "fix": "pnpm --dir ../.. exec eslint --fix packages/harness/src packages/harness/scripts",
     "lint": "pnpm --dir ../.. exec eslint packages/harness/src packages/harness/scripts",
-    "postinstall": "node dist/postinstall.mjs || true",
+    "postinstall": "node bin/postinstall.mjs",
     "test": "pnpm exec vitest run --passWithNoTests src scripts"
   },
   "engines": {

--- a/packages/harness/src/bin-shims.test.ts
+++ b/packages/harness/src/bin-shims.test.ts
@@ -1,0 +1,166 @@
+/**
+ * bin-shims.test.ts — structural and behavioural tests for the committed bin/ shims.
+ *
+ * Verifies:
+ *   1. bin/harness.mjs and bin/postinstall.mjs exist as committed files.
+ *   2. bin/harness.mjs exits non-zero with a clear error when dist/cli.mjs is absent.
+ *   3. bin/postinstall.mjs exits 0 (non-fatal) when dist/postinstall.mjs is absent.
+ *   4. bin/harness.mjs imports and runs dist/cli.mjs when present.
+ *   5. bin/postinstall.mjs imports dist/postinstall.mjs when present.
+ *
+ * Tests run the REAL committed shim files (not inlined copies) so regressions in
+ * path resolution, messages, or exit codes are caught.
+ */
+
+import {spawnSync} from 'node:child_process'
+import {copyFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {dirname, join} from 'node:path'
+import process from 'node:process'
+import {fileURLToPath} from 'node:url'
+import {afterAll, beforeAll, describe, expect, it} from 'vitest'
+
+const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const binHarness = join(pkgRoot, 'bin', 'harness.mjs')
+const binPostinstall = join(pkgRoot, 'bin', 'postinstall.mjs')
+
+// #region structural
+
+describe('bin shim files exist', () => {
+  it('bin/harness.mjs is a committed file', () => {
+    // #given / #when / #then
+    expect(existsSync(binHarness)).toBe(true)
+  })
+
+  it('bin/postinstall.mjs is a committed file', () => {
+    // #given / #when / #then
+    expect(existsSync(binPostinstall)).toBe(true)
+  })
+})
+
+// #endregion
+
+// #region graceful-degrade (dist absent)
+// Copies the REAL shim into a temp dir with no sibling dist/ so ../dist/cli.mjs is absent.
+
+describe('bin/harness.mjs: graceful degrade when dist is absent', () => {
+  let tempDir: string
+  let tempBinHarness: string
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'fro-bot-harness-'))
+    const tempBin = join(tempDir, 'bin')
+    mkdirSync(tempBin, {recursive: true})
+    tempBinHarness = join(tempBin, 'harness.mjs')
+    // #given — copy the REAL committed shim; no temp/dist/ created so ../dist/cli.mjs is absent
+    copyFileSync(binHarness, tempBinHarness)
+  })
+
+  afterAll(() => {
+    rmSync(tempDir, {recursive: true, force: true})
+  })
+
+  it('exits non-zero and prints "not built" error when dist/cli.mjs is missing', () => {
+    // #when
+    const result = spawnSync(process.execPath, [tempBinHarness], {encoding: 'utf8'})
+
+    // #then
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('@fro.bot/harness is not built')
+    expect(result.stderr).toContain('pnpm --filter @fro.bot/harness build')
+  })
+})
+
+describe('bin/postinstall.mjs: graceful degrade when dist is absent', () => {
+  let tempDir: string
+  let tempBinPostinstall: string
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'fro-bot-harness-'))
+    const tempBin = join(tempDir, 'bin')
+    mkdirSync(tempBin, {recursive: true})
+    tempBinPostinstall = join(tempBin, 'postinstall.mjs')
+    // #given — copy the REAL committed shim; no temp/dist/ created so ../dist/postinstall.mjs is absent
+    copyFileSync(binPostinstall, tempBinPostinstall)
+  })
+
+  afterAll(() => {
+    rmSync(tempDir, {recursive: true, force: true})
+  })
+
+  it('exits 0 and prints skip message when dist/postinstall.mjs is missing', () => {
+    // #when
+    const result = spawnSync(process.execPath, [tempBinPostinstall], {encoding: 'utf8'})
+
+    // #then
+    expect(result.status).toBe(0)
+    expect(result.stderr).toContain('[harness] dist not built yet; skipping postinstall')
+  })
+})
+
+// #endregion
+
+// #region present-branch (dist present)
+// Copies the REAL shim into a temp dir WITH a synthetic dist/ containing a marker module.
+
+describe('bin/harness.mjs: runs dist/cli.mjs when present', () => {
+  let tempDir: string
+  let tempBinHarness: string
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'fro-bot-harness-'))
+    const tempBin = join(tempDir, 'bin')
+    const tempDist = join(tempDir, 'dist')
+    mkdirSync(tempBin, {recursive: true})
+    mkdirSync(tempDist, {recursive: true})
+    tempBinHarness = join(tempBin, 'harness.mjs')
+    // #given — copy the REAL committed shim and create a marker dist/cli.mjs
+    copyFileSync(binHarness, tempBinHarness)
+    writeFileSync(join(tempDist, 'cli.mjs'), "process.stdout.write('CLI_RAN\\n')\n")
+  })
+
+  afterAll(() => {
+    rmSync(tempDir, {recursive: true, force: true})
+  })
+
+  it('exits 0 and runs dist/cli.mjs when present', () => {
+    // #when
+    const result = spawnSync(process.execPath, [tempBinHarness], {encoding: 'utf8'})
+
+    // #then
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('CLI_RAN')
+  })
+})
+
+describe('bin/postinstall.mjs: runs dist/postinstall.mjs when present', () => {
+  let tempDir: string
+  let tempBinPostinstall: string
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'fro-bot-harness-'))
+    const tempBin = join(tempDir, 'bin')
+    const tempDist = join(tempDir, 'dist')
+    mkdirSync(tempBin, {recursive: true})
+    mkdirSync(tempDist, {recursive: true})
+    tempBinPostinstall = join(tempBin, 'postinstall.mjs')
+    // #given — copy the REAL committed shim and create a marker dist/postinstall.mjs
+    copyFileSync(binPostinstall, tempBinPostinstall)
+    writeFileSync(join(tempDist, 'postinstall.mjs'), "process.stdout.write('POSTINSTALL_RAN\\n')\n")
+  })
+
+  afterAll(() => {
+    rmSync(tempDir, {recursive: true, force: true})
+  })
+
+  it('exits 0 and runs dist/postinstall.mjs when present', () => {
+    // #when
+    const result = spawnSync(process.execPath, [tempBinPostinstall], {encoding: 'utf8'})
+
+    // #then
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('POSTINSTALL_RAN')
+  })
+})
+
+// #endregion

--- a/packages/harness/src/postinstall.ts
+++ b/packages/harness/src/postinstall.ts
@@ -10,7 +10,9 @@
  *   4. Print a clear status message.
  *
  * Exits 0 on success or when no platform binary is available (optional dep not installed).
- * The `|| true` in package.json scripts.postinstall ensures install never fails here.
+ * The postinstall hook is invoked via bin/postinstall.mjs, which is self-contained-non-fatal:
+ * it catches import errors and always exits 0 when dist is absent, so install never fails
+ * regardless of this module's behavior.
  *
  * A missing binary is NOT a fatal install error — the harness falls back to the
  * dev scaffold (opencode on PATH). The action setup fails loud if the binary is


### PR DESCRIPTION
On every Renovate dependency PR, the action build was aborting because `@fro.bot/harness` declared its `bin` and `postinstall` against built `dist/` files that are gitignored. In a clean checkout those files don't exist, so the workspace package had install-time entrypoints pointing at nothing. An install that skips lifecycle scripts (as Renovate's does) left a broken bin, and pnpm's license tooling then failed on the half-installed package in that environment — taking down the build that depends on it.

This makes the install-time entrypoints always exist.

## What changed

- **Committed `bin/harness.mjs` and `bin/postinstall.mjs` shims.** Each dynamically imports its built `dist/` counterpart when present and degrades gracefully when not: the CLI shim prints a clear "not built — run the build" message and exits non-zero; the postinstall shim stays non-fatal and exits 0. Because they're committed (not gitignored like `dist/`), the bin and postinstall entrypoints resolve in any checkout, built or not.
- `package.json` points `bin.harness` and `postinstall` at the shims and adds `bin` to the published `files`. Published tarballs ship both the shims and the built `dist/`, which are siblings under the package root, so the installed CLI resolves the real `dist/cli.mjs` correctly.

The license collector and its fail-closed behavior are untouched, and the committed `dist/`/`THIRD_PARTY_NOTICES.txt` are byte-identical — `@fro.bot/harness` isn't a root dependency, so it was never in the attribution set. Verified by reproducing the script-skipping install locally: the bin warning is gone, license listing succeeds, and a full build leaves `dist/` unchanged.