### PR TITLE
docs(solutions): pnpm-to-bun migration learnings

### DIFF
--- a/docs/solutions/workflow-issues/build-pipeline-fallible-preflight-and-finally-cleanup-2026-06-22.md
+++ b/docs/solutions/workflow-issues/build-pipeline-fallible-preflight-and-finally-cleanup-2026-06-22.md
@@ -1,8 +1,7 @@
 ---
 title: Build pipelines — fallible work is a preflight, cleanup is a finally
 date: 2026-06-22
-category: workflow-issues
-module: build
+last_updated: 2026-06-24
 problem_type: workflow_issue
 component: tooling
 severity: low
@@ -114,7 +113,7 @@ The same lifecycle shape — fallible generation → destructive mutation → mu
 // tsdown.config.ts
 plugins: [licenseCollectorPlugin() /* throws in writeBundle */, escapeHiddenUnicodePlugin(), ...]
 // package.json
-"build": "... && tsdown ... && pnpm run dist:escape-hidden-unicode"  // escape skipped if tsdown throws
+"build": "... && tsdown ... && bun run dist:escape-hidden-unicode"  // escape skipped if tsdown throws
 ```
 
 A Renovate build where license collection fails: tsdown's `writeBundle` throws after emitting `dist/`, the `&&` short-circuits, the escape never runs, and the notice is dropped.
@@ -138,4 +137,5 @@ A Renovate build where license collection fails: the preflight throws before tsd
 - [Atomic serial channel queue handoff](../best-practices/atomic-serial-channel-queue-handoff-2026-06-09.md) and [Authenticated SSE run observation](../best-practices/authenticated-sse-run-observation-2026-06-20.md) — the runtime dual-`finally` cleanup canon this borrows for the build's finally slot.
 - [Compose topology egress guard hardening](../best-practices/compose-topology-egress-guard-hardening-2026-06-14.md) — the "a bypassable guard is worse than none" canon; a late-hook fail-closed check is its build-pipeline variant.
 - [Gateway Docker runtime-resolution crash-loop](../build-errors/gateway-docker-runtime-resolution-crash-loop-2026-05-31.md) — the "build-time invariant + CI self-check" template this refines with lifecycle placement.
+- [Migrating a pnpm workspace to Bun](migrate-pnpm-to-bun-monorepo-2026-06-24.md) — the pnpm→Bun migration that kept this preflight→mutator→finally lifecycle unchanged while replacing the package manager.
 - Source: PR #991.

--- a/docs/solutions/workflow-issues/committed-dist-attribution-and-sbom-hygiene-2026-06-21.md
+++ b/docs/solutions/workflow-issues/committed-dist-attribution-and-sbom-hygiene-2026-06-21.md
@@ -1,7 +1,7 @@
 ---
 title: 'Committed-bundle attribution and SBOM hygiene'
 date: 2026-06-21
-last_updated: 2026-06-22
+last_updated: 2026-06-24
 problem_type: workflow_issue
 component: tooling
 severity: medium
@@ -85,7 +85,7 @@ Removing the CI carve-out is only safe because Renovate already regenerates the 
 // .github/renovate.json5
 ignorePaths: ['dist/**'],          // scan exclusion only (extraction, not the safety scan)
 postUpgradeTasks: {
-  commands: ['pnpm install', 'pnpm run fix', 'pnpm run build'],  // regenerates + commits dist on dep PRs
+  commands: ['bun install', 'bun run fix', 'bun run build'],  // regenerates + commits dist on dep PRs
   executionMode: 'branch',
 }
 ```
@@ -94,13 +94,13 @@ These three commands are the ones `bfra-me/renovate-action` allowlists for `post
 
 ### 6. SBOM is a separate lane from the NOTICE — ship it as a non-blocking CI artifact
 
-The human-readable legal notice and the machine-readable SBOM serve different consumers. Generate the SBOM with native tooling (`pnpm sbom`, CycloneDX), upload it as a CI artifact, and keep it **non-blocking** — it is informational, not a build gate, and a generation failure must not fail the build.
+The human-readable legal notice and the machine-readable SBOM serve different consumers. Generate the SBOM with a CycloneDX tool (`@cyclonedx/cyclonedx-npm` via `bunx`), upload it as a CI artifact, and keep it **non-blocking** — it is informational, not a build gate, and a generation failure must not fail the build.
 
 ```yaml
 - name: Generate the dependency SBOM
   id: sbom
   continue-on-error: true
-  run: pnpm sbom --sbom-format cyclonedx --prod > sbom.cdx.json
+  run: bunx @cyclonedx/cyclonedx-npm --output-format JSON --output-file sbom.cdx.json
 - uses: actions/upload-artifact@...
   if: ${{ steps.sbom.outcome == 'success' }}   # gate on the step, not file existence — a shell redirect creates the file even on failure
   with:
@@ -145,5 +145,6 @@ Any project that commits a bundled or vendored `dist/` and redistributes third-p
 - [tool-binary-caching-ephemeral-runners](../build-errors/tool-binary-caching-ephemeral-runners.md) — the dist/ rebuild-verification convention this builds on.
 - [durable-dist-hidden-unicode-fix](durable-dist-hidden-unicode-fix-2026-06-22.md) — the durability fix for the hidden-Unicode scan Rule 5 alludes to: escape `dist/` in `build` so the scanner is irrelevant, not load-bearing.
 - [build-pipeline-fallible-preflight-and-finally-cleanup](build-pipeline-fallible-preflight-and-finally-cleanup-2026-06-22.md) — the lifecycle placement of Rule 3's fail-closed collection: run it as a preflight *before* the bundler mutates `dist/`, not inside a late hook the bundler may skip.
+- [Migrating a pnpm workspace to Bun](migrate-pnpm-to-bun-monorepo-2026-06-24.md) — the pnpm→Bun migration that replaced the `pnpm sbom` / `pnpm licenses list` primitives referenced in Rule 6 and Rule 5 with Bun-native equivalents.
 
 Source: PR #978 (no issue — arose from a maintainer question on why `dist/licenses.txt` was untracked and the modern SBOM/license approach). Files: `tsdown.config.ts`, `.github/workflows/ci.yaml`, `.github/renovate.json5`, `RULES.md`.

--- a/docs/solutions/workflow-issues/durable-dist-hidden-unicode-fix-2026-06-22.md
+++ b/docs/solutions/workflow-issues/durable-dist-hidden-unicode-fix-2026-06-22.md
@@ -1,8 +1,7 @@
 ---
 title: Escape committed dist/ artifacts independently of the bundler lifecycle
 date: 2026-06-22
-category: workflow-issues
-module: build
+last_updated: 2026-06-24
 problem_type: workflow_issue
 component: tooling
 severity: low
@@ -41,14 +40,14 @@ PR #988 fixed it by moving the guarantee out of the bundler and into the `build`
 
 ### 1. Put a dist-tree invariant in the command every consumer runs, not in the bundler hook
 
-A `writeBundle` hook is invisible to any path that commits `dist/` without re-emitting every chunk — Renovate update branches, partial caches, hand-edits. Wire the transform into `pnpm run build` so local dev, the CI Build job, and Renovate's `postUpgradeTasks` all apply it:
+A `writeBundle` hook is invisible to any path that commits `dist/` without re-emitting every chunk — Renovate update branches, partial caches, hand-edits. Wire the transform into `bun run build` so local dev, the CI Build job, and Renovate's `postUpgradeTasks` all apply it:
 
 ```json
 // package.json — the scrub is the FINAL step of build
-"build": "pnpm --filter @fro-bot/runtime build && pnpm --filter @fro-bot/action build && pnpm --filter @fro.bot/harness build && pnpm run dist:escape-hidden-unicode"
+"build": "bun run --filter @fro-bot/runtime build && bun run --filter @fro-bot/action build && bun run --filter @fro.bot/harness build && bun run dist:escape-hidden-unicode"
 ```
 
-A `pnpm run build` that exits zero is, by construction, free of the flagged codepoints.
+A `bun run build` that exits zero is, by construction, free of the flagged codepoints.
 
 ### 2. `ignorePaths` is extraction-only — fix the artifact, not the scanner config
 
@@ -61,7 +60,7 @@ Renovate's `ignorePaths: ['dist/**']` stops dependency extraction from the bundl
 ```json5
 // .github/renovate.json5 — only allowlisted commands; build does the scrubbing
 postUpgradeTasks: {
-  commands: ['pnpm install', 'pnpm run fix', 'pnpm run build'],
+  commands: ['bun install', 'bun run fix', 'bun run build'],
   executionMode: 'branch',
 }
 ```
@@ -108,9 +107,9 @@ const fixed = content.replaceAll(re, escapeChar) // escapeChar: char => `\\u${he
 ```yaml
 # .github/workflows/ci.yaml — Build job
 - name: Rebuild the dist/ directory
-  run: pnpm build
+  run: bun run build
 - name: Check dist/ for hidden Unicode characters
-  run: pnpm run dist:check-hidden-unicode
+  run: bun run dist:check-hidden-unicode
 ```
 
 ### 9. Reference the real config; trigger scripts tests on script changes
@@ -139,4 +138,5 @@ The action build pointed at a nonexistent `apps/action/tsdown.config.ts` and sil
 - [Harness base-version source of truth](harness-base-version-source-of-truth-2026-06-12.md) — the "delete the source of drift, don't add a detection test" meta-rule behind the single-source-of-truth dedup.
 - [Gateway Docker runtime-resolution crash-loop](../build-errors/gateway-docker-runtime-resolution-crash-loop-2026-05-31.md) — the "build-time invariant + CI self-check" template this refines with the bundler-lifecycle caveat.
 - [Build pipelines — fallible work is a preflight, cleanup is a finally](build-pipeline-fallible-preflight-and-finally-cleanup-2026-06-22.md) — the lifecycle-ordering refinement: *where in the build command* fail-closed work and cleanup run (preflight before the bundler, escape in a finally after it), not just that they run in `build`.
+- [Migrating a pnpm workspace to Bun](migrate-pnpm-to-bun-monorepo-2026-06-24.md) — the pnpm→Bun migration that replaced the `pnpm run build` / `pnpm install` tokens in the Renovate allowlist and the build command chain with their Bun equivalents.
 - Failed-attempt trail: PR #554 (ignorePaths), PR #571 (escape plugin), PR #654 (widen to text files); PR #988 is the durable fix.

--- a/docs/solutions/workflow-issues/migrate-pnpm-to-bun-monorepo-2026-06-24.md
+++ b/docs/solutions/workflow-issues/migrate-pnpm-to-bun-monorepo-2026-06-24.md
@@ -1,0 +1,160 @@
+---
+title: 'Migrating a pnpm workspace to Bun: diagnostics, spike-then-cutover, and the semantics that bite'
+date: 2026-06-24
+problem_type: workflow_issue
+component: tooling
+severity: high
+applies_when:
+  - 'A CI runner with a partial-restore model (Renovate, cache restore) breaks a tool that reads the package manager store rather than the lockfile'
+  - 'Migrating a multi-package workspace from pnpm to Bun (or any package-manager swap with a stricter linker / frozen-lockfile model)'
+  - 'A Docker build runs a filtered install plus a build that typechecks test files'
+  - 'A license/SBOM generator shells into a package-manager CLI instead of reading the lockfile'
+  - 'New toolchain version literals must stay Renovate-tracked across multiple files'
+tags:
+  - bun
+  - pnpm
+  - renovate
+  - migration
+  - monorepo
+  - hoisted-linker
+  - third-party-notices
+  - fail-closed
+---
+
+# Migrating a pnpm workspace to Bun
+
+## Context
+
+A recurring Renovate failure forced this migration. On every dependency PR, the post-upgrade `pnpm run build` aborted because the license collector (`generate-license-file`, which shells `pnpm licenses list`) read pnpm's content-addressable store — and Renovate restored a *partial* store missing the package index file for at least `@actions/artifact` (`ERR_PNPM_MISSING_PACKAGE_INDEX_FILE`). Lockfile-only resolution reported the store complete (`reused 0, downloaded 0, added 0`), so `pnpm install --force` was a proven no-op. The packages were present and the bundle built; only the store read failed, and the fail-closed license preflight then aborted `dist/` regeneration.
+
+The corruption lived in Renovate's restored store — upstream state the repo cannot reproduce or control. Three symptom-level fixes were merged and reverted before the real cause surfaced. The durable fix was to stop depending on the store at all: migrate the workspace from pnpm 11.8 to Bun 1.3.14 and replace the license collector with one that reads `bun.lock` directly. This shipped as a single cutover PR (#1002) backed by a spike, and was proven in production when the next Renovate run regenerated `dist/` cleanly with zero store errors.
+
+## Guidance
+
+### 1. Surface real stderr before attempting any fix
+
+A fail-closed `catch` that throws a generic message makes an environment-specific failure un-diagnosable. Three wrong fixes (harness install shims, `pnpm install --force`, an unshipped plan) were tried against a vague "license collection failed" before a diagnostics commit surfaced the actual `ERR_PNPM_MISSING_PACKAGE_INDEX_FILE`. When a toolchain command fails, join `stderr`, `stdout`, `exitCode`, and `signal` into the thrown error *before* remediation:
+
+```ts
+export function formatChildProcessError(error: unknown): string {
+  if (error == null || typeof error !== 'object') return String(error)
+  const record = error as {message?: unknown; stderr?: unknown; stdout?: unknown; code?: unknown; signal?: unknown}
+  const parts: string[] = []
+  if (typeof record.message === 'string') parts.push(record.message)
+  if (record.code != null) parts.push(`exitCode=${String(record.code)}`)
+  if (record.signal != null) parts.push(`signal=${String(record.signal)}`)
+  const stderr = typeof record.stderr === 'string' ? record.stderr.trim() : ''
+  if (stderr) parts.push(`stderr:\n${stderr}`)
+  const stdout = typeof record.stdout === 'string' ? record.stdout.trim() : ''
+  if (stdout) parts.push(`stdout:\n${stdout}`)
+  return parts.length > 0 ? parts.join('\n') : String(error)
+}
+```
+
+A fail-closed catch is not "done" until its failure path is *more* diagnostic than its success path. This matters most for CI-only failures you cannot reproduce locally — the stderr is your only evidence.
+
+### 2. Spike-then-cutover for risky toolchain migrations
+
+Do not commit the cutover until a throwaway-branch spike produces a go/no-go artifact. The spike must verify every load-bearing surface: install, filtered builds, the bundler, the test runner, the linker choice, and — critically — a **byte-faithful diff of any attribution-critical output** (here, that the Bun-native collector reproduced the full committed `THIRD_PARTY_NOTICES.txt` package set). For each divergence, decide tolerable (size/ordering) vs blocking (missing attribution, broken import); a single blocking item is a no-go. If the spike fails, you fall back having spent only cheap spike time.
+
+Stage the cutover as a small stack of revert-able PRs, not one big-bang diff — each revert is a learning artifact and keeps the bisect tractable.
+
+### 3. Bun-vs-pnpm semantics that bite at cutover
+
+These four divergences are invisible until cutover and not called out in the Bun docs:
+
+**(a) `--frozen-lockfile` validates the full workspace, even for `--filter`.** Bun checks the complete `workspaces` manifest set declared in `bun.lock` even when you only build one package. A Docker build that copies partial manifests fails with `lockfile had changes, but lockfile is frozen`. Copy **every** workspace `package.json` before the install. (pnpm tolerated partial manifests.)
+
+**(b) A `--filter` install omits root devDependencies the build needs.** The package `build` runs `tsc -p tsconfig.json` over `.test.ts` files that import `vitest`; a filtered install omits those devDeps, so the typecheck fails `TS2307: Cannot find module 'vitest'` in Docker while passing locally with a full install. Use a full `bun install --frozen-lockfile` in Docker; keep `--filter` for the *build step*, not the *install step*.
+
+**(c) Bun config lives in `package.json` + `bunfig.toml`, not a workspace yaml.** `pnpm-workspace.yaml` overrides/`onlyBuiltDependencies`/`minimumReleaseAge` map to `package.json` (`workspaces`, `overrides`, `trustedDependencies`, `packageManager`) plus `bunfig.toml` (`linker`, `minimumReleaseAge`).
+
+**(d) Hoisted vs isolated linker — TS2883 is the canary.** Bun's default isolated linker places packages under non-portable `node_modules/.bun/<pkg>@<hash>/` paths, which makes TypeScript unable to name deep dependency types — `TS2883` on a root `eslint.config.ts` that calls `defineConfig` from `@bfra.me/eslint-config` (which references `@eslint/core` internals). It also creates duplicate dependency instances. `linker = "hoisted"` fixes it cleanly but loses phantom-dependency protection. (Attempted alternatives both fail: an `as Linter.Config[]` cast hits `TS2352` because `FlatConfigComposer` is not array-assignable; excluding the config from `tsconfig.json` breaks eslint's type-aware lint with "not found by the project service".) A clean relink requires `rm -rf node_modules apps/*/node_modules packages/*/node_modules && bun install` — changing the linker in `bunfig.toml` is a no-op if `node_modules` is already linked.
+
+### 4. Store-independent license attribution: read the lockfile, walk the closure
+
+A collector that depends on a package-manager store inherits the store's failure modes. Read `bun.lock` directly, BFS the prod closure across all workspace packages (traversing `dependencies` + `optionalDependencies` + `peerDependencies`, resolving Bun's nested `parent/dep` keys), read the `LICENSE`/`LICENCE`/`COPYING`/`NOTICE` file from `node_modules/<pkg>/`, and fail closed when a prod package's directory is missing. Validate `lockfileVersion` so a future format bump fails with a clear error rather than silently wrong output. The lockfile is the contract `install` produces; the store is a cache that can be incomplete, corrupt, or evicted. This pattern generalizes to any SBOM/attribution task that currently shells into a package manager.
+
+### 5. Renovate version-tracking discipline carries to the new toolchain
+
+Every new version literal in the new toolchain needs a Renovate `customManager` or it strands silently on the next bump. The migration added four `oven-sh/bun` trackers — both Dockerfile `ARG BUN_VERSION`, the composite-action `default:`, and the root `packageManager: "bun@X.Y.Z"` — each file-scoped via `managerFilePatterns` and capped with `allowedVersions` to stay in lockstep with the harness's validated Bun. The mechanical audit: every `X.Y.Z` literal in a non-`node_modules` file is a `customManager` candidate.
+
+## Why This Matters
+
+Toolchain migrations are high-blast-radius, low-frequency changes — you do them rarely enough to forget the lessons, and each touches enough surfaces that a big-bang cutover makes the bisect useless. The original sin here was depending on a corruptible store from CI code; the fix was reading the lockfile contract instead. The spike converts every "unknown until cutover" into a yes/no answer *before* you commit, and the staged PR stack gives cheap revert points. And the failure was never at the code surface — it was at the diagnostic surface: every minute on a wrong fix is a minute not spent reading the stderr that would have named the cause.
+
+## When to Apply
+
+- **Stderr-first** when a fail-closed catch wraps a toolchain command in a CI-only environment, or three-plus fixes haven't stuck against a vague message.
+- **Spike-then-cutover** when a migration touches more than ~3 surfaces and produces a byte-diff-critical artifact.
+- **Bun-vs-pnpm semantics** for any package-manager swap to a stricter linker/frozen-lockfile model, especially with deep-type imports in root config files or a Docker build that typechecks tests.
+- **Lockfile-driven collector** when attribution shells into the package manager or has failed on a partial/incomplete-install error.
+- **Renovate tracking** whenever a new tool introduces version literals across multiple files.
+
+Do **not** reach for the full pattern when the toolchain already has a known-good store and the change is a minor bump, or when the blast radius is one script and one CI step.
+
+## Examples
+
+**The diagnostic trail (one PR if stderr had come first):**
+
+| PR | Approach | Outcome |
+| --- | --- | --- |
+| harness shims | commit install-time bin/postinstall shims | reverted — never repaired the store |
+| #997 | surface real stderr on license-collection failure | right diagnostic — revealed `ERR_PNPM_MISSING_PACKAGE_INDEX_FILE` |
+| #998 | `pnpm install --force` postUpgrade | reverted (#999) — no-op against the partial store |
+| #1002 | replace the store with a lockfile-driven collector (Bun migration) | the fix — no store, no corruption |
+
+**The load-bearing Dockerfile change (pnpm → Bun):**
+
+```dockerfile
+# Before (pnpm): partial manifests + filtered install
+RUN corepack enable
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY packages/runtime/ packages/runtime/
+COPY packages/gateway/ packages/gateway/
+RUN pnpm install --frozen-lockfile --filter @fro-bot/gateway...
+
+# After (Bun): all manifests + full install
+ARG BUN_VERSION=1.3.14
+RUN npm i -g bun@${BUN_VERSION}
+COPY package.json bun.lock bunfig.toml tsconfig.base.json ./
+COPY apps/action/package.json apps/action/package.json
+COPY apps/workspace-agent/package.json apps/workspace-agent/package.json
+COPY packages/runtime/package.json packages/runtime/package.json
+COPY packages/gateway/package.json packages/gateway/package.json
+COPY packages/harness/package.json packages/harness/package.json
+RUN bun install --frozen-lockfile
+COPY packages/runtime/ packages/runtime/
+COPY packages/gateway/ packages/gateway/
+RUN bun run --filter @fro-bot/runtime build
+RUN bun run --filter @fro-bot/gateway build
+```
+
+**Config relocation (`pnpm-workspace.yaml` deleted):**
+
+```json5
+// package.json
+{
+  "workspaces": ["apps/*", "packages/*"],
+  "packageManager": "bun@1.3.14",
+  "overrides": {"brace-expansion": ">=5.0.6", "undici": ">=7.24.0"},
+  "trustedDependencies": ["esbuild", "simple-git-hooks", "unrs-resolver"]
+}
+```
+
+```toml
+# bunfig.toml
+[install]
+linker = "hoisted"            # isolated .bun/ paths break tsc TS2883 on eslint.config.ts
+minimumReleaseAge = 259200    # 3 days
+minimumReleaseAgeExcludes = []
+```
+
+## Related
+
+- [Committed-bundle attribution and SBOM hygiene](committed-dist-attribution-and-sbom-hygiene-2026-06-21.md) — the attribution policy this migration preserves; the migration replaces its `pnpm sbom` / `pnpm licenses list` primitives.
+- [Build-pipeline fallible preflight and finally cleanup](build-pipeline-fallible-preflight-and-finally-cleanup-2026-06-22.md) — the preflight→mutator→finally lifecycle the migration kept unchanged.
+- [Durable dist hidden-Unicode fix](durable-dist-hidden-unicode-fix-2026-06-22.md) — the escape-as-final-build-step + Renovate allowlist constraint the new `postUpgradeTasks` had to honor.
+- [Versioned-tool config plugin pattern](../best-practices/versioned-tool-config-plugin-pattern-2026-03-29.md) — the single-source version-pin discipline extended to the workspace Bun pin.
+- Plan: `docs/plans/2026-06-23-001-refactor-pnpm-to-bun-migration-plan.md` — the design record for PR #1002.
+- Follow-ups: #1003 (Dockerfile verified-binary install, runtime image trim), #1004 (CI bun cache, phantom-dependency lint guard, notice-collector polish).


### PR DESCRIPTION
Captures the reusable learnings from the pnpm→Bun workspace migration (#1002) as a `docs/solutions/` entry, and refreshes three sibling docs whose pnpm command snippets are now stale.

## New doc

`migrate-pnpm-to-bun-monorepo-2026-06-24.md` documents five lessons:
1. Surface real stderr before attempting a fix — a fail-closed catch that swallows diagnostics cost three wrong fixes before the actual `ERR_PNPM_MISSING_PACKAGE_INDEX_FILE` surfaced.
2. Spike-then-cutover for risky toolchain migrations — verify every blocker (including byte-faithful attribution output) on a throwaway branch before committing.
3. The Bun-vs-pnpm semantics that bite at cutover — frozen-lockfile validates the full workspace manifest set even for filtered installs, filtered installs omit root devDeps, config relocates to `package.json`/`bunfig.toml`, and the hoisted-vs-isolated linker choice (TS2883 is the canary).
4. Store-independent license attribution — read the lockfile's resolved tree, not a corruptible package-manager store.
5. Renovate version-tracking discipline carries to every new version literal.

## Refreshed siblings

`committed-dist-attribution-and-sbom-hygiene`, `build-pipeline-fallible-preflight-and-finally-cleanup`, and `durable-dist-hidden-unicode-fix` had `pnpm` command snippets that no longer match the repo. Their lessons are unchanged; the snippets are updated to Bun and cross-linked bidirectionally with the new doc.