### PR TITLE
ci: route TOML config changes through the PR review gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
               - .github/**
               - '**.json5?'
               - '**.md'
+              - '**.toml'
               - '**.yaml'
               - '**.yml'
               - deploy/**


### PR DESCRIPTION
Config-only PRs that change a TOML file were silently skipping the Fro Bot PR review that gates approval.

## Why

The review runs in the `test-action` job, which `needs: build`. `build` only runs when the `dorny/paths-filter` step marks a change under `config` / `src-changed` / `dist-changed` / `scripts/**`. The `config` glob set covered `.github/**`, JSON/JSON5, Markdown, YAML, and `deploy/**`, but **not** `*.toml`. So a `bunfig.toml`-only PR resolved `should-build = false`, `build` was skipped, and `test-action` never ran — no review, on a repo where the review is the approval gate.

A docs-only PR doesn't hit this because `**.md` is already in the filter, which is why it wasn't obvious.

## Fix

Add `'**.toml'` to the `config` filter so config-only changes build and get reviewed like every other config file, without pulling the heavier image-smoke suite onto unrelated changes.

This PR is its own proof: it edits `ci.yaml` (under `.github/**`), so the review job runs on it.

## Blast radius closed

`bunfig.toml` and any future `*.toml` config. `bun.lock` and stray root dotfiles remain outside the filter, but those are lower-risk (Renovate's lockfile PRs are bot-authored and excluded from the agent review by design); they can be revisited separately if needed.
