### PR TITLE
feat(scripts): add a relative markdown link checker to the lint gate

### DIFF
--- a/docs/plans/2026-03-22-feat-agent-cohesion-session-continuity-plan.md
+++ b/docs/plans/2026-03-22-feat-agent-cohesion-session-continuity-plan.md
@@ -632,7 +632,7 @@ Embed the logical key only in writeback summaries and search for it via `searchS
 
 ### Origin
 
-- **Brainstorm document:** [docs/brainstorms/2026-03-22-agent-cohesion-session-context-brainstorm.md](docs/brainstorms/2026-03-22-agent-cohesion-session-context-brainstorm.md) — Key decisions carried forward: (1) optimize for stable continuity over fuzzy retrieval, (2) deterministic logical keys as first-class concept, (3) observability ships alongside continuity
+- **Brainstorm document:** [docs/brainstorms/2026-03-22-agent-cohesion-session-context-brainstorm.md](../brainstorms/2026-03-22-agent-cohesion-session-context-brainstorm.md) — Key decisions carried forward: (1) optimize for stable continuity over fuzzy retrieval, (2) deterministic logical keys as first-class concept, (3) observability ships alongside continuity
 
 ### Internal References
 

--- a/docs/plans/2026-04-07-001-refactor-prompt-xml-architecture-plan.md
+++ b/docs/plans/2026-04-07-001-refactor-prompt-xml-architecture-plan.md
@@ -360,7 +360,7 @@ parts.push(wrapXml('agent_context', buildAgentContextSection(...)))
 
 ## Sources & References
 
-- **Origin document:** [docs/brainstorms/2026-04-07-prompt-xml-architecture-requirements.md](docs/brainstorms/2026-04-07-prompt-xml-architecture-requirements.md)
+- **Origin document:** [docs/brainstorms/2026-04-07-prompt-xml-architecture-requirements.md](../brainstorms/2026-04-07-prompt-xml-architecture-requirements.md)
 - **Oracle analysis:** Session consultation on Claude-optimal prompting structure (this session)
 - **Anthropic guidance:** XML tags for mixed-content prompts, long-context ordering (data first, query last)
 - Related code: `src/features/agent/prompt.ts`, `src/features/agent/prompt.test.ts`

--- a/docs/plans/2026-05-30-001-feat-gateway-unit-6-mention-loop-plan.md
+++ b/docs/plans/2026-05-30-001-feat-gateway-unit-6-mention-loop-plan.md
@@ -663,8 +663,8 @@ startup; document the MVP behavior and limitations.
 
 ## Sources & References
 
-- **Origin document:** [docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md](docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md) (Unit 6, lines 745-817)
-- Brainstorm: [docs/brainstorms/2026-04-17-fro-bot-gateway-discord-requirements.md](docs/brainstorms/2026-04-17-fro-bot-gateway-discord-requirements.md) (Cluster B extraction, Cluster C sandbox)
+- **Origin document:** [docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md](./2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md) (Unit 6, lines 745-817)
+- Brainstorm: [docs/brainstorms/2026-04-17-fro-bot-gateway-discord-requirements.md](../brainstorms/2026-04-17-fro-bot-gateway-discord-requirements.md) (Cluster B extraction, Cluster C sandbox)
 - Reuse: `packages/runtime/src/agent/{execution,retry,streaming,session-poll,server}.ts`, `packages/runtime/src/coordination/{lock,run-state,heartbeat}.ts`
 - Extend: `packages/gateway/src/discord/mentions.ts`, `packages/gateway/src/bindings/store.ts`, `packages/gateway/src/program.ts`, `apps/workspace-agent/src/server.ts`
 - Learnings: `docs/solutions/best-practices/discord-slash-command-orchestration-patterns-2026-05-27.md`, `docs/solutions/best-practices/architectural-issues-type-safety-and-resource-cleanup.md`

--- a/docs/plans/2026-06-01-005-feat-gateway-discord-tool-approval-plan.md
+++ b/docs/plans/2026-06-01-005-feat-gateway-discord-tool-approval-plan.md
@@ -322,7 +322,7 @@ Unit 1 probe confirms the full round-trip at 1.14.41?
 
 ## Sources & References
 
-- **Origin document:** [docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md](docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md) (Unit 6 deferred items; approval design sketch at lines 183, 200, 284-286, 764, 769)
+- **Origin document:** [docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md](./2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md) (Unit 6 deferred items; approval design sketch at lines 183, 200, 284-286, 764, 769)
 - Spike findings: project memory ID 4365 (S5 remote-attach feasibility at 1.14.41)
 - Oracle architecture review + Librarian source research: project memory ID 4366 (session 2026-06-01) — BusEvent classification confirmed, `requestID = properties.id` confirmed, `permission.replied` authoritative signal confirmed, reject cascade confirmed, no server-side timeout confirmed, `GET /permission` reconciliation endpoint confirmed
 - SDK refs: installed `@opencode-ai/sdk@1.14.41` — `PermissionList` (`GET /permission`), `postPermissionRequestIdReply` (`POST /permission/{requestID}/reply`), `permission.asked` / `permission.replied` event shapes

--- a/docs/plans/2026-06-03-002-feat-fro-bot-harness-plan.md
+++ b/docs/plans/2026-06-03-002-feat-fro-bot-harness-plan.md
@@ -318,7 +318,7 @@ The pipeline is the asset; the patch list stays boring. Target **1–3 carried r
 
 ## Sources & References
 
-- **Origin:** [docs/brainstorms/2026-06-02-fro-bot-harness-patched-opencode-requirements.md](docs/brainstorms/2026-06-02-fro-bot-harness-patched-opencode-requirements.md) (full-harness spec; R4 corrected here to LLM-merge per orw)
+- **Origin:** [docs/brainstorms/2026-06-02-fro-bot-harness-patched-opencode-requirements.md](../brainstorms/2026-06-02-fro-bot-harness-patched-opencode-requirements.md) (full-harness spec; R4 corrected here to LLM-merge per orw)
 - Integration method: `cortexkit/orw` (`src/index.ts`, `prompt.txt`, `package.json`) — embedded as the harness engine
 - Build/publish model: `anomalyco/opencode` `packages/opencode/script/build.ts`, `script/publish.ts`, `.github/workflows/publish.yml`
 - Cut-over seam: `src/services/setup/opencode.ts`, `src/services/setup/setup.ts`, `src/features/agent/server.ts`, `src/services/setup/tools-cache.ts`

--- a/docs/plans/2026-06-07-004-feat-mention-loop-working-state-ux-plan.md
+++ b/docs/plans/2026-06-07-004-feat-mention-loop-working-state-ux-plan.md
@@ -237,6 +237,6 @@ Phase 2 of the production-ready `@Fro Bot` Discord mention loop. Phase 1 (clean 
 
 ## Sources & References
 
-- **Origin document:** [docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md](docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md) — Phase 2 (working-state UX), OQ1/OQ2, interaction states.
+- **Origin document:** [docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md](../brainstorms/2026-06-07-mention-loop-production-ready-requirements.md) — Phase 2 (working-state UX), OQ1/OQ2, interaction states.
 - Related code: `packages/gateway/src/discord/streaming.ts`, `packages/gateway/src/execute/run.ts`, `packages/gateway/src/execute/run-core.ts`, `packages/gateway/src/config.ts`, `packages/gateway/src/execute/format-part.ts`.
 - Phase 1 (shipped): #831 (rendering + persona), #837 (NBC follow-ups), #833 (lock-leak fix).

--- a/docs/plans/2026-06-09-002-feat-mention-loop-serial-queue-plan.md
+++ b/docs/plans/2026-06-09-002-feat-mention-loop-serial-queue-plan.md
@@ -229,6 +229,6 @@ Two serialization layers exist and only one changes: the **per-channel concurren
 
 ## Sources & References
 
-- **Origin document:** [docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md](docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md) (Phase 3 / SC5)
+- **Origin document:** [docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md](../brainstorms/2026-06-07-mention-loop-production-ready-requirements.md) (Phase 3 / SC5)
 - Related code: `packages/gateway/src/execute/concurrency.ts`, `packages/gateway/src/execute/run.ts`, `packages/gateway/src/discord/mentions.ts`, `packages/gateway/src/discord/commands/fro-bot.ts`, `packages/gateway/src/program.ts`
 - Related learnings: `docs/solutions/best-practices/gateway-opencode-mention-loop-best-practices-*.md`

--- a/docs/plans/2026-06-12-003-feat-harness-github-release-action-cutover-plan.md
+++ b/docs/plans/2026-06-12-003-feat-harness-github-release-action-cutover-plan.md
@@ -250,6 +250,6 @@ The action runs **stock** OpenCode from `anomalyco/opencode` releases. The patch
 
 ## Sources & References
 
-- **Origin document:** [docs/brainstorms/2026-06-12-harness-github-release-and-action-cutover-requirements.md](docs/brainstorms/2026-06-12-harness-github-release-and-action-cutover-requirements.md)
+- **Origin document:** [docs/brainstorms/2026-06-12-harness-github-release-and-action-cutover-requirements.md](../brainstorms/2026-06-12-harness-github-release-and-action-cutover-requirements.md)
 - Related code: `src/services/setup/opencode.ts`, `.github/workflows/harness-release.yaml`, `packages/harness/scripts/build-platform.ts`, `packages/harness/src/provenance.ts`
 - External: npm/cli #1479, npm #6379, SemVer §10 (build metadata stripping)

--- a/docs/plans/2026-06-20-004-feat-stream-web-run-output-plan.md
+++ b/docs/plans/2026-06-20-004-feat-stream-web-run-output-plan.md
@@ -280,6 +280,6 @@ Late subscriber connects after terminal:
 
 ## Sources & References
 
-- **Origin document:** [docs/brainstorms/2026-06-20-stream-web-run-output-requirements.md](docs/brainstorms/2026-06-20-stream-web-run-output-requirements.md)
+- **Origin document:** [docs/brainstorms/2026-06-20-stream-web-run-output-requirements.md](../brainstorms/2026-06-20-stream-web-run-output-requirements.md)
 - Related: `docs/solutions/best-practices/authenticated-sse-run-observation-2026-06-20.md` (the 10-rule checklist), `docs/solutions/best-practices/web-operator-launch-surface-2026-06-20.md` (names #965 as deferred), `docs/solutions/best-practices/gateway-control-surface-spine-2026-06-15.md` (sinks-over-transport), `docs/solutions/best-practices/atomic-serial-channel-queue-handoff-2026-06-09.md` (FIFO/ordering).
 - Issue: #965 (advances #907).

--- a/docs/plans/2026-06-22-002-feat-web-tool-approval-plan.md
+++ b/docs/plans/2026-06-22-002-feat-web-tool-approval-plan.md
@@ -322,6 +322,6 @@ operator decides (write-authz)                                             [Unit
 
 ## Sources & References
 
-- **Origin document:** [docs/brainstorms/2026-06-22-web-tool-approval-requirements.md](docs/brainstorms/2026-06-22-web-tool-approval-requirements.md)
+- **Origin document:** [docs/brainstorms/2026-06-22-web-tool-approval-requirements.md](../brainstorms/2026-06-22-web-tool-approval-requirements.md)
 - Related code: `packages/gateway/src/approvals/{registry,coordinator,discord-transport}.ts`, `packages/gateway/src/web/operator/{web-approval,launch-route}.ts`, `packages/gateway/src/web/sse/{manager,run-stream-route,projection}.ts`, `packages/gateway/src/web/auth/repo-authz.ts`, `packages/gateway/src/operator-contract/{approval,version}.ts`, `packages/gateway/src/web/{audit,server}.ts`.
 - Institutional learnings: gateway-control-surface-spine, web-operator-launch-surface, authenticated-sse-run-observation, sse-output-streaming-terminal-drain, effect-failure-channel-discipline, atomic-serial-channel-queue-handoff (all under docs/solutions/best-practices/).

--- a/docs/plans/2026-07-01-001-feat-harness-merge-credential-broker-plan.md
+++ b/docs/plans/2026-07-01-001-feat-harness-merge-credential-broker-plan.md
@@ -277,7 +277,7 @@ Until these are set the broker fails closed (mint 403s). The env-hygiene deliver
 
 ## Sources & References
 
-- **Origin document:** [docs/brainstorms/2026-07-01-harness-merge-credential-broker-requirements.md](docs/brainstorms/2026-07-01-harness-merge-credential-broker-requirements.md)
+- **Origin document:** [docs/brainstorms/2026-07-01-harness-merge-credential-broker-requirements.md](../brainstorms/2026-07-01-harness-merge-credential-broker-requirements.md)
 - Related code: `src/harness/config/inputs.ts`, `src/services/setup/auth-json.ts`, `.github/workflows/harness-release.yaml`, `.github/workflows/fro-bot.yaml`
 - Related issue: #1060
 - Cross-repo: `marcusrbrown/infra#725` (egress containment, deferred)

--- a/docs/solutions/best-practices/architectural-issues-type-safety-and-resource-cleanup.md
+++ b/docs/solutions/best-practices/architectural-issues-type-safety-and-resource-cleanup.md
@@ -374,7 +374,7 @@ All fixes verified with:
 
 ## Related Documentation
 
-- [Fro Bot Agent SQLite Session Support Plan](../plans/2026-02-15-feat-opencode-sqlite-session-support-plan.md)
+- [Fro Bot Agent SQLite Session Support Plan](../../plans/2026-02-15-feat-opencode-sqlite-session-support-plan.md)
 - [Build Errors: Tool Binary Caching on Ephemeral Runners](../performance-issues/tool-binary-caching-ephemeral-runners.md)
 
 ## Related Issues

--- a/docs/solutions/performance-issues/tool-binary-caching-ephemeral-runners.md
+++ b/docs/solutions/performance-issues/tool-binary-caching-ephemeral-runners.md
@@ -245,10 +245,10 @@ export async function restoreToolsCache(options: RestoreToolsCacheOptions): Prom
 ## Related Documentation
 
 ### RFC References
-- **[RFC-002: Cache Infrastructure](../../RFCs/RFC-002-Cache-Infrastructure.md)** - Core cache persistence for OpenCode storage, foundational for session durable memory across CI runs
-- **[RFC-017: Post-Action Cache Hook](../../RFCs/RFC-017-Post-Action-Cache-Hook.md)** - Reliable cache persistence via GitHub Actions `post:` lifecycle hook, handles timeout/cancellation/failure scenarios
-- **[RFC-011: Setup Action & Environment Bootstrap](../../RFCs/RFC-011-Setup-Action-Environment-Bootstrap.md)** - DEPRECATED (auto-setup integrated into main action), but documents setup orchestration including tool installation
-- **[RFC-019: S3 Storage Backend](../../RFCs/RFC-019-S3-Storage-Backend.md)** - S3 write-through backup for cross-runner persistence, serves as fallback when GitHub Actions cache evicts
+- **[RFC-002: Cache Infrastructure](../../../RFCs/RFC-002-Cache-Infrastructure.md)** - Core cache persistence for OpenCode storage, foundational for session durable memory across CI runs
+- **[RFC-017: Post-Action Cache Hook](../../../RFCs/RFC-017-Post-Action-Cache-Hook.md)** - Reliable cache persistence via GitHub Actions `post:` lifecycle hook, handles timeout/cancellation/failure scenarios
+- **[RFC-011: Setup Action & Environment Bootstrap](../../../RFCs/RFC-011-Setup-Action-Environment-Bootstrap.md)** - DEPRECATED (auto-setup integrated into main action), but documents setup orchestration including tool installation
+- **[RFC-019: S3 Storage Backend](../../../RFCs/RFC-019-S3-Storage-Backend.md)** - S3 write-through backup for cross-runner persistence, serves as fallback when GitHub Actions cache evicts
 
 ### Related Code Modules
 

--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
     "bootstrap": "bun install",
     "build": "bun run --filter @fro-bot/runtime build && bun run --filter @fro-bot/action build && bun run --filter @fro.bot/harness build && bun run dist:escape-hidden-unicode",
     "check-types": "bun run --filter @fro-bot/runtime check-types && bun run --filter @fro-bot/action check-types && bun run --filter @fro.bot/harness check-types",
+    "check:md-links": "node --experimental-strip-types scripts/check-md-links.ts",
     "dist:check-hidden-unicode": "node --experimental-strip-types scripts/check-dist-hidden-unicode.ts",
     "dist:escape-hidden-unicode": "node --experimental-strip-types scripts/escape-dist-hidden-unicode.ts",
     "fix": "bun run --filter @fro-bot/runtime fix && bun run --filter @fro-bot/action fix && bun run --filter @fro.bot/harness fix",
     "postinstall": "simple-git-hooks",
-    "lint": "bun run --filter @fro-bot/runtime lint && bun run --filter @fro-bot/action lint && bun run --filter @fro.bot/harness lint && bun run dist:check-hidden-unicode",
+    "lint": "bun run --filter @fro-bot/runtime lint && bun run --filter @fro-bot/action lint && bun run --filter @fro.bot/harness lint && bun run dist:check-hidden-unicode && bun run check:md-links",
     "test": "bun run --filter @fro-bot/runtime test && bun run --filter @fro-bot/action test && bun run --filter @fro.bot/harness test",
     "test:scripts": "vitest run scripts/"
   },

--- a/scripts/check-md-links.ts
+++ b/scripts/check-md-links.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+// Check tracked markdown files for dangling relative links. Exits non-zero if
+// any are found. Run via: node --experimental-strip-types scripts/check-md-links.ts
+//
+// This file uses .ts imports because it runs directly under Node's
+// --experimental-strip-types. The test file uses .js imports for Vitest.
+
+import {execFile} from 'node:child_process'
+import process from 'node:process'
+import {promisify} from 'node:util'
+import {collectMarkdownLinkReport} from './md-links.ts'
+
+const execFileAsync = promisify(execFile)
+
+const EXCLUDED_PREFIXES = ['.slim/', 'node_modules/', 'dist/']
+
+/** Lists tracked markdown files via `git ls-files`, excluding vendored/build dirs. */
+async function listTrackedMarkdownFiles(): Promise<readonly string[]> {
+  const {stdout} = await execFileAsync('git', ['ls-files', '*.md'])
+  return stdout
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+    .filter(file => !EXCLUDED_PREFIXES.some(prefix => file.startsWith(prefix)))
+}
+
+async function main(): Promise<void> {
+  const files = await listTrackedMarkdownFiles()
+  const {filesScanned, linksChecked, violations} = await collectMarkdownLinkReport(files)
+
+  if (violations.length === 0) {
+    console.log(`[check-md-links] OK — ${linksChecked} links across ${filesScanned} files`)
+    return
+  }
+
+  for (const {file, line, target} of violations) {
+    process.stderr.write(`FAIL ${file}:${line} -> ${target}\n`)
+  }
+
+  process.stderr.write(`[check-md-links] found ${violations.length} dangling link(s)\n`)
+  process.exitCode = 1
+}
+
+try {
+  await main()
+} catch (error: unknown) {
+  const message = error instanceof Error ? error.message : String(error)
+  process.stderr.write(`[check-md-links] error: ${message}\n`)
+  process.exitCode = 1
+}

--- a/scripts/md-links.test.ts
+++ b/scripts/md-links.test.ts
@@ -1,0 +1,290 @@
+import {describe, expect, it} from 'vitest'
+import {checkMarkdownLinks, collectMarkdownLinkReport} from './md-links.js'
+
+/** Builds injectable readFile/exists adapters backed by an in-memory file map. */
+function makeAdapters(files: Record<string, string>, existingPaths: readonly string[]) {
+  const existing = new Set(existingPaths)
+  const readFile = async (path: string): Promise<string> => {
+    const content = files[path]
+    if (content === undefined) throw new Error(`unexpected read: ${path}`)
+    return content
+  }
+  const exists = async (path: string): Promise<boolean> => existing.has(path)
+  return {readFile, exists}
+}
+
+describe('checkMarkdownLinks — dangling relative link detection', () => {
+  it('flags a relative link to a file that does not exist', async () => {
+    // #given a doc linking to a sibling file that is missing on disk
+    const {readFile, exists} = makeAdapters({'docs/a.md': '[missing](./b.md)'}, [])
+
+    // #when
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+
+    // #then
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({file: 'docs/a.md', line: 1, target: './b.md', resolved: 'docs/b.md'})
+  })
+
+  it('does not flag a relative link to a file that exists', async () => {
+    // #given
+    const {readFile, exists} = makeAdapters({'docs/a.md': '[ok](./b.md)'}, ['docs/b.md'])
+
+    // #when
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+
+    // #then
+    expect(violations).toHaveLength(0)
+  })
+})
+
+describe('checkMarkdownLinks — fenced code block skipping', () => {
+  it('does not flag a link target inside a fenced code block (backtick fence)', async () => {
+    // #given — dangling-looking link syntax inside a ``` fence must be ignored
+    const content = ['# doc', '```ts', '[..](../X.md)', '```', ''].join('\n')
+    const {readFile, exists} = makeAdapters({'docs/a.md': content}, [])
+
+    // #when
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+
+    // #then
+    expect(violations).toHaveLength(0)
+  })
+
+  it('does not flag a link target inside a fenced code block (tilde fence)', async () => {
+    // #given
+    const content = ['# doc', '~~~', '[missing](./nope.md)', '~~~', ''].join('\n')
+    const {readFile, exists} = makeAdapters({'docs/a.md': content}, [])
+
+    // #when
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+
+    // #then
+    expect(violations).toHaveLength(0)
+  })
+
+  it('flags a link target that reappears after a fence closes', async () => {
+    // #given — the fence must not leak "always skip" state past its closing delimiter
+    const content = ['```', '[inside](./ignored.md)', '```', '[outside](./missing.md)'].join('\n')
+    const {readFile, exists} = makeAdapters({'docs/a.md': content}, [])
+
+    // #when
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+
+    // #then
+    expect(violations).toHaveLength(1)
+    expect(violations[0]?.target).toBe('./missing.md')
+  })
+
+  it('does not flag a fenced block with a language info string', async () => {
+    // #given
+    const content = ['```typescript', '[..](../missing.md)', '```'].join('\n')
+    const {readFile, exists} = makeAdapters({'docs/a.md': content}, [])
+
+    // #when
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+
+    // #then
+    expect(violations).toHaveLength(0)
+  })
+})
+
+describe('checkMarkdownLinks — inline code span skipping', () => {
+  it('does not flag link syntax inside a single-backtick inline code span', async () => {
+    // #given — the corpus's illustrative `[Page Name](Page%20Name.md)` example
+    const content = 'See: `[Page Name](Page%20Name.md)` for the convention.'
+    const {readFile, exists} = makeAdapters({'docs/a.md': content}, [])
+
+    // #when
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+
+    // #then
+    expect(violations).toHaveLength(0)
+  })
+
+  it('does not flag link-shaped regex fragments inside a multi-backtick code span', async () => {
+    // #given
+    const content = 'Regex: ``[^"\']*`` matches quoted content.'
+    const {readFile, exists} = makeAdapters({'docs/a.md': content}, [])
+
+    // #when
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+
+    // #then
+    expect(violations).toHaveLength(0)
+  })
+
+  it('flags a real link on the same line as an inline code span', async () => {
+    // #given — code span must be masked, not the whole line dropped
+    const content = 'Use `code` then [missing](./nope.md) here.'
+    const {readFile, exists} = makeAdapters({'docs/a.md': content}, [])
+
+    // #when
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+
+    // #then
+    expect(violations).toHaveLength(1)
+    expect(violations[0]?.target).toBe('./nope.md')
+  })
+})
+
+describe('checkMarkdownLinks — external/anchor/data URI skipping', () => {
+  it('does not flag http(s) links', async () => {
+    const {readFile, exists} = makeAdapters(
+      {'docs/a.md': '[a](http://example.com/x.md) and [b](https://example.com/y.md)'},
+      [],
+    )
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('does not flag mailto: links', async () => {
+    const {readFile, exists} = makeAdapters({'docs/a.md': '[me](mailto:someone@example.com)'}, [])
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('does not flag anchor-only links', async () => {
+    const {readFile, exists} = makeAdapters({'docs/a.md': '[top](#section)'}, [])
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('does not flag data: URIs', async () => {
+    const {readFile, exists} = makeAdapters({'docs/a.md': '[img](data:image/png;base64,AAAA)'}, [])
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('does not flag targets containing :// for a non-standard protocol', async () => {
+    const {readFile, exists} = makeAdapters({'docs/a.md': '[x](ftp://example.com/file.md)'}, [])
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('flags a genuinely missing relative target that is not external', async () => {
+    const {readFile, exists} = makeAdapters({'docs/a.md': '[x](./missing.md)'}, [])
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+    expect(violations).toHaveLength(1)
+  })
+})
+
+describe('checkMarkdownLinks — image links', () => {
+  it('flags a dangling relative image link', async () => {
+    const {readFile, exists} = makeAdapters({'docs/a.md': '![alt](./missing.png)'}, [])
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+    expect(violations).toHaveLength(1)
+    expect(violations[0]?.target).toBe('./missing.png')
+  })
+
+  it('does not flag an image link that resolves', async () => {
+    const {readFile, exists} = makeAdapters({'docs/a.md': '![alt](./exists.png)'}, ['docs/exists.png'])
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('does not flag an external image link', async () => {
+    const {readFile, exists} = makeAdapters({'docs/a.md': '![alt](https://example.com/x.png)'}, [])
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+    expect(violations).toHaveLength(0)
+  })
+})
+
+describe('checkMarkdownLinks — anchor stripping and URL-decoding', () => {
+  it('strips a trailing #anchor before checking existence', async () => {
+    const {readFile, exists} = makeAdapters({'docs/a.md': '[x](./b.md#section)'}, ['docs/b.md'])
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('flags when the anchor-stripped target still does not exist', async () => {
+    const {readFile, exists} = makeAdapters({'docs/a.md': '[x](./missing.md#section)'}, [])
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+    expect(violations).toHaveLength(1)
+    expect(violations[0]?.resolved).toBe('docs/missing.md')
+  })
+
+  it('uRL-decodes %20 to a space before resolving', async () => {
+    const {readFile, exists} = makeAdapters({'docs/a.md': '[Page Name](Page%20Name.md)'}, ['docs/Page Name.md'])
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('flags a %20-encoded target that does not exist after decoding', async () => {
+    const {readFile, exists} = makeAdapters({'docs/a.md': '[Page Name](Page%20Name.md)'}, [])
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+    expect(violations).toHaveLength(1)
+    expect(violations[0]?.resolved).toBe('docs/Page Name.md')
+  })
+})
+
+describe('checkMarkdownLinks — resolution: relative dir, leading slash, escapes root', () => {
+  it('resolves relative to the containing file directory', async () => {
+    const {readFile, exists} = makeAdapters({'docs/plans/a.md': '[x](../brainstorms/b.md)'}, ['docs/brainstorms/b.md'])
+    const violations = await checkMarkdownLinks(['docs/plans/a.md'], readFile, exists)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('flags a repo-root-style path that does not resolve relative to the file dir', async () => {
+    // #given — the exact bug class fixed in Part 2A: `docs/...` written inside docs/plans/
+    // resolves to docs/plans/docs/... which does not exist
+    const {readFile, exists} = makeAdapters({'docs/plans/a.md': '[x](docs/brainstorms/b.md)'}, [
+      'docs/brainstorms/b.md',
+    ])
+    const violations = await checkMarkdownLinks(['docs/plans/a.md'], readFile, exists)
+    expect(violations).toHaveLength(1)
+    expect(violations[0]?.resolved).toBe('docs/plans/docs/brainstorms/b.md')
+  })
+
+  it('resolves a leading-slash target from the repo root', async () => {
+    const {readFile, exists} = makeAdapters({'docs/plans/a.md': '[x](/docs/brainstorms/b.md)'}, [
+      'docs/brainstorms/b.md',
+    ])
+    const violations = await checkMarkdownLinks(['docs/plans/a.md'], readFile, exists)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('flags a target that resolves outside the repo root without an fs probe', async () => {
+    // #given — exists() would throw if called; it must never be invoked for an out-of-root target
+    let existsCalled = false
+    const readFile = async (): Promise<string> => '[x](../../outside.md)'
+    const exists = async (): Promise<boolean> => {
+      existsCalled = true
+      return true
+    }
+
+    // #when
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+
+    // #then
+    expect(violations).toHaveLength(1)
+    expect(existsCalled).toBe(false)
+  })
+})
+
+describe('checkMarkdownLinks — directory targets', () => {
+  it('does not flag a link to a directory that exists', async () => {
+    const {readFile, exists} = makeAdapters({'docs/a.md': '[x](./solutions)'}, ['docs/solutions'])
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('flags a link to a directory that does not exist', async () => {
+    const {readFile, exists} = makeAdapters({'docs/a.md': '[x](./missing-dir)'}, [])
+    const violations = await checkMarkdownLinks(['docs/a.md'], readFile, exists)
+    expect(violations).toHaveLength(1)
+  })
+})
+
+describe('collectMarkdownLinkReport — counts', () => {
+  it('reports filesScanned and linksChecked, excluding skipped external/anchor targets from the count', async () => {
+    const content = ['[a](./b.md)', '[ext](https://example.com)', '[anchor](#top)', '`[fake](./ignored.md)`'].join('\n')
+    const {readFile, exists} = makeAdapters({'docs/a.md': content}, ['docs/b.md'])
+
+    const report = await collectMarkdownLinkReport(['docs/a.md'], readFile, exists)
+
+    expect(report.filesScanned).toBe(1)
+    expect(report.linksChecked).toBe(1)
+    expect(report.violations).toHaveLength(0)
+  })
+})

--- a/scripts/md-links.ts
+++ b/scripts/md-links.ts
@@ -1,0 +1,206 @@
+// Shared logic for checking relative markdown links resolve to real files.
+//
+// Extracts inline `[text](target)` and `![alt](target)` links from tracked
+// markdown files, skips fenced code blocks and inline code spans (both are
+// full of illustrative link syntax and regex fragments that must never be
+// flagged), skips external/anchor-only targets, and verifies every remaining
+// relative target resolves to a file or directory that actually exists.
+//
+// Run via: node --experimental-strip-types scripts/check-md-links.ts
+// (or import checkMarkdownLinks from other scripts/tests)
+//
+// This file uses .ts imports because it runs directly under Node's
+// --experimental-strip-types. The test file uses .js imports for Vitest.
+
+import {readFile as fsReadFile, stat as fsStat} from 'node:fs/promises'
+import {posix} from 'node:path'
+
+export interface LinkViolation {
+  readonly file: string
+  readonly line: number
+  readonly target: string
+  readonly resolved: string
+}
+
+export interface MarkdownLinkReport {
+  readonly filesScanned: number
+  readonly linksChecked: number
+  readonly violations: readonly LinkViolation[]
+}
+
+export type ReadFileFn = (path: string) => Promise<string>
+export type ExistsFn = (path: string) => Promise<boolean>
+
+const defaultReadFile: ReadFileFn = async path => fsReadFile(path, 'utf8')
+
+const defaultExists: ExistsFn = async path => {
+  try {
+    await fsStat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Matches a fenced-code-block delimiter line: ``` or ~~~ (3+ chars), with
+// optional leading indentation and trailing language info (ignored here).
+const FENCE_RE = /^\s*(`{3,}|~{3,})/
+
+// Matches a backtick-delimited inline code span, honoring the CommonMark rule
+// that the closing delimiter must be the same length as the opening one.
+const CODE_SPAN_RE = /(`+)(?:(?!\1)[\s\S])*?\1/g
+
+// Matches inline links and image links: [text](target) / ![alt](target).
+// The captured group may include a trailing ` "title"` which callers strip.
+const LINK_RE = /!?\[[^\]]*\]\(([^)]+)\)/g
+
+interface ExtractedLink {
+  readonly line: number
+  readonly target: string
+}
+
+/** Replaces inline code spans with equal-length blanks so link syntax inside them is never matched. */
+function maskInlineCode(line: string): string {
+  CODE_SPAN_RE.lastIndex = 0
+  return line.replace(CODE_SPAN_RE, match => ' '.repeat(match.length))
+}
+
+/** Extracts every candidate link target from markdown content, skipping fenced code blocks. */
+function extractLinks(content: string): readonly ExtractedLink[] {
+  const links: ExtractedLink[] = []
+  const lines = content.split('\n')
+
+  let inFence = false
+  let fenceChar = ''
+  let fenceLen = 0
+
+  for (const [index, line] of lines.entries()) {
+    const fenceMatch = FENCE_RE.exec(line)
+    if (fenceMatch?.[1] !== undefined) {
+      const marker = fenceMatch[1]
+      const char = marker[0] ?? ''
+      const len = marker.length
+
+      if (inFence) {
+        if (char === fenceChar && len >= fenceLen) {
+          inFence = false
+        }
+      } else {
+        inFence = true
+        fenceChar = char
+        fenceLen = len
+      }
+      continue
+    }
+
+    if (inFence) continue
+
+    const masked = maskInlineCode(line)
+    LINK_RE.lastIndex = 0
+    let match: RegExpExecArray | null = LINK_RE.exec(masked)
+    while (match !== null) {
+      const rawTarget = match[1] ?? ''
+      const target = rawTarget.trim().split(/\s+/)[0] ?? ''
+      if (target.length > 0) {
+        links.push({line: index + 1, target})
+      }
+      match = LINK_RE.exec(masked)
+    }
+  }
+
+  return links
+}
+
+/** True when a target is external (protocol-prefixed), anchor-only, or a data URI — never fs-checked. */
+function isSkippedTarget(target: string): boolean {
+  return (
+    target.startsWith('http://') ||
+    target.startsWith('https://') ||
+    target.startsWith('mailto:') ||
+    target.startsWith('#') ||
+    target.startsWith('data:') ||
+    target.includes('://')
+  )
+}
+
+/** Strips a trailing `#anchor` suffix; anchor validity is out of scope. */
+function stripAnchor(target: string): string {
+  const index = target.indexOf('#')
+  return index === -1 ? target : target.slice(0, index)
+}
+
+/** URL-decodes a target (e.g. `%20` -> space); falls back to the raw string on malformed encoding. */
+function decodeTarget(target: string): string {
+  try {
+    return decodeURIComponent(target)
+  } catch {
+    return target
+  }
+}
+
+/**
+ * Resolves a link target relative to its containing file's directory.
+ * A leading `/` resolves from the repo root. Returns the normalized
+ * repo-relative path and whether it escapes the repo root entirely.
+ */
+function resolveTarget(fileDir: string, target: string): {readonly resolved: string; readonly escapesRoot: boolean} {
+  const base = target.startsWith('/') ? target.slice(1) : posix.join(fileDir, target)
+  const resolved = posix.normalize(base)
+  const escapesRoot = resolved === '..' || resolved.startsWith('../')
+  return {resolved, escapesRoot}
+}
+
+/**
+ * Checks relative markdown links across `files` (repo-root-relative paths)
+ * and returns a full report: files scanned, links checked (after skipping
+ * external/anchor-only targets), and every dangling-link violation found.
+ */
+export async function collectMarkdownLinkReport(
+  files: readonly string[],
+  readFile: ReadFileFn = defaultReadFile,
+  exists: ExistsFn = defaultExists,
+): Promise<MarkdownLinkReport> {
+  const violations: LinkViolation[] = []
+  let linksChecked = 0
+
+  for (const file of files) {
+    const content = await readFile(file)
+    const links = extractLinks(content)
+    const fileDir = posix.dirname(file)
+
+    for (const {line, target} of links) {
+      if (isSkippedTarget(target)) continue
+
+      const decoded = decodeTarget(stripAnchor(target))
+      const {resolved, escapesRoot} = resolveTarget(fileDir, decoded)
+
+      linksChecked += 1
+
+      if (escapesRoot) {
+        violations.push({file, line, target, resolved})
+        continue
+      }
+
+      const targetExists = await exists(resolved)
+      if (!targetExists) {
+        violations.push({file, line, target, resolved})
+      }
+    }
+  }
+
+  return {filesScanned: files.length, linksChecked, violations}
+}
+
+/**
+ * Checks relative markdown links across `files` and returns the violations.
+ * Thin wrapper over collectMarkdownLinkReport for callers that only need the
+ * violation list (e.g. tests).
+ */
+export async function checkMarkdownLinks(
+  files: readonly string[],
+  readFile: ReadFileFn = defaultReadFile,
+  exists: ExistsFn = defaultExists,
+): Promise<readonly LinkViolation[]> {
+  const {violations} = await collectMarkdownLinkReport(files, readFile, exists)
+  return violations
+}


### PR DESCRIPTION
Adds a relative markdown link checker to the lint gate, closing the gap behind two review blockers this session (RFCs/RFC-018's dead PRD link in #1071, and the sibling link missed by the `tool-binary-caching` move in #1090) — both were dangling relative links no gate could catch.

## The checker

- `scripts/md-links.ts` — pure module with injectable fs adapters (repo adapter convention). Extracts inline `[text](target)` links, skipping fenced code blocks, inline code spans, and external/anchor/data targets; URL-decodes (`%20`), strips anchors, resolves relative to the containing file (leading `/` = repo root), flags out-of-root escapes without probing outside the repo.
- `scripts/check-md-links.ts` — CLI entry over `git ls-files '*.md'` (execFile, no shell interp), excluding `.slim/`, `node_modules/`, `dist/`.
- Wired as `check:md-links` and appended to the root `lint` chain, so the pre-push hook and CI's lint job both enforce it.
- 29 vitest cases covering every extraction/skip/resolution rule; the corpus's known false-positive traps (template literals and regex fragments in RFC code blocks, illustrative links in inline code) are pinned as tests and not flagged.

## The 17 dangling links it caught, fixed

- 12 repo-root-style links in `docs/plans/` (`docs/brainstorms/...` written where `../brainstorms/...` was meant — they resolved to `docs/plans/docs/...`).
- 4 RFC links in `docs/solutions/performance-issues/tool-binary-caching-ephemeral-runners.md` under-counting directory depth (`../../RFCs/` → `../../../RFCs/`).
- 1 plans link in `docs/solutions/best-practices/architectural-issues-type-safety-and-resource-cleanup.md` (same class).

## Verification

`bun run check:md-links` → OK, 185 links across 192 files. Negative test: injecting a broken link makes `bun run lint` fail with `FAIL <file>:<line> -> <target>`. Full `test:scripts` (10 files) and lint chain green; scripts tsconfig type-check clean (Node 24 strip-only constraints respected — no new dependencies).
