### PR TITLE
fix: harden gateway container with cap_drop and no-new-privileges

### DIFF
--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -201,6 +201,15 @@ services:
       - gateway-net
       - sandbox-net
     restart: unless-stopped
+    # Container hardening (#1053). The gateway binds the operator listener on an
+    # unprivileged port (4000) and its healthcheck uses `nc -z` (TCP connect, not
+    # a raw socket), so it needs no added capabilities — drop the full set. Root
+    # filesystem read-only and non-root user are deferred (the runtime writes a
+    # readiness flag to /var/run/fro-bot; that needs a tmpfs/write-path audit first).
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     logging:
       driver: json-file
       options:

--- a/deploy/validate-stack.test.sh
+++ b/deploy/validate-stack.test.sh
@@ -4657,6 +4657,71 @@ echo "  OP-12 output (stderr+stdout combined):"
 echo "${OP12_OUTPUT}" | sed 's/^/    /'
 
 # ---------------------------------------------------------------------------
+# TEST 68 — Positive regression: real deploy/compose.yaml gateway service must
+#           declare cap_drop: [ALL] and security_opt: [no-new-privileges:true]
+#           (#1053 container hardening).
+#
+# This test asserts directly against the real compose.yaml so that removing
+# either hardening key from the gateway service causes an immediate test
+# failure.  It does NOT use validate-stack.sh (which does not check cap_drop/
+# security_opt on the gateway); instead it inspects the raw YAML file with
+# grep, matching the exact indented forms that Compose requires.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- TEST 68: gateway service in real compose.yaml declares cap_drop: [ALL] and security_opt: [no-new-privileges:true] (#1053) ---"
+
+REAL_COMPOSE_FILE="deploy/compose.yaml"
+
+# #given the real compose.yaml exists
+# #when we inspect the GATEWAY service block (not the whole file) for cap_drop
+# and security_opt. Extract only the gateway service block — from the `  gateway:`
+# line up to the next top-level `  <service>:` line — so the assertions cannot
+# false-pass on keys that belong to another service (workspace/mitmproxy).
+GW_BLOCK="$(awk '
+  /^  gateway:[[:space:]]*$/ { in_block = 1; next }
+  in_block && /^  [a-zA-Z0-9_-]+:[[:space:]]*$/ { in_block = 0 }
+  in_block { print }
+' "${REAL_COMPOSE_FILE}")"
+
+# cap_drop: - ALL  (4-space indent for key, 6-space for list item)
+GW_CAP_DROP_EXIT=0
+grep -q "^    cap_drop:" <<<"${GW_BLOCK}" || GW_CAP_DROP_EXIT=$?
+GW_CAP_DROP_ALL_EXIT=0
+grep -q "^      - ALL" <<<"${GW_BLOCK}" || GW_CAP_DROP_ALL_EXIT=$?
+
+# security_opt: - no-new-privileges:true  (4-space indent for key, 6-space for list item)
+GW_SECOPT_EXIT=0
+grep -q "^    security_opt:" <<<"${GW_BLOCK}" || GW_SECOPT_EXIT=$?
+GW_SECOPT_NNP_EXIT=0
+grep -q "^      - no-new-privileges:true" <<<"${GW_BLOCK}" || GW_SECOPT_NNP_EXIT=$?
+
+# #then both hardening keys must be present in the gateway service
+
+if [[ "${GW_CAP_DROP_EXIT}" -eq 0 ]]; then
+  pass "TEST 68: real compose.yaml gateway service declares 'cap_drop:'"
+else
+  fail "TEST 68: real compose.yaml gateway service is MISSING 'cap_drop:' — add cap_drop: [ALL] (#1053)"
+fi
+
+if [[ "${GW_CAP_DROP_ALL_EXIT}" -eq 0 ]]; then
+  pass "TEST 68: real compose.yaml gateway service declares 'cap_drop: - ALL'"
+else
+  fail "TEST 68: real compose.yaml gateway service is MISSING '- ALL' under cap_drop — add cap_drop: [ALL] (#1053)"
+fi
+
+if [[ "${GW_SECOPT_EXIT}" -eq 0 ]]; then
+  pass "TEST 68: real compose.yaml gateway service declares 'security_opt:'"
+else
+  fail "TEST 68: real compose.yaml gateway service is MISSING 'security_opt:' — add security_opt: [no-new-privileges:true] (#1053)"
+fi
+
+if [[ "${GW_SECOPT_NNP_EXIT}" -eq 0 ]]; then
+  pass "TEST 68: real compose.yaml gateway service declares 'security_opt: - no-new-privileges:true'"
+else
+  fail "TEST 68: real compose.yaml gateway service is MISSING '- no-new-privileges:true' under security_opt — add security_opt: [no-new-privileges:true] (#1053)"
+fi
+
+# ---------------------------------------------------------------------------
 # LOCKSTEP-1 — Negative/Positive: egress-smoke.sh must not hardcode the
 #              mitmproxy image; it must derive it from deploy/compose.yaml.
 #


### PR DESCRIPTION
Hardens the gateway container in `deploy/compose.yaml`:

- `cap_drop: [ALL]` — the gateway needs no Linux capabilities. The operator listener binds an unprivileged port (4000), outbound traffic to Discord/GitHub/object-store is ordinary TCP, and the healthcheck uses `nc -z` (a TCP connect, not a raw socket). So nothing is added back.
- `security_opt: [no-new-privileges:true]` — blocks setuid/privilege escalation; the node process has no need to elevate.

Read-only root filesystem and a non-root user are deliberately deferred: the runtime writes a readiness flag under `/var/run/fro-bot`, so a read-only rootfs needs a tmpfs and a full write-path audit first, and a non-root user needs the secret-mount and readiness-dir ownership worked out. Splitting those keeps this change low-risk.

These additions sit cleanly within the existing containment model — `cap_drop` doesn't touch the network-topology invariants in `validate-stack.sh` (which bans `cap_add` of `NET_RAW`/etc., not `cap_drop`), and `no-new-privileges` is already on its allowlist.

## Testing

- Added a gateway-scoped regression test (`deploy/validate-stack.test.sh`) that fails if either hardening key is removed from the gateway service. It extracts only the gateway service block before asserting, so it can't false-pass on keys belonging to another service — verified by moving the keys to `mitmproxy` and watching it fail.
- `bash deploy/validate-stack.sh --topology-only` passes (the new keys parse and violate no invariant).
- Full deploy suite: 164/164.

Closes #1053
