### PR TITLE
fix(deploy): verified Bun install + production-only runtime images

### DIFF
--- a/deploy/gateway.Dockerfile
+++ b/deploy/gateway.Dockerfile
@@ -10,24 +10,33 @@ RUN apk add --no-cache curl unzip
 
 # Install Bun from the official oven-sh/bun GitHub release, verified against the
 # release SHASUMS256.txt fail-closed — matching the verified-binary posture used
-# for the OpenCode install (and CI's oven-sh/setup-bun), rather than pulling the
-# unverified `bun` npm wrapper. TARGETARCH is provided automatically by BuildKit;
-# x64 uses the AVX2-independent baseline+musl variant so the image runs on any
-# x86 host, arm64 uses the musl variant. Both are musl for Alpine.
+# for the OpenCode install in deploy/workspace.Dockerfile (and CI's
+# oven-sh/setup-bun), rather than pulling the unverified `bun` npm wrapper.
+# TARGETARCH is provided automatically by BuildKit; x64 uses the AVX2-independent
+# baseline+musl variant so the image runs on any x86 host, arm64 uses the musl
+# variant. Both are musl for Alpine.
 #
 # Any download failure, checksum-fetch failure, missing entry, or hash mismatch
 # aborts the build (no fallback, no retry-around-mismatch).
+#
+# NOTE: keep this block in sync with the same block in deploy/workspace.Dockerfile.
 ARG TARGETARCH
 RUN set -euo pipefail \
+    # Validate the version before URL interpolation (parity with the OpenCode block).
+    && case "${BUN_VERSION}" in \
+         *[!0-9A-Za-z._-]*) echo "BUN_VERSION contains disallowed characters: ${BUN_VERSION}" >&2; exit 1 ;; \
+         [0-9]*.[0-9]*.[0-9]*) : ;; \
+         *) echo "BUN_VERSION is not a semver-like version: ${BUN_VERSION}" >&2; exit 1 ;; \
+       esac \
     && case "${TARGETARCH}" in \
          amd64) bun_asset="bun-linux-x64-musl-baseline" ;; \
          arm64) bun_asset="bun-linux-aarch64-musl" ;; \
          *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
        esac \
     && bun_base="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}" \
-    && curl -fsSL --retry 3 --retry-delay 2 -o "/tmp/${bun_asset}.zip" "${bun_base}/${bun_asset}.zip" \
-    && curl -fsSL --retry 3 --retry-delay 2 -o /tmp/SHASUMS256.txt "${bun_base}/SHASUMS256.txt" \
-    && expected_hash="$(awk -v f="${bun_asset}.zip" '$2 == f {print $1}' /tmp/SHASUMS256.txt)" \
+    && curl -fsSL --connect-timeout 30 --max-time 120 --retry 3 --retry-delay 2 -o "/tmp/${bun_asset}.zip" "${bun_base}/${bun_asset}.zip" \
+    && curl -fsSL --connect-timeout 30 --max-time 120 --retry 3 --retry-delay 2 -o /tmp/SHASUMS256.txt "${bun_base}/SHASUMS256.txt" \
+    && expected_hash="$(awk -v f="${bun_asset}.zip" '$2 == f || $2 == "./" f {print $1}' /tmp/SHASUMS256.txt)" \
     && if [ -z "${expected_hash}" ]; then \
          echo "SHASUMS256.txt has no entry for ${bun_asset}.zip" >&2; exit 1; \
        fi \
@@ -78,10 +87,15 @@ RUN bun run --filter @fro-bot/gateway build
 # final image does not carry the dev toolchain (vitest, tsdown, eslint, …). The
 # full install above is required for the build typecheck (which imports vitest).
 # Bun's --production does NOT prune an already-populated node_modules, so the
-# workspace node_modules are removed first for a clean production-only install.
-# --ignore-scripts skips the root simple-git-hooks postinstall (a devDependency
-# that would otherwise fail under --production). The runtime stage copies this
-# trimmed tree.
+# workspace node_modules are removed first for a clean production-only install
+# (the rm globs cover the current flat apps/* + packages/* workspace layout).
+# --ignore-scripts is required: bun still runs the ROOT postinstall under
+# --production (workspace mode), and that script invokes simple-git-hooks — a
+# devDependency that is absent under --production, so it would fail with exit
+# 127. The flag is a blanket suppression of all lifecycle scripts; that is safe
+# today because no production dependency declares a postinstall, but a future
+# prod dep that needs one would be silently skipped (caught only by the smoke
+# tests booting the image). The runtime stage copies this trimmed tree.
 RUN rm -rf node_modules apps/*/node_modules packages/*/node_modules \
     && bun install --production --frozen-lockfile --ignore-scripts
 

--- a/deploy/gateway.Dockerfile
+++ b/deploy/gateway.Dockerfile
@@ -5,8 +5,45 @@ WORKDIR /workspace
 
 ARG BUN_VERSION=1.3.14
 
-# Install Bun (matches packageManager: bun@${BUN_VERSION})
-RUN npm i -g bun@${BUN_VERSION}
+# curl + unzip to fetch and extract the verified Bun release archive.
+RUN apk add --no-cache curl unzip
+
+# Install Bun from the official oven-sh/bun GitHub release, verified against the
+# release SHASUMS256.txt fail-closed — matching the verified-binary posture used
+# for the OpenCode install (and CI's oven-sh/setup-bun), rather than pulling the
+# unverified `bun` npm wrapper. TARGETARCH is provided automatically by BuildKit;
+# x64 uses the AVX2-independent baseline+musl variant so the image runs on any
+# x86 host, arm64 uses the musl variant. Both are musl for Alpine.
+#
+# Any download failure, checksum-fetch failure, missing entry, or hash mismatch
+# aborts the build (no fallback, no retry-around-mismatch).
+ARG TARGETARCH
+RUN set -euo pipefail \
+    && case "${TARGETARCH}" in \
+         amd64) bun_asset="bun-linux-x64-musl-baseline" ;; \
+         arm64) bun_asset="bun-linux-aarch64-musl" ;; \
+         *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+       esac \
+    && bun_base="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}" \
+    && curl -fsSL --retry 3 --retry-delay 2 -o "/tmp/${bun_asset}.zip" "${bun_base}/${bun_asset}.zip" \
+    && curl -fsSL --retry 3 --retry-delay 2 -o /tmp/SHASUMS256.txt "${bun_base}/SHASUMS256.txt" \
+    && expected_hash="$(awk -v f="${bun_asset}.zip" '$2 == f {print $1}' /tmp/SHASUMS256.txt)" \
+    && if [ -z "${expected_hash}" ]; then \
+         echo "SHASUMS256.txt has no entry for ${bun_asset}.zip" >&2; exit 1; \
+       fi \
+    && actual_hash="$(sha256sum "/tmp/${bun_asset}.zip" | awk '{print $1}')" \
+    && if [ "${actual_hash}" != "${expected_hash}" ]; then \
+         echo "SHA256 mismatch for ${bun_asset}.zip: expected ${expected_hash}, got ${actual_hash}" >&2; exit 1; \
+       fi \
+    && unzip -q "/tmp/${bun_asset}.zip" -d /tmp/bun \
+    && mv "/tmp/bun/${bun_asset}/bun" /usr/local/bin/bun \
+    && chmod 755 /usr/local/bin/bun \
+    # bunx is bun's package-runner alias (the npm wrapper installs both); the raw
+    # release archive ships only `bun`, so symlink it for `bunx tsc`/`bunx tsdown`.
+    && ln -s /usr/local/bin/bun /usr/local/bin/bunx \
+    && rm -rf "/tmp/${bun_asset}.zip" /tmp/SHASUMS256.txt /tmp/bun \
+    && bun --version \
+    && bunx --version
 
 # Copy workspace root manifests first (layer-cache friendly)
 COPY package.json bun.lock bunfig.toml tsconfig.base.json ./
@@ -36,6 +73,17 @@ RUN bun run --filter @fro-bot/runtime build
 
 # Build gateway
 RUN bun run --filter @fro-bot/gateway build
+
+# Trim the runtime image: re-resolve node_modules to production-only so the
+# final image does not carry the dev toolchain (vitest, tsdown, eslint, …). The
+# full install above is required for the build typecheck (which imports vitest).
+# Bun's --production does NOT prune an already-populated node_modules, so the
+# workspace node_modules are removed first for a clean production-only install.
+# --ignore-scripts skips the root simple-git-hooks postinstall (a devDependency
+# that would otherwise fail under --production). The runtime stage copies this
+# trimmed tree.
+RUN rm -rf node_modules apps/*/node_modules packages/*/node_modules \
+    && bun install --production --frozen-lockfile --ignore-scripts
 
 # ── Stage 2: runtime ──────────────────────────────────────────────────────────
 FROM node:24.17.0-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6 AS runtime

--- a/deploy/workspace.Dockerfile
+++ b/deploy/workspace.Dockerfile
@@ -169,8 +169,8 @@ RUN set -euo pipefail \
     && base_url="https://github.com/fro-bot/agent/releases/download/${encoded_version}" \
     # Download the asset archive and the SHA256SUMS file for this release.
     # --retry 3 --retry-delay 2: absorbs transient CDN blips; persistent 404/auth still aborts.
-    && curl -fsSL --retry 3 --retry-delay 2 -o "/tmp/${oc_asset}.tar.gz" "${base_url}/${oc_asset}.tar.gz" \
-    && curl -fsSL --retry 3 --retry-delay 2 -o /tmp/SHA256SUMS "${base_url}/SHA256SUMS" \
+    && curl -fsSL --connect-timeout 30 --max-time 120 --retry 3 --retry-delay 2 -o "/tmp/${oc_asset}.tar.gz" "${base_url}/${oc_asset}.tar.gz" \
+    && curl -fsSL --connect-timeout 30 --max-time 120 --retry 3 --retry-delay 2 -o /tmp/SHA256SUMS "${base_url}/SHA256SUMS" \
     # Verify the asset's SHA256 against the SHA256SUMS entry — fail closed on any mismatch.
     && expected_hash="$(awk -v f="${oc_asset}.tar.gz" '$2 == f {print $1}' /tmp/SHA256SUMS)" \
     && if [ -z "${expected_hash}" ]; then \

--- a/deploy/workspace.Dockerfile
+++ b/deploy/workspace.Dockerfile
@@ -23,8 +23,45 @@ WORKDIR /workspace
 
 ARG BUN_VERSION=1.3.14
 
-# Install Bun (matches packageManager: bun@${BUN_VERSION})
-RUN npm i -g bun@${BUN_VERSION}
+# curl + unzip to fetch and extract the verified Bun release archive.
+RUN apk add --no-cache curl unzip
+
+# Install Bun from the official oven-sh/bun GitHub release, verified against the
+# release SHASUMS256.txt fail-closed — matching the verified-binary posture used
+# for the OpenCode install below (and CI's oven-sh/setup-bun), rather than
+# pulling the unverified `bun` npm wrapper. TARGETARCH is provided automatically
+# by BuildKit; x64 uses the AVX2-independent baseline+musl variant so the image
+# runs on any x86 host, arm64 uses the musl variant. Both are musl for Alpine.
+#
+# Any download failure, checksum-fetch failure, missing entry, or hash mismatch
+# aborts the build (no fallback, no retry-around-mismatch).
+ARG TARGETARCH
+RUN set -euo pipefail \
+    && case "${TARGETARCH}" in \
+         amd64) bun_asset="bun-linux-x64-musl-baseline" ;; \
+         arm64) bun_asset="bun-linux-aarch64-musl" ;; \
+         *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+       esac \
+    && bun_base="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}" \
+    && curl -fsSL --retry 3 --retry-delay 2 -o "/tmp/${bun_asset}.zip" "${bun_base}/${bun_asset}.zip" \
+    && curl -fsSL --retry 3 --retry-delay 2 -o /tmp/SHASUMS256.txt "${bun_base}/SHASUMS256.txt" \
+    && expected_hash="$(awk -v f="${bun_asset}.zip" '$2 == f {print $1}' /tmp/SHASUMS256.txt)" \
+    && if [ -z "${expected_hash}" ]; then \
+         echo "SHASUMS256.txt has no entry for ${bun_asset}.zip" >&2; exit 1; \
+       fi \
+    && actual_hash="$(sha256sum "/tmp/${bun_asset}.zip" | awk '{print $1}')" \
+    && if [ "${actual_hash}" != "${expected_hash}" ]; then \
+         echo "SHA256 mismatch for ${bun_asset}.zip: expected ${expected_hash}, got ${actual_hash}" >&2; exit 1; \
+       fi \
+    && unzip -q "/tmp/${bun_asset}.zip" -d /tmp/bun \
+    && mv "/tmp/bun/${bun_asset}/bun" /usr/local/bin/bun \
+    && chmod 755 /usr/local/bin/bun \
+    # bunx is bun's package-runner alias (the npm wrapper installs both); the raw
+    # release archive ships only `bun`, so symlink it for `bunx tsc`/`bunx tsdown`.
+    && ln -s /usr/local/bin/bun /usr/local/bin/bunx \
+    && rm -rf "/tmp/${bun_asset}.zip" /tmp/SHASUMS256.txt /tmp/bun \
+    && bun --version \
+    && bunx --version
 
 # Workspace root manifests first (layer-cache friendly)
 COPY package.json bun.lock bunfig.toml tsconfig.base.json ./
@@ -49,6 +86,17 @@ RUN bun install --frozen-lockfile
 COPY apps/workspace-agent/ apps/workspace-agent/
 
 RUN bun run --filter @fro-bot/workspace-agent build
+
+# Trim the runtime image: re-resolve node_modules to production-only so the
+# final image does not carry the dev toolchain (vitest, tsdown, eslint, …). The
+# full install above is required for the build typecheck (which imports vitest).
+# Bun's --production does NOT prune an already-populated node_modules, so the
+# workspace node_modules are removed first for a clean production-only install.
+# --ignore-scripts skips the root simple-git-hooks postinstall (a devDependency
+# that would otherwise fail under --production). The runtime stage copies this
+# trimmed tree.
+RUN rm -rf node_modules apps/*/node_modules packages/*/node_modules \
+    && bun install --production --frozen-lockfile --ignore-scripts
 
 # ── Stage 2: runtime ──────────────────────────────────────────────────────────
 FROM node:24.17.0-alpine@sha256:156b55f92e98ccd5ef49578a8cea0df4679826564bad1c9d4ef04462b9f0ded6 AS runtime

--- a/deploy/workspace.Dockerfile
+++ b/deploy/workspace.Dockerfile
@@ -35,17 +35,25 @@ RUN apk add --no-cache curl unzip
 #
 # Any download failure, checksum-fetch failure, missing entry, or hash mismatch
 # aborts the build (no fallback, no retry-around-mismatch).
+#
+# NOTE: keep this block in sync with the same block in deploy/gateway.Dockerfile.
 ARG TARGETARCH
 RUN set -euo pipefail \
+    # Validate the version before URL interpolation (parity with the OpenCode block).
+    && case "${BUN_VERSION}" in \
+         *[!0-9A-Za-z._-]*) echo "BUN_VERSION contains disallowed characters: ${BUN_VERSION}" >&2; exit 1 ;; \
+         [0-9]*.[0-9]*.[0-9]*) : ;; \
+         *) echo "BUN_VERSION is not a semver-like version: ${BUN_VERSION}" >&2; exit 1 ;; \
+       esac \
     && case "${TARGETARCH}" in \
          amd64) bun_asset="bun-linux-x64-musl-baseline" ;; \
          arm64) bun_asset="bun-linux-aarch64-musl" ;; \
          *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
        esac \
     && bun_base="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}" \
-    && curl -fsSL --retry 3 --retry-delay 2 -o "/tmp/${bun_asset}.zip" "${bun_base}/${bun_asset}.zip" \
-    && curl -fsSL --retry 3 --retry-delay 2 -o /tmp/SHASUMS256.txt "${bun_base}/SHASUMS256.txt" \
-    && expected_hash="$(awk -v f="${bun_asset}.zip" '$2 == f {print $1}' /tmp/SHASUMS256.txt)" \
+    && curl -fsSL --connect-timeout 30 --max-time 120 --retry 3 --retry-delay 2 -o "/tmp/${bun_asset}.zip" "${bun_base}/${bun_asset}.zip" \
+    && curl -fsSL --connect-timeout 30 --max-time 120 --retry 3 --retry-delay 2 -o /tmp/SHASUMS256.txt "${bun_base}/SHASUMS256.txt" \
+    && expected_hash="$(awk -v f="${bun_asset}.zip" '$2 == f || $2 == "./" f {print $1}' /tmp/SHASUMS256.txt)" \
     && if [ -z "${expected_hash}" ]; then \
          echo "SHASUMS256.txt has no entry for ${bun_asset}.zip" >&2; exit 1; \
        fi \
@@ -91,10 +99,15 @@ RUN bun run --filter @fro-bot/workspace-agent build
 # final image does not carry the dev toolchain (vitest, tsdown, eslint, …). The
 # full install above is required for the build typecheck (which imports vitest).
 # Bun's --production does NOT prune an already-populated node_modules, so the
-# workspace node_modules are removed first for a clean production-only install.
-# --ignore-scripts skips the root simple-git-hooks postinstall (a devDependency
-# that would otherwise fail under --production). The runtime stage copies this
-# trimmed tree.
+# workspace node_modules are removed first for a clean production-only install
+# (the rm globs cover the current flat apps/* + packages/* workspace layout).
+# --ignore-scripts is required: bun still runs the ROOT postinstall under
+# --production (workspace mode), and that script invokes simple-git-hooks — a
+# devDependency that is absent under --production, so it would fail with exit
+# 127. The flag is a blanket suppression of all lifecycle scripts; that is safe
+# today because no production dependency declares a postinstall, but a future
+# prod dep that needs one would be silently skipped (caught only by the smoke
+# tests booting the image). The runtime stage copies this trimmed tree.
 RUN rm -rf node_modules apps/*/node_modules packages/*/node_modules \
     && bun install --production --frozen-lockfile --ignore-scripts
 

--- a/docs/plans/2026-06-24-002-fix-dockerfile-bun-hardening-plan.md
+++ b/docs/plans/2026-06-24-002-fix-dockerfile-bun-hardening-plan.md
@@ -71,7 +71,7 @@ The pnpm→Bun migration installed Bun in both `deploy/gateway.Dockerfile` and `
 
 ## Implementation Units
 
-- [ ] **Unit 1: Verified Bun binary install — gateway Dockerfile**
+- [x] **Unit 1: Verified Bun binary install — gateway Dockerfile**
 
 **Goal:** Replace `npm i -g bun@${BUN_VERSION}` in `deploy/gateway.Dockerfile` with a checksum-verified download of the official Bun musl binary.
 
@@ -91,7 +91,7 @@ The pnpm→Bun migration installed Bun in both `deploy/gateway.Dockerfile` and `
 
 **Verification:** `docker build -f deploy/gateway.Dockerfile .` succeeds; the Bun step prints the pinned version; a deliberately wrong asset name or corrupted checksum aborts the build (spot-check during implementation).
 
-- [ ] **Unit 2: Verified Bun binary install — workspace Dockerfile**
+- [x] **Unit 2: Verified Bun binary install — workspace Dockerfile**
 
 **Goal:** Same verified-Bun-install change in `deploy/workspace.Dockerfile`.
 
@@ -111,7 +111,7 @@ The pnpm→Bun migration installed Bun in both `deploy/gateway.Dockerfile` and `
 
 **Verification:** `docker build -f deploy/workspace.Dockerfile .` succeeds; Bun version reported; image boots and `/healthz` responds (existing smoke).
 
-- [ ] **Unit 3: Production-only node_modules in runtime stage — both Dockerfiles**
+- [x] **Unit 3: Production-only node_modules in runtime stage — both Dockerfiles**
 
 **Goal:** Ship a prod-only `node_modules` (devDependencies excluded) in both runtime images.
 
@@ -131,7 +131,7 @@ The pnpm→Bun migration installed Bun in both `deploy/gateway.Dockerfile` and `
 
 **Verification:** Both images build; the runtime `node_modules` excludes `vitest`/`tsdown`/`eslint`; both smoke tests pass (proving no runtime dependency was trimmed away). Spot-check final image size is reduced.
 
-- [ ] **Unit 4: Docs / comment reconciliation**
+- [x] **Unit 4: Docs / comment reconciliation**
 
 **Goal:** Update the Dockerfile comments to reflect the verified-Bun install and the prod-trim, and note any deploy-doc references.
 

--- a/docs/plans/2026-06-24-002-fix-dockerfile-bun-hardening-plan.md
+++ b/docs/plans/2026-06-24-002-fix-dockerfile-bun-hardening-plan.md
@@ -1,0 +1,178 @@
+---
+title: 'fix: harden Bun install in deploy Dockerfiles (verified binary) and trim runtime image'
+type: fix
+status: active
+date: 2026-06-24
+---
+
+# Harden Bun install in deploy Dockerfiles + trim runtime image
+
+## Overview
+
+Close #1003, the remaining Bun-migration deploy follow-up. Replace the unverified `npm i -g bun@${BUN_VERSION}` in both deploy Dockerfiles with a checksum-verified download of the official oven-sh/bun release binary (mirroring the existing OpenCode verified-binary pattern), and trim devDependencies out of the runtime images by copying a production-only `node_modules`.
+
+## Problem Frame
+
+The pnpm→Bun migration installed Bun in both `deploy/gateway.Dockerfile` and `deploy/workspace.Dockerfile` via `RUN npm i -g bun@${BUN_VERSION}` — pulling the `bun` npm wrapper package with no integrity check, unlike CI (`oven-sh/setup-bun@v2`) and unlike the workspace image's own OpenCode binary, which is fetched from a GitHub release and verified against `SHA256SUMS` fail-closed. Separately, the migration's build stage runs a full `bun install --frozen-lockfile` (devDependencies included, required because the build typechecks test files that import vitest), and the runtime stage copies that full `node_modules` — so the deployed images carry the dev toolchain (vitest, tsdown, eslint, …). This is hardening, not a correctness fix: the images work today.
+
+## Requirements Trace
+
+- R1. Both deploy Dockerfiles install Bun from the official oven-sh/bun GitHub release, verified against the release `SHASUMS256.txt` fail-closed (any download/checksum/mismatch/missing-entry aborts the build).
+- R2. Bun binary selection is arch-aware and Alpine-compatible (musl), matching the build base image.
+- R3. The runtime stage of both images carries a production-only `node_modules` (devDependencies excluded), and the gateway/workspace processes still start and pass their existing smoke tests.
+- R4. `BUN_VERSION` stays the single Renovate-tracked source for the Bun version (no second literal introduced).
+
+## Scope Boundaries
+
+- Not changing the OpenCode binary install (already verified) — only mirroring its pattern for Bun.
+- Not changing which dependencies are bundled vs external (the tsdown `noExternal` config is unchanged); the trim only affects which `node_modules` tree the runtime stage receives.
+- Not pinning per-arch SHA256 literals in the Dockerfile — fetch-and-verify against `SHASUMS256.txt` at build time, matching the OpenCode pattern (keeps `BUN_VERSION` the single source).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `deploy/workspace.Dockerfile` lines 90-126 — the **gold-standard verified-binary pattern** to mirror: `TARGETARCH` allowlist → percent-encode the tag → `curl --retry` the asset + checksum file → `awk` the expected hash → compare fail-closed → extract/chmod/verify. Reuse this shape for Bun.
+- `deploy/gateway.Dockerfile` lines 6-9, 28, 46 — Bun install + full install + runtime copy of full `node_modules`.
+- `deploy/workspace.Dockerfile` lines 24-27, 46, 139 — same shape.
+- Bun release assets (verified against `oven-sh/bun` release `bun-v1.3.14`): the Alpine-compatible musl variants are `bun-linux-x64-musl-baseline.zip` (x64, AVX2-independent — mirrors the OpenCode baseline choice) and `bun-linux-aarch64-musl.zip` (arm64). Checksums live in a single `SHASUMS256.txt` (plus a `.asc` GPG signature). Assets are `.zip` (needs `unzip`, vs OpenCode's `.tar.gz`).
+- Build stage is `node:24.17.0-alpine` with neither `curl` nor `unzip` — both must be added (then removed in the same layer to keep the build stage lean, or left since it is a discarded stage).
+- The Bun release tag format is `bun-v${BUN_VERSION}` (e.g. `bun-v1.3.14`) — no percent-encoding needed (no `+`), unlike the OpenCode harness tag.
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/migrate-pnpm-to-bun-monorepo-2026-06-24.md` — the migration doc; documents why the build needs a full install (frozen-lockfile validates the whole workspace; the build typechecks tests). The trim must preserve that build-stage behavior and only change the runtime copy.
+- The workspace image's OpenCode install is the reference implementation for fail-closed verified downloads.
+
+### Verified During Planning
+
+- `bun install --production --frozen-lockfile` resolves the prod-only tree cleanly in this monorepo (vitest/tsdown/eslint excluded; `@aws-sdk`, `discord.js`, `hono`, `@octokit` present; `typescript` present as a legitimate transitive prod dep). Prod-only `node_modules` ≈ 237M vs the larger full tree.
+- `--production` triggers the root `postinstall` (`simple-git-hooks`) which fails in a clean stage — so the production-install layer must pass `--ignore-scripts` (the build's full install does not hit this because `simple-git-hooks` is present as a devDep).
+
+## Key Technical Decisions
+
+- **Mirror the OpenCode verified-binary pattern for Bun**, fetching `SHASUMS256.txt` and verifying at build time rather than pinning per-arch SHA256 literals. Rationale: keeps `BUN_VERSION` the single Renovate-tracked source (R4), matches the established in-repo pattern, and the GitHub-release-fetch trust model is the same one already accepted for OpenCode.
+- **arch→asset allowlist**: `amd64 → bun-linux-x64-musl-baseline`, `arm64 → bun-linux-aarch64-musl`, anything else aborts. Baseline on x64 so the image runs on any x86 host regardless of builder CPU features (same reasoning as the OpenCode baseline choice).
+- **Dedicated production-install layer for the trim.** Add a `bun install --production --frozen-lockfile --ignore-scripts` after the build/typecheck completes (so the full install still satisfies the build), producing a prod-only `node_modules` that the runtime stage copies instead of the full tree. `--ignore-scripts` avoids the `simple-git-hooks` postinstall failure.
+- **Install Bun to a fixed path** (e.g. `/usr/local/bin/bun`) and `chmod 755`, mirroring the OpenCode install, so the subsequent `bun install`/`bun run` steps resolve it.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Which Bun asset for Alpine? — `bun-linux-x64-musl-baseline.zip` / `bun-linux-aarch64-musl.zip` (musl, baseline on x64).
+- Pin SHA or fetch SHASUMS? — Fetch `SHASUMS256.txt` at build, verify fail-closed (keeps `BUN_VERSION` the single source).
+- Does `--production` work in the monorepo? — Yes, with `--ignore-scripts` to skip the root postinstall.
+
+### Deferred to Implementation
+
+- Whether to drop `curl`/`unzip` in the same build-stage layer after the Bun download — build stage is discarded, so cleanup is optional; decide based on whether the Bun download layer is shared with other build steps.
+- Whether `typescript` (transitive prod dep) being in the runtime tree is worth further trimming — out of scope; the prod install is the right granularity for this PR.
+
+## Implementation Units
+
+- [ ] **Unit 1: Verified Bun binary install — gateway Dockerfile**
+
+**Goal:** Replace `npm i -g bun@${BUN_VERSION}` in `deploy/gateway.Dockerfile` with a checksum-verified download of the official Bun musl binary.
+
+**Requirements:** R1, R2, R4.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `deploy/gateway.Dockerfile`
+
+**Approach:** In the build stage, add `apk add --no-cache curl unzip` (curl to fetch, unzip for the `.zip` asset). Replace the `npm i -g bun` step with a `set -euo pipefail` block mirroring `deploy/workspace.Dockerfile` lines 90-126: `ARG TARGETARCH`, arch→asset allowlist (`bun-linux-x64-musl-baseline` / `bun-linux-aarch64-musl`), build the `https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}` base URL, `curl --retry 3 --retry-delay 2` the asset `.zip` and `SHASUMS256.txt`, `awk` the expected hash for the asset, compare to `sha256sum` fail-closed (abort on missing entry or mismatch), `unzip` to a temp dir, move the `bun` binary to `/usr/local/bin/bun`, `chmod 755`, clean up, and `bun --version` to confirm. Keep `ARG BUN_VERSION=1.3.14` unchanged (R4).
+
+**Patterns to follow:** `deploy/workspace.Dockerfile` lines 90-126 (the OpenCode verified-download block) — same control flow, adapted for `.zip`/`unzip` and the `bun-v` tag (no percent-encoding needed).
+
+**Test scenarios:**
+- Test expectation: none (Dockerfile) — verified by a successful image build and the `bun --version` step reporting `${BUN_VERSION}`, plus the existing Gateway Image Smoke Test.
+
+**Verification:** `docker build -f deploy/gateway.Dockerfile .` succeeds; the Bun step prints the pinned version; a deliberately wrong asset name or corrupted checksum aborts the build (spot-check during implementation).
+
+- [ ] **Unit 2: Verified Bun binary install — workspace Dockerfile**
+
+**Goal:** Same verified-Bun-install change in `deploy/workspace.Dockerfile`.
+
+**Requirements:** R1, R2, R4.
+
+**Dependencies:** None (parallel to Unit 1, different file).
+
+**Files:**
+- Modify: `deploy/workspace.Dockerfile`
+
+**Approach:** Identical to Unit 1, applied to the workspace build stage (lines 24-27). The runtime stage already has `curl` (line 70) but the **build** stage does not — add `apk add --no-cache curl unzip` there. The workspace image already contains the reference OpenCode verified-download block to mirror, so keep the two blocks visually consistent.
+
+**Patterns to follow:** The OpenCode block already in this same file (lines 90-126).
+
+**Test scenarios:**
+- Test expectation: none (Dockerfile) — verified by a successful image build, the `bun --version` step, and the existing Workspace Image Smoke Test.
+
+**Verification:** `docker build -f deploy/workspace.Dockerfile .` succeeds; Bun version reported; image boots and `/healthz` responds (existing smoke).
+
+- [ ] **Unit 3: Production-only node_modules in runtime stage — both Dockerfiles**
+
+**Goal:** Ship a prod-only `node_modules` (devDependencies excluded) in both runtime images.
+
+**Requirements:** R3.
+
+**Dependencies:** Units 1-2 (Bun must be installed before the prod install runs).
+
+**Files:**
+- Modify: `deploy/gateway.Dockerfile`, `deploy/workspace.Dockerfile`
+
+**Approach:** After the package build step completes in the build stage (so the full install still satisfies the typecheck/bundle), add a dedicated production install into a separate directory that the runtime stage copies. Two viable shapes — pick the cleaner during implementation: (a) run `bun install --production --frozen-lockfile --ignore-scripts` into a throwaway prod dir (e.g. copy the manifests + `bun.lock` into `/prod`, install there) and `COPY --from=build /prod/node_modules`; or (b) run the prod install in place after the build and copy the resulting `node_modules`. `--ignore-scripts` is required to skip the root `simple-git-hooks` postinstall (which fails without the devDep present). The runtime `COPY --from=build .../node_modules` lines (gateway line 46, workspace line 139) then reference the prod tree. Confirm the gateway/workspace bundles still resolve their externalized deps (e.g. `@aws-sdk/signature-v4a`) from the prod tree at runtime.
+
+**Patterns to follow:** The existing multi-stage `COPY --from=build` layout in both files.
+
+**Test scenarios:**
+- Test expectation: none (Dockerfile) — verified by the existing Gateway/Workspace Image Smoke Tests: the images must build, boot, and pass `/healthz` (workspace) / the gateway missing-secret startup error, proving the runtime process resolves all required deps from the prod-only tree.
+
+**Verification:** Both images build; the runtime `node_modules` excludes `vitest`/`tsdown`/`eslint`; both smoke tests pass (proving no runtime dependency was trimmed away). Spot-check final image size is reduced.
+
+- [ ] **Unit 4: Docs / comment reconciliation**
+
+**Goal:** Update the Dockerfile comments to reflect the verified-Bun install and the prod-trim, and note any deploy-doc references.
+
+**Requirements:** R1, R3.
+
+**Dependencies:** Units 1-3.
+
+**Files:**
+- Modify: `deploy/gateway.Dockerfile`, `deploy/workspace.Dockerfile` (comments), `deploy/README.md` (only if it documents the Bun install posture)
+
+**Approach:** Replace the `# Install Bun (matches packageManager: bun@${BUN_VERSION})` comments with a short note that Bun is fetched from the verified GitHub release (mirroring the OpenCode pattern). Add a one-line comment on the prod-install layer explaining why it exists (runtime image excludes devDeps; build stage still needs the full install for the typecheck). Check `deploy/README.md` for any "npm i -g bun" / image-build references and reconcile.
+
+**Test scenarios:**
+- Test expectation: none (comments/docs).
+
+**Verification:** Comments accurately describe the new install path; no stale `npm i -g bun` references remain in deploy docs.
+
+## System-Wide Impact
+
+- **Interaction graph:** Both images' build stages change their Bun-acquisition path and add a prod-install layer; the runtime stages change which `node_modules` they receive. No application code changes.
+- **API surface parity:** Both Dockerfiles must receive the identical Bun-install treatment (don't harden one and leave the other on `npm i -g`).
+- **State lifecycle risks:** A too-aggressive trim could drop a runtime-required dependency, surfacing only at container start. The existing smoke tests (gateway missing-secret startup, workspace `/healthz` + `opencode --version`) are the guard — both must pass.
+- **Unchanged invariants:** `BUN_VERSION` stays the single Renovate-tracked source (R4); the OpenCode verified-install block, tsdown bundling config, port model, and entrypoints are untouched.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Wrong Bun asset name for Alpine (glibc instead of musl) → binary won't run | Use the `-musl` variants explicitly; `bun --version` in the same layer fails the build fast if wrong |
+| `--production` trims a dep the runtime actually needs (externalized bundle import) | Existing smoke tests boot the real process; a missing dep fails the smoke. Verify `@aws-sdk/signature-v4a` resolves |
+| `--production` postinstall failure (`simple-git-hooks`) breaks the build | `--ignore-scripts` on the prod install |
+| SHASUMS256.txt format differs from OpenCode's SHA256SUMS (column order) | Verify the awk field mapping against a real `SHASUMS256.txt` during implementation |
+
+## Documentation / Operational Notes
+
+- These are deploy-infra changes (CI builds both images via the Gateway/Workspace Image Smoke Tests). The smoke tests are the merge gate — no separate manual deploy needed to validate.
+- `BUN_VERSION` Renovate tracking already exists (added in #1004 follow-up); confirm the new GitHub-release URL doesn't need a separate tracker (it interpolates `BUN_VERSION`).
+
+## Sources & References
+
+- Issue: #1003
+- Related: `docs/solutions/workflow-issues/migrate-pnpm-to-bun-monorepo-2026-06-24.md`, #1002 (migration), #1004 (CI hardening)
+- Code: `deploy/gateway.Dockerfile`, `deploy/workspace.Dockerfile` (OpenCode verified-install block lines 90-126), `deploy/README.md`
+- Bun releases: https://github.com/oven-sh/bun/releases (asset names + `SHASUMS256.txt`)


### PR DESCRIPTION
Closes the last Bun-migration deploy follow-up (#1003): replace the unverified Bun install with a checksum-verified GitHub-release binary, and trim the runtime images to production-only dependencies. Both `deploy/gateway.Dockerfile` and `deploy/workspace.Dockerfile`.

## Verified Bun binary install

Both Dockerfiles installed Bun via `npm i -g bun@${BUN_VERSION}` — the unverified npm wrapper. They now fetch the official oven-sh/bun release binary and verify it against the release `SHASUMS256.txt` fail-closed, mirroring the existing OpenCode verified-download pattern (and CI's `oven-sh/setup-bun`):

- TARGETARCH allowlist → `bun-linux-x64-musl-baseline` (x64, AVX2-independent) / `bun-linux-aarch64-musl` (arm64), both musl for Alpine.
- Fetch the asset + `SHASUMS256.txt`, verify SHA256, abort on any download/checksum/mismatch/missing-entry.
- `BUN_VERSION` is validated before URL interpolation, and the download curls carry connect/max timeouts so a slow CDN edge can't hold the build open. A `bunx` symlink is created because the raw archive ships only `bun` (the npm wrapper installed both).
- `BUN_VERSION` remains the single Renovate-tracked source.

## Production-only runtime images

The build stage runs a full `bun install` (devDependencies included — the build typechecks test files that import vitest). The runtime stage previously copied that full tree. It now copies a production-only `node_modules`: the workspace `node_modules` are removed and re-installed with `--production --frozen-lockfile --ignore-scripts` (Bun's `--production` does not prune an already-populated tree; `--ignore-scripts` skips the root postinstall, which invokes the dev-only `simple-git-hooks`).

## Verification

Both images were built locally and confirmed end-to-end: `bun` + `bunx` report the pinned version, the OpenCode binary still bakes (`1.17.9+harness`), the runtime trees exclude vitest/tsdown/eslint while keeping discord.js/@aws-sdk/hono/@octokit, and both processes start and resolve all dependencies. The version validation was confirmed to reject shell-metacharacter inputs fail-closed. The CI Gateway and Workspace Image Smoke Tests are the merge gate.