### PR TITLE
docs(solutions): capture the credential-broker + reusable-workflow patterns

### DIFF
--- a/docs/solutions/best-practices/reusable-workflow-permissions-replace-not-merge-2026-07-01.md
+++ b/docs/solutions/best-practices/reusable-workflow-permissions-replace-not-merge-2026-07-01.md
@@ -1,0 +1,78 @@
+---
+title: Reusable-workflow permissions replace, not merge — the id-token startup trap
+date: 2026-07-01
+category: docs/solutions/best-practices
+module: ci-orchestration
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - A caller job invokes a reusable workflow (uses:) whose job requests more permission scopes than the caller grants
+  - A workflow sets workflow-level permissions and a job needs additional scopes (e.g. id-token: write)
+  - A workflow_dispatch fails at startup with zero jobs and no logs
+tags:
+  - github-actions
+  - reusable-workflow
+  - permissions
+  - id-token
+  - startup-failure
+  - workflow-call
+  - github-token
+---
+
+# Reusable-workflow permissions replace, not merge — the id-token startup trap
+
+## Context
+
+Wiring a caller workflow (`harness-release.yaml`, workflow-level `permissions: contents: read`) to a new reusable workflow (`harness-integrate.yaml`) whose job requests `id-token: write` to mint an OIDC credential. The dispatch failed immediately — zero jobs, no logs — with:
+
+> Error calling workflow 'harness-integrate.yaml'. The nested job 'integrate' is requesting 'id-token: write', but is only allowed 'id-token: none'.
+
+Local `js-yaml` validation passed; this is a GitHub run-graph schema check that only fires at dispatch (PR #1082).
+
+## Guidance
+
+Two GitHub rules combine into one trap:
+
+1. **A job-level `permissions:` block replaces the workflow-level block entirely** — it does not merge. Any scope not listed in the job block becomes `none`, regardless of the workflow-level default.
+2. **A called reusable workflow's `GITHUB_TOKEN` permissions can only be downgraded, never elevated**, relative to the caller job's ceiling.
+
+So when a caller job invokes a reusable workflow whose job needs `{ id-token: write, contents: read }`, the caller job must declare **both** — declaring only `id-token: write` silently drops `contents` to `none`, and the called workflow's checkout (which needs `contents: read`) then exceeds the ceiling and re-fails at startup on `contents`:
+
+```yaml
+# WRONG — job block replaces workflow-level, so contents becomes none.
+integrate:
+  permissions:
+    id-token: write
+  uses: ./.github/workflows/harness-integrate.yaml
+
+# RIGHT — repeat every scope the called workflow needs.
+integrate:
+  permissions:
+    id-token: write
+    contents: read
+  uses: ./.github/workflows/harness-integrate.yaml
+```
+
+The repo-standard workflow-level `permissions: contents: read` still applies to jobs that don't declare their own block; only jobs with an explicit `permissions:` key opt out of it.
+
+## Why This Matters
+
+The failure is doubly hard: it's **silent to local validation** (js-yaml parses fine) and **loud but jobless at dispatch** (`startup_failure`, zero jobs, no step logs — the GitHub UI's "Invalid workflow file" annotation is the only source of the real error, and the API often won't surface it). Reaching for the wrong fix (only granting `id-token`) produces a second identical-shaped failure on a different scope, wasting a dispatch. Knowing "job-level replaces, called-workflow can only downgrade" gets it right on the first correction.
+
+`startup_failure` with zero jobs is the signature of a run-graph rejection (permissions ceiling, invalid `needs`, bad `uses:` ref) — distinct from a job that runs and fails. When you see it, read the workflow-file annotation in the GitHub UI, not the run logs (there are none).
+
+## When to Apply
+
+- Any caller job that `uses:` a reusable workflow whose job requests scopes beyond the workflow-level default (OIDC `id-token: write` is the common one).
+- Any time a `workflow_dispatch` completes in seconds with zero jobs — suspect a permissions ceiling or `uses:`/`needs:` graph error, and check the UI annotation.
+
+## Examples
+
+`harness-release.yaml`'s `integrate` job calls `harness-integrate.yaml`, whose job needs `id-token: write` (broker mint) and `contents: read` (checkout). The workflow-level default is `contents: read`. The correct caller-job block is `{ id-token: write, contents: read }` — both explicit, because the job-level block replaces the workflow-level one. Confirmed by a re-dispatch that cleared the graph and reached the mint step.
+
+## Related
+
+- `docs/solutions/workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md` — the first concrete use case: the caller job needs `id-token: write` precisely to mint the broker credential.
+- `docs/solutions/best-practices/cross-libc-build-and-release-safety-2026-06-14.md` — the other `workflow_call` gotcha in this repo (boolean input `!= 'true'` is a silent always-true bug); same "read the producer contract before writing the consumer" theme.
+- PR #1082 (`fix(harness): grant id-token to the integrate caller job`).

--- a/docs/solutions/best-practices/workspace-executor-opencode-provisioning-best-practices-2026-06-01.md
+++ b/docs/solutions/best-practices/workspace-executor-opencode-provisioning-best-practices-2026-06-01.md
@@ -137,3 +137,4 @@ macOS Docker Desktop silently turns a **single-file** `/tmp` bind mount into a d
 - `docs/solutions/best-practices/gateway-opencode-mention-loop-best-practices-2026-05-30.md` — the runtime attach/SSE side this deploy-time provisioning unblocks.
 - `docs/solutions/best-practices/versioned-tool-config-plugin-pattern-2026-03-29.md` — the config-declared plugin injection pattern; this doc adds the hardened-overlay rules (autoupdate pin, strings-only plugin union) for when operator config is merged over the baked config.
 - `docs/solutions/build-errors/gateway-docker-runtime-resolution-crash-loop-2026-05-31.md` — the image build-and-boot smoke discipline this change extends.
+- `docs/solutions/workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md` — the sibling `auth-json` surface: this doc is the workspace-container consumer side; that one is the harness-CI producer side that mints an OIDC-brokered short-lived credential.

--- a/docs/solutions/workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md
+++ b/docs/solutions/workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md
@@ -1,0 +1,87 @@
+---
+title: Isolate a CI credential from an autonomous agent via an OIDC broker
+date: 2026-07-01
+category: docs/solutions/workflow-issues
+module: harness/release pipeline
+problem_type: workflow_issue
+component: tooling
+severity: high
+applies_when:
+  - A GitHub Actions job runs an autonomous/untrusted agent that must not read a durable provider credential
+  - A reusable workflow is called with secrets: inherit but should only receive a subset of secrets
+  - You need a short-lived, revocable credential minted per run instead of a durable key on the runner
+related_components:
+  - development_workflow
+tags:
+  - oidc
+  - id-token
+  - credential-broker
+  - secrets-inherit
+  - reusable-workflow
+  - auth-json
+  - fail-closed
+  - cliproxy
+---
+
+# Isolate a CI credential from an autonomous agent via an OIDC broker
+
+## Context
+
+The harness LLM-merge (`.github/workflows/harness-release.yaml` `integrate` job) runs an autonomous OpenCode agent whose tools (`bash`/`read`/`edit`) execute with host-user filesystem authority. It was provisioned the durable model credential (`AUTH_JSON`) via `secrets: inherit` and an on-disk `auth.json`, so a compromised or misbehaving tool could read the durable key. An OpenCode permission config cannot sandbox those tools, so the fix has to be at the credential-lifetime and process layers, not in agent config. Issue #1060; shipped in PRs #1080, #1081.
+
+The fix has two halves — a caller-side secret withholding and a called-side broker mint — that only work together. Documenting them in one place because a reader debugging the broker needs both.
+
+## Guidance
+
+### Withhold the durable secret by construction (caller side)
+
+`secrets: inherit` forwards **all** caller secrets to a called reusable workflow. To keep a durable credential off the called workflow's runner, drop `secrets: inherit` and pass only the named secrets the job actually needs:
+
+```yaml
+# caller (harness-release.yaml integrate job)
+uses: ./.github/workflows/harness-integrate.yaml
+secrets:
+  FRO_BOT_PAT: ${{ secrets.FRO_BOT_PAT }}
+  OPENCODE_CONFIG: ${{ secrets.OPENCODE_CONFIG }}
+  # NO AUTH_JSON — the durable model key never reaches this workflow.
+```
+
+Caveat: `GITHUB_TOKEN` is **auto-injected** into every called workflow regardless of the `secrets:` block and cannot be withheld — it can only be capability-restricted via the job `permissions:` block. So the isolation target must be the durable third-party key, not `GITHUB_TOKEN`; treat `GITHUB_TOKEN` as always present and restrict its scope instead.
+
+### Mint a short-lived credential from an OIDC broker (called side)
+
+A dedicated reusable workflow requests a GitHub OIDC token and exchanges it at a broker for a short-lived, revocable credential. Keep the mint logic in a testable `scripts/` module, not inline YAML (there is no workflow linter; the security logic deserves unit tests). The security contract:
+
+1. `core.getIDToken(audience)`, then **immediately** `core.setSecret(oidcToken)` — mask the JWT before any HTTP call, log, or stack trace can surface it.
+2. A **single** `POST /v1/mint` with `Authorization: Bearer <oidc-token>` (the OIDC token IS the bearer — no separate broker API key) under a bounded `AbortSignal.timeout`. **No retry** — the OIDC token is single-use per `jti`; a retry either fails replay protection or risks a duplicate credential. Share one `AbortSignal` across the fetch and the body read so a hung body can't exceed the bound.
+3. Validate the response **all-or-nothing** (every provider well-formed or reject the entire payload).
+4. Emit the credential as a `core.setSecret`-masked step output — never write it to disk, never place it or the OIDC token in `process.env`.
+5. **Fail closed**: any error (OIDC failure, non-2xx, timeout, bad shape) exits non-zero and emits nothing. Never fall back to the durable key; never `continue-on-error`.
+
+### Complete the env hygiene on the shared paths
+
+The paths that still use the durable key should scrub it from `process.env` after reading it, so it is not inherited by the agent's child process (which the OpenCode SDK spawns with `{ ...process.env }`). Note `@actions/core` maps input names replacing **spaces** only with underscores — `auth-json` reads from `INPUT_AUTH-JSON`, not `INPUT_AUTH_JSON` (PR #1080).
+
+## Why This Matters
+
+The durable model key is the highest-value secret on the runner. Removing it entirely (broker path) shrinks the credential's value and lifetime; a stolen minted token is cliproxy-scoped and expires. The two halves are load-bearing together: dropping `secrets: inherit` without the broker leaves the merge with no credential; minting without dropping `secrets: inherit` leaves the durable key inherited into the called workflow's env, making the isolation fake.
+
+**Diagnostic — 401 vs 403 from the broker:** `401` = unauthenticated (bad/missing token). `403` = authenticated but the allowlist claim match failed — the OIDC token passed issuer/signature/audience/expiry, so the fix is on the broker's allowlist config (the pinned `repository_id` / `repository_owner_id` / `job_workflow_ref`), not the workflow. This distinction localizes a mint failure to the correct repo in seconds.
+
+## When to Apply
+
+- Any CI job running an autonomous or untrusted agent that must not read a durable provider credential.
+- When a reusable workflow is invoked with `secrets: inherit` but should only receive a subset.
+- When you want per-run, revocable credentials instead of a durable key on the runner.
+
+## Examples
+
+Fail-closed verified in practice: a dry-run `harness-release` dispatch whose broker allowlist was still mismatched returned `broker returned HTTP 403` at the mint step, and the subsequent "Run Fro Bot" merge step was **skipped** — no merge ran on a bad or absent credential. After the allowlist was corrected, the same dispatch minted cleanly and the merge authenticated on the short-lived token.
+
+## Related
+
+- `docs/solutions/best-practices/reusable-workflow-permissions-replace-not-merge-2026-07-01.md` — the permissions trap this work hit (a caller job needs `id-token: write` for the broker mint; getting the `permissions:` block wrong fails the run at startup).
+- `docs/solutions/best-practices/workspace-executor-opencode-provisioning-best-practices-2026-06-01.md` — the sibling `auth-json` surface (workspace container entrypoint). This doc is the harness-CI producer side; that doc is the container consumer side.
+- `docs/solutions/workflow-issues/build-pipeline-fallible-preflight-and-finally-cleanup-2026-06-22.md` — the preflight → mutator → finally lifecycle the mint script follows.
+- `docs/solutions/best-practices/release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md` — the `scripts/`-as-testable-module precedent for the mint script.
+- Issue #1060; PRs #1080 (env scrub), #1081 (broker mint + workflow), #1082 (permissions fix). Egress containment for the integrate runner remains deferred to `marcusrbrown/infra#725`.


### PR DESCRIPTION
Captures the reusable patterns from the harness merge credential isolation work (#1060, PRs #1080–#1082) as documented solutions, so the next occurrence is a lookup rather than a rediscovery.

## What's added

- **`docs/solutions/workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md`** — isolating a CI credential from an autonomous agent: withhold a durable secret from a called reusable workflow (drop `secrets: inherit`, pass only named secrets; `GITHUB_TOKEN` is auto-injected and can only be capability-restricted, not withheld), mint a short-lived credential from an OIDC broker (the OIDC token is the bearer, single bounded attempt with no retry, all-or-nothing validation, fail-closed with no durable-key fallback), and the 401-vs-403 mint diagnostic (401 = unauthenticated, 403 = authenticated but allowlist mismatch — localizes the fix to the broker config).
- **`docs/solutions/best-practices/reusable-workflow-permissions-replace-not-merge-2026-07-01.md`** — the permissions trap: a job-level `permissions:` block replaces (not merges) the workflow-level one, and a called workflow can only downgrade — so a caller job must declare every scope the called workflow needs, or the run fails at startup with zero jobs and no logs. Split out as its own doc because it applies to any reusable-workflow work, not just the broker.
- A forward link from the sibling `workspace-executor` provisioning doc (the container consumer side) to the new harness-CI producer doc.

## Why split into two

The permissions replace-not-merge trap is platform-level and independently useful — any future reusable-workflow wiring hits it without the OIDC-broker context being relevant. Co-locating it under the broker doc would bury a generally useful pattern under a specific use case.

## Scope

Documentation only; `docs/solutions/` is lint-excluded. No overlap with existing solutions (all three patterns were previously undocumented).
