### PR TITLE
revert(renovate): drop ineffective `pnpm install --force`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -166,13 +166,9 @@
     },
   ],
   postUpgradeTasks: {
-    // `install --force` repairs the pnpm content-addressable store before the
-    // build. Renovate restores a cached store that can be missing package index
-    // files (ERR_PNPM_MISSING_PACKAGE_INDEX_FILE); a plain `install` no-ops
-    // against that partial store and the build's license collection then fails.
     // `build` escapes dist hidden Unicode as its final step, so a rebuilt dist on
     // update branches stays free of characters Renovate would otherwise flag.
-    commands: ['pnpm install --force', 'pnpm run fix', 'pnpm run build'],
+    commands: ['pnpm install', 'pnpm run fix', 'pnpm run build'],
     executionMode: 'branch',
   },
 }


### PR DESCRIPTION
#998 added `pnpm install --force` to repair Renovate's partial pnpm store, but it was a **proven no-op** in production (validation run 28063498652):

```
command: pnpm install --force
[WARN] using --force I sure hope you know what you are doing
Already up to date
Done in 660ms
```

The build then failed with the identical `ERR_PNPM_MISSING_PACKAGE_INDEX_FILE` for `@actions/artifact@6.2.1`. `--force` does not rebuild a missing pnpm store *index file* when the lockfile/store metadata already considers the package present.

Reverting to plain `pnpm install`. The real fix — making license collection store-independent so it no longer shells `pnpm licenses list` (which is what `generate-license-file`'s `getProjectLicenses()` does internally for pnpm projects) — is planned separately. The diagnostics from #997 remain in place to confirm. Upstream store-integrity bug: bfra-me/renovate-action#3414.