### PR TITLE
docs: add ARCHITECTURE.md and STRUCTURE.md; slim AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,155 +1,29 @@
-# PROJECT KNOWLEDGE BASE
+# AGENTS.md
 
-**Generated:** 2026-03-29
-**Commit:** 045cac8
-**Branch:** main
+Agent-operational knowledge base for fro-bot/agent. For human-facing system design and layout, see the living docs:
+
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — system design, invariants, the three data flows, cross-cutting concerns, full code map.
+- **[STRUCTURE.md](STRUCTURE.md)** — directory layout, directory purposes, key file locations, where to add new code.
 
 ## OVERVIEW
 
-GitHub Action harness for [OpenCode](https://opencode.ai/) + [oMo](https://github.com/code-yeongyu/oh-my-openagent) agents with **persistent session state** across CI runs. Includes bundled `@fro.bot/systematic` plugin injection during setup. TypeScript, ESM-only, Node 24.
-
-## STRUCTURE
-
-```
-./
-├── src/                  # TypeScript source (145 source files, 15.0k lines)
-│   ├── main.ts           # Thin entry point → harness/run.ts
-│   ├── post.ts           # Thin entry point → harness/post.ts
-│   ├── index.ts          # Public API re-exports
-│   ├── shared/           # Layer 0: Pure types, utils, constants (no external deps)
-│   │   ├── types.ts      # Core interfaces (ActionInputs, TokenUsage, etc.)
-│   │   ├── constants.ts  # Shared configuration constants
-│   │   ├── logger.ts     # JSON logging with auto-redaction
-│   │   ├── env.ts        # Environment variable readers
-│   │   ├── errors.ts     # Error conversion utilities
-│   │   ├── validation.ts # Input validation
-│   │   ├── format.ts     # String formatting
-│   │   ├── async.ts      # Async utilities (sleep)
-│   │   ├── console.ts    # Console output helpers
-│   │   └── paths.ts      # Path utilities
-│   ├── services/         # Layer 1: External adapters (GitHub, cache, session, setup, object-store)
-│   │   ├── github/       # Octokit client, context parsing, NormalizedEvent
-│   │   ├── session/      # Persistence layer (search, prune, storage, writeback)
-│   │   ├── setup/        # Bun, oMo, OpenCode + Systematic config/install
-│   │   │   ├── ci-config.ts         # CI config assembly (extracted from setup.ts)
-│   │   │   ├── systematic-config.ts # Systematic plugin config writer
-│   │   │   └── adapters.ts          # Extracted adapter factories
-│   │   ├── cache/        # Cache restore/save with corruption detection (accelerator)
-│   │   └── object-store/ # S3-compatible canonical persistence (sessions, artifacts, metadata)
-│   ├── features/         # Layer 2: Business logic (agent, triggers, reviews, etc.)
-│   │   ├── agent/        # SDK execution, prompts, reactions, streaming
-│   │   ├── triggers/     # Event routing, skip conditions, context builders
-│   │   ├── comments/     # GitHub comment read/write, error formatting
-│   │   ├── context/      # GraphQL hydration for issues/PRs
-│   │   ├── reviews/      # PR diff parsing, review comments
-│   │   ├── attachments/  # File attachment processing
-│   │   ├── delegated/    # Branch/commit/PR operations
-│   │   └── observability/# Metrics collection, run summaries
-│   └── harness/          # Layer 3: Workflow composition (entry points, phases)
-│       ├── run.ts        # Main orchestration (delegates to phases)
-│       ├── post.ts       # Post-action hook (durable cache save)
-│       ├── config/       # Input parsing, outputs, state keys, omo-providers
-│       └── phases/       # Bootstrap, routing, execute, finalize, cleanup, etc.
-├── dist/                 # Bundled output (COMMITTED, must stay in sync)
-├── RFCs/                 # 19 RFC documents (architecture specs)
-├── docs/plans/           # Architecture plans and design docs
-├── docs/solutions/       # Documented solutions to past problems (bugs, best practices, workflow patterns) — searchable by YAML frontmatter (module, tags, problem_type)
-├── action.yaml           # GitHub Action definition (node24)
-└── tsdown.config.ts      # esbuild bundler config (dual entry points)
-```
+GitHub Action harness for [OpenCode](https://opencode.ai/) + [oMo](https://github.com/code-yeongyu/oh-my-openagent) agents with **persistent session state** across CI runs. Includes bundled `@fro.bot/systematic` plugin injection during setup. A Bun monorepo (TypeScript, ESM-only, Node 24): the Action lives in the layered root `src/`, with `@fro-bot/gateway` (Discord daemon + operator surface), `@fro.bot/harness` (patched-OpenCode build/publish), and `@fro-bot/runtime` (shared primitives) alongside.
 
 ## WHERE TO LOOK
 
-| Task | Location | Notes |
-| --- | --- | --- |
-| Add action logic | `src/harness/run.ts` | Main orchestration via phases |
-| Post-action hook | `src/harness/post.ts` | Durable cache save (RFC-017) |
-| Setup library | `src/services/setup/` | Bun/oMo/OpenCode installation (auto-setup) |
-| CI config | `src/services/setup/ci-config.ts` | `buildCIConfig()` — assembles OPENCODE_CONFIG_CONTENT |
-| Systematic config | `src/services/setup/systematic-config.ts` | `writeSystematicConfig()` — plugin config writer |
-| Cache operations | `src/services/cache/` | `restore.ts`, `save.ts` |
-| GitHub API | `src/services/github/client.ts` | `createClient()`, `createAppClient()` |
-| Event parsing | `src/services/github/context.ts` | `parseGitHubContext()`, `normalizeEvent()` |
-| Event types | `src/services/github/types.ts` | `NormalizedEvent` discriminated union (8 variants) |
-| Agent execution | `src/features/agent/execution.ts` | `executeOpenCode()` logic |
-| Prompt building | `src/features/agent/prompt.ts` | `buildAgentPrompt()`, XML-tagged prompt architecture |
-| Session storage | `src/services/session/` | `storage.ts`, `storage-mappers.ts` |
-| Session search | `src/services/session/search.ts` | `listSessions()`, `searchSessions()` |
-| Event routing | `src/features/triggers/router.ts` | `routeEvent()` orchestration |
-| Context hydrate | `src/features/context/` | GraphQL/REST issue/PR data (RFC-015) |
-| Comment posting | `src/features/comments/writer.ts` | `postComment()`, GraphQL mutations |
-| PR reviews | `src/features/reviews/reviewer.ts` | `submitReview()`, line comments |
-| Input parsing | `src/harness/config/inputs.ts` | `parseActionInputs()` returns Result |
-| Logging | `src/shared/logger.ts` | `createLogger()` with redaction |
-| Core types | `src/shared/types.ts` | `ActionInputs`, `CacheResult`, `RunContext` |
-| Build config | `tsdown.config.ts` | ESM shim, bundled deps, license extraction |
+Highest-traffic entry points — see [STRUCTURE.md](STRUCTURE.md) for the full directory layout and where-to-add-code map, and [ARCHITECTURE.md](ARCHITECTURE.md) for the complete code map.
 
-## CODE MAP
-
-| Symbol | Type | Location | Role |
-| --- | --- | --- | --- |
-| `run` | Function | `src/harness/run.ts` | Main entry, phase orchestration |
-| `runPost` | Function | `src/harness/post.ts` | Post-action cache save |
-| `runSetup` | Function | `src/services/setup/setup.ts` | Setup orchestration |
-| `buildCIConfig` | Function | `src/services/setup/ci-config.ts` | CI config assembly with plugin injection |
-| `writeSystematicConfig` | Function | `src/services/setup/systematic-config.ts` | Systematic plugin config writer |
-| `restoreCache` | Function | `src/services/cache/restore.ts` | Restore OpenCode state |
-| `saveCache` | Function | `src/services/cache/save.ts` | Persist state to cache |
-| `executeOpenCode` | Function | `src/features/agent/execution.ts` | SDK execution orchestration |
-| `buildAgentPrompt` | Function | `src/features/agent/prompt.ts` | XML-tagged prompt with authority hierarchy |
-| `buildAgentContextSection` | Function | `src/features/agent/prompt.ts` | Consolidated agent operations block |
-| `buildHarnessRulesSection` | Function | `src/features/agent/prompt-thread.ts` | Non-negotiable rules with precedence declaration |
-| `sendPromptToSession` | Function | `src/features/agent/prompt-sender.ts` | Send prompt to SDK session |
-| `runPromptAttempt` | Function | `src/features/agent/retry.ts` | Execute prompt with retry logic |
-| `pollForSessionCompletion` | Function | `src/features/agent/session-poll.ts` | Poll SDK for completion status |
-| `processEventStream` | Function | `src/features/agent/streaming.ts` | Process SDK event stream |
-| `bootstrapOpenCodeServer` | Function | `src/features/agent/server.ts` | Initialize SDK server lifecycle |
-| `normalizeEvent` | Function | `src/services/github/context.ts` | Raw payload → typed NormalizedEvent |
-| `parseGitHubContext` | Function | `src/services/github/context.ts` | Global context → typed GitHubContext |
-| `routeEvent` | Function | `src/features/triggers/router.ts` | Event routing orchestration |
-| `postComment` | Function | `src/features/comments/writer.ts` | Create or update comment |
-| `submitReview` | Function | `src/features/reviews/reviewer.ts` | Submit PR review |
-| `parseActionInputs` | Function | `src/harness/config/inputs.ts` | Parse/validate inputs |
-| `createLogger` | Function | `src/shared/logger.ts` | Logger with redaction |
-| `DEFAULT_SYSTEMATIC_VERSION` | Constant | `src/shared/constants.ts` | Pinned Systematic version |
-| `ActionInputs` | Interface | `src/shared/types.ts` | Input schema |
-| `NormalizedEvent` | Union | `src/services/github/types.ts` | 8-variant discriminated event union |
-| `TriggerDirective` | Interface | `src/features/agent/prompt.ts` | Directive + appendMode for triggers |
-| `TriggerResult` | Interface | `src/features/triggers/types.ts` | Routing decision |
-
-## EXECUTION FLOW
-
-```
-main.ts → harness/run.ts
-  │
-  ├─→ bootstrap phase (parseActionInputs, ensureOpenCodeAvailable, restoreCache)
-  ├─→ routing phase (parseGitHubContext, normalizeEvent, routeEvent)
-  ├─→ dedup phase (skip if agent already ran for this PR/issue recently)
-  ├─→ acknowledge phase (acknowledgeReceipt)
-  ├─→ cache-restore phase (dedicated session state restore)
-  ├─→ session-prep phase (processAttachments, buildAgentPrompt)
-  ├─→ execute phase (executeOpenCode via SDK)
-  ├─→ finalize phase (writeSessionSummary, pruneSessions)
-  └─→ cleanup phase (saveCache, writeJobSummary)
-
-post.ts → harness/post.ts
-  └─→ saveCache (durable persistence)
-```
-
-## COMPLEXITY HOTSPOTS
-
-| File                              | Lines | Reason                                                 |
-| --------------------------------- | ----- | ------------------------------------------------------ |
-| `features/triggers/__fixtures__/` | 627   | Factory-style payload generation                       |
-| `features/agent/prompt.ts`        | 762   | XML-tagged prompt architecture, trigger directives     |
-| `services/session/types.ts`       | 292   | Session/message/part type hierarchy                    |
-| `services/github/api.ts`          | 289   | Reactions, labels, branch discovery                    |
-| `features/context/types.ts`       | 279   | GraphQL context types, budget constraints              |
-| `features/comments/reader.ts`     | 257   | Thread reading, pagination                             |
-| `services/github/context.ts`      | 254   | normalizeEvent() 8-variant union builder               |
-| `harness/config/inputs.ts`        | 247   | Input parsing and validation                           |
-| `services/session/search.ts`      | 220   | Session listing and cross-session search               |
-| `services/setup/setup.ts`         | 209   | Refactored setup orchestration (split config/adapters) |
+| Task | Location |
+| --- | --- |
+| Action orchestration | `src/harness/run.ts` (`run`) |
+| Agent SDK execution | `src/features/agent/execution.ts` (`executeOpenCode`) |
+| Event routing | `src/features/triggers/router.ts` (`routeEvent`) |
+| Event parsing / types | `src/services/github/context.ts`, `src/services/github/types.ts` (`NormalizedEvent`) |
+| Prompt building | `packages/runtime/src/agent/prompt.ts` (`buildAgentPrompt`) |
+| Setup / CI config | `src/services/setup/` (`runSetup`, `buildCIConfig`) |
+| Comment / review posting | `src/features/comments/writer.ts`, `src/features/reviews/reviewer.ts` |
+| Gateway mention loop | `packages/gateway/src/execute/run.ts` (`runMention`) |
+| Version pins | `packages/runtime/src/shared/constants.ts` |
 
 ## CONVENTIONS
 
@@ -191,18 +65,14 @@ bun run dist:check-hidden-unicode    # Verify dist/ has no raw hidden Unicode (l
 
 ## NOTES
 
-- **Four-layer architecture**: shared/ → services/ → features/ → harness/
-- **Layer dependency rules**: Each layer may only import from layers below it
-- **dist/ committed**: CI fails if `git diff dist/` shows changes after build
+For architecture (the four-layer rule, committed `dist/`, NormalizedEvent, dual entry points, XML-tagged prompt) see [ARCHITECTURE.md](ARCHITECTURE.md). Operational notes:
+
 - **Node 24 required**: Matches `action.yaml` runtime
-- **19 RFCs total**: Foundation, cache, GitHub client, sessions, triggers, security, observability, comments, PR review, delegated work, setup, execution, SDK mode, file attachments, GraphQL context, additional triggers, post-action hook, plugin, S3 backend
+- **19 RFCs total**: Foundation, cache, GitHub client, sessions, triggers, security, observability, comments, PR review, delegated work, setup, execution, SDK mode, file attachments, GraphQL context, additional triggers, post-action hook, agent-invokable delegated work, S3 backend
 - **SDK-based execution**: Uses `@opencode-ai/sdk` for server lifecycle + event streaming
 - **Bundled Systematic plugin**: Setup injects `@fro.bot/systematic@<version>` into CI OpenCode config by default
 - **Persistent memory**: Sessions survive across CI runs via GitHub Actions cache
-- **NormalizedEvent**: All webhook payloads pass through `normalizeEvent()` before routing; router never touches raw payloads
-- **Dual action entry points**: `main.ts` (execution) and `post.ts` (durable cache save)
-- **Pre-push hook**: Runs test + lint + build + dist diff check
-- **XML-tagged prompt**: Prompt sections wrapped in XML tags (`<harness_rules>`, `<task>`, `<user_supplied_instructions>`, `<agent_context>`, etc.) with explicit authority hierarchy and Anthropic-recommended section ordering (reference data first, task/instructions last)
+- **Pre-push hook**: Runs lint + build (the lint step includes the dist hidden-Unicode check)
 - **Release-notes narration**: After a release publishes, a `@semantic-release/exec` `successCmd` (`scripts/release/dispatch-release-notes.ts`) dispatches `fro-bot.yaml` on `main` to rewrite the GitHub Release body into a `## What's new` narrative. The model is operator-configurable via the `RELEASE_NOTES_MODEL` repository variable (must be a cliproxy-served id, e.g. `anthropic/claude-haiku-4-5-20251001`); narration is skipped with a warning if the variable is unset. Dispatch auth is `FRO_BOT_PAT` (`RELEASE_NOTES_DISPATCH_TOKEN`), not the read-only App token. It is idempotent (skips when the body already carries `<!-- fro-bot-narration-v1 -->`) and fail-soft: narrative-quality failures warn and never block the release, while security-relevant anomalies (off-target release edits, auth failures) fail the step.
 
 ## EXTERNAL RESOURCES

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,255 @@
+# Architecture
+
+This document describes the system design, invariants, and data flows for the fro-bot/agent monorepo. For directory layout and where to add new code, see [STRUCTURE.md](STRUCTURE.md). For operational knowledge, symbol tables, and commands, see [AGENTS.md](AGENTS.md).
+
+> **Deep dives:** [Architecture Overview](docs/wiki/Architecture%20Overview.md) · [Execution Lifecycle](docs/wiki/Execution%20Lifecycle.md) · [Conventions and Patterns](docs/wiki/Conventions%20and%20Patterns.md)
+
+## Bird's-Eye Overview
+
+This monorepo ships three distinct deployable surfaces from one codebase:
+
+- **GitHub Action** — a CI harness that runs OpenCode agents in response to GitHub webhook events (issues, PRs, comments, reviews, scheduled runs, workflow dispatches). The Action entry points are `src/main.ts` and `src/post.ts`; the real logic lives in the 4-layer `src/` tree and `packages/runtime/`. Sessions persist across CI runs via GitHub Actions cache and an S3-compatible object store.
+- **`@fro-bot/gateway`** (`packages/gateway/`) — a Discord-first daemon that listens for `@fro-bot` mentions in bound guild channels and runs OpenCode inside a sandboxed workspace container. Includes an operator web surface (Hono, gateway-net only), an inbound announce webhook, and an S3-backed coordination layer.
+- **`@fro.bot/harness`** (`packages/harness/`) — a patched OpenCode binary built via an LLM-merge integration pipeline. Published to npm and GitHub Releases; consumed by the Action setup phase as the default OpenCode binary.
+
+Supporting packages: `@fro-bot/runtime` (`packages/runtime/`) owns shared runtime primitives and version-pin constants; `@fro-bot/action` (`apps/action/`) is a thin workspace wrapper whose build produces the committed root `dist/`; `@fro-bot/workspace-agent` (`apps/workspace-agent/`) is the Hono HTTP sidecar inside the workspace container.
+
+## Codemap
+
+Symbols verified against the live source tree. Where a symbol has moved to `packages/runtime/`, the canonical location is noted.
+
+### Action / Root `src/`
+
+| Symbol | Type | Location | Role |
+| --- | --- | --- | --- |
+| `run` | Function | `src/harness/run.ts` | Main entry, phase orchestration |
+| `runPost` | Function | `src/harness/post.ts` | Post-action cache save |
+| `runSetup` | Function | `src/services/setup/setup.ts` | Setup orchestration |
+| `buildCIConfig` | Function | `src/services/setup/ci-config.ts` | CI config assembly with plugin injection |
+| `writeSystematicConfig` | Function | `src/services/setup/systematic-config.ts` | Systematic plugin config writer |
+| `restoreCache` | Function | `src/services/cache/restore.ts` | Restore OpenCode state |
+| `saveCache` | Function | `src/services/cache/save.ts` | Persist state to cache |
+| `executeOpenCode` | Function | `src/features/agent/execution.ts` | SDK execution orchestration |
+| `normalizeEvent` | Function | `src/services/github/context.ts` | Raw payload → typed NormalizedEvent |
+| `parseGitHubContext` | Function | `src/services/github/context.ts` | Global context → typed GitHubContext |
+| `routeEvent` | Function | `src/features/triggers/router.ts` | Event routing orchestration |
+| `postComment` | Function | `src/features/comments/writer.ts` | Create or update comment |
+| `submitReview` | Function | `src/features/reviews/reviewer.ts` | Submit PR review |
+| `parseActionInputs` | Function | `src/harness/config/inputs.ts` | Parse/validate inputs |
+| `createLogger` | Function | `src/shared/logger.ts` | Logger with redaction |
+| `ActionInputs` | Interface | `src/shared/types.ts` | Input schema |
+| `NormalizedEvent` | Union | `src/services/github/types.ts` | 8-variant discriminated event union |
+| `TriggerResult` | Interface | `src/features/triggers/types.ts` | Routing decision |
+
+### `packages/runtime/` (canonical prompt + agent primitives)
+
+`src/features/agent/prompt.ts` re-exports from `@fro-bot/runtime`; the implementations live here.
+
+| Symbol | Type | Location | Role |
+| --- | --- | --- | --- |
+| `buildAgentPrompt` | Function | `packages/runtime/src/agent/prompt.ts` | XML-tagged prompt with authority hierarchy |
+| `buildAgentContextSection` | Function | `packages/runtime/src/agent/prompt.ts` | Consolidated agent operations block |
+| `buildHarnessRulesSection` | Function | `packages/runtime/src/agent/prompt-thread.ts` | Non-negotiable rules with precedence declaration |
+| `sendPromptToSession` | Function | `src/features/agent/prompt-sender.ts` | Send prompt to SDK session |
+| `runPromptAttempt` | Function | `src/features/agent/retry.ts` | Execute prompt with retry logic |
+| `pollForSessionCompletion` | Function | `src/features/agent/session-poll.ts` | Poll SDK for completion status |
+| `processEventStream` | Function | `src/features/agent/streaming.ts` | Process SDK event stream |
+| `bootstrapOpenCodeServer` | Function | `src/features/agent/server.ts` | Initialize SDK server lifecycle |
+| `TriggerDirective` | Interface | `packages/runtime/src/agent/prompt.ts` | Directive + appendMode for triggers |
+| `DEFAULT_SYSTEMATIC_VERSION` | Constant | `packages/runtime/src/shared/constants.ts` | Pinned Systematic version (`2.32.1`) |
+| `DEFAULT_OPENCODE_VERSION` | Constant | `packages/runtime/src/shared/constants.ts` | Pinned harness version (`1.17.11+harness.bf0e9bed`) |
+
+### `packages/gateway/`
+
+| Symbol               | Type     | Location                                 | Role                             |
+| -------------------- | -------- | ---------------------------------------- | -------------------------------- |
+| `runMention`         | Function | `packages/gateway/src/execute/run.ts`    | Full mention execution lifecycle |
+| `launchWork`         | Function | `packages/gateway/src/execute/run.ts`    | Fire-and-return web launch path  |
+| `buildDiscordPrompt` | Function | `packages/gateway/src/execute/prompt.ts` | Discord-specific prompt builder  |
+| `buildOperatorApp`   | Function | `packages/gateway/src/web/server.ts`     | Operator Hono app factory        |
+
+## Invariants
+
+These are CI-enforced constraints. Violating any of them breaks the build or the system contract.
+
+1. **4-layer import rule.** The root `src/` tree is strictly layered: `shared/` → `services/` → `features/` → `harness/`. Each layer may only import from layers below it. Cross-layer imports in the wrong direction are a type error and a lint error.
+2. **Committed `dist/` must stay in sync.** CI runs `bun run build` and fails if `git diff dist/` shows changes. The pre-push hook enforces the same check locally. Never edit `dist/` by hand.
+3. **Strict booleans.** No implicit falsy checks (`!value`). Use explicit comparisons (`=== null`, `=== undefined`, `.length === 0`). Enforced by ESLint.
+4. **Functions only — no classes for stateful patterns.** Closures, not ES6 classes, carry state across the codebase (the only classes are a handful of `Error` subclasses in the gateway). Enforced by convention and code review.
+5. **Exactly one comment or review per invocation (Response Protocol).** The agent must post exactly one GitHub comment or PR review per Action run. Multiple comments are forbidden. This is a hard rule in `buildHarnessRulesSection()` and enforced by prompt architecture.
+6. **`NormalizedEvent` is never bypassed.** All webhook payloads must pass through `normalizeEvent()` before routing. The router never reads `context.payload` directly. Raw event access is an anti-pattern caught in code review.
+7. **No type suppression.** `as any`, `@ts-ignore`, and `@ts-expect-error` are forbidden project-wide.
+8. **Redaction-before-query (gateway).** The gateway denylist check runs before any binding lookup, run-state read, or GitHub API call. A repo redacted in `metadata/repos.yaml` is never queried. Cold-start failure → deny all (fail-closed).
+
+> See also: [Conventions and Patterns](docs/wiki/Conventions%20and%20Patterns.md)
+
+## Data Flow
+
+Three distinct execution flows operate in this system. They share the `packages/runtime/` primitives but have separate entry points, triggers, and lifecycles.
+
+### 1. Action Phase Pipeline
+
+Triggered by a GitHub webhook event dispatched to the Action runner.
+
+```
+main.ts
+  └─→ harness/run.ts (run)
+        │
+        ├─→ bootstrap phase
+        │     parseActionInputs → ensureOpenCodeAvailable → restoreCache
+        │
+        ├─→ routing phase
+        │     parseGitHubContext → normalizeEvent → routeEvent
+        │     (produces TriggerResult; skips if no matching trigger)
+        │
+        ├─→ dedup phase
+        │     skip if agent already ran for this PR/issue within dedup window
+        │     (happy path shown; lock acquisition and review reconciliation
+        │      phases also run where applicable)
+        │
+        ├─→ acknowledge phase
+        │     acknowledgeReceipt (reaction + comment stub)
+        │
+        ├─→ cache-restore phase
+        │     dedicated session state restore from S3 / Actions cache
+        │
+        ├─→ session-prep phase
+        │     processAttachments → buildAgentPrompt (packages/runtime)
+        │
+        ├─→ execute phase
+        │     executeOpenCode → bootstrapOpenCodeServer → sendPromptToSession
+        │       → runPromptAttempt → processEventStream (SSE)
+        │
+        ├─→ finalize phase
+        │     writeSessionSummary → pruneSessions
+        │
+        └─→ cleanup phase
+              saveCache → writeJobSummary
+
+post.ts (separate Action step)
+  └─→ harness/post.ts (runPost)
+        └─→ saveCache (durable persistence, runs even on failure)
+```
+
+> See also: [Execution Lifecycle](docs/wiki/Execution%20Lifecycle.md)
+
+### 2. Gateway Mention-Loop
+
+Triggered by an `@fro-bot` mention in a Discord guild channel bound to a repo.
+
+```
+Discord messageCreate event
+  └─→ packages/gateway/src/discord/mentions.ts
+        │
+        ├─→ thread guard (skip if already in a thread)
+        ├─→ authorization gate
+        │     guild.members.fetch() [REST, never cache]
+        │     → role check (GATEWAY_TRIGGER_ROLE_ID) or ManageChannels
+        │     → fail-closed on any resolution error
+        │
+        ├─→ binding lookup
+        │     S3 object-store index → RepoBinding
+        │
+        └─→ runMention (packages/gateway/src/execute/run.ts)
+              │
+              ├─→ concurrency cap + per-channel FIFO queue
+              ├─→ thread creation on source message
+              ├─→ S3 conditional-write lock acquisition
+              │     (coordination/lock.ts; heartbeat renews lease)
+              │
+              ├─→ run-state lifecycle
+              │     PENDING → ACKNOWLEDGED → EXECUTING
+              │
+              ├─→ execute/run-core.ts
+              │     buildDiscordPrompt → OpenCode (workspace:9200, bearer auth)
+              │     → SSE event stream → discord/streaming.ts → thread reply
+              │
+              ├─→ tool approval (if any tool set to `ask`)
+              │     permission.asked → Discord embed (Approve/Deny buttons)
+              │     → approval registry → workspace resume/reject
+              │
+              └─→ completion
+                    run → COMPLETED; heartbeat stop; lock release
+                    on failure → FAILED; coarse error reply to thread
+```
+
+> See also: [Architecture Overview](docs/wiki/Architecture%20Overview.md) · [Operator Web Control Surface](docs/wiki/Operator%20Web%20Control%20Surface.md)
+
+### 3. Harness Release Pipeline
+
+Triggered by `workflow_dispatch` on `.github/workflows/harness-release.yaml`.
+
+```
+harness-release.yaml (workflow_dispatch)
+  │
+  ├─→ prepare-integrate job
+  │     resolve base_version → render prompt from packages/harness/prompt.txt
+  │     → emit: base_version, rendered_prompt, has_refs
+  │
+  ├─→ integrate job (skipped when has_refs == 'false')
+  │     uses: .github/workflows/fro-bot.yaml (Fro Bot agent, secrets: inherit)
+  │     agent:
+  │       clone anomalyco/opencode → create integration branch at base tag
+  │       → merge configured refs (harness.config.json carry-policy allowlist)
+  │       → build + verify host CLI
+  │       → push to refs/harness-integrate/<version>
+  │
+  ├─→ build matrix (linux-x64, linux-arm64, darwin-x64, darwin-arm64)
+  │     needs: [prepare-integrate, integrate]
+  │     fetch refs/harness-integrate/<version> (or stock tag if has_refs=false)
+  │     → build-platform.ts --source-tree <tree> --integration-commit <sha>
+  │     → emit: integration_commit
+  │
+  └─→ publish job (gated by npm-publish environment + required reviewers)
+        OIDC trusted publishing (id-token: write, publish job only)
+        → npm publish @fro.bot/harness + 4 per-platform packages
+        → GitHub Release (OpenCode-shaped assets + SHA256SUMS)
+```
+
+> See also: [Architecture Overview](docs/wiki/Architecture%20Overview.md)
+
+## Cross-Cutting Concerns
+
+### Redaction and Logging Gate
+
+Every function takes an injected `logger` parameter (never `console.log`). The logger (`createLogger` in `src/shared/logger.ts`) auto-redacts secrets and sensitive values before any log line is emitted. In the gateway, the operator denylist gate (`packages/gateway/src/operator-contract/redaction.ts`, `REDACTION_OBLIGATION`) enforces that redacted repo identity is never stored, logged, or returned — only deny keys (`databaseId` / `nodeId`) are retained.
+
+> See also: [Conventions and Patterns](docs/wiki/Conventions%20and%20Patterns.md)
+
+### NormalizedEvent Discriminated Union
+
+All GitHub webhook payloads are normalized through `normalizeEvent()` (`src/services/github/context.ts`) into a typed `NormalizedEvent` discriminated union (`src/services/github/types.ts`) with 8 variants before any routing logic runs. The router (`routeEvent`) operates exclusively on `NormalizedEvent`; raw `context.payload` access is forbidden. This is Invariant 6 above.
+
+> See also: [Execution Lifecycle](docs/wiki/Execution%20Lifecycle.md)
+
+### XML-Tagged Prompt Architecture
+
+Agent prompts are assembled from named XML-tagged sections with an explicit authority hierarchy. Section order follows Anthropic's recommended pattern: reference data first (`<harness_rules>`, `<identity>`, `<environment>`, `<issue>`/`<pull_request>`, `<session_context>`), task and instructions last (`<task>`, `<user_supplied_instructions>`, `<output_contract>`, `<agent_context>`). `<harness_rules>` takes precedence over `<user_supplied_instructions>`. The canonical builder is `buildAgentPrompt` in `packages/runtime/src/agent/prompt.ts`.
+
+> See also: [Prompt Architecture](docs/wiki/Prompt%20Architecture.md)
+
+### OIDC Trusted Publishing
+
+The harness release workflow publishes to npm via OIDC (no long-lived npm token). `id-token: write` is scoped to the `publish` job only; `integrate` and `build` jobs run with `contents: read` and no `id-token`. Each of the five packages (`@fro.bot/harness` + four per-platform packages) requires a one-time trusted-publisher configuration on npmjs.com before OIDC publishes can succeed.
+
+### S3 Conditional-Write Lock (Gateway)
+
+The gateway uses S3 conditional writes (`If-None-Match` / `If-Match`) as a distributed coordination lock for per-repo execution. Lock acquisition, lease renewal (heartbeat), and release live in `packages/runtime/src/coordination/lock.ts` (runtime-owned, called by the gateway). The lock is always released in a `finally` block. Stale locks (expired lease + stale heartbeat) are recovered by `packages/gateway/src/execute/recovery.ts` on gateway startup.
+
+### Mitmproxy Egress Topology (Workspace)
+
+The workspace container runs inside a sandboxed Docker Compose network. All outbound traffic from the workspace is routed through a `mitmproxy` instance on `egress-net`; the workspace itself is on `sandbox-net` with no direct internet access. The mitmproxy enforces an allowlist of permitted outbound hosts. The gateway reaches the workspace via Docker Compose service DNS (`workspace:9100` for the workspace agent, `workspace:9200` for the OpenCode reverse proxy).
+
+```
+workspace container (sandbox-net)
+  └─→ mitmproxy (sandbox-net ↔ egress-net)
+        └─→ internet (allowlisted hosts only)
+
+gateway container (gateway-net)
+  └─→ workspace:9100  (workspace-agent clone/setup API)
+  └─→ workspace:9200  (OpenCode reverse proxy, bearer auth)
+```
+
+### Effect / Result Boundary (Gateway)
+
+`packages/gateway/` is the only package in the monorepo that uses `effect`. The Action and `packages/runtime/` stay on hand-rolled `Result<T, E>` from `@bfra.me/es`. The boundary adapter is `packages/gateway/src/runtime-effect.ts`, which wraps every `@fro-bot/runtime` function the gateway uses. All gateway code outside that file works exclusively in `Effect.Effect<A, E, R>`.

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,0 +1,150 @@
+# Structure
+
+This document maps the repository's directory layout and explains where code lives. For system design, invariants, and data flows see [`ARCHITECTURE.md`](ARCHITECTURE.md) (forthcoming). For agent-operational knowledge — commands, conventions, and the full code map — see [`AGENTS.md`](AGENTS.md).
+
+## Directory Layout
+
+```text
+fro-bot/agent/
+├── src/                        # GitHub Action logic — 4-layer architecture (40 k lines)
+│   ├── shared/                 # Layer 0: pure types, utils, constants (only @bfra.me/es Result; no heavy deps)
+│   ├── services/               # Layer 1: external adapters (GitHub, cache, setup, object-store, artifact)
+│   │   ├── github/             # Octokit client, context parsing, NormalizedEvent
+│   │   ├── cache/              # Restore/save with corruption detection
+│   │   ├── setup/              # Bun, oMo, OpenCode + Systematic install/config
+│   │   ├── artifact/           # Artifact upload
+│   │   └── session/            # (stub — session types migrated to packages/runtime)
+│   ├── features/               # Layer 2: business logic
+│   │   ├── agent/              # SDK execution, prompts, streaming, retry
+│   │   ├── triggers/           # Event routing, skip conditions, context builders
+│   │   ├── comments/           # GitHub comment read/write, error formatting
+│   │   ├── context/            # GraphQL hydration for issues/PRs
+│   │   ├── reviews/            # PR diff parsing, review comments
+│   │   ├── attachments/        # File attachment processing
+│   │   ├── delegated/          # Branch/commit/PR operations
+│   │   └── observability/      # Metrics collection, run summaries
+│   └── harness/                # Layer 3: workflow composition (entry points, phases)
+│       ├── config/             # Input parsing, outputs, state keys, omo-providers
+│       └── phases/             # Bootstrap, routing, dedup, execute, finalize, cleanup, …
+│
+├── apps/
+│   ├── action/                 # @fro-bot/action — thin wrapper; main.ts = import '../../../src/main.js'
+│   └── workspace-agent/        # @fro-bot/workspace-agent — Hono HTTP service in workspace container
+│
+├── packages/
+│   ├── gateway/                # @fro-bot/gateway — Discord daemon + operator web surface
+│   │   └── src/
+│   │       ├── discord/        # Discord client, mentions, commands, streaming
+│   │       ├── execute/        # run-core, queue, concurrency, recovery
+│   │       ├── web/            # Operator HTTP routes, SSE, audit
+│   │       ├── workspace-api/  # Workspace API surface
+│   │       ├── approvals/      # Approval gate
+│   │       ├── operator-contract/ # Operator contract types
+│   │       └── redaction/      # PII/secret redaction gate
+│   ├── harness/                # @fro.bot/harness — patched-OpenCode build + publish pipeline
+│   └── runtime/                # @fro-bot/runtime — shared runtime primitives + version-pin constants
+│       └── src/
+│           ├── shared/         # Logger, types, constants (owns real version pins)
+│           ├── session/        # Session storage, search, prune, writeback
+│           ├── object-store/   # S3-compatible canonical persistence
+│           ├── agent/          # Shared agent execution primitives
+│           └── coordination/   # Heartbeat, lock, run-state
+│
+├── deploy/                     # Docker Compose stack, Dockerfiles, mitmproxy egress topology
+│   └── scripts/                # Plain Node ESM (.mjs) deploy helpers; node --test runner
+│
+├── scripts/                    # Repo-level build scripts (build-action-dist, unicode checks, release)
+│   └── release/                # Release dispatch scripts
+│
+├── .github/
+│   └── workflows/              # 10 CI/CD workflow files
+│
+├── RFCs/                       # 19 RFC documents (architecture specs)
+├── docs/
+│   ├── wiki/                   # 8 Obsidian deep-dive pages
+│   ├── plans/                  # Architecture plans and design docs
+│   ├── solutions/              # Documented solutions to past problems
+│   └── decisions/              # Architecture decision records
+│
+├── action.yaml                 # GitHub Action definition (node24 runtime)
+├── dist/                       # Committed bundled output — must stay in sync with src/
+├── tsdown.config.ts            # tsdown/rolldown bundler config (dual entry points)
+├── vitest.config.ts            # Vitest workspace config
+└── package.json                # Bun workspace root
+```
+
+## Directory Purposes
+
+- **`src/`** — The GitHub Action's real logic; all four layers live here and are bundled into root `dist/`.
+- **`src/shared/`** — Pure utilities and types with no external dependencies; every other layer imports from here.
+- **`src/services/`** — Adapters that talk to external systems (GitHub API, Actions cache, S3, tool installers); no business logic.
+- **`src/features/`** — Business logic organized by capability; imports from `shared/` and `services/` only.
+- **`src/harness/`** — Entry points and phase orchestration; the only layer allowed to compose across all others.
+- **`apps/action/`** — Thin workspace package whose sole purpose is re-exporting `src/main.ts` and `src/post.ts`; its build produces the committed root `dist/`.
+- **`apps/workspace-agent/`** — Hono HTTP service that runs inside the workspace container; touch when adding workspace-side API endpoints.
+- **`packages/gateway/`** — Discord-first daemon and operator web surface; the largest package, containing the mention loop, command handlers, approval gate, and redaction pipeline.
+- **`packages/harness/`** — Patched-OpenCode build and publish pipeline; touch when updating the bundled OpenCode binary.
+- **`packages/runtime/`** — Shared runtime primitives consumed by both `src/` and `packages/gateway/`; owns the authoritative version-pin constants.
+- **`deploy/`** — Docker Compose stack, Dockerfiles, mitmproxy egress topology, and deploy validation scripts.
+- **`deploy/scripts/`** — Plain Node ESM (`.mjs`) helpers for deploy-time operations; uses `node --test`, not Vitest.
+- **`scripts/`** — Repo-level build tooling: action dist builder, hidden-Unicode scrubber, third-party notices, release dispatch.
+- **`.github/workflows/`** — All CI/CD automation; 10 workflow files covering tests, releases, security scanning, and bot triggers.
+- **`RFCs/`** — 19 architecture specification documents; read before making cross-cutting changes.
+- **`docs/wiki/`** — 8 Obsidian deep-dive pages covering architecture, execution lifecycle, prompt design, and operator surface.
+- **`dist/`** — Committed bundle output; CI fails if a fresh build produces a diff here.
+
+## Key File Locations
+
+### Packages and Apps
+
+| Package | Path | Role |
+| --- | --- | --- |
+| `@fro-bot/action` | `apps/action/` | Thin wrapper re-exporting root `src/`; build produces committed `dist/` |
+| `@fro-bot/workspace-agent` | `apps/workspace-agent/` | Hono HTTP service in the workspace container |
+| `@fro-bot/gateway` | `packages/gateway/` | Discord daemon, operator web surface, mention loop, redaction |
+| `@fro.bot/harness` | `packages/harness/` | Patched-OpenCode build and publish pipeline |
+| `@fro-bot/runtime` | `packages/runtime/` | Shared runtime primitives; owns authoritative version-pin constants |
+
+### CI Workflows
+
+| Workflow | Trigger | Role |
+| --- | --- | --- |
+| `auto-release.yaml` | `pull_request` | Automated release preparation on PR merge |
+| `ci.yaml` | `push`, `pull_request`, `workflow_dispatch`, `release` | Main CI: test, lint, type-check, build, dist diff |
+| `codeql-analysis.yaml` | `push`, `pull_request`, `schedule`, `workflow_dispatch` | CodeQL security scanning |
+| `copilot-setup-steps.yaml` | `push`, `pull_request`, `workflow_dispatch` | Copilot environment setup steps |
+| `fro-bot.yaml` | `issue_comment`, `issues`, `schedule`, `workflow_dispatch` | Fro Bot agent invocation (the Action under development) |
+| `harness-release.yaml` | `push`, `workflow_dispatch` | Build matrix and publish for `@fro.bot/harness` |
+| `prepare-release-pr.yaml` | `schedule`, `workflow_dispatch` | Opens release PR via semantic-release |
+| `renovate.yaml` | `issues`, `pull_request`, `push`, `workflow_dispatch`, `workflow_run` | Renovate dependency update automation |
+| `scorecard.yaml` | `schedule`, `push` | OpenSSF Scorecard security posture |
+| `update-repo-settings.yaml` | `push`, `schedule`, `workflow_dispatch` | Sync repository settings from config |
+
+### Deploy
+
+| File                                   | Builds                                                |
+| -------------------------------------- | ----------------------------------------------------- |
+| `deploy/gateway.Dockerfile`            | `@fro-bot/gateway` daemon container                   |
+| `deploy/workspace.Dockerfile`          | Workspace container (runs `@fro-bot/workspace-agent`) |
+| `deploy/compose.yaml`                  | Full stack: gateway + workspace + mitmproxy egress    |
+| `deploy/compose.override.example.yaml` | Local override template for `compose.yaml`            |
+
+## Naming Conventions
+
+- **ESM `.js` extensions** — all relative imports in TypeScript source use `.js` extensions (e.g. `import './utils.js'`), even though the source files are `.ts`.
+- **Colocated tests** — test files live next to the code they test as `<name>.test.ts`; no separate `__tests__/` directories.
+- **Per-directory `AGENTS.md`** — every significant directory carries its own `AGENTS.md` with local conventions, symbols, and notes for that layer.
+- **Kebab-case filenames** — all source files use kebab-case (e.g. `cache-key.ts`, `build-action-dist.ts`).
+- **`deploy/scripts/` carve-out** — files under `deploy/scripts/` are plain Node ESM (`.mjs`) and use `node --test`, not Vitest; they are not workspace packages and have no build step.
+
+## Where to Add New Code
+
+Use this decision tree to find the right home for new code:
+
+- **New Action phase, trigger handler, comment handler, or reviewer** → `src/features/<capability>/` (e.g. `src/features/triggers/`, `src/features/comments/`); wire it into `src/harness/phases/` or `src/features/triggers/router.ts`.
+- **New Discord command** → `packages/gateway/src/discord/commands/`; register it in the commands index.
+- **New bundled CLI tool or version-pinned binary** (Bun, oMo, OpenCode, Systematic) → add a versioned-tool entry in `src/services/setup/` following the existing adapter pattern; pin the version constant in `packages/runtime/src/shared/constants.ts`.
+- **New workspace API endpoint** → `apps/workspace-agent/src/`; add the route to the Hono server.
+- **Shared primitive used by both Action and gateway** → `packages/runtime/src/`; export from its `index.ts`.
+- **New GitHub API helper** → `src/services/github/api.ts` or a new file under `src/services/github/`.
+- **New deploy service or container** → `deploy/` (Dockerfile + compose service entry).

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Structure
 
-This document maps the repository's directory layout and explains where code lives. For system design, invariants, and data flows see [`ARCHITECTURE.md`](ARCHITECTURE.md) (forthcoming). For agent-operational knowledge — commands, conventions, and the full code map — see [`AGENTS.md`](AGENTS.md).
+This document maps the repository's directory layout and explains where code lives. For system design, invariants, and data flows see [`ARCHITECTURE.md`](ARCHITECTURE.md). For agent-operational knowledge — commands, conventions, and the full code map — see [`AGENTS.md`](AGENTS.md).
 
 ## Directory Layout
 


### PR DESCRIPTION
Adds the two canonical onboarding docs and slims `AGENTS.md` so each fact has one home.

## What changed

- **`ARCHITECTURE.md`** (new) — bird's-eye overview, a codemap of the load-bearing symbols, the CI-enforced invariants (4-layer import rule, committed `dist/`, strict booleans, NormalizedEvent, Response Protocol), the three execution flows (Action phase pipeline, gateway mention-loop, harness release pipeline), and cross-cutting concerns (redaction gate, OIDC trusted publishing, the S3 conditional-write lock, the mitmproxy egress topology, the XML-tagged prompt).
- **`STRUCTURE.md`** (new) — the directory layout (special-casing the layered `src/` Action and the package/app surfaces), one-line directory purposes, key-file-location tables for packages/apps, CI workflows, and deploy, the naming conventions, and a where-to-add-new-code decision tree.
- **`AGENTS.md`** — slimmed from 233 to ~100 lines. The architecture, code map, execution flow, and structure content moved into the two new docs; what remains is the operational material an agent needs (conventions, anti-patterns, commands, external resources, cloned-deps) plus a compact where-to-look pointer index and links to the new docs.

## How it was produced

Both docs were generated from live-repo facts using the `generating-project-docs` skill (added in #1073): file paths and symbols resolve against the current tree, counts come from live `find`/`wc` output rather than the stale numbers AGENTS.md used to carry, and version pins come from `packages/runtime/src/shared/constants.ts`.

## Accuracy pass

A review pass caught and fixed several facts the first draft got wrong: the package-name convention (only `@fro.bot/harness` is dotted — `gateway`/`runtime`/`workspace-agent`/`action` are `@fro-bot/`), the bundler (tsdown/rolldown, not esbuild), the pre-push hook contents, the "no classes anywhere" invariant (the gateway has a few `Error` subclasses; the rule is convention, not ESLint), and the RFC list. All cross-doc links resolve; `bun run lint` is clean.

## Scope

Unit 3 of the staged documentation reconciliation. Unit 4 (CONTRIBUTING.md from RULES.md + SECURITY.md) and Unit 5 (README refresh) follow. Units 1 (#1071) and 2 (#1073) are merged.

Refs `docs/plans/2026-06-30-001-feat-generating-project-docs-skill-plan.md`
