### PR TITLE
fix(renovate): force pnpm install to repair partial store before build

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -166,9 +166,13 @@
     },
   ],
   postUpgradeTasks: {
+    // `install --force` repairs the pnpm content-addressable store before the
+    // build. Renovate restores a cached store that can be missing package index
+    // files (ERR_PNPM_MISSING_PACKAGE_INDEX_FILE); a plain `install` no-ops
+    // against that partial store and the build's license collection then fails.
     // `build` escapes dist hidden Unicode as its final step, so a rebuilt dist on
     // update branches stays free of characters Renovate would otherwise flag.
-    commands: ['pnpm install', 'pnpm run fix', 'pnpm run build'],
+    commands: ['pnpm install --force', 'pnpm run fix', 'pnpm run build'],
     executionMode: 'branch',
   },
 }


### PR DESCRIPTION
Renovate's `postUpgradeTasks` build has been failing on dependency PRs, blocking dist regeneration. With the stderr now surfaced (#997), the root cause is confirmed:

```
pnpm licenses list --json --prod →
ERR_PNPM_MISSING_PACKAGE_INDEX_FILE: Failed to find package index file for
@actions/artifact@6.2.1 (at sha512-...), please consider running 'pnpm install'
```

Renovate restores a cached pnpm content-addressable store that is **partially populated** — missing the package index file for at least `@actions/artifact` — while the lockfile-only resolution reports the store as complete (`reused 0, downloaded 0, added 0`). The postUpgrade `pnpm install` then no-ops against that partial store, so the build's license collection fails reading the missing index file and aborts.

This changes the first postUpgrade task to `pnpm install --force`, which refetches/repairs store content before `fix`/`build`. It matches the action's allowed-command regex and keeps the fail-closed license gate intact.

The store corruption lives in Renovate's restored cache (not reproducible from a clean checkout), so this can't be pre-validated locally — but the diagnostics from #997 remain in place, so if `--force` doesn't repair it the next run will show the same error immediately. The underlying store-integrity bug is filed upstream: bfra-me/renovate-action#3414.