### PR TITLE
fix(renovate): suppress stability status checks broken by the runner's Renovate version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,19 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['github>fro-bot/.github'],
+  // Renovate 43.234.0 (pinned by the runner action) regressed productLinks
+  // handling, so the stability-days / merge-confidence status checks build a
+  // scheme-relative target_url that GitHub rejects with a 422 whose `errors`
+  // body is a string. Renovate's error handler assumes `errors` is an array and
+  // crashes (`errors?.find is not a function`), aborting the entire run — no
+  // Dependency Dashboard update, no branches processed. Suppressing these two
+  // status-check names skips the broken POST while leaving the minimumReleaseAge
+  // policy (below) fully in effect. Remove once the runner advances past the fix
+  // (Renovate >= 43.234.1).
+  statusCheckNames: {
+    minimumReleaseAge: null,
+    mergeConfidence: null,
+  },
   // dist/ is bundled vendor code (committed for the GitHub Action runtime).
   // ignorePaths excludes it from dependency extraction only — it does NOT
   // suppress the hidden-Unicode safety scan, which runs on these files


### PR DESCRIPTION
Fixes the real reason Renovate stopped working — the Dependency Dashboard stopped updating and no branches were being processed. This is distinct from the bun artifact-update issue (#1011); both were failing independently.

## Root cause (reproduced against the GitHub API)

The runner's Renovate (43.234.0) has a regression in `productLinks` handling, so the `renovate/stability-days` and merge-confidence status checks build a **scheme-relative** `target_url` (`key-concepts/minimum-release-age/`). GitHub rejects it:

```
POST /repos/.../statuses/<sha> → 422
{"message":"Validation Failed","errors":"Validation failed: Target url must use http(s) scheme","status":"422"}
```

Crucially, GitHub returns `errors` as a **string** for this 422, and Renovate's error handler assumes it's an array (`err.body?.errors?.find(...)`) — so it throws `TypeError: errors?.find is not a function`, which is uncaught and **aborts the entire repository run**. That abort happens during status-check setting at the end of the run, which is why the Dependency Dashboard stopped updating and branches stopped processing.

I reproduced this directly: posting a status with a scheme-relative `target_url` returns exactly that 422, while a normal `target_url` succeeds. Our `minimumReleaseAge: '3 days'` is what activates the broken status path.

## Fix

Set `statusCheckNames: { minimumReleaseAge: null, mergeConfidence: null }` so Renovate skips those two commit-status posts entirely. The `minimumReleaseAge` policy itself stays fully in effect — only the (broken) status surface is suppressed. `renovate-config-validator` passes.

## Upstream

The runner action pins Renovate `43.234.0`, which is inside the known-broken window (regression in 43.232.1, fixed upstream in 43.234.1). Issues will be filed for the action to bump its pin and for Renovate's error handler to tolerate a string-shaped `errors` body. This workaround can be removed once the runner advances.