### PR TITLE
docs(plans): mark post-bridge hardening plan done

### DIFF
--- a/docs/plans/2026-06-12-002-feat-harness-post-bridge-hardening-plan.md
+++ b/docs/plans/2026-06-12-002-feat-harness-post-bridge-hardening-plan.md
@@ -1,9 +1,11 @@
 ---
 title: "feat: Harness post-bridge hardening (#775)"
 type: feat
-status: active
+status: done
 date: 2026-06-12
 ---
+
+> **Status: done.** R2 (error redaction), R3 (doctor version form), R4 (per-ref provenance), and R5 (clean-snapshot tests) shipped in #873. R1 (config-based merge-agent sandbox) was dropped after review as unworkable and off the production path. #775 is closed; the production merge-agent credential-isolation concern is tracked separately in #1060.
 
 # feat: Harness post-bridge hardening (#775)
 


### PR DESCRIPTION
Marks the post-bridge hardening plan as done now that #775 is closed.

R2 (error redaction), R3 (doctor version form), R4 (per-ref provenance), and R5 (clean-snapshot tests) all shipped in #873. R1 (config-based merge-agent sandbox) was dropped after review as unworkable and off the production path. The production merge-agent credential-isolation concern is tracked separately in #1060.

Docs-only: flips the frontmatter status and adds a one-line resolution note at the top of the plan.
