### PR TITLE
fix: install workspace deps for harness release

### DIFF
--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -284,7 +284,7 @@ jobs:
           install-dependencies: 'false'
 
       - name: Install harness dependencies
-        run: bun install --filter @fro.bot/harness --frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Build harness package (for scripts/verify-binary.ts import)
         run: bun run --filter @fro.bot/harness build
@@ -863,7 +863,7 @@ jobs:
         run: npm install -g npm@11.17.0
 
       - name: Install harness dependencies
-        run: bun install --filter @fro.bot/harness --frozen-lockfile
+        run: bun install --frozen-lockfile
 
       - name: Build harness package
         run: bun run --filter @fro.bot/harness build

--- a/packages/harness/scripts/build-platform.test.ts
+++ b/packages/harness/scripts/build-platform.test.ts
@@ -70,6 +70,21 @@ describe('drift guard: harness-release.yaml bun-version literals', () => {
       ).toBe(HARNESS_BUN_VERSION)
     }
   })
+
+  it('installs workspace dependencies before building the harness package', async () => {
+    // #given — harness build imports root tsconfig/tooling, so release CI must install the workspace, not just the package.
+    const thisDir = path.dirname(fileURLToPath(import.meta.url))
+    const repoRoot = path.resolve(thisDir, '..', '..', '..')
+    const workflowPath = path.join(repoRoot, '.github', 'workflows', 'harness-release.yaml')
+
+    // #when
+    const realFs = await vi.importActual<typeof import('node:fs')>('node:fs')
+    const content = realFs.readFileSync(workflowPath, 'utf8')
+
+    // #then
+    expect(content).toContain('run: bun install --frozen-lockfile')
+    expect(content).not.toContain('run: bun install --filter @fro.bot/harness --frozen-lockfile')
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- install workspace dependencies in harness-release build/publish jobs before building `@fro.bot/harness`
- add a workflow drift test that prevents reintroducing harness-only filtered installs

## Root cause

`@fro.bot/harness` builds through the root TypeScript config, which extends `@bfra.me/tsconfig`. The harness-release workflow used `bun install --filter @fro.bot/harness --frozen-lockfile`, so CI skipped the root dev dependency that provides that shared config and every matrix build failed before native binary compilation.

## Verification

- watched the new targeted test fail against the filtered install
- `bunx vitest run packages/harness/scripts/build-platform.test.ts`
- `bun run --filter @fro.bot/harness build`
- `git diff --check`
