### PR TITLE
docs(brainstorms): track brainstorm documents in the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,9 +97,6 @@ Thumbs.db
 # Worktrees
 .worktrees/
 
-# Workflow docs
-docs/brainstorms/
-
 # eslint-typegen (https://github.com/antfu/eslint-typegen)
 eslint-typegen.d.ts
 

--- a/docs/brainstorms/2026-02-14-prompt-builder-audit-brainstorm.md
+++ b/docs/brainstorms/2026-02-14-prompt-builder-audit-brainstorm.md
@@ -1,0 +1,62 @@
+---
+date: 2026-02-14
+topic: prompt-builder-audit
+---
+
+# Prompt Builder Audit (Trigger Guidance)
+
+## What We’re Building
+
+A documented audit of the current prompt builder (`src/lib/agent/prompt.ts`) and its trigger-specific directives, with a focus on whether ordering and templates provide clear, actionable guidance per event type. The outcome is a findings report that identifies gaps (especially for PR reviews) and proposes what the prompt should instruct (not how to implement it). Emphasis: trigger-aware guidance for `pull_request` and `pull_request_review_comment` events, and explicit conditions for collaborator and review-request scenarios.
+
+## Why This Approach
+
+The existing prompt sections are comprehensive, but the task directive is minimal and not tailored to nuanced workflows (e.g., when to post a review vs. comment, or when to decide approve/request-changes). We’ll preserve the current multi-section structure while strengthening the trigger-specific directives to reduce ambiguity. This is aligned with prompt best practices: clear instructions, separation of context from directives, and trigger-specific success criteria.
+
+## Key Decisions
+
+- **Findings-only deliverable:** No code changes; output is an audit report with actionable gaps and recommended directive language themes.
+- **PR review action policy:** Require explicit review action only when the agent is confident; otherwise allow comment-only review.
+- **Review-capable triggers:** Focus on `pull_request` and `pull_request_review_comment` for review actions.
+- **Explicit condition text:** Prompt should spell out collaborator/reviewer-request cases instead of relying on routing alone.
+
+## Observations from Current Code
+
+- **Directive mapping is centralized** in `getTriggerDirective()` with simple, event-type-only text. No nuanced conditions for review status or requested-reviewer state.
+- **Task directive appears early** (after the system header) but before environment/context sections, so the agent receives instruction before context.
+- **Hydrated PR context includes reviews** (review states and comments), but the task directive doesn’t leverage it.
+- **Router skip logic is strict**, but it doesn’t pass through “requested reviewer” or “collaborator” context, so prompts can’t currently mention those conditions.
+- **Prompt tests** confirm section inclusion but not ordering constraints; ordering is implicit by build order in `buildAgentPrompt()`.
+
+## Approaches to Improve Trigger Guidance (Conceptual)
+
+### Approach A — Minimal Directive Expansion (Recommended)
+
+Add explicit trigger-specific directives for PR events that enumerate expected review outputs (approve/request changes when confident; comment-only otherwise). Keep prompt structure unchanged and avoid conditional instructions that require new context plumbing.
+
+**Pros:** Minimal change, aligns with current structure, low risk of confusion. **Cons:** Doesn’t add new context fields; limited to instruction wording.
+
+### Approach B — Context-Aware Directive Templates
+
+Introduce directive templates that vary based on contextual flags (e.g., requested reviewer, collaborator) once those are surfaced in context. The directive would mention the conditions when applicable, otherwise fallback to generic PR review instruction.
+
+**Pros:** More precise guidance; reduces ambiguity. **Cons:** Requires new context plumbing and conditional logic.
+
+### Approach C — Output Contract per Trigger
+
+Define a lightweight “output contract” per trigger (e.g., PR reviews must include: summary, risk, test suggestions, review action if confident). Keep in prompt as a standard section appended to the task.
+
+**Pros:** Consistency of responses; easier to validate. **Cons:** Slightly more verbose; could constrain agent flexibility.
+
+## Open Questions
+
+- What is the most reliable signal for “requested to review” in the current context/hydration pipeline (needs confirmation of availability)?
+- Should collaborator status be derived from author association in the payload, or via API lookup? What are acceptable latency/permission impacts?
+- Do we want explicit instructions to use review API vs. comment API when the event is `pull_request_review_comment`?
+
+## Next Steps
+
+- Produce the audit findings report referencing specific code locations and gaps.
+- If moving to planning: decide whether to pursue Approach A only (wording), or add context plumbing (Approach B/C).
+
+→ `/workflows:plan` for implementation details once an approach is selected.

--- a/docs/brainstorms/2026-03-22-agent-cohesion-session-context-brainstorm.md
+++ b/docs/brainstorms/2026-03-22-agent-cohesion-session-context-brainstorm.md
@@ -1,0 +1,144 @@
+# Brainstorm: Agent Cohesion, Session Continuity, and Prompt Context
+
+Date: 2026-03-22
+
+## What We're Building
+
+We want Fro Bot to behave like it remembers the work it already did for the same PR, issue, discussion, schedule task, or manual dispatch instead of starting from a vaguely related fresh session each time.
+
+The target is stable continuity: repeated runs on the same logical entity should preferentially continue the same session lineage, with deterministic retrieval as a fallback when the mapped session is missing, stale, or unusable.
+
+This brainstorm also covers prompt quality and observability. Better session continuity is not enough if prompts bury the important context or if non-PR runs do not preserve prompt/log artifacts for later analysis.
+
+## Why This Approach
+
+The current system persists OpenCode storage across runs, but it does not preserve stable session identity.
+
+- `src/features/agent/execution.ts` always calls `client.session.create()`, so every run starts a new OpenCode session with a timestamp-style title.
+- `src/harness/phases/session-prep.ts` searches prior work using `issueTitle ?? repo`, which is fuzzy and unstable across repeated runs on the same entity.
+- `src/features/agent/prompt.ts` includes prior-session context, but it is not anchored to a deterministic logical thread, so the prompt often has context nearby rather than context that is definitely the right one.
+
+That means we currently have persistence without strong continuity.
+
+## Case Study Findings
+
+### Examined Runs
+
+- `CI` / PR run `23398824784` - has `opencode-logs`
+- `CI` / PR run `23397708292` - has `opencode-logs`
+- `Fro Bot` / schedule run `23383114696` - no uploaded `opencode-logs` artifact
+- `Fro Bot` / issue comment run `23399143120` - no uploaded `opencode-logs` artifact
+
+### What The Runs Show
+
+- PR test runs preserve prompt and OpenCode logs because `ci.yaml` uploads `~/.local/share/opencode/log` as the `opencode-logs` artifact.
+- Real `Fro Bot` runs do execute and do write local prompt artifacts, as shown in the job logs, but `fro-bot.yaml` never uploads that log directory.
+- OpenCode creates sessions with titles like `New session - 2026-03-22T06:52:13.670Z`, which are useless as stable lookup keys.
+- Prompt artifacts for PR runs show a strong structure, but the prompt is long and front-loads generic operating rules before the most important continuity signal.
+- Logs include noise that should either be surfaced intentionally or suppressed from the case-study signal:
+  - `Blocked 3 postinstalls. Run bun pm untrusted for details.`
+  - repeated `tool.registry ... invalid`
+
+### Practical Interpretation
+
+The main problem is not that persistence is absent. The problem is that the system cannot say with confidence: "this run belongs to the same logical conversation as the last run for PR 347".
+
+## Approaches Considered
+
+### 1. Retrieval-First
+
+Keep creating a fresh OpenCode session every run, but introduce deterministic logical keys such as `pr-347`, `issue-123`, `discussion-12`, `schedule-daily-maintenance`, and `dispatch-<slug>`. Use those keys to retrieve exact prior sessions before falling back to broader search.
+
+Pros:
+- Lowest implementation risk
+- Fits current `client.session.create()` behavior
+- Improves relevance immediately
+
+Cons:
+- Still fragments work across many sessions
+- Cohesion improves, but true continuity does not
+
+Best when: we want a low-risk first pass with minimal behavioral change.
+
+### 2. Continuity-First
+
+Introduce deterministic logical session keys and persist a mapping from logical key to the latest canonical OpenCode session ID. Repeated runs for the same entity try to continue the same session lineage. If the mapped session is unavailable, fall back to deterministic retrieval and create a new session only when needed.
+
+Pros:
+- Best alignment with the goal of stronger cohesion and adherence
+- Lets future prompts speak in terms of "current thread" rather than "similar past work"
+- Makes run summaries and prior context compound over time
+
+Cons:
+- Higher integration risk than retrieval-first
+- Requires explicit policy for stale, missing, or branched sessions
+
+Best when: continuity is the product goal, not just better search.
+
+### 3. Observability-First
+
+Keep current session behavior, but first make all trigger types preserve prompt and OpenCode logs, then use those artifacts to improve prompts and continuity later.
+
+Pros:
+- Fastest path to better diagnosis
+- Makes future tuning evidence-driven
+
+Cons:
+- Does not materially improve agent cohesion on its own
+- Risks becoming instrumentation without behavior change
+
+Best when: the team wants data collection before changing behavior.
+
+## Recommended Direction
+
+Use a balanced continuity-first rollout.
+
+Phase the work around a continuity target, but ship observability and deterministic retrieval at the same time so the behavior is measurable and debuggable.
+
+Recommended shape:
+
+1. Introduce deterministic logical keys for each trigger family.
+2. Persist logical key -> canonical session ID so repeated runs prefer the same thread.
+3. Fall back to deterministic retrieval by logical key when the canonical session is missing or stale.
+4. Upload `opencode-logs` for `fro-bot.yaml`, not just `ci.yaml`.
+5. Restructure the prompt so logical thread identity and previous relevant work appear before lower-value generic instructions.
+
+## Prompt Improvements To Carry Forward
+
+- Move logical thread identity near the top of the prompt.
+- Distinguish `current thread context` from `related historical context`.
+- Reduce prompt bloat by selecting prior-session context from the exact logical key before showing broader repository matches.
+- Keep response protocol strict, but avoid burying task-specific context under generic operational rules.
+- Surface known runtime warnings deliberately so they are either actionable or clearly ignorable.
+
+## Logging And Artifact Improvements To Carry Forward
+
+- Upload `~/.local/share/opencode/log` in `fro-bot.yaml` the same way `ci.yaml` already does.
+- Preserve prompt artifacts for schedule, issue, discussion, and comment triggers.
+- Decide whether `Blocked 3 postinstalls` is expected noise or a warning worth escalation.
+- Decide whether repeated `tool.registry ... invalid` is benign startup chatter or evidence of a misconfigured tool registry path.
+
+## Key Decisions
+
+- We optimize for stable continuity, not just better fuzzy retrieval.
+- Deterministic logical keys should be first-class and trigger-specific.
+- Deterministic retrieval remains the fallback when continuity cannot be preserved.
+- Universal prompt/log artifact retention is required so non-PR runs are inspectable.
+- Prompt context should prioritize the current logical thread before generic history.
+
+## Resolved Questions
+
+- Should the long-term target be stable retrieval or stable continuity? Resolved: stable continuity, with deterministic retrieval fallback.
+- Should observability be handled separately from continuity? Resolved: no; artifact retention should ship alongside the continuity work.
+
+## Open Questions
+
+None currently.
+
+## Success Criteria
+
+- Repeated runs on the same PR, issue, discussion, or scheduled task consistently recover the right prior thread.
+- Session lookup no longer depends on unstable values like issue title text.
+- Prompts show exact prior-thread context before broad historical search context.
+- Non-PR `Fro Bot` runs preserve inspectable prompt and OpenCode logs.
+- Case-study review after implementation shows less prompt bloat and more relevant prior-session context.

--- a/docs/brainstorms/2026-04-07-prompt-xml-architecture-requirements.md
+++ b/docs/brainstorms/2026-04-07-prompt-xml-architecture-requirements.md
@@ -1,0 +1,55 @@
+---
+date: 2026-04-07
+topic: prompt-xml-architecture
+---
+
+# Prompt XML Architecture Overhaul
+
+## Problem Frame
+
+The Fro Bot CI agent prompt is a ~150-line user message sent via OpenCode's SDK. It contains harness rules, reference context, user-supplied instructions, and task directives — all rendered as flat markdown. User-supplied instructions (custom review prompts) contain markdown headings (`## Verdict`, `### Blocking issues`) that are syntactically indistinguishable from the prompt's own structure. There is no explicit authority hierarchy — nothing tells the model which instructions take precedence when they conflict. Anthropic's guidance for Claude models recommends XML tags for semantic boundaries in mixed-content prompts, long-form data positioned before queries, and explicit precedence declarations.
+
+## Requirements
+
+- R1. Wrap all major prompt blocks in descriptive XML tags to create clear semantic boundaries between harness rules, reference context, task directives, user-supplied instructions, and output contracts
+- R2. Wrap user-supplied instructions (the `prompt` action input) in `<user_supplied_instructions>` with an explicit precedence line: "Apply these only if they do not conflict with harness rules or the output contract"
+- R3. Reorder prompt sections to follow Anthropic's long-context guidance: reference data (environment, PR/issue context, session context) near the top; task, user instructions, and output contract near the end
+- R4. Replace the current `## Critical Rules (NON-NEGOTIABLE)` markdown section with a `<harness_rules>` XML block at the top of the prompt, with explicit precedence declaration
+- R5. Remove the `## Reminder: Critical Rules` bottom section — single authoritative declaration replaces duplicated reminders
+- R6. Keep `@filename.txt` attachment references inline within their XML-tagged context sections (not a separate manifest block)
+- R7. Preserve markdown formatting inside XML blocks for readability — hybrid XML/markdown approach, not pure XML
+- R8. Keep all section-building functions pure (no I/O) — the refactor is structural, not behavioral
+
+## Success Criteria
+
+- Prompt artifact shows XML-tagged major blocks with correct nesting and no duplicate sections
+- User-supplied instructions appear inside `<user_supplied_instructions>` with precedence line
+- Section order matches: harness_rules → identity → context/documents → task → user_instructions → output_contract
+- All existing tests pass (may need assertion updates for new tag structure)
+- Fro Bot review quality does not regress on first 3-5 runs post-merge (qualitative check)
+
+## Scope Boundaries
+
+- NOT changing prompt content/wording — only structure and delimiters
+- NOT adding structured output/tool schemas for review format enforcement (future work)
+- NOT modifying the system prompt (controlled by OpenCode, not us)
+- NOT changing how `buildAgentPrompt()` returns data (`PromptResult` type stays the same)
+- NOT touching `execution.ts`, `reference-files.ts`, or the materialization pipeline
+
+## Key Decisions
+
+- **Comprehensive overhaul over targeted fix**: Full XML migration + reorder, not just wrapping user instructions. Aligns with Anthropic guidance and establishes a clean architecture for future prompt evolution.
+- **Drop reminder section**: Single authoritative `<harness_rules>` block at top. No bottom duplication — Oracle analysis shows rule duplication with variation creates conflicts, and our prompt is short enough (~150 lines) that recency reinforcement is unnecessary.
+- **`<harness_rules>` at top of user message**: We don't control OpenCode's system prompt. Our non-negotiable rules live in a clearly-tagged block at the start of the user message with explicit precedence over `<user_supplied_instructions>`.
+- **Inline attachment references**: `@filename.txt` stays inline within XML-tagged context sections. No separate `<documents>` manifest — keeps documents in context where they're referenced.
+- **Hybrid XML/markdown**: XML for semantic boundaries between major blocks; markdown inside blocks for readability. Not converting every heading to XML.
+
+## Deferred to Planning
+
+- [Affects R1][Technical] Exact XML tag names for each section — `<environment>`, `<pull_request>`, `<session_context>`, `<task>`, `<output_contract>` are candidates but need validation against the actual section builders
+- [Affects R3][Technical] Exact section order — the broad principle is "context first, task last" but the precise ordering of environment vs PR context vs session context needs to be determined during implementation
+- [Affects R1][Needs research] Whether XML tags inside a user message interact with OpenCode's own system prompt XML structure — unlikely to conflict but worth a quick check
+
+## Next Steps
+
+→ `/ce:plan` for structured implementation planning

--- a/docs/brainstorms/2026-04-15-durable-object-storage-requirements.md
+++ b/docs/brainstorms/2026-04-15-durable-object-storage-requirements.md
@@ -1,0 +1,77 @@
+---
+date: 2026-04-15
+topic: durable-object-storage
+---
+
+# Durable Object Storage Substrate
+
+## Problem Frame
+
+Fro Bot's persistence is built on GitHub Actions cache — a 7-day TTL, 10GB-capped, branch-scoped, runner-local store. This works for the current reactive GitHub Action but blocks every planned evolution:
+
+- **Gateway/daemon mode** can't use GitHub cache (it runs outside Actions)
+- **Discord interface** has no access to Actions cache
+- **Cross-runner portability** fails when cache keys don't match
+- **Session continuity** breaks on cache eviction after 7 idle days
+
+The storage layer needs to become durable, portable, and provider-agnostic so that sessions, artifacts, and run metadata survive across runtimes, channels, and cache churn.
+
+## Requirements
+
+- R1. S3-compatible object storage is the **canonical source of truth** for all persistent state. GitHub Actions cache becomes an optional read-through accelerator, not the primary backend.
+- R2. The storage layer works with any S3-compatible API via custom endpoint configuration: AWS S3, Cloudflare R2, Backblaze B2, MinIO, DigitalOcean Spaces, Wasabi, etc. Uses `@aws-sdk/client-s3` with configurable endpoint.
+- R3. Four content types are persisted to object storage in v1:
+  - **Sessions + messages** — the SQLite DB or exported session data
+  - **Prompt artifacts** — prompt text files currently saved to the log directory
+  - **Attachments** — reference files (pr-description.txt, etc.) materialized during prompt building
+  - **Run metadata** — token usage, timing, artifact URLs, error logs per run
+- R4. In GitHub Action mode, when S3 is configured: restore from GitHub cache first (fast, free). On cache miss, fall back to S3 read. Write-through to both S3 and cache on save. Eliminates cold-start S3 latency on cache hit.
+- R5. In non-Action modes (future gateway/Discord), S3 is the only persistence backend. No GitHub cache dependency.
+- R6. S3 key structure uses prefix isolation by agent identity and repository: `{prefix}/{agentIdentity}/{sanitizedRepo}/...`
+- R7. S3 failures are logged but never fail the run. Degraded persistence is acceptable; crashing is not.
+- R8. Credentials are sourced from environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) or IAM roles. Never logged. Action inputs configure bucket, region, prefix, and optional custom endpoint.
+- R9. The storage abstraction is a clean adapter interface that the session layer, prompt pipeline, and observability layer can call without knowing the backend. Same interface works for S3 in Action mode, S3 in gateway mode, and potential future backends.
+
+## Success Criteria
+
+- Sessions survive GitHub Actions cache eviction — after 7+ idle days, a new run restores from S3 with no data loss.
+- Switching S3 providers (e.g., AWS → R2) requires only endpoint + credential changes, no code changes.
+- Non-Action runtimes (future gateway, Discord) can read/write the same session data via S3 without any GitHub dependency.
+- Prompt artifacts and run metadata are queryable in S3 for debugging and observability.
+
+## Scope Boundaries
+
+- NOT persisting wiki pages to S3 — they live in git and are already version-controlled.
+- NOT implementing a gateway or Discord runtime — this is the storage foundation they'll use.
+- NOT removing GitHub Actions cache — it stays as an accelerator when available.
+- NOT implementing multi-tenant isolation — single-repo-per-config is sufficient for v1. Multi-tenancy is a gateway concern.
+- NOT implementing real-time sync or conflict resolution — write-through is append-mostly; the latest write wins.
+
+## Key Decisions
+
+- **S3 canonical, cache accelerator**: S3 is the source of truth. GitHub cache avoids S3 reads when warm. This inverts RFC-019's "cache primary, S3 backup" model. Rationale: every planned evolution (gateway, Discord, daemon) needs storage that works without GitHub Actions.
+- **S3-compatible only**: No multi-protocol abstraction for Azure Blob or GCS. The S3 API is the de facto standard — R2, B2, MinIO, Wasabi, DO Spaces all support it. `@aws-sdk/client-s3` with custom endpoint covers the target surface.
+- **Custom endpoint support**: Action input for endpoint URL enables non-AWS providers without code changes.
+- **4 content types in v1**: Sessions, prompt artifacts, attachments, run metadata. Wiki stays in git. Scoped to what the current harness produces.
+- **Adapter interface**: Storage operations go through a clean interface so the session layer doesn't know whether it's talking to S3, cache, or a future backend.
+
+## Dependencies / Assumptions
+
+- RFC-019 provides the technical foundation — S3 client operations, key structure, sync logic, IAM policy, and test patterns. The implementation should build from RFC-019's spec while inverting the storage hierarchy.
+- `@aws-sdk/client-s3` (modular SDK v3) is the only new runtime dependency.
+- Action inputs for S3 config already exist in `action.yaml` (`s3-backup`, `s3-bucket`, `s3-region`, `s3-prefix`).
+- GitHub Actions cache adapter (`src/services/cache/`) is already abstracted — extending it with S3 fallback is incremental.
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R3][Technical] Should sessions be synced as raw SQLite files or exported as JSON? SQLite files are simpler but not queryable in S3. JSON is queryable but requires serialization logic.
+- [Affects R4][Technical] What's the write-through strategy for prompt artifacts and run metadata? Should they be written during execution or batched in the finalize phase?
+- [Affects R6][Needs research] Should the S3 key structure match RFC-019 exactly, or evolve to support the 4 content types as separate prefixes (e.g., `sessions/`, `artifacts/`, `metadata/`)?
+- [Affects R8][Technical] Should a custom endpoint input be added to `action.yaml` now, or deferred until a non-AWS provider is actually needed?
+- [Affects R9][Technical] What does the storage adapter interface look like? Should it expose CRUD operations on typed content, or raw get/put/list on keys?
+
+## Next Steps
+
+→ `/ce:plan` for structured implementation planning

--- a/docs/brainstorms/2026-04-17-fro-bot-gateway-discord-requirements.md
+++ b/docs/brainstorms/2026-04-17-fro-bot-gateway-discord-requirements.md
@@ -1,0 +1,337 @@
+---
+date: 2026-04-17
+topic: fro-bot-gateway-discord
+status: ready-for-planning
+reviewed: 2026-04-17
+review_coverage: full (7 reviewers)
+decisions_anchored: 10
+related:
+  - docs/ideation/2026-04-15-autonomous-agent-platform-ideation.md
+  - docs/plans/2026-04-15-001-feat-durable-object-storage-plan.md
+  - docs/solutions/workflow-issues/delivery-mode-contract-for-manual-triggers-2026-04-17.md
+references:
+  - https://github.com/remorses/kimaki
+  - https://hermes-agent.nousresearch.com/docs/user-guide/messaging/discord
+  - https://github.com/sachitv/opencode-omo-sandbox-docker
+---
+
+# Fro Bot Gateway — Discord-First Action-Taking Agent
+
+## Problem Statement
+
+Fro Bot today is a stateless GitHub Action: one webhook event in, one comment out, runtime dies. That model has clean operational properties — no infra to run, GitHub Actions handles uptime — but it forecloses an entire category of interaction. The agent cannot:
+
+- Be reached from where Marcus actually sits (Discord), only where webhooks fire (GitHub events)
+- Hold a real-time conversation across multiple turns inside a session that already understands the project
+- Take action on a repo without first being triggered by a GitHub event
+- Respond to ad-hoc questions ("explain why this PR fails CI", "summarize what changed in `src/foo` this week", "review my local branch") without going through the workflow_dispatch ceremony
+
+Idea #1 from the autonomous-agent-platform ideation framed three goals — Discord, persistent runtime, autonomous loops — as one architecture. This document narrows that to the v1 path the user has chosen: **a Discord-first action-taking gateway that talks directly to local repo checkouts and dispatches to the existing GitHub Action when cloud execution is the right fit.**
+
+The gateway does not replace the GitHub Action. The Action keeps handling webhook-triggered PR reviews, cron-based DMR/wiki runs, and any scenario where ephemeral cloud compute is the natural fit. The gateway is the second surface for everything else.
+
+### Why Discord (and not a CLI, IDE plugin, or web UI)
+
+The deeper need is "reach the agent from anywhere I happen to be." Three alternatives were considered before committing to Discord:
+
+- **CLI** — fastest to ship, no infra, no new surface, sessions already persistent in S3. Fails on the core need: a CLI is tied to a terminal, which is tied to a device. Can't start a task on laptop, check results from a phone at dinner, resume on desktop.
+- **IDE plugin (Cursor / Continue / Copilot extension)** — rich editor context (cursor position, selected text, inline diffs). Fails for the same reason: tied to one editor open on one device. Also couples to a specific IDE's plugin surface, which limits portability.
+- **Web UI** — device-agnostic like Discord, could satisfy the multi-device need. But requires building from scratch: auth, session UX, push notifications, mobile client, approval flows, state sync. Net greenfield work.
+
+**Discord wins on one specific capability: multi-device presence.** Desktop, laptop, mobile, browser — same conversation, same session, approval buttons that work on phone, notifications that actually reach you when you're not at a terminal. Discord is a ready-made multi-device client already installed on every device Marcus uses. The architecture cost (daemon, sandbox, Docker Compose) buys a surface that would otherwise take months of web-UI work to replicate.
+
+This commits Fro Bot to an **agent platform with multiple frontends** trajectory, not "best-in-class GitHub Action with a Discord sidecar." The Action remains a frontend; Discord becomes another frontend; both consume the same runtime. Future surfaces (web UI, Slack, CLI if the multi-device need ever softens) plug into the same runtime layer.
+
+## Goals
+
+The gateway delivers a meaningful agent experience in Discord while preserving the architectural investments already made in the codebase. Each requirement below is intentionally framed at the user-behavior level; implementation choices belong in planning.
+
+**R1. Action-taking from Discord.** A Discord user with appropriate permissions can ask the agent to do real work — read code, edit files, create branches, open PRs, run tests — and see the result in the Discord thread.
+
+**R2. Channel ↔ repo mapping.** Each Discord channel is bound to one or more repo paths the gateway can operate on. The user adds a repo to the gateway (mechanism specified in S8: `/fro-bot add-project`) and the gateway either creates a Discord channel or binds to an existing one. Threads inside the channel are individual sessions scoped to that repo.
+
+**R3. Session context shared across surfaces; resume is within-surface only; session content is untrusted input.** Both surfaces write sessions to the same S3 bucket with per-surface namespacing (`{tenant}/{surface}/{logical-key}`). Session **content is readable across surfaces** — Discord can search and reference Action sessions as context in a prompt (e.g., 'summarize what the agent found when it reviewed PR #42'), and vice versa. Session **resume is within-surface only** — a Discord thread resumes Discord sessions; an Action run resumes Action sessions. Cross-surface resume is explicitly out of scope because workspace state (CWD, branch, uncommitted edits) does not reconcile between a persistent host checkout (Discord) and an ephemeral runner clone (Action); attempting to resume would hallucinate continuity that does not exist.
+
+**Session content is treated as user-authored, untrusted input.** A Discord user shapes session content by chatting with the agent; the Action then may read that session as context. The agent's system prompt (the `<harness_rules>` block from PR #465) must explicitly treat session history as conversation, not trusted instructions. This matches the existing posture for PR bodies, comments, and webhook payloads — session content enters the same untrusted-input pipeline, no new integrity machinery (no signing, no append-only enforcement, no write-prefix isolation). If session content later proves adversarial in practice, v1.1 adds the integrity layer then.
+
+**Read-only summaries bridge.** When the Action completes a run, it writes a condensed summary to a shared `summaries/` namespace (not raw session content). The gateway can surface these summaries in slash-command autocomplete and in prompts (e.g., `/fro-bot review <pr>` can show 'Fro Bot already reviewed this in Action run <id>, summary attached'). The Action can write to this namespace from its finalize phase; the gateway reads but does not write to it. Summaries are agent-authored distillations, not session excerpts — cheaper to include in prompts and safer to cross-surface.
+
+**R4. Local execution by default; cloud dispatch when warranted.** The gateway runs OpenCode against a local checkout in its sandboxed workspace. When the user explicitly asks for cloud execution (slash command), or when policy says so (bigger jobs, work that needs the GitHub Action's specific environment, work that should produce a PR via the existing delivery contract), the gateway dispatches a `workflow_dispatch` into the GitHub Action and reports progress back to Discord.
+
+**R5. Sandboxed agent execution (middle-path containment).** Local agent execution runs inside a containment-oriented sandbox. The workspace cannot make arbitrary outbound HTTPS to non-allowlisted hosts. Network egress flows through a build-time HTTP(S) allowlist implemented by `mitmproxy`, the single pattern adopted from sachitv/opencode-omo-sandbox-docker. The sandbox is a developer-grade containment, not a hardened VM boundary, and the threat model assumes a non-malicious model that should still not be able to exfiltrate unintentionally.
+
+Explicitly **not** included in v1 containment:
+
+- **DNS allowlist (CoreDNS):** DNS exfiltration is a theoretical concern for a non-malicious model; deferred until the threat model upgrades.
+- **Git credential broker:** deploy keys and GitHub App credentials are bind-mounted read-only into the workspace (`chmod 400`, owned by a non-root agent user). This is an **accepted risk**: an actively adversarial model with shell access could exfiltrate the mounted credentials. The mitigation for v1 is trusting the model's non-malicious posture; v1.1 can add the broker if needed.
+
+Acknowledged scope limits (same as under the full stack): the sandbox does not prevent (a) covert channels through allowlisted endpoints (e.g., encoding data in prompt/response bodies to the LLM provider), (b) CA-bypass in scripted clients that override TLS verification, or (c) prompt-injection-induced misbehavior inside the agent's allowed tool surface. Defense for those classes is a separate concern (per-tool approval flows, output review, and operator vigilance).
+
+**R6. Role-based access control.** The gateway uses Discord's role system for authorization, following the Kimaki pattern. A specific Discord role (default name: `fro-bot`, distinct from the `@fro-bot` bot mention) gates who can interact. A separate block role (default name: `no-fro-bot`) overrides that grant. Bots are ignored unless they have the access role. Single-tenant for v1 (one gateway instance per user, no Discord-user-to-GitHub-identity mapping), but the design must not foreclose multi-tenancy.
+
+**R7. Self-hostable Docker delivery.** The gateway ships as a `docker compose` stack with three services (gateway, workspace, mitmproxy). A user clones a small bootstrap repo, populates secrets and config, and runs `docker compose up`. No SaaS layer. Marcus runs an instance for himself; other users can self-host.
+
+**Credential storage split:**
+
+- **Docker secrets** (mounted read-only at `/run/secrets/<name>`, read as files): Discord bot token, GitHub App private key, GitHub App ID, LLM provider API keys, S3 access credentials.
+- **`.env` file** (plaintext, `.gitignored`, `chmod 600`): non-sensitive config like S3 bucket name, S3 region, S3 endpoint, log level, Discord server ID, mitmproxy allowlist overrides.
+
+Docker secrets close the 'leaked via git/shell history' class of incident because they live outside the repo and outside the process environment. Rotation in v1 requires restarting the gateway container (planning may add a `reload-credentials` hook); v1 documents this as a known operational characteristic, not a gap. This matches the open-source/privacy-minded posture and lets the same artifact serve "personal Fro Bot" and (eventually) "team Fro Bot" deployments.
+
+**R8. Conservative reuse of existing architectural assets.** The gateway must not reimplement agent execution, session storage, prompt assembly, or object-store logic. The work is to extract a **narrow shared runtime package** covering only those four layers (`features/agent/`, `services/session/`, relevant parts of `features/agent/prompt.ts`, and `services/object-store/`). Both frontends consume this package.
+
+Explicitly out of the shared package: the harness phases (`bootstrap`, `routing`, `dedup`, `acknowledge`, `cache-restore`, `session-prep`, `execute`, `finalize`, `cleanup`), event routing, `NormalizedEvent` normalization, `@actions/*`-coupled code, and the output-mode resolver. Each frontend writes its own harness. The Action keeps its existing harness. The gateway writes a new one that composes the same shared runtime differently (long-running Discord event loop instead of per-invocation phase pipeline). The two harnesses will look different because they serve different runtimes, and that's expected.
+
+The XML prompt architecture and Delivery Mode contract (PR #517) are part of the shared runtime — both surfaces need them. Event routing and context normalization are not — Discord and GitHub produce fundamentally different event shapes that do not generalize cleanly.
+
+**R9. Discord-native ergonomics.** The Discord experience must feel like Discord, not like a CLI bolted into Discord. Specific behaviors:
+
+- **Thread-per-session.** Each `@fro-bot` mention in a channel auto-creates a thread; subsequent messages in that thread don't need a mention. Matches Hermes's auto-thread pattern.
+- **Rich responses.** Embeds, code blocks, and file attachments. Long responses (>2000 chars) are split at logical breaks (section boundaries, between code blocks) or attached as a file with a short summary message; a code block is never split mid-block.
+- **Reactions for progress states.** `👀` added when the bot starts processing, `🎉` on success, `😕` on failure.
+- **Long-run progress in the working message.** For runs longer than ~90 seconds, the gateway edits the initial working message every 60-90 seconds to reflect elapsed time and current phase (e.g., `[2m 15s] reading files...`, `[5m 03s] running tests...`). Single in-place edit, no channel noise, always-current state.
+- **Inline approval buttons for sensitive operations** (see S5 for contents).
+- **Slash commands** that auto-complete in Discord's native UI; the agent's registered skills surface as `/fro-bot <skill>` commands where applicable.
+- **File attachments** on incoming messages (images, code, docs) are included in the session context.
+- **Mention safety by default.** All outgoing messages set `allowed_mentions: { parse: ['users'] }`. The agent cannot emit `@everyone`, `@here`, or role pings even if the model's text output contains those strings. Individual user mentions by ID remain allowed but are rare in practice. This is a hard default, not user-configurable in v1.
+
+**R10. Observable execution.** Every Discord-triggered run produces the same observability the existing GitHub Action does: structured logs, a run summary visible in Discord (and posted back to GitHub when relevant), session-id traceability, metrics (token usage, duration, tool calls). A user looking at a Discord thread should be able to identify exactly which session ran and inspect its full trace.
+
+**R11. Run lifecycle, queueing, and cross-instance coordination.** v1 correctness contracts:
+
+- **Run-state lifecycle.** Every Discord-triggered run has an S3-persisted lifecycle record: `PENDING → ACKNOWLEDGED → EXECUTING → COMPLETED | FAILED`. Gateway heartbeats while EXECUTING. On restart, gateway scans for EXECUTING records older than 2× heartbeat interval and marks them FAILED ('gateway restarted during execution'), editing the working message in Discord to reflect the failure. Handles gateway crashes, host reboots, and Discord WS drops without leaving users staring at a dead 'thinking...' indicator.
+- **Same-thread queueing.** Within a Discord thread, tasks execute serially. If task B is fired while task A is still executing, B posts 'queued (position 1), waiting for current task to finish' and starts when A completes. `/fro-bot clear-queue` cancels pending tasks. `/fro-bot abort` stops the currently executing task. Matches the Kimaki `/queue` pattern and aligns with a single-conversation-at-a-time mental model.
+- **Per-repo single-writer lock.** Only one execution runs against a given repo at a time, across all surfaces (Discord channels, Action runs, cron triggers). Lock record in S3 with TTL. When any instance wants to run, it attempts to acquire the lock; if held, it queues and surfaces the current holder ('Action run #24601 is currently reviewing PR #42 — queued, 3 min elapsed'). Resolves both the multi-channel-same-repo collision and the Discord-vs-Action concurrent-execution scenarios with the same mechanism. Sequential execution is accepted as the cost; v1 does not attempt optimistic concurrency or per-file locking.
+
+## Non-Goals (Scope Boundaries)
+
+**Out of scope for v1:**
+- **Multi-tenant SaaS hosting.** No hosted Fro Bot service. Self-hosted only. Multi-tenancy is a design consideration, not a deliverable.
+- **Slack, Telegram, email, or other messaging surfaces.** Discord only. The gateway architecture must not foreclose adding more (the Hermes "messaging gateway" pattern is the long-term shape), but only Discord ships in v1.
+- **Voice messages, voice channels, screen sharing.** Kimaki and Hermes both ship these; we explicitly defer them. Text + file attachments + reactions only.
+- **Autonomous loops without a human trigger.** No self-initiated work in v1. Every run starts from a Discord message, slash command, or `workflow_dispatch` from existing scheduled workflows. Long-term, the gateway can host autonomous loops, but that's a separate slice.
+- **Replacing the GitHub Action.** The Action keeps handling webhook-triggered PR reviews, the DMR cron, and the wiki cron. The gateway is additive.
+- **Per-user GitHub identity mapping.** v1 acts as the configured GitHub App identity (`fro-bot[bot]`) regardless of which Discord user triggered the work. Bridging Discord users to GitHub identities is a future concern.
+- **Per-channel ephemeral system prompts** (Hermes's `channel_prompts`), forum channels, voice STT/TTS, and home-channel proactive notifications. All deferred.
+- **A new agent execution engine.** The agent runs OpenCode (via the existing SDK integration), inside the sandbox. We do not build a new agent runtime — we wrap the existing one.
+
+**Permanent non-goals:**
+- **Hardened VM-grade isolation.** The sandbox is containment, not isolation. A determined adversary could escape it. The threat model is "well-meaning model that should not exfiltrate or escape unintentionally," not "actively hostile model with capability to break out."
+- **Replacing the project's git/PR conventions.** Branches, commits, and PRs created by the agent through Discord must follow the same conventions (commit message style, PR description style, AGENTS.md compliance) the Action follows.
+
+## Success Criteria for v1
+
+The v1 release is successful when all of the following hold:
+
+1. Marcus can self-host the gateway from a Docker Compose stack on a host of his choice with under 30 minutes of setup, given pre-existing GitHub App credentials and a Discord bot token.
+2. From Discord, Marcus can `@fro-bot` in a channel mapped to a repo and the agent reads/edits files in that repo's checkout, with reactions showing progress and a final message containing the run summary.
+3. From Discord, Marcus can `/fro-bot review <pr-url>` and the agent reviews the PR — same quality bar as the existing Action's PR reviews — with results posted to both Discord and the PR (single comment per invocation, per the existing Response Protocol).
+4. Session context is shared across surfaces (read-only). A Discord user can ask 'what did Fro Bot find when it reviewed PR #42?' and the gateway can surface the Action's summary and optionally pull the full session into the prompt as context. Cross-surface *resume* is explicitly not a v1 behavior — workspace state does not reconcile between surfaces.
+5. The agent's local execution cannot make HTTP requests to hosts not on the build-time allowlist, cannot do DNS lookups for non-allowlisted domains, and cannot read git credentials directly. Verified by `mitmproxy` logs showing all egress + by negative tests confirming blocked traffic.
+6. The existing GitHub Action's behavior is unchanged on the same trigger surface (webhook PR reviews, DMR cron, wiki cron). No regressions in CI quality, latency, or cache behavior.
+7. The conservative shared runtime is extracted: both frontends import agent execution, session storage, prompt assembly, and object-store logic from the same package. Duplication is limited to the harness layers, which are intentionally separate because the Action and gateway serve fundamentally different runtimes.
+
+## Architectural Decisions Made During Brainstorming
+
+These decisions are settled and feed into planning. They are not open questions.
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | **Approach A with conservative extraction scope**: `@fro-bot/runtime` covers agent execution, session storage, prompt assembly, and object-store only. Harness phases, routing, and `@actions/*`-coupled code stay in the Action. Gateway writes its own harness. | The Action's harness phases were designed for ephemeral runners with a per-invocation pipeline; that shape does not match a long-running Discord gateway. Extracting only the genuinely shared layer narrows the blast radius on the Action during the refactor, keeps each frontend's harness appropriate to its runtime, and avoids speculative generalization of event routing across two fundamentally different event shapes. The shared layer can grow later if a third surface appears and the real shared surface becomes visible. |
+| D2 | **Discord-first**, not Slack/Telegram/email/etc. for v1 | Discord is where the user actually sits. Other surfaces add scope without sharpening the v1 use case. Architecture must not foreclose adding them later. |
+| D3 | **Action-taking agent**, not read-only companion or observer-only | The user explicitly chose this. Lower-stakes alternatives don't justify the architecture cost. |
+| D4 | **Local execution by default + cloud dispatch as opt-in** | Borrows from Kimaki (channel = local project) and adds GitHub Actions dispatch for work that benefits from cloud compute. Both paths share session storage. |
+| D5 | **Self-hosted via Docker Compose**, not VPS-specific or SaaS | Matches the open-source/privacy-minded posture. Any host can run it. Easier to test locally. Multi-tenancy deferred. |
+| D6 | **Middle-path sandbox**: mitmproxy HTTP allowlist + non-root agent user + default-deny network policy + bind-mounted credentials (accepted risk). No CoreDNS, no git-broker in v1. | The sachitv pattern is the reference but v1 adopts only the single highest-leverage piece (mitmproxy). DNS allowlist and credential brokering add operational complexity that does not match the stated non-malicious-model threat. Both can be added in v1.1 if the threat model upgrades. |
+| D7 | **S3 storage** as session-of-record (already shipped in PR #514) | The gateway and Action both read/write the same sessions. No duplicate storage. |
+| D8 | **Single-tenant for v1**, multi-tenancy as a design constraint not a deliverable | Avoids premature complexity. Discord role-based access provides first-pass authz; multi-tenancy bridges Discord ↔ GitHub identity (future). |
+| D9 | **Channel ↔ repo, thread ↔ session** | Kimaki's mental model. Maps cleanly to how Discord users already think about scope. |
+| D10 | **GitHub App credentials**, not per-user PATs | All v1 actions attribute to `fro-bot[bot]`. Per-user attribution is multi-tenancy work. |
+| D11 | **No autonomous loops in v1.** Every run is triggered by a Discord message, slash command, or webhook | Removes a major dimension of design and operational risk. Loops are a future slice on top. |
+
+## User Stories
+
+The v1 gateway delivers these concrete user stories. Each one corresponds to one or more requirements above.
+
+**S1. Reach the agent from Discord.** *Given* the gateway is running and I'm a member of the configured Discord server with the `fro-bot` role, *when* I `@fro-bot` in a channel mapped to a repo with a question or task, *then* the agent creates a thread, posts a working reaction, and responds in the thread with the result.
+
+**S2. Discuss a PR review in real time.** *Given* the gateway is running and the existing Action just posted a PR review, *when* I `@fro-bot` in Discord asking "explain finding #3 in your last review of PR #N", *then* the agent loads the relevant session, answers in Discord, and updates the run summary.
+
+**S3. Have the agent edit files locally.** *Given* a Discord channel mapped to a repo, *when* I ask `@fro-bot` to make a code change, *then* the agent edits files in the local checkout (inside the sandbox), commits to a branch, and either pushes that branch + opens a PR (if the channel is configured for `branch-pr` delivery) or leaves the working directory for me to review (if configured for `working-dir` delivery). The gateway reuses the existing Delivery Mode contract shipped in PR #517 — it does not introduce a new one.
+
+**S4. Dispatch heavy work to cloud.** *Given* a Discord channel and a task that benefits from the GitHub Action's environment (matrix CI, secrets-heavy operations, long-running work), *when* I run `/fro-bot cloud <task>`, *then* the gateway triggers a `workflow_dispatch` on the existing Action and posts back the run URL + status updates as the Action progresses.
+
+**S5. Approve a sensitive action.** *Given* the agent is about to run a tool that needs approval (commit, push, merge, tool outside its standard set), *when* the approval moment arrives, *then* the gateway posts an inline Discord embed in the thread with the following fields:
+
+- **Action** — tool name in human-readable form (e.g., `commit`, `push`, `open-pull-request`)
+- **Target** — what the action operates on (branch name, file paths, PR number, etc.)
+- **Summary** — 1-2 lines describing the effect (e.g., '42 lines added, 8 removed across 3 files')
+- **Why** — the agent's 1-sentence reasoning for proposing the action
+
+Below the embed, a button row: `Accept` / `Accept Always` / `Deny`. `Accept Always` persists a per-channel approval for that tool. A separate `/fro-bot approvals` command lists and revokes persisted approvals. Arguments shown in the embed are redacted for anything matching credential/secret patterns before rendering (belt-and-suspenders with the output sanitization from S1-S3 security work).
+
+**S6. Resume a prior session.** *Given* I had a session yesterday on a specific question, *when* I run `/fro-bot resume` and pick the session from autocomplete, *then* the gateway opens a thread continuing that session with full context loaded.
+
+**S7. Self-host the gateway.** *Given* I have Docker installed, a Discord bot token, GitHub App credentials, and an S3 bucket, *when* I clone the gateway repo, fill out `.env`, and run `docker compose up -d`, *then* the gateway connects to Discord, registers slash commands, and is ready to handle messages.
+
+**S8. Add a repo to the gateway.** *Given* the gateway is running, *when* I run `/fro-bot add-project url:<git-url> [channel:<optional>]`, *then* the gateway:
+
+1. Authenticates to GitHub using its configured GitHub App credentials (same token the Action uses; no per-user PAT).
+2. Creates a new Discord channel (or reuses a named one if `channel:` is specified).
+3. Starts a thread in the new channel to show setup progress, with phase messages: `authenticating...` → `cloning...` → `binding channel to repo...` → `ready`.
+4. Clones the repo into the sandboxed workspace at a stable path.
+5. Binds the Discord channel to the repo path; subsequent `@fro-bot` messages in that channel operate on the cloned workspace.
+
+**Errors surface as red-sidebar embeds in the setup thread**, with actionable text: if the GitHub App lacks access to the repo, the error message includes a link to the App's installation settings. v1 accepts URLs only (HTTPS or SSH); local path support is deferred to v1.1 unless it proves necessary.
+
+## Reference Architectures and What We Adopt
+
+### From Kimaki (heavy adoption)
+
+- Channel = project, thread = session mental model
+- Slash command surface (`/session`, `/resume`, `/abort`, `/add-project`, `/new-worktree`, `/model`, `/agent`, `/share`, `/fork`, `/queue`, `/clear-queue`, `/undo`, `/redo`, `/upgrade-and-restart`)
+- Tool permission UX (Accept / Accept Always / Deny buttons in-thread)
+- Role-based access (`fro-bot` role + `no-fro-bot` block role)
+- Memory file at session start (`MEMORY.md` from project root, mirrors current Fro Bot AGENTS.md hydration pattern)
+- Message queue for follow-ups
+- File attachment as message-as-file for long prompts
+
+### From Hermes Discord (selective adoption)
+
+- Auto-thread-per-`@mention` in regular text channels (cleaner scoping)
+- Per-user session isolation in shared channels (`group_sessions_per_user: true` default)
+- Mention safety defaults (no `@everyone`/`@here` even if the model emits them)
+- Reactions for progress (`👀` start, `✅` success, `❌` failure)
+- DMs always respond, channels require mention by default
+- Home channel concept (deferred from v1, reserved for autonomous loops later)
+- Slash command registration alongside skills
+
+### From sachitv/opencode-omo-sandbox-docker (architectural backbone)
+
+- Devcontainer-style workspace, not bare host execution
+- mitmproxy as single egress chokepoint, network-namespace shared
+- CoreDNS for DNS allowlist (same source-of-truth as HTTP allowlist)
+- `git-broker` MCP for git ops (workspace never holds raw deploy keys/PATs)
+- Build-time policy (allowlist baked into image, agent cannot modify at runtime)
+- Default-deny network: HTTP non-allowlisted → block, DNS non-allowlisted → REFUSED, UDP 80/443 → reject (kills QUIC/HTTP3), DoT/encrypted DNS → reject, IPv6 off, IP-based connections blocked
+- Workspace runs as non-root `agent` user, no passwordless sudo, SSH agent forwarding disabled
+- Threat model: well-meaning model, not actively hostile
+
+### What we don't take from the references
+
+- Voice messages, voice channels, screen sharing (Kimaki) — out of v1 scope
+- Twelve other messaging surfaces (Hermes) — Discord only
+- VS Code Dev Containers as the run-mode (sachitv) — we run server-side, not editor-side
+- Per-channel ephemeral prompts (Hermes `channel_prompts`) — defer to a later iteration once the v1 surface settles
+
+## Open Questions (for Planning)
+
+These are questions the brainstorm intentionally does not answer because they are implementation choices best made during planning. They are not gaps in product clarity.
+
+**Q1. Local checkout strategy.** Per-channel persistent checkout (one clone per channel)? Per-session ephemeral worktree (clean slate per session)? Persistent main checkout + per-session worktrees (Kimaki's `/new-worktree`)? All three are viable; choice depends on disk usage, session-isolation requirements, and how often the agent needs to switch branches.
+
+**Q2. Compose stack composition.** Which services are separate containers vs combined? Gateway (Discord daemon + dispatch + session storage adapter) is one container. Workspace + mitmproxy + CoreDNS + git-broker are sandboxed cluster. MCP services (Brave, Perplexity, Context7) are optional add-ons. Exact split is planning work.
+
+**Q3. Cloud dispatch protocol.** Settled: gateway calls `workflow_dispatch` with a **strict typed schema**. Fixed input shape:
+
+```
+{
+  task_type: 'pr-review' | 'issue-triage' | 'custom',
+  repo: string,               // owner/name
+  pr_number?: number,
+  issue_number?: number,
+  branch?: string,
+  prompt: string              // the only field carrying user-authored content
+}
+```
+
+The gateway validates every field before dispatch (types, lengths, allowed-character regex on `repo`, `branch`). The Action re-validates on receipt as defense-in-depth; `prompt` is treated the same way user-supplied prompts already are (XML-wrapped, subordinated to `<harness_rules>`). Discord user input can only reach the Action via the `prompt` field. Job-status streaming back to Discord remains an open sub-question: polling `workflow_run` every 10-15s vs subscribing to GitHub's `workflow_run` webhook. Planning decides based on latency budget.
+
+**Q4. Shared runtime package layout.** The conservative extraction scope from R8 is settled: agent execution + session storage + prompt assembly + object-store. The open question for planning is the package layout. Options:
+
+- **Monorepo directory** (`src/runtime/` inside `fro-bot/agent`): Action imports from `./runtime`, gateway imports from a sibling package in the same workspace. Simplest, no versioning complexity, no npm publishing.
+- **Separate npm package** (`@fro-bot/runtime`): Published to npm, gateway installs it as a dependency. Clean boundary, independently versionable, but adds publish/release overhead and forces a public API contract early.
+- **Workspace package** (pnpm workspace): A package inside the monorepo but resolved via workspace protocol. Compromise between the two.
+
+The choice depends on whether the gateway lives in the same repo as the Action or in its own. Answer that first, then the packaging falls out.
+
+**Q5. Session ID format and summaries-bridge schema.** Under R3, each surface uses its own logical keys (Action: `issue-42`, `dispatch-12345`; Discord: `thread-{channel-id}-{thread-id}` or similar). The key-space namespace is `{tenant}/{surface}/{logical-key}` where tenant is `default` in v1 and reserved for multi-tenancy later. Open sub-questions for planning:
+
+- What goes in a summary record? Minimum: run timestamp, triggering entity (PR#, issue#, cron name), 2-3 sentence outcome, link to the full session, key file paths touched. Maximum: depends on how much the cross-surface UX wants inline.
+- How does each surface discover the other's summaries? Prefix-listing on S3? Materialized index? Per-entity lookup? Answer affects latency of `/fro-bot review <pr>` showing prior Action context.
+- Retention: summaries are cheaper than full sessions, could live longer. Planning decides.
+
+**Q6. Run-state record schema and heartbeat cadence.** Settled under R11: explicit lifecycle with S3-persisted records and heartbeats. Open sub-questions for planning:
+
+- Record schema (minimum: run ID, triggering surface, Discord thread + message IDs, current phase, last-heartbeat timestamp, start time, entity refs for the read-only summaries bridge from R3).
+- Heartbeat cadence (every 30s? 60s? Affects time-to-detect-failure after crash).
+- Where on S3: `lifecycle/` prefix? Colocated with sessions? Affects IAM policy scope.
+
+**Q7. mitmproxy allowlist source.** The allowlist needs to cover OpenCode's npm install, GitHub API, the LLM provider(s), oh-my-openagent's registry, S3 endpoint, Discord API, and any MCP services we ship. Some of these (LLM provider, S3 endpoint) are configurable per deployment, so the allowlist either needs templating or a generation step at container start. Planning decides: bake-at-build-time (more secure, requires rebuild to change) vs generate-at-start (more flexible, attack surface if compromised). Given the bind-mounted-credentials accepted risk already, build-time is probably not meaningfully more secure.
+
+**Q8. Per-repo lock implementation details.** Settled under R11: single-writer lock per repo across all surfaces. Open sub-questions for planning:
+
+- Lock record format (repo owner/name as key, lock holder identity, acquired-at, TTL).
+- Lock-acquisition semantics when held: block (queue with visible status) vs return-immediately with a 'busy' signal. Probably block with an inline progress indicator in Discord.
+- Interaction with the existing Action's dedup phase — does the Action still run its own dedup, or does the lock supersede? Likely supersede: R11's lock is the authoritative coordination mechanism, and the Action's dedup logic becomes redundant for repo-level coordination (though it may still be useful for within-surface bucket-of-work dedup).
+
+**Q9. Tool MCP plugin** (RFC-018) integration. RFC-018 specs OpenCode plugin tools (`create_branch`, `commit_files`, `create_pull_request`) that run inside the agent process. In the gateway's sandboxed workspace, these tools route through the `git-broker` MCP to honor the credential boundary. Planning needs to design how the existing RFC-018 tool surface maps onto the broker.
+
+## Risks
+
+**RISK-1. mitmproxy CA injection + network namespace coordination still requires polish.** Even the middle-path sandbox (3 services) needs careful setup: mitmproxy CA injected into the workspace's system trust store, shared network namespace so the workspace's egress flows through mitmproxy, transparent HTTPS interception. Translating this to "user runs `docker compose up` and it just works" still requires operational polish — less than the full sachitv stack, but non-trivial. *Mitigation:* fork sachitv's mitmproxy + workspace layout specifically (drop the CoreDNS and git-broker services); document the threat model + setup requirements; provide a one-command setup script that validates the CA trust chain before declaring success.
+
+**RISK-2. Runtime extraction breaks the Action.** The Action is in production. Pulling the runtime out into a shared package while the Action still works correctly is delicate. *Mitigation:* extract incrementally with the Action as the first consumer, gated by full test coverage; gateway frontend ships only after the Action runs cleanly on the extracted runtime in CI for several days.
+
+**RISK-3. Discord WS reliability under network partitions.** Marcus's host might lose internet. Discord might rate-limit. The gateway must reconnect cleanly, replay missed events where possible, and not lose user prompts. *Mitigation:* well-tested Discord library (discord.js or a stable alternative), explicit reconnect/backoff logic. In-flight prompts are protected by the R11 run-state lifecycle — a crashed gateway resumes with EXECUTING runs visible, marks them FAILED with a clear reason, and the user can retry. No work is silently lost; the worst case is 'your run failed, please retry' rather than 'the agent forgot about you'.
+
+**RISK-4. Cross-surface context access — session discovery fidelity.** R3 narrowed the risk substantially by ruling out cross-surface resume. What remains: the read-only summaries bridge and cross-surface context access need reliable discovery. Current `searchSessions()` is substring-based against session titles; the gateway's use case (pull the Action's summary for a specific PR when the user asks about it) is entity-based lookup, not full-text search. *Mitigation:* design the summaries record schema with entity-indexed keys (PR#, issue#, cron name) so surface-to-surface discovery is O(1) lookup, not O(N) search. Full-text search remains available for ad-hoc 'what do you know about X' queries but is not on the critical path.
+
+**RISK-5. Cost and complexity of self-hosting.** Marcus is willing to self-host. Other early users might not be. If we want adoption beyond Marcus, the self-host UX has to be excellent — probably better than Kimaki's "npx kimaki" by being closer to "docker compose up" with a sane default config. *Mitigation:* aim for a "happy path setup in <30 min" success criterion (S1); accept that complex deployments are an explicit non-goal for v1.
+
+**RISK-6. Soft-control prompt guidance is the same soft-control limitation as PR #517.** The agent is told not to do things; that's not the same as it being unable to. The sandbox closes the network egress hole. The git-broker closes the credential hole. But the agent can still misbehave inside its allowed surface — see R5 acknowledged scope limits for the full enumeration (covert channels through allowed endpoints, CA-bypass in scripted clients, prompt-injection-induced misbehavior). *Mitigation:* combine the network/credential boundaries with explicit per-tool approval flows (S5); accept that soft control + sandbox together is the design ceiling, not the model behaving perfectly.
+
+**RISK-7. Multi-tenancy retrofit cost.** The brainstorm decided single-tenant for v1. If we get six months in and want multi-tenant, will the design absorb that or require rewriting? *Mitigation:* document multi-tenancy as a design constraint (D8); resist single-tenant shortcuts that break the path (e.g., hardcoding "the user", hardcoding GitHub identity, sharing global state across implicit tenants).
+
+**RISK-8. Operational maturity gap.** The Action's "operations" is GitHub's responsibility. The gateway's "operations" is Marcus's. Logs, metrics, alerts, restart, upgrade — all become real concerns. *Mitigation:* default to structured logs to stdout (host captures), expose minimal metrics endpoint, document upgrade paths from day one. Don't ship an admin UI in v1 — CLI-via-Docker-exec is fine.
+
+## Recommended v1 Slice
+
+The brainstorm narrows to this concrete v1 slice for the planning phase to chew on:
+
+**v1 ships when:**
+- Conservative `@fro-bot/runtime` extracted (agent exec + session storage + prompt assembly + object-store); existing GitHub Action runs on it cleanly in CI
+- Docker Compose stack: `gateway` + `workspace` + `mitmproxy` (**3 services**, middle-path sandbox)
+- Gateway speaks Discord — connects, joins channels, listens for `@mentions` and slash commands, posts back
+- Sessions stored in S3 (existing backend). Discord and Action write to same bucket with per-surface namespacing. Resume is within-surface only; cross-surface context access via read-only summaries bridge
+- Channel ↔ repo binding via `/fro-bot add-project`
+- Local execution via OpenCode in workspace, inside sandbox, against a checkout
+- Cloud dispatch via `/fro-bot cloud <task>` triggering `workflow_dispatch`
+- Tool approval buttons for sensitive operations
+- Reactions, working/done emoji, run summary in thread
+- Role-based access (`fro-bot` role required, `no-fro-bot` blocks)
+- Documentation: setup guide, threat model, known limits, upgrade path
+
+**v1 explicitly does NOT ship:**
+- Voice anything
+- Forum channels
+- Multi-tenancy
+- Per-user GitHub identity mapping
+- Autonomous loops
+- Hosted SaaS
+- Slack / Telegram / any other surface
+- Per-channel ephemeral prompts
+- Replay/eval harness (idea #6 — independent)
+- Memory router (idea #4 — compounds later)
+- Self-improving skill distillation (idea #5 — compounds later)
+
+## Source
+
+- Ideation: `docs/ideation/2026-04-15-autonomous-agent-platform-ideation.md` (idea #1)
+- Foundation: PR #514 (S3 storage backend), PR #517 (delivery contract), PR #465 (XML prompt architecture, harness_rules authority)
+- References: [remorses/kimaki](https://github.com/remorses/kimaki), [Hermes Discord docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/discord), [sachitv/opencode-omo-sandbox-docker](https://github.com/sachitv/opencode-omo-sandbox-docker)
+- Brainstorm session: 2026-04-17 — DEEP scope, single-select dialogue across motivator → use case → approach → hosting model → sandbox adoption
+
+## Session Log
+
+- 2026-04-17: Initial brainstorm. Resolved: Discord as primary surface (not autonomous loops or persistent runtime), full action-taking agent (not read-only or observer), Approach A (extract runtime + new Discord surface, not fork Kimaki or hybrid), Docker image deliverable (not VPS-specific or SaaS), adopt sachitv sandbox patterns (mitmproxy + CoreDNS + git-broker + namespace sharing). Drafted v1 scope and 7 success criteria. 11 architectural decisions captured. 9 open questions deferred to planning. 8 risks identified with mitigations.

--- a/docs/brainstorms/2026-04-25-effect-adoption-gateway-requirements.md
+++ b/docs/brainstorms/2026-04-25-effect-adoption-gateway-requirements.md
@@ -1,0 +1,110 @@
+---
+status: ready-for-planning
+created: 2026-04-25
+topic: Effect adoption for the Discord gateway
+related:
+  - docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
+  - docs/brainstorms/2026-04-17-fro-bot-gateway-discord-requirements.md
+---
+
+# Effect Adoption for the Discord Gateway
+
+## Context
+
+PR #547 (lock primitives) and PR #548 (Action lock acquisition) shipped the cross-surface coordination layer. Both PRs surfaced the same three categories of friction:
+
+- **Schema validation** — hand-rolled `hasValidLockRecordShape` / `hasValidRunStateShape` type guards plus `as T` casts at every JSON parse boundary. Defensive but ad-hoc.
+- **Result<> verbosity** — `if (result.success === false) return err(result.error)` chains repeated 341 times across runtime + Action.
+- **Manual concurrency** — `findStaleRuns` N+1 (review finding #7), s3-adapter list pagination, content-sync. Each needs its own bounded-concurrency helper if hand-rolled.
+
+The Discord gateway (Unit 4 of the gateway plan) is the natural venue for adopting better primitives: it's greenfield, it has more sophisticated needs (queue, retry, scheduled work, Discord webhook validation), and it's the long-lived process where retry/scheduler primitives compound.
+
+## Decision: gateway-first Effect adoption
+
+Effect lands alongside Unit 4 as a foundation sub-task, with clear package boundaries:
+
+| Package           | Status                | Effect adoption                                   |
+| ----------------- | --------------------- | ------------------------------------------------- |
+| `@fro-bot/runtime`  | Stays on Result<>       | None. Coordination, object-store, session APIs unchanged. |
+| `@fro-bot/action`   | Stays on Result<>       | None. Bundle untouched.                             |
+| `@fro-bot/gateway`  | New, Effect-native      | Core + Schedule + Schema. Lives at `packages/gateway/` per Unit 4. |
+
+The boundary lives at the gateway package edge: gateway has a small `runtime-effect.ts` adapter that wraps each runtime call in `Effect.tryPromise` + flatMap on the Result tag. Gateway code consumes Effect throughout; runtime stays Result<>-typed.
+
+## Why these decisions
+
+### Gateway-first, not whole-project
+
+- Action runs in GitHub Actions runner (cold-start sensitive); adding Effect to runtime affects Action bundle.
+- Migrating 341 Result<> sites is a large carrying cost with no immediate user-visible value.
+- Gateway is greenfield — Effect can prove itself in a contained space.
+- If Effect-in-gateway compounds well, runtime migration is a future option; if it doesn't, runtime never paid the migration cost.
+
+### Boundary at gateway package edge
+
+- Runtime APIs already stable; rewriting them is gratuitous churn.
+- Adapter is small (~50 lines) — one wrapper per runtime function, all in `packages/gateway/src/runtime-effect.ts`.
+- Gateway code reads as native Effect; contributors don't see two paradigms inside one file.
+- Runtime team (mostly Marcus) doesn't have to think about Effect when working on coordination primitives.
+
+### Core + Schedule + Schema
+
+- **Core** (`Effect.Effect`, `pipe`, `tryPromise`, `flatMap`, `gen`): composing async error paths. The gateway has many of them — Discord webhook handlers, queue dispatch, S3 ops via runtime adapter.
+- **Schedule** (`Effect.Schedule`, `Effect.retry`, `Effect.timeout`): the gateway needs a real retry layer for queue dispatch, GitHub `workflow_dispatch` calls, and S3 ops. Hand-rolling backoff for 3+ different operation types is wasteful when Schedule does it composably.
+- **Schema** (Effect.Schema): Discord interaction payloads have meaningful validation surface (slash command options, button custom_ids, modal submissions). Approval-token records also benefit. Parse-don't-validate at the gateway's untrusted-input edge.
+
+## Scope boundaries
+
+In scope:
+
+- Add `effect` (3.x) as a dependency in `packages/gateway/`.
+- Create `packages/gateway/src/runtime-effect.ts` adapter wrapping every runtime function gateway uses (`acquireLock`, `releaseLock`, `renewLease`, `forceReleaseLock`, `createRun`, `transitionRun`, `findStaleRuns`, `validateProviderSemantics`, S3 sync helpers).
+- Use Effect natively in gateway code (Discord client, slash command handlers, queue, approval flow, locking).
+- Use Effect.Schedule for retries on Discord HTTP, GitHub workflow_dispatch, and runtime adapter calls.
+- Use Effect.Schema for Discord interaction validation and approval-token records.
+
+Out of scope:
+
+- Migrating any code in `@fro-bot/runtime` or `apps/action/` (root `src/`) to Effect. They stay on Result<>.
+- Coordination review residuals (#7 N+1, #15 regex). These remain in the runtime layer; Effect doesn't reach them.
+- @effect/schema in runtime parsers (`parseLockRecord`, `parseRunState`). They stay manual.
+- Adopting Effect's `Layer`/`Context` for dependency injection. Gateway uses plain function injection (matches runtime's adapter pattern).
+
+## Constraints
+
+- **Effect 3.x**: Schema is part of the `effect` package itself (no separate `@effect/schema` install in 3.0+).
+- **Bundle size**: gateway is a Docker container; bundle size doesn't constrain Effect adoption the way it constrains Action.
+- **Testing**: gateway tests use vitest. `@effect/vitest` is the canonical test runner for Effect; evaluate whether its TestClock/Layer support justifies adoption alongside vanilla vitest.
+- **Discord.js compatibility**: discord.js returns Promises; gateway wraps each at the boundary using `Effect.tryPromise`.
+- **Type imports**: gateway imports types from `@fro-bot/runtime` (`LockRecord`, `RunState`, etc.) and uses them in Effect.Effect signatures. No issue.
+- **Failure semantics**: runtime's `Result<T, Error>` maps to `Effect.Effect<T, Error>`. The adapter unwraps `success: false` into `Effect.fail(error)`.
+
+## Success criteria
+
+- `packages/gateway/src/runtime-effect.ts` adapter compiles with full type safety (no `any`, no `as`).
+- Every gateway-side async operation that calls runtime returns `Effect.Effect<T, E>`.
+- Gateway retry logic (queue, HTTP, runtime adapter) uses `Effect.Schedule` — no hand-rolled `setTimeout` backoff loops.
+- Discord interaction handlers parse incoming payloads with `Effect.Schema` before processing.
+- Tests cover: adapter wraps Result<>.success → Effect.succeed; adapter wraps Result<>.failure → Effect.fail; retry with Schedule.exponential; Schema parse failure produces actionable error.
+- Action bundle size unchanged.
+- Runtime API surface unchanged.
+
+## Risks
+
+| Risk                                                             | Mitigation                                                                                                    |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Two paradigms (Result<> in runtime + Effect in gateway) confuse contributors | Document the boundary in `packages/gateway/AGENTS.md`. Adapter file naming makes the bridge explicit.               |
+| Effect's learning curve slows Unit 4                             | Effect's surface is broad but the gateway uses a narrow slice (Effect.Effect, pipe, gen, Schedule, Schema). Document the slice. |
+| Bundle bloat in gateway Docker image                             | Docker base image is Node 24-slim; Effect tree-shakes well. Build size is not a startup-latency concern for a long-lived process.   |
+| Future migration of runtime to Effect requires re-engineering    | Adapter pattern means runtime-effect.ts becomes a no-op when runtime goes Effect-native. No throwaway work.   |
+| Effect 3.x churn (rapid major releases)                          | Pin exact version; pre-push lint/build catches breaking upgrades before they land.                            |
+
+## Open questions for planning
+
+- Does gateway adopt `@effect/vitest` for tests, or keep vanilla vitest with manual Effect.runPromise wrappers? (Decide during Unit 4 step 1.)
+- Naming for adapter file: `runtime-effect.ts` vs `runtime-bridge.ts` vs `runtime/index.ts`? (Decide during Unit 4 step 1.)
+- Should Effect.forEach with concurrency replace hand-rolled S3 list pagination in gateway code, or stay manual? (Decide when the gateway needs to list S3 objects.)
+
+## Handoff
+
+Add to `docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md` Unit 4: explicit "Effect setup" sub-task as step 1, before Discord client / slash commands / queue / approval flow.

--- a/docs/brainstorms/2026-04-29-disable-omo-by-default-requirements.md
+++ b/docs/brainstorms/2026-04-29-disable-omo-by-default-requirements.md
@@ -1,0 +1,116 @@
+---
+title: Disable oMo setup and use by default
+status: ready-for-planning
+created: 2026-04-29
+---
+
+# Disable oMo setup and use by default
+
+## Problem
+
+The action installs Oh My OpenAgent (oMo) and configures Sisyphus as the default agent on every run. This adds ~15-20s of cold-start work for callers who don't use oMo, advertises a non-default agent to users via `action.yaml`, and entangles the setup phase with a third-party plugin that doesn't apply to most workflows.
+
+`prompt-sender.ts` already silently elides `body.agent` when the value equals `DEFAULT_AGENT`, so the build agent runs in practice today even though the input shows `sisyphus`. The plumbing is half-done — this brainstorm closes the loop.
+
+## Goals
+
+- Default behavior: oMo not installed, OpenCode build agent used, model overrides work as today.
+- Opt-in via single boolean input. When enabled, behavior matches today's defaults (oMo installed, providers honored, custom omo-config respected).
+- Single setup-time warning if any `omo-*` input is set while oMo is disabled. Inputs are otherwise ignored cleanly.
+
+## Non-goals
+
+- Removing oMo support entirely. It remains a fully-supported opt-in.
+- Migrating known external callers (`marcusrbrown/containers`, `marcusrbrown/marcusrbrown.github.io`). Their workflows don't reference any oMo input, so disabling by default produces no observable change for them. Track downstream subagent-delegation behavior reactively if real breaks appear.
+- "Doctor" surface removal. No code matches `doctor` anywhere; the user's note refers to oMo's internal command, not anything we expose.
+
+## Requirements
+
+### R0 — OpenCode's build agent is a sufficient default (RESOLVED 2026-04-29)
+
+Validated by deep research into OpenCode SDK + source. Findings:
+
+- **SDK contract:** `body.agent` is optional in `node_modules/@opencode-ai/sdk/dist/gen/types.gen.d.ts:2326-2350`. When omitted, the server (`anomalyco/opencode/packages/opencode/src/session/prompt.ts` — `createUserMessage`) calls `agents.defaultAgent()`, which returns the first non-subagent, non-hidden agent in the registry: `build`. Caller's `config.default_agent` setting wins if set.
+- **Build is documented default:** `https://opencode.ai/docs/agents` and `anomalyco/opencode` README both state "**build** — Default, full-access agent for development work" with "all tools enabled."
+- **Tool parity for our use cases:** Build's permissions in `packages/opencode/src/agent/agent.ts` are `defaults ("*": "allow") + question:"allow" + plan_enter:"allow"`. That covers everything our prompt requires: `bash` (for `gh` CLI and `git`), `edit`, `read`, `task` (subagent delegation to `general`/`explore`), `grep`, `glob`, `lsp`, `websearch`, `webfetch`, `skill`, registered MCPs.
+- **Already in production today:** `src/features/agent/prompt-sender.ts:47-48` elides `body.agent` when it equals `DEFAULT_AGENT='sisyphus'`. So Build is what runs in production when oMo isn't loaded — this work makes that explicit rather than half-implicit.
+- **Subagent catalog gap:** Build delegates to OpenCode's stock `general` and `explore` subagents; oMo's specialist stack (Hephaestus, Oracle, Librarian, Prometheus) is unavailable. Acceptable for our hot paths (PR review, comment reply, DMR, wiki maintenance). Multi-file refactors that benefit from specialist routing must opt-in via `enable-omo: true`.
+
+Confidence: HIGH (~90%). Remaining 10% is output-quality on complex multi-file refactors — not a primary use case. Mitigated by R8.
+
+### R1 — `enable-omo` action input
+
+A new boolean input `enable-omo` is added to `action.yaml`, default `false`. When `true`, current setup behavior is preserved. When `false` (the default), the setup phase skips Bun install, the oMo installer, the `omo-config` write, and any oMo-specific plugin merging.
+
+### R2 — Default agent is OpenCode's build agent
+
+The `agent` action input default in `action.yaml` is removed (no default value, optional input). The fallback in `src/harness/config/inputs.ts:290-291` (`agentRaw.length > 0 ? agentRaw : DEFAULT_AGENT`) is also removed; `parseActionInputs` returns `agent: string | null` (null when caller supplied empty). The execution config carries the same null through to `body.agent` and the runtime sets it iff non-null. When unset, OpenCode falls through to its build agent. Setting `agent: <name>` still works exactly as today and is honored by the SDK.
+
+### R3 — Model override unchanged
+
+The `model` input continues to take precedence over the agent's default model. With oMo disabled, no oMo provider configuration is read, so `resolvePromptModel` should resolve to the user's `model` if set, otherwise to the existing `DEFAULT_MODEL` constant. Behavior matches today's "no providers configured" path.
+
+### R4 — Disabled-mode warning
+
+When `enable-omo: false` and any of `omo-version`, `omo-providers` are set to a non-default, non-empty value, log exactly one warning per run via `core.warning(...)` naming all set inputs. Do not fail the run. Inputs are silently ignored — no further validation, no parse errors. Note: `omo-config` is removed from the action surface as part of this work (see R7), so it does not participate in R4's warning.
+
+### R5 — Removal of "sisyphus" naming from defaults
+
+The `DEFAULT_AGENT = 'sisyphus'` constant and any references that exist purely to elide it from SDK requests are removed. The omit-when-undefined contract becomes the model: the runtime omits `body.agent` when the caller didn't set one. Test fixtures and assertions that hard-code `'sisyphus'` outside of oMo-enabled regression coverage are updated to reflect the no-default semantic; oMo-enabled tests may continue asserting `'sisyphus'` as the canonical agent for that path.
+
+Scope inventory — every site touched by R5:
+
+- `packages/runtime/src/shared/constants.ts` — `DEFAULT_AGENT` declaration (canonical)
+- `src/shared/constants.ts` — re-exports `DEFAULT_AGENT` from `@fro-bot/runtime`
+- `packages/runtime/src/agent/prompt-sender.ts` — elide-when-equals-default logic
+- `packages/runtime/src/agent/execution.ts` — `agent: config?.agent ?? DEFAULT_AGENT` log line
+- `src/features/agent/prompt-sender.ts` — elide-when-equals-default logic (mirror of runtime)
+- `src/features/agent/execution.ts` — `config?.agent ?? DEFAULT_AGENT` log line (mirror of runtime)
+- `src/harness/config/inputs.ts:290-291` — `agentRaw.length > 0 ? agentRaw : DEFAULT_AGENT` fallback (must change to `string | null`)
+- Test fixtures asserting `agent: 'sisyphus'` across `src/features/agent/opencode.test.ts`, `src/features/observability/{run,job}-summary.test.ts`, `src/features/comments/error-format.test.ts`
+
+### R6 — Caller migration in this repo
+
+`.github/workflows/fro-bot.yaml` currently passes `omo-providers: ${{ secrets.OMO_PROVIDERS }}` and `opencode-config: ${{ secrets.OPENCODE_CONFIG }}`. It depends on oMo provider registration today. R6 audits this workflow as part of the same PR and adds `enable-omo: true` to the `with:` block so daily DMR + weekly wiki + on-demand dispatch invocations continue to use the Sisyphus path. No semantic change for this caller — same agent, same providers, same model resolution.
+
+### R7 — Remove `omo-config` action input
+
+The `omo-config` input is currently declared in `action.yaml` but never read by `parseActionInputs`; downstream callers (`ensureOpenCodeAvailable`) hardcode `omoConfig: null`. R7 removes the input from `action.yaml` and removes the unused `omoConfig` plumbing from `SetupInputs`/`ensureOpenCodeAvailable`. The `writeOmoConfig` function and its tests stay because the function is still consumed by direct `setup.test.ts` test injection. If a future caller needs custom oMo config, the input can be added back (properly wired) at that time.
+
+### R8 — Pin `default_agent: "build"` in generated `opencode.json` when oMo disabled
+
+Defense-in-depth against fallback drift. When `enable-omo: false`, `buildCIConfig()` writes `default_agent: "build"` into the generated `opencode.json`. Two threats neutralized:
+
+1. Future OpenCode versions could reorder the `agents` Record literal in `packages/opencode/src/agent/agent.ts`, changing which agent `defaultAgent()` returns when no `default_agent` is configured. Pinning eliminates this dependency on insertion order.
+2. Callers may have a stale `default_agent: "sisyphus"` in a per-project `opencode.json` from a previous oMo-enabled run. Without pinning, OpenCode would throw `"default agent 'sisyphus' not found"` at request time. Our explicit pin overrides the stale value cleanly.
+
+When `enable-omo: true`, `default_agent` is not pinned by the harness — oMo's installer or the caller's `opencode-config` input controls it (preserving today's behavior).
+
+## Success criteria
+
+- A clean run of the action with no inputs other than `github-token` and `auth-json` does not invoke `bunx`, does not write `oh-my-openagent.json`, does not register the oMo plugin in `opencode.json`, and uses OpenCode's `build` agent. Generated `opencode.json` contains `default_agent: "build"` (per R8).
+- A run with `enable-omo: true` and existing oMo inputs behaves identically to the current main-branch behavior. Generated `opencode.json` does NOT pin `default_agent` (oMo / `opencode-config` input controls it).
+- A run with `enable-omo: false` and any oMo input set produces exactly one `::warning::` line and otherwise behaves like the disabled case.
+- Existing tests pass without re-asserting "sisyphus" anywhere except in regression coverage for the oMo-enabled path.
+- New tests cover: disabled default path skips oMo install; warning fires when oMo inputs set with `enable-omo: false`; agent omit-when-undefined contract; model override works under disabled-oMo path; `default_agent: "build"` appears in `opencode.json` when oMo disabled and is absent when oMo enabled.
+
+## Open questions for planning
+
+- Does the `omo-providers` parser path stay alive (used only when `enable-omo: true`) or get gated at the input layer? Either works; planning picks the cleanest split.
+- Bun install: today's only consumer is the oMo installer. The plan gates Bun install behind `enable-omo: true`. If a future non-oMo caller needs Bun, that's a separate input.
+- Tools cache key: planning decides whether to partition the cache by `enable-omo` (avoid cross-contamination) or to scrub `omoVersion`/`bunCachePath`/`omoConfigPath` from the key+paths when disabled.
+- `SetupResult.omoInstalled`: planning decides whether to add an `omoSkipped: boolean` (or migrate to `'installed' | 'failed' | 'skipped'`) so observability can distinguish skipped-by-design from install-failure.
+
+## References
+
+- `src/services/setup/setup.ts` — oMo install path
+- `src/services/setup/omo.ts` — bunx install logic
+- `src/services/setup/bun.ts` — Bun runtime install (only consumer is the oMo installer)
+- `src/services/setup/tools-cache.ts` — cache key includes `omoVersion`; planning decides partition strategy
+- `src/features/agent/prompt-sender.ts` AND `packages/runtime/src/agent/prompt-sender.ts` — agent omit logic, model resolution (mirrored after Unit 1 extraction)
+- `src/features/agent/execution.ts` AND `packages/runtime/src/agent/execution.ts` — agent fallback log line (mirrored)
+- `src/harness/config/inputs.ts` — `agent` and `omo-*` input parsing
+- `packages/runtime/src/shared/constants.ts` — canonical `DEFAULT_AGENT`, `DEFAULT_MODEL`
+- `src/shared/constants.ts` — re-exports the runtime constants
+- `action.yaml` — input definitions
+- `.github/workflows/fro-bot.yaml:198-202` — dogfood workflow that currently uses oMo providers

--- a/docs/brainstorms/2026-05-31-fro-bot-agent-github-app-identity-requirements.md
+++ b/docs/brainstorms/2026-05-31-fro-bot-agent-github-app-identity-requirements.md
@@ -1,0 +1,97 @@
+# Fro Bot Agent GitHub App — In-Repo Identity Deliverables
+
+- **Date:** 2026-05-31
+- **Status:** ready-for-planning
+- **Source:** issue #703 + Fro Bot triage
+- **Scope:** Lightweight–Standard (docs + assets + one correctness fix)
+
+## Problem
+
+The "Fro Bot Agent" GitHub App is registered and owned by the `fro-bot` GitHub
+user account, public at `https://github.com/apps/fro-bot-agent` (App ID
+3918015), installed across `marcusrbrown` repos with `contents: read` only. The
+runtime that consumes it (App auth, installation discovery, token minting for
+`/fro-bot add-project`) already shipped in v0.45.0/v0.46.x. What's missing is the
+**in-repo public identity**: docs, a creation/ownership runbook, an avatar, and
+a correctness fix to the install-URL slug.
+
+## Background (verified against current source)
+
+- **Install-URL slug is wrong in code.** Ten literals hardcode
+  `https://github.com/apps/fro-bot/installations/new` — a runtime default at
+  `packages/gateway/src/config.ts:331`, a second default at
+  `packages/gateway/src/github/app-client.ts:130`, and 6 test sites
+  (`program.test.ts`, `config.test.ts`, `app-client.test.ts`,
+  `discord/commands/add-project.test.ts` ×3, `discord/commands/index.test.ts`).
+  The real app slug is **`fro-bot-agent`**. Today the "app not installed"
+  message points operators at the wrong page.
+- **Permission is correct** — `contents: 'read'` at
+  `packages/gateway/src/github/app-client.ts:59`, verified on installation.
+- **Both docs missing** — no `docs/github-app.md`, no `docs/github-app-setup.md`.
+- **Ownership needs no transfer** — the `fro-bot` account already owns the app.
+  The runbook documents existing reality, not a migration.
+
+## Requirements
+
+### R1 — Slug correctness fix (independent, ship-ready)
+Replace `apps/fro-bot/installations/new` → `apps/fro-bot-agent/installations/new`
+across all 10 sites (runtime defaults in `config.ts` + `app-client.ts`, and the 6
+test literals — they must change together). Run `pnpm build` so `dist/` stays in
+sync per AGENTS.md. This is a correctness fix and can land independently of the
+identity deliverables.
+
+### R2 — Public docs page (`docs/github-app.md`)
+Plain markdown, GitHub-Pages-friendly (no build tooling). Covers: what the app
+does; exact permission (`contents: read` only); privacy posture ("inert unless
+paired with a Fro Bot gateway in your Discord server — no webhook, no data
+collected by this repo"); install link
+(`https://github.com/apps/fro-bot-agent`); how to uninstall; link to the setup
+runbook. Includes the listing copy (R4) inline or adjacent.
+
+### R3 — Setup / ownership runbook (`docs/github-app-setup.md`)
+Operator-facing: how the app is registered (name "Fro Bot Agent",
+`contents: read`, public, no webhook), that the `fro-bot` account owns it, how to
+generate the private key, and **where credentials live** — the operator's own
+gateway deployment env (`GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`), never
+committed to this repo. Notes that GitHub does not live-reconcile app settings
+from a repo file (no GitOps); this runbook is the source of truth for recreation.
+
+### R4 — Listing copy
+~150-char App description + a short tagline for the GitHub App listing page.
+Trustworthy, plain, no hype. Lives in `docs/github-app.md`.
+
+### R5 — Logo assets (DONE in brainstorm)
+Simplified flat geometric mark derived from Fro Bot's head icon, anchored to
+`assets/styleguide.md` palette. Delivered and verified:
+- `assets/github-app-logo.svg` — primary "Cyber Token" (cyan→teal token, purple
+  afro silhouette, white faceplate, dark visor, magenta+amber optics; glow
+  filter removed and optics enlarged for 64px legibility).
+- `assets/github-app-logo-alt.svg` — dark "Deep Space Neon" variant (kept for
+  reference).
+- `assets/github-app-logo-512.png` — 512×512 export (reproducible via
+  `rsvg-convert -w 512 -h 512`).
+
+## Non-Goals
+
+- No ownership transfer (the `fro-bot` account already owns the app).
+- No live GitOps / app-config reconciliation from the repo (GitHub doesn't
+  support it).
+- No committed manifest snapshot, no GitHub Pages automation, no Pages publish
+  step (deferred — keep deliverables as plain static files).
+- App registration itself is a human-only GitHub UI action, already done.
+
+## Success Criteria
+
+- The `/add-project` "app not installed" message links to
+  `https://github.com/apps/fro-bot-agent/installations/new`; all slug literals
+  consistent; `dist/` in sync; tests green.
+- `docs/github-app.md` and `docs/github-app-setup.md` exist, plain markdown,
+  accurate permission + privacy posture, correct slug + install/uninstall links.
+- Logo assets committed; primary mark legible as a 64px circle on light and dark.
+
+## Open Items for Planning
+
+- Whether R1 (slug fix) ships as its own PR (unblocks the real install path now)
+  or folds into the single identity PR. Either is fine; R1 is independently
+  valid.
+- Final avatar upload to the App settings is a manual step (documented in R3).

--- a/docs/brainstorms/2026-06-01-omo-slim-optional-dependency-requirements.md
+++ b/docs/brainstorms/2026-06-01-omo-slim-optional-dependency-requirements.md
@@ -1,0 +1,141 @@
+---
+date: 2026-06-01
+topic: omo-slim-optional-dependency
+---
+
+# OMO Slim as an Optional Dependency
+
+## Summary
+
+Add **OMO Slim** (`oh-my-opencode-slim`) as an optional, mutually-exclusive alternative to OMO: an `enable-omo-slim` action input with a single `omo-slim-preset` selector and a pinned `omo-slim-version`, plus the version-constant + Renovate tracking that every external tool in this repo uses. When OMO Slim is enabled, the CI OpenCode config pins `default_agent` to `orchestrator`. A gateway preset passthrough is planned but **deferred until the workspace container runs OpenCode (Unit 7)** — see Scope Boundaries.
+
+---
+
+## Problem Frame
+
+The only optional agent-orchestration plugin wired into the harness today is **OMO** (`oh-my-openagent`), configured action-side via `enable-omo` + `omo-providers` + `omo-version`. OMO Slim is a separate, preset-based orchestration fork of oh-my-opencode that some users prefer: it selects a whole agent/model bundle by a single preset name, is orchestrator-centric, and ships no telemetry. There is currently no way to opt into Slim instead of OMO, and the gateway — which drives OpenCode inside the sandboxed workspace container for mention-loop runs — has no way to select a Slim preset for those runs. Users who want Slim must hand-edit `opencode.json`, which the setup step then overwrites. (Selecting a Slim preset for gateway-driven mention-loop runs is a related need, but the workspace container does not run OpenCode yet — so that piece is deferred to Unit 7.)
+
+---
+
+## Actors
+
+- A1. Action / CI caller: sets `enable-omo-slim` + `omo-slim-preset` in a workflow that uses the action.
+- A2. Gateway operator: sets the preset env var in `deploy/compose.yaml` so workspace-container OpenCode runs use a chosen Slim preset. *(Applies only to the deferred Unit-7 gateway path.)*
+- A3. OMO Slim plugin (`oh-my-opencode-slim`): the installed orchestration plugin, registered in `opencode.json`'s `plugin` array, owning agent routing and the `orchestrator` default agent.
+- A4. OMO plugin (`oh-my-openagent`): the mutually-exclusive incumbent that owns the same plugin/agent surface.
+
+---
+
+## Key Flows
+
+- F1. CI run with OMO Slim
+  - **Trigger:** A workflow sets `enable-omo-slim: true`, optionally `omo-slim-preset: openai`.
+  - **Actors:** A1, A3
+  - **Steps:** Inputs parsed → mutual-exclusivity check passes (OMO not enabled) → Slim installed via Bun at the pinned version → CI `opencode.json` registers the Slim plugin and pins `default_agent: orchestrator` → the chosen preset is applied → OpenCode runs driven by Slim.
+  - **Outcome:** OpenCode executes under Slim's orchestrator with the selected preset; OMO is not installed.
+  - **Covered by:** R1, R2, R3, R4, R7, R8, R10
+
+- F2. *(Deferred — gated on Unit 7.)* Gateway mention-loop preset passthrough: the gateway reads the preset env var and passes it to the workspace OpenCode as `OH_MY_OPENCODE_SLIM_PRESET`. Not buildable until the workspace container runs OpenCode — see Scope Boundaries → Deferred to Separate Tasks.
+
+---
+
+## Requirements
+
+**Action inputs & mutual exclusivity**
+- R1. Add action input `enable-omo-slim` (boolean, default `false`), mirroring `enable-omo`.
+- R2. Add action input `omo-slim-preset` (optional, single preset name such as `openai` or `opencode-go`) — the Slim analog of `omo-providers`. It is a single name, not a comma-separated list, because Slim selects exactly one preset.
+- R3. Add action input `omo-slim-version` (optional; no hardcoded default in `action.yaml` — falls through to the pinned constant).
+- R4. `enable-omo` and `enable-omo-slim` are mutually exclusive. Enabling both fails fast at input parse time with a clear, actionable error; the harness does not silently choose one. Defense-in-depth: CI config assembly also refuses to emit an `opencode.json` containing both plugins (a second fail-closed guard), so a cache-restored or externally-merged config cannot smuggle both in.
+
+**Version pinning (versioned-tool pattern)**
+- R5. Add `DEFAULT_OMO_SLIM_VERSION` to `src/shared/constants.ts` as the single source of truth (semver string, no `v` prefix), pinned to a stable release (Slim's latest stable is `1.1.1`; `2.0.0-beta.*` are prereleases and are not the default).
+- R6. Add a Renovate `customManagers` regex entry + `packageRules` entry tracking `oh-my-opencode-slim` on the `npm` datasource with `semanticCommitType: build`, matching the existing OMO/Systematic pattern.
+
+**Setup / install**
+- R7. When `enable-omo-slim` is true, install Slim via Bun at the resolved version (analogous to `installOmo`). No telemetry opt-out env vars are exported — Slim ships no telemetry (verified in source).
+- R8. The selected preset is applied so it is active for the run (mechanism — install flag, config key, or `OH_MY_OPENCODE_SLIM_PRESET` — deferred to planning).
+- R9. `SetupResult` reports an OMO-Slim status (`installed` | `failed` | `skipped`) and error, parallel to `omoStatus`/`omoError`.
+
+**CI config (`opencode.json`) assembly**
+- R10. When `enable-omo-slim` is true, `buildCIConfig` registers the Slim plugin (`oh-my-opencode-slim@{version}`) in the `plugin` array and pins `default_agent: 'orchestrator'`.
+- R11. The `@fro.bot/systematic` plugin continues to be injected in all modes. Existing behavior is unchanged when neither OMO nor Slim is enabled (build-agent default).
+- R12. Plugin assembly is mode-authoritative: after cache restore, the `plugin` array is rebuilt for the active mode rather than appended to, then exactly the allowed plugins are added (Systematic always; OMO only in OMO mode; Slim only in Slim mode). This prevents a stale plugin entry from a prior run on a flipped flag surviving across mode switches — the same cache-restore + plugin-key class of bug the repo has hit before.
+
+**Input parsing & warnings**
+- R16. `inputs.ts` parses the three inputs into `ActionInputs`, warns when `omo-slim-preset` or a non-default `omo-slim-version` is provided while `enable-omo-slim` is false (parallel to the OMO warnings), and enforces R4.
+
+**Compatibility & permissions**
+- R19. Before pinning `default_agent: 'orchestrator'`, the setup step verifies the installed Slim version actually exposes the `orchestrator` agent; if it does not (e.g. a future Slim whose agent set changed), it fails with a versioned compatibility error rather than writing a config that breaks OpenCode startup. The pinned version (R5) is verified to expose `orchestrator` and the documented config schema.
+- R20. The agent permission posture under Slim mode is explicitly defined (not deferred): state whether Slim's orchestrator inherits the disabled-mode `external_directory: deny` posture, a narrower orchestrator-specific policy, or another allowlist — with a fail-closed default if it cannot be determined at setup time.
+
+**Tests & CI introspection**
+- R17. Test coverage parallels OMO: setup, CI-config, and input-parsing suites plus a Slim installer test — asserting mutual-exclusivity failure, the `orchestrator` default, plugin registration and stripping, and version pinning.
+- R18. CI introspection asserts the Slim mode (`default_agent == "orchestrator"`, Slim plugin present, exactly one `@fro.bot/systematic`, OMO absent) and disabled-mode Slim plugin/config-file absence.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R4.** Given a workflow with both `enable-omo: true` and `enable-omo-slim: true`, when the action parses inputs, it fails fast with an error naming the conflict and exits without installing either plugin.
+- AE2. **Covers R10, R7.** Given `enable-omo-slim: true` and `omo-slim-preset: openai`, when setup completes, the written `opencode.json` contains the `oh-my-opencode-slim` plugin and `default_agent: "orchestrator"`, and OMO is not installed.
+- AE3. **Covers R16.** Given `enable-omo-slim: false` but `omo-slim-preset: openai` is supplied, when the action parses inputs, it emits a warning that the preset is ignored because OMO Slim is disabled.
+- AE5. **Covers R12.** Given a prior OMO run left `oh-my-openagent` in a cache-restored `opencode.json`, when a subsequent run sets `enable-omo-slim: true`, the written config contains the Slim plugin and `orchestrator` default and contains NO `oh-my-openagent` entry. Flipping back to a disabled run leaves neither plugin.
+
+---
+
+## Success Criteria
+
+- A workflow can set `enable-omo-slim: true` + `omo-slim-preset: openai` and get an OpenCode run driven by Slim's orchestrator with that preset, with OMO not installed.
+- Enabling both OMO and OMO Slim fails with a clear, actionable error rather than silent precedence.
+- Renovate opens PRs that bump `DEFAULT_OMO_SLIM_VERSION`.
+- `ce:plan` can sequence the implementation without inventing product behavior, scope, or success criteria.
+
+---
+
+## Scope Boundaries
+
+- Not deprecating or removing OMO — Slim is an additive, alternative option.
+- Not building machinery to run OMO and Slim simultaneously — they conflict over plugin/agent ownership, so the relationship is mutual exclusion.
+- Not authoring or customizing Slim's internal preset definitions — only selecting among Slim's existing presets.
+- Not exposing Slim's broader features (council, multiplexer, subtask, interview, etc.) as action inputs — only enable + preset + version.
+- Not changing how OMO itself works.
+
+### Deferred to Separate Tasks (gated on Unit 7)
+
+The gateway → workspace preset passthrough is **not buildable until Unit 7 ships the real workspace OpenCode image** — today `deploy/workspace.Dockerfile` is a placeholder idle container (`sleep infinity`, no OpenCode) and the workspace client only does `POST /clone`, so there is no workspace OpenCode process to inject env into. When Unit 7 lands, implement:
+
+- R13. *(deferred)* The gateway reads an optional preset env var in `packages/gateway/src/config.ts` via the existing optional-secret/env pattern (as `DISCORD_PRIVILEGED_INTENTS` does), defaulting to unset.
+- R14. *(deferred)* The gateway passes the preset value through to the workspace OpenCode as `OH_MY_OPENCODE_SLIM_PRESET`, with **allowlist validation of known preset names** (reject unknown values; no free-string passthrough across the container boundary).
+- R15. *(deferred)* `deploy/compose.yaml` and `deploy/README.md` surface the env var using the optional-secret `_FILE` convention and document the migration step.
+
+---
+
+## Key Decisions
+
+- Mutually exclusive with fail-fast on both-enabled: research confirmed Slim and OMO both own the `opencode.json` plugin array and agent routing, so coexistence would require conflict-resolution machinery with no clear payoff.
+- `default_agent: 'orchestrator'` when Slim is enabled: matches Slim's orchestrator-centric design (the `orchestrator` agent is its primary entry; Slim supports a `setDefaultAgent` option) and parallels our existing pattern of pinning `default_agent` per mode (`build` when disabled).
+- Single `omo-slim-preset` name, not a comma-list: Slim selects exactly one preset, unlike OMO's multi-provider list. The user-facing wording "presets" maps to choosing one preset by name.
+- Gateway env var = workspace preset passthrough, **deferred to Unit 7**: OMO is action-only and never touched the gateway. Slim would run inside the workspace container (the mention loop), so the gateway env var would select the preset there via Slim's native `OH_MY_OPENCODE_SLIM_PRESET` — but the workspace container does not run OpenCode yet, so this is gated on Unit 7 (see Deferred to Separate Tasks).
+- No telemetry env exports: Slim ships no telemetry, so the OMO telemetry opt-out knobs have no analog.
+- Pin a stable version (`1.1.1`), not the `2.0.0-beta` prerelease line.
+
+---
+
+## Dependencies / Assumptions
+
+- Source inspected at `.slim/clonedeps/repos/alvinunreal__oh-my-opencode-slim` (v1.1.1; latest remote tag `2.0.0-beta.13`). Install: `bunx oh-my-opencode-slim@{version} install`; config file `~/.config/opencode/oh-my-opencode-slim.json[c]`; preset env `OH_MY_OPENCODE_SLIM_PRESET`; built-in presets `openai`, `opencode-go`; agent literal `orchestrator`.
+- The gateway preset passthrough depends on the workspace container running OpenCode with Slim available — which does not exist until Unit 7. This dependency is why R13-R15 are deferred.
+- Bun is already an install dependency for the OMO path and is reused for Slim.
+- **Preset credentials**: Slim's built-in presets (`openai`, `opencode-go`) select provider-specific models (e.g. `openai/gpt-5.5`). They are non-functional without the corresponding provider credentials, which the harness does not provide in its default free-model posture. Selecting a preset therefore assumes the caller supplies the needed provider auth; this is a premise of the feature, not something the integration provides.
+- **Install/preset contract** (R7/R8): the install surface is Slim's own `bunx oh-my-opencode-slim@{version} install`, and preset application uses Slim's documented mechanism (install flag / config `preset` key / `OH_MY_OPENCODE_SLIM_PRESET` env) confirmed against the clone during planning — not OMO's provider/telemetry pattern.
+- **Supply chain**: Slim is fetched and executed via `bunx` at setup time, the same posture as the existing OMO path (version-pinned, no artifact-hash verification) — an accepted, pre-existing risk shared with OMO.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R8][Needs research] Exact mechanism to apply the selected preset during CI install — install `--preset` flag vs config key vs exporting `OH_MY_OPENCODE_SLIM_PRESET`. Confirm against the clone's `install.ts`/`loader.ts`.
+- [Affects R13-R15][Deferred to Unit 7] Exact gateway env var name (`GATEWAY_OMO_SLIM_PRESET` vs direct `OH_MY_OPENCODE_SLIM_PRESET`), and how the preset env reaches the workspace OpenCode process across the container boundary — resolved when the passthrough is built atop the Unit 7 workspace runtime. Allowlist validation is already mandated in R14 (deferred).
+- [Affects R12][Technical] Whether Slim's CI config needs the same `external_directory: deny` / permission handling that OMO-disabled mode applies, or a different policy under the orchestrator default.

--- a/docs/brainstorms/2026-06-02-fro-bot-harness-patched-opencode-requirements.md
+++ b/docs/brainstorms/2026-06-02-fro-bot-harness-patched-opencode-requirements.md
@@ -1,0 +1,178 @@
+---
+date: 2026-06-02
+topic: fro-bot-harness-patched-opencode
+status: ready-for-planning
+---
+
+# @fro.bot/harness — Patched OpenCode Build + Forwarding CLI
+
+## Summary
+
+A new published package `@fro.bot/harness` that ships a **deterministically patched build of upstream OpenCode** behind a thin forwarding CLI (`harness <args>` → patched `opencode <args>`), distributed as native per-platform binaries the way OpenCode itself is packaged. It gets the Fro Bot agent **back onto a recent, deliberately-pinned OpenCode release** (1.15.13+) while giving us durable, reproducible control over a small set of non-mainline patches. The **action** consumes the prebuilt patched binary in v1; the **gateway** follows as a fast-follow (R16).
+
+---
+
+## Problem Frame
+
+Fro Bot is pinned to OpenCode **1.14.41** because 1.14.42+ regressed `/event` SSE SyncEvent delivery and broke visible tool-call output. That pin has held for weeks: every upstream improvement since (startup perf, PermissionV2, SSE-hydration fixes, plugin reliability) is unreachable, and the gap widens with every release. The pin is also brittle — it is a bare version constant in two places (action setup, gateway Dockerfile) with no validation layer between "upstream cut a release" and "our agent runs it."
+
+Separately, several behaviors we want or have wanted from OpenCode live in PRs that are **closed (upstream-rejected) or open/stalled** — they will never arrive in a stock release. Today we have no mechanism to carry such changes; we either fork mentally and re-discover the gap each time, or do without.
+
+The cost shape is twofold: **staleness risk** (stranded on an old release, manually re-validating any bump from scratch) and **no carry path** (no reproducible way to apply changes upstream won't take). Both compound every time OpenCode releases.
+
+---
+
+## Actors
+
+- A1. **harness CI**: Clones upstream OpenCode at the pinned ref, applies the patch set deterministically, compiles native per-platform binaries, runs verification (incl. the streaming spike), publishes the package set, and runs the scheduled upgrade-check.
+- A2. **Action setup step** (`src/services/setup/`): Installs/obtains the patched harness binary instead of stock `opencode` and invokes it via the harness CLI.
+- A3. **Gateway / workspace image** (`deploy/*.Dockerfile`): Obtains the same patched binary at image-build time (phase 2 — fast follow).
+- A4. **Upstream `anomalyco/opencode`**: The MIT-licensed base we track, patch onto, and monitor for new releases.
+- A5. **Maintainer (Marcus)**: Reviews and merges deliberate version bumps and patch-set changes; the upgrade-check never auto-merges.
+
+---
+
+## Key Flows
+
+- F1. **Build a patched release**
+  - **Trigger:** A pinned-version change lands on harness `main`, or a release is cut.
+  - **Actors:** A1, A4
+  - **Steps:** Clone opencode@`<pinned>` → apply patch set (fail hard on any patch that doesn't apply clean) → compile each native binary **on its own platform-native runner** (per-OS/arch matrix — the model OpenCode itself uses in `publish.yml`; not cross-compiled from one job) → assemble artifacts → run verification (version assertion + streaming/tool-output spike on linux x64) → publish the main package + per-platform `optionalDependencies` with provenance + integrity attestation (base version + patch list + build sha).
+  - **Outcome:** A reproducible set of native patched binaries is published under `@fro.bot/harness`, each tagged with exactly which base + patches produced it.
+  - **Covered by:** R4, R5, R6, R7, R8, R9, R12, R19
+
+- F2. **Consume the patched binary (action)**
+  - **Trigger:** An action run reaches the setup phase.
+  - **Actors:** A2
+  - **Steps:** Setup obtains the pinned `@fro.bot/harness` binary (cache-first, same accelerator pattern as today) → invokes `harness serve` → SDK talks HTTP to it exactly as it does to stock opencode today.
+  - **Outcome:** The agent runs on the patched OpenCode with no change to SDK/event-stream code.
+  - **Covered by:** R9, R10
+
+- F3. **Deliberate upgrade-check**
+  - **Trigger:** Scheduled CI detects a new upstream OpenCode release.
+  - **Actors:** A1, A5
+  - **Steps:** Re-apply the patch set onto the new base → build → run the streaming spike + verification → **only if all green**, open a PR bumping the pinned version → maintainer reviews and merges.
+  - **Outcome:** Staying current becomes a reviewable, automated signal; a failing patch/spike blocks the bump instead of breaking production.
+  - **Covered by:** R13, R14
+
+---
+
+## Requirements
+
+**Package & CLI**
+- R1. Add a new package named **`@fro.bot/harness`** (published scope — dot, matching `@fro.bot/systematic`; distinct from the internal hyphen-scoped `@fro-bot/runtime` / `@fro-bot/gateway` workspace packages) developed under `packages/harness/`, ESM-only / Node 24, consistent with existing workspace conventions (tsdown build, colocated vitest, AGENTS.md).
+- R2. Expose a `harness` binary that **passes through** arbitrary OpenCode commands/args/stdio/env (`harness serve`, `harness run`, etc.) to the patched `opencode` with zero per-command maintenance, so it is a drop-in replacement.
+- R3. Provide harness-specific commands beyond passthrough: `harness doctor` (verify the patched binary is present, runnable, and reports the expected base+patch provenance), `harness patches` (list the applied patches), and version/info reporting (`harness --version` / `harness info` → base OpenCode version + applied patch set + build sha).
+- R18. `@fro.bot/harness` is **published to the public npm registry** and runnable with **zero prior local setup** via `bunx @fro.bot/harness <command>` (mirrors `bunx @cortexkit/orw`). Running it fetches the package and obtains/invokes the correct patched binary for the host; inspection commands (`info`, `patches`, `doctor`) work without a server. This is the local dogfooding + operator install path, not only a CI-internal artifact.
+
+**Patch pipeline (deterministic)**
+- R4. Patches are applied **deterministically** via git-native tooling (cherry-pick / `git am` / a versioned `patches/` dir) — **never** by an LLM-driven merge at build time. The applied result must be byte-reproducible from `(base ref, patch set)`.
+- R5. If any patch fails to apply cleanly against the pinned base, the build **fails hard** with a clear report of which patch conflicted — no silent skips, no partial application.
+- R6. The patch set is **streaming-gated minimal**: carry only patches that deliver value not available in the pinned mainline release. Mainline-merged changes are obtained for free by riding latest, not re-carried as patches.
+- R7. Each patch in the set is recorded with provenance: upstream PR/source, why it is carried (and whether upstream rejected it → indefinite-ownership flag), so the maintenance cost of each patch is explicit and auditable.
+
+**Build & distribution**
+- R8. Each platform's patched OpenCode is compiled to a **native standalone binary** (the `bun build --compile` model OpenCode itself uses) at publish time, **each on its own platform-native CI runner** (a per-OS/arch matrix — verified against upstream `publish.yml`, which builds darwin on `macos-*` hosts and linux on `ubuntu` hosts; bun does not cross-compile these from a single runner). No bun/node runtime or compile toolchain is required at install/run time on the consumer.
+- R9. Distribution **mirrors OpenCode's own npm packaging** (verified against `script/publish.ts`): a main `@fro.bot/harness` package declares per-platform packages as **`optionalDependencies`** (`@fro.bot/harness-linux-x64`, `-linux-arm64`, `-darwin-x64`, `-darwin-arm64`), each containing only that platform's native binary; the main package ships a `bin` shim + `postinstall` resolver that selects and execs the host's binary. npm/bun installs only the matching platform package. `bunx @fro.bot/harness <cmd>`, the action setup, and the gateway Dockerfile all consume this same package set via the harness CLI.
+- R10. The published artifact carries verifiable provenance (base OpenCode version, applied patch list, build sha) retrievable via the harness CLI and at the artifact level.
+- R19. The build matrix **mirrors OpenCode's platform set**: at minimum **linux (x64 + arm64)** and **darwin (x64 + arm64)**. linux x64 serves CI (the action); linux serves the gateway Docker image (multi-arch); darwin arm64 gives full local `harness serve` parity on the maintainer's Apple-Silicon machine. Every platform is built and published per bump; the streaming spike + verification run on linux x64 (the production-critical target) at minimum.
+
+**Security & supply-chain**
+- R20. Published packages carry **npm provenance attestation** (signed build provenance), and consumers **verify integrity before exec** (lockfile integrity hash / signed checksum). The `postinstall` resolver must only resolve a pre-verified, integrity-checked binary — never fetch-and-exec arbitrary code. In credentialed contexts (action CI, gateway) the binary is verified **before** any secrets/tokens are loaded.
+- R21. **Publish authority is fenced**: only a protected CI workflow on a trusted ref may publish `@fro.bot/harness*`, using a narrowly-scoped npm automation token; publishing is gated by the same maintainer-review boundary as bump PRs (never auto-published).
+- R22. Each carried patch is **pinned by immutable upstream commit SHA + patch-file content hash**; the build fails if fetched patch content differs from the reviewed digest (a PR number alone is not a sufficient pin — PR content can change).
+- R23. The consumer version pin is **integrity-enforced** (lockfile/integrity); unexpected version or content drift is rejected at install and reported by `harness doctor`.
+- R24. **MIT attribution is preserved** in the published package (LICENSE + attribution to upstream OpenCode) as required for redistributing modified MIT code.
+- R25. **Publish is all-or-nothing across the platform matrix**: a partial publish (some platforms missing) must not leave consumers resolving a half-published version; behavior on an unsupported/unbuilt platform is a clear error, and a non-`postinstall` install path is documented for locked-down/airgapped runners.
+
+**Version & bump model**
+- R11. `@fro.bot/harness` pins an **exact, validated** upstream OpenCode version. "Latest" means "a recent upstream release we deliberately validated and pinned," never auto-tracked dev.
+- R12. v1 targets OpenCode **1.15.13 or the latest validated release** as the initial pinned base.
+- R13. A **scheduled CI job** detects new upstream OpenCode releases, re-applies the patch set + runs the streaming spike + verification against the new base, and opens a **bump PR only when all checks pass**.
+- R14. The bump PR is **never auto-merged** into action/gateway; a maintainer reviews and merges. A failing patch-apply or streaming spike blocks the bump.
+
+**Consumer integration (phased)**
+- R15. v1 ships the harness package + build/patch pipeline **and cuts the action over** to consume the patched binary via the harness CLI (high-frequency surface, easy version-pin rollback = best validation).
+- R16. Gateway + workspace-image cutover is a **fast follow-up** after the action validates the patched binary in production — not in v1.
+- R17. Consumer cutover must **verify** SDK/event-stream compatibility against the patched base — not assume it. A compatibility check runs the existing consumer against the patched binary and asserts the exact event types/shapes it depends on (the streaming spike checks tool-output visibility; this check additionally covers the event/permission lifecycle the consumer relies on, e.g. PermissionV2-era shapes vs 1.14.41). If the event contract changed, an adapter change is budgeted rather than claiming zero code change. The existing cache-accelerator install pattern is preserved.
+- R26. **Patch-conflict workflow is explicit**: when a patch fails to apply on a new base, the scheduled upgrade-check opens a **maintenance issue** (not a silent red build and not a bump PR); each carried patch has a stated per-bump revalidation owner, and the patch set has a documented threshold for dropping/upstreaming a patch rather than carrying it indefinitely.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R5.** Given a pinned base and a patch that no longer applies cleanly, when harness CI builds, the build fails and names the conflicting patch — it does not publish a partially-patched artifact.
+- AE2. **Covers R6, R12.** Given v1 pins 1.15.13 and #30182 is already merged upstream into the pinned base, when assembling the patch set, #30182 is NOT carried as a patch (it comes for free from the base).
+- AE3. **Covers R13, R14.** Given a new upstream release where the patch set applies clean and the streaming spike passes, when the scheduled job runs, it opens a bump PR; given the spike fails on the new base, no PR is opened and the failure is reported.
+- AE4. **Covers R3.** Given the patched binary is installed, when `harness doctor` runs, it reports the expected base version + patch set and exits non-zero if the binary is missing, unrunnable, or reports unexpected provenance.
+- AE5. **Covers R2, R17.** Given the action setup obtains the harness binary, when it runs `harness serve`, the SDK connects and streams events exactly as against stock `opencode serve` today.
+- AE6. **Covers R9, R19.** Given `bunx @fro.bot/harness serve` is run on darwin/arm64, when npm resolves the package, only `@fro.bot/harness-darwin-arm64` is installed and the shim execs its native binary; on linux x64 CI, only `@fro.bot/harness-linux-x64` is installed.
+
+---
+
+## Success Criteria
+
+- **The spike runs first and right-sizes v1**: a recorded result (1.15.13 streams cleanly or not; real patch count) determines whether v1 is the full harness or the lean pin-bump path — no heavy pipeline is built before that evidence exists.
+- The Fro Bot agent runs on a deliberately-pinned OpenCode **1.15.13+** in the action, with visible tool-call output confirmed in live CI logs (the thing the 1.14.41 pin was protecting).
+- The patch set is small, each patch's carrying rationale is explicit, and any patch that stops applying breaks the build loudly rather than silently degrading.
+- A maintainer can bump the OpenCode base by reviewing one automated, pre-validated PR — not by re-running a manual patch+build+spike from scratch.
+- A downstream planner can implement from this doc without inventing the build model, patch policy, CLI contract, or cutover sequencing.
+
+---
+
+## Scope Boundaries
+
+- **Gateway/workspace cutover is not in v1** — it is the immediate fast-follow after the action proves the patched binary (R16).
+- **Platform matrix mirrors OpenCode** (R19) — native builds for linux x64/arm64 + darwin x64/arm64 are in scope (full local `serve` parity included); **windows is out of scope** for v1.
+- **No install-time/on-consumer build** — explicitly rejected in favor of prebuilt artifacts (R8); not even as a fallback in v1.
+- **No LLM-driven merge pipeline** (the orw approach) — explicitly rejected for non-determinism (R4).
+- **No auto-tracking of upstream dev/latest** — explicitly rejected given the 1.14.42 regression history (R11, R14).
+- **Carrying upstream-rejected (CLOSED) PRs is opt-in, not automatic** — #28582 and #26036 are upstream-rejected; they are carried in v1 only if they deliver value we need now, with the indefinite-ownership cost acknowledged (R6, R7, R26). Each indefinitely-carried patch is a standing per-bump rebase-conflict tax, not a one-time cost. The streaming spike result, not assumption, drives the final set.
+- **The streaming fix is not assumed present** — #27959 (PubSub eager-subscribe) is confirmed an ancestor of v1.15.13, but whether 1.15.13 fully resolves OUR tool-output drop is unproven; the spike decides whether a streaming patch is still required.
+
+---
+
+## Key Decisions
+
+- **Spike-gated scope (load-bearing)**: the empirical streaming spike against isolated mainline 1.15.13 is **planning Unit 1** and gates v1 *scope*, not just the patch set. If 1.15.13 still drops tool output for our `subscribeAll` pattern, OR ≥2 non-mainline patches are genuinely needed → build the full harness as specified below. If 1.15.13 streams cleanly AND the real delta is ~1 patch → the plan recommends the lean path (pin-bump 1.15.13 + thin patch/shim layer, defer the multi-platform publish pipeline + scheduled-bump automation). Nothing heavy is built speculatively before the spike proves the pain. All requirements below describe the **full-harness branch**; the lean branch is a documented planning off-ramp.
+- **Both deterministic patch pipeline AND latest-tracking are co-equal goals** *(in the full-harness branch)*: the harness must give reproducible patch control *and* be the safe mechanism for riding a recent release.
+- **Publish-time prebuilt artifact over install-time build**: reproducibility + fast consumers; build/compile toolchain isolated to harness CI; consumers need no runtime.
+- **Streaming-gated minimal patch set**: ride latest for everything mainline; patch only non-mainline value; an empirical spike gates whether a streaming patch is needed at all.
+- **Passthrough CLI + harness-specific ops commands**: drop-in `opencode` replacement plus `doctor`/`patches`/`info` for provenance and operability.
+- **Deliberate pinned bumps + automated upgrade-check PR**: never auto-merge; the scheduled job turns "stay current" into a reviewable, pre-validated signal.
+- **Phased cutover (action first, gateway follows)**: validate the new build on the disposable high-frequency surface before the long-lived daemon.
+- **Published as `@fro.bot/harness`, bunx-runnable**: the harness is a public npm package (dot-scope, like `@fro.bot/systematic`) runnable via `bunx @fro.bot/harness <command>` with zero prior setup — the local dogfooding + operator install path, not only a CI artifact.
+- **Native builds, mirroring OpenCode's npm packaging**: per-platform native binaries distributed via a main package + per-platform `optionalDependencies` (the esbuild/swc/OpenCode pattern), so no runtime/toolchain is needed on consumers and `bunx` resolves the host binary automatically. Build matrix mirrors OpenCode: linux x64/arm64 + darwin x64/arm64.
+- **MIT license confirmed**: upstream OpenCode is MIT, so redistributing a modified build is permitted with attribution.
+
+---
+
+## Dependencies / Assumptions
+
+- Upstream `anomalyco/opencode` remains MIT-licensed and buildable from source at the pinned ref.
+- The from-source build is required because the target patches modify OpenCode **server internals** (`bus`, session prompt-building, plugin events) — these are not SDK-client patches.
+- `@opencode-ai/sdk` continues to talk HTTP/SSE to the patched `opencode serve` unchanged; the harness changes the binary, not the protocol.
+- The existing cache-accelerator install pattern (tools cache) can host/serve the harness binary the way it hosts stock opencode today.
+
+---
+
+## Outstanding Questions
+
+### Resolved
+
+- **Streaming spike — DONE (2026-06-02), regression FIXED in 1.15.13.** Ran an isolated `--pure` opencode@1.15.13 server (darwin arm64, `opencode/big-pickle`) with a vanilla SDK subscriber (`createOpencodeClient` with `directory` baked in, mirroring production). Result: `message.part.updated` (16) and `message.updated` (9) — the SyncEvents 1.14.42+ dropped — reached the `/event` subscriber, and the bash tool executed end-to-end (`tool.registry status=completed bash`). The bus/SSE regression that forced the 1.14.41 pin is empirically gone. **Caveat (contract shift):** 1.15.13 emits the tool lifecycle via `message.part.updated` (partType:tool, pending→running→completed) and emits **zero** `session.next.tool.called/success` and **zero** `session.next.text.delta`. `src/features/agent/streaming.ts` already has a `message.part.updated` tool-completed handler (~lines 255-275), so the action *may* already be compatible — but the action's `retry.ts` turn-arming/fallback path (where the KNOWN_ISSUE "tool output unrendered when `message.part.updated` arrives before the turn is armed" becomes the PRIMARY path on 1.15.13) needs an end-to-end integration check before flipping the pin.
+- **Scope implication — LEAN PATH selected by the spike gate.** The streaming fix is in mainline 1.15.13, so it is NOT a patch we need to carry. With the primary pain dissolved, the spike-gated decision resolves to the **lean path**: pin-bump to 1.15.13 + any integration fix to `streaming.ts`/`retry.ts`, and defer the full multi-platform harness pipeline. The full-harness requirements below remain a documented future option if the carried-patch count ever grows, but are not v1.
+
+### Resolve Before Planning
+
+- [Affects pin-bump][Needs verification] **End-to-end integration check** — does the action harness (`retry.ts` arming + `streaming.ts` `message.part.updated` path) render tool output end-to-end on 1.15.13, given `session.next.tool.*` no longer fires? Gate before flipping `DEFAULT_OPENCODE_VERSION`.
+- [Affects R6, R7, R17, scope][SUPERSEDED — see Resolved] ~~Empirical streaming spike~~ — does deliberately-pinned mainline 1.15.13 (which contains #27959) still drop visible tool-call output for our `subscribeAll` consumption pattern? This is a **gating prerequisite**: its result determines whether the patch set includes a streaming fix (and whether we must author/upstream one). Planning must define the exact CI assertion surface before this is a hard gate: server mode (isolated `--pure`), the trigger that fires a tool/permission event (e.g. `external_directory` read), timeout budget, and the precise observable signature that counts as "tool output streamed" (which event types over `/event`). If a deterministic CI assertion is not achievable, it becomes a documented manual validation step, not a hard gate. Run as the first planning/spike step against an isolated 1.15.13 server before finalizing the patch set.
+- [Affects R6][User decision] **CLOSED-PR carry decision** — confirm whether #28582 (resume-from-stored-dir) and #26036 (summary-diff opt-out) deliver value we need badly enough to own indefinitely, or are dropped from v1.
+
+### Deferred to Planning
+
+- [Affects R8, R9][Technical] How the action setup + gateway Dockerfile fetch and cache the per-platform harness packages in the existing tools-cache accelerator (the artifact form itself is settled in R9: main package + per-platform `optionalDependencies`).
+- [Affects R4][Technical] Patch storage mechanism (`patches/` + `git am` vs scripted cherry-pick) and how patches are refreshed when a bump conflicts.
+- [Affects R13][Technical] Scheduled upgrade-check wiring (reuse existing Renovate/cron patterns vs a dedicated workflow) and how it builds against a candidate base in CI.
+- [Affects R2][Technical] How `harness` resolves and execs the embedded `opencode` binary (bin shim form, path resolution) given ESM/Node 24.
+- [Affects R6, R7][Needs research] Confirm #20084 and #19961 still apply cleanly onto 1.15.13 and deliver the intended behavior — **both target `dev`, not the release tag**, so cherry-picking onto a 1.15.x release tag may conflict; classify each carried patch by its base branch and define the fallback when a `dev`-only patch won't rebase (drop / rewrite / pin a release that already includes the hunk).

--- a/docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md
+++ b/docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md
@@ -1,0 +1,271 @@
+---
+title: Production-ready @Fro Bot Discord mention loop
+date: 2026-06-07
+status: ready-for-planning
+scope: deep
+---
+
+# Production-ready @Fro Bot Discord mention loop
+
+## Problem
+
+The gateway mention loop (`@Fro Bot <message>` in a bound Discord channel) works mechanically —
+it opens a thread, runs OpenCode in the workspace, and streams output back — but the UX is bad
+enough to block real use. Two concrete failures, observed in Fronomenal:
+
+- **Raw chain-of-thought leaks.** A "create a file" request streamed the model's hedging verbatim:
+  *"I'm wondering if we really need a specific skill set for this task. It seems simple…"* The
+  gateway never distinguishes OpenCode's `ReasoningPart` from a normal text part, so reasoning is
+  streamed as text.
+- **Every tool call is dumped.** `🔧 skill: Loaded skill: ce:work`, `🔧 apply_patch: Success…`,
+  `🔧 bash: …` followed by a wall of `git ls-files` output. The thread reads like a CI log, not a
+  conversation.
+
+Verified root cause (against current source):
+
+- `packages/gateway/src/execute/run-core.ts` streams every text delta with no part-type inspection
+  and renders every completed tool as `🔧 <tool>: <title>`.
+- `packages/gateway/src/execute/prompt.ts` `buildDiscordPrompt()` is bare — `Repository: owner/repo`
+  plus the raw message. No persona, no "be concise," no "you're in chat, don't narrate your process."
+  The agent behaves exactly as it would for a GitHub task.
+
+The mention loop should feel like talking to a capable teammate, not watching a job scroll.
+
+## Goals
+
+- Make `@Fro Bot` read as a **clean conversational assistant**: concise answers, reasoning hidden,
+  tool noise collapsed, light progress while working.
+- Give the agent a **Discord-appropriate prompt** so it *wants* to respond like a chat participant —
+  using Fro Bot's established voice, not a generic assistant tone.
+- Replace the current "reject concurrent same-channel runs" behavior with a **serial per-channel
+  queue** so a busy channel feels responsive, not broken.
+- Round out the **core command surface** and the **native approval UX** so the loop feels finished,
+  not like a demo.
+
+**Framing refinement (from review):** "clean conversational" means **low-noise, not opaque**. For a
+coding agent, developers trust the result partly by seeing what it did. The default is terse —
+reasoning hidden, read-only tools hidden, actions collapsed — but the *essential actions remain
+visible* (the collapsed one-line summaries of edits/writes/bash are the audit trace), and a missing
+action trail is a failure mode, not a feature. The goal is a clean surface that is still inspectable,
+not a polished black box. (Whether to go further with an expandable full trace is Open Question 7.)
+
+## Non-goals
+
+- No change to the underlying transport/plumbing — the OpenCode SDK event stream already works
+  (subscribe-before-prompt, `message.part.updated`, `session.idle`). This is a formatting + prompt +
+  lifecycle effort, not a rewrite.
+- **The single v1 user-facing knob is the working-state mode** (live-status-message vs typing-only).
+  Verbosity is **fixed** in v1 — the renderer applies one "clean conversational" verbosity (text +
+  essential tools; read-only tools hidden) with no user-facing verbosity control. Only the *minimal*
+  rendering logic this fixed shape needs is ported from Kimaki — not its full configurable verbosity
+  system. A per-channel verbosity setting (Kimaki's `tools_and_text` / `text_only`) is deferred.
+- No persistent cross-restart queue — v1 queue is in-memory per the existing Unit 6 R11 boundary.
+- No new GitHub-side or control-plane work; this is gateway-only (`fro-bot/agent`).
+
+## Key decisions
+
+| Decision | Choice |
+| --- | --- |
+| Target experience | Clean conversational assistant (not a worklog) |
+| Output rendering | Port Kimaki's `formatPart` / tool-summary / verbosity logic (MIT), adapted to our types |
+| Reasoning | Content is suppressed — never streamed. Whether a minimal "thinking" marker remains is open (see Open Question 3) |
+| Tool rendering | Collapsed to one-line human summaries; read-only tools (read/grep/glob) hidden by default |
+| Working-state UX | One live status message + typing indicator by default; **configurable to typing-only** |
+| Persona | Reuse canonical `fro-bot-persona.md` + Discord-mechanical guidance (concise, no process narration, chat formatting) |
+| Persona delivery | Deploy-time `GATEWAY_PERSONA_FILE` bind-mount; `fro-bot/.github` stays the source of truth |
+| Concurrency | Serial per-channel queue + `/clear-queue` (replaces reject-concurrent) |
+| Commands | Add `/sessions`, `/resume`, `/force-release-lock` (alongside existing `ping`, `add-project`) |
+| Approvals | Native Discord button/component UX, building on existing `GATEWAY_APPROVAL_MODE` |
+
+## Proposed shape (WHAT, not HOW)
+
+### 1. Output rendering layer (the foundation)
+
+A `formatPart`-equivalent sits between the SDK event stream and the Discord sink. For each renderable
+part:
+
+  - **Reasoning** → content suppressed (never streamed). A minimal "thinking" marker may remain or be
+    fully hidden — see Open Question 3. **Implementation note:** `run-core.ts` currently branches only
+    on text deltas and completed tool parts; suppression requires an explicit
+    `part.type === 'reasoning'` branch on `message.part.updated`. (If the configured 1.15.13 model does
+    not emit reasoning parts, suppression is a safe no-op, not a claimed capability.)- **Text** → passed through (the answer).
+- **Tool (completed/error only)** → a one-line human summary: verb + target + magnitude
+  (`◼︎ edit file.ts (+12-3)`, `┣ grep pattern`, `┣ bash <short cmd or description>`). Unknown/MCP
+  tool args truncated. Pending/running states do not each post.
+- **Verbosity filter (fixed for v1):** show text + *essential* tools (edits, writes, side-effecting
+  bash, `todowrite`, subagent tasks, MCP); **hide** read-only tools (read, grep, glob, list).
+- **Structural parts** (step-start/finish, snapshot, patch) render nothing.
+- Long output is batched to Discord's 2000-char limit, split on safe boundaries (never mid-code-fence),
+  with huge output (full diffs/logs) attached as a file rather than inlined.
+
+This layer is the shared dependency for both the streamed final answer and the live status message.
+
+### 2. Working-state UX (configurable)
+
+- **Default:** a single editable status message ("⏳ Working… edited 2 files, ran tests") updated on a
+  rate-limit-safe cadence (one edited message, not per-token), plus the Discord typing indicator
+  re-pulsed while the session is `busy`. The status message is replaced by the clean final answer.
+  **Implementation note:** the current sink (`packages/gateway/src/discord/streaming.ts`) only buffers
+  and flushes a final message — it has no edit/update surface. The live-status UX needs a dedicated
+  status-message manager that owns one message ID and edits it on cadence, kept separate from
+  final-answer flushing. This is a real new component, not a formatting tweak.
+- **Configurable to typing-only:** a deploy/channel setting suppresses the status message entirely —
+  typing indicator + final answer only (Kimaki's quietest mode).
+- The typing indicator starts only on real work (`session.status: busy`), and is cleared on
+  idle/abort/approval-wait so it never sticks.
+
+### 3. Discord persona prompt
+
+- The gateway prepends the **canonical `fro-bot-persona.md`** (the same versioned voice used by the
+  `@fro-bot` GitHub account — it already defines a "Social (Discord/BlueSky)" tone register:
+  *observational, slightly theatrical, trickster energy*) to the agent prompt.
+- Layered with **Discord-mechanical guidance**: you're in a Discord thread talking to humans; be
+  concise; do not narrate your internal process or reasoning; format for chat (short, markdown, code
+  blocks for code); the persona's anti-patterns (no sycophancy, no sign-offs, no apologies) already
+  reinforce this.
+- The persona reaches the gateway via a deploy-time `GATEWAY_PERSONA_FILE` (bind-mount or env),
+  supplied by `marcusrbrown/infra`, pulling the canonical file from `fro-bot/.github`. The gateway
+  treats a missing persona file as fail-soft (falls back to the Discord-mechanical guidance alone).
+
+### 4. Serial per-channel queue
+
+- Replace the current behavior (reject a mention while a same-channel run is in flight) with a
+  **serial per-channel queue**: a new mention while busy is queued and runs when the current one
+  finishes, with a brief acknowledgement so the user knows it's queued.
+- `/clear-queue` drops pending queued tasks (the in-flight task runs to completion).
+- v1 queue is **in-memory** (per the existing Unit 6 R11 boundary) — tasks pending at gateway restart
+  are lost; documented, not solved here.
+
+### 5. Core commands + native approval UX
+
+- Add the core slash commands the Unit 6 reconciliation deferred: `/sessions` (list within-surface
+  sessions), `/resume` (resume a prior session), `/force-release-lock` (operational escape hatch for a
+  stuck repo lock). Alongside the existing `ping` / `add-project`.
+- **Approvals as native components:** risky tool calls gated behind Discord buttons (approve/deny)
+  rather than text prompts, building on the existing `GATEWAY_APPROVAL_MODE` (default
+  `approval-required`) and the shipped S5 approval registry. Read-only actions are not gated.
+
+## Recommended build order (phasing)
+
+The five areas are not equal-priority. The output-rendering fix is the foundation and the actual
+80/20 of the reported pain — it must land first, and the live-status UX depends on it. Recommended
+sequence for planning (the user has confirmed all five are in scope; this is order, not exclusion):
+
+1. **Phase 1 — Output rendering + Discord persona prompt.** ✅ Shipped (PR #831). The `formatPart` layer (reasoning
+   suppression, tool summarization, verbosity filter) + the persona/Discord-mechanical prompt. This
+   alone resolves SC1-SC3 and is the production-ready minimum. Everything else builds on the renderer.
+2. **Phase 2 — Working-state UX.** ✅ Shipped (PR #843). The status-message manager + typing indicator (default), then the
+   typing-only mode. Depends on Phase 1's summaries for the status content.
+3. **Phase 3 — Serial per-channel queue.** ✅ Shipped (PR #850). Replaces reject-concurrent; resolves SC5.
+4. **Phase 4 — Remaining command surface + reaction/progress affordances.** Native tool-approval UX
+   (S5) already shipped — no longer part of this phase. Remaining scope: `/fro-bot sessions` (list
+   within-surface sessions), `/fro-bot resume` (resume a prior session), `/fro-bot force-release-lock`
+   (operator escape hatch for stuck repo locks); optionally `/fro-bot review` and `/fro-bot approvals`
+   command surface; reactions/R9 progress affordances. Resolves SC6 command gaps. Most separable —
+   could ship incrementally without blocking the UX wins already landed.
+
+This is a recommendation for the plan to sequence against, not a re-scoping.
+
+## Success criteria
+
+- **SC1** — A simple mention ("create a file named X") produces a clean conversational response with
+  **no chain-of-thought** and **no raw tool dump** — at most collapsed action summaries plus the
+  answer.
+- **SC2** — A "what files are in this repo" mention answers conversationally without dumping
+  `git ls-files` output or the `🔧 bash:` line; long lists are summarized or attached, not inlined.
+- **SC3** — The agent's responses read in **Fro Bot's voice** (direct, terse, light trickster energy),
+  not a generic assistant tone, because the canonical persona is in the prompt.
+- **SC4** — During a longer task the user sees a single updating status message (default) OR just a
+  typing indicator (when configured), never a wall of progress posts; the status message is replaced
+  by the final answer.
+- **SC5** — A second mention in a busy channel is **queued and runs**, not rejected; `/clear-queue`
+  drops pending tasks.
+- **SC6** — `/sessions`, `/resume`, and `/force-release-lock` are registered and functional; risky
+  tools prompt a Discord **button** approval, not a text prompt.
+- **SC7** — A missing persona file does not break the loop (fail-soft to mechanical guidance).
+
+## Open questions (for planning)
+
+1. **Status-message config granularity.** Is typing-only a single deploy-wide setting
+   (`GATEWAY_STATUS_MODE`-style) or per-channel? v1 leans deploy-wide for simplicity; confirm.
+2. **Status-message update cadence + content.** Exact debounce interval and what the status line
+   summarizes (count of essential actions? last action?). Resolve against Discord edit rate limits in
+   planning.
+3. **Reasoning marker — show or fully hide?** Kimaki shows a `┣ thinking` marker. For "clean
+   conversational," do we show even that, or fully suppress reasoning? Lean fully suppress for v1;
+   confirm.
+4. **`/resume` scope.** Within-surface session resume only (the established Unit 6 boundary), or does
+   it need the autocomplete session-list source? Defer the autocomplete data-source detail to planning.
+5. **Persona + task-prompt composition.** Exact ordering/precedence of persona vs. Discord-mechanical
+   guidance vs. the user message — mirror the Action tier's persona-then-task layering. Planning detail.
+6. **Footer/turn-terminator.** Kimaki posts a compact footer (duration · model · context%). For a
+   coding agent this is a mild trust/accountability signal, not pure noise. In scope as an optional
+   minimal footer, or skip for v1? Lean: optional, low-priority.
+7. **Auditability depth.** The default is clean-but-inspectable (essential actions visible as collapsed
+   summaries). Is that enough, or does v1 also need an *expandable* full action trace (all tools incl.
+   read-only, on demand) for developers verifying multi-step work? Lean: collapsed essential summaries
+   are enough for v1; full expandable trace deferred. Confirm.
+
+### Interaction states to resolve in planning
+
+Intentionally deferred to the plan, but must be resolved there (not left to implementer guess):
+
+- **Failure/timeout/abort presentation.** How a FAILED/timed-out/aborted run reads conversationally —
+  a terse failure note in Fro Bot's voice, not a raw error/tool dump; whether the status message is
+  edited into the failure note or followed by a new message.
+- **Final-answer transition mechanics.** "Replaced by the final answer" = edit-status-in-place vs
+  delete-status-then-post vs post-separate-and-archive-status. Materially different thread UX.
+- **Queued-task acknowledgement.** Surface (reply vs reaction vs status edit), copy, whether it updates
+  when the queued task starts, how many queued items are visible.
+- **Approval-wait thread state.** What stays visible while a button approval is pending (typing pauses;
+  status shows the permission prompt), and immediate after-approve vs after-deny behavior.
+- **Empty/trivial responses.** Whether a no-op/already-done task emits silence, a reaction, or a tiny
+  acknowledgement instead of the current `_(no output)_`.
+- **Multi-part / attachment answers.** How a >2000-char or attached answer reads conversationally
+  (chunk labeling, which message carries the summary, how an attachment is introduced).
+
+### Implementation constraints to honor (verified against source)
+
+- **Approval mode:** `GATEWAY_APPROVAL_MODE` currently supports only `approval-required`;
+  `autonomous-low-risk` is deferred (OpenCode rule-ordering). The button approval UX must live inside
+  `approval-required` + the existing permission coordinator / S5 registry path — do not plan on
+  mode-switching.
+- **Queue ownership:** a per-channel in-memory FIFO in the mention handler; dequeue only after the
+  prior run's final cleanup/lock-release completes. Define whether queued items survive approval
+  timeout / repo-lock failure; `/clear-queue` drops only pending items (in-flight runs to completion).
+- **Status sink:** the live-status UX requires a new status-message manager (own message ID, edit on
+  cadence) — the current sink has no edit surface.
+
+## Dependencies
+
+- **OpenCode SDK event model** (already consumed): `message.part.updated` carries the full `Part`
+  (discriminated union incl. `ReasoningPart`, `ToolPart` with `ToolState`); `session.status` busy/idle;
+  `permission.updated`/`permission.replied` for approvals. The gap is formatting, not plumbing.
+- **Canonical persona** `fro-bot/.github` `persona/fro-bot-persona.md` — delivered to the gateway at
+  deploy time via `marcusrbrown/infra`.
+- **Existing gateway primitives reused:** `GATEWAY_APPROVAL_MODE` + the S5 approval registry; the
+  `readSecret`/`_FILE` config pattern; the repo lock / run-state coordination; the workspace
+  remote-attach topology.
+- **Reference implementation:** Kimaki (`remorses/kimaki`, MIT) — `cli/src/message-formatting.ts`
+  (`formatPart`, `getToolSummaryText`), `cli/src/external-opencode-sync.ts` (verbosity), and
+  `cli/src/session-handler/thread-session-runtime.ts` (typing keepalive). Port adapted, credit MIT.
+
+## Anti-patterns to avoid (from SotA research)
+
+- Streaming raw chain-of-thought; dumping verbatim tool calls/output.
+- Token-by-token message edits (429 storms) — batch on a timed cadence, edit one stable message.
+- Splitting code blocks mid-fence at the 2000-char boundary.
+- "Typing" with nothing happening, or stuck typing — start only on `busy`, always clear on idle/abort.
+- Mutable run-state in message handlers — keep the event stream the single source of truth.
+- Pasting long diffs/logs inline — attach or link.
+
+## References
+
+- Source (the bad UX): `packages/gateway/src/execute/run-core.ts`,
+  `packages/gateway/src/execute/prompt.ts`, `packages/gateway/src/discord/streaming.ts`,
+  `packages/gateway/src/execute/run.ts`
+- Deferred Unit 6 items: `docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md`
+  (Unit 6 reconciliation block, 2026-06-01)
+- Persona: `fro-bot/.github` `persona/fro-bot-persona.md` (+ `persona/README.md`)
+- Reference bridge: `remorses/kimaki` (MIT) — output-rendering, verbosity, typing patterns
+- OpenCode SDK part/event model: `.slim/clonedeps/repos/anomalyco__opencode/packages/sdk/js/src/gen/types.gen.ts`

--- a/docs/brainstorms/2026-06-07-release-notes-narrative-requirements.md
+++ b/docs/brainstorms/2026-06-07-release-notes-narrative-requirements.md
@@ -1,0 +1,179 @@
+---
+title: LLM-narrated release notes for the multi-part release flow
+date: 2026-06-07
+status: ready-for-planning
+tier: standard
+---
+
+# LLM-narrated release notes
+
+## Problem
+
+Releases publish with the default `@semantic-release/release-notes-generator` body — a flat
+list of conventional-commit lines (`fix(deploy): ...`, `feat(gateway): ...`). It is accurate
+but not readable: it doesn't tell a human what actually changed or why it matters. Systematic
+solved this with an LLM narration step that, after a release publishes, rewrites the release
+body into a prose "What's new" narrative by dispatching its agent against the just-published tag.
+
+We want the same capability for `fro-bot/agent`, adapted to this repo's multi-part release flow
+and its TypeScript-scripts convention.
+
+## Goal
+
+After a release is published, dispatch `fro-bot.yaml` to rewrite the GitHub Release body into a
+readable narrative, waiting for and classifying the outcome so that:
+
+- a successful narration replaces the release body in place;
+- narrative-quality failures (agent timeout, model error, already-applied) are **non-fatal** —
+  the release itself is never blocked or rolled back;
+- security-relevant anomalies (off-target release edits, auth failures, policy blocks) **fail
+  the step loudly** so they are not silently ignored.
+
+## Source being ported
+
+Systematic's `scripts/dispatch-release-notes.sh` (a `@semantic-release/exec` `successCmd`) plus
+its `tests/integration/release-notes-ci.test.ts` (19 structural scenarios). The behavioral
+contract — validate → dispatch → poll → watch → classify — is the thing of value; it is ported
+to TypeScript and re-integrated, not copied verbatim.
+
+## How this repo differs from Systematic (the integration deltas)
+
+These are verified against source and drive the requirements below.
+
+| Aspect | Systematic | fro-bot/agent |
+| --- | --- | --- |
+| Where `semantic-release` runs | `main` push | `auto-release.yaml` `perform-release` job, fired by the `next → release` PR merge (`pull_request.closed` on `release`) |
+| `@semantic-release/exec` hook | `successCmd` present | only `verifyReleaseCmd` configured — **no `successCmd` yet** (`.releaserc.yaml:9-10`) |
+| Release-job auth | a PAT | GitHub App installation token from `actions/create-github-app-token`, workflow `permissions: contents: read` (`auto-release.yaml:9-10,26-32`) |
+| `fro-bot.yaml` dispatch input | has `correlation-id` | has `prompt` (+ `use-schedule/wiki-prompt`); **no `correlation-id`** |
+| Scripts runtime | bash + `bun:test` | TypeScript via `node --experimental-strip-types`, Vitest (`scripts/release/preview.ts` + `preview.test.ts`) |
+| Bun in release job | n/a | **not available** — Node + pnpm only |
+| The narration skill | `.agents/skills/release-notes-narrative/SKILL.md` exists | **does not exist** in this repo or in the bundled `@fro.bot/systematic` plugin |
+
+## Decisions
+
+### D1 — Runtime and placement (confirmed)
+
+Port to `scripts/release/dispatch-release-notes.ts` (pure, testable logic) plus a thin CLI entry
+(`scripts/release/dispatch-release-notes-cli.ts` or an exported `main`), mirroring the existing
+`preview.ts` / `preview-next-release.ts` split. Run via `node --experimental-strip-types`. No Bun,
+no bash. Tests are Vitest, ported from the 19 structural scenarios.
+
+### D2 — Hook point (confirmed)
+
+Add a `successCmd` to the existing `@semantic-release/exec` plugin in `.releaserc.yaml`, invoking
+the CLI with `${nextRelease.gitTag}`. `successCmd` runs only after a release actually publishes,
+inside the `perform-release` job, so `gh` and the App token are already in scope. The existing
+`verifyReleaseCmd` is preserved.
+
+### D3 — Run identification (confirmed)
+
+Add a `correlation-id` input to `fro-bot.yaml`'s `workflow_dispatch` (audit anchor, forwarded
+verbatim). Primary run identification stays **timestamp-based** (newest `workflow_dispatch` run on
+the dispatch branch created strictly after the pre-dispatch epoch), exactly as Systematic does —
+this is robust against the agent's multi-minute boot time, which defeated log-scanning.
+
+### D4 — Outcome classification (ported as-is)
+
+Preserve the security-vs-narrative precedence:
+
+- **Hard fail (exit 1, `::error::`):** off-target release edit (a `release edit vX.Y.Z` for a tag
+  other than the target), auth-failure keywords (`HTTP 401/403`, `Bad credentials`,
+  `Resource not accessible`, `permission denied`), `action_required`, `skipped` (policy/branch
+  protection), `success` but body shorter than the integrity floor, and any unexpected
+  `gh run watch` exit code.
+- **Soft warn (exit 0, `::warning::`):** dispatch sent but run never confirmed within the poll
+  budget, watch timeout (124), `cancelled`, generic `failure`, unknown conclusion.
+- **Clean exit 0:** `success` with a substantive body; `neutral` (idempotent short-circuit).
+
+The release must never fail because of a narration problem; it must fail when narration shows a
+security signal.
+
+### D5 — The narration procedure / skill (needs a planning decision)
+
+Systematic's prompt tells the agent to "load `.agents/skills/release-notes-narrative/SKILL.md`
+and execute its 13-step procedure." **We have no such skill.** Two options for planning to resolve:
+
+- **D5a — Inline the procedure into the dispatch prompt.** The TS script renders a self-contained
+  prompt describing the narration steps (fetch tag body, idempotency check on a `## What's new`
+  heading, rewrite into prose, apply via `gh release edit`, scope constraints). No new skill file.
+  Simplest; keeps the whole contract in one place; prompt is longer.
+- **D5b — Port/author a `release-notes-narrative` skill** into `.agents/skills/` and have the
+  prompt load it. Mirrors Systematic; reusable; but adds a skill artifact and its own
+  maintenance, and the skill must be present in the checked-out release branch at dispatch time.
+
+Recommendation to carry into planning: **D5a (inline)** for v1 — fewer moving parts, nothing new
+to keep in sync across branches, and the prompt is the natural home for the contract. Revisit a
+skill if the procedure grows.
+
+### D6 — Auth / permissions (must be verified during planning)
+
+`gh workflow run fro-bot.yaml` requires `actions: write`. The release job's App token carries the
+`fro-bot-agent` App's **full installation permissions** (no explicit `permissions:` input on
+`get-app-token`), so whether the dispatch is authorized depends on the App's configured scopes —
+**not verifiable from the repo.** Planning must:
+
+1. Confirm the App grants `actions: write` (and the dispatched narration run has the `contents`/
+   release-edit scope it needs to `gh release edit`), or add the needed scope.
+2. Because authorization is uncertain, the dispatch failure path is **fail-soft** (warn, exit 0):
+   a missing permission degrades to "no narrative this release," never a broken release.
+
+### D7 — Idempotency
+
+The narration is safe to re-run: the agent first checks whether the release body already starts
+with `## What's new` and short-circuits (`neutral`) if so. This protects against re-dispatch and
+manual re-runs.
+
+## Requirements
+
+- **R1** — A `scripts/release/dispatch-release-notes.ts` module with pure, unit-testable logic for
+  tag validation, prompt construction, run selection (timestamp-after-epoch, newest-wins), and
+  outcome classification.
+- **R2** — A thin CLI entry runnable via `node --experimental-strip-types`, taking the target tag
+  as its argument, mirroring `preview-next-release.ts`.
+- **R3** — A Vitest test port of the structural scenarios (validation, classification precedence,
+  run selection, prompt construction, idempotent short-circuit). Prose/skill-specific assertions
+  from the Systematic test are dropped; security and control-flow assertions are kept. Uses the
+  mock-`gh`-on-PATH strategy adapted to Vitest + `node`.
+- **R4** — A `successCmd` in `.releaserc.yaml`'s `@semantic-release/exec`, invoking the CLI with
+  `${nextRelease.gitTag}`, preserving the existing `verifyReleaseCmd`.
+- **R5** — A `correlation-id` `workflow_dispatch` input on `fro-bot.yaml` (audit anchor).
+- **R6** — A self-contained narration prompt (D5a) carrying the idempotency check, the rewrite
+  instruction, the `gh release edit` application step, and explicit scope constraints
+  (edit only the target release; no PR/issue/discussion comments; no file changes; no
+  branches/tags/commits).
+- **R7** — The release step is never failed by a narrative-quality outcome and is always failed by
+  a security-relevant outcome, per D4.
+- **R8** — Test wiring: ensure the new Vitest tests are actually executed in CI (the root `test`
+  script and `vitest.config.ts` cover `scripts/` today; confirm the new files are picked up).
+- **R9** — Documentation: a short note on the narration step in the release docs / AGENTS.md so the
+  behavior and its fail-soft/fail-hard contract are discoverable.
+
+## Non-goals
+
+- No change to *which* releases are cut or to the conventional-commit / version logic.
+- No rollback or re-publish behavior — narration only edits the already-published release body.
+- No narration of pre-1.0 historical releases (forward-only from adoption).
+- No new general-purpose skill unless planning chooses D5b.
+
+## Success criteria
+
+- After a real release publishes, the GitHub Release body is rewritten into a `## What's new`
+  narrative within the watch budget, with the commit list preserved or summarized faithfully.
+- A forced re-dispatch on an already-narrated release short-circuits (`neutral`) and changes
+  nothing.
+- An induced narration failure (e.g. agent error) leaves the release published with its default
+  body and surfaces a `::warning::`, not a failed release.
+- An induced off-target edit or auth failure fails the step with `::error::`.
+
+## Open questions for planning
+
+- **Q1 (D5):** inline prompt vs ported skill — recommendation is inline (D5a).
+- **Q2 (D6):** confirm/grant `actions: write` on the App and the dispatched run's release-edit
+  scope; define the exact fail-soft behavior when the permission is absent.
+- **Q3:** the dispatch `--ref` — Systematic dispatches `fro-bot.yaml` on `main`; our release job is
+  checked out on `release`. Decide which ref the narration run should target (likely `main` so it
+  uses the current agent config, narrating the `release`-tag artifact). Verify the timestamp run
+  selection uses the matching `--branch`.
+- **Q4:** body integrity floor (Systematic uses 200 chars) — confirm a sensible minimum for our
+  releases.

--- a/docs/brainstorms/2026-06-12-harness-github-release-and-action-cutover-requirements.md
+++ b/docs/brainstorms/2026-06-12-harness-github-release-and-action-cutover-requirements.md
@@ -1,0 +1,120 @@
+---
+title: Harness GitHub Release + action cutover (C1)
+status: ready-for-planning
+created: 2026-06-12
+scope: deep
+---
+
+# Harness GitHub Release + action cutover (C1)
+
+## Problem
+
+The Fro Bot action and gateway run **stock** OpenCode downloaded from `anomalyco/opencode` GitHub Releases. The patched `@fro.bot/harness` build (base `1.17.3` + carried upstream refs) is published **only to npm** (main + 4 platform packages via OIDC trusted publishing); no GitHub Release is created. So the action/gateway cannot consume the patched binary the way they already consume stock OpenCode — by downloading a release tarball.
+
+We want the action and gateway to run the **harness** build, distributed through a channel they already know how to consume, without losing the local `bunx @fro.bot/harness` / `mise npm:@fro.bot/harness` ergonomics.
+
+## Scope split
+
+This is **C1**. The workspace executor image (Alpine, needs musl) is **C2 (deferred)** because the harness build does not yet produce musl/baseline Linux assets.
+
+- **C1 (this doc):** harness GitHub Release with generic glibc assets + **action-only** cutover.
+- **C2 (deferred):** add musl/baseline Linux target builds to the harness matrix, then cut the **workspace** over (which is also how the gateway gets the harness — see below).
+
+### The gateway is NOT a C1 consumer (resolved Q3)
+The gateway reaches OpenCode in production purely by **remote-attach** to the workspace proxy (`packages/gateway/src/execute/opencode-attach.ts` → `http://workspace:9200`). It does **not** download or run its own OpenCode binary for the mention loop. (The gateway's bundled `dist` contains `installOpenCode`/`anomalyco/opencode` only because it bundles `@fro-bot/runtime`; that path is never invoked in the gateway runtime.) Therefore the gateway inherits the harness binary **from the workspace** — it cuts over automatically when C2 lands the workspace musl cutover. **C1 requires no gateway change.**
+
+The split is clean: only the **action** downloads a generic glibc linux/darwin binary in C1 (which the current `--single` build already produces); the **workspace** needs musl (C2); the **gateway** rides the workspace.
+
+## Decisions (settled)
+
+### D1 — Dual distribution channels
+The harness publishes to **both**:
+- **GitHub Release** (new) — OpenCode-shaped binary assets the action/gateway download exactly like stock OpenCode today.
+- **npm** (unchanged) — for local `bunx`/`mise` dogfooding.
+
+### D2 — Versioning (npm prerelease + GitHub build-metadata)
+The npm version and the GitHub Release tag encode the same identity in two different forms, forced by npm's SemVer handling (verified: npm strips build metadata on publish — npm/cli #1479, npm #6379 — so `1.17.3+harness.<sha>` collapses to bare `1.17.3` in the registry, is not distinctly installable, and a second integration commit collides as a duplicate).
+
+- **GitHub Release tag** = `v1.17.3+harness.<short8>` (build metadata; `+` is valid in git refs and release-download URL path segments; matches the binary's internal `--version`).
+- **npm version** = `1.17.3-harness.<short8>` (**prerelease** — distinct, installable, republishable per integration commit, `latest`-taggable).
+
+The current publish flow sets bare `1.17.3`, which is **wrong** — indistinguishable from stock OpenCode `1.17.3`. The fix:
+- compute `<base>-harness.<short8>` from the existing `BASE_VERSION` + `INTEGRATION_COMMIT` the publish job already resolves;
+- apply the **identical** prerelease string to all 5 packages (main + 4 platform packages — `optionalDependencies` exact-match requirement);
+- **explicitly set the `latest` dist-tag** to the prerelease (prereleases are excluded from default range/`latest` resolution otherwise).
+
+The `-`/`+` asymmetry is deliberate and forced by npm constraints, not preference.
+
+### D3 — Asset shape (generic glibc only in C1)
+The release reproduces the exact stock asset names the action consumer expects:
+- `opencode-linux-x64.tar.gz`, `opencode-linux-arm64.tar.gz`
+- `opencode-darwin-x64.zip`, `opencode-darwin-arm64.zip`
+
+Each archive contains `opencode` at archive root (matching upstream), repackaged from the existing per-platform build artifacts (`harness-binary-{platform}-{arch}`). **musl/baseline variants are out of scope for C1.**
+
+### D4 — Consumer source swap (not just asset names)
+Consumers currently hardcode `anomalyco/opencode`:
+- `src/services/setup/opencode.ts:9` (`DOWNLOAD_BASE_URL`)
+- `src/services/setup/opencode.ts:161` (`getLatestVersion()` API call)
+
+The action must download the harness binary from `fro-bot/agent` releases at tag `v1.17.3+harness.<short8>`. `DEFAULT_OPENCODE_VERSION` (`packages/runtime/src/shared/constants.ts`) becomes the full harness version. **`getLatestVersion()` rule (resolves Q1):** bypass the stock `anomalyco/opencode/releases/latest` probe entirely for harness pins — never silently resolve a stock "latest" when the active version is a harness build (`opencode.ts:161` always queries the stock latest today, a real misroute bug the cutover must fix).
+
+**Edit surface (resolves Q2):** the shared constant `DEFAULT_OPENCODE_VERSION` lives in `packages/runtime/src/shared/constants.ts` and is the single version source of truth consumed by the action's setup path. C1 edits that constant + the download-source logic in `opencode.ts` (both action-tier `src/features/agent` and runtime-tier consume the same constant; no separate pin). This is still "action-only" in the sense that no gateway/workspace runtime behavior changes — the runtime *package* is where the shared constant happens to live.
+
+### D5 — Consumer bump is MANUAL in C1 (automation deferred)
+Document-review (5/6 reviewers) found release-side consumer-bump automation is over-built for C1's single consumer, and feasibility proved it is **not implementable** from the release workflow as written (it has `contents: read` / `id-token: write` only — no `pull-requests: write`, no PR-capable token). For C1's one consumer (the action), a **manual one-line pin bump** is correct. Automation is deferred to C2, where a second consumer (the workspace) and a PR-capable credential justify it. No moving `latest` tag for production consumers (reproducibility).
+
+### D9 — Stock fallback preserved (safety)
+The action's installer falls back to `FALLBACK_VERSION = DEFAULT_OPENCODE_VERSION` on download failure. If `DEFAULT_OPENCODE_VERSION` becomes the harness version, a missing/broken harness release would leave **no escape hatch** — every production run fails. C1 must preserve an explicit **stock `anomalyco/opencode` fallback**: on harness download/verify failure, attempt the stock binary before hard-failing.
+
+### D10 — Download integrity verification (safety/supply-chain)
+The release-binaries job repackages artifacts from the **untrusted** build job (runs the LLM-merged upstream build). C1 must verify integrity end-to-end: the release job validates each asset's digest against the existing harness `provenance.json` (`buildSha`/`integrationCommit`) before publishing, and the action verifies the downloaded binary against a published checksum before execution. (Preserve/parity any integrity check the stock path has today.)
+
+### D11 — All-or-nothing release gate (safety)
+The harness GitHub Release must be created only after **all four** expected platform assets are present and verified. A partial (3/4) release must fail the workflow, not publish a release that installs fine on three platforms and fails on the fourth at runtime.
+
+### D6 — Remove the redundant `npm-publish` environment — gated
+`environment: npm-publish` on the publish job adds a GitHub deployment record + approval gate but contributes nothing the OIDC publish needs (tokenless; no env-scoped secrets — verified). Remove it **only after verifying** the npmjs.com trusted-publisher config for all 5 packages is **not bound** to the environment name `npm-publish`; if it is, removing the workflow environment breaks OIDC publishing. Keep `id-token: write`.
+
+### D7 — Release job permission isolation
+The release-binaries step needs `contents: write`. It must **not** live in the untrusted `build` job (which runs the LLM-merged upstream build and is deliberately read-only / no `id-token`). Structure:
+- `build` — `contents: read`, no `id-token` (unchanged).
+- `release-binaries` (new) — `needs: build`, `contents: write`, **no** `id-token`; downloads artifacts, repackages OpenCode-shaped assets, creates the GitHub Release.
+- `publish-npm` — `needs: build`, `id-token: write`, `contents: read`.
+
+### D8 — Windows
+Harness-backed OpenCode is **linux/darwin only**. Document explicitly; the action's Windows download path remains stock-only / unsupported for harness.
+
+## Requirements
+
+- **R1** Harness-release workflow creates a GitHub Release tagged `v<base>+harness.<short8>` with generic glibc assets (`opencode-{linux-x64,linux-arm64}.tar.gz`, `opencode-{darwin-x64,darwin-arm64}.zip`), repackaged from build artifacts, archive root = `opencode`.
+- **R2** New `release-binaries` job: `needs: build`, `contents: write`, no `id-token`; isolated from build and npm publish.
+- **R3** Action (`opencode.ts`) downloads from `fro-bot/agent` harness releases; `DOWNLOAD_BASE_URL` + version handling point at the harness release; `getLatestVersion()` bypasses stock-latest for harness pins (D4 / Q1).
+- **R4** `DEFAULT_OPENCODE_VERSION` becomes `1.17.3+harness.<short8>` (single shared constant; D4 / Q2). The gateway needs no change in C1 (remote-attach; rides the workspace in C2).
+- **R5** npm version becomes the prerelease `<base>-harness.<short8>` across all 5 packages with the `latest` dist-tag explicitly set to it (D2). Replaces the wrong bare `1.17.3`.
+- **R6** Pre-removal verification gate for the npm trusted-publisher environment binding; remove `environment: npm-publish` only if safe, else keep + document.
+- **R7** Workspace Dockerfile is **untouched** in C1 — stays on stock `anomalyco/opencode` musl assets until C2.
+- **R8** Stock `anomalyco/opencode` fallback preserved (D9): harness download/verify failure attempts the stock binary before hard-failing.
+- **R9** Download integrity verification (D10): release job validates assets against `provenance.json`; action verifies the downloaded binary against a published checksum before execution.
+- **R10** All-or-nothing release gate (D11): release fails unless all four platform assets are present and verified.
+- **R11** Windows posture documented as unsupported for harness.
+
+## C2 exit criteria (so the split doesn't stall)
+C2 is committed, not open-ended. C2 lands when: (a) the harness matrix builds the musl/baseline Linux targets (`opencode-linux-x64-baseline-musl.tar.gz`, `opencode-linux-arm64-musl.tar.gz`); and (b) `deploy/workspace.Dockerfile` is cut over to download those from the harness release. Completing C2 also automatically moves the gateway onto the harness (it remote-attaches to the workspace). Until C2, production runs a **mixed fleet**: action on harness, workspace+gateway on stock — an accepted, documented interim state, not the end state. Consumer-bump automation (deferred D5) is built in C2 when the workspace becomes the second consumer.
+
+## Out of scope (C2 / later)
+- musl/baseline Linux target builds in the harness matrix.
+- Workspace executor + gateway cutover to harness.
+- Consumer-bump PR automation (needs `pull-requests: write` + a second consumer).
+- Windows harness builds.
+
+## Open questions for planning
+- Q1 — **RESOLVED** (D4): bypass stock-latest for harness pins.
+- Q2 — **RESOLVED** (D4): single shared `DEFAULT_OPENCODE_VERSION` constant; action + download logic only.
+- Q3 — **RESOLVED:** gateway uses remote-attach; C1 is action-only, gateway rides the workspace in C2.
+
+## Risks
+- Removing `environment: npm-publish` without verifying npm-side binding breaks publishing (R6 gate).
+- A harness release lacking musl assets must not be consumed by the workspace (R7).
+- `+` in the GitHub tag/URL: start with `v<base>+harness.<sha>`; fallback to `%2B` encoding or `-harness.<sha>` tag form if tooling chokes. Validate the tag→release→download path end-to-end before locking.
+- Same-base re-integration: a new integration commit off base `1.17.3` gets a new npm prerelease + new GitHub tag cleanly; the bare-`1.17.3` collision that motivated D2 is removed.

--- a/docs/brainstorms/2026-06-13-workspace-harness-cutover-requirements.md
+++ b/docs/brainstorms/2026-06-13-workspace-harness-cutover-requirements.md
@@ -1,0 +1,115 @@
+---
+title: "Workspace/gateway cutover to the harness OpenCode binary (C2)"
+type: requirements
+status: ready-for-planning
+date: 2026-06-13
+---
+
+# Workspace/gateway cutover to the harness OpenCode binary (C2)
+
+## Problem & Goal
+
+The GitHub Action now runs the patched harness OpenCode build by default (PR #884). The deployed gateway's **workspace executor image** still bakes **stock** OpenCode from `anomalyco/opencode`. C2 completes the harness rollout: the workspace executor (which runs the agent for the `@fro-bot` mention loop) should run the same patched harness binary the action does, so carried upstream patches apply consistently across both surfaces.
+
+The gateway process itself needs no change — it remote-attaches to the workspace OpenCode proxy and bakes no binary.
+
+## Background (verified)
+
+- The workspace image is **Alpine-based** and bakes **musl** OpenCode variants: `opencode-linux-x64-baseline-musl.tar.gz` (amd64, AVX2-independent baseline) and `opencode-linux-arm64-musl.tar.gz` (arm64). Source: `deploy/workspace.Dockerfile:51-65`.
+- The harness build (`packages/harness/scripts/build-platform.ts:245`) invokes upstream `build.ts --single`, which builds only the current platform and **skips abi-specific (musl) targets**, defaulting to **glibc** (`FFF_LIBC: "gnu"`). Source: `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/script/build.ts:116-129,190,196`.
+- Therefore the harness release publishes **generic glibc** assets (`opencode-linux-x64.tar.gz`, `opencode-linux-arm64.tar.gz`, darwin zips, `SHA256SUMS`) — no `-musl`/`-baseline` variants. Source: `.github/workflows/harness-release.yaml:495-547`.
+- A glibc binary **will not run on the workspace's Alpine (musl) base.** So C2 is not a simple repoint — the harness must additionally produce musl/baseline Linux assets.
+- The gateway image bakes no OpenCode binary. Source: `deploy/gateway.Dockerfile`.
+- The workspace `OPENCODE_VERSION` is Renovate-tracked against `anomalyco/opencode`. Source: `.github/renovate.json5:84-92`.
+
+## Approach (decided)
+
+**Extend the harness release to publish both libc flavors, then repoint the workspace.**
+
+The harness Linux build additionally produces **musl + x64-baseline** variants and publishes them as new release assets, **without disturbing** the existing generic glibc assets the action just cut over to (#884). Each consumer gets the right libc:
+- **Action** → glibc `opencode-linux-{x64,arm64}.tar.gz` (runs on the glibc GitHub Actions runner). Unchanged.
+- **Workspace** → musl `opencode-linux-x64-baseline-musl.tar.gz` + `opencode-linux-arm64-musl.tar.gz` (runs on Alpine).
+
+## Requirements
+
+- **R1.** The harness release publishes, in addition to the existing generic glibc Linux assets, `opencode-linux-x64-baseline-musl.tar.gz` and `opencode-linux-arm64-musl.tar.gz` built from the same pinned integration commit, with version `--version` reporting `<base>+harness.<sha>`.
+- **R2.** The new musl/baseline assets are included in the release `SHA256SUMS`.
+- **R3.** `deploy/workspace.Dockerfile` downloads the OpenCode binary from `fro-bot/agent` harness releases (not `anomalyco/opencode`), using the `+harness.<sha>` version (URL-encoding `+` as `%2B`, matching the action's C1 download pattern), keeping the existing musl/baseline asset names.
+- **R4.** The workspace download verifies the asset against the release `SHA256SUMS` before use (fail-closed), matching the action's harness-download posture — an upgrade from today's unchecked `curl | tar`.
+- **R5.** The workspace `OPENCODE_VERSION` pin stays **independently controllable** (not coupled to the action's self-update). Its Renovate manager retargets to the `fro-bot/agent` harness release channel, and the workspace can be reverted to a prior release without touching the action's harness SHA. This preserves the lag/rollback safety valve the action/workspace split was designed for.
+- **R6.** The existing action glibc download path (PR #884) is unchanged.
+- **R7.** The gateway image and process are unchanged.
+- **R8.** Verification goes beyond `--version`: the `Workspace Image Smoke Test` proves the musl harness binary boots on Alpine AND exercises a real execution path (e.g. launches the binary in the production server mode and verifies one real interaction), because `--version` does not catch libc-loader mismatches, runtime syscall/path issues, or mention-loop regressions.
+- **R9.** The release workflow's Linux asset handling — download, existence gate, repackaging, `SHA256SUMS`, and upload — is expanded from the current 4-asset world to include the new musl/baseline assets at every step (the workflow is currently hardcoded around exactly 4 assets).
+- **R10.** Workspace download fail-closed semantics are explicit: any download, `SHA256SUMS` fetch, hash mismatch, partial download, or 404 aborts the build/startup with **no fallback** to a cached or pre-existing binary. Smoke coverage includes a hash-mismatch / missing-checksum negative path.
+
+## Scope Boundaries
+
+**In scope:** harness Linux build matrix gains musl + x64-baseline targets; release workflow packages/checksums/publishes the new assets; workspace Dockerfile repoint + checksum verification; workspace version-pin/Renovate update; workspace smoke verification.
+
+**Out of scope / unchanged:** the action glibc path (#884); the gateway (no binary bake); the SDK pin; darwin assets (workspace is Linux-only); the harness npm packages (those wrap the action-facing binary, not the workspace).
+
+## Spike Result (resolved 2026-06-13)
+
+The build contract is now proven against upstream `build.ts` (`.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/script/build.ts:53-135`):
+
+- `allTargets` already includes `linux-x64-baseline-musl` (`arch:x64, abi:musl, avx2:false`), `linux-arm64-musl` (`arch:arm64, abi:musl`), and `linux-x64-musl` — the matrix entries exist.
+- **`--single` CANNOT emit musl.** Lines 116-135: `--single` filters to the current platform/arch, includes baseline only if `--baseline` is passed, and **unconditionally skips `abi:"musl"`** (lines 129-131) with no flag to include it. Without `--single`, `build.ts` builds the **entire 12-target matrix** (all OS/arch/abi/baseline combos).
+- The harness build matrix (`.github/workflows/harness-release.yaml:213-228`) is **per-platform**: `linux/x64`→ubuntu-24.04, `linux/arm64`→ubuntu-24.04-arm, darwin→macOS. Each runs `build-platform.ts --platform X --arch Y` → `build.ts --single`.
+
+**Implication for planning (build-invocation fork, real tradeoff):** to emit the workspace's musl/baseline Linux assets, the harness Linux build cannot keep using bare `--single`. Options for planning to choose:
+1. **Extend `build-platform.ts` + matrix with explicit variant selection** (`--abi musl`, `--baseline`) and invoke `build.ts` so it produces exactly that one target. Requires `build.ts` to honor explicit single-target selection — which it does NOT today (`--single` is hard-coded to current-platform-glibc). This likely needs a **harness carry patch** to `build.ts` adding an explicit-target mode, or driving the non-`--single` path filtered to one target.
+2. **Run the non-`--single` full matrix on the Linux runners** and package only the wanted Linux musl assets — simpler invocation, but builds extra unused targets (cost: measure the CI wall-clock delta; the "incremental compile" claim remains unmeasured).
+The matrix would also grow new Linux entries (x64-glibc kept for the action; x64-baseline-musl + arm64-musl added for the workspace). Planning must pick the invocation strategy and measure CI cost via a dry-run before locking build units.
+
+## Key Technical Decisions
+
+- **Both libc flavors published — framed as a compatibility constraint, not a goal.** The workspace cutover only *needs* musl/baseline assets; the existing generic glibc assets are kept **solely** to avoid breaking the action path PR #884 just shipped. This is a deliberate compatibility hedge, not core scope; if the action path were ever migrated to musl, the glibc assets could drop.
+- **x64-baseline retained for the workspace.** Matches OpenCode's own image and keeps the image runnable on any x86 host regardless of the build runner's CPU features.
+- **Per-platform native build retained.** The harness build runs per-platform on native runners; the cleanest way to add musl is to have the Linux runners additionally build the musl/baseline targets (upstream `build.ts` already encodes `abi:"musl"` and `baseline` targets) rather than dropping `--single` and cross-building the whole matrix on one runner.
+
+## Open Questions
+
+### Resolved During Brainstorm
+
+- Is C2 a simple repoint? — No; the harness must produce musl/baseline assets first (verified glibc-only today).
+- Does the gateway need a binary change? — No (no bake; remote-attach).
+- musl-only or both libc flavors? — Both, as a compatibility constraint to avoid disturbing the action (#884).
+- Workspace pin coupling? — Independent (R5); preserves the rollback safety valve.
+
+### Resolved — Cutover Value Confirmed
+
+- **Is the workspace cutover valuable, or parity-for-parity's-sake? → VALUE (verified 2026-06-13).** All three carried harness patches affect the workspace mention-loop execution path (3/3 affect workspace, 0/3 action-only):
+  - **#19961 (session-transform ordering)** touches `session/prompt.ts`, `compaction.ts`, `llm.ts`, `llm/request.ts` — all on the `session.promptAsync` path the gateway drives on every mention-loop turn (`packages/gateway/src/execute/run-core.ts:243-300`).
+  - **#31859 (plugin runtime)** touches `plugin/index.ts` startup loading; the workspace bakes `@fro.bot/systematic` as a plugin (`deploy/workspace.Dockerfile:67-75`), so it exercises this runtime.
+  - **#31638 (compaction hydration)** touches `message-v2.ts` model conversion, hitting long-running workspace mention-loop sessions.
+  The workspace runs the same core session/plugin/compaction code these patches fix, so the cutover buys real behavior fixes, not aesthetic consistency. C2 is justified.
+
+### Security / Threat Model
+
+- Moving the workspace binary source from upstream `anomalyco/opencode` to our **self-built** `fro-bot/agent` harness release shifts the trust boundary onto our LLM-merge build/publish pipeline. `SHA256SUMS` (same-release) proves integrity-in-transit, **not** provenance. Blast radius is bounded by the workspace `sandbox-net` + mitmproxy egress containment, but planning should note the trust-boundary shift explicitly. Input validation (allowlisted version/asset names, no shell interpolation, extracted-path containment) applies to the new download path.
+
+### Deferred to Planning
+
+- **How exactly to parameterize the harness Linux build** to emit musl + x64-baseline alongside (or instead of) the generic glibc output on the Linux runners: does `build.ts --single` accept libc/baseline selection, or does the harness build need explicit per-target invocations? Requires reading upstream `build.ts` target logic and the harness build matrix in `harness-release.yaml`. Confirm CI build time/cost of the extra Linux targets.
+- **Workspace version-pin story:** the action's self-update PR (#884) bumps only `DEFAULT_OPENCODE_VERSION`. Should the same self-update extend to bump the workspace `ARG OPENCODE_VERSION`, or does the workspace stay on its own Renovate/manual pin? (The workspace deliberately lagged the action during the 1.15.13/1.17.3 cutovers — coupling them removes that safety valve.)
+- **Asset naming consistency** between upstream's emitted names and what the harness packaging/release step attaches (the harness currently renames to generic `opencode-<os>-<arch>`; musl/baseline assets must carry the suffixes the workspace expects).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| musl/baseline build fails or is mis-targeted on CI | Dry-run the harness release; verify `--version` + `file`/`ldd` libc on each new asset before publish |
+| Workspace gets a glibc binary by mistake (won't boot on Alpine) | Smoke test (R8) catches it; checksum + explicit musl asset name |
+| Coupling workspace pin to action self-update removes the lag safety valve | Decide in planning; default to keeping the workspace pin independent |
+| Extra Linux build targets increase release CI time/cost | Measure in the dry-run; baseline+musl are incremental compiles on existing runners |
+
+## Sources & References
+
+- Memory 5392 (C2 gap analysis, verified).
+- `deploy/workspace.Dockerfile:41-65`, `deploy/gateway.Dockerfile`.
+- `packages/harness/scripts/build-platform.ts:219-320`.
+- `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/script/build.ts:116-240`.
+- `.github/workflows/harness-release.yaml` (Release Binaries / publish jobs).
+- `.github/renovate.json5:84-92`.
+- PR #884 (action harness cutover, C1 download/checksum pattern).

--- a/docs/brainstorms/2026-06-15-gateway-control-surface-phase-b-requirements.md
+++ b/docs/brainstorms/2026-06-15-gateway-control-surface-phase-b-requirements.md
@@ -1,0 +1,176 @@
+---
+date: 2026-06-15
+topic: gateway-control-surface-phase-b
+---
+
+# Gateway control surface Phase B requirements
+
+## Summary
+
+Phase B adds an authenticated web operator control surface for the Gateway. It lets approved human operators launch work, observe run state, and approve or reject tool requests through the same execution and approval spine Discord already uses.
+
+---
+
+## Problem Frame
+
+The Gateway can already run Fro Bot work from Discord and settle OpenCode permission requests through Discord approvals. Phase A extracted the shared execution and approval seam so non-Discord transports can use the same queue, concurrency, and fail-closed permission model.
+
+The web side is still missing. The existing HTTP surface is HMAC-authenticated announce ingress, not browser operator control. A dashboard or web console cannot safely launch work, stream status, or settle approvals until the Gateway has a dedicated authenticated operator surface with a real human identity boundary.
+
+---
+
+## Actors
+
+- A1. Web operator: a GitHub-authenticated human present in the configured operator allowlist.
+- A2. Gateway: the trusted first-party service that owns run coordination, approval settlement, and coarse user-facing errors.
+- A3. Discord operator: an existing Discord user path that must keep working through the shared execution and approval spine.
+- A4. Workspace/container caller: an untrusted network neighbor that must not gain a new egress bypass through the web surface.
+- A5. Operator web client: the first-party browser surface used by an authenticated operator.
+
+---
+
+## Key Flows
+
+- F1. Web-launched work
+  - **Trigger:** An allowed web operator submits work for a bound repository.
+  - **Actors:** A1, A2, A5
+  - **Steps:** The operator authenticates, chooses a bound repository, submits work, and receives status updates while the Gateway runs the work through the shared execution front door.
+  - **Outcome:** The run follows the same queue, concurrency, shutdown, and failure semantics as Discord-launched work.
+  - **Covered by:** R1, R2, R3, R6, R10, R11
+- F2. Web approval decision
+  - **Trigger:** A running OpenCode session asks for a tool permission.
+  - **Actors:** A1, A2, A3
+  - **Steps:** The Gateway exposes the pending approval to authorized operators, accepts the first valid decision, and settles it through the shared approval registry.
+  - **Outcome:** Approval behavior remains fail-closed and single-winner across Discord and web transports.
+  - **Covered by:** R7, R8, R9
+- F3. Run state observation
+  - **Trigger:** A web operator opens an active or recent run.
+  - **Actors:** A1, A2, A5
+  - **Steps:** The client reads a bounded run-status taxonomy, receives progress updates, and sees terminal status without access to secrets or raw internal payloads.
+  - **Outcome:** The operator can understand what the Gateway is doing without bypassing the agent or workspace trust boundary.
+  - **Covered by:** R7, R10, R11, R12
+- F4. Read-only bindings lookup
+  - **Trigger:** The operator web client needs Gateway repo-to-Discord binding data to support repo selection or dashboard state.
+  - **Actors:** A1, A2, A5
+  - **Steps:** The authenticated surface exposes binding reads scoped to the operator and requested repository context without exposing create, update, or delete operations.
+  - **Outcome:** The operator can see relevant binding state while v1 keeps binding mutation out of the web surface.
+  - **Covered by:** R18, R19, R20
+
+---
+
+## Requirements
+
+**Operator access**
+- R1. The web surface is available only to GitHub-authenticated humans who are present in a configured operator allowlist.
+- R2. Operator sessions must have explicit lifetime, logout, and revocation semantics.
+- R3. State-changing browser requests must be protected against CSRF and invalid origins.
+- R4. The web surface rejects unauthenticated users, unauthorized users, expired sessions, and invalid browser-origin requests without disclosing sensitive internal state.
+- R5. Phase B v1 excludes standalone machine/API callers, long-lived API tokens, and agent-to-agent orchestration.
+
+**Execution and approval semantics**
+- R6. Web-launched work must enter the same public execution front door used by Discord-launched work.
+- R7. Web approvals must settle through the same fail-closed approval registry used by Discord approvals.
+- R8. Approval settlement must remain single-winner across transports, stale tabs, retries, and replayed decision submissions.
+- R9. Approval states must distinguish pending, already settled, expired, failed to settle, and unavailable cases for the operator.
+- R10. Web launch must prevent accidental duplicate submissions and make empty, unbound, or disabled repository states visible before work starts.
+- R11. The web surface must expose a bounded run status taxonomy covering queued, running, waiting for approval, blocked, failed, cancelled, and succeeded states.
+- R12. Run progress must use a safe-field allowlist and must not expose raw workspace paths, tool arguments, prompts, internal URLs, tokens, or secret-bearing payload fragments.
+
+**Security and trust boundary**
+- R13. The control surface must preserve the Gateway ingress and egress trust boundary; workspace-reachable callers must not be able to use it as an outbound proxy or privileged command channel.
+- R14. Operator actions must be attributable to a stable operator identity, including launch, run-state reads, binding reads, approve, reject, and failed authorization attempts.
+- R15. User-facing errors must stay coarse, while internal logs keep enough structured context to diagnose auth, queue, run, approval, and transport failures.
+- R16. Audit records for auth, launch, approval, rejection, and authorization failures must have a defined retention and protection story.
+- R17. The surface must avoid logging raw prompts, request bodies, bearer tokens, session secrets, raw tool payloads, and internal URLs by default.
+
+**Read-only bindings support**
+- R18. The authenticated surface may expose read-only Gateway binding data needed for operator repo selection or dashboard state.
+- R19. Binding reads must be scoped so an allowed operator cannot enumerate unrelated repositories by default.
+- R20. Binding writes, binding deletes, repo onboarding, and binding repair are out of scope for Phase B v1.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R4.** Given a GitHub-authenticated user who is not in the operator allowlist, when they attempt to open or use the web control surface, the Gateway rejects the request with a coarse authorization failure and records a structured denial.
+- AE2. **Covers R2, R3.** Given an allowed operator with an expired session or invalid browser origin, when they submit a launch or approval request, the Gateway rejects the request before changing run or approval state.
+- AE3. **Covers R5.** Given a caller with only an API token and no browser operator session, when it attempts to launch work, the Gateway rejects it because standalone machine callers are not included in Phase B v1.
+- AE4. **Covers R6, R13.** Given an allowed operator launches work for a bound repository, when the run starts, it uses the shared execution front door and cannot bypass the queue or global concurrency cap.
+- AE5. **Covers R7, R8, R9.** Given a permission request visible in Discord and web, when the web operator approves first, stale Discord or web submissions cannot reverse or duplicate the decision and see an already-settled state.
+- AE6. **Covers R10.** Given an operator selects an unbound or disabled repository, when they attempt to submit work, the web surface explains the blocked state before a run starts.
+- AE7. **Covers R11, R12, R15, R17.** Given an active run fails because the workspace is unavailable, when the operator views the run, they see a coarse failure while logs retain structured internal cause without secrets.
+- AE8. **Covers R18, R19, R20.** Given the operator web client reads repo binding data, when it uses the authenticated surface, it can list or retrieve scoped bindings but cannot create or modify them.
+
+---
+
+## Success Criteria
+
+- Approved operators can launch and observe Gateway work from the web without changing Discord behavior.
+- Web and Discord approvals share the same fail-closed registry, so no transport can bypass permission settlement.
+- The web surface has a concrete human auth boundary with revocation and browser-origin protection.
+- The ingress and egress boundary remains documented, tested, and reviewable before any listener or topology change ships.
+- If included in Phase B, the operator web client can consume read-only binding data without introducing binding mutation in v1.
+- A downstream planner does not need to invent actor scope, auth scope, approval semantics, or v1 non-goals.
+
+---
+
+## Scope Boundaries
+
+- No machine/API callers in Phase B v1.
+- No agent-to-agent orchestration.
+- No dashboard UI implementation in this repo.
+- No binding writes, binding deletes, or repo onboarding from the web surface.
+- No general Gateway API proxy and no raw workspace/OpenCode API proxy.
+- No Discord behavior changes.
+- No weakening of the ingress-pin boundary without a documented security rationale and matching tests.
+- No persistent approval recovery unless it is deliberately added in planning.
+
+---
+
+## Key Decisions
+
+- **Configured allowlist for v1:** The first web operator surface uses GitHub identity plus an explicit allowlist to minimize blast radius.
+- **One execution spine:** Web-launched work uses the shared execution front door so queueing, concurrency, and shutdown semantics stay centralized.
+- **One approval gate:** Web approvals reuse the same fail-closed registry as Discord approvals instead of adding a parallel gate.
+- **Separate control-surface trust boundary:** The web surface is security-critical and must not be treated as an extension of HMAC announce ingress.
+- **Read-only bindings may ride Phase B:** Binding reads can be included as Phase-B-adjacent support if they remain scoped, read-only, and use the same authenticated operator surface.
+
+---
+
+## Dependencies / Assumptions
+
+- Phase A shipped the transport-neutral execution and approval seam via `launchWork`, transport sinks, and a generalized approval registry.
+- The preferred topology is a separate web listener or interface that is not reachable from the workspace sandbox network.
+- The deploy topology in `marcusrbrown/infra` must support the chosen listener and network boundary.
+- The operator allowlist source of truth must be configurable and auditable.
+- The state-stream transport can be chosen during planning as long as it supports active observation and safe failure behavior.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1, R2, R3][Technical] What is the exact GitHub login/session mechanism and cookie or token shape?
+- [Affects R1, R14, R16][Technical] Where does the operator allowlist live, and how is it updated or revoked?
+- [Affects R11, R12][Technical] Should run progress use SSE, WebSocket, or polling for v1?
+- [Affects R13][Needs research] Which deploy topology keeps the web surface off the workspace sandbox network with the least operational risk?
+- [Affects R18, R19][Technical] Does the binding read path ship in the same first implementation PR as launch/status/approval, or as a follow-up on the same authenticated surface?
+
+---
+
+## Sources / Research
+
+- Tracking issue: https://github.com/fro-bot/agent/issues/907
+- Existing brainstorm: `docs/brainstorms/2026-06-15-gateway-control-surface-spine-requirements.md`
+- Phase A plan: `docs/plans/2026-06-15-001-feat-gateway-control-surface-spine-phase-a-plan.md`
+- Spine pattern doc: `docs/solutions/best-practices/gateway-control-surface-spine-2026-06-15.md`
+- Signed ingress hardening: `docs/solutions/best-practices/signed-webhook-ingress-hardening-2026-05-29.md`
+- Compose topology hardening: `docs/solutions/best-practices/compose-topology-egress-guard-hardening-2026-06-14.md`
+- Mention-loop best practices: `docs/solutions/best-practices/gateway-opencode-mention-loop-best-practices-2026-05-30.md`
+- Current execution seam: `packages/gateway/src/execute/run.ts`
+- Launch contracts: `packages/gateway/src/execute/launch-types.ts`
+- Approval registry and coordinator: `packages/gateway/src/approvals/registry.ts`, `packages/gateway/src/approvals/coordinator.ts`
+- Current HTTP announce auth: `packages/gateway/src/http/server.ts`, `packages/gateway/src/http/hmac.ts`
+- Ingress boundary pin: `packages/gateway/src/http/ingress-pin.test.ts`
+- Bindings store: `packages/gateway/src/bindings/store.ts`

--- a/docs/brainstorms/2026-06-15-gateway-control-surface-spine-requirements.md
+++ b/docs/brainstorms/2026-06-15-gateway-control-surface-spine-requirements.md
@@ -1,0 +1,93 @@
+---
+date: 2026-06-15
+topic: gateway-control-surface-spine
+---
+
+# Gateway inbound control surface + operator web auth (the spine)
+
+## Problem Frame
+
+The gateway (`packages/gateway`) is the live presence and execution engine for Fro Bot. Today every way to command it or approve its actions flows through Discord: `/fro-bot` slash commands, `@fro-bot` mention-triggered runs (`runMention`), and OpenCode `permission.asked` → Discord approval buttons. Its only inbound HTTP surface is `POST /v1/announce` (outbound presence announcements: `survey_completed` / `invitation_accepted` / `daily_digest`), authenticated by shared-secret HMAC over the raw body — there is no user/session auth and no inbound command, state, or query API.
+
+This blocks the broader vision (see `fro-bot/.github` `docs/brainstorms/2026-06-15-fro-bot-personal-agent-north-star-requirements.md`): an operator dashboard that can launch work and approve actions from the web, push notifications with action handling, and agent-to-agent coordination all need an authenticated inbound web control surface. A read-only monitoring dashboard is already being built (`fro-bot/dashboard`), but its third data population — gateway repo↔Discord bindings — has no read path out of the gateway today.
+
+This brainstorm scopes the spine: the inbound control surface, operator web auth, the transport-agnostic execution/approval refactor it requires, and a bindings read path. Tracking issue: [fro-bot/agent#907](https://github.com/fro-bot/agent/issues/907).
+
+## Requirements
+
+### Grounded constraints (verified current facts)
+
+- **The ingress-pin constraint (load-bearing):** `packages/gateway/src/http/ingress-pin.test.ts` statically scans gateway source and asserts exactly one `serve()` call, located in `server.ts`. Rationale: the gateway is workspace-reachable over sandbox-net, so any new inbound listener could reopen the egress trust boundary (a workspace-reachable endpoint doing outbound requests would let the workspace bypass the mitmproxy egress filter). A new control surface must therefore be a separate listener on a non-sandbox-net interface (preferred) OR a deliberately-reviewed `EXPECTED_ROUTES`/pin update + deploy/README egress-topology update + security review. This is a hard architectural gate, not a detail.
+- **Execution is Discord-coupled:** `packages/gateway/src/execute/run.ts` exports `runMention(message: Message, binding: RepoBinding, deps)` — the entry point still takes a Discord `Message`. `packages/gateway/AGENTS.md` explicitly notes that mention-triggered execution and `addProject` are Discord-only and that a Discord-independent execution primitive is "deferred until a non-Discord caller exists." This spine is that caller.
+- **Approvals are Discord-hard-coupled:** `packages/gateway/src/approvals/coordinator.ts` and `registry.ts` bridge OpenCode `permission.asked`/`replied` to Discord buttons. The coordinator/registry are not transport-agnostic yet. Fail-closed semantics exist (timeout/restart → reject/dispose). A web approval path must reuse the same fail-closed gate by construction, not a parallel one.
+- **Auth is HMAC-only:** `packages/gateway/src/http/hmac.ts` (raw-body HMAC, `REPLAY_WINDOW_MS=5min`, constant-time, fail-closed) + `config.ts` secret loading (`readSecret`/`readMultilineSecret`, `*_FILE` precedence, `O_NOFOLLOW`). No user/session/browser-auth concept exists anywhere — operator web auth is genuinely net-new.
+- **Bindings store:** `packages/gateway/src/bindings/store.ts` `createBindingsStore({adapter, storeConfig, identity})` exposes `createBinding` / `getBindingByRepo` / `getBindingByChannelId` / `listBindings` (create/read/list only, no delete/update), S3-backed via `@fro-bot/runtime` `ObjectStoreAdapter`. `RepoBinding = {owner, repo, channelId, channelName, workspacePath, createdAt, createdByDiscordId}`. There is no HTTP/read surface exposing bindings outside the gateway process today.
+- **`@fro-bot/runtime` scope:** `packages/runtime` (`private: true`) exports shared/session/coordination/object-store/agent primitives. The gateway's HTTP/Hono primitives (server bootstrap, HMAC, replay-cache, rate-limit) and the GitHub App client are still gateway-local, not extracted. Extraction is related future work, not in scope here.
+
+### Phase A — Transport-agnostic execution + approval extraction
+
+_No new listener, no new auth. The prerequisite every web path needs and the "non-Discord caller" the `AGENTS.md` note defers to._
+
+- A1. Extract a transport-agnostic `launchWork(request, deps)` core from `runMention` so both the Discord path and a future web caller invoke the same execution engine. `runMention` becomes a thin Discord adapter over it.
+- A2. Generalize the approval coordinator/registry so a decision can arrive from Discord OR a future web operator surface, preserving fail-closed/timeout/restart semantics by construction — one gate, multiple transports.
+- A3. No behavior change to the Discord experience. This is a refactor that adds a seam, not a feature.
+- A4. The new `launchWork` seam and the generalized approval gate are covered by tests before Phase B begins.
+
+### Phase B — Inbound web control surface (S1) + operator web auth (S2)
+
+_Depends on Phase A._
+
+- B1. A separate authenticated inbound listener — honoring the ingress-pin egress boundary (separate interface/port, not sandbox-net-reachable; or a deliberately-reviewed pin update) — exposing: launch a unit of work, query run/agent state, stream state back.
+- B2. Operator web auth (S2): a real browser auth/session model (operator identity, sessions, revocation, CSRF/origin binding) replacing shared-secret-HMAC-only for this surface. The security keystone, treated as first-class hard work, not Discord parity.
+- B3. Web-launched work routes through the same fail-closed approval gate as Discord work (depends on A2). No parallel approval path.
+- B4. The ingress-pin constraint is either honored (separate listener on a non-sandbox-net interface) or deliberately and reviewably updated with a documented egress-topology rationale.
+
+### Phase C — Bindings read path
+
+_Unblocks the dashboard's third data population. Depends on Phase B's authenticated surface or ships as a minimal read endpoint._
+
+- C1. A read surface for gateway bindings (`listBindings` / `getBindingByRepo`) consumable by the dashboard — either via the authenticated control surface from Phase B, or a minimal read endpoint, honoring the same egress/auth boundaries.
+- C2. No write or create capability over this path in v1.
+
+## Success Criteria
+
+- Each phase is independently shippable and reviewable.
+- Phase A ships with zero Discord behavior change; the new `launchWork` core and generalized approval gate are covered by tests.
+- The ingress-pin constraint is either honored (separate listener) or deliberately and reviewably updated — never silently bypassed.
+- Web auth is real session auth (operator identity, sessions, revocation, CSRF/origin binding), not shared-secret HMAC repurposed for a browser.
+- Web-launched work cannot bypass the fail-closed approval gate; the same coordinator/registry handles all transports.
+- The bindings read path exposes no write capability.
+
+## Scope Boundaries
+
+- **Not in scope:** building the dashboard app (`fro-bot/dashboard` is a separate repo and effort).
+- **Not in scope:** agent-to-agent negotiation (north-star frontier, later).
+- **Not in scope:** real-time push notifications (later).
+- **Not in scope:** write/create over the bindings read path in v1.
+- **Not in scope:** extracting `@fro-bot/runtime` as part of this work. The gateway's HTTP primitives and GitHub App client are extraction candidates, but that is its own effort.
+
+## Key Decisions
+
+- **Separate listener strongly preferred over pin-update.** A separate listener on a non-sandbox-net interface respects the egress boundary with the least risk and the clearest security story. A pin-update is permissible only with a deliberate, documented, reviewed rationale.
+- **Phase A first.** It is the lowest-risk, highest-leverage move: it unblocks every web path, resolves the deferred `AGENTS.md` note, and produces a testable seam before any new listener or auth lands.
+- **One approval gate, shared across transports.** The fail-closed coordinator/registry is the trust anchor. A parallel web gate would be a security regression by construction.
+- **Operator web auth is net-new and security-critical.** It is not a thin wrapper over HMAC. It requires a real session model, operator allowlist, revocation, and CSRF/origin binding — designed and reviewed as a first-class security primitive.
+
+## Dependencies / Assumptions
+
+- The ingress-pin egress-boundary decision must be settled in review before any new listener lands. The preferred path (separate non-sandbox-net interface) needs confirmation that the deploy topology (`marcusrbrown/infra` gateway compose + mitmproxy egress filter) can keep it off sandbox-net.
+- Phase B and Phase C depend on Phase A's `launchWork` seam and generalized approval gate.
+- Assumes the separate-listener interface can be made non-sandbox-net-reachable in the deploy topology.
+
+## Outstanding Questions
+
+- **Separate listener bind interface/port:** which interface and port, and how does the deploy topology (`marcusrbrown/infra`) keep it off sandbox-net? Needs coordination with infra.
+- **Web auth mechanism:** GitHub OAuth operator allowlist + signed cookie (mirroring the dashboard's own auth)? Or device-flow/token? What is the operator allowlist source of truth?
+- **State-stream transport:** SSE vs. WebSocket vs. poll for streaming run/agent state back to the web caller?
+- **Phase C delivery:** does the bindings read path ride Phase B's authenticated surface, or ship as a separate minimal read endpoint? The answer affects sequencing and the auth surface area.
+
+## Next Steps
+
+→ Run `ce:plan` against this brainstorm to produce `docs/plans/2026-06-15-001-feat-...`, starting with Phase A as the first buildable plan or a phased plan covering all three phases.
+
+Reference the north-star (`fro-bot/.github` `docs/brainstorms/2026-06-15-fro-bot-personal-agent-north-star-requirements.md`) and the dashboard requirements as upstream context. Tracking issue: [fro-bot/agent#907](https://github.com/fro-bot/agent/issues/907).

--- a/docs/brainstorms/2026-06-20-stream-web-run-output-requirements.md
+++ b/docs/brainstorms/2026-06-20-stream-web-run-output-requirements.md
@@ -1,0 +1,89 @@
+---
+title: Stream web-launched run output to the operator
+date: 2026-06-20
+status: ready-for-planning
+issue: 965
+surface: gateway operator SSE
+---
+
+# Stream web-launched run output to the operator
+
+## Problem
+
+A web operator can launch a run (`POST /operator/runs`) and watch it reach `succeeded`/`failed` over the SSE run-stream (`GET /operator/runs/:runId/stream`), but **cannot read what the agent actually said**. The agent's output text flows into the web `ReplySink` during execution, but `createWebReplySink()` (`packages/gateway/src/web/operator/web-sinks.ts:69-123`) buffers it in memory and its `flush`/`send` are no-ops — the text is dropped. The operator SSE projection (`packages/gateway/src/web/sse/projection.ts:57-90`) carries only run status, never message content.
+
+The Discord transport already delivers the same text (its `flush()` posts the buffered output to the thread — `packages/gateway/src/discord/streaming.ts:163-210`). This issue brings parity to the web surface.
+
+## Goal
+
+Deliver a web-launched run's agent output to the operator over the **existing** SSE run-stream — live as it's produced, with a guaranteed complete answer at the end — reusing the run-observation manager and the single run-stream connection. Closes #965 (advances #907).
+
+Live streaming (vs the simpler final-answer-only the issue triage suggested) is a deliberate bet: an operator watching a long run benefits from reading along in real time — to intervene, debug, or just perceive progress — rather than waiting for a terminal dump. The cost is the streaming machinery below; the final-answer frame keeps the guarantee simple regardless. (Acknowledged tradeoff: for short runs the live value over final-only is marginal; the design keeps final-answer delivery authoritative so the streaming layer can degrade to "deltas are best-effort, the final frame is the contract.")
+
+Two output frame shapes carry the contract:
+- **`output` (delta)** — incremental agent text as it's produced. The client **appends** these.
+- **`output` (final)** — a single authoritative snapshot of the complete answer, marked `final: true`. The client **replaces** its accumulated live text with this. This is the completeness guarantee.
+
+1. **Live delta-streaming + authoritative final frame.** Output flows as the agent produces it (the operator reads along, like the Discord thread filling in). On terminal status, a single `final: true` `output` frame carries the complete answer, which **replaces** the accumulated deltas — so the operator always ends with the full, correct text even if mid-stream deltas were coalesced. Clients render deltas optimistically (append) and replace with the final frame on completion.
+
+2. **Hard ordering: final answer before terminal status.** The final `output` frame for a run MUST be enqueued before the terminal status frame (`succeeded`/`failed`) is published to a subscriber. A subscriber can never observe terminal status without the final answer already in its queue — closing the race where the operator sees "succeeded" with no answer. (Requires per-run serialization between the output and status entry points; the planning doc owns the mechanism.)
+
+3. **Terminal-output snapshot cached for late subscribers.** The manager caches the final answer alongside the latest status (it already caches latest status). A subscriber connecting **after** the run reached a terminal phase receives both the terminal status and the cached final `output` frame — so reconnect-after-completion still delivers the answer. This is a single bounded snapshot per run, not a delta history.
+
+4. **Overflow: silent coalesce, keep the connection.** Output frames flow through the manager's per-subscriber queue cap (`DEFAULT_SUBSCRIBER_QUEUE_CAP_BYTES = 64 KB`, `packages/gateway/src/web/sse/manager.ts:37`). Under queue pressure, pending output deltas are coalesced/dropped **silently** — no elision marker — and the connection is **not** dropped. The authoritative final frame restores completeness, so a coalesced live stream is always corrected at the end. (Status-frame overflow keeps its existing drop-on-overflow behavior; only output frames coalesce. Per-subscriber queues are independent — a slow subscriber's coalescing never affects a fast one.)
+
+5. **Output delivered as-is; the repo-authz gate is the trust boundary.** The operator passed the same denylist + repo-authz gate that protects the status stream and could see this output in the Discord thread. Stream the agent's visible output text as-is, reusing run-core's existing visible-output discipline (reasoning suppressed, tools summarized — `packages/gateway/src/execute/run-core.ts:373-400`). Do **not** add a per-message scrub. The trust boundary is the connection's authz, not per-frame redaction.
+
+6. **Output rides the same continuous-authz lease.** Output frames flow on the same authenticated connection as status frames, gated by the existing ~30s lease. If access is revoked mid-run, the whole connection closes — status and output stop together. No separate authz path for output (it can't leak to a de-authorized operator because the connection itself is torn down).
+
+## Security posture
+
+The web SSE stream is **not a new authorization boundary** — output reaches only operators who passed the same denylist + repo-authz gate that already protects the status stream, exactly as they would see it in the Discord thread. It **is** a new *exposure surface*: browser-readable, copy-pasteable, screenshot-able, potentially client-cached. This is parity with Discord for already-authorized operators, **not** a broadening of access to new principals. Two consciously-accepted properties:
+
+- **Bounded revocation window.** Output rides the same ~30s continuous-authz lease as status. If access is revoked mid-run, up to ~30s of output can still flow before the lease tears down the connection — identical to the status-stream behavior, accepted as the same bounded lag.
+- **Secret-scanning deferred by policy, not omission.** Output may contain repo contents, paths, tool output, or inadvertent secrets. v1 relies on run-core's existing visible-output discipline only, with no active secret-detection pass — matching the Discord transport (which doesn't scrub either). Revisiting a minimal high-risk-token filter for the browser surface is a possible follow-up, not a v1 gap.
+
+## Scope
+
+### In scope
+- An additive `output` frame on the closed `ObservationFrame` union (`status | reset | heartbeat` → `+ output`), carrying operator-safe agent text, with a `final: boolean` flag distinguishing delta (append) from final-snapshot (replace).
+- A content entry point on the run-observation manager (e.g. `observeOutput(runId, text)`) alongside the existing observer-only `observe(runState)`, keeping `RunObservationManagerDeps` content-pushed rather than run-state-pulled.
+- Per-run serialization so the final `output` frame is enqueued before the terminal status frame (the ordering guarantee), and a per-run terminal-output snapshot cache so late subscribers receive the final answer.
+- Wire the web `ReplySink` (`web-sinks.ts`) to push deltas through that entry point on `append`, and the final answer on terminal-status/`flush`. This requires the web sink to reach the manager + runId at construction (see Open questions / construction-order).
+- Silent coalescing in the per-subscriber queue path for output frames (status frames keep their existing drop-on-overflow path; per-subscriber queues stay independent).
+- `writeFrame` event mapping for the new `output` frame (`packages/gateway/src/web/sse/run-stream-route.ts:174-191`).
+- A terminal `output` frame on **every** terminal run, including empty/early-failure runs — with empty content (or an explicit empty marker) so the operator can distinguish "no output" from "missing output".
+- MINOR operator-contract bump → **1.3.0** (`packages/gateway/src/operator-contract/version.ts`, currently `1.2.0`). The `ready` frame already advertises `contractVersion`; 1.2.x clients keep working via feature detection — 1.3.0 only adds the `output` frame type, no breaking change.
+
+### Non-goals (v1)
+- No mid-stream elision marker. Overflow coalesces output silently; the authoritative final frame is the completeness mechanism. (Re-add an elision signal later only if operators report needing real-time awareness of skipped detail.)
+- No secret-scanning / active redaction pass on output text (deferred by policy — see Security posture).
+- No second SSE channel — reuse the run-observation manager + run-stream route.
+- **No mid-stream delta replay/scrollback.** A reconnecting subscriber resumes live; it does **not** replay the individual deltas produced while it was disconnected. The terminal-output snapshot (in scope above) IS cached and re-delivered — that is the bounded exception that makes the completeness guarantee hold on reconnect-after-completion, not a full delta history.
+- No tighter-than-Discord projection (e.g. excluding the tool summaries run-core already shows) — parity with the existing visible-output discipline, not a new one.
+
+## Success criteria
+
+- A web operator subscribed to a run's stream sees the agent's output arrive live as the run executes.
+- The operator **always** ends with the complete answer: the `final: true` `output` frame is enqueued before terminal status and replaces any coalesced live text — whether the operator was connected throughout, was slow (coalesced), or connected after the run completed (cached snapshot).
+- A run with no output (empty or early failure) still produces a terminal `output` frame, so the operator can tell "no output" apart from "missing output".
+- Under a slow/overflowing subscriber, the connection stays alive; output coalesces silently and the final frame restores completeness. A slow subscriber never affects a fast one.
+- Output is never delivered to an operator who has lost repo access mid-run (the lease tears down the connection, within the accepted ~30s window).
+- The Discord transport's behavior is unchanged (the `ReplySink` change is additive to the web sink only).
+- No raw tool args / secrets beyond what run-core's existing visible-output discipline already emits.
+
+## Open questions for planning
+
+- **Construction-order (load-bearing):** the web `ReplySink` is built in `launch-route.ts` with no manager/runId today. Planning must specify how the sink reaches the observation manager + runId — thread `{runId, manager}` into the sink factory, or wrap the sink with a run-scoped adapter at the launch site.
+- The per-run serialization mechanism for the ordering guarantee (e.g. accept output until terminal status is observed, then flush/coalesce output before emitting terminal status).
+- Coalescing strategy in the queue (merge adjacent output deltas vs newest-wins) and the byte-accounting interaction with the existing status-frame queue path.
+- Final-frame payload: send the complete buffered answer (client replaces) vs tail-only — confirm the complete-answer approach against the 64 KB cap (a very large answer may itself need chunking).
+
+## Grounding (verified against `main` @ d0b34ce5)
+
+- `ReplySink` interface (`append`/`flush`/`buffered`/`send` + visible-output tracking): `packages/gateway/src/execute/launch-types.ts:189-299`; doc anticipates "a web transport may implement `append`/`flush` as SSE pushes" (`:216-220`).
+- Web sink no-op gap: `packages/gateway/src/web/operator/web-sinks.ts:69-123` (`append` buffers, `flush`/`send` no-op).
+- Manager observer-only + closed frame union + 64 KB cap: `packages/gateway/src/web/sse/manager.ts:37,53-78,106-135`.
+- SSE frame writing + `ready`/`contractVersion`: `packages/gateway/src/web/sse/run-stream-route.ts:174-191,442-448`.
+- Output text already flows into `replySink.append`: `packages/gateway/src/execute/run-core.ts:373-400`; final answer via `replySink.buffered()` → `statusSink.resolveToAnswer(...)`: `packages/gateway/src/execute/run.ts:635-645`.
+- Contract version `1.2.0`: `packages/gateway/src/operator-contract/version.ts:15`.

--- a/docs/brainstorms/2026-06-22-web-tool-approval-requirements.md
+++ b/docs/brainstorms/2026-06-22-web-tool-approval-requirements.md
@@ -1,0 +1,163 @@
+---
+date: 2026-06-22
+topic: web-tool-approval
+---
+
+# Web Tool Approval (Gateway Operator Surface)
+
+## Summary
+
+Give gateway-launched runs a real interactive tool-approval flow on the web operator surface: when a run hits a tool gate, an operator with write access sees the pending request — including the actual command or file path it wants to touch — over the existing SSE run-stream and submits once/always/reject through a new decision route, wired into the same transport-neutral approval registry the Discord flow already uses. Approving is a write-gated action (read-only operators can observe but not approve); a full diff/patch preview is deferred to a Phase 2.
+
+---
+
+## Problem Frame
+
+Web-launched runs cannot do tool-gated work. When such a run reaches a tool permission gate, the gateway's web approval transport (`createWebAutoDenyApproval`) immediately rejects every request — so any step needing `bash`, `edit`, or another gated tool is denied and the run proceeds or fails without it. A web operator can launch a run and watch it stream, but cannot authorize the very actions that make an agent run useful.
+
+That auto-deny stub is not the intended end state; it exists to avoid a worse failure. Without an explicit web transport, the engine falls through to the Discord approval transport, which posts the prompt to a thread that does not exist for a web run and holds the repo lock until the approval deadline (~13 minutes), blocking every run in that repo. Auto-deny was the safe placeholder while the interactive web path was unbuilt.
+
+The foundation for the real path already exists. The approval registry is transport-neutral (it carries an `approvalScopeId`, a `handleDecision` entry point, and a typed actor). The SSE run-stream already overlays a `waiting_for_approval` status when a run's scope has a pending request. The operator contract already defines the decision vocabulary (`once`/`always`/`reject`) and the settlement outcomes. What is missing is the web transport itself: a way for the pending request's detail to reach the operator's browser, and a way for the operator's decision to return to the registry.
+
+---
+
+## Actors
+
+- A1. Web operator: an authenticated dashboard user. With read access to the repo they can launch and observe a gateway run; with write (or admin) access they can also approve or reject its tool-permission requests.
+- A2. Gateway run engine: drives the OpenCode session, raises a pending request on `permission.asked`, and blocks the gated tool until the request settles.
+- A3. Approval registry: the transport-neutral component that holds open requests per approval scope and settles them on a decision, a reject cascade, or the deadline.
+
+---
+
+## Key Flows
+
+- F1. Operator approves a pending tool request
+  - **Trigger:** A running web-launched run raises a tool-permission request (`permission.asked`); the run blocks the gated tool.
+  - **Actors:** A1, A2, A3
+  - **Steps:** The registry registers the open request. The SSE run-stream pushes an approval frame (requestID + the gated command/filepath + tool category) and the run's status overlays to `waiting_for_approval`. A write-authorized operator sees the prompt and submits a decision (once/always/reject) to the decision route. The route re-checks write-level repo-authz and binds the requestID to the run's scope, then calls the registry's decision entry point. The registry settles the request and the engine unblocks (or rejects) the tool. The SSE stream emits a settle/clear frame.
+  - **Outcome:** The tool proceeds (once/always) or is rejected; the run continues; the operator surface reflects the settled state.
+  - **Covered by:** R1, R2, R3, R4, R6, R7, R9, R10, R11, R12
+
+- F2. Reconnecting operator recovers an open request
+  - **Trigger:** The operator's SSE connection drops and reconnects (or a second operator opens the run) while a request is still open.
+  - **Actors:** A1, A3
+  - **Steps:** The browser, on seeing `waiting_for_approval` (or on reconnect), calls the GET pending-approvals endpoint for the run. The endpoint returns the open request(s) with the same redaction-safe detail. The operator decides as in F1.
+  - **Outcome:** A reconnecting or late-joining operator recovers the open request instead of the run hanging unseen until the deadline.
+  - **Covered by:** R5, R6, R7, R11, R13, R14
+
+- F3. No operator answers in time
+  - **Trigger:** A request is open but no operator submits a decision.
+  - **Actors:** A2, A3
+  - **Steps:** The existing approval deadline elapses. The registry settles the request fail-closed (deny). The engine rejects the tool and the run proceeds or fails accordingly. The lock releases on the normal run lifecycle.
+  - **Outcome:** An unanswered request cannot hold the repo lock indefinitely; the run settles deterministically.
+  - **Covered by:** R8
+
+---
+
+## Requirements
+
+**Web approval transport**
+- R1. Replace `createWebAutoDenyApproval` with a real web approval transport that registers each tool-permission request as an open entry in the transport-neutral approval registry (the same registry the Discord transport uses), instead of immediately rejecting it.
+- R2. The transport must settle a registered request when the operator's decision arrives, mapping the operator's choice to the registry's decision entry point with the matching reply value (once/always/reject).
+
+**Pending-request delivery to the browser**
+- R3. When a request opens, the SSE run-stream must emit an approval frame carrying the requestID, the tool category, and the decision context (the `command` for command-gated tools and the `filepath` for file-gated tools, from the event metadata), so the operator can make an informed decision and target it at the correct request. When the request settles, the stream must emit a settle/clear frame.
+- R4. v1 surfaces the concrete gated action — the `command` and `filepath` from the `permission.asked` metadata — so the operator approves with real context, not a bare title. v1 stops short of a full file-content diff/patch preview (the would-be result of the edit), which is deferred to Phase 2. The surfaced detail must be bounded (length-capped/escaped) so a hostile or oversized command/path cannot break or abuse the browser surface.
+- R5. A GET pending-approvals endpoint for a run must return the currently-open request(s) with the same redaction-safe detail, so a reconnecting or late-joining browser can recover open requests. This is the reconciliation fallback to the SSE frame.
+
+**Decision route and authorization**
+- R6. A decision route must accept an operator's once/always/reject decision for a specific requestID on a specific run and forward it to the approval registry.
+- R7. Submitting a decision must require WRITE (or admin) permission on the run's repo, re-verified at submit time — a strictly higher bar than observing, which requires only read access. Approving authorizes a repo-mutating tool, so a read-only operator may watch the run stream but must not be able to approve. This requires extending the authz path beyond the current read-access boolean (`checkRepoAuthz` proves read access only) to determine the operator's permission level (read vs write/admin) for the repo.
+- R9. Each settled decision must be attributed to the submitting operator's identity using the registry's existing typed actor, so there is a record of who approved or rejected what.
+- R10. The decision route must bind the submitted requestID to the run's `approvalScopeId` and reject any cross-scope, cross-run, or stale decision with no side effects. A decision for a requestID the operator's authorized run does not own must fail without settling anything.
+- R11. The decision route must be idempotent against already-settled requests: a decision for a requestID that has already settled (by an earlier decision, a reject cascade, or the deadline) is a no-op that returns a clear already-settled response, never a second settlement.
+- R12. The `always` reply persists as an OpenCode permission rule beyond the single request (it is an always-rule in OpenCode's permission model, not a one-shot grant). The doc and the operator UI must treat `always` as the broader-blast-radius choice; v1 inherits OpenCode's existing always-rule scope rather than introducing a new persistence scope.
+
+**Pending-request authorization and exposure**
+- R13. The GET pending-approvals endpoint must authorize on the exact run scope using the same repo-authz check as the SSE stream, and must not reveal open-request existence, count, or detail to an operator who lacks access to that run/repo (no cross-scope existence oracle). An unauthorized request returns the same denial the SSE stream uses.
+
+**Safety and lifecycle**
+- R8. With auto-deny removed, a web-launched run can legitimately block on a pending approval and hold the repo lock until the request settles. The existing approval deadline must remain the safety valve, enforced per request: an unanswered request settles fail-closed (deny) at its deadline, and the lock is never held indefinitely by an undecided approval. A tool-heavy run that opens many sequential requests can hold the lock for up to the per-request deadline at a time; v1 accepts this per-request bound and does not add a separate cumulative-lock cap (the run's own concurrency/lifecycle already bounds it).
+- R14. When multiple tool requests are open for the same run, all open requests must be recoverable (via the SSE frames and the GET endpoint) and individually decidable by requestID. The operator UI's presentation of concurrent open requests (queue, list, or one-at-a-time) and the mid-decision settle state (an open request that settles while the operator is deciding must become non-actionable with a clear settled/replaced signal) are interaction decisions for planning, but the transport must expose enough per-request state to support them.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R3.** Given a running web-launched run that raises a `bash` permission request, when the request opens, then the SSE stream emits an approval frame with the requestID, the `bash` category, and the gated `command`, and the run status shows `waiting_for_approval`.
+- AE2. **Covers R2, R6, R7.** Given an open request and an authenticated operator with write access to the repo, when the operator submits `once` for that requestID, then the decision route re-checks write-level authz, the registry settles the request as allowed-once, and the gated tool proceeds.
+- AE3. **Covers R4.** Given a `bash` request whose metadata carries a shell command, when it is surfaced to the browser, then the command is present (length-capped/escaped) so the operator decides on real context, while the full would-be file diff is not rendered.
+- AE4. **Covers R5.** Given an open request and an operator whose SSE connection dropped, when the operator reconnects and calls the GET pending-approvals endpoint, then the open request is returned with its decision context so the operator can still decide.
+- AE5. **Covers R7.** Given an authenticated operator with only read access to the run's repo, when they attempt to submit a decision, then the decision route denies the submission (read can observe but not approve), while they may still watch the run stream.
+- AE6. **Covers R8.** Given an open request that no operator answers, when the approval deadline elapses, then the registry settles it fail-closed (deny), the tool is rejected, and the repo lock is not held beyond the run's normal lifecycle.
+- AE7. **Covers R9.** Given an open request, when an authenticated operator settles it, then the registry records the submitting operator's identity (typed actor) alongside the decision outcome.
+- AE8. **Covers R10.** Given an operator authorized for run A's repo, when they submit a decision for a requestID that belongs to run B (a different scope), then the decision route rejects it with no side effects and run B's request stays open.
+- AE9. **Covers R11.** Given a requestID that already settled (by the deadline or an earlier decision), when an operator submits a decision for it (e.g. via a stale SSE frame or reconnect GET), then the route returns an already-settled response and does not settle the request a second time.
+- AE10. **Covers R13.** Given an operator who lacks read access to a run's repo, when they call the GET pending-approvals endpoint for that run, then the endpoint returns the same denial as the SSE stream and reveals no open-request existence or detail.
+
+---
+
+## Success Criteria
+
+- A web operator can launch a run that needs tool approvals, see each pending request in the browser in real time, and approve or reject it — completing tool-gated work that previously could only run through Discord.
+- A dropped/reconnecting browser recovers an open request rather than letting the run hang unseen until the deadline.
+- An unanswered request never holds the repo lock indefinitely; it settles fail-closed at the deadline exactly as before.
+- Operators decide on the real gated action (the command/filepath), not a bare title — and a read-only operator can observe but cannot approve.
+- A downstream planner can implement the transport, the SSE approval frame, the GET reconciliation endpoint, the write-level authz extension, and the decision route against the existing registry/contract seams without inventing approval semantics.
+
+---
+
+## Scope Boundaries
+
+- A full file-content diff/patch preview (rendering what an edit would produce before deciding) is deferred to a clearly-scoped Phase 2. v1 shows the gated `command`/`filepath` but not the resulting diff.
+- Policy-based pre-approval (operator-configured allow/deny rules that auto-resolve requests without a prompt) is not in scope. Per-request interactive approval is the foundational primitive a policy layer would build on; it must exist first. The click-tax concern for high-approval-volume runs is a documented Phase-2 driver.
+- Changes to the Discord approval flow are out of scope; this work adds a parallel web transport and leaves the Discord transport unchanged.
+- Changing the underlying OpenCode permission model, the approval deadline duration, or the registry's settlement semantics is out of scope; v1 reuses them.
+
+---
+
+## Key Decisions
+
+- Show the gated action in v1, defer only the diff preview: v1 surfaces the actual `command`/`filepath` from the `permission.asked` metadata so the operator approves on real context. A title-only approval would invite blind rubber-stamping and give operators no reason to use the web surface over Discord. This deliberately surfaces more than the Discord embed does (which renders only a redaction-safe title), justified because the operator surface is authenticated and repo-authz-gated — a more trusted audience than a Discord channel. The richer artifact still deferred to Phase 2 is the full file-content diff/patch preview (what the edit would produce), not the command/path itself.
+- Write/admin permission to approve, read to observe: approving runs a repo-mutating tool, so it carries a strictly higher bar than watching. A read-only collaborator can observe a run but cannot authorize changes to the repo. This requires extending the authz path to surface permission level (the current `checkRepoAuthz` only proves read access), which is new capability v1 must build — a deliberate cost accepted for least-privilege on a mutate-capable action.
+- SSE approval frame as primary delivery, GET endpoint as reconciliation: the browser already holds the SSE connection, so pushing the prompt in-stream avoids a round-trip and matches how the run-observation manager already pushes status/output frames. The GET endpoint mirrors the run-stream's existing latest-known-state recovery philosophy so a reconnecting browser cannot silently miss an open request.
+- Identity attribution comes for free: the registry's existing typed actor records who decided at no extra access cost, so v1 keeps an audit trail of approvals/rejections.
+- Auto-deny removal makes the deadline load-bearing: today the deadline is a backstop behind an immediate auto-deny. Once requests can legitimately stay open, the deadline becomes the real safety valve for the no-operator-answers case, and v1 must treat it as such rather than as a stub. The deadline is per request; a tool-heavy run holds the lock at most one deadline at a time, which v1 accepts rather than adding a cumulative-lock cap.
+- `always` is a persistent OpenCode permission rule, not a one-shot: the registry treats `always` as an always-rule in OpenCode's permission model, so approving `always` grants beyond the single request. v1 inherits that existing scope rather than redefining it, and surfaces `always` as the higher-blast-radius choice (the operator UI must make it harder to pick by accident — an interaction detail for planning).
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R7][Technical] How to source and cache the operator's repo permission level (read vs write/admin) so the submit-time re-check is both correct and revocation-safe — the GitHub `permissions` field on `GET /repos`, the collaborator-permission endpoint, or another path, and how its caching interacts with the existing authz cache.
+- [Affects R3, R14][Design] Where the approval prompt lives relative to the run's streaming output (inline banner, docked panel, or modal) and how concurrent open requests are presented (queue, list, or one-at-a-time). Interaction decisions for the dashboard, captured so planning surfaces them.
+- [Affects R12][Design] Whether the `always` choice needs a stronger affordance or confirmation than `once` to prevent an accidental persistent grant.
+
+### Monitored Risk
+
+- Per-request clicking could become a click-tax on high-approval-volume runs, pushing operators back to Discord. Policy-based pre-approval (a Phase-2 follow-up) is the mitigation; v1 ships per-request because it is the primitive policy builds on. Watch adoption to decide whether policy should be prioritized next.
+
+---
+
+## Dependencies / Assumptions
+
+- The transport-neutral approval registry (`approvalScopeId`, the `handleDecision` decision entry point, typed actor `WebOperatorActor`) and the operator contract's `PermissionReply`/decision-outcome vocabulary exist and are reused as-is. Swapping `createWebAutoDenyApproval` for an interactive transport is a clean seam.
+- The SSE run-stream surfaces the `waiting_for_approval` status overlay (`hasPendingForScope`) today, but its frame union (`ObservationFrame = StatusFrame | ResetFrame | HeartbeatFrame | OutputFrame`) carries status/output only, not the requestID/title. Adding the approval frame (R3) is a real protocol change across the manager's closed frame union, the SSE writer's exhaustiveness guard, the tests, and any client consumer — not a status overlay. Planning must treat it as a frame-type addition.
+- The GET pending-approvals endpoint (R5/R13) does not exist yet; it is a net-new route whose shape, response DTO, and reconciliation behavior planning must design. The shared `checkRepoAuthz` helper used by the other privileged routes (launch, run-state, SSE) is reusable for both this endpoint's and the decision route's authz, so the authz primitive is shared even though no approval routes exist yet.
+- The `permission.asked` event carries `requestID` (`properties.id`), `sessionID`, `permission` (gate category), `patterns`, and optional `metadata` (including `command`/`filepath`). v1 surfaces the `command`/`filepath` and category (R4), not a full file-content diff.
+- Determining the operator's permission level (read vs write/admin) for R7 is new capability: the current `checkRepoAuthz` proves read access only. Planning must source the permission level (e.g. the GitHub `GET /repos/{owner}/{repo}` `permissions` field or the collaborator-permission endpoint) and decide its caching/freshness against the submit-time re-check.
+- The deadline/claim machinery (atomic single-winner claim, fail-close at the deadline) is load-bearing for R8 and is reused exactly as-is; v1 does not change the deadline duration or settlement semantics.
+
+---
+
+## Sources / Research
+
+- `packages/gateway/src/web/operator/web-approval.ts` — `createWebAutoDenyApproval`, the auto-deny stub being replaced (and its documented rationale for existing).
+- `packages/gateway/src/approvals/` — `coordinator.ts` (`PermissionRequest` shape, `deriveTitle` reading `metadata.command`/`metadata.filepath`), `registry.ts` (transport-neutral registry, `ApprovalActor`), `discord-transport.ts` (the proven reference transport), `approval-flow.integration.test.ts`.
+- `packages/gateway/src/web/sse/projection.ts` — the `waiting_for_approval` overlay via `hasPendingForScope`; the SSE frame currently carries status only, not the requestID/title.
+- `packages/gateway/src/operator-contract/approval.ts` — `PermissionReply` (`once`/`always`/`reject`) and the decision-outcome vocabulary.
+- `packages/gateway/src/operator-contract/run-status.ts` — `OperatorRunStatus` (the current SSE frame shape).
+- `packages/gateway/src/discord/approvals.ts` — `buildApprovalEmbed`, the redaction-safe rendering reference ("never renders raw patterns, tool inputs, or the requestID").
+- `docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md` — the Phase B web-operator surface plan this unit completes.

--- a/docs/brainstorms/2026-06-23-pnpm-to-bun-migration-requirements.md
+++ b/docs/brainstorms/2026-06-23-pnpm-to-bun-migration-requirements.md
@@ -1,0 +1,104 @@
+---
+date: 2026-06-23
+topic: pnpm-to-bun-migration
+---
+
+# Migrate the workspace from pnpm to Bun
+
+## Summary
+
+Replace pnpm with Bun as the workspace package manager via a staged migration: a spike phase verifies every blocker on a branch with real evidence, and the cutover (lockfile, CI, Renovate) lands only after the spike clears. The migration consolidates the toolchain on Bun (already used for the harness build), and removes the `pnpm licenses list` store dependency that breaks dist regeneration on dependency PRs.
+
+---
+
+## Problem Frame
+
+The repo runs two package managers: pnpm@11.8.0 for the workspace and Bun 1.3.14 for the harness OpenCode build. That split means two install models, two version pins, and two mental models for one codebase.
+
+The acute pain is a pnpm store-cache fault. On every Renovate dependency PR, the post-upgrade `pnpm run build` fails because `generate-license-file`'s `getProjectLicenses()` shells `pnpm licenses list --json --prod`, which reads pnpm's content-addressable store index — and Renovate restores a partial store missing the index file for at least `@actions/artifact@6.2.1` (`ERR_PNPM_MISSING_PACKAGE_INDEX_FILE`). The packages are present and the bundle builds; only the store read fails, and the fail-closed license preflight then aborts dist regeneration. `pnpm install --force` was tried and proved a no-op against this corruption. This blocks committed-`dist/` updates on every dependency PR.
+
+The corruption lives in Renovate's restored store cache — upstream state the repo cannot reproduce or control. So the failure is recurring, environment-specific, and not fixable by configuring pnpm.
+
+---
+
+## Requirements
+
+**Spike phase (gate before cutover)**
+
+- R1. Run the full workspace gate under Bun on a branch without committing the package-manager switch: `bun install`, build, test, lint, check-types across all workspace packages.
+- R2. Verify `bun run --filter` (or `--workspaces`) reproduces the current per-package script execution, including dependency-respecting build order for `@fro-bot/runtime` → `@fro-bot/action` / `@fro-bot/gateway` / `@fro.bot/harness`.
+- R3. Validate that tsdown (bundler) and vitest run correctly when invoked under Bun's install layout. The repo keeps running scripts under `node --experimental-strip-types`; the spike confirms whether tools that previously resolved through pnpm's layout still resolve under Bun's.
+- R4. Generate `THIRD_PARTY_NOTICES.txt` under Bun and byte-diff it against the current pnpm-produced file. Any difference must be explained (package set, ordering, license text) before the cutover is trusted.
+- R5. Decide the linker mode (isolated vs hoisted) on evidence: run `bun install --linker isolated` to surface phantom dependencies, and confirm whether the Bun 1.3 isolated-install bug tail (catalog dedup, stale-store non-cleanup, no-op install performance) affects this graph.
+- R6. The spike is throwaway-friendly: if any blocker proves fatal, fall back to making the license collector store-independent (keep pnpm) without having committed the switch.
+
+**Config relocation**
+
+- R7. Move the 14 dependency overrides from `pnpm-workspace.yaml#overrides` to root `package.json#overrides`, confirming each is top-level (Bun does not support pnpm's nested/selector overrides). Most are top-level style (`brace-expansion: '>=5.0.6'`); two use pnpm's `name@range` selector syntax (`tar@^7: '>=7.5.11'`, `undici@^7: '>=7.24.0'`) — confirm Bun's override syntax expresses these or rewrite them.
+- R8. Move `onlyBuiltDependencies`/`allowBuilds` (`esbuild`, `simple-git-hooks`, `unrs-resolver`) to `trustedDependencies` in root `package.json`. Bun runs no lifecycle scripts unless a dependency is trusted; the `trustedDependencies` array replaces (not extends) Bun's built-in allowlist.
+- R9. Create `bunfig.toml` (no such file exists today) and move `minimumReleaseAgeExclude` to Bun's native `minimumReleaseAge` + `minimumReleaseAgeExcludes` there (seconds, not minutes/version-strings as pnpm uses). Define how `bunfig.toml` coexists with the existing root config files.
+- R10. Map the remaining install/build-affecting `pnpm-workspace.yaml` settings: `shamefullyHoist` → linker choice (R5), `autoInstallPeers`/`strictPeerDependencies:false` → Bun defaults. Treat purely legacy knobs (`ignoreWorkspaceRootCheck`, `savePrefix`, `shellEmulator`) as drop-if-obsolete cleanup, not cutover blockers. (`allowBuilds` is owned by R8.)
+
+**Cutover**
+
+- R11. Replace `pnpm-lock.yaml` with `bun.lock` (text format), remove `pnpm-workspace.yaml`, and set/remove `packageManager` appropriately.
+- R12. Rewrite the workspace scripts in root `package.json` from `pnpm --filter <pkg> <script>` to the Bun equivalent, preserving the `dist:escape-hidden-unicode` / `dist:check-hidden-unicode` build/lint tails.
+- R13. Rewire the ~16 pnpm references across the 6 CI/workflow files (`ci.yaml`, `auto-release.yaml`, `copilot-setup-steps.yaml`, `fro-bot.yaml`, `harness-release.yaml`, `prepare-release-pr.yaml`) to Bun setup + install + run.
+- R14. Switch Renovate to the Bun manager: update `.github/renovate.json5` postUpgradeTasks to Bun commands and confirm the self-hosted action's allowedCommands accept them. Lockfile maintenance for `bun.lock` is available (the self-hosted Renovate is 43.234.0, above the 41.160.1 fix).
+- R15. Pre-commit (`lint-staged`) and pre-push (`pnpm lint && pnpm build`) hooks via `simple-git-hooks` keep working under Bun, on a `simple-git-hooks` release that includes the Bun isolated-layout postinstall fix.
+
+---
+
+## Success Criteria
+
+- A Renovate dependency PR completes its post-upgrade build and regenerates `dist/` with accurate `THIRD_PARTY_NOTICES.txt`, with no `pnpm licenses list` / store-index failure.
+- The workspace installs, builds, tests, and lints under Bun with parity to the current pnpm gate; CI is green across all 6 workflows.
+- One package manager governs the workspace; the harness build and the workspace install share the same Bun toolchain.
+- A downstream planner has a verified blocker list (each spike item resolved yes/no with evidence) so the cutover plan executes without re-discovering Bun's behavior.
+
+---
+
+## Scope Boundaries
+
+- Not switching the test or script RUNTIME to Bun. Tests run under vitest, scripts under `node --experimental-strip-types`. This migration is package-manager only; Bun-as-runtime is a separate, larger decision.
+- Not changing the harness build's existing Bun usage — it already uses Bun and is out of scope except where workspace install changes touch it.
+- Not adopting Bun catalogs in v1. Catalogs interact with the Bun 1.3 isolated-install bug tail (peer placement, dedup); defer until the migration is stable.
+- Not pursuing the store-independent license-collector rewrite if the migration proceeds — Bun's npm-resolver fallback supersedes it. (It remains the fallback if the spike kills the migration.)
+
+---
+
+## Key Decisions
+
+- Staged over big-bang: the Bun 1.3 isolated-install bug tail and several unverified-for-this-repo items (tsdown/vitest under Bun, build ordering, license output under the symlinked layout) make a faith-based full migration the wrong risk posture. Spike-verify, then cut over.
+- Renovate version blocker cleared: the self-hosted Renovate is 43.234.0, well above the 41.160.1 release that fixed `bun.lock` lockFileMaintenance. The single most likely silent breakage is a non-issue.
+- The license-collector fix and the migration solve the same root cause; the migration is preferred because it also delivers consolidation and supply-chain feature upgrades, but it must clear the spike first.
+
+---
+
+## Dependencies / Assumptions
+
+- The self-hosted Renovate (`bfra-me/.github` renovate workflow, currently pinned `v4.16.28`, running Renovate 43.234.0) supports the Bun manager and `bun.lock` maintenance. The repo cannot edit the action's `allowedCommands` allowlist, only which allowed commands appear in postUpgradeTasks — confirm Bun commands are within the allowlist during the spike.
+- `generate-license-file` resolves the package manager solely by `pnpm-lock.yaml` presence; with pnpm-lock.yaml removed it falls through to the npm/arborist resolver (reads `node_modules`, store-independent). The arborist + Bun isolated-layout (`node_modules/.bun` symlinks) combination is unverified for notice output — R4 validates it.
+- Bun 1.3.14 is installed locally and already drives the harness build. The harness pins `HARNESS_BUN_VERSION = '1.3.14'` to exactly match upstream `anomalyco/opencode`'s `packageManager` field at the harness base version. Making Bun the workspace package manager creates a version coupling: decide whether the workspace Bun version must equal the harness pin, or whether the two pins may diverge (and how). A forced lockstep means a future harness/upstream bump also bumps the workspace toolchain.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R5][Technical] Isolated vs hoisted linker — isolated matches pnpm semantics and preserves phantom-dependency protection but carries the Bun 1.3 isolated bug tail; hoisted is more stable but loses that protection. Decide on spike evidence.
+- [Affects R2][Needs research] Does `bun run --filter` guarantee dependency-topological build ordering equivalent to `pnpm -r`, or must the build script enforce order explicitly?
+- [Affects R3][Needs research] Confirm tsdown/rolldown and vitest run cleanly under Bun's install layout for this repo's configs.
+- [Affects R13][Technical] Whether any CI workflow depends on pnpm-specific behavior (cache action keys, `pnpm exec`, frozen-lockfile semantics) that needs a non-mechanical Bun translation.
+- [Affects R15][Technical] Confirm the pinned `simple-git-hooks` version includes the Bun isolated-layout postinstall fix, or bump it.
+
+---
+
+## Sources / Research
+
+- Renovate self-hosted version: `RENOVATE_VERSION: 43.234.0` (run 28063498652 logs) — above the 41.160.1 `bun.lock` lockFileMaintenance fix.
+- `generate-license-file@4.2.1` resolver: `node_modules/.pnpm/generate-license-file@4.2.1_.../src/lib/internal/resolveDependencies/index.js` (`resolvePackageManager` checks only `pnpm-lock.yaml`) and `.../utils/pnpmCli.utils.js` (`execAsync("pnpm licenses list --json --prod")`).
+- Current pnpm config surface: `pnpm-workspace.yaml` (overrides, onlyBuiltDependencies, minimumReleaseAgeExclude, shamefullyHoist, autoInstallPeers, strictPeerDependencies), `package.json` (`packageManager: pnpm@11.8.0`, workspace scripts, `workspace:*` deps).
+- Confirmed root cause of the Renovate failure: `ERR_PNPM_MISSING_PACKAGE_INDEX_FILE` for `@actions/artifact@6.2.1`, surfaced by the stderr diagnostics in PR #997; `pnpm install --force` refuted as a no-op (run 28063498652).
+- Bun feature parity (workspaces, `workspace:*`, text `bun.lock` default since 1.2, `trustedDependencies`, native `minimumReleaseAge`, security-scanner API, isolated installs default since 1.3) and migration risks (isolated-install bug tail, no-op install perf regressions, simple-git-hooks/lint-staged caveats) — 2026 research pass; validate the unverified items in the spike.

--- a/docs/brainstorms/2026-06-30-generating-project-docs-skill-requirements.md
+++ b/docs/brainstorms/2026-06-30-generating-project-docs-skill-requirements.md
@@ -1,0 +1,114 @@
+---
+date: 2026-06-30
+topic: generating-project-docs-skill
+---
+
+# Add a `generating-project-docs` skill for living project documentation
+
+## Summary
+
+Add an agent skill at `.agents/skills/generating-project-docs/SKILL.md` that generates and refreshes this repo's **living** documentation — `README.md`, `ARCHITECTURE.md` (new), `STRUCTURE.md` (new), `CONTRIBUTING.md`, and community-health files — from live-repo facts, modeled on the `generating-project-docs` skills in `marcusrbrown/systematic` and `fro-bot/.github`. The skill owns only the living docs and how to keep them current; it does not reconcile or archive legacy documentation.
+
+A separate, gated legacy-prep task runs first to give the skill a clean field: archive stale planning docs, fold contributor rules into `CONTRIBUTING.md`, and re-point the agent knowledge base and automation at the new canonical docs.
+
+---
+
+## Problem
+
+Project documentation has drifted badly. `README.md`'s body is stale (its last change was an OpenCode version bump). There is no `ARCHITECTURE.md` or `STRUCTURE.md`. Meanwhile the repo root carries ~2.6K lines of stale planning prose (`PRD.md` from January, `FEATURES.md` from March) and overlapping convention/spec docs (`RULES.md`, `RFCS.md`). `AGENTS.md` is a hand-maintained "PROJECT KNOWLEDGE BASE" that already holds most of the structural content a `STRUCTURE.md`/`ARCHITECTURE.md` would, so naive new docs would create a third drifting copy.
+
+There is no repeatable, fact-grounded way to regenerate the human-facing docs, so they rot between releases.
+
+## Goals
+
+- A durable skill that regenerates/refreshes the living docs on demand, deriving every fact from the live repo.
+- Establish `ARCHITECTURE.md` and `STRUCTURE.md` as canonical human-contributor onboarding docs.
+- Make doc refresh a section-scoped, low-drift operation rather than a full rewrite.
+- Keep public docs free of session/process/agent-internal leakage.
+
+## Non-Goals
+
+- The skill does not own, rewrite, or archive legacy docs (`PRD.md`, `FEATURES.md`, `RFCS.md`, `RULES.md`) — that is the separate legacy-prep task.
+- The skill does not regenerate `AGENTS.md` (hand-maintained) or the `RFCs/` specs; it cross-references them.
+- No engineering-backlog work (e.g. the action/gateway timeout convergence) is in scope.
+
+## Document taxonomy
+
+Audience-based split that removes the current overlap:
+
+| Doc | Audience | Owner |
+| --- | --- | --- |
+| `README.md` | Entry point / users | Skill (living) |
+| `ARCHITECTURE.md` *(new)* | Human contributors — system design | Skill (living) |
+| `STRUCTURE.md` *(new)* | Human contributors — where code lives | Skill (living) |
+| `CONTRIBUTING.md` | Human contributors — how to work | Skill (living) |
+| `SECURITY.md`, `.github/copilot-instructions.md` | Community-health | Skill (living) |
+| `AGENTS.md` | Agent operational knowledge base | Hand-maintained; references the living docs |
+| `RFCs/` + `RFCS.md` index | Design specs | Hand-maintained; referenced by `ARCHITECTURE.md` |
+| `PRD.md`, `FEATURES.md` | Historical planning | Archived to `docs/product/` |
+
+Relationship decision: `ARCHITECTURE.md` and `STRUCTURE.md` are **human + agent** useful and become the home for the architecture and structure/code-map content currently carried in `AGENTS.md`. `AGENTS.md` is slimmed simply by extracting that content into them; what remains is the genuinely agent-operational material (conventions, anti-patterns, commands, prompt rules) that an agent still needs. No source-of-truth inversion — the new docs own the extracted architecture/structure knowledge; `AGENTS.md` keeps what's operational and references the living docs for the rest.
+
+## The skill
+
+Lives at `.agents/skills/generating-project-docs/SKILL.md`. Modeled on the two reference skills, adapted to this repo.
+
+### Core rules (from the references)
+
+- Derive every fact from the live repo. If a sentence can't point to a file, command, or commit, don't write it.
+- Re-derive any count in prose from live CLI output (`ls`, `find`, test runner), never from memory.
+- Preserve the existing doc's evolved structure on re-runs; update only what changed.
+- Support section-scoped updates: read the current doc, replace only the target section, preserve surrounding structure exactly.
+- No session/process/agent-internal leakage in public docs.
+- Backtick paths, commands, and env vars; language-tag code blocks; terse, fact-first voice.
+
+### Per-document structure the skill defines
+
+- **`README.md`** — `<picture>` dark/light header, flat-square badges, ` · `-separated nav, overview, features, getting started, repository structure, automation, development, resources. Avoid tables in README.
+- **`ARCHITECTURE.md`** — `# Architecture` orientation (pointing at `STRUCTURE.md` and `AGENTS.md`) → Bird's-Eye Overview → Codemap (pipeline diagram + symbol→file table) → Invariants (CI-enforced, numbered) → Data Flow (ASCII tree) → Cross-Cutting Concerns. References `RFCs/` for deep specs.
+- **`STRUCTURE.md`** — `# Structure` with cross-references → Directory Layout (annotated ASCII tree) → Directory Purposes → Key File Locations (the one place tables are allowed: `| File | Role |`) → Naming Conventions → Where to Add New Code (prescriptive checklist).
+- **`CONTRIBUTING.md`** — contributor workflow: setup, the `bun run` command surface, testing standards, commit/PR conventions, anti-patterns. De-duplicated against `ARCHITECTURE.md`/`STRUCTURE.md` (points at them rather than restating).
+- **Community-health** — `SECURITY.md` (reporting channel, supported versions, OpenSSF badges), `.github/copilot-instructions.md`.
+
+### Generation flow
+
+1. Inventory live repo facts (structure, symbols, commands, counts).
+2. **First run (doc does not exist):** author the full doc from the bootstrap contract — the required section ordering and headings defined per-document below — populated from live-repo facts. There is no evolved structure to preserve, so the skill uses the prescribed structure as the seed rather than improvising one from the reference repos.
+3. **Re-run (doc exists):** diff against the current doc and write the minimal diff, preserving the doc's evolved structure and changing only what drifted.
+4. Re-read the target doc end-to-end; verify counts match live output and every file/symbol name resolves; verify cross-links between README/ARCHITECTURE/STRUCTURE/CONTRIBUTING.
+
+### Argument surface
+
+`[readme | architecture | structure | contributing | security | all | <section-name>]` — generate/refresh one doc, one section, or all.
+
+## Separate legacy-prep (gated task, runs first)
+
+Not part of the skill. Gives the skill a clean field before it is authored and first run:
+
+- Archive `PRD.md` + `FEATURES.md` → `docs/product/` with a one-line "historical; see README/ARCHITECTURE for current state" note.
+- Fold the genuinely contributor-facing content of `RULES.md` into `CONTRIBUTING.md`; retire/redirect `RULES.md`.
+- Keep `RFCS.md` as the `RFCs/` index; ensure `ARCHITECTURE.md` references it.
+- Slim `AGENTS.md` to reference the living docs instead of restating structure/architecture.
+- Update the `fro-bot.yaml` Daily Maintenance Report prompt, which currently instructs the agent not to duplicate `AGENTS.md` prescriptive content and not to modify `AGENTS.md` — re-point/extend it for the new canonical living docs. The prompt must stay fenced to an explicit file allowlist so the maintenance agent cannot treat `README.md`/`ARCHITECTURE.md`/`STRUCTURE.md` as fair game to mutate.
+
+## Sequencing
+
+1. **Legacy-prep** (gated) — taxonomy migration above.
+2. **Author the skill** (gated) — against the cleaned doc field.
+3. **First generation run** (gated) — skill generates/refreshes the living docs.
+
+Each step is reviewed before the next begins.
+
+## Open questions / risks
+
+- `AGENTS.md` slimming vs. the harness's tuned knowledge-base format: the agent harness reads `AGENTS.md` operationally. Slimming must preserve the operational signal the harness depends on while moving the human-onboarding content to the living docs — confirm the harness still has what it needs after the split.
+- `CONTRIBUTING.md` boundary with `ARCHITECTURE.md`/`STRUCTURE.md`: avoid re-introducing the duplication we're removing; CONTRIBUTING references, doesn't restate.
+- `fro-bot.yaml` prompt change interacts with the live DMR automation — verify the maintenance agent behaves correctly against the new doc targets before relying on it.
+
+## Acceptance criteria
+
+- A `generating-project-docs` skill exists at `.agents/skills/generating-project-docs/SKILL.md` defining the structures, style rules, generation flow, and argument surface above.
+- The skill generates `README.md`, `ARCHITECTURE.md`, `STRUCTURE.md`, `CONTRIBUTING.md`, and community-health files from live-repo facts, and supports section-scoped refresh.
+- Re-running the skill on an existing doc preserves its evolved structure and changes only what drifted.
+- Generated docs contain no session/process leakage and every cited count/file/symbol resolves against the live repo.
+- The legacy-prep leaves a clean field (PRD/FEATURES archived, RULES folded into CONTRIBUTING, AGENTS.md and the DMR prompt re-pointed) — tracked and gated separately from the skill.

--- a/docs/brainstorms/2026-07-01-harness-merge-credential-broker-requirements.md
+++ b/docs/brainstorms/2026-07-01-harness-merge-credential-broker-requirements.md
@@ -1,0 +1,121 @@
+---
+date: 2026-07-01
+topic: harness-merge-credential-broker
+---
+
+# Harness Merge Credential Broker — Consuming Side
+
+## Summary
+
+Wire the harness merge path to run on a short-lived, broker-minted cliproxy token instead of the durable model credential. Two sequenced deliverables: an env-hygiene scrub that ships independently, then a dedicated `harness-integrate.yaml` reusable workflow that requests a GitHub OIDC token, mints an `auth.json` from `broker.fro.bot`, and provisions it to the merge agent — with revocation handled by the broker's TTL and sweeper.
+
+---
+
+## Problem Frame
+
+The production harness integrate job runs an autonomous LLM merge with the durable model credential reachable on the same filesystem as the merge agent's tools. `harness-release.yaml`'s `integrate` job calls `fro-bot.yaml` as a reusable workflow (`secrets: inherit`, `response-mode: none`), which provisions `auth-json` from `secrets.AUTH_JSON` and runs the merge agent (`--agent build`). The job is read-only toward GitHub, and the credential is written `0600` and never echoed — but the merge agent's bash/read/edit tools execute with host-user filesystem authority, so nothing structurally prevents a spawned tool from reading the credential path.
+
+Two exposures compound. First, `auth-json` is read via `core.getInput('auth-json')` from `INPUT_AUTH_JSON`, which GitHub Actions leaves in the step's process env; there is no scrub after the on-disk write, so the raw secret stays env-dumpable and is inherited by the merge agent's child processes. Second, the durable provider key itself is present on the runner for the whole merge. An OpenCode permission config cannot close this — bash permission checks are advisory only — so the boundary has to be at the credential-lifetime and process layers.
+
+The infra side is already built: an OIDC credential broker at `broker.fro.bot` mints a short-lived, revocable cliproxy token in exchange for a verified GitHub OIDC assertion, so the merge agent never holds the durable key. This work is the consuming side in this repo.
+
+---
+
+## Actors
+
+- A1. Release orchestrator (`harness-release.yaml`): resolves the carry set and invokes the merge path when `has_refs == 'true'`.
+- A2. Merge workflow (`harness-integrate.yaml`, new): the dedicated reusable workflow that requests the OIDC token, mints and provisions the credential, and runs the merge agent.
+- A3. Merge agent (OpenCode `--agent build`): the autonomous process whose tools must never reach the durable credential.
+- A4. Credential broker (`broker.fro.bot`, infra-side): verifies the OIDC assertion against its allowlist, mints the short-lived cliproxy token, and reaps it via TTL and a sweeper.
+- A5. Operator (Marcus): un-placeholders the broker allowlist on `marcusrbrown/infra` so the mint can succeed.
+
+---
+
+## Key Flows
+
+- F1. Harness merge on a brokered credential
+  - **Trigger:** `harness-release.yaml` `integrate` invokes the merge path with a non-empty carry set.
+  - **Actors:** A1, A2, A3, A4
+  - **Steps:** (1) the merge workflow requests a GitHub OIDC token for audience `https://broker.fro.bot`; (2) it POSTs the token to `/v1/mint`; (3) the broker verifies issuer/signature/audience/expiry and matches claims against its allowlist; (4) on a match it returns an `auth.json` payload carrying a short-lived cliproxy token; (5) the workflow provisions that payload as the merge agent's `auth-json`, with the durable key never written on the runner; (6) the merge agent runs; (7) the minted token expires and is swept by the broker's TTL/sweeper after the run.
+  - **Outcome:** the merge completes using a credential that is cliproxy-scoped and short-lived, with the durable provider key absent from the runner.
+  - **Covered by:** R3, R4, R5, R6
+
+---
+
+## Requirements
+
+**Environment hygiene (ships first, no infra dependency)**
+- R1. After the auth credential is written to disk, scrub the raw secret from the harness process environment (`INPUT_AUTH_JSON`) so it is no longer env-dumpable.
+- R2. Do not propagate the raw auth secret in the environment inherited by the OpenCode server child process.
+
+**Brokered credential for the harness merge (needs the infra allowlist un-placeholdered)**
+- R3. Extract the harness merge path into a dedicated reusable workflow (`harness-integrate.yaml`) that `harness-release.yaml` calls in place of the current direct `fro-bot.yaml` invocation, so `id-token: write` is scoped to the merge path only and never granted to the shared `fro-bot.yaml`.
+- R4. In the merge workflow, request a GitHub OIDC token for audience `https://broker.fro.bot` and exchange it at `POST https://broker.fro.bot/v1/mint`.
+- R5. Provision the minted `auth.json` as the merge agent's credential, and withhold the durable provider key from the integrate path entirely — the dedicated workflow must not use `secrets: inherit` and must not receive `secrets.AUTH_JSON`, so the durable key is neither written to disk nor present in any step's environment on the integrate runner.
+- R6. When the mint fails or returns no credential, the merge path fails closed — it does not fall back to the durable key.
+- R7. Rely on the broker's TTL and sweeper for revocation; the minted token's short lifetime bounds exposure. The broker exposes no caller-facing revoke endpoint, so the consuming side sends no run-end ping. The residual exposure window equals the token TTL: if the token is stolen mid-run, it stays valid until expiry/sweep with no in-run kill switch — acceptable because egress from the integrate job plus the token's cliproxy-only scope bound its value. Confirm the broker's actual TTL is short enough to cover a normal merge without over-extending this window; if immediate revocation is wanted later, file an infra follow-up to add a revoke endpoint.
+
+**Cross-repo enablement**
+- R8. Surface the exact broker-allowlist values the operator must set on `marcusrbrown/infra`, with instructions, so the mint can be un-placeholdered and the end-to-end path verified.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R5.** Given the dedicated integrate workflow does not inherit `AUTH_JSON` (no `secrets: inherit`, secret not passed), when the merge agent and any of its child processes or sibling steps run, then the durable `secrets.AUTH_JSON` / `INPUT_AUTH_JSON` value is unreachable in every step environment, child-process environment, and on disk — only the short-lived cliproxy token is present. The assertion checks all inherited step and child envs, not just the final agent context.
+- AE2. **Covers R6.** Given the broker returns a non-match or error, when the mint step runs, then the workflow fails without provisioning the durable credential.
+- AE3. **Covers R1, R2.** Given the credential has been written to disk, when the merge agent spawns a child process, then that child's environment does not contain the raw auth secret.
+- AE4. **Covers R7.** Given the merge finishes, when the run ends, then no durable credential remains valid — the minted token is bounded by the broker's TTL and reaped by its sweeper, and the workflow sends no revoke call.
+
+---
+
+## Success Criteria
+
+- The merge agent cannot read the durable model credential path — the durable key is never on the integrate runner, only a short-lived cliproxy token.
+- Verified against a real harness dispatch (not config inspection): a live integrate run completes on the minted credential after the operator un-placeholders the allowlist.
+- The env-hygiene deliverable lands and verifies independently, before the broker allowlist is settled.
+- The operator has an unambiguous, copy-ready list of the infra-side values and steps, surfaced at the point they are needed.
+
+---
+
+## Scope Boundaries
+
+- Egress containment for the integrate job (retained item 1 of #1060) — deferred to `infra#725`. The broker shrinks the credential's value and lifetime; it does not constrain in-run network reach.
+- The infra-side broker implementation and the allowlist un-placeholder action — owned by `marcusrbrown/infra`; this doc only surfaces the values and instructions the operator needs.
+- Log redaction — already handled by `formatPipelineError`; this work is about read-access and credential lifetime, not log hygiene.
+- Changing the merge agent, model, or carry-set resolution logic — unchanged; only how its credential is provisioned changes.
+
+---
+
+## Key Decisions
+
+- Dedicated `harness-integrate.yaml` over gating the shared `fro-bot.yaml`: keeps `id-token: write` entirely off the general Fro Bot path (issues/comments/schedule/dispatch), at the cost of some setup duplication between the two workflows. Because the dedicated workflow does only the merge, no extra `credential-source` marker gate is needed to keep the mint off non-harness runs.
+- Pin the broker allowlist on the `job_workflow_ref` claim → `fro-bot/agent/.github/workflows/harness-integrate.yaml@refs/heads/main`: GitHub designed `job_workflow_ref` to constrain which reusable workflow actually ran, independent of caller; it binds the mint to the exact code that touches the key, which is tighter than the caller-side `workflow_ref`.
+- Withhold `AUTH_JSON` by construction, not by scrubbing: the dedicated workflow drops `secrets: inherit` and passes only the secrets the merge genuinely needs, so the durable key is never on the integrate runner. This is what makes R5 satisfiable — under `secrets: inherit` the durable key would still be inherited into the called workflow's environment and the "brokered only" boundary would be fake. The env scrub (R1–R2) is defense-in-depth for the shared non-harness paths that still carry `AUTH_JSON`, not the primary control for the harness path.
+- Sequence the env scrub first (no infra dependency, independently testable) and the broker wiring second (blocked on the allowlist un-placeholder), so credential-lifetime progress is not gated on the disk-exposure reduction and vice versa. The two are genuinely independent: the scrub hardens the shared `fro-bot.yaml` paths that keep using `AUTH_JSON`, while the harness path drops `AUTH_JSON` entirely — neither depends on the other landing first.
+- Ship the two deliverables as separate PRs: R1–R2 (env-hygiene scrub, shared-flow defense-in-depth) land first as their own focused change; R3–R8 (broker wiring) land second. They live in one requirements doc because they tell one credential-isolation story, but the env scrub touches the shared auth-json plumbing and earns its own review surface.
+- Revocation via the broker's TTL/sweeper, no run-end ping: the broker exposes no caller-facing revoke endpoint, and the minted token's short lifetime bounds exposure. Keeps the consuming side simple; an immediate-revoke endpoint can be added infra-side later if wanted.
+
+---
+
+## Dependencies / Assumptions
+
+- The broker at `broker.fro.bot` is live: `POST /v1/mint` with `Authorization: Bearer <github-oidc-token>`, verifying GitHub issuer, RS256 against the published JWKS, audience, expiry, and `jti` replay; it refuses `pull_request`/`pull_request_target` events and fail-closes on a non-matching or placeholder allowlist.
+- The broker returns the minted credential shaped as an OpenCode `auth.json` payload.
+- Workflow-file integrity is a load-bearing part of the trust model: the `job_workflow_ref` pin authorizes whatever `harness-integrate.yaml` contains on `refs/heads/main`, so the guarantee depends on `main` being edit-protected. `main` enforces branch protection with admin enforcement, so an unauthorized edit to the minting logic on the pinned ref is blocked — but any change to `harness-integrate.yaml` is security-relevant and must be reviewed as such.
+- **Cross-repo action required on `marcusrbrown/infra` before the end-to-end path can succeed** — the broker allowlist is deployed fail-closed with placeholders and must be un-placeholdered with these exact values:
+  - `repository_id`: `1126485011`
+  - `repository_owner_id`: `80104189` (`fro-bot` org)
+  - `job_workflow_ref`: `fro-bot/agent/.github/workflows/harness-integrate.yaml@refs/heads/main`
+  - Until these are set, the mint fails closed and R3–R7 cannot be verified live. This is the one blocking external dependency; the env-hygiene deliverable (R1–R2) does not depend on it.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R3][Technical] Whether `harness-integrate.yaml` re-invokes the same `fro-bot/agent` action with the minted `auth-json` or is a trimmed copy of the merge setup — determines how much of `fro-bot.yaml`'s setup is shared vs duplicated.
+- [Affects R4][Technical] The token-request mechanism inside the workflow (`core.getIDToken('https://broker.fro.bot')` in a small step vs an action) and where the mint HTTP call lives.
+- [Affects R1, R2][Technical] The exact scrub seam — where in `src/harness/config/inputs.ts` / `src/features/agent/server.ts` the env delete and child-env exclusion belong so the file write still succeeds.
+- [Affects R5][Technical] The exact secret-passing mechanics for the dedicated workflow — R5 requires dropping `secrets: inherit` and passing only the secrets the merge needs explicitly (not `AUTH_JSON`). Planning confirms which secrets the merge genuinely requires (e.g. `FRO_BOT_PAT`, `OPENCODE_CONFIG`) and wires them individually.


### PR DESCRIPTION
Removes `docs/brainstorms/` from `.gitignore` and checks in the 21 previously-untracked brainstorm/requirements documents.

## Why

Plan docs in `docs/plans/` have always linked to their origin brainstorms — but the targets were gitignored working files, so every one of those links was dead on GitHub and only resolved on a local checkout that happened to have the files. This surfaced concretely in #1091: the new markdown link checker passed locally (files on disk) and failed in CI (files not in the checkout) — the same split GitHub readers have always experienced.

Tracking the brainstorms makes the plan → origin chain navigable end-to-end and puts the requirements history under version control.

## Notes

- 21 documents added; `docs/brainstorms/2026-04-13-compounding-wiki-requirements.md` was already tracked (pre-dating the ignore rule).
- Scanned for secrets and private-repo identifiers before adding — clean.
- `eslint.config.ts` and `.markdownlint-cli2.yaml` already ignore-list `docs/brainstorms/`, so lint gates are unaffected (verified: `bun run lint` exit 0).
- Unblocks #1091, whose CI lint currently fails on plan → brainstorm links that only existed locally.
