### PR TITLE
fix(gateway): mount the operator launch route (POST /operator/runs)

### DIFF
--- a/docs/plans/2026-06-25-002-fix-operator-launch-route-unmounted-plan.md
+++ b/docs/plans/2026-06-25-002-fix-operator-launch-route-unmounted-plan.md
@@ -1,0 +1,207 @@
+---
+title: "fix: Operator launch route (POST /operator/runs) unmounted in production"
+type: fix
+status: active
+date: 2026-06-25
+---
+
+# Operator launch route (POST /operator/runs) unmounted in production
+
+## Overview
+
+`POST /operator/runs` — the web operator launch route (the surface that lets an
+authenticated operator launch a run from the dashboard) — is gated in
+`buildOperatorApp` (`packages/gateway/src/web/server.ts`) on BOTH
+`deps.getBindingByRepo` and `deps.launchWorkDeps` being present. The gateway boot
+path (`packages/gateway/src/program.ts`) constructs the `OperatorServerDeps` passed
+to `startOperatorServer` but **never sets either field**, so the route is never
+registered and returns 404 in the deployed gateway. This is a live, pre-existing
+production bug in the same class as #1001 (a route silently unmounted because a
+runtime dep is not wired).
+
+## Problem Frame
+
+- `server.ts` registers `POST /operator/runs` only when the browser guard +
+  `sessionStore` + `denylistCache` + `getBindingByRepo` + `launchWorkDeps` are all
+  present (see the `buildOperatorApp` JSDoc and the launch-route mount gate).
+- In `program.ts`, the operator `OperatorServerDeps` object wires `denylistCache`,
+  `bindingsLookup`, `listBindings`, `runObservationManager`, `runIndex`,
+  `approvalRegistry`, session/OAuth/CSRF — but NOT `getBindingByRepo` and NOT
+  `launchWorkDeps`. The `OperatorServerDeps` type declares both as optional, so the
+  omission compiled silently.
+- Result: the launch route is absent from the running app's route table; the
+  dashboard's launch action hits a 404.
+- `getBindingByRepo` is available as `bindingsStore.getBindingByRepo`. The engine
+  deps needed for `launchWorkDeps` (`RunMentionDeps`) are constructed today INSIDE
+  the `messageCreate` handler as `mentionDeps` (per-message). The launch route does
+  not need the per-message Discord context — `launchWork(request, deps.launchWorkDeps)`
+  builds its own request from the HTTP call — so the message-INDEPENDENT engine deps
+  must be hoisted/constructed once at program scope and passed as `launchWorkDeps`.
+
+## Requirements Trace
+
+- R1. `POST /operator/runs` registers in the running gateway when operator web is
+  enabled (the route is present in `buildOperatorApp(...).routes`).
+- R2. `getBindingByRepo` and `launchWorkDeps` are wired into the `OperatorServerDeps`
+  the gateway passes to `startOperatorServer`, using the same engine deps the Discord
+  mention path uses (no behavior divergence between Discord-launched and
+  web-launched runs; the fail-closed approval gate constraint still holds).
+- R3. A regression test proves the route mounts with the production wiring and is
+  absent if `getBindingByRepo` or `launchWorkDeps` is dropped — so this class of
+  unmount is caught going forward.
+
+## Scope Boundaries
+
+- No change to the launch route's behavior, auth, or the approval gate — only its
+  registration wiring.
+- No change to the Discord mention path's behavior.
+- The image-level operator-route smoke (the `feat/operator-surface-unit8-tail`
+  branch) is OUT of scope here — that branch rebases on this fix and removes its
+  manual `getBindingByRepo`/`launchWorkDeps` injection afterward so it routes through
+  the now-correct production wiring.
+
+### Deferred to Separate Tasks
+
+- Image-level operator-route smoke de-vacuuming: `feat/operator-surface-unit8-tail`
+  (rebases on this fix).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/gateway/src/web/server.ts` — `buildOperatorApp` launch-route mount gate
+  (requires `getBindingByRepo` + `launchWorkDeps`); the JSDoc enumerating route gates.
+- `packages/gateway/src/web/operator/launch-route.ts` — `LaunchRouteDeps`:
+  `bindingsLookup.getBindingByRepo`, `launchWorkDeps: RunMentionDeps`,
+  `sessionStore`, `isRepoDenied`, `repoAuthzDeps`, `idempotencyGuard`. The route
+  resolves the binding server-side via `getBindingByRepo` and calls
+  `launchWork(request, deps.launchWorkDeps)`.
+- `packages/gateway/src/program.ts` — the operator `OperatorServerDeps` construction
+  (missing the two fields) and the `messageCreate` handler's `mentionDeps`
+  (`RunMentionDeps`) construction, which is the reference for the engine deps.
+- `packages/gateway/src/discord/mentions.ts` — `handleMention` / `RunMentionDeps`
+  consumer; confirms which deps are engine vs message-specific.
+- `packages/gateway/src/web/server.test.ts` — the existing operator route-set
+  registration test (it DOES wire `getBindingByRepo` + a stub `launchWorkDeps`, which
+  is why the unit suite did not catch the production omission — note this when adding
+  the regression test).
+
+### Institutional Learnings
+
+- This is the #1001 class: a route gated on a runtime dep that the program forgets to
+  wire. The fix pattern is to wire the dep in the production deps construction and add
+  a test that asserts the route's presence/absence keys off that exact dep.
+
+## Key Technical Decisions
+
+- **Hoist the message-independent engine deps.** `RunMentionDeps` is built
+  per-message in `messageCreate` today. Identify the subset that is message-INDEPENDENT
+  (engine/runtime deps: workspace client, run index, run observer, lock/coordination,
+  isShuttingDown, logger, config, etc. — everything except the specific Discord
+  message/channel context) and construct it once at program scope. Use it for the
+  operator `launchWorkDeps`, and (ideally) have the `messageCreate` handler reuse the
+  same hoisted engine deps so the two paths cannot diverge. If full reuse is too
+  invasive, construct the engine deps once and spread message context in the Discord
+  path; do NOT duplicate the engine wiring.
+- **`getBindingByRepo` is a direct passthrough** of `bindingsStore.getBindingByRepo`
+  (bind for `this` if needed, mirroring the `listBindings` pattern already present).
+- **Preserve the fail-closed approval gate.** Web-launched runs must route through the
+  same approval path as Discord (the launch route's `launchWork` already enforces
+  this via `launchWorkDeps`); wiring the same engine deps preserves it.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Where do `getBindingByRepo`/`launchWorkDeps` come from? `getBindingByRepo` =
+  `bindingsStore.getBindingByRepo`; `launchWorkDeps` = the message-independent
+  `RunMentionDeps` engine deps currently built inline in `messageCreate`.
+
+### Deferred to Implementation
+
+- The exact field-by-field split of `RunMentionDeps` into message-independent (hoist)
+  vs message-specific (stays in `messageCreate`). Trace the actual `mentionDeps`
+  object and `RunMentionDeps`/`launchWork` to determine it. The test is the gate:
+  Discord mention behavior must be unchanged and the launch route must mount.
+
+## Implementation Units
+
+- [ ] **Unit 1: Wire getBindingByRepo + launchWorkDeps into the operator server deps**
+
+**Goal:** `POST /operator/runs` registers in the running gateway; the launch route
+receives the same engine deps the Discord mention path uses.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/gateway/src/program.ts`
+- Test: `packages/gateway/src/program.test.ts` (and/or `web/server.test.ts` if the
+  registration assertion fits better there)
+
+**Approach:**
+- Trace the `mentionDeps` (`RunMentionDeps`) construction in the `messageCreate`
+  handler. Extract the message-INDEPENDENT engine deps into a value built once at
+  program scope (before/independent of the operator deps construction). Prefer having
+  the Discord handler reuse this hoisted value (spreading only the per-message context)
+  so Discord and web launch share one engine-deps source and cannot diverge.
+- Set `getBindingByRepo: bindingsStore.getBindingByRepo.bind(bindingsStore)` (or
+  direct reference if no `this` dependency — match the `listBindings` treatment) and
+  `launchWorkDeps: <hoisted engine deps>` on the `OperatorServerDeps` passed to
+  `startOperatorServer`.
+- Verify the launch route's other required deps (`sessionStore`, `denylistCache`,
+  `bindingsLookup`, browser guard pieces) are already present (they are — only the two
+  fields are missing).
+
+**Execution note:** test-first — write a failing test asserting `POST /operator/runs`
+is in the operator app's route set under production-shaped wiring before fixing, and
+a test that dropping `getBindingByRepo` or `launchWorkDeps` removes the route.
+
+**Patterns to follow:** the existing `listBindings` wiring in the operator deps
+(the same "distinct dep gates a distinct route" comment pattern); the `mentionDeps`
+construction for the engine-deps shape.
+
+**Test scenarios:**
+- Happy path: with production-shaped operator deps (all wired), `buildOperatorApp`
+  (or the program's operator deps fed to it) registers `POST /operator/runs`.
+- Regression guard: dropping `getBindingByRepo` → `POST /operator/runs` absent;
+  dropping `launchWorkDeps` → `POST /operator/runs` absent. (This is the #1001-class
+  guard for the launch route specifically.)
+- Discord parity: the `messageCreate`/`handleMention` path still receives an
+  equivalent `RunMentionDeps` (the hoist did not change Discord behavior) — assert the
+  engine deps the mention path uses are unchanged in shape.
+
+**Verification:** `POST /operator/runs` is present in the operator app route set with
+production wiring; absent when either new dep is dropped; the Discord mention path is
+behavior-unchanged; gateway type-check, tests, lint clean; gateway-only (no root dist
+drift).
+
+## System-Wide Impact
+
+- **Interaction graph:** the launch route now actually reaches `launchWork` with the
+  engine deps — the same path Discord mentions use. The approval gate, lock/coordination,
+  run index, and run observer must all be the same instances the Discord path uses so
+  web and Discord launches share run-state/coordination (no second copies).
+- **Unchanged invariants:** the launch route's auth, CSRF, denylist-before-authz,
+  idempotency, and fail-closed approval behavior are unchanged — only its registration
+  wiring is fixed. The Discord mention path behavior is unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Hoisting `RunMentionDeps` engine deps changes Discord mention behavior | Have the Discord handler reuse the hoisted engine deps (spread per-message context only); add/keep a test asserting the mention path's deps are unchanged in shape. |
+| Web and Discord launches use different run-index/coordination instances | Wire the SAME program-scoped instances (runIndex, runObservationManager, lock store, etc.) into both — do not construct second copies. |
+| `getBindingByRepo` `this`-binding | Mirror the existing `listBindings.bind(bindingsStore)` treatment. |
+
+## Sources & References
+
+- Related code: `packages/gateway/src/program.ts`,
+  `packages/gateway/src/web/server.ts`,
+  `packages/gateway/src/web/operator/launch-route.ts`,
+  `packages/gateway/src/discord/mentions.ts`,
+  `packages/gateway/src/web/server.test.ts`.
+- Class precedent: #1001 (operator route unmounted because a dep was not wired).
+- Follow-on: `feat/operator-surface-unit8-tail` (image-level smoke that rebases on
+  this fix and removes its manual dep injection).

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -1331,3 +1331,214 @@ describe('button interaction handler (approval flow)', () => {
     await expect(fakeRegistry.disposeAll('gateway shutdown')).resolves.toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Launch route wiring — POST /operator/runs must mount with production deps
+// ---------------------------------------------------------------------------
+//
+// These tests assert that the production OperatorServerDeps wired by
+// makeGatewayProgram include getBindingByRepo and launchWorkDeps, so that
+// buildOperatorApp registers POST /operator/runs. The existing server.test.ts
+// tests wire those deps manually (which is why they didn't catch this omission).
+// These tests prove the PRODUCTION wiring mounts the route.
+
+describe('launch route wiring — POST /operator/runs', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    // Re-stub what clearAllMocks reset
+    const {createApprovalRegistry} = await import('./approvals/registry.js')
+    vi.mocked(createApprovalRegistry).mockReturnValue({
+      register: vi.fn(),
+      has: vi.fn().mockReturnValue(false),
+      pending: vi.fn().mockReturnValue([]),
+      hasPendingForScope: vi.fn().mockReturnValue(false),
+      describePendingForScope: vi.fn().mockReturnValue([]),
+      handleDecision: vi.fn().mockResolvedValue('ok'),
+      applySettlement: vi.fn().mockResolvedValue(undefined),
+      attachMessage: vi.fn(),
+      markMessagePostFailed: vi.fn(),
+      confirmReply: vi.fn(),
+      disposeRun: vi.fn(),
+      disposeAll: vi.fn().mockResolvedValue(undefined),
+    })
+  })
+
+  /**
+   * Helper: run the program with operatorWeb configured, capture the
+   * OperatorServerDeps passed to startOperatorServer, and return them.
+   */
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  async function captureOperatorServerDeps(): Promise<import('./web/server.js').OperatorServerDeps> {
+    const fakeConfig = makeFakeConfig({
+      announce: undefined,
+      operatorWeb: makeOperatorWebConfig(),
+    })
+    const fakeClient = makeFakeClient()
+    const fakeOperatorHandle = makeFakeServerHandle()
+    const startOperatorServerSpy = vi.fn().mockReturnValue(fakeOperatorHandle)
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: startOperatorServerSpy,
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    expect(startOperatorServerSpy).toHaveBeenCalledOnce()
+    const [serverDeps] = startOperatorServerSpy.mock.calls[0] as [
+      import('./web/server.js').OperatorServerDeps,
+      import('./web/server.js').OperatorServerConfig,
+    ]
+    return serverDeps
+  }
+
+  it('wires getBindingByRepo into the operator server deps', async () => {
+    // #given / #when
+    const serverDeps = await captureOperatorServerDeps()
+
+    // #then — getBindingByRepo must be wired so the launch route can mount
+    expect(serverDeps.getBindingByRepo).toBeDefined()
+    expect(typeof serverDeps.getBindingByRepo).toBe('function')
+  })
+
+  it('wires launchWorkDeps into the operator server deps', async () => {
+    // #given / #when
+    const serverDeps = await captureOperatorServerDeps()
+
+    // #then — launchWorkDeps must be wired so the launch route can mount
+    expect(serverDeps.launchWorkDeps).toBeDefined()
+    expect(typeof serverDeps.launchWorkDeps).toBe('object')
+  })
+
+  it('registers POST /operator/runs when production deps are fed to buildOperatorApp', async () => {
+    // #given — capture the production-shaped operator deps from the program
+    const serverDeps = await captureOperatorServerDeps()
+
+    // #when — feed those deps to buildOperatorApp with matching githubOAuth config
+    // (production deps include githubOAuth, so config must also include it)
+    const {buildOperatorApp} = await import('./web/server.js')
+    const app = buildOperatorApp(serverDeps, {
+      bindHost: '127.0.0.1',
+      bindPort: 0,
+      publicOrigin: 'https://operator.example.com',
+      githubOAuth: {
+        clientId: 'test-oauth-client-id',
+        clientSecret: 'test-oauth-client-secret',
+        publicOrigin: 'https://operator.example.com',
+        callbackPath: '/operator/auth/github/callback',
+        allowedReturnPaths: ['/operator'],
+        stateTtlMs: 600_000,
+        maxOutstandingAttemptsPerKey: 5,
+      },
+    })
+
+    // #when — extract unique logical routes
+    interface RouteEntry {
+      readonly method: string
+      readonly path: string
+    }
+    const seen = new Set<string>()
+    const routes = app.routes
+      .map((route: RouteEntry) => ({method: route.method, path: route.path}))
+      .filter((route: RouteEntry) => {
+        if (route.method === 'ALL' && route.path === '/*') return false
+        const key = `${route.method}:${route.path}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+
+    // #then — POST /operator/runs is present (the launch route is mounted)
+    expect(routes).toContainEqual({method: 'POST', path: '/operator/runs'})
+  })
+
+  it('omits POST /operator/runs when getBindingByRepo is dropped from production deps', async () => {
+    // #given — production deps with getBindingByRepo removed
+    // Drop githubOAuth from deps too so buildOperatorApp doesn't throw on partial OAuth config
+    const serverDeps = await captureOperatorServerDeps()
+    const depsWithoutGetBindingByRepo = {...serverDeps, getBindingByRepo: undefined, githubOAuth: undefined}
+
+    // #when
+    const {buildOperatorApp} = await import('./web/server.js')
+    const app = buildOperatorApp(depsWithoutGetBindingByRepo, {
+      bindHost: '127.0.0.1',
+      bindPort: 0,
+      publicOrigin: 'https://operator.example.com',
+    })
+
+    interface RouteEntry {
+      readonly method: string
+      readonly path: string
+    }
+    const seen = new Set<string>()
+    const routes = app.routes
+      .map((route: RouteEntry) => ({method: route.method, path: route.path}))
+      .filter((route: RouteEntry) => {
+        if (route.method === 'ALL' && route.path === '/*') return false
+        const key = `${route.method}:${route.path}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+
+    // #then — launch route is absent when getBindingByRepo is missing
+    expect(routes).not.toContainEqual({method: 'POST', path: '/operator/runs'})
+  })
+
+  it('omits POST /operator/runs when launchWorkDeps is dropped from production deps', async () => {
+    // #given — production deps with launchWorkDeps removed
+    // Drop githubOAuth from deps too so buildOperatorApp doesn't throw on partial OAuth config
+    const serverDeps = await captureOperatorServerDeps()
+    const depsWithoutLaunchWorkDeps = {...serverDeps, launchWorkDeps: undefined, githubOAuth: undefined}
+
+    // #when
+    const {buildOperatorApp} = await import('./web/server.js')
+    const app = buildOperatorApp(depsWithoutLaunchWorkDeps, {
+      bindHost: '127.0.0.1',
+      bindPort: 0,
+      publicOrigin: 'https://operator.example.com',
+    })
+
+    interface RouteEntry {
+      readonly method: string
+      readonly path: string
+    }
+    const seen = new Set<string>()
+    const routes = app.routes
+      .map((route: RouteEntry) => ({method: route.method, path: route.path}))
+      .filter((route: RouteEntry) => {
+        if (route.method === 'ALL' && route.path === '/*') return false
+        const key = `${route.method}:${route.path}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+
+    // #then — launch route is absent when launchWorkDeps is missing
+    expect(routes).not.toContainEqual({method: 'POST', path: '/operator/runs'})
+  })
+
+  it('discord mention path still receives RunMentionDeps with the same engine deps shape', async () => {
+    // #given — run the program and capture the deps passed to handleMention
+    const capturedDeps = await runAndCaptureMentionDeps('approval-required')
+
+    // #then — the mention path still receives a full RunMentionDeps
+    // (the hoist did not change Discord behavior)
+    expect(capturedDeps.run).toBeDefined()
+    expect(typeof capturedDeps.run.coordinationConfig).toBe('object')
+    expect(typeof capturedDeps.run.concurrency).toBe('object')
+    expect(typeof capturedDeps.run.queue).toBe('object')
+    expect(typeof capturedDeps.run.logger).toBe('object')
+    expect(typeof capturedDeps.run.approvalRegistry).toBe('object')
+    expect(capturedDeps.run.approvalMode).toBe('approval-required')
+    expect(typeof capturedDeps.run.ensureClone).toBe('function')
+    expect(typeof capturedDeps.run.readyz).toBe('function')
+    expect(typeof capturedDeps.run.isShuttingDown).toBe('function')
+    expect(capturedDeps.run.runIndex).toBeDefined()
+    expect(capturedDeps.run.runObserver).toBeDefined()
+  })
+})

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -1414,6 +1414,24 @@ describe('launch route wiring — POST /operator/runs', () => {
     expect(typeof serverDeps.launchWorkDeps).toBe('object')
   })
 
+  /**
+   * Extract unique logical routes from a Hono app, excluding the catch-all
+   * ALL /* middleware entry and deduplicating by method+path.
+   */
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  function extractRoutes(app: {routes: {method: string; path: string}[]}): {method: string; path: string}[] {
+    const seen = new Set<string>()
+    return app.routes
+      .map(route => ({method: route.method, path: route.path}))
+      .filter(route => {
+        if (route.method === 'ALL' && route.path === '/*') return false
+        const key = `${route.method}:${route.path}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+  }
+
   it('registers POST /operator/runs when production deps are fed to buildOperatorApp', async () => {
     // #given — capture the production-shaped operator deps from the program
     const serverDeps = await captureOperatorServerDeps()
@@ -1436,24 +1454,8 @@ describe('launch route wiring — POST /operator/runs', () => {
       },
     })
 
-    // #when — extract unique logical routes
-    interface RouteEntry {
-      readonly method: string
-      readonly path: string
-    }
-    const seen = new Set<string>()
-    const routes = app.routes
-      .map((route: RouteEntry) => ({method: route.method, path: route.path}))
-      .filter((route: RouteEntry) => {
-        if (route.method === 'ALL' && route.path === '/*') return false
-        const key = `${route.method}:${route.path}`
-        if (seen.has(key)) return false
-        seen.add(key)
-        return true
-      })
-
     // #then — POST /operator/runs is present (the launch route is mounted)
-    expect(routes).toContainEqual({method: 'POST', path: '/operator/runs'})
+    expect(extractRoutes(app)).toContainEqual({method: 'POST', path: '/operator/runs'})
   })
 
   it('omits POST /operator/runs when getBindingByRepo is dropped from production deps', async () => {
@@ -1470,23 +1472,8 @@ describe('launch route wiring — POST /operator/runs', () => {
       publicOrigin: 'https://operator.example.com',
     })
 
-    interface RouteEntry {
-      readonly method: string
-      readonly path: string
-    }
-    const seen = new Set<string>()
-    const routes = app.routes
-      .map((route: RouteEntry) => ({method: route.method, path: route.path}))
-      .filter((route: RouteEntry) => {
-        if (route.method === 'ALL' && route.path === '/*') return false
-        const key = `${route.method}:${route.path}`
-        if (seen.has(key)) return false
-        seen.add(key)
-        return true
-      })
-
     // #then — launch route is absent when getBindingByRepo is missing
-    expect(routes).not.toContainEqual({method: 'POST', path: '/operator/runs'})
+    expect(extractRoutes(app)).not.toContainEqual({method: 'POST', path: '/operator/runs'})
   })
 
   it('omits POST /operator/runs when launchWorkDeps is dropped from production deps', async () => {
@@ -1503,23 +1490,8 @@ describe('launch route wiring — POST /operator/runs', () => {
       publicOrigin: 'https://operator.example.com',
     })
 
-    interface RouteEntry {
-      readonly method: string
-      readonly path: string
-    }
-    const seen = new Set<string>()
-    const routes = app.routes
-      .map((route: RouteEntry) => ({method: route.method, path: route.path}))
-      .filter((route: RouteEntry) => {
-        if (route.method === 'ALL' && route.path === '/*') return false
-        const key = `${route.method}:${route.path}`
-        if (seen.has(key)) return false
-        seen.add(key)
-        return true
-      })
-
     // #then — launch route is absent when launchWorkDeps is missing
-    expect(routes).not.toContainEqual({method: 'POST', path: '/operator/runs'})
+    expect(extractRoutes(app)).not.toContainEqual({method: 'POST', path: '/operator/runs'})
   })
 
   it('discord mention path still receives RunMentionDeps with the same engine deps shape', async () => {
@@ -1540,5 +1512,71 @@ describe('launch route wiring — POST /operator/runs', () => {
     expect(typeof capturedDeps.run.isShuttingDown).toBe('function')
     expect(capturedDeps.run.runIndex).toBeDefined()
     expect(capturedDeps.run.runObserver).toBeDefined()
+
+    // #and — botUserId is the concrete value from client.user.id (not the lazy getter's fallback)
+    expect(capturedDeps.run.botUserId).toBe('bot-user-id')
+  })
+
+  it('launchWorkDeps and Discord mention run deps share the same engine-deps instances (reference identity)', async () => {
+    // #given — run the program once, capturing both operator server deps and mention deps.
+    // Both paths must share the SAME runEngineDeps object so run-state/coordination
+    // instances are never accidentally duplicated by a future spread/copy refactor.
+    const {handleMention} = await import('./discord/mentions.js')
+    const handleMentionMock = vi.mocked(handleMention)
+
+    const botUserId = 'bot-user-id'
+    const fakeClient = {
+      ...makeFakeClient(),
+      user: {id: botUserId},
+    }
+    const fakeConfig = makeFakeConfig({
+      announce: undefined,
+      operatorWeb: makeOperatorWebConfig(),
+    })
+    const fakeOperatorHandle = makeFakeServerHandle()
+    const startOperatorServerSpy = vi.fn().mockReturnValue(fakeOperatorHandle)
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: startOperatorServerSpy,
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // Capture operator server deps
+    expect(startOperatorServerSpy).toHaveBeenCalledOnce()
+    const [operatorDeps] = startOperatorServerSpy.mock.calls[0] as [
+      import('./web/server.js').OperatorServerDeps,
+      import('./web/server.js').OperatorServerConfig,
+    ]
+
+    // Fire the messageCreate handler to capture mention deps
+    const onCalls = (fakeClient.on as ReturnType<typeof vi.fn>).mock.calls as [string, (msg: unknown) => void][]
+    const messageCreateHandler = onCalls.find(([event]) => event === 'messageCreate')?.[1]
+    if (messageCreateHandler === undefined) throw new Error('messageCreate handler not registered')
+
+    messageCreateHandler(makeFakeMentionMessage(botUserId))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(handleMentionMock).toHaveBeenCalledOnce()
+    const mentionDeps = handleMentionMock.mock.calls[0]?.[2] as import('./discord/mentions.js').MentionDeps
+    if (mentionDeps === undefined) throw new Error('handleMention was not called with deps')
+
+    // #then — launchWorkDeps IS the same object as the engine deps spread into mention run
+    // (reference identity on each shared instance proves no accidental copy was made)
+    const launchDeps = operatorDeps.launchWorkDeps
+    if (launchDeps === undefined) throw new Error('launchWorkDeps not wired')
+    const mentionRunDeps = mentionDeps.run
+
+    // These instances must be the exact same objects — not copies or re-creations.
+    expect(launchDeps.concurrency).toBe(mentionRunDeps.concurrency)
+    expect(launchDeps.queue).toBe(mentionRunDeps.queue)
+    expect(launchDeps.approvalRegistry).toBe(mentionRunDeps.approvalRegistry)
+    expect(launchDeps.runIndex).toBe(mentionRunDeps.runIndex)
+    expect(launchDeps.runObserver).toBe(mentionRunDeps.runObserver)
   })
 })

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -359,10 +359,11 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
     // instances and cannot diverge.
     //
     // botUserId is read lazily via a getter: client.user is set after login, but
-    // the operator server starts before login. For web-launched runs the
-    // promptBuilder override means botUserId is never consulted; for Discord
-    // mentions the messageCreate handler spreads these deps and overrides
-    // botUserId with the concrete client.user.id value.
+    // the operator server starts before login. On the web path botUserId is
+    // destructured by executeWorkOnHeldSlot but never consumed — the web path
+    // always supplies a promptBuilder that does not use it. On the Discord path
+    // the messageCreate handler spreads these deps and overrides botUserId with
+    // the concrete client.user.id value.
     // ---------------------------------------------------------------------------
     const runEngineDeps: import('./execute/run.js').RunMentionDeps = {
       coordinationConfig: makeCoordinationConfig(s3Adapter, config),

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -353,6 +353,65 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
       })
     })
 
+    // ---------------------------------------------------------------------------
+    // Engine deps for launchWork — shared between Discord mentions and the web
+    // operator launch route so both paths use the same run-state/coordination
+    // instances and cannot diverge.
+    //
+    // botUserId is read lazily via a getter: client.user is set after login, but
+    // the operator server starts before login. For web-launched runs the
+    // promptBuilder override means botUserId is never consulted; for Discord
+    // mentions the messageCreate handler spreads these deps and overrides
+    // botUserId with the concrete client.user.id value.
+    // ---------------------------------------------------------------------------
+    const runEngineDeps: import('./execute/run.js').RunMentionDeps = {
+      coordinationConfig: makeCoordinationConfig(s3Adapter, config),
+      identity: config.identity,
+      concurrency: concurrencyRegistry,
+      queue: channelQueue,
+      attachUrl: config.workspaceOpencodeUrl,
+      attachToken: config.workspaceOpencodeToken,
+      runTimeoutMs: config.runTimeoutMs,
+      // Lazy getter: client.user is non-null after login. Web-launched runs
+      // always supply a promptBuilder so botUserId is never read on that path.
+      get botUserId() {
+        return client.user?.id ?? ''
+      },
+      persona: config.persona,
+      logger,
+      approvalRegistry,
+      approvalMode: config.approvalMode,
+      statusMode: config.statusMode,
+      // Workspace readiness gate — uses the same :9100 base as the clone endpoint.
+      // Placed inside run so it is called after the concurrency gate, not before.
+      readyz: async () => workspaceClient.readyz(),
+      // Ensure workspace checkout exists. Called after the concurrency gate so
+      // same-channel mention storms do not each mint GitHub App tokens before
+      // the busy/cap rejection fires. Adapts GatewayLogger (context-first) to
+      // the EnsureCloneDeps logger (message-first) inline.
+      ensureClone: async (owner: string, repo: string) =>
+        ensureWorkspaceClone({
+          owner,
+          repo,
+          appClient,
+          workspaceClient,
+          logger: {
+            info: (msg, meta) => logger.info(meta ?? {}, msg),
+            warn: (msg, meta) => logger.warn(meta ?? {}, msg),
+            error: (msg, meta) => logger.error(meta ?? {}, msg),
+          },
+        }),
+      // Shutdown gate: suppress handoff to next queued task once SIGTERM fires.
+      // The in-memory queue is lossy by design; dropping pending tasks on graceful
+      // shutdown matches that contract and is consistent with the messageCreate
+      // guard above that refuses new mentions once isShuttingDown() returns true.
+      isShuttingDown,
+      // Server-owned run index: populated at run creation for privileged route authz.
+      runIndex,
+      // Feeds the run-observation manager at each lifecycle transition.
+      runObserver: runObservationManager,
+    }
+
     // Track in-flight mention run promises so SIGTERM can await them before tearing down.
     const inFlightRuns = new Set<Promise<void>>()
 
@@ -363,51 +422,14 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
       // Stop accepting new mentions once shutdown has been requested.
       if (isShuttingDown()) return
 
+      // Reuse the program-scoped engine deps; override botUserId with the
+      // concrete value now that client.user is guaranteed non-null.
       const mentionDeps = {
         bindingsStore,
         triggerRoleId: config.triggerRoleId,
         run: {
-          coordinationConfig: makeCoordinationConfig(s3Adapter, config),
-          identity: config.identity,
-          concurrency: concurrencyRegistry,
-          queue: channelQueue,
-          attachUrl: config.workspaceOpencodeUrl,
-          attachToken: config.workspaceOpencodeToken,
-          runTimeoutMs: config.runTimeoutMs,
+          ...runEngineDeps,
           botUserId: client.user.id,
-          persona: config.persona,
-          logger,
-          approvalRegistry,
-          approvalMode: config.approvalMode,
-          statusMode: config.statusMode,
-          // Workspace readiness gate — uses the same :9100 base as the clone endpoint.
-          // Placed inside run so it is called after the concurrency gate, not before.
-          readyz: async () => workspaceClient.readyz(),
-          // Ensure workspace checkout exists. Called after the concurrency gate so
-          // same-channel mention storms do not each mint GitHub App tokens before
-          // the busy/cap rejection fires. Adapts GatewayLogger (context-first) to
-          // the EnsureCloneDeps logger (message-first) inline.
-          ensureClone: async (owner: string, repo: string) =>
-            ensureWorkspaceClone({
-              owner,
-              repo,
-              appClient,
-              workspaceClient,
-              logger: {
-                info: (msg, meta) => logger.info(meta ?? {}, msg),
-                warn: (msg, meta) => logger.warn(meta ?? {}, msg),
-                error: (msg, meta) => logger.error(meta ?? {}, msg),
-              },
-            }),
-          // Shutdown gate: suppress handoff to next queued task once SIGTERM fires.
-          // The in-memory queue is lossy by design; dropping pending tasks on graceful
-          // shutdown matches that contract and is consistent with the messageCreate
-          // guard above that refuses new mentions once isShuttingDown() returns true.
-          isShuttingDown,
-          // Server-owned run index: populated at run creation for privileged route authz.
-          runIndex,
-          // Feeds the run-observation manager at each lifecycle transition.
-          runObserver: runObservationManager,
         },
         logger,
       }
@@ -515,6 +537,14 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           // GET /operator/repos mount on listBindings, so omitting it leaves that
           // route unmounted (404). bindingsLookup only covers the run-stream route.
           listBindings: bindingsStore.listBindings.bind(bindingsStore),
+          // getBindingByRepo gates the POST /operator/runs launch route mount.
+          // Mirrors the listBindings pattern: bind for `this` safety.
+          getBindingByRepo: bindingsStore.getBindingByRepo.bind(bindingsStore),
+          // launchWorkDeps gates the POST /operator/runs launch route mount.
+          // Uses the same program-scoped engine deps as the Discord mention path
+          // so web and Discord launches share run-state/coordination instances
+          // and the fail-closed approval gate is enforced on both paths.
+          launchWorkDeps: runEngineDeps,
           runObservationManager,
           runIndex,
         },


### PR DESCRIPTION
`POST /operator/runs` — the web operator launch route — was never registered in the deployed gateway and returned 404. `buildOperatorApp` gates that route on both `getBindingByRepo` and `launchWorkDeps` being present in the operator server deps, but the gateway boot path wired neither (the `OperatorServerDeps` type declares both optional, so the omission compiled silently). The route that lets an authenticated operator launch a run from the dashboard could not mount.

## The fix

The engine dependencies the launch route needs (`launchWorkDeps: RunMentionDeps`) are the same ones the Discord mention path builds. Those deps are entirely engine-level — the Discord-specific context lives in the outer message wrapper, not in `RunMentionDeps` — so they were hoisted once to program scope as a shared `runEngineDeps`:

- The Discord `messageCreate` path and the operator `launchWorkDeps` now reference the **same** `runEngineDeps` instance, so web-launched and Discord-launched runs share the same run index, run-observation manager, approval registry, concurrency, and queue. Web launches route through the **same fail-closed approval gate** as Discord — they cannot bypass the permission model.
- `botUserId` (derived from the Discord client, which logs in after the operator server starts) is read lazily; the web path never consumes it because it always supplies its own prompt builder.
- `getBindingByRepo` is passed through from the bindings store.

## Why it wasn't caught

The operator route-registration unit test wired `getBindingByRepo` and a stub `launchWorkDeps` by hand, so it asserted the route mounts against hand-wired deps rather than the production wiring. The new tests close that gap: one captures the **real** operator deps the program constructs, feeds them to `buildOperatorApp`, and asserts `POST /operator/runs` mounts; regression tests drop each dep and assert the route is absent; and a reference-identity test asserts the launch deps share the exact same engine instances as the Discord mention path, so a future copy-instead-of-share change fails.

Gateway-only, no behavior change beyond mounting the route and sharing the engine deps. Gateway suite green (2670 tests), type-check and lint clean.