### PR TITLE
docs(solutions): capture the INPUT_ env-mapping trap + broker failure taxonomy

### DIFF
--- a/.agents/skills/versioned-tool/SKILL.md
+++ b/.agents/skills/versioned-tool/SKILL.md
@@ -7,7 +7,7 @@ description: Use when adding or updating external CLI tools managed by pinned ve
 
 ## Overview
 
-This project manages external CLI tools through a **single-source-of-truth version constant** pattern. Every tool's default version lives in `src/shared/constants.ts`, with Renovate automation tracking updates via `.github/renovate.json5`.
+This project manages external CLI tools through a **single-source-of-truth version constant** pattern. Every tool's default version lives in `packages/runtime/src/shared/constants.ts` (the root `src/shared/constants.ts` is a re-export barrel with no version literals — edits go in the runtime package), with Renovate automation tracking updates via `.github/renovate.json5`.
 
 **Current tools:**
 
@@ -27,11 +27,12 @@ This project manages external CLI tools through a **single-source-of-truth versi
 
 ### Bump an existing tool version
 
-1. Update `DEFAULT_<TOOL>_VERSION` in `src/shared/constants.ts`.
+1. Update `DEFAULT_<TOOL>_VERSION` in `packages/runtime/src/shared/constants.ts`.
 2. Verify the installer imports that constant (not a duplicate string).
 3. For user-facing tools, verify `src/harness/config/inputs.ts` falls back to the constant.
 4. Update any docs that surface the pinned default.
-5. Run: `bun run test && bun run lint && bun run build`.
+5. If the bump pulls an npm package published within the last 3 days (e.g. `@opencode-ai/sdk` on a same-day OpenCode bump), `bun install` refuses it under `bunfig.toml`'s `minimumReleaseAge` — add a temporary `minimumReleaseAgeExcludes = ["<pkg>"]` and file a removal reminder for when the window clears (precedent: PRs #1066, #1084).
+6. Run: `bun run test && bun run lint && bun run build`.
 
 ### Add a new external tool
 
@@ -77,26 +78,20 @@ All tools share the same version-source and Renovate tracking. User-facing tools
 
 #### 1. Define the Constant
 
-All default versions live in `src/shared/constants.ts`:
+All default versions live in `packages/runtime/src/shared/constants.ts` (re-exported through the root barrel `src/shared/constants.ts`):
 
 ```typescript
-export const DEFAULT_OPENCODE_VERSION = "1.2.24"
 export const DEFAULT_BUN_VERSION = "1.3.9"
 export const DEFAULT_OMO_VERSION = "3.11.2"
 ```
 
-Rules: semver string, no `v` prefix, named `DEFAULT_<TOOL>_VERSION`. This is the ONLY place the version literal appears.
+Rules: semver string, no `v` prefix, named `DEFAULT_<TOOL>_VERSION`. This is the ONLY place the version literal appears. (Exception: `DEFAULT_OPENCODE_VERSION` carries the harness build format `<base>+harness.<sha>` and is bumped by the release job, not by hand.)
 
 #### 2. Import from Installer
 
-Each installer imports the constant. If a fallback is needed, alias it:
+Each installer imports the constant. Never duplicate the same version string across files.
 
-```typescript
-import {DEFAULT_OPENCODE_VERSION} from "../../shared/constants.js"
-export const FALLBACK_VERSION = DEFAULT_OPENCODE_VERSION
-```
-
-Never duplicate the version string.
+**OpenCode is the exception, not the template:** `FALLBACK_VERSION` in `src/services/setup/opencode.ts` is an independent **stock** pin (e.g. `1.17.13`), deliberately NOT aliased from `DEFAULT_OPENCODE_VERSION` (the harness build, e.g. `1.17.13+harness.<sha>`). They are different artifacts on different update cadences, each with its own Renovate/release-job tracking — do not "deduplicate" them into an alias.
 
 #### 3. Add Renovate Tracking
 
@@ -188,7 +183,7 @@ Installers reuse the pinned version constant instead of hardcoding version liter
 
 Repo-specific behaviors today:
 
-- **OpenCode**: supports explicit `latest` resolution, falls back to `FALLBACK_VERSION` (aliased from `DEFAULT_OPENCODE_VERSION`)
+- **OpenCode**: supports explicit `latest` resolution, falls back to `FALLBACK_VERSION` (independent stock pin in `src/services/setup/opencode.ts` — deliberately not the harness-build `DEFAULT_OPENCODE_VERSION`)
 - **Bun**: installs from `DEFAULT_BUN_VERSION`, no user override
 - **oMo**: installs from `DEFAULT_OMO_VERSION`, but package/runtime identity differs
 
@@ -196,7 +191,7 @@ Do not copy installer structure blindly between tools. Copy the version-source p
 
 ## Verification Checklist
 
-- [ ] Constant updated in `src/shared/constants.ts`
+- [ ] Constant updated in `packages/runtime/src/shared/constants.ts`
 - [ ] No duplicate version literals elsewhere (grep for old version string)
 - [ ] `action.yaml` has no hardcoded default for the version input
 - [ ] Renovate customManager regex matches the constant pattern exactly
@@ -212,7 +207,7 @@ Do not copy installer structure blindly between tools. Copy the version-source p
 | Mistake | Why It's Wrong | Fix |
 | --- | --- | --- |
 | Hardcoding default in `action.yaml` | Creates two sources of truth; version drifts | Remove `default:` line, let `inputs.ts` fall back to constant |
-| Duplicating version string in installer | Stale fallback when constant updates | Import and alias: `export const FALLBACK = DEFAULT_X_VERSION` |
+| Duplicating version string in installer | Stale fallback when constant updates | Import the constant (exception: OpenCode's `FALLBACK_VERSION` is an independent stock pin — see §2) |
 | Wrong Renovate `extractVersionTemplate` | Renovate can't parse tag format | Check actual tag format: `v1.2.3` vs `bun-v1.2.3` |
 | Using `latest` as default | Non-reproducible builds, surprise breakage | Pin to known stable; let users opt in to `latest` explicitly |
 | Assuming package name == runtime identity | Config paths, version parsing, plugin names break | Verify install name, stdout output, and config file independently |

--- a/docs/solutions/logic-errors/actions-core-input-env-hyphen-mapping-2026-07-01.md
+++ b/docs/solutions/logic-errors/actions-core-input-env-hyphen-mapping-2026-07-01.md
@@ -1,0 +1,64 @@
+---
+title: '@actions/core input env scrub targeted the wrong key — hyphens survive in INPUT_ names'
+date: 2026-07-01
+category: logic-errors
+module: src/harness/config
+problem_type: logic_error
+component: tooling
+severity: high
+symptoms:
+  - 'delete process.env.INPUT_AUTH_JSON ran without error but the secret remained in the process env'
+  - "Child processes spawned with {...process.env} still inherited the credential after the 'scrub'"
+  - 'All unit tests passed while the production control was a silent no-op'
+root_cause: wrong_api
+resolution_type: code_fix
+related_components:
+  - development_workflow
+tags:
+  - actions-core
+  - getinput
+  - input-env-mapping
+  - env-scrub
+  - silent-noop
+  - test-mocking
+---
+
+# `@actions/core` input env scrub targeted the wrong key — hyphens survive in `INPUT_` names
+
+## Problem
+
+PR #1080 added a security scrub that deletes the `auth-json` action input from `process.env` after parsing, so the OpenCode child process (spawned with `{...process.env}`) cannot inherit the credential. The first implementation deleted `process.env.INPUT_AUTH_JSON` — which is not the variable GitHub sets. The scrub was a silent no-op: no error, tests green, credential still in every child env on a real runner.
+
+## Root Cause
+
+`@actions/core`'s `getInput` maps an input name to its env var as:
+
+```js
+process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`]
+```
+
+Only **spaces** become underscores. Hyphens survive. So the input `auth-json` is read from `INPUT_AUTH-JSON` (hyphen preserved), not `INPUT_AUTH_JSON`. GitHub's runner sets the same hyphenated form. An env var with a hyphen is unusual enough that the underscore spelling looks obviously correct — and dot-notation (`process.env.INPUT_AUTH_JSON`) compounds the trap because the hyphenated name is not even expressible that way.
+
+The tests passed because they mocked `getInput` and stubbed the **same wrong name** — the test encoded the author's assumption instead of the platform's behavior.
+
+## Fix
+
+Bracket notation with the real key, at the single parse seam (`src/harness/config/inputs.ts`):
+
+```ts
+// eslint-disable-next-line dot-notation
+delete process.env['INPUT_AUTH-JSON']
+```
+
+Tests were corrected to stub `INPUT_AUTH-JSON` and — more importantly — to assert the **name-independent behavioral outcome**: after parsing, no value in the simulated child env (`Object.values(childEnv)`) contains the raw credential. That assertion fails no matter which wrong name a future regression targets.
+
+## Prevention
+
+- When code depends on a library's name-mangling contract, verify the mangle rule **in the library source**, not from memory. The one-line check against `@actions/core/lib/core.js` is cheaper than a silently dead security control.
+- Don't let tests mock the assumption under test. If the claim is "the env var is gone," at least one assertion must be name-independent (scan values, not keys).
+- Treat `delete process.env.X` in dot-notation as a smell whenever `X` derives from a kebab-case action input.
+
+## Related
+
+- `docs/solutions/workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md` — the credential-isolation work this scrub belongs to (PR #1080, issue #1060).
+- Fro Bot's review on PR #1080 independently re-verified the mapping against `@actions/core` source.

--- a/docs/solutions/workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md
+++ b/docs/solutions/workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md
@@ -66,7 +66,15 @@ The paths that still use the durable key should scrub it from `process.env` afte
 
 The durable model key is the highest-value secret on the runner. Removing it entirely (broker path) shrinks the credential's value and lifetime; a stolen minted token is cliproxy-scoped and expires. The two halves are load-bearing together: dropping `secrets: inherit` without the broker leaves the merge with no credential; minting without dropping `secrets: inherit` leaves the durable key inherited into the called workflow's env, making the isolation fake.
 
-**Diagnostic — 401 vs 403 from the broker:** `401` = unauthenticated (bad/missing token). `403` = authenticated but the allowlist claim match failed — the OIDC token passed issuer/signature/audience/expiry, so the fix is on the broker's allowlist config (the pinned `repository_id` / `repository_owner_id` / `job_workflow_ref`), not the workflow. This distinction localizes a mint failure to the correct repo in seconds.
+**Diagnostic — failure taxonomy (each code localizes the fix to a different place):**
+
+| Signal | Meaning | Fix lives in |
+| --- | --- | --- |
+| `401` at **mint** | Unauthenticated — bad/missing OIDC token | The workflow (`id-token: write`, audience) |
+| `403` at **mint** | Authenticated but allowlist claim match failed — the token passed issuer/signature/audience/expiry | The broker's allowlist config (pinned `repository_id` / `repository_owner_id` / `job_workflow_ref`) |
+| `401` **mid-run** from the credential consumer (e.g. `cliproxy … Invalid API key`, `isRetryable: false`) after the mint succeeded and calls worked | The minted credential was invalidated after issue — in practice: **the broker was redeployed while the run was in flight** | Operations — re-run the job; don't redeploy the broker while a consuming run is active |
+
+The mid-run case was hit live (2026-07-02): mint succeeded at 04:37:10Z, the merge made ~90s of authenticated model calls, then every call returned `401 Invalid API key` — the broker had been redeployed mid-run, invalidating the in-flight minted key. The agent failed closed (exit 1, no partial push) and a re-run of the same job succeeded on a fresh mint. Corollary: treat broker redeploys as draining operations — check for active integrate runs first.
 
 ## When to Apply
 


### PR DESCRIPTION
Compound round from the 1.17.13 release cycle — two learnings captured, one skill corrected.

## New: `@actions/core` INPUT_ env-mapping trap (`docs/solutions/logic-errors/`)

`getInput` maps input names to env vars replacing **spaces** only — hyphens survive. The `auth-json` input lives at `INPUT_AUTH-JSON`, so PR #1080's first cut deleted `INPUT_AUTH_JSON`: a silent no-op the tests couldn't catch because they mocked `getInput` with the same wrong name. The doc pins the real mapping rule, the bracket-notation fix, and the name-independent assertion pattern (`Object.values(childEnv)` must not contain the secret) that catches any future wrong-name regression.

## Extended: broker failure taxonomy (`isolate-ci-credential-via-oidc-broker`)

The 401-vs-403 mint diagnostic becomes a three-row taxonomy adding the case we hit live on 2026-07-02: **401 mid-run after a successful mint means the broker was redeployed while the run was in flight**, invalidating the minted credential (`cliproxy` returned `Invalid API key`, `isRetryable: false`, ~3 min into the merge; the agent failed closed and a re-run succeeded). Corollary recorded: broker redeploys are draining operations — check for active integrate runs first.

## Corrected: `versioned-tool` skill drift

- Version constants live in `packages/runtime/src/shared/constants.ts`; the root `src/shared/constants.ts` is a re-export barrel with no literals (the skill predated the runtime extraction).
- The skill prescribed `FALLBACK_VERSION` as an alias of `DEFAULT_OPENCODE_VERSION` — reality is deliberately the opposite: independent stock pin vs harness build, on different update cadences with different automation. "Deduplicating" them would break both.
- Added the `bunfig.toml` `minimumReleaseAgeExcludes` step for bumps that pull an npm release younger than the 3-day supply-chain gate (precedent: #1066, #1084).
