### PR TITLE
fix(gateway): dedupe operator listing fanout

### DIFF
--- a/packages/gateway/src/web/operator/repos-route.test.ts
+++ b/packages/gateway/src/web/operator/repos-route.test.ts
@@ -7,8 +7,9 @@
  *   3. Resolve OAuth token via session store
  *   4. listBindings() — all bound repos
  *   5. filterDeniedRecords() — drop denylisted repos BEFORE any authz call
- *   6. checkRepoAuthz() per surviving binding — keep only authorized repos
- *   7. Cap at MAX_REPOS_PER_LISTING; map to RepoSummary[]; return 200
+ *   6. Dedup by owner/repo, then cap before the authz fan-out
+ *   7. checkRepoAuthz() per surviving binding — keep only authorized repos
+ *   8. Map to RepoSummary[]; return 200
  *
  * Security invariants:
  *   - Denylisted repos are dropped before checkRepoAuthz is called (no oracle).
@@ -325,6 +326,25 @@ describe('GET /operator/repos — error paths', () => {
     expect(Array.isArray(body)).toBe(false)
   })
 
+  it('returns coarse 503 when listBindings throws (not just success:false)', async () => {
+    // #given — listBindings rejects (unexpected throw, not a Result failure)
+    const deps = makeBaseDeps({
+      listBindings: vi.fn(async () => {
+        throw new Error('unexpected network crash')
+      }),
+    })
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await app.fetch(new Request('http://localhost/operator/repos'))
+
+    // #then — coarse 503; body is not an array
+    expect(res.status).toBe(503)
+    const body = (await res.json()) as {error?: string}
+    expect(typeof body.error).toBe('string')
+    expect(Array.isArray(body)).toBe(false)
+  })
+
   it('logs the store error without including the token', async () => {
     // #given listBindings fails
     const warnSpy = vi.fn()
@@ -362,6 +382,44 @@ describe('GET /operator/repos — error paths', () => {
     expect(res.status).not.toBe(200)
     const body = (await res.json()) as {error?: string}
     expect(typeof body.error).toBe('string')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Degraded path — authz throws for one repo, succeeds for the other
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/repos — checkRepoAuthz throws (degraded path)', () => {
+  it('silently omits a repo when checkRepoAuthz throws — other repos still returned', async () => {
+    // #given — 2 bindings; checkRepoAuthz throws for broken-authz, succeeds for good-repo
+    const bindings = [makeBinding('acme', 'broken-authz'), makeBinding('acme', 'good-repo')]
+
+    // authzFetch throws for broken-authz, returns 200 for good-repo
+    const authzFetch = vi.fn(async (url: string | URL | Request) => {
+      const urlStr = String(url)
+      if (urlStr.includes('broken-authz')) {
+        throw new Error('GitHub API timeout')
+      }
+      return new Response('{}', {status: 200})
+    }) as typeof globalThis.fetch
+
+    const deps = makeBaseDeps({
+      listBindings: vi.fn(async () => ({success: true as const, data: bindings})),
+      repoAuthzDeps: makeRepoAuthzDeps(new Set(['acme/good-repo']), {fetch: authzFetch}),
+    })
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await app.fetch(new Request('http://localhost/operator/repos'))
+
+    // #then — 200 (not 500); broken-authz omitted; good-repo present
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {repo: string}[]
+    // Response is an array (not an error object)
+    expect(Array.isArray(body)).toBe(true)
+    const repos = body.map(r => r.repo)
+    expect(repos).toContain('good-repo')
+    expect(repos).not.toContain('broken-authz')
   })
 })
 
@@ -468,6 +526,77 @@ describe('GET /operator/repos — contract', () => {
 
     // #then
     expect(res.headers.get('cache-control')).toBe('no-store, private')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fix — dedup bindings by owner/repo BEFORE the authz fan-out cap
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/repos — dedup before authz cap', () => {
+  it('reaches the 101st unique repo when two earlier bindings share the same owner/repo', async () => {
+    // #given — 101 bindings: 2 share acme/shared (different channelIds), 98 distinct repos,
+    // plus acme/last-unique. After dedup: 100 distinct repos, all within the cap of 100.
+    // Without dedup-before-cap, last-unique (index 100) would be dropped by the cap.
+
+    const sharedBindingA = makeBinding('acme', 'shared', {channelId: 'chan-shared-A'})
+    const sharedBindingB = makeBinding('acme', 'shared', {channelId: 'chan-shared-B'})
+    // 98 distinct repos (indices 2..99 in the original list)
+    const distinctBindings = Array.from({length: 98}, (_, i) =>
+      makeBinding('acme', `repo-${i + 2}`, {channelId: `chan-repo-${i + 2}`}),
+    )
+    const lastUniqueBinding = makeBinding('acme', 'last-unique', {channelId: 'chan-last-unique'})
+
+    const bindings = [sharedBindingA, sharedBindingB, ...distinctBindings, lastUniqueBinding]
+
+    // All repos are authorized
+    const authorizedRepos = new Set<string>([
+      'acme/shared',
+      ...distinctBindings.map(b => `${b.owner}/${b.repo}`),
+      'acme/last-unique',
+    ])
+
+    // Track which repos authz was called for
+    const authzFetch = vi.fn(async (url: string | URL | Request) => {
+      const urlStr = String(url)
+      const match = /\/repos\/([^/]+)\/([^/]+)$/.exec(urlStr)
+      if (match !== null) {
+        const key = `${match[1]}/${match[2]}`
+        const status = authorizedRepos.has(key) ? 200 : 404
+        return new Response('{}', {status})
+      }
+      return new Response('{}', {status: 404})
+    }) as typeof globalThis.fetch
+
+    const deps = makeBaseDeps({
+      listBindings: vi.fn(async () => ({success: true as const, data: bindings})),
+      repoAuthzDeps: makeRepoAuthzDeps(authorizedRepos, {fetch: authzFetch}),
+    })
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await app.fetch(new Request('http://localhost/operator/repos'))
+
+    // #then — status 200
+    expect(res.status).toBe(200)
+
+    // authz was called for acme/last-unique (dedup-before-cap allows it through)
+    const authzCalls = (authzFetch as ReturnType<typeof vi.fn>).mock.calls as [string | URL | Request][]
+    const calledUrls = authzCalls.map(([url]) => String(url))
+    expect(calledUrls.some(u => u.includes('last-unique'))).toBe(true)
+
+    // response includes last-unique
+    const body = (await res.json()) as {owner: string; repo: string}[]
+    const repoNames = body.map(r => r.repo)
+    expect(repoNames).toContain('last-unique')
+
+    // acme/shared appears exactly once in the response
+    const sharedEntries = body.filter(r => r.owner === 'acme' && r.repo === 'shared')
+    expect(sharedEntries).toHaveLength(1)
+
+    // acme/shared was authz-checked exactly once
+    const sharedAuthzCalls = calledUrls.filter(u => u.endsWith('/repos/acme/shared'))
+    expect(sharedAuthzCalls).toHaveLength(1)
   })
 })
 

--- a/packages/gateway/src/web/operator/repos-route.ts
+++ b/packages/gateway/src/web/operator/repos-route.ts
@@ -11,15 +11,16 @@
  *   3. Resolve OAuth token via session store
  *   4. listBindings() — enumerate all bound repos
  *   5. filterDeniedRecords() — drop denylisted repos BEFORE any authz call
- *   6. checkRepoAuthz() per surviving binding — keep only authorized repos
- *   7. Cap at MAX_REPOS_PER_LISTING; map to RepoSummary[]; return 200
+ *   6. Dedup by owner/repo, then cap before the authz fan-out
+ *   7. checkRepoAuthz() per surviving binding — keep only authorized repos
+ *   8. Map to RepoSummary[]; return 200
  *
  * Security invariants:
  *   - Denylisted repos are dropped before checkRepoAuthz is called (no oracle).
  *   - Unauthorized repos are silently omitted (no oracle).
  *   - Store errors return a coarse error; no partial list leaks.
  *   - Response carries no deny-keys, workspacePath, channelId, or internal IDs.
- *   - Result is capped at MAX_REPOS_PER_LISTING (no pagination machinery).
+ *   - Result is capped at MAX_REPOS_PER_LISTING distinct owner/repo pairs (no pagination machinery).
  *   - Token is never logged.
  *   - Rate limit is operator-keyed (not socket-keyed) to prevent OAuth-budget
  *     self-DoS from the per-repo authz fan-out (up to 100 GitHub calls per request).
@@ -43,13 +44,14 @@ import {rateLimitedResponse} from '../safe-response.js'
 // ---------------------------------------------------------------------------
 
 /**
- * Hard cap on the number of repos returned per listing.
+ * Hard cap on the number of distinct owner/repo pairs returned per listing.
  *
  * Authz checks are per-repo and the authz cache coalesces concurrent misses,
  * so N bindings is acceptable for small-to-medium deployments. The cap prevents
  * unbounded authz fan-out for unusually large binding sets. No pagination is
- * provided — the cap is the contract. Bindings beyond the cap are silently
- * truncated (first MAX_REPOS_PER_LISTING bindings after denylist filtering).
+ * provided — the cap is the contract. Distinct repos beyond the cap are silently
+ * truncated (first MAX_REPOS_PER_LISTING distinct owner/repo pairs after denylist
+ * filtering and dedup).
  */
 export const MAX_REPOS_PER_LISTING = 100
 
@@ -180,11 +182,23 @@ export function buildReposRoute(app: Hono, deps: ReposRouteDeps): void {
     // Extract deny keys from each binding; null/null means no usable key (fail closed).
     const allowed = filterDeniedRecords(bindings, bindingToRepoKey, deps.isRepoDenied)
 
-    // Apply the hard cap BEFORE authz fan-out to bound the number of GitHub calls.
-    // Bindings beyond the cap are silently truncated (first MAX_REPOS_PER_LISTING).
-    const capped = allowed.slice(0, MAX_REPOS_PER_LISTING)
+    // Dedup by owner/repo BEFORE the cap — duplicate channelId bindings for the same
+    // repo would otherwise consume cap slots and crowd out distinct repos.
+    const seenBeforeCap = new Set<string>()
+    const dedupedAllowed = allowed.filter(b => {
+      const key = `${b.owner}/${b.repo}`
+      if (seenBeforeCap.has(key)) {
+        return false
+      }
+      seenBeforeCap.add(key)
+      return true
+    })
 
-    // ── Gate 6: Per-repo authz — keep only repos the operator can access ──────
+    // Cap AFTER dedup to bound the number of GitHub authz calls.
+    // Distinct repos beyond the cap are silently truncated (first MAX_REPOS_PER_LISTING).
+    const capped = dedupedAllowed.slice(0, MAX_REPOS_PER_LISTING)
+
+    // ── Gate 7: Per-repo authz — keep only repos the operator can access ──────
     // checkRepoAuthz is called per binding. A denial silently omits the repo.
     // Per-repo authz failures are NOT errors — they are silent omissions (R19).
     const authorized: RepoBinding[] = []

--- a/packages/gateway/src/web/operator/runs-route.test.ts
+++ b/packages/gateway/src/web/operator/runs-route.test.ts
@@ -7,9 +7,10 @@
  *   3. Resolve OAuth token via session store
  *   4. listBindings() — all bound repos
  *   5. filterDeniedRecords() — drop denylisted repos BEFORE any authz call
- *   6. checkRepoAuthz() per surviving binding — keep only authorized repos
- *   7. For each authorized binding: listRunsForRepo() → project via toRunSummary()
- *   8. Flatten, sort newest-first, cap at MAX_RUNS_PER_LISTING; return 200 {runs:[]}
+ *   6. Dedup by owner/repo, then cap before the authz fan-out
+ *   7. checkRepoAuthz() per surviving binding — keep only authorized repos
+ *   8. For each authorized binding: listRunsForRepo() → project via toRunSummary()
+ *   9. Flatten, sort newest-first, cap at MAX_RUNS_PER_LISTING; return 200 {runs:[]}
  *
  * Security invariants:
  *   - Denylisted repos are dropped before checkRepoAuthz is called (no oracle).
@@ -776,6 +777,74 @@ describe('GET /operator/runs — entity_ref not logged on mismatch (Fix 2)', () 
 })
 
 // ---------------------------------------------------------------------------
+// Dedup bindings by owner/repo BEFORE the authz fan-out cap
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs — dedup before authz cap', () => {
+  it('reaches the 101st unique repo when two earlier bindings share the same owner/repo', async () => {
+    // #given — 101 bindings: 2 share acme/shared (different channelIds), 98 distinct repos,
+    // plus acme/last-unique. After dedup: 100 distinct repos, all within the cap of 100.
+    // Without dedup-before-cap, last-unique (index 100) would be dropped by the cap.
+
+    const sharedBindingA = makeBinding('acme', 'shared', {channelId: 'chan-shared-A'})
+    const sharedBindingB = makeBinding('acme', 'shared', {channelId: 'chan-shared-B'})
+    // 98 distinct repos (indices 2..99 in the original list)
+    const distinctBindings = Array.from({length: 98}, (_, i) =>
+      makeBinding('acme', `repo-${i + 2}`, {channelId: `chan-repo-${i + 2}`}),
+    )
+    const lastUniqueBinding = makeBinding('acme', 'last-unique', {channelId: 'chan-last-unique'})
+
+    const bindings = [sharedBindingA, sharedBindingB, ...distinctBindings, lastUniqueBinding]
+
+    // All repos are authorized
+    const authorizedRepos = new Set<string>([
+      'acme/shared',
+      ...distinctBindings.map(b => `${b.owner}/${b.repo}`),
+      'acme/last-unique',
+    ])
+
+    // Track which repos authz was called for
+    const authzFetch = vi.fn(async (url: string | URL | Request) => {
+      const urlStr = String(url)
+      const match = /\/repos\/([^/]+)\/([^/]+)$/.exec(urlStr)
+      if (match !== null) {
+        const key = `${match[1]}/${match[2]}`
+        const status = authorizedRepos.has(key) ? 200 : 404
+        return new Response('{}', {status})
+      }
+      return new Response('{}', {status: 404})
+    }) as typeof globalThis.fetch
+
+    const listRunsForRepo = vi.fn(async (_repo: string) => [])
+
+    const deps = makeBaseDeps({
+      listBindings: vi.fn(async () => ({success: true as const, data: bindings})),
+      repoAuthzDeps: makeRepoAuthzDeps(authorizedRepos, {fetch: authzFetch}),
+      listRunsForRepo,
+    })
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await app.fetch(new Request('http://localhost/operator/runs'))
+
+    // #then — authz was called for acme/last-unique (dedup-before-cap allows it through)
+    expect(res.status).toBe(200)
+
+    const authzCalls = (authzFetch as ReturnType<typeof vi.fn>).mock.calls as [string | URL | Request][]
+    const calledUrls = authzCalls.map(([url]) => String(url))
+    expect(calledUrls.some(u => u.includes('last-unique'))).toBe(true)
+
+    // listRunsForRepo was also called for acme/last-unique (it passed authz)
+    const listCalls = listRunsForRepo.mock.calls as [string][]
+    expect(listCalls.some(([repo]) => repo === 'acme/last-unique')).toBe(true)
+
+    // acme/shared was only authz-checked once (dedup collapsed the two bindings)
+    const sharedAuthzCalls = calledUrls.filter(u => u.includes('/acme/shared'))
+    expect(sharedAuthzCalls).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Fix 5 — additional error paths and authz fan-out cap
 // ---------------------------------------------------------------------------
 
@@ -854,9 +923,10 @@ describe('GET /operator/runs — authz fan-out cap (Fix 5)', () => {
     // #when
     await app.fetch(new Request('http://localhost/operator/runs'))
 
-    // #then — authzFetch called at most 100 times (cap enforced before authz fan-out)
+    // #then — authzFetch called exactly 100 times (all first 100 bindings reach authz;
+    // the remaining 10 are silently truncated by the cap before the fan-out).
     // Each checkRepoAuthz call makes one fetch call to the GitHub API.
     const callCount = (authzFetch as ReturnType<typeof vi.fn>).mock.calls.length
-    expect(callCount).toBeLessThanOrEqual(100)
+    expect(callCount).toBe(100)
   })
 })

--- a/packages/gateway/src/web/operator/runs-route.ts
+++ b/packages/gateway/src/web/operator/runs-route.ts
@@ -11,11 +11,12 @@
  *   3. Resolve OAuth token via session store
  *   4. listBindings() — enumerate all bound repos
  *   5. filterDeniedRecords() — drop denylisted repos BEFORE any authz call
- *   6. checkRepoAuthz() per surviving binding — keep only authorized repos
- *   7. listRunsForRepo() per authorized binding — enumerate run-states
- *   8. toRunSummary() projection — drop null (entity_ref mismatch) + warn
- *   9. Flatten; sort newest-first by createdAt; cap at MAX_RUNS_PER_LISTING
- *  10. Cache-Control: no-store, private; return 200 {runs: RunSummary[]}
+ *   6. Dedup by owner/repo, then cap before the authz fan-out
+ *   7. checkRepoAuthz() per surviving binding — keep only authorized repos
+ *   8. listRunsForRepo() per authorized binding — enumerate run-states
+ *   9. toRunSummary() projection — drop null (entity_ref mismatch) + warn
+ *  10. Flatten; sort newest-first by createdAt; cap at MAX_RUNS_PER_LISTING
+ *  11. Cache-Control: no-store, private; return 200 {runs: RunSummary[]}
  *
  * Security invariants:
  *   - Denylisted repos are dropped before checkRepoAuthz is called (no oracle).
@@ -59,8 +60,8 @@ export const MAX_RUNS_PER_LISTING = 100
 /**
  * Authz fan-out cap: maximum number of bindings that proceed to checkRepoAuthz.
  *
- * Mirrors the repos-route cap. Bindings beyond this are silently truncated
- * (first MAX_REPOS_AUTHZ_FANOUT bindings after denylist filtering).
+ * Bindings beyond this are silently truncated (first MAX_REPOS_AUTHZ_FANOUT
+ * distinct owner/repo pairs after denylist filtering).
  */
 const MAX_REPOS_AUTHZ_FANOUT = 100
 
@@ -199,11 +200,22 @@ export function buildRunsRoute(app: Hono, deps: RunsRouteDeps): void {
     // Their run-states are never read — tighter than "scan all then filter."
     const allowed = filterDeniedRecords(bindings, bindingToRepoKey, deps.isRepoDenied)
 
-    // Apply the authz fan-out cap BEFORE authz to bound the number of GitHub calls.
-    // Bindings beyond the cap are silently truncated (first MAX_REPOS_AUTHZ_FANOUT).
-    const capped = allowed.slice(0, MAX_REPOS_AUTHZ_FANOUT)
+    // Dedup by owner/repo BEFORE the cap — duplicate channelId bindings for the same
+    // repo would otherwise consume cap slots and crowd out distinct repos.
+    const seenBeforeCap = new Set<string>()
+    const dedupedAllowed = allowed.filter(b => {
+      const key = `${b.owner}/${b.repo}`
+      if (seenBeforeCap.has(key)) {
+        return false
+      }
+      seenBeforeCap.add(key)
+      return true
+    })
 
-    // ── Gate 6: Per-repo authz — keep only repos the operator can access ──────
+    // Cap AFTER dedup to bound GitHub API calls; excess distinct repos are silently truncated.
+    const capped = dedupedAllowed.slice(0, MAX_REPOS_AUTHZ_FANOUT)
+
+    // ── Gate 7: Per-repo authz — keep only repos the operator can access ──────
     // checkRepoAuthz is called per binding. A denial silently omits the repo.
     // Per-repo authz failures are NOT errors — they are silent omissions (no oracle).
     const authorized: RepoBinding[] = []


### PR DESCRIPTION
## Summary

- Deduplicate operator repo bindings by `owner/repo` before authz fan-out caps in `GET /operator/repos` and `GET /operator/runs`.
- Preserve denylist-before-authz ordering and existing response shapes while preventing duplicate channel bindings from crowding out distinct repos.
- Add regression coverage for duplicate-binding cap fairness plus degraded-path coverage for repo listing errors.

## Verification

- `bun vitest run src/web/operator/repos-route.test.ts src/web/operator/runs-route.test.ts`
- `bun run check-types`
- `bun run lint`
- `bun run build`
- `bun run --filter @fro-bot/gateway test`

Refs #1036. The broader run-index scale/retention follow-ups remain tracked there.