### PR TITLE
chore: remove Renovate status check workaround

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,19 +1,6 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['github>fro-bot/.github'],
-  // Renovate 43.234.0 (pinned by the runner action) regressed productLinks
-  // handling, so the stability-days / merge-confidence status checks build a
-  // scheme-relative target_url that GitHub rejects with a 422 whose `errors`
-  // body is a string. Renovate's error handler assumes `errors` is an array and
-  // crashes (`errors?.find is not a function`), aborting the entire run — no
-  // Dependency Dashboard update, no branches processed. Suppressing these two
-  // status-check names skips the broken POST while leaving the minimumReleaseAge
-  // policy (below) fully in effect. Remove once the runner advances past the fix
-  // (Renovate >= 43.234.1).
-  statusCheckNames: {
-    minimumReleaseAge: null,
-    mergeConfidence: null,
-  },
   // dist/ is bundled vendor code (committed for the GitHub Action runtime).
   // ignorePaths excludes it from dependency extraction only — it does NOT
   // suppress the hidden-Unicode safety scan, which runs on these files


### PR DESCRIPTION
## Summary

- remove the obsolete Renovate `statusCheckNames` workaround for stability-days and merge-confidence checks
- keep the Bun `skipArtifactsUpdate` workaround, which is unrelated and still needed

## Verification

- confirmed this repo consumes `bfra-me/.github@v4.16.31`
- confirmed that reusable workflow pins `bfra-me/renovate-action@9.125.2`
- confirmed that action runs `RENOVATE_VERSION=43.242.0`, past the `43.234.1` fix threshold
- `bun run fix`
- `bun run lint`
- `bunx --package renovate renovate-config-validator .github/renovate.json5`
- `git diff --check`
