### PR TITLE
fix: prevent fork-PR secret exfiltration in workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,7 +145,7 @@ jobs:
       github.event_name != 'push' && (
         github.event.pull_request == null ||
         (
-          !github.event.pull_request.head.repo.fork &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
           !endsWith(github.event.pull_request.user.login || '', '[bot]') &&
           (github.event.pull_request.user.login || '') != 'fro-bot'
         )

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -60,6 +60,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: >-
@@ -174,7 +175,7 @@ jobs:
       (
         github.event.pull_request == null ||
         (
-          !github.event.pull_request.head.repo.fork &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
           !endsWith(github.event.pull_request.user.login || '', '[bot]')
         )
       ) &&
@@ -199,16 +200,44 @@ jobs:
     name: Fro Bot
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve same-repo PR-head ref
+        id: prehead
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          IS_PR_COMMENT: ${{ github.event.issue.pull_request != null }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          ref=""
+          pr_number=""
+          if [ "${EVENT_NAME}" = "issue_comment" ] && [ "${IS_PR_COMMENT}" = "true" ]; then
+            pr_number="${ISSUE_NUMBER}"
+          elif [ "${EVENT_NAME}" = "pull_request_review_comment" ]; then
+            pr_number="${PR_NUMBER}"
+          fi
+          if [ -n "${pr_number}" ]; then
+            if pr_json="$(gh api "repos/${REPO}/pulls/${pr_number}" 2>/dev/null)"; then
+              head_repo="$(printf '%s' "${pr_json}" | jq -r '.head.repo.full_name // empty')"
+              if [ "${head_repo}" = "${REPO}" ]; then
+                ref="$(printf '%s' "${pr_json}" | jq -r '.head.sha // empty')"
+              else
+                echo "PR ${pr_number} head repo '${head_repo:-unknown}' is not this repository — using default branch." >&2
+              fi
+            else
+              echo "Could not resolve PR ${pr_number} head (API error) — using default branch." >&2
+            fi
+          fi
+          echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
+
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          ref: >-
-            ${{
-              (github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number))
-              || github.event.pull_request.head.sha
-              || ''
-            }}
+          persist-credentials: false
+          ref: ${{ steps.prehead.outputs.ref }}
           token: ${{ secrets.FRO_BOT_PAT }}
 
       - name: Setup Node.js and Bun

--- a/docs/examples/fro-bot.yaml
+++ b/docs/examples/fro-bot.yaml
@@ -27,9 +27,6 @@
 # step before checkout and pass it the same way. This is useful when the
 # repository already uses a GitHub App for other workflows.
 #
-# workflow_dispatch is the exception: it uses the built-in GITHUB_TOKEN
-# because the caller typed a manual prompt — no @mention identity needed.
-#
 # ── PERMISSIONS ─────────────────────────────────────────────────────────────
 # The workflow-level `permissions` block sets a read-only baseline. The
 # job-level block grants `contents: write` which is needed when the agent
@@ -349,7 +346,7 @@ jobs:
       (
         github.event.pull_request == null ||
         (
-          !github.event.pull_request.head.repo.fork &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
           !endsWith(github.event.pull_request.user.login || '', '[bot]')
         )
       ) && (
@@ -379,22 +376,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # Check out PR code when:
-          # 1. Issue comment on PR: refs/pull/{number}/head
-          # 2. Direct PR event: pull_request.head.sha
-          # 3. Other events: default to workflow ref
-          ref: >-
-            ${{
-              (github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number))
-              || github.event.pull_request.head.sha
-              || ''
-            }}
-          token: >-
-            ${{
-              github.event_name == 'workflow_dispatch'
-              && secrets.GITHUB_TOKEN
-              || secrets.FRO_BOT_PAT
-            }}
+          persist-credentials: false
+          token: ${{ secrets.FRO_BOT_PAT }}
 
       # CUSTOMIZE: Add project-specific setup steps here (e.g. install deps).
 
@@ -410,11 +393,6 @@ jobs:
               || ''
             }}
         with:
-          github-token: >-
-            ${{
-              github.event_name == 'workflow_dispatch'
-              && secrets.GITHUB_TOKEN
-              || secrets.FRO_BOT_PAT
-            }}
+          github-token: ${{ secrets.FRO_BOT_PAT }}
           auth-json: ${{ secrets.OPENCODE_AUTH_JSON }}
           prompt: ${{ env.PROMPT }}


### PR DESCRIPTION
Closes a HIGH-severity secret-exfiltration vector in the workflows.

## The vulnerability

`issue_comment` events don't populate `github.event.pull_request` — a PR comment surfaces only as `github.event.issue.pull_request`. The fork guard checked `github.event.pull_request.head.repo.fork`, which is null for comment events, so it never gated PR comments. The checkout step then resolved `refs/pull/N/head` (the fork's code) with `FRO_BOT_PAT` in scope. A trusted collaborator commenting `@fro-bot` on a fork PR would run attacker-controlled code with the long-lived PAT present — exfiltratable until rotation, and it crosses repo boundaries.

This was live in the production workflow, not just the example.

## The fix

**Example workflow** — never checks out PR-head code. `@fro-bot` mentions operate on the default branch. Simplest secure default for the file people copy.

**Production workflow** — a preflight step resolves a PR-head ref only after confirming, via the read-only `GITHUB_TOKEN`, that the PR head is in this same repository. Fork PRs and any API failure fall back to a default-branch checkout, so attacker-controlled code never reaches the `FRO_BOT_PAT`-bearing checkout. Preserves the ability to act on same-repo PRs by mention.

**Both** — the `pull_request` guard is hardened from `!head.repo.fork` to an explicit `head.repo.full_name == github.repository` check, `persist-credentials: false` keeps the token out of `.git/config`, and the example is simplified to a single token. The same guard hardening is applied to the CI action-test job for consistency.

## Verification

- Independent security trace of every event path (issue_comment, review comment, discussion comment, issues, pull_request, schedule, dispatch, workflow_call) in all three files: no path reaches a PAT-bearing checkout of fork code.
- The preflight is fail-closed — a fork, a null/deleted head, or a transient API error all yield an empty ref → default-branch checkout.
- `actions/checkout` pushes are unaffected: the action authenticates via the GitHub Data API and its token input, not checkout-persisted git credentials.
- actionlint clean; all three workflows parse.

Closes #919
