### PR TITLE
fix(build): surface real stderr when license collection fails

### DIFF
--- a/scripts/third-party-notices.test.ts
+++ b/scripts/third-party-notices.test.ts
@@ -1,7 +1,7 @@
 import {execFile} from 'node:child_process'
 import {getProjectLicenses} from 'generate-license-file'
 import {describe, expect, it, vi} from 'vitest'
-import {collectThirdPartyNotices, formatThirdPartyNotices} from './third-party-notices.js'
+import {collectThirdPartyNotices, formatChildProcessError, formatThirdPartyNotices} from './third-party-notices.js'
 
 // All mocks use .js imports (Vitest convention for this project)
 vi.mock('generate-license-file', () => ({
@@ -141,7 +141,7 @@ describe('collectThirdPartyNotices — error path', () => {
 
     // #when / #then throws with cause in message
     await expect(collectThirdPartyNotices()).rejects.toThrow(
-      /license collection failed.*ENOENT.*no such file or directory/,
+      /license collection failed[\s\S]*ENOENT[\s\S]*no such file or directory/,
     )
   })
 
@@ -175,7 +175,58 @@ describe('collectThirdPartyNotices — error path', () => {
     mockGetProjectLicenses.mockRejectedValue('string rejection reason')
 
     // #when / #then message includes the string value
-    await expect(collectThirdPartyNotices()).rejects.toThrow(/license collection failed.*string rejection reason/)
+    await expect(collectThirdPartyNotices()).rejects.toThrow(/license collection failed[\s\S]*string rejection reason/)
+  })
+})
+
+describe('formatChildProcessError', () => {
+  it('surfaces stderr, stdout, exit code, and signal from an execFile-style error', () => {
+    // #given an execFile rejection carrying the diagnostics that the generic
+    // "Command failed" message alone hides
+    const execError = Object.assign(new Error('Command failed: pnpm licenses list --json --prod'), {
+      code: 1,
+      signal: 'SIGTERM',
+      stderr: '  ERR_PNPM_LICENSES_NO_LOCKFILE  the real underlying reason\n',
+      stdout: '  partial stdout content  ',
+    })
+
+    // #when formatted
+    const formatted = formatChildProcessError(execError)
+
+    // #then every diagnostic field is surfaced (stderr/stdout trimmed)
+    expect(formatted).toContain('Command failed: pnpm licenses list --json --prod')
+    expect(formatted).toContain('exitCode=1')
+    expect(formatted).toContain('signal=SIGTERM')
+    expect(formatted).toContain('stderr:\nERR_PNPM_LICENSES_NO_LOCKFILE  the real underlying reason')
+    expect(formatted).toContain('stdout:\npartial stdout content')
+  })
+
+  it('falls back to the message alone when no child-process fields are present', () => {
+    // #given a plain Error with no stderr/stdout/code
+    const plain = new Error('plain failure')
+
+    // #when / #then only the message is returned
+    expect(formatChildProcessError(plain)).toBe('plain failure')
+  })
+
+  it('stringifies a non-object rejection value', () => {
+    // #given a string rejection
+    // #when / #then the raw value is stringified
+    expect(formatChildProcessError('string reason')).toBe('string reason')
+  })
+
+  it('omits empty stderr/stdout and reports only present fields', () => {
+    // #given an error with an exit code but empty stream output
+    const execError = Object.assign(new Error('boom'), {code: 2, stderr: '', stdout: '   '})
+
+    // #when formatted
+    const formatted = formatChildProcessError(execError)
+
+    // #then empty streams are omitted, code is present
+    expect(formatted).toContain('boom')
+    expect(formatted).toContain('exitCode=2')
+    expect(formatted).not.toContain('stderr:')
+    expect(formatted).not.toContain('stdout:')
   })
 })
 

--- a/scripts/third-party-notices.ts
+++ b/scripts/third-party-notices.ts
@@ -16,6 +16,47 @@ import {getProjectLicenses} from 'generate-license-file'
 
 const execFileAsync = promisify(execFile)
 
+/**
+ * Formats the real diagnostics from a failed child-process invocation.
+ *
+ * execFile rejections carry `stderr`, `stdout`, `code`, and `signal` alongside
+ * `message`, but `message` alone is just the generic "Command failed: ..." line.
+ * When a license-tooling command fails in a constrained environment (e.g. a
+ * Renovate runner), the actual reason lives in `stderr`/`stdout` — so surface
+ * all of it instead of swallowing it behind the generic message.
+ */
+export function formatChildProcessError(error: unknown): string {
+  if (error == null || typeof error !== 'object') {
+    return String(error)
+  }
+  const record = error as {
+    message?: unknown
+    stderr?: unknown
+    stdout?: unknown
+    code?: unknown
+    signal?: unknown
+  }
+  const parts: string[] = []
+  if (typeof record.message === 'string' && record.message.length > 0) {
+    parts.push(record.message)
+  }
+  if (record.code != null) {
+    parts.push(`exitCode=${String(record.code)}`)
+  }
+  if (record.signal != null) {
+    parts.push(`signal=${String(record.signal)}`)
+  }
+  const stderr = typeof record.stderr === 'string' ? record.stderr.trim() : ''
+  if (stderr.length > 0) {
+    parts.push(`stderr:\n${stderr}`)
+  }
+  const stdout = typeof record.stdout === 'string' ? record.stdout.trim() : ''
+  if (stdout.length > 0) {
+    parts.push(`stdout:\n${stdout}`)
+  }
+  return parts.length > 0 ? parts.join('\n') : String(error)
+}
+
 export interface LicenseEntry {
   readonly version: string
   readonly license: string
@@ -108,7 +149,7 @@ async function getPnpmLicensesJson(): Promise<PnpmLicensesJson> {
     return parsed
   } catch (error) {
     console.warn(
-      `[license-collector] pnpm licenses list failed (${error instanceof Error ? error.message : String(error)}); license types will be "Unknown"`,
+      `[license-collector] pnpm licenses list failed; license types will be "Unknown"\n${formatChildProcessError(error)}`,
     )
     return {}
   }
@@ -205,10 +246,11 @@ export async function collectThirdPartyNotices(packageJsonPath = './package.json
   try {
     licenses = await getProjectLicenses(packageJsonPath)
   } catch (error) {
-    const cause = error instanceof Error ? error.message : String(error)
-    throw new Error(`[license-collector] license collection failed; cannot produce THIRD_PARTY_NOTICES.txt: ${cause}`, {
-      cause: error instanceof Error ? error : new Error(cause),
-    })
+    const diagnostics = formatChildProcessError(error)
+    throw new Error(
+      `[license-collector] license collection failed; cannot produce THIRD_PARTY_NOTICES.txt:\n${diagnostics}`,
+      {cause: error instanceof Error ? error : new Error(diagnostics)},
+    )
   }
 
   for (const license of licenses) {


### PR DESCRIPTION
When third-party license collection fails, the collector logged only the generic `Command failed: pnpm licenses list --json --prod` message and swallowed the underlying `stderr`/`stdout`/exit code. In a constrained environment (like a Renovate runner, where the post-upgrade `pnpm run build` has been failing here), the real reason was unrecoverable from CI logs — making the failure impossible to diagnose.

This adds `formatChildProcessError(error)` to extract `stderr`, `stdout`, exit code, and signal from child-process rejections, and uses it in both collection paths:

- the fail-soft `pnpm licenses list` warning, and
- the fail-closed `getProjectLicenses` throw.

The fail-closed behavior is unchanged — a total license-collection failure still throws and aborts the build (preserving the committed-`dist/` attribution guarantee). It just now carries the real diagnostics so the next failing run shows the actual cause instead of a black box.

Diagnostics only; no change to the build's success/failure outcome. Scripts-only, no `dist/` change. New unit tests cover the helper (stderr/stdout/code/signal surfaced, message-only fallback, non-object stringify, empty-stream omission).