### PR TITLE
fix(gateway): wire listBindings so GET /operator/repos mounts

### DIFF
--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -1003,6 +1003,38 @@ describe('button interaction handler (approval flow)', () => {
     expect(serverConfig.publicOrigin).toBe('https://operator.example.com')
   })
 
+  it('wires listBindings into the operator server so GET /operator/repos mounts', async () => {
+    // #given — config has operatorWeb present
+    const fakeConfig = makeFakeConfig({
+      announce: undefined,
+      operatorWeb: makeOperatorWebConfig(),
+    })
+    const fakeClient = makeFakeClient()
+    const fakeOperatorHandle = makeFakeServerHandle()
+    const startOperatorServerSpy = vi.fn().mockReturnValue(fakeOperatorHandle)
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: startOperatorServerSpy,
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    // #when
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then — listBindings must be wired, otherwise server.ts gates out the
+    // repos-route mount and GET /operator/repos returns 404 instead of mounting.
+    const [serverDeps] = startOperatorServerSpy.mock.calls[0] as [
+      import('./web/server.js').OperatorServerDeps,
+      import('./web/server.js').OperatorServerConfig,
+    ]
+    expect(serverDeps.listBindings).toBeDefined()
+    expect(typeof serverDeps.listBindings).toBe('function')
+  })
+
   it('operator server does NOT start when operatorWeb is absent', async () => {
     // #given — config has no operatorWeb block
     const fakeConfig = makeFakeConfig({announce: undefined, operatorWeb: undefined})

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -511,6 +511,10 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           // can reach them without creating second copies.
           denylistCache,
           bindingsLookup: bindingsStore,
+          // listBindings is a distinct dep from bindingsLookup: server.ts gates the
+          // GET /operator/repos mount on listBindings, so omitting it leaves that
+          // route unmounted (404). bindingsLookup only covers the run-stream route.
+          listBindings: bindingsStore.listBindings.bind(bindingsStore),
           runObservationManager,
           runIndex,
         },


### PR DESCRIPTION
`GET /operator/repos` was unreachable on a running gateway — it returned `404 {"error":"not-found"}` (the catch-all), not `401`, because the route was never mounted.

## Root cause

`server.ts` gates the repos-route mount on `deps.listBindings !== undefined`, but `program.ts` passed `bindingsLookup: bindingsStore` (used by the run-stream route) and **never** `listBindings`. So the mount condition was false, the route was never registered, and requests fell through to `app.notFound`. The asymmetry compiled silently because `listBindings` is an optional dep.

The result: an authenticated operator session could never list its bound repos, so the dashboard operator page had no live repo source.

## Fix

Thread `bindingsStore.listBindings` into the operator server deps:

```ts
listBindings: bindingsStore.listBindings.bind(bindingsStore),
```

`bindingsStore.listBindings()` already exists and is type-compatible with the dep signature; this is purely the missing wiring.

## Test

Added a test asserting the operator server is started with `listBindings` defined (the dep that gates the repos-route mount). Verified test-first: it failed on `undefined` before the fix, passes after. Full `program.test.ts` suite green (35/35), typecheck and lint clean. Gateway-only.

Closes #1001.