### PR TITLE
fix(renovate): skip bun artifact update instead of pinning the constraint

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,16 +1,6 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['github>fro-bot/.github'],
-  // The Renovate runner image (bfra-me/renovate-action) bakes Bun 1.3.6 and runs
-  // as a non-root user. Without this, the bun manager derives its lockfile-update
-  // tool version from package.json's `packageManager: bun@<newer>` and runs
-  // `install-tool bun <newer>`, which fails EACCES trying to write the root-owned
-  // containerbase tool dir — failing the `renovate/artifacts` check. Pinning the
-  // constraint to the baked version keeps `bun.lock` updates on the installed Bun.
-  // Bump this when the runner image's baked Bun advances.
-  constraints: {
-    bun: '1.3.6',
-  },
   // dist/ is bundled vendor code (committed for the GitHub Action runtime).
   // ignorePaths excludes it from dependency extraction only — it does NOT
   // suppress the hidden-Unicode safety scan, which runs on these files
@@ -142,6 +132,19 @@
     },
   ],
   packageRules: [
+    {
+      // The Renovate runner image (bfra-me/renovate-action) curl-installs Bun
+      // globally as root and runs Renovate as a non-root user, so the bun
+      // manager's lockfile regeneration (`install-tool bun <ver>` →
+      // updateArtifacts) fails EACCES writing the root-owned containerbase tool
+      // dir — failing the `renovate/artifacts` check on every branch, for any
+      // version. Skip Renovate's bun artifact update; the `postUpgradeTasks`
+      // `bun install` below regenerates bun.lock on the runner's installed Bun,
+      // so the lockfile still stays current. Dependency update PRs are
+      // unaffected. Remove if the runner switches to binarySource=global.
+      matchManagers: ['bun'],
+      skipArtifactsUpdate: true,
+    },
     {matchFileNames: ['.github/workflows/**'], semanticCommitType: 'ci'},
     {matchDatasources: ['docker'], semanticCommitType: 'build'},
     {


### PR DESCRIPTION
Supersedes the `constraints.bun` approach (#1009), which the live Renovate run proved ineffective, and fixes the `renovate/artifacts` "Artifact file update failure" properly.

## Why #1009 didn't work

After #1009 merged, the live Renovate run showed `install-tool bun 1.3.6` **still** fails:

```
INFO: Installing tool bun@1.3.6...
ERROR: EACCES: permission denied, open '/opt/containerbase/bin/bun'
FATAL: Install tool bun failed
```

The runner curl-installs Bun globally as root and runs Renovate as a non-root user, so the bun manager's lockfile regeneration (`install-tool bun <ver>` → `updateArtifacts`) fails writing the root-owned containerbase tool dir **for any version** — pinning the constraint to the baked version doesn't help, because the problem is the write permission, not the version.

## The fix

Skip the bun manager's artifact update entirely (`skipArtifactsUpdate: true`), and remove the ineffective `constraints.bun`. The lockfile still stays current because the `postUpgradeTasks` `bun install` already regenerates `bun.lock` on the runner's installed Bun — confirmed in the same live run (`Post-upgrade file saved: bun.lock`). Dependency update PRs are unaffected; only the broken `install-tool` path is bypassed. `renovate-config-validator` passes.

## Validation

The next Renovate dependency run should no longer set `renovate/artifacts` to failure. A separate upstream issue for `bfra-me/renovate-action` (the proper fix is `binarySource=global` to match its global Bun install) will follow, after which this rule can be removed.