### PR TITLE
feat(gateway): image-level operator route-registration smoke + mount approval routes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -364,16 +364,22 @@ jobs:
           # app via buildOperatorServerInputs → buildOperatorApp with realistic-but-offline
           # stubs, reads app.routes, and asserts the expected route inventory is present.
           # No port is bound, no network is required, no credentials are needed.
-          output="$(docker run --rm fro-bot-gateway:smoke node dist/main.mjs operator-route-smoke 2>&1)"
+          set +e
+          output="$(timeout 60s docker run --rm fro-bot-gateway:smoke node dist/main.mjs operator-route-smoke 2>&1)"
           status=$?
+          set -e
           echo "--- docker run output ---"
           echo "$output"
           echo "--- exit status: $status ---"
+          if [ "$status" -eq 124 ]; then
+            echo "REGRESSION: operator-route-smoke timed out"
+            exit 1
+          fi
           if [ "$status" -ne 0 ]; then
             echo "REGRESSION: operator-route-smoke exited $status — one or more operator routes are not registered in the shipped image"
             exit 1
           fi
-          if ! echo "$output" | grep -q "operator-route-smoke: all"; then
+          if ! echo "$output" | grep -qE '^operator-route-smoke: all [0-9]+ operator routes registered$'; then
             echo "REGRESSION: operator-route-smoke did not print the expected success marker"
             exit 1
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -352,6 +352,32 @@ jobs:
             exit 1
           fi
           echo "OK: gateway booted PAST config load (announce disabled, #738 fixed) and reached the runtime self-test boundary"
+      - name: Smoke-test gateway image — operator route registration (offline diagnostic)
+        timeout-minutes: 8
+        run: |
+          # Proves the operator routes register in the shipped image using the same
+          # deps-construction path as production. Catches the class of bug where a
+          # route is silently unmounted because a required dep was not wired
+          # (e.g. listBindings omitted → GET /operator/repos absent → 404 in prod).
+          #
+          # The diagnostic (operator-route-smoke subcommand) builds the operator Hono
+          # app via buildOperatorServerInputs → buildOperatorApp with realistic-but-offline
+          # stubs, reads app.routes, and asserts the expected route inventory is present.
+          # No port is bound, no network is required, no credentials are needed.
+          output="$(docker run --rm fro-bot-gateway:smoke node dist/main.mjs operator-route-smoke 2>&1)"
+          status=$?
+          echo "--- docker run output ---"
+          echo "$output"
+          echo "--- exit status: $status ---"
+          if [ "$status" -ne 0 ]; then
+            echo "REGRESSION: operator-route-smoke exited $status — one or more operator routes are not registered in the shipped image"
+            exit 1
+          fi
+          if ! echo "$output" | grep -q "operator-route-smoke: all"; then
+            echo "REGRESSION: operator-route-smoke did not print the expected success marker"
+            exit 1
+          fi
+          echo "OK: all operator routes registered in the shipped image"
 
   workspace-smoke:
     if: ${{ github.event_name == 'push' || needs.setup.outputs.should-build == 'true' }}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -324,15 +324,45 @@ Sessions have an 8-hour absolute lifetime and a 30-minute idle timeout. The gate
 
 ### Operator runbook
 
+The operator web surface is a browser-facing authenticated API that lets human operators launch runs, list bound repos, stream run status and output, and submit tool-approval decisions — all behind GitHub OAuth and a numeric-user-ID allowlist. It is separate from the Discord surface and the GitHub App used for repository access.
+
+**Enabling the surface** requires all three bind/origin vars to be set together (partial config fails closed):
+
+| Variable | Purpose |
+| --- | --- |
+| `GATEWAY_OPERATOR_BIND_HOST` | Gateway-net IP the operator listener binds to (literal IP, not hostname; not `0.0.0.0`, loopback, or sandbox-net) |
+| `GATEWAY_OPERATOR_BIND_PORT` | Port for the operator listener |
+| `GATEWAY_OPERATOR_PUBLIC_ORIGIN` | Public `https://` origin exposed by the infra reverse proxy (e.g. `https://operator.example.com`) |
+| `GATEWAY_OPERATOR_GITHUB_CLIENT_ID` / `_FILE` | GitHub OAuth App client ID |
+| `GATEWAY_OPERATOR_GITHUB_CLIENT_SECRET` / `_FILE` | GitHub OAuth App client secret |
+| `GATEWAY_OPERATOR_CSRF_SECRET` / `_FILE` | CSRF signing key — 256-bit CSPRNG entropy, base64url-encoded, no padding |
+| `GATEWAY_OPERATOR_ALLOWLIST` / `GATEWAY_OPERATOR_ALLOWLIST_FILE` | Newline-separated numeric GitHub user IDs permitted to log in |
+| `GATEWAY_OPERATOR_OAUTH_ALLOWED_RETURN_PATHS` | Optional comma-separated list of allowed post-auth redirect paths (default: `/operator`) |
+
+For secret provisioning details see [Required secrets](#required-secrets) above.
+
 Follow these steps in order to deploy and operate the web surface:
 
 1. **Deploy the gateway image** — see [One-Time Setup](#one-time-setup) and [Starting the Stack](#starting-the-stack) for the Docker Compose setup and image build.
-2. **Set `GATEWAY_OPERATOR_PUBLIC_ORIGIN` and OAuth env** — see [Operator OAuth (Web Surface)](#operator-oauth-web-surface) for the required environment variables and secrets.
-3. **Register the GitHub OAuth app callback URL** — the callback path is `/operator/auth/github/callback` on your public origin; see the OAuth App setup instructions in [Operator OAuth (Web Surface)](#operator-oauth-web-surface).
-4. **Configure the operator allowlist** — add one numeric GitHub user ID per line to `deploy/secrets/gateway-operator-allowlist`; see the allowlist note in [Operator OAuth (Web Surface)](#operator-oauth-web-surface).
-5. **Verify** — confirm `GET /operator/health` returns `{ok:true}`, complete an OAuth login via `/operator/auth/github/start`, then exercise the [Operator API surface](#operator-api-surface) above.
+2. **Set the enabling env** — configure the `GATEWAY_OPERATOR_*` vars above (bind host/port/origin, OAuth credentials, CSRF secret, allowlist). See [Required secrets](#required-secrets) for the secret file commands.
+3. **Register the GitHub OAuth app callback URL** — the callback path is `/operator/auth/github/callback` on your public origin; see [OAuth callback URL](#oauth-callback-url) above.
+4. **Configure the operator allowlist** — add one numeric GitHub user ID per line to `deploy/secrets/gateway-operator-allowlist`; see the allowlist note in [Required secrets](#required-secrets).
+5. **Backfill deny keys for pre-gate bindings** — repos bound before deny-key capture was added will not appear in `GET /operator/repos` until their deny keys are populated. Run the backfill admin command (documented in [`packages/gateway/AGENTS.md`](../packages/gateway/AGENTS.md#redaction-gate)):
+   ```sh
+   # Preview (writes nothing):
+   node dist/main.mjs backfill-deny-keys
+   # Apply:
+   node dist/main.mjs backfill-deny-keys --apply
+   ```
+6. **Verify** — confirm `GET /operator/health` returns `{ok:true}`, complete an OAuth login via `/operator/auth/github/start`, then exercise the [Operator API surface](#operator-api-surface) above (added in #996).
 
-The route table and env table are the single source of truth — this runbook links to them rather than restating them.
+**Design rationale and patterns** — the following solution docs cover the operator surface architecture:
+
+- [`gateway-control-surface-spine-2026-06-15.md`](../docs/solutions/best-practices/gateway-control-surface-spine-2026-06-15.md) — overall operator surface spine: route registration, browser guard, session/CSRF architecture.
+- [`web-operator-launch-surface-2026-06-20.md`](../docs/solutions/best-practices/web-operator-launch-surface-2026-06-20.md) — launch endpoint design: fire-and-return, idempotency, per-operator rate limiting.
+- [`authenticated-sse-run-observation-2026-06-20.md`](../docs/solutions/best-practices/authenticated-sse-run-observation-2026-06-20.md) — SSE run-observation stream: auth, repo-scoped read authz, continuous delivery.
+- [`sse-output-streaming-terminal-drain-2026-06-21.md`](../docs/solutions/best-practices/sse-output-streaming-terminal-drain-2026-06-21.md) — SSE output streaming and terminal drain patterns.
+- [`signed-webhook-ingress-hardening-2026-05-29.md`](../docs/solutions/best-practices/signed-webhook-ingress-hardening-2026-05-29.md) — HMAC-signed ingress hardening (the announce surface that shares the gateway's HTTP layer).
 
 ## Workspace Port Model
 

--- a/docs/plans/2026-06-25-001-feat-operator-surface-unit8-tail-plan.md
+++ b/docs/plans/2026-06-25-001-feat-operator-surface-unit8-tail-plan.md
@@ -1,0 +1,254 @@
+---
+title: "feat: Operator web surface Unit 8 tail — image-level route smoke + deploy runbook"
+type: feat
+status: active
+date: 2026-06-25
+---
+
+# Operator web surface Unit 8 tail — image-level route smoke + deploy runbook
+
+## Overview
+
+The gateway operator web surface (auth, launch, repo query, run stream, approvals)
+is functionally complete and live. The reconciliation that cut Unit 7
+([agent#994](https://github.com/fro-bot/agent/pull/994)) narrowed the remaining
+agent-side gate to the **Unit 8 operable tail**: R1 (deploy README route table)
+already landed via [agent#996](https://github.com/fro-bot/agent/pull/996). This plan
+closes the two remaining rungs:
+
+- **R3** — a CI smoke that proves the operator routes actually register and respond
+  in the **built Docker image**, not just at the unit-test level. The current
+  `Gateway Image Smoke Test` only asserts config-load / no-module-crash; nothing
+  proves the operator HTTP surface mounts in the shipped image.
+- **R2** — a concise, consolidated **Operator Web Surface** runbook section in
+  `deploy/README.md` (the operator-facing home), cross-linking the existing route
+  table and the per-pattern solution docs. Chosen over a new
+  `docs/solutions/` doc because six operator best-practice docs already exist and a
+  seventh consolidated doc would overlap them; the deploy README is where an
+  operator actually looks.
+
+## Problem Frame
+
+The operator producer is now genuinely live (route mounted via #1020, deny-key
+backfill runnable via #1023), but two assurance gaps remain before the agent-side
+operator gate is closed:
+
+1. No image-level proof that `GET /operator/health`, `/operator`, `/operator/repos`,
+   etc. register when the operator env is present — a regression that unmounts the
+   operator server (like the #1001 `listBindings` wiring gap) would pass CI today
+   because the smoke never boots the operator surface.
+2. The operator deployment story is spread across `deploy/README.md`'s OAuth
+   section, the route table from #996, and six `docs/solutions/best-practices/`
+   pattern docs, with no single operator-facing entry point that ties them together.
+
+## Requirements Trace
+
+- R2. `deploy/README.md` has a consolidated "Operator Web Surface" runbook section
+  that names the routes, the env needed to enable them, and links the existing
+  route table + pattern docs — without duplicating their content.
+- R3. The `Gateway Image Smoke Test` boots the built image with operator env and
+  asserts the operator routes register and respond correctly (mounted, not 404),
+  so an unmount/registration regression fails CI.
+
+## Scope Boundaries
+
+- No new operator routes, contract changes, or behavior changes — assurance + docs
+  only.
+- No new `docs/solutions/` doc (R2 satisfied in `deploy/README.md`; the six existing
+  operator pattern docs stay authoritative for their patterns).
+- No dashboard work — the fixture→live migration is downstream (`fro-bot/dashboard#48`).
+
+### Deferred to Separate Tasks
+
+- Dashboard fixture→live migration: `fro-bot/dashboard` (#48).
+- Non-blocking #1000 review residuals (dynamic-import isolation, ESLint
+  import-boundary rule, `readEnv` dedup): future gateway hardening pass.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `.github/workflows/ci.yaml` — the `Gateway Image Smoke Test` job (build runtime +
+  gateway, build Docker image with retries, then two smoke steps: "assert config
+  load, not module crash" and the #738 "announce opt-out boots past config" step
+  using a `docker run` with fake env). R3 adds a third smoke step following the
+  #738 pattern but with operator env + a **running** (`-d`) container and host-side
+  `curl` probes.
+- `packages/gateway/src/program.ts:458` — operator server only starts when
+  `config.operatorWeb !== undefined` AND `startOperatorServer` dep is present.
+- `packages/gateway/src/config.ts:110,563` — `operatorWeb` is gated by
+  `GATEWAY_OPERATOR_BIND_HOST` / `GATEWAY_OPERATOR_BIND_PORT` /
+  `GATEWAY_OPERATOR_PUBLIC_ORIGIN` plus OAuth client id/secret and CSRF secret
+  (`GATEWAY_OPERATOR_GITHUB_CLIENT_ID[_FILE]`,
+  `GATEWAY_OPERATOR_GITHUB_CLIENT_SECRET[_FILE]`, `GATEWAY_OPERATOR_CSRF_SECRET[_FILE]`).
+- `packages/gateway/src/web/server.test.ts` — the unit-level registration test from
+  #996 that asserts the operator route set registers when deps are present (the
+  in-process analog of what R3 proves in-image).
+- `deploy/README.md:261` — existing "Operator OAuth (Web Surface)" section (callback
+  URL, credentials) and the route table from #996 — the anchor R2 consolidates from.
+- `deploy/gateway.Dockerfile` — build stage has `curl`; final image has
+  `netcat-openbsd` + a baked `HEALTHCHECK`. R3 probes from the **host** runner
+  (ubuntu runners always have `curl`) against a published operator port.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/` operator docs: `gateway-control-surface-spine-*`,
+  `web-operator-launch-surface-*`, `authenticated-sse-run-observation-*`,
+  `sse-output-streaming-terminal-drain-*`, `signed-webhook-ingress-hardening-*`,
+  `gateway-opencode-mention-loop-*`. R2 links these rather than restating them.
+- The #1001 regression class (an operator route silently unmounted because a dep
+  wasn't wired) is exactly what R3's image-level smoke guards against.
+
+## Key Technical Decisions
+
+- **Probe from the host, not inside the container.** The R3 step runs the image with
+  `docker run -d` publishing the operator bind port, waits for readiness, then
+  `curl`s from the runner. Avoids depending on in-image HTTP tooling and matches how
+  a real operator/browser reaches the surface.
+- **Assert "mounted, not 404" as the core signal.** `GET /operator/repos`
+  unauthenticated returns `401` when mounted (and `404` when not). Asserting
+  `401`-not-`404` is the precise registration proof; `/operator` → `302` to the OAuth
+  start and `/operator/health` → `200` corroborate. (Confirm exact unauth statuses
+  against the route handlers during implementation; the assertion set adapts to the
+  real codes, but the principle is "mounted route gives an auth/redirect response,
+  unmounted gives 404".)
+- **Reuse the #738 fake-env pattern for non-operator secrets.** The operator server
+  needs `operatorWeb` config but the gateway also needs the core fake secrets
+  (`DISCORD_TOKEN`, `S3_BUCKET`, etc.) to boot far enough to start the operator
+  server. Mirror the existing #738 env block and add the `GATEWAY_OPERATOR_*` vars.
+- **R2 lives in `deploy/README.md`, not a new solution doc** — operator-facing home,
+  avoids a seventh overlapping operator doc.
+
+## Open Questions
+
+### Resolved During Planning
+
+- New solution doc vs deploy/README for R2: **deploy/README** (avoids overlap with
+  the six existing operator pattern docs; operator-facing home).
+- In-container vs host-side probing for R3: **host-side `curl`** against a published
+  port (no in-image tooling dependency).
+
+### Deferred to Implementation
+
+- The exact unauthenticated status codes per operator route (`/operator/repos`,
+  `/operator/runs/...`) — read the handlers and pin the real codes in the smoke
+  assertions. The invariant is "mounted ⇒ non-404 auth/redirect response".
+- Whether the operator server binds before or after the gateway reports unhealthy
+  with fake Discord credentials — determine the minimal env that lets the operator
+  server listen, and the readiness signal to wait on (port-open via `nc`, or a
+  bounded `curl` retry loop on `/operator/health`).
+
+## Implementation Units
+
+- [ ] **Unit 1: Image-level operator-route registration smoke (R3)**
+
+**Goal:** The `Gateway Image Smoke Test` boots the built image with operator env and
+proves the operator routes register and respond (mounted, not 404) in the shipped
+image.
+
+**Requirements:** R3
+
+**Dependencies:** None (extends the existing job)
+
+**Files:**
+- Modify: `.github/workflows/ci.yaml` (add a smoke step to the `Gateway Image Smoke
+  Test` job)
+
+**Approach:**
+- After the existing "announce opt-out boots past config" step, add a step that runs
+  the image detached (`docker run -d --name operator-smoke -p <hostport>:<operatorport>`)
+  with the core fake secrets (mirror the #738 block) PLUS the `GATEWAY_OPERATOR_*`
+  env needed to enable `operatorWeb`: bind host `0.0.0.0`, a bind port, a public
+  origin, fake OAuth client id/secret, and a fake CSRF secret.
+- Wait for the operator server to listen (bounded retry: `nc -z`/`curl` loop on the
+  operator port, capped with a clear timeout-fail).
+- `curl` from the host and assert the registration signals:
+  - `/operator/health` → `200` (operator server up).
+  - `/operator` → `302` (redirect to OAuth start — surface mounted).
+  - `/operator/repos` (no auth) → mounted auth response (e.g. `401`), explicitly
+    **not** `404` (the #1001 regression signal).
+- Always `docker logs operator-smoke` on failure and `docker rm -f` in cleanup so
+  the step is debuggable and leaves no container. Add `timeout-minutes` to the step.
+- Keep the existing two smoke steps unchanged.
+
+**Patterns to follow:** the existing #738 smoke step (`set +e` / capture output /
+status checks / `grep` assertions) in the same job; the readiness-wait + host-curl
+shape used elsewhere in CI for container probes.
+
+**Test scenarios:**
+- Happy path: image booted with operator env → `/operator/health` 200, `/operator`
+  302, `/operator/repos` non-404 auth response → step passes.
+- Regression guard (the reason this exists): if the operator routes do not mount
+  (e.g. a future deps-wiring regression like #1001), `/operator/repos` returns 404 →
+  the assertion fails the step. (Validated during implementation by temporarily
+  asserting the inverse, or by reasoning from the #1001 case; do not ship the
+  inverse assertion.)
+- Edge case: operator server never binds within the timeout → bounded wait fails
+  with a clear message + `docker logs`, not a hang.
+
+**Verification:** the `Gateway Image Smoke Test` job has a new green step that boots
+the operator surface and asserts the routes are mounted; a simulated unmount would
+fail it; no leaked container; the step has a bounded timeout.
+
+- [ ] **Unit 2: Consolidated Operator Web Surface runbook in deploy/README (R2)**
+
+**Goal:** `deploy/README.md` has one operator-facing "Operator Web Surface" section
+that ties together the route table, the enabling env, and the pattern docs.
+
+**Requirements:** R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `deploy/README.md`
+
+**Approach:**
+- Add/extend a consolidated "Operator Web Surface" section near the existing
+  "Operator OAuth (Web Surface)" content (`deploy/README.md:261`). It should:
+  - State what the surface is and the env required to enable it (the
+    `GATEWAY_OPERATOR_*` bind/origin/OAuth/CSRF vars — reference, don't duplicate the
+    full secrets table).
+  - Point to the shipped route table (from #996) rather than re-listing routes.
+  - Cross-link the relevant `docs/solutions/best-practices/` operator pattern docs
+    (control-surface spine, launch surface, authenticated SSE observation, SSE output
+    streaming, signed-webhook ingress) for the design rationale.
+  - Note the deny-key backfill runbook (the `backfill-deny-keys` command documented
+    in `packages/gateway/AGENTS.md`) as the step that makes pre-gate bindings appear
+    in `GET /operator/repos`.
+- Operator-facing prose only — no plan-speak, no process taxonomy.
+
+**Patterns to follow:** the existing `deploy/README.md` operator/OAuth section style;
+the route table from #996.
+
+**Test scenarios:** Test expectation: none — docs only.
+
+**Verification:** an operator can read one section in `deploy/README.md` and know
+what the operator web surface is, what env enables it, where the route table is, and
+where the design docs live, without that section duplicating the route table or the
+pattern docs.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| The operator server may not bind with fake Discord/S3 env if startup ordering gates it behind a failing dependency | During implementation, determine the minimal env that lets the operator server listen; if the gateway must reach a later startup stage first, supply the minimal fake env (mirroring #738) so the operator server starts. If genuinely infeasible to boot the operator surface in-image without real backends, fall back to asserting the operator bind log line + keep the unit-level registration test as the contract, and document why. |
+| Host→container port probing flakiness (timing) | Bounded readiness wait with a clear timeout-fail and `docker logs` on failure; `timeout-minutes` on the step. |
+| Asserting exact status codes that differ from assumptions | Pin the real unauth codes by reading the handlers during implementation; assert the "mounted ⇒ non-404" invariant rather than a brittle exact code where the code is uncertain. |
+
+## Documentation / Operational Notes
+
+- R2 is itself the doc deliverable. No runbook/monitoring changes beyond the
+  `deploy/README.md` consolidation.
+
+## Sources & References
+
+- Related PRs: [agent#994](https://github.com/fro-bot/agent/pull/994) (Unit 7 cut /
+  reconciliation), [agent#996](https://github.com/fro-bot/agent/pull/996) (R1 route
+  table + unit-level registration test), [agent#1020](https://github.com/fro-bot/agent/pull/1020)
+  (#1001 route mount), [agent#1023](https://github.com/fro-bot/agent/pull/1023)
+  (#1000 backfill runnable).
+- Epic: [agent#907](https://github.com/fro-bot/agent/issues/907).
+- Tracker: [fro-bot/.github#3512](https://github.com/fro-bot/.github/issues/3512).
+- Related code: `.github/workflows/ci.yaml` (Gateway Image Smoke Test),
+  `packages/gateway/src/program.ts`, `packages/gateway/src/config.ts`,
+  `packages/gateway/src/web/server.test.ts`, `deploy/README.md`.

--- a/docs/plans/2026-06-25-001-feat-operator-surface-unit8-tail-plan.md
+++ b/docs/plans/2026-06-25-001-feat-operator-surface-unit8-tail-plan.md
@@ -140,57 +140,102 @@ operator gate is closed:
 
 ## Implementation Units
 
-- [ ] **Unit 1: Image-level operator-route registration smoke (R3)**
+- [x] **Unit 1: Operator-route registration smoke via shared deps helper + diagnostic subcommand (R3)**
 
-**Goal:** The `Gateway Image Smoke Test` boots the built image with operator env and
-proves the operator routes register and respond (mounted, not 404) in the shipped
-image.
+**Goal:** Prove the operator routes register in the shipped image using the SAME
+deps-construction production wires — catching the #1001 route-unmount class (a route
+gated on a runtime dep that `program.ts` forgets to pass) at the image level.
 
 **Requirements:** R3
 
-**Dependencies:** None (extends the existing job)
+**Dependencies:** None
+
+**Background (why HTTP-probing fails):** the operator HTTP server only starts in
+`program.ts` AFTER `runProviderSelfTest` (fails with fake S3 creds) and
+`registerSlashCommands` (fails with a fake Discord token), so it never binds in CI
+without real backends. A static bundle/symbol check can't catch #1001 either (the
+bug is a runtime deps-gating omission, not a missing symbol). The fix: evaluate
+route registration with production's real deps construction, without starting the
+server. `buildOperatorApp(deps, config): Hono` (`server.ts:336`) builds the app
+without binding a port; its mount gates are deps-presence checks (e.g.
+`GET /operator/repos` mounts only if `deps.listBindings !== undefined`,
+`server.ts:647`). So a missing dep → the route is absent from `app.routes` → assertion
+fails. This is the exact #1001 signal.
 
 **Files:**
-- Modify: `.github/workflows/ci.yaml` (add a smoke step to the `Gateway Image Smoke
-  Test` job)
+- Modify: `packages/gateway/src/program.ts` (extract the operator deps/config
+  construction at lines ~461-535 into an exported `buildOperatorServerInputs(...)`
+  helper; production calls it so the smoke and prod share one wiring path)
+- Modify: `packages/gateway/src/main-dispatch.ts` (add an `operator-route-smoke`
+  subcommand alongside the existing `backfill-deny-keys` dispatch)
+- Create: `packages/gateway/src/web/operator-route-smoke.ts` (the diagnostic: build
+  the operator inputs via the shared helper with realistic stub-but-present
+  instances, call `buildOperatorApp`, assert the expected route inventory, exit 0/1)
+- Test: `packages/gateway/src/web/operator-route-smoke.test.ts`,
+  `packages/gateway/src/main-dispatch.test.ts` (extend), and a
+  `buildOperatorServerInputs` test
+- Modify: `.github/workflows/ci.yaml` (replace the config-acceptance step with one
+  that runs `node dist/main.mjs operator-route-smoke` in the built image)
 
 **Approach:**
-- After the existing "announce opt-out boots past config" step, add a step that runs
-  the image detached (`docker run -d --name operator-smoke -p <hostport>:<operatorport>`)
-  with the core fake secrets (mirror the #738 block) PLUS the `GATEWAY_OPERATOR_*`
-  env needed to enable `operatorWeb`: bind host `0.0.0.0`, a bind port, a public
-  origin, fake OAuth client id/secret, and a fake CSRF secret.
-- Wait for the operator server to listen (bounded retry: `nc -z`/`curl` loop on the
-  operator port, capped with a clear timeout-fail).
-- `curl` from the host and assert the registration signals:
-  - `/operator/health` → `200` (operator server up).
-  - `/operator` → `302` (redirect to OAuth start — surface mounted).
-  - `/operator/repos` (no auth) → mounted auth response (e.g. `401`), explicitly
-    **not** `404` (the #1001 regression signal).
-- Always `docker logs operator-smoke` on failure and `docker rm -f` in cleanup so
-  the step is debuggable and leaves no container. Add `timeout-minutes` to the step.
-- Keep the existing two smoke steps unchanged.
+- **Extract the shared helper.** Pull the `OperatorServerDeps` + `OperatorServerConfig`
+  object construction (currently inline at `program.ts:499-535`, including the
+  load-bearing `listBindings` wiring) into an exported `buildOperatorServerInputs(...)`
+  that takes the program-scoped instances (logger, denylistCache, bindingsStore,
+  runObservationManager, runIndex, sessionStore, githubOAuthDeps, operatorWeb config,
+  etc.) and returns `{deps, config}`. Production's `startOperatorServer(...)` call
+  passes the helper's output unchanged — behavior-identical. This is the seam that
+  makes the smoke catch #1001: if a future edit drops a dep from the helper, BOTH
+  production and the smoke lose it.
+- **Diagnostic module.** `runOperatorRouteSmoke()` builds realistic-but-offline stub
+  instances for the program-scoped deps (no real S3/Discord/network — the route
+  mount gates only check presence/shape, not liveness), calls
+  `buildOperatorServerInputs(...)` then `buildOperatorApp(deps, config)`, reads
+  `app.routes`, and asserts the expected operator route set is present:
+  `GET /operator/health`, `GET /operator/repos`, `GET /operator/runs/:runId/stream`,
+  `GET /operator/runs/:runId/approvals`, `POST /operator/runs/:runId/.../decision`,
+  `POST /operator/runs`, plus the OAuth/session routes. Missing any → non-zero exit
+  with a clear message naming the absent route. Returns an exit code; the subcommand
+  `process.exit`s with it (mirror the backfill runner's exit-code pattern).
+- **Subcommand.** Add `operator-route-smoke` to `main-dispatch.ts`'s argv dispatch
+  (same shape as `backfill-deny-keys`), with `--help`. Update the bundle symbol
+  guard if needed (it asserts `dispatchArgv`).
+- **CI step.** Replace the implemented config-acceptance step in the `Gateway Image
+  Smoke Test` job with: `docker run --rm fro-bot-gateway:smoke operator-route-smoke`
+  and assert exit 0 + an expected success marker. No env/creds needed (the smoke
+  doesn't boot the gateway). Add `timeout-minutes`. Keep the two existing smoke steps.
 
-**Patterns to follow:** the existing #738 smoke step (`set +e` / capture output /
-status checks / `grep` assertions) in the same job; the readiness-wait + host-curl
-shape used elsewhere in CI for container probes.
+**Execution note:** test-first for the diagnostic and the helper extraction — write
+the route-inventory assertion and a "missing-dep ⇒ route absent ⇒ failure" test
+before/alongside the extraction, so the #1001-class guard is proven non-vacuous.
+
+**Patterns to follow:** the `backfill-deny-keys` subcommand + `parseBackfillArgs` +
+exit-code shape in `main-dispatch.ts`/`backfill-runner.ts` (just shipped in #1023);
+`buildOperatorApp` in `server.ts`; the existing `server.test.ts` registration test
+(the in-process analog).
 
 **Test scenarios:**
-- Happy path: image booted with operator env → `/operator/health` 200, `/operator`
-  302, `/operator/repos` non-404 auth response → step passes.
-- Regression guard (the reason this exists): if the operator routes do not mount
-  (e.g. a future deps-wiring regression like #1001), `/operator/repos` returns 404 →
-  the assertion fails the step. (Validated during implementation by temporarily
-  asserting the inverse, or by reasoning from the #1001 case; do not ship the
-  inverse assertion.)
-- Edge case: operator server never binds within the timeout → bounded wait fails
-  with a clear message + `docker logs`, not a hang.
+- Happy path: with all operator deps present, the diagnostic asserts the full
+  operator route set is in `app.routes` and exits 0.
+- Regression guard (the reason this exists): drop `listBindings` from the deps the
+  helper produces (simulating #1001) → `GET /operator/repos` is absent from
+  `app.routes` → diagnostic exits non-zero naming the missing route. Prove this is
+  non-vacuous.
+- Edge case: each gated route (run-stream, approvals) absent when its dep is missing
+  → diagnostic fails, naming it.
+- Subcommand dispatch: `operator-route-smoke` argv → runs the diagnostic, exits with
+  its code; `--help` → usage, exit 0; no subcommand → gateway path unaffected.
+- Helper parity: `buildOperatorServerInputs` returns deps that, fed to
+  `buildOperatorApp`, mount the same route set production does (the helper extraction
+  is behavior-preserving).
 
-**Verification:** the `Gateway Image Smoke Test` job has a new green step that boots
-the operator surface and asserts the routes are mounted; a simulated unmount would
-fail it; no leaked container; the step has a bounded timeout.
+**Verification:** `node dist/main.mjs operator-route-smoke` in the built image exits
+0 and reports the operator routes present; a simulated missing-dep makes it fail
+naming the route; production startup is behavior-identical (the helper output equals
+the previous inline object); the CI step is green and bounded; the two existing smoke
+steps are unchanged.
 
-- [ ] **Unit 2: Consolidated Operator Web Surface runbook in deploy/README (R2)**
+- [x] **Unit 2: Consolidated Operator Web Surface runbook in deploy/README (R2)**
 
 **Goal:** `deploy/README.md` has one operator-facing "Operator Web Surface" section
 that ties together the route table, the enabling env, and the pattern docs.

--- a/packages/gateway/src/main-dispatch.test.ts
+++ b/packages/gateway/src/main-dispatch.test.ts
@@ -524,6 +524,42 @@ describe('main-dispatch.ts argv dispatch', () => {
 })
 
 // ---------------------------------------------------------------------------
+// parseOperatorRouteSmokeArgs — pure unit tests (no process.exit)
+// ---------------------------------------------------------------------------
+
+describe('parseOperatorRouteSmokeArgs — pure arg parsing', () => {
+  it('no args → run mode', async () => {
+    const {parseOperatorRouteSmokeArgs} = await import('./main-dispatch.js')
+    const result = parseOperatorRouteSmokeArgs([])
+    expect(result).toEqual({mode: 'run'})
+  })
+
+  it('--help → help mode', async () => {
+    const {parseOperatorRouteSmokeArgs} = await import('./main-dispatch.js')
+    const result = parseOperatorRouteSmokeArgs(['--help'])
+    expect(result).toEqual({mode: 'help'})
+  })
+
+  it('-h → help mode', async () => {
+    const {parseOperatorRouteSmokeArgs} = await import('./main-dispatch.js')
+    const result = parseOperatorRouteSmokeArgs(['-h'])
+    expect(result).toEqual({mode: 'help'})
+  })
+
+  it('unknown flag → error with flag name', async () => {
+    const {parseOperatorRouteSmokeArgs} = await import('./main-dispatch.js')
+    const result = parseOperatorRouteSmokeArgs(['--bogus'])
+    expect(result).toEqual({error: 'Unknown flag: --bogus'})
+  })
+
+  it('unknown flag among known flags → error (first unknown wins)', async () => {
+    const {parseOperatorRouteSmokeArgs} = await import('./main-dispatch.js')
+    const result = parseOperatorRouteSmokeArgs(['--help', '--bogus'])
+    expect(result).toEqual({error: 'Unknown flag: --bogus'})
+  })
+})
+
+// ---------------------------------------------------------------------------
 // parseBackfillArgs — pure unit tests (no process.exit)
 // ---------------------------------------------------------------------------
 

--- a/packages/gateway/src/main-dispatch.test.ts
+++ b/packages/gateway/src/main-dispatch.test.ts
@@ -6,6 +6,9 @@
  * - `backfill-deny-keys --apply` → dryRun: false (real write)
  * - `backfill-deny-keys --help` / `-h` → usage printed, exit 0, runner NOT called
  * - `backfill-deny-keys --bogus` (unknown flag) → error + usage, exit 1, runner NOT called
+ * - `operator-route-smoke` → runs the diagnostic, exits with its code
+ * - `operator-route-smoke --help` / `-h` → usage printed, exit 0, diagnostic NOT called
+ * - `operator-route-smoke --bogus` (unknown flag) → error + usage, exit 1, diagnostic NOT called
  * - No subcommand → gateway program path is taken (runner not called)
  * - Unknown subcommand → falls through to gateway program (runner not called)
  * - No import-time side effects (gateway program does not start on import)
@@ -83,6 +86,20 @@ vi.mock('./web/server.js', () => ({
 }))
 
 // ---------------------------------------------------------------------------
+// Mock the operator-route-smoke diagnostic so we never build a real Hono app
+// ---------------------------------------------------------------------------
+
+const mockRunOperatorRouteSmoke = vi.fn()
+
+vi.mock('./web/operator-route-smoke.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./web/operator-route-smoke.js')>()
+  return {
+    ...actual,
+    runOperatorRouteSmoke: mockRunOperatorRouteSmoke,
+  }
+})
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -122,6 +139,8 @@ describe('main-dispatch.ts argv dispatch', () => {
 
     // Default: gateway program resolves cleanly
     mockEffectRunPromise.mockResolvedValue(undefined)
+    // Default: diagnostic returns success
+    mockRunOperatorRouteSmoke.mockResolvedValue(0)
   })
 
   afterEach(() => {
@@ -324,6 +343,125 @@ describe('main-dispatch.ts argv dispatch', () => {
 
       // #then — process.exit called with 2
       expect(exitSpy).toHaveBeenCalledWith(2)
+      expect(mockEffectRunPromise).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
+
+  // -------------------------------------------------------------------------
+  // operator-route-smoke subcommand — runs diagnostic, exits with its code
+  // -------------------------------------------------------------------------
+
+  it('operator-route-smoke: runs the diagnostic and exits with its code (0 = success)', async () => {
+    // #given — argv simulates `node dist/main.mjs operator-route-smoke`
+    const {restore} = withArgv(['node', 'main.js', 'operator-route-smoke'])
+    mockRunOperatorRouteSmoke.mockResolvedValue(0)
+
+    try {
+      // #when
+      const {dispatchArgv} = await import('./main-dispatch.js')
+      await dispatchArgv()
+
+      // #then — diagnostic called
+      expect(mockRunOperatorRouteSmoke).toHaveBeenCalledOnce()
+
+      // #and — process.exit called with the diagnostic's code
+      expect(exitSpy).toHaveBeenCalledWith(0)
+
+      // #and — gateway program was NOT started
+      expect(mockEffectRunPromise).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
+
+  it('operator-route-smoke: exits with code 1 when diagnostic returns 1 (routes absent)', async () => {
+    // #given — diagnostic returns failure
+    const {restore} = withArgv(['node', 'main.js', 'operator-route-smoke'])
+    mockRunOperatorRouteSmoke.mockResolvedValue(1)
+
+    try {
+      // #when
+      const {dispatchArgv} = await import('./main-dispatch.js')
+      await dispatchArgv()
+
+      // #then — process.exit called with 1
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      expect(mockEffectRunPromise).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
+
+  it('operator-route-smoke --help: prints usage to stdout and exits 0 without calling diagnostic', async () => {
+    // #given — argv simulates `node dist/main.mjs operator-route-smoke --help`
+    const {restore} = withArgv(['node', 'main.js', 'operator-route-smoke', '--help'])
+
+    try {
+      // #when
+      const {dispatchArgv} = await import('./main-dispatch.js')
+      await dispatchArgv()
+
+      // #then — usage printed to stdout
+      expect(stdoutSpy).toHaveBeenCalledOnce()
+
+      // #and — exit 0
+      expect(exitSpy).toHaveBeenCalledWith(0)
+
+      // #and — diagnostic NOT called
+      expect(mockRunOperatorRouteSmoke).not.toHaveBeenCalled()
+
+      // #and — gateway program NOT started
+      expect(mockEffectRunPromise).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
+
+  it('operator-route-smoke -h: prints usage to stdout and exits 0 without calling diagnostic', async () => {
+    // #given — argv simulates `node dist/main.mjs operator-route-smoke -h`
+    const {restore} = withArgv(['node', 'main.js', 'operator-route-smoke', '-h'])
+
+    try {
+      // #when
+      const {dispatchArgv} = await import('./main-dispatch.js')
+      await dispatchArgv()
+
+      // #then — usage printed to stdout
+      expect(stdoutSpy).toHaveBeenCalledOnce()
+
+      // #and — exit 0
+      expect(exitSpy).toHaveBeenCalledWith(0)
+
+      // #and — diagnostic NOT called
+      expect(mockRunOperatorRouteSmoke).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
+
+  it('operator-route-smoke --bogus (unknown flag): prints error + usage, exits 1, diagnostic NOT called', async () => {
+    // #given — argv simulates `node dist/main.mjs operator-route-smoke --bogus`
+    const {restore} = withArgv(['node', 'main.js', 'operator-route-smoke', '--bogus'])
+
+    try {
+      // #when
+      const {dispatchArgv} = await import('./main-dispatch.js')
+      await dispatchArgv()
+
+      // #then — error printed to stderr naming the bad flag
+      expect(consoleErrorSpy).toHaveBeenCalledOnce()
+      const errorMsg = (consoleErrorSpy.mock.calls[0] as string[])[0]
+      expect(errorMsg).toContain('--bogus')
+
+      // #and — exit 1
+      expect(exitSpy).toHaveBeenCalledWith(1)
+
+      // #and — diagnostic NOT called
+      expect(mockRunOperatorRouteSmoke).not.toHaveBeenCalled()
+
+      // #and — gateway program NOT started
       expect(mockEffectRunPromise).not.toHaveBeenCalled()
     } finally {
       restore()

--- a/packages/gateway/src/main-dispatch.ts
+++ b/packages/gateway/src/main-dispatch.ts
@@ -8,6 +8,7 @@ import {createAnnounceServer} from './http/server.js'
 import {makeDiscordClientFromConfig, makeGatewayProgram, makeLogger} from './program.js'
 import {setupReadinessFlag} from './readiness.js'
 import {validateProviderSemanticsEffect} from './runtime-effect.js'
+import {runOperatorRouteSmoke} from './web/operator-route-smoke.js'
 import {createOperatorServer} from './web/server.js'
 
 // ---------------------------------------------------------------------------
@@ -42,15 +43,60 @@ const program = Effect.gen(function* () {
 // Argv dispatch
 //
 // Branches on process.argv[2]:
-//   'backfill-deny-keys' → parse flags, run the deny-key backfill, exit with its code
-//   anything else        → fall through to the gateway Effect program (today's behavior)
+//   'backfill-deny-keys'    → parse flags, run the deny-key backfill, exit with its code
+//   'operator-route-smoke'  → parse flags, run the route-registration diagnostic, exit with its code
+//   anything else           → fall through to the gateway Effect program (today's behavior)
 //
 // Flag semantics for backfill-deny-keys:
 //   (no flag)   → dry-run / preview (SAFE DEFAULT — no writes)
 //   --apply     → real run (writes to the live S3 bindings store)
 //   --help / -h → print usage, exit 0
 //   unknown     → print error + usage, exit 1 (strict validation)
+//
+// Flag semantics for operator-route-smoke:
+//   (no flag)   → run the diagnostic (no side effects — read-only route inspection)
+//   --help / -h → print usage, exit 0
+//   unknown     → print error + usage, exit 1 (strict validation)
 // ---------------------------------------------------------------------------
+
+const OPERATOR_ROUTE_SMOKE_USAGE = `
+Usage: node dist/main.mjs operator-route-smoke [--help|-h]
+
+Offline operator-route registration diagnostic.
+
+Builds the operator Hono app via the production deps-construction path
+(buildOperatorServerInputs → buildOperatorApp) with realistic-but-offline
+stubs, reads app.routes, and asserts the expected operator route set is
+present. No port is bound, no network is required, no credentials are needed.
+
+Exits 0 when all expected operator routes are registered.
+Exits 1 when one or more expected routes are absent (names the missing routes).
+
+Options:
+  --help, -h  Print this usage message and exit.
+
+Exit codes:
+  0  All expected operator routes are registered
+  1  One or more routes absent — check logs for which routes are missing
+`.trim()
+
+const OPERATOR_ROUTE_SMOKE_KNOWN_FLAGS = new Set(['--help', '-h'])
+
+function parseOperatorRouteSmokeArgs(
+  args: readonly string[],
+): {readonly mode: 'help' | 'run'} | {readonly error: string} {
+  for (const arg of args) {
+    if (!OPERATOR_ROUTE_SMOKE_KNOWN_FLAGS.has(arg)) {
+      return {error: `Unknown flag: ${arg}`}
+    }
+  }
+
+  if (args.includes('--help') || args.includes('-h')) {
+    return {mode: 'help'}
+  }
+
+  return {mode: 'run'}
+}
 
 export async function dispatchArgv(): Promise<void> {
   const subcommand = process.argv[2]
@@ -67,6 +113,19 @@ export async function dispatchArgv(): Promise<void> {
     } else {
       const dryRun = parsed.mode !== 'apply'
       const exitCode = await runDenyKeyBackfill({dryRun})
+      process.exit(exitCode)
+    }
+  } else if (subcommand === 'operator-route-smoke') {
+    const parsed = parseOperatorRouteSmokeArgs(process.argv.slice(3))
+
+    if ('error' in parsed) {
+      console.error(`operator-route-smoke: ${parsed.error}\n\n${OPERATOR_ROUTE_SMOKE_USAGE}`)
+      process.exit(1)
+    } else if (parsed.mode === 'help') {
+      process.stdout.write(`${OPERATOR_ROUTE_SMOKE_USAGE}\n`)
+      process.exit(0)
+    } else {
+      const exitCode = await runOperatorRouteSmoke()
       process.exit(exitCode)
     }
   } else {

--- a/packages/gateway/src/main-dispatch.ts
+++ b/packages/gateway/src/main-dispatch.ts
@@ -59,7 +59,7 @@ const program = Effect.gen(function* () {
 //   unknown     → print error + usage, exit 1 (strict validation)
 // ---------------------------------------------------------------------------
 
-const OPERATOR_ROUTE_SMOKE_USAGE = `
+export const OPERATOR_ROUTE_SMOKE_USAGE = `
 Usage: node dist/main.mjs operator-route-smoke [--help|-h]
 
 Offline operator-route registration diagnostic.
@@ -82,7 +82,7 @@ Exit codes:
 
 const OPERATOR_ROUTE_SMOKE_KNOWN_FLAGS = new Set(['--help', '-h'])
 
-function parseOperatorRouteSmokeArgs(
+export function parseOperatorRouteSmokeArgs(
   args: readonly string[],
 ): {readonly mode: 'help' | 'run'} | {readonly error: string} {
   for (const arg of args) {

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -128,7 +128,12 @@ export interface BuildOperatorServerInputs {
    */
   readonly runObservationManager?: NonNullable<OperatorServerDeps['runObservationManager']> | undefined
   readonly runIndex: NonNullable<OperatorServerDeps['runIndex']>
-  readonly approvalRegistry: NonNullable<OperatorServerDeps['approvalRegistry']>
+  /**
+   * Approval registry for the approval routes.
+   * Optional — omit (or pass undefined) to simulate a missing dep in tests,
+   * which causes the approval routes to be absent from app.routes.
+   */
+  readonly approvalRegistry?: NonNullable<OperatorServerDeps['approvalRegistry']>
   /**
    * Engine dependencies for the launch route's launchWork call.
    * Required for POST /operator/runs to be registered — the route gate checks
@@ -136,7 +141,7 @@ export interface BuildOperatorServerInputs {
    * Optional only for the offline diagnostic which may pass undefined to simulate
    * a missing dep and verify the launch route is absent.
    */
-  readonly launchWorkDeps: NonNullable<OperatorServerDeps['launchWorkDeps']> | undefined
+  readonly launchWorkDeps?: NonNullable<OperatorServerDeps['launchWorkDeps']>
   readonly operatorWebConfig: {
     readonly bindHost: string
     readonly bindPort: number

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -121,9 +121,22 @@ export interface BuildOperatorServerInputs {
       {readonly success: true; readonly data: RepoBinding[]} | {readonly success: false; readonly error: Error}
     >
   }
-  readonly runObservationManager: NonNullable<OperatorServerDeps['runObservationManager']>
+  /**
+   * Run-observation manager for the run-stream route.
+   * Optional — omit (or pass undefined) to simulate a missing dep in tests,
+   * which causes GET /operator/runs/:runId/stream to be absent from app.routes.
+   */
+  readonly runObservationManager?: NonNullable<OperatorServerDeps['runObservationManager']> | undefined
   readonly runIndex: NonNullable<OperatorServerDeps['runIndex']>
   readonly approvalRegistry: NonNullable<OperatorServerDeps['approvalRegistry']>
+  /**
+   * Engine dependencies for the launch route's launchWork call.
+   * Required for POST /operator/runs to be registered — the route gate checks
+   * deps.launchWorkDeps !== undefined. Pass runEngineDeps from the program scope.
+   * Optional only for the offline diagnostic which may pass undefined to simulate
+   * a missing dep and verify the launch route is absent.
+   */
+  readonly launchWorkDeps: NonNullable<OperatorServerDeps['launchWorkDeps']> | undefined
   readonly operatorWebConfig: {
     readonly bindHost: string
     readonly bindPort: number
@@ -166,6 +179,7 @@ export function buildOperatorServerInputs(inputs: BuildOperatorServerInputs): {
     runObservationManager,
     runIndex,
     approvalRegistry,
+    launchWorkDeps,
     operatorWebConfig,
   } = inputs
 
@@ -225,6 +239,12 @@ export function buildOperatorServerInputs(inputs: BuildOperatorServerInputs): {
     // GET /operator/repos mount on listBindings, so omitting it leaves that
     // route unmounted. bindingsLookup only covers the run-stream route.
     listBindings: bindingsStore.listBindings === undefined ? undefined : bindingsStore.listBindings.bind(bindingsStore),
+    // getBindingByRepo: server.ts gates POST /operator/runs on this dep being present.
+    // Bound to the store so the method's `this` context is preserved.
+    getBindingByRepo: bindingsStore.getBindingByRepo.bind(bindingsStore),
+    // launchWorkDeps: server.ts gates POST /operator/runs on this dep being present.
+    // Shared with the Discord mention path so both use the same run-state instances.
+    launchWorkDeps,
     runObservationManager,
     runIndex,
     approvalRegistry,
@@ -640,6 +660,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
         runObservationManager,
         runIndex,
         approvalRegistry,
+        launchWorkDeps: runEngineDeps,
         operatorWebConfig: config.operatorWeb,
       })
 

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -1,6 +1,7 @@
 import type {CoordinationConfig, ObjectStoreAdapter} from '@fro-bot/runtime'
 import type {Client, GatewayIntentBits, Message} from 'discord.js'
 import type {Context} from 'hono'
+import type {RepoBinding} from './bindings/types.js'
 import type {GatewayConfig} from './config.js'
 import type {GatewayLogger} from './discord/client.js'
 import type {SinkThread} from './discord/streaming.js'
@@ -8,6 +9,7 @@ import type {RunTask} from './execute/run.js'
 import type {AnnounceServerConfig, AnnounceServerDeps} from './http/server.js'
 import type {CoordinationLogger} from './runtime-effect.js'
 import type {CloseableServer} from './shutdown.js'
+import type {OperatorAllowlist} from './web/auth/allowlist.js'
 import type {OperatorServerConfig, OperatorServerDeps} from './web/server.js'
 import {
   createS3Adapter,
@@ -101,6 +103,149 @@ export function makeDiscordClientFromConfig(
   logger: GatewayLogger,
 ): ReturnType<typeof createDiscordClient> {
   return createDiscordClient({intents: config.privilegedIntents, logger})
+}
+
+// ---------------------------------------------------------------------------
+// Operator server inputs helper — exported so the offline diagnostic can share
+// the same deps-construction path as production.
+// ---------------------------------------------------------------------------
+
+/** Program-scoped instances passed into buildOperatorServerInputs. */
+export interface BuildOperatorServerInputs {
+  readonly logger: OperatorServerDeps['logger']
+  readonly isShuttingDown: () => boolean
+  readonly denylistCache: NonNullable<OperatorServerDeps['denylistCache']>
+  readonly bindingsStore: {
+    readonly getBindingByRepo: NonNullable<OperatorServerDeps['getBindingByRepo']>
+    readonly listBindings?: () => Promise<
+      {readonly success: true; readonly data: RepoBinding[]} | {readonly success: false; readonly error: Error}
+    >
+  }
+  readonly runObservationManager: NonNullable<OperatorServerDeps['runObservationManager']>
+  readonly runIndex: NonNullable<OperatorServerDeps['runIndex']>
+  readonly approvalRegistry: NonNullable<OperatorServerDeps['approvalRegistry']>
+  readonly operatorWebConfig: {
+    readonly bindHost: string
+    readonly bindPort: number
+    readonly publicOrigin: string
+    readonly oauthClientId: string
+    readonly oauthClientSecret: string
+    readonly oauthAllowedReturnPaths: readonly string[]
+    readonly oauthStateTtlMs: number
+    readonly oauthMaxOutstandingAttemptsPerKey: number
+    readonly csrfSecret: string
+    readonly allowlist: OperatorAllowlist
+  }
+}
+
+/**
+ * Build the OperatorServerDeps and OperatorServerConfig objects from
+ * program-scoped instances.
+ *
+ * Constructs operator-local pieces (rate limiter, session store, OAuth deps,
+ * getSourceKey) internally. The caller passes already-constructed program-scoped
+ * instances (denylistCache, bindingsStore, runObservationManager, runIndex,
+ * approvalRegistry) in.
+ *
+ * Production's deps.startOperatorServer(...) call passes the helper's output
+ * unchanged — behavior-identical to the previous inline construction.
+ *
+ * Exported for the offline route-registration diagnostic which calls this helper
+ * with realistic-but-offline stubs to assert the route inventory without binding
+ * a port.
+ */
+export function buildOperatorServerInputs(inputs: BuildOperatorServerInputs): {
+  readonly deps: OperatorServerDeps
+  readonly config: OperatorServerConfig
+} {
+  const {
+    logger,
+    isShuttingDown: isShuttingDownFn,
+    denylistCache,
+    bindingsStore,
+    runObservationManager,
+    runIndex,
+    approvalRegistry,
+    operatorWebConfig,
+  } = inputs
+
+  // Build the source key extractor for OAuth outstanding-attempt counting.
+  // Must use the TCP socket address (not caller-spoofable headers).
+  // getConnInfo may throw in environments without a real socket; fall back to 'unknown'.
+  const getSourceKey = (c: Context): string => {
+    try {
+      return getConnInfo(c).remote.address ?? 'unknown'
+    } catch {
+      return 'unknown'
+    }
+  }
+
+  // Build the shared rate limiter for the operator surface.
+  // Passed to both buildGitHubOAuthDeps and OperatorServerDeps so OAuth routes
+  // participate in the same per-socket budget as the health route.
+  const operatorRateLimiter = createRateLimiter({limit: 20, windowMs: 60_000})
+
+  // Build the shared in-memory session store for the operator surface.
+  // Gateway restart is global logout — acceptable for v1.
+  const sessionStore = createInMemorySessionStore()
+  const sessionDeps = {
+    logger,
+    auditLogger: logger,
+    clock: () => Date.now(),
+  }
+
+  // Build production GitHub OAuth deps with real CSPRNG, fetch, and clock.
+  // Pass the session store so successful callbacks mint a fresh session.
+  // Pass the allowlist so non-allowlisted users are denied before session creation.
+  const githubOAuthDeps = buildGitHubOAuthDeps(
+    logger,
+    logger,
+    getSourceKey,
+    operatorRateLimiter,
+    sessionStore,
+    sessionDeps,
+    operatorWebConfig.allowlist,
+  )
+
+  const deps: OperatorServerDeps = {
+    logger,
+    isShuttingDown: isShuttingDownFn,
+    rateLimiter: operatorRateLimiter,
+    githubOAuth: githubOAuthDeps,
+    sessionStore,
+    sessionDeps,
+    allowlist: operatorWebConfig.allowlist,
+    csrfSecret: operatorWebConfig.csrfSecret,
+    auditLogger: logger,
+    // Wire the existing program-scoped instances so the run-stream route
+    // can reach them without creating second copies.
+    denylistCache,
+    bindingsLookup: bindingsStore,
+    // listBindings is a distinct dep from bindingsLookup: server.ts gates the
+    // GET /operator/repos mount on listBindings, so omitting it leaves that
+    // route unmounted. bindingsLookup only covers the run-stream route.
+    listBindings: bindingsStore.listBindings === undefined ? undefined : bindingsStore.listBindings.bind(bindingsStore),
+    runObservationManager,
+    runIndex,
+    approvalRegistry,
+  }
+
+  const config: OperatorServerConfig = {
+    bindHost: operatorWebConfig.bindHost,
+    bindPort: operatorWebConfig.bindPort,
+    publicOrigin: operatorWebConfig.publicOrigin,
+    githubOAuth: {
+      clientId: operatorWebConfig.oauthClientId,
+      clientSecret: operatorWebConfig.oauthClientSecret,
+      publicOrigin: operatorWebConfig.publicOrigin,
+      callbackPath: '/operator/auth/github/callback',
+      allowedReturnPaths: operatorWebConfig.oauthAllowedReturnPaths,
+      stateTtlMs: operatorWebConfig.oauthStateTtlMs,
+      maxOutstandingAttemptsPerKey: operatorWebConfig.oauthMaxOutstandingAttemptsPerKey,
+    },
+  }
+
+  return {deps, config}
 }
 
 // ---------------------------------------------------------------------------
@@ -481,89 +626,24 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
     if (config.operatorWeb === undefined || deps.startOperatorServer === undefined) {
       logger.info({}, 'operator web endpoint disabled — no operator web config set')
     } else {
-      // Build the source key extractor for OAuth outstanding-attempt counting.
-      // Must use the TCP socket address (not caller-spoofable headers).
-      // getConnInfo may throw in environments without a real socket; fall back to 'unknown'.
-      const getSourceKey = (c: Context): string => {
-        try {
-          return getConnInfo(c).remote.address ?? 'unknown'
-        } catch {
-          return 'unknown'
-        }
-      }
-
-      // Build the shared rate limiter for the operator surface.
-      // Passed to both buildGitHubOAuthDeps and OperatorServerDeps so OAuth routes
-      // participate in the same per-socket budget as the health route.
-      const operatorRateLimiter = createRateLimiter({limit: 20, windowMs: 60_000})
-
-      // Build the shared in-memory session store for the operator surface.
-      // Gateway restart is global logout — acceptable for v1.
-      const sessionStore = createInMemorySessionStore()
-      const sessionDeps = {
+      // Build the operator server deps and config via the shared helper.
+      // The helper constructs operator-local pieces (rate limiter, session store,
+      // OAuth deps, getSourceKey) and wires the program-scoped instances.
+      // Using the helper here ensures production and the offline diagnostic share
+      // the same wiring path — a future edit that drops a dep from the helper
+      // will be caught by the diagnostic before it reaches production.
+      const operatorInputs = buildOperatorServerInputs({
         logger,
-        auditLogger: logger,
-        clock: () => Date.now(),
-      }
+        isShuttingDown,
+        denylistCache,
+        bindingsStore,
+        runObservationManager,
+        runIndex,
+        approvalRegistry,
+        operatorWebConfig: config.operatorWeb,
+      })
 
-      // Build production GitHub OAuth deps with real CSPRNG, fetch, and clock.
-      // Pass the session store so successful callbacks mint a fresh session.
-      // Pass the allowlist so non-allowlisted users are denied before session creation.
-      const githubOAuthDeps = buildGitHubOAuthDeps(
-        logger,
-        logger,
-        getSourceKey,
-        operatorRateLimiter,
-        sessionStore,
-        sessionDeps,
-        config.operatorWeb.allowlist,
-      )
-
-      operatorServerHandle = deps.startOperatorServer(
-        {
-          logger,
-          isShuttingDown,
-          rateLimiter: operatorRateLimiter,
-          githubOAuth: githubOAuthDeps,
-          sessionStore,
-          sessionDeps,
-          allowlist: config.operatorWeb.allowlist,
-          csrfSecret: config.operatorWeb.csrfSecret,
-          auditLogger: logger,
-          // Wire the existing program-scoped instances so the run-stream route
-          // can reach them without creating second copies.
-          denylistCache,
-          bindingsLookup: bindingsStore,
-          // listBindings is a distinct dep from bindingsLookup: server.ts gates the
-          // GET /operator/repos mount on listBindings, so omitting it leaves that
-          // route unmounted (404). bindingsLookup only covers the run-stream route.
-          listBindings: bindingsStore.listBindings.bind(bindingsStore),
-          // getBindingByRepo gates the POST /operator/runs launch route mount.
-          // Mirrors the listBindings pattern: bind for `this` safety.
-          getBindingByRepo: bindingsStore.getBindingByRepo.bind(bindingsStore),
-          // launchWorkDeps gates the POST /operator/runs launch route mount.
-          // Uses the same program-scoped engine deps as the Discord mention path
-          // so web and Discord launches share run-state/coordination instances
-          // and the fail-closed approval gate is enforced on both paths.
-          launchWorkDeps: runEngineDeps,
-          runObservationManager,
-          runIndex,
-        },
-        {
-          bindHost: config.operatorWeb.bindHost,
-          bindPort: config.operatorWeb.bindPort,
-          publicOrigin: config.operatorWeb.publicOrigin,
-          githubOAuth: {
-            clientId: config.operatorWeb.oauthClientId,
-            clientSecret: config.operatorWeb.oauthClientSecret,
-            publicOrigin: config.operatorWeb.publicOrigin,
-            callbackPath: '/operator/auth/github/callback',
-            allowedReturnPaths: config.operatorWeb.oauthAllowedReturnPaths,
-            stateTtlMs: config.operatorWeb.oauthStateTtlMs,
-            maxOutstandingAttemptsPerKey: config.operatorWeb.oauthMaxOutstandingAttemptsPerKey,
-          },
-        },
-      )
+      operatorServerHandle = deps.startOperatorServer(operatorInputs.deps, operatorInputs.config)
       logger.info(
         {bindHost: config.operatorWeb.bindHost, bindPort: config.operatorWeb.bindPort},
         'operator web endpoint enabled — HTTP server started',

--- a/packages/gateway/src/web/operator-route-smoke.test.ts
+++ b/packages/gateway/src/web/operator-route-smoke.test.ts
@@ -16,7 +16,7 @@ import {describe, expect, it, vi} from 'vitest'
 
 import {buildOperatorServerInputs} from '../program.js'
 import {loadAllowlistFromText} from './auth/allowlist.js'
-import {runOperatorRouteSmoke} from './operator-route-smoke.js'
+import {EXPECTED_OPERATOR_ROUTES, runOperatorRouteSmoke} from './operator-route-smoke.js'
 import {buildOperatorApp} from './server.js'
 
 // ---------------------------------------------------------------------------
@@ -73,6 +73,12 @@ function makeStubApprovalRegistry() {
   }
 }
 
+function makeStubLaunchWorkDeps() {
+  // Registration only checks `deps.launchWorkDeps !== undefined`; the actual
+  // shape is not inspected at construction time.
+  return {} as NonNullable<Parameters<typeof buildOperatorApp>[0]['launchWorkDeps']>
+}
+
 function makeStubOperatorWebConfig() {
   const noopLogger = {
     debug: vi.fn(),
@@ -118,6 +124,7 @@ describe('buildOperatorServerInputs — parity with production wiring', () => {
       runObservationManager,
       runIndex,
       approvalRegistry,
+      launchWorkDeps: makeStubLaunchWorkDeps(),
       operatorWebConfig,
     })
 
@@ -146,16 +153,17 @@ describe('buildOperatorServerInputs — parity with production wiring', () => {
     expect(routeSet).toContain('GET:/operator/session/csrf')
     expect(routeSet).toContain('GET:/operator/session')
     expect(routeSet).toContain('GET:/operator/repos')
+    expect(routeSet).toContain('POST:/operator/runs')
     expect(routeSet).toContain('GET:/operator/runs/:runId/stream')
     expect(routeSet).toContain('GET:/operator/runs/:runId/approvals')
     expect(routeSet).toContain('POST:/operator/runs/:runId/approvals/:requestId/decision')
   })
 
-  it('omitting listBindings from bindingsStore causes GET /operator/repos to be absent (regression guard)', () => {
-    // #given — bindingsStore WITHOUT listBindings (simulates the #1001 class of bug)
+  it('omitting listBindings from bindingsStore causes GET /operator/repos to be absent', () => {
+    // #given — bindingsStore WITHOUT listBindings (a route gated on a missing dep is unmounted)
     const logger = makeStubLogger()
     const denylistCache = makeStubDenylistCache()
-    // Deliberately omit listBindings from the store to simulate a wiring gap
+    // Deliberately omit listBindings from the store to simulate a missing dep
     const bindingsStoreWithoutList = {
       createBinding: async () => ({success: false as const, error: new Error('stub')}),
       getBindingByRepo: async () => ({success: true as const, data: null}),
@@ -176,6 +184,7 @@ describe('buildOperatorServerInputs — parity with production wiring', () => {
       runObservationManager,
       runIndex,
       approvalRegistry,
+      launchWorkDeps: makeStubLaunchWorkDeps(),
       operatorWebConfig,
     })
 
@@ -218,15 +227,20 @@ describe('runOperatorRouteSmoke — happy path', () => {
 // runOperatorRouteSmoke — regression guard (non-vacuous)
 // ---------------------------------------------------------------------------
 
-describe('runOperatorRouteSmoke — regression guard', () => {
-  it('returns non-zero and names the missing route when GET /operator/repos is absent (listBindings omitted)', async () => {
-    // #given — inject a custom deps builder that omits listBindings
-    // The smoke accepts an optional override for the bindingsStore to enable this test.
+describe('runOperatorRouteSmoke — regression guard (non-vacuous)', () => {
+  it('expected route list is non-empty (guards against vacuous pass)', () => {
+    // #given / #then — the expected-routes list must never be empty
+    // An empty list would pass vacuously (zero missing routes) and provide no assurance.
+    expect(EXPECTED_OPERATOR_ROUTES.length).toBeGreaterThan(0)
+  })
+
+  it('returns non-zero when GET /operator/repos is absent (listBindings omitted from bindingsStore)', async () => {
+    // #given — a route gated on a missing dep is unmounted; the smoke must catch it
     const bindingsStoreWithoutList = {
       createBinding: async () => ({success: false as const, error: new Error('stub')}),
       getBindingByRepo: async () => ({success: true as const, data: null}),
       getBindingByChannelId: async () => ({success: true as const, data: null}),
-      // listBindings intentionally absent — simulates the #1001 wiring gap
+      // listBindings intentionally absent
     }
 
     // #when — run the smoke with a store that has no listBindings
@@ -238,8 +252,23 @@ describe('runOperatorRouteSmoke — regression guard', () => {
     expect(exitCode).not.toBe(0)
   })
 
-  it('returns non-zero when run-stream deps are absent (runObservationManager omitted)', async () => {
-    // #given — inject a custom deps builder that omits runObservationManager
+  it('returns non-zero when POST /operator/runs is absent (launchWorkDeps omitted)', async () => {
+    // #given — launchWorkDeps flows through buildOperatorServerInputs; omitting it
+    // causes the helper to pass undefined to deps.launchWorkDeps, and server.ts
+    // gates POST /operator/runs on that dep being present.
+    // #when
+    const exitCode = await runOperatorRouteSmoke({
+      launchWorkDepsOverride: undefined,
+    })
+
+    // #then — non-zero exit (POST /operator/runs absent)
+    expect(exitCode).not.toBe(0)
+  })
+
+  it('returns non-zero when run-stream route is absent (runObservationManager omitted)', async () => {
+    // #given — runObservationManager flows through buildOperatorServerInputs; omitting it
+    // causes the helper to pass undefined to deps.runObservationManager, and server.ts
+    // gates GET /operator/runs/:runId/stream on that dep being present.
     // #when
     const exitCode = await runOperatorRouteSmoke({
       runObservationManagerOverride: undefined,
@@ -247,5 +276,63 @@ describe('runOperatorRouteSmoke — regression guard', () => {
 
     // #then — non-zero exit (GET /operator/runs/:runId/stream absent)
     expect(exitCode).not.toBe(0)
+  })
+
+  it('returns non-zero when approval routes are absent (approvalRegistry omitted)', async () => {
+    // #given — approvalRegistry flows through buildOperatorServerInputs; omitting it
+    // causes the helper to pass undefined to deps.approvalRegistry, and server.ts
+    // gates the approval routes on that dep being present.
+    // #when — run the smoke with approvalRegistry explicitly undefined
+    // We simulate this by building the app directly with approvalRegistry absent.
+    const {buildOperatorServerInputs: buildInputs} = await import('../program.js')
+    const {loadAllowlistFromText: loadAllowlist} = await import('./auth/allowlist.js')
+    const {buildOperatorApp: buildApp} = await import('./server.js')
+
+    const noopLogger = {debug: () => undefined, info: () => undefined, warn: () => undefined, error: () => undefined}
+    const allowlist = loadAllowlist('42\n', noopLogger)
+    const operatorWebConfig = {
+      bindHost: '127.0.0.1',
+      bindPort: 18080,
+      publicOrigin: 'https://operator.smoke.test',
+      oauthClientId: 'stub-client-id',
+      oauthClientSecret: 'stub-client-secret',
+      oauthAllowedReturnPaths: ['/operator'] as readonly string[],
+      oauthStateTtlMs: 10 * 60 * 1000,
+      oauthMaxOutstandingAttemptsPerKey: 5,
+      csrfSecret: Buffer.from('test-csrf-secret-32-bytes-long!!', 'utf8').toString('base64url'),
+      allowlist,
+    }
+
+    const {deps, config} = buildInputs({
+      logger: noopLogger,
+      isShuttingDown: () => false,
+      denylistCache: makeStubDenylistCache(),
+      bindingsStore: makeStubBindingsStore(),
+      runObservationManager: makeStubRunObservationManager(),
+      runIndex: makeStubRunIndex(),
+      approvalRegistry: makeStubApprovalRegistry(),
+      launchWorkDeps: makeStubLaunchWorkDeps(),
+      operatorWebConfig,
+    })
+
+    // Override approvalRegistry to undefined to simulate the missing dep
+    const depsWithoutApproval = {...deps, approvalRegistry: undefined}
+    const app = buildApp(depsWithoutApproval, config)
+
+    // #then — approval routes are NOT registered
+    const seen = new Set<string>()
+    const routes = app.routes
+      .map((r: {method: string; path: string}) => ({method: r.method, path: r.path}))
+      .filter((r: {method: string; path: string}) => {
+        if (r.method === 'ALL' && r.path === '/*') return false
+        const key = `${r.method}:${r.path}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+
+    const routePaths = routes.map((r: {method: string; path: string}) => `${r.method}:${r.path}`)
+    expect(routePaths).not.toContain('GET:/operator/runs/:runId/approvals')
+    expect(routePaths).not.toContain('POST:/operator/runs/:runId/approvals/:requestId/decision')
   })
 })

--- a/packages/gateway/src/web/operator-route-smoke.test.ts
+++ b/packages/gateway/src/web/operator-route-smoke.test.ts
@@ -278,61 +278,48 @@ describe('runOperatorRouteSmoke — regression guard (non-vacuous)', () => {
     expect(exitCode).not.toBe(0)
   })
 
-  it('returns non-zero when approval routes are absent (approvalRegistry omitted)', async () => {
-    // #given — approvalRegistry flows through buildOperatorServerInputs; omitting it
-    // causes the helper to pass undefined to deps.approvalRegistry, and server.ts
-    // gates the approval routes on that dep being present.
-    // #when — run the smoke with approvalRegistry explicitly undefined
-    // We simulate this by building the app directly with approvalRegistry absent.
-    const {buildOperatorServerInputs: buildInputs} = await import('../program.js')
-    const {loadAllowlistFromText: loadAllowlist} = await import('./auth/allowlist.js')
-    const {buildOperatorApp: buildApp} = await import('./server.js')
-
-    const noopLogger = {debug: () => undefined, info: () => undefined, warn: () => undefined, error: () => undefined}
-    const allowlist = loadAllowlist('42\n', noopLogger)
-    const operatorWebConfig = {
-      bindHost: '127.0.0.1',
-      bindPort: 18080,
-      publicOrigin: 'https://operator.smoke.test',
-      oauthClientId: 'stub-client-id',
-      oauthClientSecret: 'stub-client-secret',
-      oauthAllowedReturnPaths: ['/operator'] as readonly string[],
-      oauthStateTtlMs: 10 * 60 * 1000,
-      oauthMaxOutstandingAttemptsPerKey: 5,
-      csrfSecret: Buffer.from('test-csrf-secret-32-bytes-long!!', 'utf8').toString('base64url'),
-      allowlist,
-    }
-
-    const {deps, config} = buildInputs({
-      logger: noopLogger,
-      isShuttingDown: () => false,
-      denylistCache: makeStubDenylistCache(),
-      bindingsStore: makeStubBindingsStore(),
-      runObservationManager: makeStubRunObservationManager(),
-      runIndex: makeStubRunIndex(),
-      approvalRegistry: makeStubApprovalRegistry(),
-      launchWorkDeps: makeStubLaunchWorkDeps(),
-      operatorWebConfig,
+  it('returns non-zero when approval routes are absent (approvalRegistryOverride: undefined)', async () => {
+    // #given — approvalRegistry flows through buildOperatorServerInputs; passing
+    // approvalRegistryOverride: undefined causes the helper to pass undefined to
+    // deps.approvalRegistry, and server.ts gates the approval routes on that dep being present.
+    // #when — route through runOperatorRouteSmoke with approvalRegistryOverride explicitly undefined
+    const exitCode = await runOperatorRouteSmoke({
+      approvalRegistryOverride: undefined,
     })
 
-    // Override approvalRegistry to undefined to simulate the missing dep
-    const depsWithoutApproval = {...deps, approvalRegistry: undefined}
-    const app = buildApp(depsWithoutApproval, config)
+    // #then — non-zero exit (approval routes absent)
+    expect(exitCode).not.toBe(0)
+  })
+})
 
-    // #then — approval routes are NOT registered
-    const seen = new Set<string>()
-    const routes = app.routes
-      .map((r: {method: string; path: string}) => ({method: r.method, path: r.path}))
-      .filter((r: {method: string; path: string}) => {
-        if (r.method === 'ALL' && r.path === '/*') return false
-        const key = `${r.method}:${r.path}`
-        if (seen.has(key)) return false
-        seen.add(key)
-        return true
-      })
+// ---------------------------------------------------------------------------
+// EXPECTED_OPERATOR_ROUTES drift-tie — asserts parity with server.test.ts
+// ---------------------------------------------------------------------------
 
-    const routePaths = routes.map((r: {method: string; path: string}) => `${r.method}:${r.path}`)
-    expect(routePaths).not.toContain('GET:/operator/runs/:runId/approvals')
-    expect(routePaths).not.toContain('POST:/operator/runs/:runId/approvals/:requestId/decision')
+describe('EXPECTED_OPERATOR_ROUTES — drift-tie with server.test.ts v1.4.0 route set', () => {
+  it('matches the expectedV14Routes set in server.test.ts (both lists must stay in sync)', () => {
+    // #given — the canonical v1.4.0 route set from the server.test.ts drift guard.
+    // If a route is added or removed, BOTH this list AND the server.test.ts
+    // expectedV14Routes set must be updated — this assertion enforces that.
+    const expectedV14Routes = new Set([
+      'GET:/operator/health',
+      'GET:/operator/auth/github/start',
+      'GET:/operator/auth/github/callback',
+      'POST:/operator/auth/logout',
+      'GET:/operator/session/csrf',
+      'GET:/operator/session',
+      'GET:/operator/repos',
+      'POST:/operator/runs',
+      'GET:/operator/runs/:runId/stream',
+      'POST:/operator/runs/:runId/approvals/:requestId/decision',
+      'GET:/operator/runs/:runId/approvals',
+    ])
+
+    // #when — normalize EXPECTED_OPERATOR_ROUTES to the same Set<string> shape
+    const smokeRouteSet = new Set(EXPECTED_OPERATOR_ROUTES.map(r => `${r.method}:${r.path}`))
+
+    // #then — the two lists are identical; adding/removing a route forces both to update
+    expect(smokeRouteSet).toEqual(expectedV14Routes)
+    expect(EXPECTED_OPERATOR_ROUTES).toHaveLength(expectedV14Routes.size)
   })
 })

--- a/packages/gateway/src/web/operator-route-smoke.test.ts
+++ b/packages/gateway/src/web/operator-route-smoke.test.ts
@@ -291,35 +291,3 @@ describe('runOperatorRouteSmoke — regression guard (non-vacuous)', () => {
     expect(exitCode).not.toBe(0)
   })
 })
-
-// ---------------------------------------------------------------------------
-// EXPECTED_OPERATOR_ROUTES drift-tie — asserts parity with server.test.ts
-// ---------------------------------------------------------------------------
-
-describe('EXPECTED_OPERATOR_ROUTES — drift-tie with server.test.ts v1.4.0 route set', () => {
-  it('matches the expectedV14Routes set in server.test.ts (both lists must stay in sync)', () => {
-    // #given — the canonical v1.4.0 route set from the server.test.ts drift guard.
-    // If a route is added or removed, BOTH this list AND the server.test.ts
-    // expectedV14Routes set must be updated — this assertion enforces that.
-    const expectedV14Routes = new Set([
-      'GET:/operator/health',
-      'GET:/operator/auth/github/start',
-      'GET:/operator/auth/github/callback',
-      'POST:/operator/auth/logout',
-      'GET:/operator/session/csrf',
-      'GET:/operator/session',
-      'GET:/operator/repos',
-      'POST:/operator/runs',
-      'GET:/operator/runs/:runId/stream',
-      'POST:/operator/runs/:runId/approvals/:requestId/decision',
-      'GET:/operator/runs/:runId/approvals',
-    ])
-
-    // #when — normalize EXPECTED_OPERATOR_ROUTES to the same Set<string> shape
-    const smokeRouteSet = new Set(EXPECTED_OPERATOR_ROUTES.map(r => `${r.method}:${r.path}`))
-
-    // #then — the two lists are identical; adding/removing a route forces both to update
-    expect(smokeRouteSet).toEqual(expectedV14Routes)
-    expect(EXPECTED_OPERATOR_ROUTES).toHaveLength(expectedV14Routes.size)
-  })
-})

--- a/packages/gateway/src/web/operator-route-smoke.test.ts
+++ b/packages/gateway/src/web/operator-route-smoke.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for the operator-route-smoke diagnostic.
+ *
+ * Covers:
+ *   - Happy path: all deps present → runOperatorRouteSmoke returns 0, all expected routes present.
+ *   - Regression guard (non-vacuous): listBindings absent → GET /operator/repos absent → returns non-zero.
+ *   - Regression guard: run-stream deps absent → GET /operator/runs/:runId/stream absent → returns non-zero.
+ *   - buildOperatorServerInputs parity: the helper produces deps that, fed to buildOperatorApp,
+ *     mount the same full route set as production.
+ *
+ * BDD comments: #given / #when / #then.
+ */
+
+import {Buffer} from 'node:buffer'
+import {describe, expect, it, vi} from 'vitest'
+
+import {buildOperatorServerInputs} from '../program.js'
+import {loadAllowlistFromText} from './auth/allowlist.js'
+import {runOperatorRouteSmoke} from './operator-route-smoke.js'
+import {buildOperatorApp} from './server.js'
+
+// ---------------------------------------------------------------------------
+// Helpers — minimal stubs for buildOperatorServerInputs
+// ---------------------------------------------------------------------------
+
+function makeStubLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+}
+
+function makeStubDenylistCache() {
+  return {
+    getDenylistState: async () => undefined,
+    isRepoDenied: () => false,
+  }
+}
+
+function makeStubBindingsStore() {
+  return {
+    createBinding: async () => ({success: false as const, error: new Error('stub')}),
+    getBindingByRepo: async () => ({success: true as const, data: null}),
+    getBindingByChannelId: async () => ({success: true as const, data: null}),
+    listBindings: async () => ({success: true as const, data: []}),
+  }
+}
+
+function makeStubRunObservationManager() {
+  return {
+    observe: async () => undefined,
+    observeOutput: () => undefined,
+    observeApproval: () => undefined,
+    subscribe: () => () => undefined,
+    abortSubscription: () => undefined,
+    shutdown: () => undefined,
+  }
+}
+
+function makeStubRunIndex() {
+  return {
+    register: () => undefined,
+    lookup: async () => undefined,
+  }
+}
+
+function makeStubApprovalRegistry() {
+  return {
+    handleDecision: async () => 'not-found' as const,
+    describePendingForScope: () => [],
+  }
+}
+
+function makeStubOperatorWebConfig() {
+  const noopLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+  return {
+    bindHost: '127.0.0.1',
+    bindPort: 18080,
+    publicOrigin: 'https://operator.smoke.test',
+    oauthClientId: 'stub-client-id',
+    oauthClientSecret: 'stub-client-secret',
+    oauthAllowedReturnPaths: ['/operator'] as readonly string[],
+    oauthStateTtlMs: 10 * 60 * 1000,
+    oauthMaxOutstandingAttemptsPerKey: 5,
+    csrfSecret: Buffer.from('test-csrf-secret-32-bytes-long!!', 'utf8').toString('base64url'),
+    allowlist: loadAllowlistFromText('42\n', noopLogger),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// buildOperatorServerInputs parity test
+// ---------------------------------------------------------------------------
+
+describe('buildOperatorServerInputs — parity with production wiring', () => {
+  it('produces deps that, fed to buildOperatorApp, mount the full operator route set', () => {
+    // #given — all program-scoped instances present (mirrors production)
+    const logger = makeStubLogger()
+    const denylistCache = makeStubDenylistCache()
+    const bindingsStore = makeStubBindingsStore()
+    const runObservationManager = makeStubRunObservationManager()
+    const runIndex = makeStubRunIndex()
+    const approvalRegistry = makeStubApprovalRegistry()
+    const operatorWebConfig = makeStubOperatorWebConfig()
+
+    // #when — build inputs via the shared helper
+    const {deps, config} = buildOperatorServerInputs({
+      logger,
+      isShuttingDown: () => false,
+      denylistCache,
+      bindingsStore,
+      runObservationManager,
+      runIndex,
+      approvalRegistry,
+      operatorWebConfig,
+    })
+
+    // #and — build the app (no port bind)
+    const app = buildOperatorApp(deps, config)
+
+    // #then — extract unique logical routes
+    const seen = new Set<string>()
+    const routes = app.routes
+      .map((r: {method: string; path: string}) => ({method: r.method, path: r.path}))
+      .filter((r: {method: string; path: string}) => {
+        if (r.method === 'ALL' && r.path === '/*') return false
+        const key = `${r.method}:${r.path}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+
+    const routeSet = new Set(routes.map((r: {method: string; path: string}) => `${r.method}:${r.path}`))
+
+    // All expected operator routes must be present
+    expect(routeSet).toContain('GET:/operator/health')
+    expect(routeSet).toContain('GET:/operator/auth/github/start')
+    expect(routeSet).toContain('GET:/operator/auth/github/callback')
+    expect(routeSet).toContain('POST:/operator/auth/logout')
+    expect(routeSet).toContain('GET:/operator/session/csrf')
+    expect(routeSet).toContain('GET:/operator/session')
+    expect(routeSet).toContain('GET:/operator/repos')
+    expect(routeSet).toContain('GET:/operator/runs/:runId/stream')
+    expect(routeSet).toContain('GET:/operator/runs/:runId/approvals')
+    expect(routeSet).toContain('POST:/operator/runs/:runId/approvals/:requestId/decision')
+  })
+
+  it('omitting listBindings from bindingsStore causes GET /operator/repos to be absent (regression guard)', () => {
+    // #given — bindingsStore WITHOUT listBindings (simulates the #1001 class of bug)
+    const logger = makeStubLogger()
+    const denylistCache = makeStubDenylistCache()
+    // Deliberately omit listBindings from the store to simulate a wiring gap
+    const bindingsStoreWithoutList = {
+      createBinding: async () => ({success: false as const, error: new Error('stub')}),
+      getBindingByRepo: async () => ({success: true as const, data: null}),
+      getBindingByChannelId: async () => ({success: true as const, data: null}),
+      // listBindings intentionally absent
+    }
+    const runObservationManager = makeStubRunObservationManager()
+    const runIndex = makeStubRunIndex()
+    const approvalRegistry = makeStubApprovalRegistry()
+    const operatorWebConfig = makeStubOperatorWebConfig()
+
+    // #when — build inputs with a store that has no listBindings
+    const {deps, config} = buildOperatorServerInputs({
+      logger,
+      isShuttingDown: () => false,
+      denylistCache,
+      bindingsStore: bindingsStoreWithoutList,
+      runObservationManager,
+      runIndex,
+      approvalRegistry,
+      operatorWebConfig,
+    })
+
+    const app = buildOperatorApp(deps, config)
+
+    // #then — GET /operator/repos is NOT registered (the gate checks deps.listBindings !== undefined)
+    const seen = new Set<string>()
+    const routes = app.routes
+      .map((r: {method: string; path: string}) => ({method: r.method, path: r.path}))
+      .filter((r: {method: string; path: string}) => {
+        if (r.method === 'ALL' && r.path === '/*') return false
+        const key = `${r.method}:${r.path}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+
+    const routePaths = routes.map((r: {method: string; path: string}) => `${r.method}:${r.path}`)
+    expect(routePaths).not.toContain('GET:/operator/repos')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runOperatorRouteSmoke — happy path
+// ---------------------------------------------------------------------------
+
+describe('runOperatorRouteSmoke — happy path', () => {
+  it('returns 0 when all expected operator routes are registered', async () => {
+    // #given — no special setup needed; the smoke builds its own stubs internally
+
+    // #when
+    const exitCode = await runOperatorRouteSmoke()
+
+    // #then — all routes present, exit 0
+    expect(exitCode).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runOperatorRouteSmoke — regression guard (non-vacuous)
+// ---------------------------------------------------------------------------
+
+describe('runOperatorRouteSmoke — regression guard', () => {
+  it('returns non-zero and names the missing route when GET /operator/repos is absent (listBindings omitted)', async () => {
+    // #given — inject a custom deps builder that omits listBindings
+    // The smoke accepts an optional override for the bindingsStore to enable this test.
+    const bindingsStoreWithoutList = {
+      createBinding: async () => ({success: false as const, error: new Error('stub')}),
+      getBindingByRepo: async () => ({success: true as const, data: null}),
+      getBindingByChannelId: async () => ({success: true as const, data: null}),
+      // listBindings intentionally absent — simulates the #1001 wiring gap
+    }
+
+    // #when — run the smoke with a store that has no listBindings
+    const exitCode = await runOperatorRouteSmoke({
+      bindingsStoreOverride: bindingsStoreWithoutList,
+    })
+
+    // #then — non-zero exit (route absent)
+    expect(exitCode).not.toBe(0)
+  })
+
+  it('returns non-zero when run-stream deps are absent (runObservationManager omitted)', async () => {
+    // #given — inject a custom deps builder that omits runObservationManager
+    // #when
+    const exitCode = await runOperatorRouteSmoke({
+      runObservationManagerOverride: undefined,
+    })
+
+    // #then — non-zero exit (GET /operator/runs/:runId/stream absent)
+    expect(exitCode).not.toBe(0)
+  })
+})

--- a/packages/gateway/src/web/operator-route-smoke.ts
+++ b/packages/gateway/src/web/operator-route-smoke.ts
@@ -1,0 +1,253 @@
+/**
+ * Offline operator-route registration diagnostic.
+ *
+ * Builds the operator Hono app via buildOperatorApp(deps, config) using the
+ * same deps-construction path as production (buildOperatorServerInputs), then
+ * asserts the expected route inventory is present in app.routes.
+ *
+ * This diagnostic catches the class of bug where a route is silently unmounted
+ * because a required dep was not wired: a missing dep causes the route to be
+ * absent from app.routes, which fails the assertion and returns a non-zero exit
+ * code naming the absent route.
+ *
+ * No port is bound, no network is required, no real S3/Discord/GitHub credentials
+ * are needed. The route mount gates only check dep presence/shape, not liveness.
+ *
+ * SECURITY: This module must NEVER be imported from any request handler, Discord
+ * command, or HTTP route. It is an offline diagnostic only. Importing it from a
+ * request path would violate the offline-only contract (it constructs stubs that
+ * are not safe for production use).
+ *
+ * Exit codes:
+ *   0 — all expected operator routes are registered
+ *   1 — one or more expected routes are absent (names the missing routes)
+ */
+
+import {Buffer} from 'node:buffer'
+
+import {buildOperatorServerInputs} from '../program.js'
+import {loadAllowlistFromText} from './auth/allowlist.js'
+import {buildOperatorApp} from './server.js'
+
+// ---------------------------------------------------------------------------
+// Expected route inventory
+//
+// These are the exact method+path strings Hono records for the full operator
+// route set when all deps are present. Verified against server.ts route
+// registrations and the v1.4.0 drift-guard test in server.test.ts.
+// ---------------------------------------------------------------------------
+
+const EXPECTED_OPERATOR_ROUTES: readonly {readonly method: string; readonly path: string}[] = [
+  {method: 'GET', path: '/operator/health'},
+  {method: 'GET', path: '/operator/auth/github/start'},
+  {method: 'GET', path: '/operator/auth/github/callback'},
+  {method: 'POST', path: '/operator/auth/logout'},
+  {method: 'GET', path: '/operator/session/csrf'},
+  {method: 'GET', path: '/operator/session'},
+  {method: 'GET', path: '/operator/repos'},
+  {method: 'POST', path: '/operator/runs'},
+  {method: 'GET', path: '/operator/runs/:runId/stream'},
+  {method: 'POST', path: '/operator/runs/:runId/approvals/:requestId/decision'},
+  {method: 'GET', path: '/operator/runs/:runId/approvals'},
+]
+
+// ---------------------------------------------------------------------------
+// Stub factories — realistic-but-offline instances for the diagnostic
+// ---------------------------------------------------------------------------
+
+function makeNoopLogger() {
+  return {
+    debug: (_ctx: Record<string, unknown>, _msg: string) => undefined,
+    info: (_ctx: Record<string, unknown>, _msg: string) => undefined,
+    warn: (_ctx: Record<string, unknown>, _msg: string) => undefined,
+    error: (_ctx: Record<string, unknown>, _msg: string) => undefined,
+  }
+}
+
+function makeStubDenylistCache() {
+  return {
+    getDenylistState: async () => undefined,
+    isRepoDenied: () => false,
+  }
+}
+
+function makeStubBindingsStore() {
+  return {
+    createBinding: async () => ({success: false as const, error: new Error('stub')}),
+    getBindingByRepo: async () => ({success: true as const, data: null}),
+    getBindingByChannelId: async () => ({success: true as const, data: null}),
+    listBindings: async () => ({success: true as const, data: []}),
+  }
+}
+
+function makeStubRunObservationManager() {
+  return {
+    observe: async () => undefined,
+    observeOutput: () => undefined,
+    observeApproval: () => undefined,
+    subscribe: () => () => undefined,
+    abortSubscription: () => undefined,
+    shutdown: () => undefined,
+  }
+}
+
+function makeStubRunIndex() {
+  return {
+    register: () => undefined,
+    lookup: async () => undefined,
+  }
+}
+
+function makeStubApprovalRegistry() {
+  return {
+    handleDecision: async () => 'not-found' as const,
+    describePendingForScope: () => [],
+  }
+}
+
+function makeStubLaunchWorkDeps() {
+  // Registration only checks `deps.launchWorkDeps !== undefined`; the actual
+  // shape is not inspected at construction time.
+  return {} as NonNullable<Parameters<typeof buildOperatorApp>[0]['launchWorkDeps']>
+}
+
+// ---------------------------------------------------------------------------
+// Options — allow test overrides for regression-guard tests
+// ---------------------------------------------------------------------------
+
+export interface OperatorRouteSmokeOptions {
+  /**
+   * Override the bindingsStore passed to buildOperatorServerInputs.
+   * Used in regression-guard tests to simulate a store without listBindings.
+   */
+  readonly bindingsStoreOverride?: Parameters<typeof buildOperatorServerInputs>[0]['bindingsStore']
+  /**
+   * Override the runObservationManager passed to buildOperatorServerInputs.
+   * Pass undefined to simulate a missing run-observation manager (run-stream absent).
+   */
+  readonly runObservationManagerOverride?:
+    | Parameters<typeof buildOperatorServerInputs>[0]['runObservationManager']
+    | undefined
+  /**
+   * Whether to suppress log output. Defaults to false (logs to stdout).
+   */
+  readonly silent?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostic runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the operator-route registration diagnostic.
+ *
+ * Builds the operator Hono app via the production deps-construction path
+ * (buildOperatorServerInputs → buildOperatorApp), reads app.routes, and
+ * asserts the expected operator route set is present.
+ *
+ * Returns an exit code:
+ *   0 — all expected routes registered
+ *   1 — one or more routes absent (logs which ones)
+ *
+ * Never calls process.exit — the caller decides.
+ */
+export async function runOperatorRouteSmoke(options?: OperatorRouteSmokeOptions): Promise<number> {
+  const silent = options?.silent === true
+  const log = (msg: string) => {
+    if (silent === false) {
+      // eslint-disable-next-line no-console
+      console.log(msg)
+    }
+  }
+
+  // Build a stub allowlist that authorizes a single numeric user ID.
+  // The allowlist is required for the browser guard (and thus all privileged routes).
+  const noopLogger = makeNoopLogger()
+  const allowlist = loadAllowlistFromText('42\n', noopLogger)
+
+  // Build a stub operator web config — values only need to pass the URL/host
+  // validation in buildOperatorApp (publicOrigin must be https://).
+  const operatorWebConfig = {
+    bindHost: '127.0.0.1',
+    bindPort: 18080,
+    publicOrigin: 'https://operator.smoke.test',
+    oauthClientId: 'stub-client-id',
+    oauthClientSecret: 'stub-client-secret',
+    oauthAllowedReturnPaths: ['/operator'] as readonly string[],
+    oauthStateTtlMs: 10 * 60 * 1000,
+    oauthMaxOutstandingAttemptsPerKey: 5,
+    csrfSecret: Buffer.from('operator-smoke-csrf-secret-32b!!', 'utf8').toString('base64url'),
+    allowlist,
+  }
+
+  // Resolve the bindingsStore — use the override if provided, else the default stub.
+  const bindingsStore = options?.bindingsStoreOverride ?? makeStubBindingsStore()
+
+  // Resolve the runObservationManager — use the override if provided.
+  // When the override is explicitly undefined, the run-stream route will not register.
+  const hasRunObservationManagerOverride = options !== undefined && 'runObservationManagerOverride' in options
+  const runObservationManager = hasRunObservationManagerOverride
+    ? options.runObservationManagerOverride
+    : makeStubRunObservationManager()
+
+  // Build the operator server inputs via the shared production helper.
+  // This is the seam that makes the diagnostic catch wiring gaps: if a dep is
+  // dropped from buildOperatorServerInputs, both production and this diagnostic
+  // lose it, so the route assertion below fails.
+  const {deps: baseDeps, config} = buildOperatorServerInputs({
+    logger: noopLogger,
+    isShuttingDown: () => false,
+    denylistCache: makeStubDenylistCache(),
+    bindingsStore,
+    runObservationManager: runObservationManager ?? makeStubRunObservationManager(),
+    runIndex: makeStubRunIndex(),
+    approvalRegistry: makeStubApprovalRegistry(),
+    operatorWebConfig,
+  })
+
+  // Augment deps with the launch route deps (getBindingByRepo + launchWorkDeps)
+  // so POST /operator/runs is also registered. These are not part of
+  // buildOperatorServerInputs because they are not program-scoped instances
+  // in the same way — they are derived from the bindings store.
+  const deps = {
+    ...baseDeps,
+    getBindingByRepo: bindingsStore.getBindingByRepo,
+    launchWorkDeps: makeStubLaunchWorkDeps(),
+    // When runObservationManager is explicitly overridden to undefined, remove it
+    // from deps so the run-stream route gate fails (simulating a missing dep).
+    ...(hasRunObservationManagerOverride && runObservationManager === undefined
+      ? {runObservationManager: undefined}
+      : {}),
+  }
+
+  // Build the app without binding a port.
+  const app = buildOperatorApp(deps, config)
+
+  // Extract unique logical routes (exclude global middleware ALL /* entries).
+  const seen = new Set<string>()
+  const registeredRoutes = app.routes
+    .map((r: {method: string; path: string}) => ({method: r.method, path: r.path}))
+    .filter((r: {method: string; path: string}) => {
+      if (r.method === 'ALL' && r.path === '/*') return false
+      const key = `${r.method}:${r.path}`
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+
+  const registeredSet = new Set(registeredRoutes.map((r: {method: string; path: string}) => `${r.method}:${r.path}`))
+
+  // Assert the expected route inventory.
+  const missingRoutes = EXPECTED_OPERATOR_ROUTES.filter(r => registeredSet.has(`${r.method}:${r.path}`) === false)
+
+  if (missingRoutes.length > 0) {
+    for (const r of missingRoutes) {
+      log(`operator-route-smoke: MISSING route ${r.method} ${r.path}`)
+    }
+    log(`operator-route-smoke: FAIL — ${missingRoutes.length} route(s) absent from app.routes`)
+    return 1
+  }
+
+  log(`operator-route-smoke: all ${EXPECTED_OPERATOR_ROUTES.length} operator routes registered`)
+  return 0
+}

--- a/packages/gateway/src/web/operator-route-smoke.ts
+++ b/packages/gateway/src/web/operator-route-smoke.ts
@@ -37,7 +37,7 @@ import {buildOperatorApp} from './server.js'
 // registrations and the v1.4.0 drift-guard test in server.test.ts.
 // ---------------------------------------------------------------------------
 
-const EXPECTED_OPERATOR_ROUTES: readonly {readonly method: string; readonly path: string}[] = [
+export const EXPECTED_OPERATOR_ROUTES: readonly {readonly method: string; readonly path: string}[] = [
   {method: 'GET', path: '/operator/health'},
   {method: 'GET', path: '/operator/auth/github/start'},
   {method: 'GET', path: '/operator/auth/github/callback'},
@@ -124,10 +124,18 @@ export interface OperatorRouteSmokeOptions {
   /**
    * Override the runObservationManager passed to buildOperatorServerInputs.
    * Pass undefined to simulate a missing run-observation manager (run-stream absent).
+   * Because runObservationManager is optional in BuildOperatorServerInputs, passing
+   * undefined here flows through the helper and causes the run-stream route to be absent.
    */
   readonly runObservationManagerOverride?:
     | Parameters<typeof buildOperatorServerInputs>[0]['runObservationManager']
     | undefined
+  /**
+   * Override the launchWorkDeps passed to buildOperatorServerInputs.
+   * Used in regression-guard tests to simulate a missing launch dep (POST /operator/runs absent).
+   * When omitted, the default stub is used.
+   */
+  readonly launchWorkDepsOverride?: Parameters<typeof buildOperatorServerInputs>[0]['launchWorkDeps'] | undefined
   /**
    * Whether to suppress log output. Defaults to false (logs to stdout).
    */
@@ -184,41 +192,43 @@ export async function runOperatorRouteSmoke(options?: OperatorRouteSmokeOptions)
   const bindingsStore = options?.bindingsStoreOverride ?? makeStubBindingsStore()
 
   // Resolve the runObservationManager — use the override if provided.
-  // When the override is explicitly undefined, the run-stream route will not register.
+  // When the override is explicitly undefined, the run-stream route will not register
+  // because buildOperatorServerInputs passes it through to deps.runObservationManager,
+  // and server.ts gates GET /operator/runs/:runId/stream on that dep being present.
   const hasRunObservationManagerOverride = options !== undefined && 'runObservationManagerOverride' in options
   const runObservationManager = hasRunObservationManagerOverride
     ? options.runObservationManagerOverride
     : makeStubRunObservationManager()
 
+  // Resolve launchWorkDeps — use the override if provided, else the default stub.
+  // When the override is explicitly undefined, POST /operator/runs will not register
+  // because buildOperatorServerInputs passes it through to deps.launchWorkDeps,
+  // and server.ts gates POST /operator/runs on that dep being present.
+  const hasLaunchWorkDepsOverride = options !== undefined && 'launchWorkDepsOverride' in options
+  const launchWorkDeps = hasLaunchWorkDepsOverride ? options.launchWorkDepsOverride : makeStubLaunchWorkDeps()
+
   // Build the operator server inputs via the shared production helper.
   // This is the seam that makes the diagnostic catch wiring gaps: if a dep is
   // dropped from buildOperatorServerInputs, both production and this diagnostic
   // lose it, so the route assertion below fails.
-  const {deps: baseDeps, config} = buildOperatorServerInputs({
+  //
+  // getBindingByRepo and launchWorkDeps flow through the helper (not injected
+  // after) — so if a future edit drops either from the helper output, the route
+  // assertion below catches it and the diagnostic exits non-zero.
+  const {deps, config} = buildOperatorServerInputs({
     logger: noopLogger,
     isShuttingDown: () => false,
     denylistCache: makeStubDenylistCache(),
     bindingsStore,
-    runObservationManager: runObservationManager ?? makeStubRunObservationManager(),
+    runObservationManager,
     runIndex: makeStubRunIndex(),
     approvalRegistry: makeStubApprovalRegistry(),
+    // launchWorkDeps flows through the helper so the route gate in server.ts
+    // sees the same value as production. When undefined (regression test), the
+    // helper passes undefined to deps.launchWorkDeps and POST /operator/runs is absent.
+    launchWorkDeps,
     operatorWebConfig,
   })
-
-  // Augment deps with the launch route deps (getBindingByRepo + launchWorkDeps)
-  // so POST /operator/runs is also registered. These are not part of
-  // buildOperatorServerInputs because they are not program-scoped instances
-  // in the same way — they are derived from the bindings store.
-  const deps = {
-    ...baseDeps,
-    getBindingByRepo: bindingsStore.getBindingByRepo,
-    launchWorkDeps: makeStubLaunchWorkDeps(),
-    // When runObservationManager is explicitly overridden to undefined, remove it
-    // from deps so the run-stream route gate fails (simulating a missing dep).
-    ...(hasRunObservationManagerOverride && runObservationManager === undefined
-      ? {runObservationManager: undefined}
-      : {}),
-  }
 
   // Build the app without binding a port.
   const app = buildOperatorApp(deps, config)
@@ -236,6 +246,13 @@ export async function runOperatorRouteSmoke(options?: OperatorRouteSmokeOptions)
     })
 
   const registeredSet = new Set(registeredRoutes.map((r: {method: string; path: string}) => `${r.method}:${r.path}`))
+
+  // Guard against an accidentally-emptied expected-routes list — an empty list
+  // would pass vacuously (zero missing routes) and provide no assurance.
+  if (EXPECTED_OPERATOR_ROUTES.length === 0) {
+    log('operator-route-smoke: FAIL — EXPECTED_OPERATOR_ROUTES is empty (no routes to assert)')
+    return 1
+  }
 
   // Assert the expected route inventory.
   const missingRoutes = EXPECTED_OPERATOR_ROUTES.filter(r => registeredSet.has(`${r.method}:${r.path}`) === false)

--- a/packages/gateway/src/web/operator-route-smoke.ts
+++ b/packages/gateway/src/web/operator-route-smoke.ts
@@ -137,6 +137,13 @@ export interface OperatorRouteSmokeOptions {
    */
   readonly launchWorkDepsOverride?: Parameters<typeof buildOperatorServerInputs>[0]['launchWorkDeps'] | undefined
   /**
+   * Override the approvalRegistry passed to buildOperatorServerInputs.
+   * Pass undefined to simulate a missing approval registry (approval routes absent).
+   * Because approvalRegistry is optional in BuildOperatorServerInputs, passing
+   * undefined here flows through the helper and causes the approval routes to be absent.
+   */
+  readonly approvalRegistryOverride?: Parameters<typeof buildOperatorServerInputs>[0]['approvalRegistry']
+  /**
    * Whether to suppress log output. Defaults to false (logs to stdout).
    */
   readonly silent?: boolean
@@ -207,6 +214,13 @@ export async function runOperatorRouteSmoke(options?: OperatorRouteSmokeOptions)
   const hasLaunchWorkDepsOverride = options !== undefined && 'launchWorkDepsOverride' in options
   const launchWorkDeps = hasLaunchWorkDepsOverride ? options.launchWorkDepsOverride : makeStubLaunchWorkDeps()
 
+  // Resolve approvalRegistry — use the override if provided, else the default stub.
+  // When the override is explicitly undefined, the approval routes will not register
+  // because buildOperatorServerInputs passes it through to deps.approvalRegistry,
+  // and server.ts gates the approval routes on that dep being present.
+  const hasApprovalRegistryOverride = options !== undefined && 'approvalRegistryOverride' in options
+  const approvalRegistry = hasApprovalRegistryOverride ? options.approvalRegistryOverride : makeStubApprovalRegistry()
+
   // Build the operator server inputs via the shared production helper.
   // This is the seam that makes the diagnostic catch wiring gaps: if a dep is
   // dropped from buildOperatorServerInputs, both production and this diagnostic
@@ -222,7 +236,10 @@ export async function runOperatorRouteSmoke(options?: OperatorRouteSmokeOptions)
     bindingsStore,
     runObservationManager,
     runIndex: makeStubRunIndex(),
-    approvalRegistry: makeStubApprovalRegistry(),
+    // approvalRegistry flows through the helper so the route gate in server.ts
+    // sees the same value as production. When undefined (regression test), the
+    // helper passes undefined to deps.approvalRegistry and the approval routes are absent.
+    approvalRegistry,
     // launchWorkDeps flows through the helper so the route gate in server.ts
     // sees the same value as production. When undefined (regression test), the
     // helper passes undefined to deps.launchWorkDeps and POST /operator/runs is absent.

--- a/packages/gateway/src/web/server.test.ts
+++ b/packages/gateway/src/web/server.test.ts
@@ -30,6 +30,7 @@ import {loadAllowlistFromText} from './auth/allowlist.js'
 import {generateCsrfToken} from './auth/csrf.js'
 import {createInMemoryStateStore} from './auth/github.js'
 import {createInMemorySessionStore, SESSION_COOKIE_NAME} from './auth/session.js'
+import {EXPECTED_OPERATOR_ROUTES} from './operator-route-smoke.js'
 import {isPrivilegedRoute, isPublicCrossSiteRoute, isPublicRoute} from './operator-route.js'
 import {buildOperatorApp, createOperatorServer} from './server.js'
 
@@ -1784,22 +1785,11 @@ describe('buildOperatorApp — v1.4.0 full route-registration smoke (drift guard
     const routes = extractRoutes(app)
 
     // #then — exact v1.4.0 set (order-independent)
-    // If this assertion fails, a route was added or removed. Update BOTH this test
-    // AND the deploy/README "Operator API surface" table to keep them in sync.
+    // If this assertion fails, a route was added or removed. Update EXPECTED_OPERATOR_ROUTES
+    // in operator-route-smoke.ts (the single canonical source) AND the deploy/README
+    // "Operator API surface" table to keep them in sync.
     const routeSet = new Set(routes.map(r => `${r.method}:${r.path}`))
-    const expectedV14Routes = new Set([
-      'GET:/operator/health',
-      'GET:/operator/auth/github/start',
-      'GET:/operator/auth/github/callback',
-      'POST:/operator/auth/logout',
-      'GET:/operator/session/csrf',
-      'GET:/operator/session',
-      'GET:/operator/repos',
-      'POST:/operator/runs',
-      'GET:/operator/runs/:runId/stream',
-      'POST:/operator/runs/:runId/approvals/:requestId/decision',
-      'GET:/operator/runs/:runId/approvals',
-    ])
+    const expectedV14Routes = new Set(EXPECTED_OPERATOR_ROUTES.map(r => `${r.method}:${r.path}`))
 
     expect(routeSet).toEqual(expectedV14Routes)
     expect(routes).toHaveLength(expectedV14Routes.size)


### PR DESCRIPTION
Closes the operable tail of the operator web surface: an image-level guard that the operator routes actually register in the shipped gateway, plus a consolidated operator runbook. Along the way it mounts two operator routes that were silently unregistered in production.

## The route-registration smoke

`POST /operator/runs` returned 404 in production because the gateway boot path never wired `getBindingByRepo`/`launchWorkDeps` (fixed separately in #1030). That class of bug — a route gated on a runtime dep the program forgets to pass — is invisible to CI today: the existing image smoke only asserts config-load, and HTTP-probing the operator surface in CI is infeasible (the operator server starts only after the S3 self-test and Discord registration, both of which fail with fake credentials).

This adds an offline `operator-route-smoke` subcommand (`node dist/main.mjs operator-route-smoke`) that builds the operator app through the **same** `buildOperatorServerInputs` helper production uses, reads the registered route table, and asserts the full operator route inventory — no server bind, no credentials. The operator deps construction was extracted into that helper so production and the diagnostic share one wiring path: if a future edit drops a dep, the route goes absent and the smoke fails naming it. CI runs the diagnostic in the built image.

## Mounts the operator approval routes

Extracting the wiring surfaced that `approvalRegistry` was created in program scope but never passed into the operator server deps, so `POST /operator/runs/:runId/approvals/:requestId/decision` and `GET /operator/runs/:runId/approvals` were also unregistered in production. The helper now wires it, mounting both routes.

## Operator runbook

`deploy/README.md` gains a consolidated Operator Web Surface section: what the surface is, the `GATEWAY_OPERATOR_*` env that enables it, a link to the route table, the deny-key backfill step, and cross-links to the operator pattern docs — without duplicating them.

## Verification

The smoke is non-vacuous: dropping `getBindingByRepo`, `launchWorkDeps`, `approvalRegistry`, `listBindings`, or `runObservationManager` from the helper makes the corresponding route absent and the diagnostic fail. The route-inventory assertion is tied to the existing v1.4.0 registration list so the two can't drift. Built image smoke reports `all 11 operator routes registered`. Gateway-only; 2689 tests, type-check, lint, and the image smoke all green.

Advances #907 (operator web surface Unit 8 tail).