### PR TITLE
perf(gateway): bound operator-runs read amplification

### DIFF
--- a/packages/gateway/src/execute/run-index.test.ts
+++ b/packages/gateway/src/execute/run-index.test.ts
@@ -1427,5 +1427,244 @@ describe('createRunIndex', () => {
       expect(listWithMetadataMock).not.toHaveBeenCalled()
       expect(getObjectMock).not.toHaveBeenCalled()
     })
+
+    // ── limit parameter (read-amplification fix) ─────────────────────────────
+
+    it('explicit limit smaller than available objects caps getObject calls to that limit (newest by lastModified)', async () => {
+      // #given — 30 entries in listWithMetadata; we pass limit=10
+      const totalEntries = 30
+      const baseTime = new Date('2026-06-01T00:00:00.000Z').getTime()
+
+      // Entry i has lastModified = baseTime + i*1000 (entry 29 is newest)
+      const metadataEntries = Array.from({length: totalEntries}, (_, i) => ({
+        key: `prefix/run-${String(i).padStart(3, '0')}.json`,
+        lastModified: new Date(baseTime + i * 1000),
+      }))
+
+      // The newest 10 are entries 20..29 (indices 20 to 29 inclusive)
+      const newestKeys = new Set(metadataEntries.slice(20).map(e => e.key))
+
+      const getObjectMock = vi.fn(async (key: string) => ({
+        success: true as const,
+        data: {
+          data: JSON.stringify(makeRunState(key, 'acme/widget')),
+          etag: 'etag-1',
+        },
+      }))
+
+      const coordinationConfig: CoordinationConfig = {
+        ...makeCoordinationConfig(),
+        storeAdapter: {
+          upload: vi.fn(),
+          download: vi.fn(),
+          list: vi.fn().mockResolvedValue({success: true, data: []}),
+          getObject: getObjectMock,
+          listWithMetadata: vi.fn().mockResolvedValue({
+            success: true,
+            data: metadataEntries,
+          }),
+        },
+      }
+
+      const deps = makeDeps()
+      const index = createRunIndex({
+        bindingsStore: deps.bindingsStore,
+        coordinationConfig,
+        identity: 'gateway',
+        logger: deps.logger,
+        now,
+        // No findRunsForRepo injection — use the production path with listWithMetadata
+      })
+
+      // #when — pass limit=10 (smaller than 30 available and smaller than MAX_RUNS_PER_REPO)
+      const result = await index.listRunsForRepo('acme/widget', 10)
+
+      // #then — exactly 10 getObject calls (the explicit limit)
+      expect(getObjectMock).toHaveBeenCalledTimes(10)
+
+      // All called keys must be from the newest 10
+      const calledKeys = getObjectMock.mock.calls.map(call => String(call[0]))
+      for (const key of calledKeys) {
+        expect(newestKeys.has(key)).toBe(true)
+      }
+
+      // The 20 oldest entries must NOT have been read
+      for (let i = 0; i < 20; i++) {
+        const oldKey = `prefix/run-${String(i).padStart(3, '0')}.json`
+        expect(calledKeys).not.toContain(oldKey)
+      }
+
+      // Result has exactly 10 runs
+      expect(result).toHaveLength(10)
+    })
+
+    it('explicit limit larger than MAX_RUNS_PER_REPO is clamped to MAX_RUNS_PER_REPO', async () => {
+      // #given — 210 entries; we pass limit=999 (above MAX_RUNS_PER_REPO=200)
+      const totalEntries = 210
+      const baseTime = new Date('2026-06-01T00:00:00.000Z').getTime()
+
+      const metadataEntries = Array.from({length: totalEntries}, (_, i) => ({
+        key: `prefix/run-${String(i).padStart(3, '0')}.json`,
+        lastModified: new Date(baseTime + i * 1000),
+      }))
+
+      const getObjectMock = vi.fn(async (key: string) => ({
+        success: true as const,
+        data: {
+          data: JSON.stringify(makeRunState(key, 'acme/widget')),
+          etag: 'etag-1',
+        },
+      }))
+
+      const coordinationConfig: CoordinationConfig = {
+        ...makeCoordinationConfig(),
+        storeAdapter: {
+          upload: vi.fn(),
+          download: vi.fn(),
+          list: vi.fn().mockResolvedValue({success: true, data: []}),
+          getObject: getObjectMock,
+          listWithMetadata: vi.fn().mockResolvedValue({
+            success: true,
+            data: metadataEntries,
+          }),
+        },
+      }
+
+      const deps = makeDeps()
+      const index = createRunIndex({
+        bindingsStore: deps.bindingsStore,
+        coordinationConfig,
+        identity: 'gateway',
+        logger: deps.logger,
+        now,
+      })
+
+      // #when — pass limit=999 (above the hard ceiling of 200)
+      const result = await index.listRunsForRepo('acme/widget', 999)
+
+      // #then — clamped to MAX_RUNS_PER_REPO=200; exactly 200 getObject calls
+      expect(getObjectMock).toHaveBeenCalledTimes(200)
+      expect(result).toHaveLength(200)
+    })
+
+    it('omitting limit still caps at MAX_RUNS_PER_REPO (backward-compatible default)', async () => {
+      // #given — 210 entries; no limit argument
+      const totalEntries = 210
+      const baseTime = new Date('2026-06-01T00:00:00.000Z').getTime()
+
+      const metadataEntries = Array.from({length: totalEntries}, (_, i) => ({
+        key: `prefix/run-${String(i).padStart(3, '0')}.json`,
+        lastModified: new Date(baseTime + i * 1000),
+      }))
+
+      const getObjectMock = vi.fn(async (key: string) => ({
+        success: true as const,
+        data: {
+          data: JSON.stringify(makeRunState(key, 'acme/widget')),
+          etag: 'etag-1',
+        },
+      }))
+
+      const coordinationConfig: CoordinationConfig = {
+        ...makeCoordinationConfig(),
+        storeAdapter: {
+          upload: vi.fn(),
+          download: vi.fn(),
+          list: vi.fn().mockResolvedValue({success: true, data: []}),
+          getObject: getObjectMock,
+          listWithMetadata: vi.fn().mockResolvedValue({
+            success: true,
+            data: metadataEntries,
+          }),
+        },
+      }
+
+      const deps = makeDeps()
+      const index = createRunIndex({
+        bindingsStore: deps.bindingsStore,
+        coordinationConfig,
+        identity: 'gateway',
+        logger: deps.logger,
+        now,
+      })
+
+      // #when — no limit argument (omitted)
+      const result = await index.listRunsForRepo('acme/widget')
+
+      // #then — defaults to MAX_RUNS_PER_REPO=200
+      expect(getObjectMock).toHaveBeenCalledTimes(200)
+      expect(result).toHaveLength(200)
+    })
+
+    it('non-positive limit (0) falls back to MAX_RUNS_PER_REPO rather than reading nothing', async () => {
+      // #given — 210 entries; we pass limit=0, which must NOT zero out the read
+      const totalEntries = 210
+      const baseTime = new Date('2026-06-01T00:00:00.000Z').getTime()
+
+      const metadataEntries = Array.from({length: totalEntries}, (_, i) => ({
+        key: `prefix/run-${String(i).padStart(3, '0')}.json`,
+        lastModified: new Date(baseTime + i * 1000),
+      }))
+
+      const getObjectMock = vi.fn(async (key: string) => ({
+        success: true as const,
+        data: {
+          data: JSON.stringify(makeRunState(key, 'acme/widget')),
+          etag: 'etag-1',
+        },
+      }))
+
+      const coordinationConfig: CoordinationConfig = {
+        ...makeCoordinationConfig(),
+        storeAdapter: {
+          upload: vi.fn(),
+          download: vi.fn(),
+          list: vi.fn().mockResolvedValue({success: true, data: []}),
+          getObject: getObjectMock,
+          listWithMetadata: vi.fn().mockResolvedValue({
+            success: true,
+            data: metadataEntries,
+          }),
+        },
+      }
+
+      const deps = makeDeps()
+      const index = createRunIndex({
+        bindingsStore: deps.bindingsStore,
+        coordinationConfig,
+        identity: 'gateway',
+        logger: deps.logger,
+        now,
+      })
+
+      // #when — limit=0 (rejected by the `> 0` guard)
+      const result = await index.listRunsForRepo('acme/widget', 0)
+
+      // #then — falls back to MAX_RUNS_PER_REPO=200, not an empty read
+      expect(getObjectMock).toHaveBeenCalledTimes(200)
+      expect(result).toHaveLength(200)
+    })
+
+    it('findRunsForRepo override path ignores the limit and returns fixtures verbatim', async () => {
+      // #given — findRunsForRepo injected with 5 runs; limit=2 passed
+      const injectedRuns = Array.from({length: 5}, (_, i) => makeRunState(`run-${i}`, 'acme/widget'))
+
+      const deps = makeDeps()
+      const index = createRunIndex({
+        bindingsStore: deps.bindingsStore,
+        coordinationConfig: makeCoordinationConfig(),
+        identity: 'gateway',
+        logger: deps.logger,
+        now,
+        findRunsForRepo: async () => injectedRuns,
+      })
+
+      // #when — pass limit=2 (smaller than the 5 injected runs)
+      const result = await index.listRunsForRepo('acme/widget', 2)
+
+      // #then — all 5 runs returned verbatim (override path is not limited)
+      expect(result).toHaveLength(5)
+      expect(result).toEqual(injectedRuns)
+    })
   })
 })

--- a/packages/gateway/src/execute/run-index.ts
+++ b/packages/gateway/src/execute/run-index.ts
@@ -91,7 +91,7 @@ export interface RunIndex {
    * Does NOT touch the accelerator or negative cache — this is a read scan,
    * not a runId resolution. A failing key is skipped (not fatal).
    */
-  listRunsForRepo: (repo: string) => Promise<readonly RunState[]>
+  listRunsForRepo: (repo: string, limit?: number) => Promise<readonly RunState[]>
 }
 
 // ---------------------------------------------------------------------------
@@ -459,7 +459,7 @@ export function createRunIndex(deps: RunIndexDeps): RunIndex {
     return runs
   }
 
-  async function listRunsForRepo(repo: string): Promise<readonly RunState[]> {
+  async function listRunsForRepo(repo: string, limit?: number): Promise<readonly RunState[]> {
     // Injectable override takes precedence (used in tests; production uses the store adapter).
     if (deps.findRunsForRepo !== undefined) {
       return deps.findRunsForRepo(repo)
@@ -494,9 +494,17 @@ export function createRunIndex(deps: RunIndexDeps): RunIndex {
         return []
       }
 
-      // Sort newest-first, take the cap.
+      // Sort newest-first, take the effective cap.
+      // The caller may pass a limit to tighten the cap (e.g. MAX_RUNS_PER_LISTING when the
+      // final result never returns more than that). The limit can only tighten, never raise,
+      // the hard MAX_RUNS_PER_REPO ceiling. A non-positive, non-integer, or absent limit
+      // falls back to the ceiling.
+      const effectiveCap =
+        limit !== undefined && Number.isInteger(limit) && limit > 0
+          ? Math.min(limit, MAX_RUNS_PER_REPO)
+          : MAX_RUNS_PER_REPO
       const sorted = listed.data.slice().sort((a, b) => b.lastModified.getTime() - a.lastModified.getTime())
-      const capped = sorted.slice(0, MAX_RUNS_PER_REPO)
+      const capped = sorted.slice(0, effectiveCap)
       return fetchRunsForKeys(
         capped.map(e => e.key),
         getObject,

--- a/packages/gateway/src/web/operator/runs-route.test.ts
+++ b/packages/gateway/src/web/operator/runs-route.test.ts
@@ -722,10 +722,10 @@ describe('GET /operator/runs — dedup repos (Fix 1)', () => {
     // #when
     const res = await app.fetch(new Request('http://localhost/operator/runs'))
 
-    // #then — listRunsForRepo called exactly once (dedup by owner/repo)
+    // #then — listRunsForRepo called exactly once (dedup by owner/repo), with the per-repo limit
     expect(res.status).toBe(200)
     expect(listRunsForRepo).toHaveBeenCalledTimes(1)
-    expect(listRunsForRepo).toHaveBeenCalledWith('acme/shared-repo')
+    expect(listRunsForRepo).toHaveBeenCalledWith('acme/shared-repo', MAX_RUNS_PER_LISTING)
 
     // Runs appear exactly once (no duplicates)
     const body = (await res.json()) as {runs: {runId: string}[]}
@@ -928,5 +928,57 @@ describe('GET /operator/runs — authz fan-out cap (Fix 5)', () => {
     // Each checkRepoAuthz call makes one fetch call to the GitHub API.
     const callCount = (authzFetch as ReturnType<typeof vi.fn>).mock.calls.length
     expect(callCount).toBe(100)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Read-amplification fix — per-repo limit passed to listRunsForRepo
+// ---------------------------------------------------------------------------
+
+describe('GET /operator/runs — per-repo limit (read-amplification fix)', () => {
+  it('invokes listRunsForRepo with MAX_RUNS_PER_LISTING as the second argument', async () => {
+    // #given — 1 authorized binding; spy on listRunsForRepo to capture call args
+    const binding = makeBinding('acme', 'widget')
+    const authorizedRepos = new Set(['acme/widget'])
+    const run = makeRunState('acme', 'widget', 'run-widget-1', '2024-01-01T00:00:00Z')
+    const listRunsForRepo = vi.fn(async (_repo: string, _limit?: number) => [run])
+
+    const deps = makeBaseDeps({
+      listBindings: vi.fn(async () => ({success: true as const, data: [binding]})),
+      repoAuthzDeps: makeRepoAuthzDeps(authorizedRepos),
+      listRunsForRepo,
+    })
+    const app = buildTestApp(deps)
+
+    // #when
+    const res = await app.fetch(new Request('http://localhost/operator/runs'))
+
+    // #then — 200 response and listRunsForRepo was called with MAX_RUNS_PER_LISTING as limit
+    expect(res.status).toBe(200)
+    expect(listRunsForRepo).toHaveBeenCalledTimes(1)
+    expect(listRunsForRepo).toHaveBeenCalledWith('acme/widget', MAX_RUNS_PER_LISTING)
+  })
+
+  it('passes MAX_RUNS_PER_LISTING to every authorized repo scan (multiple repos)', async () => {
+    // #given — 3 authorized bindings; spy captures all call args
+    const bindings = [makeBinding('acme', 'alpha'), makeBinding('acme', 'beta'), makeBinding('acme', 'gamma')]
+    const authorizedRepos = new Set(['acme/alpha', 'acme/beta', 'acme/gamma'])
+    const listRunsForRepo = vi.fn(async (_repo: string, _limit?: number) => [])
+
+    const deps = makeBaseDeps({
+      listBindings: vi.fn(async () => ({success: true as const, data: bindings})),
+      repoAuthzDeps: makeRepoAuthzDeps(authorizedRepos),
+      listRunsForRepo,
+    })
+    const app = buildTestApp(deps)
+
+    // #when
+    await app.fetch(new Request('http://localhost/operator/runs'))
+
+    // #then — called once per repo, each with MAX_RUNS_PER_LISTING as the limit
+    expect(listRunsForRepo).toHaveBeenCalledTimes(3)
+    for (const call of listRunsForRepo.mock.calls as [string, number][]) {
+      expect(call[1]).toBe(MAX_RUNS_PER_LISTING)
+    }
   })
 })

--- a/packages/gateway/src/web/operator/runs-route.ts
+++ b/packages/gateway/src/web/operator/runs-route.ts
@@ -119,7 +119,7 @@ export interface RunsRouteDeps {
    * the route will not compile without this field. Injected via RunIndex.listRunsForRepo
    * in production; injected as a Map-backed stub in tests.
    */
-  readonly listRunsForRepo: (repo: string) => Promise<readonly RunState[]>
+  readonly listRunsForRepo: (repo: string, limit?: number) => Promise<readonly RunState[]>
   /**
    * Optional injectable per-minute rate limiter (operator-keyed).
    * When absent, a fresh limiter is created with RUNS_RATE_LIMIT_PER_MIN.
@@ -243,6 +243,15 @@ export function buildRunsRoute(app: Hono, deps: RunsRouteDeps): void {
     // Discord channels can share the same owner/repo. Scanning the same repo twice
     // would produce duplicate runs and double the S3 cost. Keep the first binding
     // per unique owner/repo (they project identically — repo comes from owner/repo).
+    //
+    // Each repo is read with at most MAX_RUNS_PER_LISTING candidates to bound read
+    // amplification: the final result never returns more than MAX_RUNS_PER_LISTING
+    // summaries, so a full per-repo scan costs S3 reads that the global cap discards.
+    // This is an approximation: the per-repo cap selects newest-by-lastModified while
+    // the final listing sorts by createdAt, so a run whose createdAt would rank in the
+    // global top-N but whose lastModified ranks below its repo's cap can be missed. The
+    // prior 200-cap had the same property; tightening to MAX_RUNS_PER_LISTING widens it
+    // slightly in exchange for halving worst-case reads — acceptable for this listing.
     const allSummaries: RunSummary[] = []
     const scannedRepos = new Set<string>()
 
@@ -255,7 +264,7 @@ export function buildRunsRoute(app: Hono, deps: RunsRouteDeps): void {
 
       let runs: readonly RunState[]
       try {
-        runs = await deps.listRunsForRepo(repo)
+        runs = await deps.listRunsForRepo(repo, MAX_RUNS_PER_LISTING)
       } catch (error: unknown) {
         deps.logger.warn({githubUserId, repo, error}, 'runs: listRunsForRepo threw — skipping repo')
         continue


### PR DESCRIPTION
Bounds read amplification on the operator runs listing — the first of the two remaining items in #1036.

## The problem

`GET /operator/runs` reads up to `MAX_REPOS_AUTHZ_FANOUT × MAX_RUNS_PER_REPO` (100 × 200 = 20,000) run-state objects from S3 to return at most `MAX_RUNS_PER_LISTING` (100) summaries. Since the endpoint never returns more than 100 total, no single repo needs to contribute more than 100 candidates — the rest is read cost the global cap throws away.

## The change

`listRunsForRepo` takes an optional per-repo `limit`, and the route passes `MAX_RUNS_PER_LISTING`. Worst-case object reads halve to 10,000. The limit can only tighten the existing `MAX_RUNS_PER_REPO` ceiling, never raise it; a non-positive, non-integer, or absent limit falls back to the ceiling, so every existing caller keeps its current behavior.

This is an approximation, and the code comment now says so honestly: the per-repo cap selects newest-by-`lastModified` while the final listing sorts by `createdAt`, so a run whose `createdAt` would rank in the global top-N but whose `lastModified` ranks below its repo's cap can be missed. The prior 200-cap already had that property; tightening to the listing size widens it slightly in exchange for halving the reads. Acceptable for a capped admin listing.

## Scope

Item 1 of #1036 only. Item 3 (long-term run-state retention / S3 lifecycle) is infra-side and stays open. The binding-dedup item already shipped in #1038.

## Tests

- `run-index.test.ts`: explicit `limit` smaller than available fetches exactly that many newest-by-lastModified; `limit` above the ceiling clamps to it; omitted `limit` and `limit=0` both fall back to the ceiling; the injected override path ignores the limit.
- `runs-route.test.ts`: the route invokes `listRunsForRepo` with `MAX_RUNS_PER_LISTING`.
- Type-check and the operator + run-index suites pass.

Refs #1036
