### PR TITLE
fix(harness): grant id-token to the integrate caller job

### DIFF
--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -200,6 +200,9 @@ jobs:
     name: integrate (LLM merge via Fro Bot)
     needs: prepare-integrate
     if: ${{ needs.prepare-integrate.outputs.has_refs == 'true' }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/harness-integrate.yaml
     secrets:
       FRO_BOT_PAT: ${{ secrets.FRO_BOT_PAT }}


### PR DESCRIPTION
Restores the `harness-release` workflow, which fails at startup after #1081 because the `integrate` job can't obtain the `id-token: write` it needs to mint the broker credential.

## The failure

A `harness-release` dispatch fails before any job runs:

> Error calling workflow `harness-integrate.yaml`. The nested job 'integrate' is requesting 'id-token: write', but is only allowed 'id-token: none'.

## Root cause

`harness-release.yaml` sets workflow-level `permissions: contents: read`. A called reusable workflow's `GITHUB_TOKEN` permissions can only be *downgraded*, never *elevated*, relative to the caller job's ceiling — so with the caller granting no `id-token`, the called `harness-integrate.yaml` is capped at `id-token: none` and its `id-token: write` request is rejected at validation time.

## The fix

Grant the `integrate` caller job an explicit `permissions` block with both `id-token: write` and `contents: read`. Job-level permissions **replace** (not merge with) the workflow-level block — unlisted scopes become `none` — so `contents: read` must be repeated here for the called workflow's checkout to stay within the ceiling. The repo-standard workflow-level `contents: read` remains for the other jobs.

The permission semantics (downgrade-only for called workflows; job-level replaces workflow-level) were validated against GitHub's documented behavior before this change.

## Verification note

This only takes effect on a `harness-release` dispatch — PR CI does not exercise the `integrate` path. A dry-run re-dispatch after merge is the end-to-end proof.
