### PR TITLE
feat(harness): mint the integrate merge credential from the OIDC broker

### DIFF
--- a/.github/workflows/harness-integrate.yaml
+++ b/.github/workflows/harness-integrate.yaml
@@ -1,0 +1,88 @@
+---
+# ONE-JOB SECURITY INVARIANT
+# ---------------------------------------------------------------------------
+# This workflow MUST have exactly one job.
+#
+# The broker's allowlist pins `job_workflow_ref` to
+# `fro-bot/agent/.github/workflows/harness-integrate.yaml@refs/heads/main`.
+# That pin authorizes ANY job in THIS file to mint a credential — it does not
+# distinguish between jobs. A second job would silently inherit the same
+# minting authority without a corresponding allowlist review.
+#
+# Any change that adds a job to this file is security-critical and must be
+# reviewed as such. Keep `id-token: write` scoped to the single `integrate`
+# job below; do not add other jobs.
+# ---------------------------------------------------------------------------
+name: harness-integrate
+
+on:
+  workflow_call:
+    inputs:
+      model:
+        description: Model override for the merge agent (e.g. anthropic/claude-sonnet-4-6). Falls back to vars.HARNESS_MODEL when omitted.
+        type: string
+        required: false
+      prompt:
+        description: The rendered integration prompt to run.
+        type: string
+        required: false
+    secrets:
+      FRO_BOT_PAT:
+        description: PAT used for checkout and as the action's github-token. Required.
+        required: true
+      OPENCODE_CONFIG:
+        description: JSON merged into the OpenCode config (OPENCODE_CONFIG_CONTENT). Optional.
+        required: false
+      OMO_PROVIDERS:
+        description: Comma-separated oMo providers passed through to the merge (enable-omo is true on this path). Optional.
+        required: false
+      # NO AUTH_JSON. NO secrets: inherit. The durable model credential must
+      # never reach this workflow — see docs/plans/2026-07-01-001-feat-harness-merge-credential-broker-plan.md.
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Single job: id-token: write is required to request the OIDC token minted
+  # against the credential broker. contents: read is required for checkout.
+  # Everything else is omitted (denied by default). See the ONE-JOB SECURITY
+  # INVARIANT comment at the top of this file before adding anything here.
+  # ---------------------------------------------------------------------------
+  integrate:
+    name: integrate
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.FRO_BOT_PAT }}
+
+      - name: Setup Node.js and Bun
+        uses: ./.github/actions/setup
+
+      - name: Mint broker credential
+        id: mint
+        run: node --experimental-strip-types scripts/harness/mint-broker-credential.ts
+
+      # SYNC: keep the shared merge inputs in step with fro-bot.yaml's Run Fro Bot step
+      - name: Run Fro Bot
+        uses: ./
+        with:
+          auth-json: ${{ steps.mint.outputs.auth-json }}
+          github-token: ${{ secrets.FRO_BOT_PAT }}
+          model: ${{ inputs.model || vars.HARNESS_MODEL }}
+          prompt: ${{ inputs.prompt }}
+          response-mode: none
+          output-mode: working-dir
+          # Preserve the current integrate behavior: the merge runs with oMo
+          # enabled (the correlation-id-gated disable in fro-bot.yaml applies
+          # only to release-notes narration, not this path).
+          enable-omo: true
+          omo-providers: ${{ secrets.OMO_PROVIDERS }}
+          opencode-config: ${{ secrets.OPENCODE_CONFIG }}
+          timeout: '0'

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -189,8 +189,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   # ---------------------------------------------------------------------------
-  # Integrate job — calls fro-bot.yaml as a reusable workflow.
-  # Fro Bot installs opencode, provisions auth, and runs the LLM merge.
+  # Integrate job — calls harness-integrate.yaml as a reusable workflow.
+  # harness-integrate.yaml mints a short-lived credential from the OIDC
+  # credential broker (no secrets: inherit, no AUTH_JSON) and runs the LLM
+  # merge on it via the Fro Bot action.
   # vars.HARNESS_MODEL must be set to anthropic/claude-sonnet-4-6 in repo vars.
   # Skipped when the carry set is empty (has_refs == 'false').
   # ---------------------------------------------------------------------------
@@ -198,12 +200,14 @@ jobs:
     name: integrate (LLM merge via Fro Bot)
     needs: prepare-integrate
     if: ${{ needs.prepare-integrate.outputs.has_refs == 'true' }}
-    uses: ./.github/workflows/fro-bot.yaml
-    secrets: inherit
+    uses: ./.github/workflows/harness-integrate.yaml
+    secrets:
+      FRO_BOT_PAT: ${{ secrets.FRO_BOT_PAT }}
+      OPENCODE_CONFIG: ${{ secrets.OPENCODE_CONFIG }}
+      OMO_PROVIDERS: ${{ secrets.OMO_PROVIDERS }}
     with:
       model: ${{ vars.HARNESS_MODEL }}
       prompt: ${{ needs.prepare-integrate.outputs.rendered_prompt }}
-      response-mode: none
 
   # ---------------------------------------------------------------------------
   # Per-platform build matrix

--- a/scripts/harness/mint-broker-credential.test.ts
+++ b/scripts/harness/mint-broker-credential.test.ts
@@ -369,6 +369,26 @@ describe('main — error paths (fail closed)', () => {
     expect(mocks.setOutput).not.toHaveBeenCalled()
   })
 
+  it('exits non-zero and emits nothing when the response body read fails or hangs', async () => {
+    // #given: a 2xx response whose body read rejects (e.g. the shared AbortSignal
+    // aborts a slow/hung body) — must be caught and fail closed, not escape.
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => {
+        throw new Error('The operation was aborted due to timeout')
+      },
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
   it('exits non-zero and emits nothing for a one-valid-one-invalid-provider payload (all-or-nothing)', async () => {
     // #given
     const fetchMock = vi.fn().mockResolvedValue(

--- a/scripts/harness/mint-broker-credential.test.ts
+++ b/scripts/harness/mint-broker-credential.test.ts
@@ -1,0 +1,448 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getIDToken: vi.fn<(audience?: string) => Promise<string>>(),
+  setSecret: vi.fn<(value: string) => void>(),
+  setOutput: vi.fn<(name: string, value: unknown) => void>(),
+}))
+
+vi.mock('@actions/core', () => ({
+  getIDToken: mocks.getIDToken,
+  setSecret: mocks.setSecret,
+  setOutput: mocks.setOutput,
+}))
+
+const {BROKER_AUDIENCE, main, resolveBrokerUrl, validateBrokerResponse} = await import('./mint-broker-credential.js')
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+  } as Response
+}
+
+const VALID_AUTH_JSON = {anthropic: {type: 'api', key: 'sk-ant-test-123'}}
+
+describe('resolveBrokerUrl', () => {
+  it('returns the BROKER_URL override when set', () => {
+    // #given
+    const env = {BROKER_URL: 'https://broker.test.local'}
+
+    // #when
+    const result = resolveBrokerUrl(env)
+
+    // #then
+    expect(result).toBe('https://broker.test.local')
+  })
+
+  it('returns the production default when BROKER_URL is unset', () => {
+    // #given
+    const env: NodeJS.ProcessEnv = {}
+
+    // #when
+    const result = resolveBrokerUrl(env)
+
+    // #then
+    expect(result).toBe('https://broker.fro.bot')
+  })
+
+  it('returns the production default when BROKER_URL is empty/whitespace', () => {
+    // #given
+    const env = {BROKER_URL: '   '}
+
+    // #when
+    const result = resolveBrokerUrl(env)
+
+    // #then
+    expect(result).toBe('https://broker.fro.bot')
+  })
+})
+
+describe('validateBrokerResponse', () => {
+  it('accepts a well-formed single-provider payload', () => {
+    // #given
+    const raw = JSON.stringify(VALID_AUTH_JSON)
+
+    // #when
+    const result = validateBrokerResponse(raw)
+
+    // #then
+    expect(result.ok).toBe(true)
+    expect((result as {ok: true; authJson: string}).authJson).toBe(JSON.stringify(VALID_AUTH_JSON))
+  })
+
+  it('accepts a well-formed multi-provider payload', () => {
+    // #given
+    const raw = JSON.stringify({
+      anthropic: {type: 'api', key: 'sk-ant-1'},
+      openai: {type: 'api', key: 'sk-openai-2'},
+    })
+
+    // #when
+    const result = validateBrokerResponse(raw)
+
+    // #then
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects invalid JSON', () => {
+    // #given
+    const raw = 'not valid json{{'
+
+    // #when
+    const result = validateBrokerResponse(raw)
+
+    // #then
+    expect(result.ok).toBe(false)
+    expect((result as {ok: false; reason: string}).reason).toContain('not valid JSON')
+  })
+
+  it('rejects a JSON array', () => {
+    // #given
+    const raw = '["anthropic"]'
+
+    // #when
+    const result = validateBrokerResponse(raw)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a JSON string', () => {
+    // #given
+    const raw = '"just a string"'
+
+    // #when
+    const result = validateBrokerResponse(raw)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects null', () => {
+    // #given
+    const raw = 'null'
+
+    // #when
+    const result = validateBrokerResponse(raw)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects an empty object (zero providers)', () => {
+    // #given
+    const raw = '{}'
+
+    // #when
+    const result = validateBrokerResponse(raw)
+
+    // #then
+    expect(result.ok).toBe(false)
+    expect((result as {ok: false; reason: string}).reason).toContain('zero providers')
+  })
+
+  it('rejects a provider missing "type"', () => {
+    // #given
+    const raw = JSON.stringify({anthropic: {key: 'sk-ant-test'}})
+
+    // #when
+    const result = validateBrokerResponse(raw)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a provider with a non-"api" type', () => {
+    // #given
+    const raw = JSON.stringify({anthropic: {type: 'oauth', key: 'sk-ant-test'}})
+
+    // #when
+    const result = validateBrokerResponse(raw)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a provider with an empty key', () => {
+    // #given
+    const raw = JSON.stringify({anthropic: {type: 'api', key: ''}})
+
+    // #when
+    const result = validateBrokerResponse(raw)
+
+    // #then
+    expect(result.ok).toBe(false)
+    expect((result as {ok: false; reason: string}).reason).toContain('empty or missing key')
+  })
+
+  it('rejects a provider with a non-string key', () => {
+    // #given
+    const raw = JSON.stringify({anthropic: {type: 'api', key: 12345}})
+
+    // #when
+    const result = validateBrokerResponse(raw)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a provider id with invalid characters', () => {
+    // #given — provider id contains a space, which the allowlist pattern forbids
+    const raw = '{"bad provider": {"type": "api", "key": "sk-ant-test"}}'
+
+    // #when
+    const result = validateBrokerResponse(raw)
+
+    // #then
+    expect(result.ok).toBe(false)
+    expect((result as {ok: false; reason: string}).reason).toContain('invalid characters')
+  })
+
+  it('rejects an entire payload with one valid and one invalid provider (all-or-nothing)', () => {
+    // #given
+    const raw = JSON.stringify({
+      anthropic: {type: 'api', key: 'sk-ant-valid'},
+      openai: {type: 'api', key: ''}, // invalid: empty key
+    })
+
+    // #when
+    const result = validateBrokerResponse(raw)
+
+    // #then — the entire payload is rejected, not just the bad provider
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a provider value that is not an object', () => {
+    // #given
+    const raw = JSON.stringify({anthropic: 'sk-ant-test'})
+
+    // #when
+    const result = validateBrokerResponse(raw)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a provider value that is an array', () => {
+    // #given
+    const raw = JSON.stringify({anthropic: ['type', 'api']})
+
+    // #when
+    const result = validateBrokerResponse(raw)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+})
+
+describe('main — happy path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.exitCode = undefined
+    mocks.getIDToken.mockResolvedValue('fake-oidc-jwt')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    process.exitCode = undefined
+  })
+
+  it('emits the masked payload as a step output and does not set a non-zero exit code', async () => {
+    // #given a valid OIDC token and a well-formed broker response
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, VALID_AUTH_JSON))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBeUndefined()
+    expect(mocks.setOutput).toHaveBeenCalledWith('auth-json', JSON.stringify(VALID_AUTH_JSON))
+    expect(mocks.setSecret).toHaveBeenCalledWith(JSON.stringify(VALID_AUTH_JSON))
+  })
+
+  it('masks the OIDC token via setSecret before the broker POST fires', async () => {
+    // #given
+    const callOrder: string[] = []
+    mocks.setSecret.mockImplementation((value: string) => {
+      if (value === 'fake-oidc-jwt') callOrder.push('setSecret(oidc)')
+    })
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      callOrder.push('fetch')
+      return jsonResponse(200, VALID_AUTH_JSON)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then — setSecret(oidc) happened strictly before fetch
+    expect(callOrder).toEqual(['setSecret(oidc)', 'fetch'])
+  })
+
+  it('uses the correct broker audience for getIDToken', async () => {
+    // #given
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, VALID_AUTH_JSON))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(mocks.getIDToken).toHaveBeenCalledWith(BROKER_AUDIENCE)
+  })
+
+  it('sends exactly one POST to <brokerUrl>/v1/mint with the bearer token', async () => {
+    // #given
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, VALID_AUTH_JSON))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://broker.fro.bot/v1/mint')
+    expect(init.method).toBe('POST')
+    const headers = init.headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer fake-oidc-jwt')
+    expect(headers['Content-Type']).toBe('application/json')
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+  })
+})
+
+describe('main — error paths (fail closed)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.exitCode = undefined
+    mocks.getIDToken.mockResolvedValue('fake-oidc-jwt')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    process.exitCode = undefined
+  })
+
+  it('exits non-zero and emits nothing when the broker returns a non-2xx status', async () => {
+    // #given
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(403, {error: 'forbidden'}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('exits non-zero and emits nothing when the broker returns 200 with a zero-provider body', async () => {
+    // #given
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, {}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('exits non-zero and emits nothing when the broker returns 200 with a malformed body', async () => {
+    // #given
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => 'not valid json{{',
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('exits non-zero and emits nothing for a one-valid-one-invalid-provider payload (all-or-nothing)', async () => {
+    // #given
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(200, {
+        anthropic: {type: 'api', key: 'sk-ant-valid'},
+        openai: {type: 'api', key: ''},
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('fails fast on timeout without retrying (fetch called exactly once)', async () => {
+    // #given — simulate what AbortSignal.timeout produces: fetch rejects with a timeout-shaped error
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      throw new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('exits non-zero immediately on a transient network error without retrying', async () => {
+    // #given
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('fetch failed: ECONNRESET'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when getIDToken throws (no id-token permission)', async () => {
+    // #given
+    mocks.getIDToken.mockRejectedValue(new Error('Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable'))
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then — never reaches the network call, never emits a credential
+    expect(process.exitCode).toBe(1)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('never places the OIDC token or minted credential in process.env on any failure branch', async () => {
+    // #given
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(500, {}))
+    vi.stubGlobal('fetch', fetchMock)
+    const envSnapshotBefore = {...process.env}
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(process.env).toEqual(envSnapshotBefore)
+  })
+})

--- a/scripts/harness/mint-broker-credential.ts
+++ b/scripts/harness/mint-broker-credential.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+// Mints a short-lived OpenCode auth.json from the OIDC credential broker.
+//
+// Security contract (docs/plans/2026-07-01-001-feat-harness-merge-credential-broker-plan.md):
+//   1. Request a GitHub OIDC token and IMMEDIATELY mask it via core.setSecret,
+//      before any HTTP call, error log, or stack trace can surface the JWT.
+//   2. Exchange it at the broker with a SINGLE POST under a bounded timeout —
+//      no retry loop. The OIDC token is single-use per jti; a retry either
+//      fails replay protection or risks minting a duplicate credential.
+//   3. Validate the broker's auth.json response ALL-OR-NOTHING: every
+//      provider must be well-formed or the entire payload is rejected — no
+//      partial acceptance.
+//   4. Emit the minted credential as a masked GitHub Actions step output —
+//      never write it to disk, never place it (or the OIDC token) in
+//      process.env.
+//   5. Fail closed: any error exits non-zero and emits nothing usable. Never
+//      fall back to a durable key.
+//
+// Run via: node --experimental-strip-types scripts/harness/mint-broker-credential.ts
+//
+// This file uses no sibling .ts imports. main() is exported (not called at
+// module top level) and only invoked by the guard at the bottom of this
+// file, which fires solely when the script is executed directly — mirrors
+// packages/harness/scripts/build-platform.ts. This keeps the module
+// import-safe for the test file (imported under Vitest, .js extension),
+// while `node --experimental-strip-types` execution still runs main().
+
+import process from 'node:process'
+import {fileURLToPath} from 'node:url'
+import * as core from '@actions/core'
+
+export const BROKER_AUDIENCE = 'https://broker.fro.bot'
+
+const DEFAULT_BROKER_URL = 'https://broker.fro.bot'
+const MINT_TIMEOUT_MS = 30_000
+const PROVIDER_ID_PATTERN = /^[\w.-]+$/
+
+/**
+ * Resolve the broker base URL. Reads BROKER_URL as a test/override seam;
+ * defaults to the production broker otherwise.
+ */
+export function resolveBrokerUrl(env: NodeJS.ProcessEnv): string {
+  const override = env.BROKER_URL?.trim() ?? ''
+  return override.length > 0 ? override : DEFAULT_BROKER_URL
+}
+
+export type ValidateBrokerResponseResult =
+  {readonly ok: true; readonly authJson: string} | {readonly ok: false; readonly reason: string}
+
+/**
+ * Validate the broker's response body as an OpenCode auth.json, ALL-OR-NOTHING.
+ * Mirrors the shape rules in src/services/setup/auth-json.ts
+ * (parseAuthJsonInput), plus the stricter per-provider {type:'api', key}
+ * and provider-id constraints the minted credential must satisfy. Pure —
+ * no I/O, never throws; every branch returns a discriminated result. Any
+ * single malformed provider rejects the entire payload.
+ */
+export function validateBrokerResponse(raw: string): ValidateBrokerResponseResult {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return {ok: false, reason: 'broker response is not valid JSON'}
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {ok: false, reason: 'broker response must be a JSON object'}
+  }
+
+  const entries = Object.entries(parsed as Record<string, unknown>)
+  if (entries.length === 0) {
+    return {ok: false, reason: 'broker response has zero providers'}
+  }
+
+  for (const [providerId, value] of entries) {
+    if (!PROVIDER_ID_PATTERN.test(providerId)) {
+      return {ok: false, reason: `provider id "${providerId}" contains invalid characters`}
+    }
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      return {ok: false, reason: `provider "${providerId}" is not an object`}
+    }
+    const provider = value as Record<string, unknown>
+    if (provider.type !== 'api') {
+      return {ok: false, reason: `provider "${providerId}" has an unsupported type`}
+    }
+    if (typeof provider.key !== 'string' || provider.key.length === 0) {
+      return {ok: false, reason: `provider "${providerId}" has an empty or missing key`}
+    }
+  }
+
+  // Re-serialize the parsed+validated object rather than passing the raw
+  // string through, so the emitted payload is exactly the shape that was
+  // validated (no incidental whitespace/formatting from the broker).
+  return {ok: true, authJson: JSON.stringify(parsed)}
+}
+
+/**
+ * Orchestrates the mint: OIDC token → mask → single bounded-timeout POST
+ * (no retry) → all-or-nothing validation → masked step output.
+ *
+ * Fails closed: every error branch throws inside the try block, caught by
+ * the single catch below. The try/finally guarantees a non-zero exit and
+ * that no output is emitted on any failure branch — it is NOT memory
+ * zeroing (out of the threat model: the child inherits process.env, not the
+ * V8 heap). The OIDC token and minted credential live only in local
+ * (function-scope) variables and are never placed in process.env.
+ */
+export async function main(): Promise<void> {
+  let succeeded = false
+  try {
+    const oidcToken = await core.getIDToken(BROKER_AUDIENCE)
+    // Mask IMMEDIATELY — before any HTTP call, log, or thrown error can
+    // surface the JWT.
+    core.setSecret(oidcToken)
+
+    const brokerUrl = resolveBrokerUrl(process.env)
+    let response: Response
+    try {
+      response = await fetch(`${brokerUrl}/v1/mint`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${oidcToken}`,
+          'Content-Type': 'application/json',
+        },
+        // Single attempt, bounded — no retry loop. The OIDC token is
+        // single-use per jti; a retry either fails replay protection or
+        // risks minting a duplicate credential.
+        signal: AbortSignal.timeout(MINT_TIMEOUT_MS),
+      })
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`broker request failed: ${message}`)
+    }
+
+    if (!response.ok) {
+      throw new Error(`broker returned HTTP ${response.status}`)
+    }
+
+    const raw = await response.text()
+    const result = validateBrokerResponse(raw)
+    if (!result.ok) {
+      throw new Error(`broker response rejected: ${result.reason}`)
+    }
+
+    core.setSecret(result.authJson)
+    core.setOutput('auth-json', result.authJson)
+    succeeded = true
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`[mint-broker-credential] ${message}\n`)
+  } finally {
+    if (!succeeded) {
+      process.exitCode = 1
+    }
+  }
+}
+
+// Only run when executed directly (node --experimental-strip-types ...), not
+// when imported by the test file under Vitest.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main()
+}

--- a/scripts/harness/mint-broker-credential.ts
+++ b/scripts/harness/mint-broker-credential.ts
@@ -115,6 +115,11 @@ export async function main(): Promise<void> {
     core.setSecret(oidcToken)
 
     const brokerUrl = resolveBrokerUrl(process.env)
+    // One AbortSignal bounds the ENTIRE exchange. A signal passed to fetch also
+    // aborts an in-progress response body read, so the response.text() below is
+    // covered by the same timeout, not just the initial POST — a slow/hung body
+    // cannot exceed the bound.
+    const signal = AbortSignal.timeout(MINT_TIMEOUT_MS)
     let response: Response
     try {
       response = await fetch(`${brokerUrl}/v1/mint`, {
@@ -123,10 +128,10 @@ export async function main(): Promise<void> {
           Authorization: `Bearer ${oidcToken}`,
           'Content-Type': 'application/json',
         },
-        // Single attempt, bounded — no retry loop. The OIDC token is
-        // single-use per jti; a retry either fails replay protection or
-        // risks minting a duplicate credential.
-        signal: AbortSignal.timeout(MINT_TIMEOUT_MS),
+        // Single attempt — no retry loop. The OIDC token is single-use per jti;
+        // a retry either fails replay protection or risks minting a duplicate
+        // credential.
+        signal,
       })
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error)
@@ -137,7 +142,13 @@ export async function main(): Promise<void> {
       throw new Error(`broker returned HTTP ${response.status}`)
     }
 
-    const raw = await response.text()
+    let raw: string
+    try {
+      raw = await response.text()
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`broker response read failed: ${message}`)
+    }
     const result = validateBrokerResponse(raw)
     if (!result.ok) {
       throw new Error(`broker response rejected: ${result.reason}`)


### PR DESCRIPTION
Runs the production harness LLM-merge on a short-lived, broker-minted credential instead of the durable model key. Second of two deliverables isolating the merge agent from `AUTH_JSON` (env-scrub landed in #1080).

## What changed

- **`scripts/harness/mint-broker-credential.ts`** (new) — requests a GitHub OIDC token, masks it immediately, exchanges it at `POST https://broker.fro.bot/v1/mint` (the OIDC token is the bearer — no separate broker key) with a single bounded-timeout request and no retry, validates the response as an OpenCode `auth.json` all-or-nothing, and emits it as a masked step output. Fails closed on any error — no fallback to a durable key. The OIDC token and minted credential live only in local variables, never in `process.env` or on disk.
- **`.github/workflows/harness-integrate.yaml`** (new) — a dedicated reusable workflow with `id-token: write` scoped to a single job. It checks out, mints via the script, and runs the merge on the minted credential. It drops `secrets: inherit` and never receives `AUTH_JSON`, so the durable model key is not present on the integrate runner. A one-job security invariant is documented at the top: the broker allowlist pins `job_workflow_ref`, which authorizes any job in the file, so a second job would silently share the minting authority.
- **`.github/workflows/harness-release.yaml`** — the `integrate` job now calls `harness-integrate.yaml` with an explicit `secrets:` block (`FRO_BOT_PAT`, `OPENCODE_CONFIG`, `OMO_PROVIDERS`) instead of `fro-bot.yaml` + `secrets: inherit`. Merge behavior is unchanged — `enable-omo` stays `true` and `omo-providers` still flow (the `correlation-id` disable in `fro-bot.yaml` applies only to release-notes narration, not this path).

## Security shape

`id-token: write` lives on exactly one job in one dedicated workflow — never on the shared `fro-bot.yaml`. `secrets: inherit` and `AUTH_JSON` appear nowhere on the integrate path. The mint is single-attempt (the OIDC token is single-use per `jti`), validation is all-or-nothing, and every failure branch exits non-zero without emitting a credential. `continue-on-error` is absent from the path.

## Merge / rollout ordering

The mint fails closed until the broker allowlist is un-placeholdered on `marcusrbrown/infra`. **If a `harness-release` runs with a non-empty carry set after this merges but before the allowlist is set, the integrate job fails (mint 403) and blocks the release** — correct fail-closed behavior, but the two need to be sequenced. Set the allowlist before (or immediately alongside) merging this:

### Broker allowlist values (for `marcusrbrown/infra`, tracked in `infra#725`)

- `repository_id`: `1126485011`
- `repository_owner_id`: `80104189` (`fro-bot` org)
- `job_workflow_ref`: `fro-bot/agent/.github/workflows/harness-integrate.yaml@refs/heads/main`

A pre-allowlist smoke test (dispatch expecting a 403 fail-closed) can verify the OIDC plumbing and broker reachability before the allowlist is set.

## Scope

Units 2–4 of the plan. Egress containment for the integrate runner (the remaining half of the isolation story) stays deferred to `infra#725`; the broker shrinks the credential's value and lifetime, not the runner's network reach.

## Verification

256/256 `scripts/` tests (30 new for the mint script, covering the validator's every branch, OIDC-mask-before-POST call order, single-POST/no-retry, and all fail-closed paths). Type-check, ESLint, and both workflow YAML files parse clean.
