### PR TITLE
fix(renovate): pin bun constraint to the runner's baked version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,16 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['github>fro-bot/.github'],
+  // The Renovate runner image (bfra-me/renovate-action) bakes Bun 1.3.6 and runs
+  // as a non-root user. Without this, the bun manager derives its lockfile-update
+  // tool version from package.json's `packageManager: bun@<newer>` and runs
+  // `install-tool bun <newer>`, which fails EACCES trying to write the root-owned
+  // containerbase tool dir — failing the `renovate/artifacts` check. Pinning the
+  // constraint to the baked version keeps `bun.lock` updates on the installed Bun.
+  // Bump this when the runner image's baked Bun advances.
+  constraints: {
+    bun: '1.3.6',
+  },
   // dist/ is bundled vendor code (committed for the GitHub Action runtime).
   // ignorePaths excludes it from dependency extraction only — it does NOT
   // suppress the hidden-Unicode safety scan, which runs on these files


### PR DESCRIPTION
Fixes the `renovate/artifacts` "Artifact file update failure" that has been failing on every dependency branch since the pnpm→Bun migration.

## Root cause

The Renovate runner image (`bfra-me/renovate-action`) curl-installs Bun **1.3.6** globally and runs Renovate as a non-root user. Renovate's bun manager derives its lockfile-update tool version from `package.json`'s `"packageManager": "bun@1.3.14"`, and because the action runs with `binarySource=install`, it calls `install-tool bun 1.3.14` to regenerate `bun.lock`. That install fails:

```
INFO: Installing tool bun@1.3.14...
ERROR: EACCES: permission denied, open '/opt/containerbase/bin/bun'
FATAL: Install tool bun failed
WARN: Failed to update lock file (lockfile: bun.lock)
```

— the non-root user can't write the root-owned containerbase tool directory to provision a version newer than the baked one. (The `postUpgradeTasks` build steps succeed, because they use the baked 1.3.6; only the lockfile artifact update fails.) Bumping the action pin does not help — the latest runner image still bakes 1.3.6.

## Fix

Pin `constraints.bun` to the runner's baked `1.3.6` so the lockfile update runs on the already-installed Bun without a privileged write. This is scoped to the Renovate lockfile-update path only — the action, CI, and Docker Bun pins stay at 1.3.14. `renovate-config-validator` passes.

## Validation

The real proof is a live Renovate run: after merge, the next dependency branch's `renovate/artifacts` status should turn green. An upstream issue for `bfra-me/renovate-action` (the proper fix is `binarySource=global` to match its global curl-install of Bun) will follow.