### PR TITLE
chore: drop temporary OpenCode SDK age-gate exclusion

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -12,8 +12,3 @@ linker = "hoisted"
 # Supply-chain age gate: refuse dependency versions published within this window.
 # Mirrors the prior pnpm minimumReleaseAge policy. Seconds (3 days).
 minimumReleaseAge = 259200
-
-# Temporarily fast-track the deliberate OpenCode 1.17.11 SDK bump before the
-# 3-day age gate clears. Bun exclusions are package-scoped, so keep Renovate's
-# OpenCode cap tight and remove this after 2026-06-28T12:09Z.
-minimumReleaseAgeExcludes = ["@opencode-ai/sdk"]


### PR DESCRIPTION
Removes the temporary package-scoped age-gate exclusion for `@opencode-ai/sdk`.

It was added to fast-track the deliberate OpenCode 1.17.11 SDK bump ahead of the 3-day supply-chain age gate. 1.17.11 was published 2026-06-25, so it's now well past the window — `bun install` resolves it cleanly under the standard `minimumReleaseAge` gate, with no exclusion needed. The general gate stays in place for everything else.

Verified: `bun install` succeeds with the exclusion removed; `bun.lock` is unchanged.
