### PR TITLE
docs(plans): reconcile plan statuses with shipped reality

### DIFF
--- a/docs/plans/2026-05-18-001-fix-deploy-contract-hardening-plan.md
+++ b/docs/plans/2026-05-18-001-fix-deploy-contract-hardening-plan.md
@@ -1,10 +1,12 @@
 ---
 title: 'fix: deploy contract hardening for external IaC consumers'
 type: fix
-status: active
+status: done
 date: 2026-05-18
 deepened: 2026-05-18
 ---
+
+> **Status: done.** All 3 units shipped: explicit S3 `credentials:` plumbing, compose AWS credential mounts + log rotation + secret-path guard, and the gateway readiness healthcheck + docs — verified on `main` (`packages/runtime/src/object-store/s3-adapter.ts:99-111`, `deploy/compose.yaml`, PR #649).
 
 # fix: deploy contract hardening for external IaC consumers
 
@@ -104,7 +106,7 @@ The two stale claims in the original handoff brief (`DISCORD_GUILD_ID` plumbing 
 
 ## Implementation Units
 
-- [ ] **Unit 1: AWS credential plumbing (config + adapter + tests)**
+- [x] **Unit 1: AWS credential plumbing (config + adapter + tests)**
 
 **Goal:** Read optional AWS credentials from secret files in `loadGatewayConfig`, pass them through `ObjectStoreConfig`, and inject them into the `S3Client` constructor when both are present.
 
@@ -156,7 +158,7 @@ The two stale claims in the original handoff brief (`DISCORD_GUILD_ID` plumbing 
 - `pnpm check-types` clean across the workspace.
 - `pnpm lint` clean.
 
-- [ ] **Unit 2: Compose AWS credential mounts + log rotation + secret-path guard**
+- [x] **Unit 2: Compose AWS credential mounts + log rotation + secret-path guard**
 
 **Goal:** Wire the new AWS credential `*_FILE` env vars + bind-mounts in `deploy/compose.yaml`. Add bounded `logging:` to gateway, workspace, and mitmproxy. Add the `isFile()` guard to `readOptionalSecret` so directory-as-secret-path fails with a clear error.
 
@@ -194,7 +196,7 @@ The two stale claims in the original handoff brief (`DISCORD_GUILD_ID` plumbing 
 - `pnpm --filter @fro-bot/gateway test` passes new directory-guard test.
 - `docker compose -f deploy/compose.yaml config --quiet` exits 0 after running `touch deploy/secrets/aws-{access-key-id,secret-access-key}`.
 
-- [ ] **Unit 3: Gateway readiness healthcheck + docs**
+- [x] **Unit 3: Gateway readiness healthcheck + docs**
 
 **Goal:** Replace the no-op Dockerfile healthcheck with a real readiness check backed by a `/tmp/gateway-ready` flag file touched by the Discord `ready` handler. Remove the compose healthcheck override (the Dockerfile's becomes authoritative). Update `deploy/README.md` to reflect AWS credentials + the readiness behavior.
 

--- a/docs/plans/2026-05-19-001-fix-gateway-intent-posture-flip-plan.md
+++ b/docs/plans/2026-05-19-001-fix-gateway-intent-posture-flip-plan.md
@@ -1,10 +1,12 @@
 ---
 title: 'fix: Gateway intent-posture flip — privileged intents become opt-in'
 type: fix
-status: active
+status: done
 date: 2026-05-19
 origin: https://github.com/fro-bot/agent/issues/646
 ---
+
+> **Status: done.** All 3 units shipped: `DEFAULT_INTENTS` flipped to `[Guilds, GuildMessages]`, `DISCORD_PRIVILEGED_INTENTS` config knob, and tests/docs — verified on `main` (`packages/gateway/src/discord/client.ts:10`, PR #651).
 
 # Gateway intent-posture flip — privileged intents become opt-in
 
@@ -113,7 +115,7 @@ This plan flips the baseline to the non-privileged set (`Guilds`, `GuildMessages
 
 ## Implementation Units
 
-- [ ] **Unit 1: Flip `DEFAULT_INTENTS` to non-privileged baseline**
+- [x] **Unit 1: Flip `DEFAULT_INTENTS` to non-privileged baseline**
 
 **Goal:** Change `DEFAULT_INTENTS` in `packages/gateway/src/discord/client.ts` to contain only `Guilds` and `GuildMessages`. The merge logic in `createDiscordClient` is unchanged.
 
@@ -143,7 +145,7 @@ This plan flips the baseline to the non-privileged set (`Guilds`, `GuildMessages
 
 ---
 
-- [ ] **Unit 2: Add `DISCORD_PRIVILEGED_INTENTS` config knob in `loadGatewayConfig`**
+- [x] **Unit 2: Add `DISCORD_PRIVILEGED_INTENTS` config knob in `loadGatewayConfig`**
 
 **Goal:** Parse `DISCORD_PRIVILEGED_INTENTS` from env (via `readOptionalSecret`), validate against the two-value allowlist, and expose as `privilegedIntents: GatewayIntentBits[]` on `GatewayConfig`. Wire it into `main.ts` so it flows into `createDiscordClient` as the `intents` override.
 
@@ -201,7 +203,7 @@ This plan flips the baseline to the non-privileged set (`Guilds`, `GuildMessages
 
 ---
 
-- [ ] **Unit 3: Client-level tests + test-isolation guard + AGENTS.md docs**
+- [x] **Unit 3: Client-level tests + test-isolation guard + AGENTS.md docs**
 
 **Goal:** Add the client-level test scenarios from R4, install the test-isolation guard in `client.test.ts`, and document the `DISCORD_PRIVILEGED_INTENTS` knob in `packages/gateway/AGENTS.md`.
 

--- a/docs/plans/2026-05-23-001-feat-gateway-unit-5-add-project-plan.md
+++ b/docs/plans/2026-05-23-001-feat-gateway-unit-5-add-project-plan.md
@@ -1,12 +1,14 @@
 ---
 title: "feat: Gateway v1 Unit 5 — channel-repo binding + /fro-bot add-project"
 type: feat
-status: active
+status: done
 date: 2026-05-23
 origin: docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
 parent_unit: Unit 5 of the Gateway v1 plan
 deepened: 2026-05-24 (coherence + feasibility + security review applied)
 ---
+
+> **Status: done.** All 4 PRs shipped: the bindings store, GitHub App auth, `apps/workspace-agent` scaffold, and `/fro-bot add-project` — verified on `main` (PR #672/#673/#674/#676).
 
 # feat: Gateway v1 Unit 5 — channel-repo binding + /fro-bot add-project
 
@@ -190,7 +192,7 @@ deploy/compose.yaml                          (PR B — GitHub App secret mounts)
 
 ## Implementation Units
 
-- [ ] **PR A: Channel-repo bindings store**
+- [x] **PR A: Channel-repo bindings store**
 
 **Goal:** A typed, S3-backed store for repo bindings using the two-key shape from the Binding Storage Model section above. Primary record per repo + channel-to-repo index. Read, list, create-only-write (via `IfNoneMatch: '*'`). No Discord, no GitHub — pure storage layer.
 
@@ -239,7 +241,7 @@ deploy/compose.yaml                          (PR B — GitHub App secret mounts)
 
 ---
 
-- [ ] **PR B: GitHub App authentication for the gateway**
+- [x] **PR B: GitHub App authentication for the gateway**
 
 **Goal:** Octokit-backed App client with auto-discovered `installation_id`. No Discord wiring, no slash command — just the authenticated client that PR D will use.
 
@@ -291,7 +293,7 @@ deploy/compose.yaml                          (PR B — GitHub App secret mounts)
 
 ---
 
-- [ ] **PR C: apps/workspace-agent scaffold + Hono HTTP service**
+- [x] **PR C: apps/workspace-agent scaffold + Hono HTTP service**
 
 **Goal:** New `apps/workspace-agent/` sub-app: Hono server on port 9100, `/clone` route handler, packaged + built + wired into `workspace.Dockerfile` to replace `sleep infinity`. Nothing in the gateway calls it yet — that's PR D.
 
@@ -353,7 +355,7 @@ deploy/compose.yaml                          (PR B — GitHub App secret mounts)
 
 ---
 
-- [ ] **PR D: workspace-api client + Discord channel management + /add-project slash command**
+- [x] **PR D: workspace-api client + Discord channel management + /add-project slash command**
 
 **Goal:** Ship the slash command. Wire together PR A (bindings) + PR B (auth) + the workspace-api HTTP client. Operator runs `/fro-bot add-project url:<git-url>` and gets a Discord channel bound to a freshly cloned repo. Setup thread shows phase progression. End-to-end `/add-project` works after this lands.
 

--- a/docs/plans/2026-05-29-001-feat-gateway-announce-webhook-plan.md
+++ b/docs/plans/2026-05-29-001-feat-gateway-announce-webhook-plan.md
@@ -1,11 +1,13 @@
 ---
 title: "feat: Gateway announce webhook (POST /v1/announce) for control-plane presence messages"
 type: feat
-status: active
+status: done
 date: 2026-05-29
 origin: https://github.com/fro-bot/agent/issues/671
 deepened: 2026-05-29
 ---
+
+> **Status: done.** All 8 units shipped: the Hono dependency, config, HMAC verification, the announce payload schema, the presence-posting helper, embed templates, the HTTP server + route handler, and program-lifecycle wiring — verified on `main` (PR #697).
 
 # feat: Gateway announce webhook (POST /v1/announce)
 
@@ -138,7 +140,7 @@ See origin: https://github.com/fro-bot/agent/issues/671 (issue body + Fro Bot tr
 
 ## Implementation Units
 
-- [ ] **Unit 0: Add Hono dependency to the gateway package**
+- [x] **Unit 0: Add Hono dependency to the gateway package**
 
 **Goal:** Make `hono` + `@hono/node-server` available to `packages/gateway` so Unit 6 can compile. They currently exist only in `apps/workspace-agent/package.json`, NOT in the gateway.
 
@@ -158,7 +160,7 @@ See origin: https://github.com/fro-bot/agent/issues/671 (issue body + Fro Bot tr
 
 **Verification:** `hono` resolves in the gateway package; `pnpm install` leaves a clean lockfile; no version divergence from workspace-agent.
 
-- [ ] **Unit 1: Config — webhook secret, presence channel, HTTP port**
+- [x] **Unit 1: Config — webhook secret, presence channel, HTTP port**
 
 **Goal:** Thread the three new config values through `GatewayConfig` and `loadGatewayConfig()`.
 
@@ -186,7 +188,7 @@ See origin: https://github.com/fro-bot/agent/issues/671 (issue body + Fro Bot tr
 
 **Verification:** `loadGatewayConfig()` returns the new fields; missing required secrets fail fast; invalid port rejected.
 
-- [ ] **Unit 2: HMAC verification + timestamp binding (pure utility)**
+- [x] **Unit 2: HMAC verification + timestamp binding (pure utility)**
 
 **Goal:** A pure, well-tested module that verifies an HMAC-SHA256 signature over `timestamp + "." + rawBody` and enforces the replay window.
 
@@ -218,7 +220,7 @@ See origin: https://github.com/fro-bot/agent/issues/671 (issue body + Fro Bot tr
 
 **Verification:** every tampering and skew case rejects; only an exact match within window passes; no input shape throws.
 
-- [ ] **Unit 3: Announce payload schema (Effect Schema)**
+- [x] **Unit 3: Announce payload schema (Effect Schema)**
 
 **Goal:** Validate the decoded JSON into a typed `AnnouncePayload`, rejecting unknown event types.
 
@@ -255,7 +257,7 @@ See origin: https://github.com/fro-bot/agent/issues/671 (issue body + Fro Bot tr
 
 **Verification:** valid payloads decode; every malformed shape returns Left with a content-free reason.
 
-- [ ] **Unit 4: Presence channel posting helper**
+- [x] **Unit 4: Presence channel posting helper**
 
 **Goal:** Resolve the presence channel by ID and post an embed via the existing discord.js client.
 
@@ -282,7 +284,7 @@ See origin: https://github.com/fro-bot/agent/issues/671 (issue body + Fro Bot tr
 
 **Verification:** posts to the configured channel; all failure modes return typed errors, never throw, never log content.
 
-- [ ] **Unit 5: Embed templates registry**
+- [x] **Unit 5: Embed templates registry**
 
 **Goal:** Map `event_type` → embed (accent color + in-character text), honoring `rendered_text` override.
 
@@ -308,7 +310,7 @@ See origin: https://github.com/fro-bot/agent/issues/671 (issue body + Fro Bot tr
 
 **Verification:** correct color + copy per type; `rendered_text` override wins.
 
-- [ ] **Unit 6: HTTP server + announce route handler**
+- [x] **Unit 6: HTTP server + announce route handler**
 
 **Goal:** The Hono server and the `POST /v1/announce` handler that composes size-cap → HMAC → timestamp cross-check → decode → render → post, with the rate limiter and structured logging.
 
@@ -345,7 +347,7 @@ See origin: https://github.com/fro-bot/agent/issues/671 (issue body + Fro Bot tr
 
 **Verification:** every status-code branch behaves per spec; auth failures are indistinguishable to the caller; no secret/body leakage in logs; oversized bodies rejected before hashing.
 
-- [ ] **Unit 7: Wire server into program lifecycle + shutdown drain**
+- [x] **Unit 7: Wire server into program lifecycle + shutdown drain**
 
 **Goal:** Start the announce server in `makeGatewayProgram` and close it in the shutdown drain.
 

--- a/docs/plans/2026-05-30-001-feat-gateway-unit-6-mention-loop-plan.md
+++ b/docs/plans/2026-05-30-001-feat-gateway-unit-6-mention-loop-plan.md
@@ -1,11 +1,13 @@
 ---
 title: "feat: Gateway Unit 6 MVP — @fro-bot mention → OpenCode interaction loop (remote attach)"
 type: feat
-status: active
+status: done
 date: 2026-05-30
 origin: docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
 deepened: 2026-05-30
 ---
+
+> **Status: done.** All 6 units shipped: the Unit 0 remote-attach spike (verdict GO, `docs/plans/2026-05-30-001-unit-0-spike-findings.md`), the workspace-agent OpenCode SDK server lifecycle, the gateway remote-attach client + execution orchestrator, the Discord streaming sink, mention → execution wiring with run-state lifecycle + lock, and startup stale-run recovery — verified on `main` (`packages/gateway/src/execute/recovery.ts`, PR #705). The deferred UX/approval/queue layers (reactions, working-message heartbeat, approvals, per-thread queue, extra slash commands) shipped separately in the follow-up plans this reconciliation also marks done.
 
 # Gateway Unit 6 MVP — `@fro-bot` Mention → OpenCode Interaction Loop
 
@@ -288,7 +290,7 @@ EXECUTING by a crash is transitioned FAILED, its lock released, and (best-effort
 
 ## Implementation Units
 
-- [ ] **Unit 0: Spike — prove remote-attach streaming (de-risk the topology)**
+- [x] **Unit 0: Spike — prove remote-attach streaming (de-risk the topology)**
 
 **Goal:** Empirically confirm that `createOpencodeClient({baseURL})` against a *remote* OpenCode server
 can run the full prompt → SSE stream → `session.idle` flow (not just `v2.session.wait()`), with tool
@@ -335,7 +337,7 @@ until the topology is confirmed. The output is a go/no-go finding, not shippable
 - A written go/no-go note: remote streaming works (proceed to Unit 1) or does not (escalate, re-plan
   to Option B). Capture the exact event kinds observed.
 
-- [ ] **Unit 1: Workspace-agent — OpenCode SDK server lifecycle**
+- [x] **Unit 1: Workspace-agent — OpenCode SDK server lifecycle**
 
 **Goal:** The workspace container runs an OpenCode SDK server at boot, bound to `/workspace/repos`,
 reachable on the internal `sandbox-net`. `GET /healthz` reflects server readiness so the gateway can
@@ -386,7 +388,7 @@ gate on it.
 - Tests pass; manual: container boots, `/healthz` flips to `ready`, the OpenCode port answers from a
   peer container on `sandbox-net` but not from the host.
 
-- [ ] **Unit 2: Gateway remote-attach client + execution orchestrator**
+- [x] **Unit 2: Gateway remote-attach client + execution orchestrator**
 
 **Goal:** A gateway-side module that attaches to the remote OpenCode server, creates a session, sends
 a prompt against the repo `directory`, and drives it to completion using the reused runtime
@@ -450,7 +452,7 @@ makes the gateway close the remote server would break every subsequent mention.
 - Tests pass; the execute core resolves text from a fake remote stream and never closes the injected
   handle.
 
-- [ ] **Unit 3: Discord streaming sink**
+- [x] **Unit 3: Discord streaming sink**
 
 **Goal:** Consume the execution event stream and render the agent's text into the Discord thread —
 incremental where sensible, with a `.md` attachment fallback for long output and `@everyone` stripped.
@@ -489,7 +491,7 @@ incremental where sensible, with a `.md` attachment fallback for long output and
 **Verification:**
 - Tests pass; manual: a short prompt renders inline in the thread; a long prompt yields a `.md` file.
 
-- [ ] **Unit 4: Mention → execution wiring + run-state lifecycle + lock**
+- [x] **Unit 4: Mention → execution wiring + run-state lifecycle + lock**
 
 **Goal:** Replace the `pong` stub. On a real `@fro-bot` mention in a bound channel, run the full
 orchestration: resolve binding → thread → lock → run-state lifecycle → execute (Unit 2) → stream
@@ -566,7 +568,7 @@ handler-only tests.
 - Tests pass; live smoke: `@fro-bot explain <file>` in a bound channel → thread → text response →
   COMPLETED; S3 shows run-state + a released lock.
 
-- [ ] **Unit 5: Startup stale-run recovery + integration + docs**
+- [x] **Unit 5: Startup stale-run recovery + integration + docs**
 
 **Goal:** On gateway boot, recover runs a prior crash left mid-flight; wire the recovery into program
 startup; document the MVP behavior and limitations.

--- a/docs/plans/2026-06-01-001-fix-isnotfound-s3-classification-plan.md
+++ b/docs/plans/2026-06-01-001-fix-isnotfound-s3-classification-plan.md
@@ -1,9 +1,11 @@
 ---
 title: 'fix: isNotFound() misclassifies S3 NoSuchKey as fatal'
 type: fix
-status: active
+status: done
 date: 2026-06-01
 ---
+
+> **Status: done.** Both units shipped: structured S3 error classification preserved through the object-store adapter (`packages/runtime/src/object-store/s3-adapter.ts`), and regression tests — verified on `main`.
 
 # fix: isNotFound() misclassifies S3 NoSuchKey as fatal
 

--- a/docs/plans/2026-06-01-002-feat-omo-slim-optional-dependency-plan.md
+++ b/docs/plans/2026-06-01-002-feat-omo-slim-optional-dependency-plan.md
@@ -1,10 +1,12 @@
 ---
 title: 'feat: OMO Slim as an optional dependency'
 type: feat
-status: active
+status: done
 date: 2026-06-01
 origin: docs/brainstorms/2026-06-01-omo-slim-optional-dependency-requirements.md
 ---
+
+> **Status: done.** All 6 units shipped: `DEFAULT_OMO_SLIM_VERSION` (`packages/runtime/src/shared/constants.ts`), `enable-omo-slim`/`omo-slim-preset` action inputs, the installer, CI config assembly, tests, and docs — verified on `main` (`action.yaml`, PR #722). R13-R15 (gateway passthrough) remain explicitly deferred per the plan's own scope.
 
 # feat: OMO Slim as an optional dependency
 
@@ -88,7 +90,7 @@ Implements R1-R12, R16-R20 from the origin requirements doc. R13-R15 (gateway pa
 
 ## Implementation Units
 
-- [ ] **Unit 1: Version constant + Renovate tracking**
+- [x] **Unit 1: Version constant + Renovate tracking**
 
 **Goal:** Single-source-of-truth pinned Slim version with Renovate updates.
 
@@ -113,7 +115,7 @@ Implements R1-R12, R16-R20 from the origin requirements doc. R13-R15 (gateway pa
 
 **Verification:** `grep` finds no duplicate `1.1.1` literal elsewhere; Renovate regex matches the constant; `pnpm build` clean.
 
-- [ ] **Unit 2: Action inputs, parsing, mutual exclusivity, warnings**
+- [x] **Unit 2: Action inputs, parsing, mutual exclusivity, warnings**
 
 **Goal:** Expose `enable-omo-slim` / `omo-slim-preset` / `omo-slim-version`; parse into `ActionInputs`; enforce mutual exclusion with `enable-omo`; warn on disabled-mode usage.
 
@@ -144,7 +146,7 @@ Implements R1-R12, R16-R20 from the origin requirements doc. R13-R15 (gateway pa
 
 **Verification:** inputs.test.ts green; mutual-exclusion + warnings covered.
 
-- [ ] **Unit 3: Slim installer**
+- [x] **Unit 3: Slim installer**
 
 **Goal:** Install Slim via Bun at the resolved version with the selected preset; report status.
 
@@ -175,7 +177,7 @@ Implements R1-R12, R16-R20 from the origin requirements doc. R13-R15 (gateway pa
 
 **Verification:** installer + setup tests green; command/preset asserted against the mocked adapter.
 
-- [ ] **Unit 4: CI config assembly (orchestrator default, mode-authoritative plugins, guards)**
+- [x] **Unit 4: CI config assembly (orchestrator default, mode-authoritative plugins, guards)**
 
 **Goal:** When Slim is enabled, register the Slim plugin and pin `default_agent: 'orchestrator'`; rebuild the plugin array mode-authoritatively; refuse a both-plugins config; verify orchestrator presence; set the Slim permission posture.
 
@@ -205,7 +207,7 @@ Implements R1-R12, R16-R20 from the origin requirements doc. R13-R15 (gateway pa
 
 **Verification:** ci-config + setup tests green; cache-restore flip scenario covered.
 
-- [ ] **Unit 5: Tests + CI introspection**
+- [x] **Unit 5: Tests + CI introspection**
 
 **Goal:** Round out coverage and add disabled/enabled Slim introspection to the Test GitHub Action job.
 
@@ -226,7 +228,7 @@ Implements R1-R12, R16-R20 from the origin requirements doc. R13-R15 (gateway pa
 
 **Verification:** full suite green; `pnpm build` clean; `dist/` in sync; a Test GitHub Action run shows the slim introspection passing.
 
-- [ ] **Unit 6: Documentation**
+- [x] **Unit 6: Documentation**
 
 **Goal:** Surface the new inputs and the pinned default.
 

--- a/docs/plans/2026-06-01-003-feat-workspace-executor-image-plan.md
+++ b/docs/plans/2026-06-01-003-feat-workspace-executor-image-plan.md
@@ -1,10 +1,12 @@
 ---
 title: "feat: Workspace executor image — make /fro-bot add-project and the mention loop work end-to-end"
 type: feat
-status: active
+status: done
 date: 2026-06-01
 origin: docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
 ---
+
+> **Status: done.** All 5 units shipped: `deploy/workspace.Dockerfile`, the CA-trust entrypoint, compose wiring, the `workspace-smoke` CI job, and deploy docs — verified on `main` (PR #725).
 
 # feat: Workspace executor image
 
@@ -129,7 +131,7 @@ Egress clients inside workspace → mitmproxy:8080 (HTTPS_PROXY) → allowlist
 
 ## Implementation Units
 
-- [ ] **Unit 1: Workspace executor Dockerfile**
+- [x] **Unit 1: Workspace executor Dockerfile**
 
 **Goal:** Replace the placeholder with a multi-stage Alpine image that builds `apps/workspace-agent` and bakes OpenCode 1.14.41 (musl) + the system packages the clone/OpenCode paths need.
 
@@ -156,7 +158,7 @@ Egress clients inside workspace → mitmproxy:8080 (HTTPS_PROXY) → allowlist
 **Verification:**
 - `docker build -f deploy/workspace.Dockerfile .` succeeds; `opencode --version` inside the image prints `1.14.41`; `git --version` resolves; `node dist/main.mjs` is the launch target.
 
-- [ ] **Unit 2: CA-trust entrypoint script**
+- [x] **Unit 2: CA-trust entrypoint script**
 
 **Goal:** Make outbound TLS through mitmproxy work for git/opencode (system CA bundle) before the supervisor starts.
 
@@ -182,7 +184,7 @@ Egress clients inside workspace → mitmproxy:8080 (HTTPS_PROXY) → allowlist
 **Verification:**
 - In a composed stack, `docker exec workspace git clone https://github.com/octocat/Hello-World /tmp/t` succeeds (no `SSL certificate problem`); the smoke job (no CA mounted) still reaches `:9100` listening.
 
-- [ ] **Unit 3: Compose wiring for the real workspace**
+- [x] **Unit 3: Compose wiring for the real workspace**
 
 **Goal:** Wire the workspace service to the real image with CA trust and a health gate, preserving the sandbox port model.
 
@@ -208,7 +210,7 @@ Egress clients inside workspace → mitmproxy:8080 (HTTPS_PROXY) → allowlist
 **Verification:**
 - `docker compose -f deploy/compose.yaml config` parses; workspace builds from the real Dockerfile; no host ports published; CA volume mounted at the dedicated path.
 
-- [ ] **Unit 4: `workspace-smoke` CI job**
+- [x] **Unit 4: `workspace-smoke` CI job**
 
 **Goal:** Prove the image builds and the clone path boots independently of OpenCode, guarding against module-resolution and missing-binary regressions.
 
@@ -238,7 +240,7 @@ Egress clients inside workspace → mitmproxy:8080 (HTTPS_PROXY) → allowlist
 **Verification:**
 - The job runs on this PR (the `deploy/**` + `ci.yaml` changes trigger it), builds the image, and passes the assertions.
 
-- [ ] **Unit 5: Deploy docs**
+- [x] **Unit 5: Deploy docs**
 
 **Goal:** Document that the workspace is now a real executor: the OpenCode token requirement, the `OBJECT_STORE_HOSTS` allowlist relationship, and the CA-trust behavior.
 

--- a/docs/plans/2026-06-01-004-feat-workspace-opencode-auth-provisioning-plan.md
+++ b/docs/plans/2026-06-01-004-feat-workspace-opencode-auth-provisioning-plan.md
@@ -1,10 +1,12 @@
 ---
 title: "feat: Provision OpenCode model/auth into the workspace executor for the mention loop"
 type: feat
-status: active
+status: done
 date: 2026-06-01
 reviewed: 2026-06-01
 ---
+
+> **Status: done.** All 4 units shipped: file-based entrypoint auth provisioning, `WORKSPACE_OPENCODE_MODEL`/`WORKSPACE_OPENCODE_CONFIG` overlay with no baked default, compose wiring, and smoke/docs — verified on `main` (`deploy/compose.yaml:242-251`, PR #728).
 
 # feat: Workspace OpenCode model/auth provisioning
 
@@ -116,7 +118,7 @@ The workspace container clones and may execute untrusted repository code in the 
 
 ## Implementation Units
 
-- [ ] **Unit 1: Entrypoint auth provisioning (file-based)**
+- [x] **Unit 1: Entrypoint auth provisioning (file-based)**
 
 **Goal:** The entrypoint writes a validated `auth.json` to OpenCode's data path from a mounted secret, so the server authenticates — without baking the secret or exposing it via env.
 
@@ -143,7 +145,7 @@ The workspace container clones and may execute untrusted repository code in the 
 **Verification:**
 - With a valid secret, `$XDG_DATA_HOME/opencode/auth.json` exists `0600` with the blob; with a malformed/empty-provider blob, the container exits with a clear error; with no secret, it boots and the clone path works; the secret never appears in logs.
 
-- [ ] **Unit 2: Model + provider-config overlay (entrypoint), no baked default**
+- [x] **Unit 2: Model + provider-config overlay (entrypoint), no baked default**
 
 **Goal:** The workspace OpenCode server's model and provider config are supplied at deploy time, mirroring the action's `model` + `opencode-config`.
 
@@ -168,7 +170,7 @@ The workspace container clones and may execute untrusted repository code in the 
 **Verification:**
 - With the cliproxyapi-shaped env, the effective `opencode.json` carries the overlaid model + provider `baseURL` + the Systematic plugin; with neither env, no `model` field and the plugin remains; malformed JSON exits non-zero.
 
-- [ ] **Unit 3: Compose wiring**
+- [x] **Unit 3: Compose wiring**
 
 **Goal:** Wire the auth secret into the `workspace` service, preserving secret/network conventions.
 
@@ -193,7 +195,7 @@ The workspace container clones and may execute untrusted repository code in the 
 **Verification:**
 - `docker compose -f deploy/compose.yaml config` parses; the workspace mounts the auth secret; no host ports added.
 
-- [ ] **Unit 4: Smoke extension + docs**
+- [x] **Unit 4: Smoke extension + docs**
 
 **Goal:** Guard the config shape in CI and document the new secret + the model for operators, stating precisely what CI does and does not prove.
 

--- a/docs/plans/2026-06-01-005-feat-gateway-discord-tool-approval-plan.md
+++ b/docs/plans/2026-06-01-005-feat-gateway-discord-tool-approval-plan.md
@@ -1,10 +1,12 @@
 ---
 title: "feat: Gateway Discord tool-approval (S5) — probe-first"
 type: feat
-status: active
+status: done
 date: 2026-06-01
 origin: docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
 ---
+
+> **Status: done.** All 4 units shipped: the runtime permission-round-trip probe (PASSED 2026-06-01), the permission coordinator + run-core integration (`packages/gateway/src/approvals/coordinator.ts`), the Discord approval embed/buttons (`packages/gateway/src/discord/approvals.ts`), and integration tests + deploy docs — verified on `main`.
 
 # feat: Gateway Discord tool-approval (S5) — probe-first
 
@@ -175,7 +177,7 @@ Unit 1 probe confirms the full round-trip at 1.14.41?
 **Verification:**
 - A documented finding: "full round-trip {confirmed | partially confirmed | failed}; `permission.asked` over SSE = {yes | no}; `GET /permission` lists pending = {yes | no}; `POST /permission/{requestID}/reply` unblocks = {yes | no}; `requestID = properties.id` = {confirmed | contradicted}; reject cascade = {confirmed | contradicted}; `session.idle` interleaving = {…}; create-subscribe-prompt ordering = {…}." The decision gate is resolved and the chosen branch is recorded.
 
-- [ ] **Unit 2: Permission coordinator + run-core integration**
+- [x] **Unit 2: Permission coordinator + run-core integration**
 
 **Goal:** Add a permission coordinator with an explicit seam (`onPermissionAsked` / `onPermissionReplied`) and an in-memory registry keyed by `requestID`. run-core consumes both `permission.asked` (register pending + signal the coordinator) and `permission.replied` (authoritative settle — reconcile sibling embeds on reject cascade). The coordinator owns the blocking wait; run-core stays transport-focused.
 
@@ -209,7 +211,7 @@ Unit 1 probe confirms the full round-trip at 1.14.41?
 
 **Verification:** run-core emits structured pending-permission signals on `permission.asked`, processes `permission.replied` as the authoritative settle, and continues to handle all existing event types unchanged.
 
-- [ ] **Unit 3: Discord approval embed/buttons + live auth + channel binding + pause/resume**
+- [x] **Unit 3: Discord approval embed/buttons + live auth + channel binding + pause/resume**
 
 **Goal:** When the coordinator signals a pending permission, post a Discord approval embed with Approve/Deny buttons (`custom_id = approve:<requestID>` / `deny:<requestID>`); the run pauses on the coordinator promise. Handle button clicks: verify channel binding, authorize the clicker (live fetch), POST the decision to OpenCode's reply endpoint (with workspace routing), and settle the coordinator registry entry. Single authoritative sub-deadline and single-winner settle guard govern the entire flow.
 
@@ -254,7 +256,7 @@ Unit 1 probe confirms the full round-trip at 1.14.41?
 
 **Verification:** a permission-requiring run posts an approval prompt, blocks, and resumes or fail-closes deterministically; the concurrency slot is released within the sub-deadline bound; N-concurrent requests do not interfere; shutdown drains cleanly.
 
-- [ ] **Unit 4: Integration/failure tests + deploy docs**
+- [x] **Unit 4: Integration/failure tests + deploy docs**
 
 **Goal:** End-to-end failure-mode tests covering the scenarios that unit mocks cannot prove, plus deploy documentation: the workspace `permission: ask` config knob (the deploy-time switch that activates S5) and `AGENTS.md` permission posture.
 

--- a/docs/plans/2026-06-02-001-feat-optional-announce-endpoint-plan.md
+++ b/docs/plans/2026-06-02-001-feat-optional-announce-endpoint-plan.md
@@ -1,9 +1,11 @@
 ---
 title: "feat: Make gateway announce/presence endpoint opt-in"
 type: feat
-status: active
+status: done
 date: 2026-06-02
 ---
+
+> **Status: done.** All 3 units shipped: `GATEWAY_WEBHOOK_SECRET`/`GATEWAY_PRESENCE_CHANNEL_ID` are optional with both-or-neither validation, announce server startup gated on opt-in, and compose/docs/CI updated — verified on `main` (`packages/gateway/src/config.ts:562-573`).
 
 # feat: Make gateway announce/presence endpoint opt-in
 
@@ -82,7 +84,7 @@ The maintainer decision (per triage) is to make the endpoint **optional** rather
 
 ## Implementation Units
 
-- [ ] **Unit 1: Make announce secrets optional with both-or-neither validation (`config.ts`)**
+- [x] **Unit 1: Make announce secrets optional with both-or-neither validation (`config.ts`)**
 
 **Goal:** `loadGatewayConfig()` no longer throws when both announce secrets are absent; models them as an optional `announce` object with pair-validation.
 
@@ -115,7 +117,7 @@ The maintainer decision (per triage) is to make the endpoint **optional** rather
 
 ---
 
-- [ ] **Unit 2: Gate announce server startup on opt-in (`program.ts`)**
+- [x] **Unit 2: Gate announce server startup on opt-in (`program.ts`)**
 
 **Goal:** The announce HTTP server starts only when `config.announce` is present; when absent, the gateway boots with no HTTP server and shutdown handles the undefined handle.
 
@@ -147,7 +149,7 @@ The maintainer decision (per triage) is to make the endpoint **optional** rather
 
 ---
 
-- [ ] **Unit 3: Compose + docs + CI no-secrets boot smoke (`deploy/`, `ci.yaml`)**
+- [x] **Unit 3: Compose + docs + CI no-secrets boot smoke (`deploy/`, `ci.yaml`)**
 
 **Goal:** The shipped compose boots without announce secrets (closing #738); enabling announce is a documented opt-in; CI proves the no-secrets image boot.
 

--- a/docs/plans/2026-06-03-001-fix-workspace-egress-topology-plan.md
+++ b/docs/plans/2026-06-03-001-fix-workspace-egress-topology-plan.md
@@ -1,9 +1,11 @@
 ---
 title: "fix: Workspace egress topology + configurable OpenCode proxy allowlist"
 type: fix
-status: active
+status: done
 date: 2026-06-03
 ---
+
+> **Status: done.** All 5 units shipped: the dedicated `egress-net` (`deploy/compose.yaml`), `WORKSPACE_EGRESS_HOSTS` + shared validation, DNS-rebinding defense (`_resolve_has_disallowed_ip` in `deploy/mitmproxy/allowlist.py`), the CI compose-topology + allowlist test guard, and operator-facing docs — verified on `main` (PR #747).
 
 # fix: Workspace egress topology + configurable OpenCode proxy allowlist
 
@@ -106,7 +108,7 @@ Implementer must confirm no additional host is reached at runtime before calling
 
 ## Implementation Units
 
-- [ ] **Unit 1: Egress topology — dedicated `egress-net` for mitmproxy's upstream leg**
+- [x] **Unit 1: Egress topology — dedicated `egress-net` for mitmproxy's upstream leg**
 
 **Goal:** mitmproxy can resolve and reach the internet while the workspace retains zero direct egress and `sandbox-net` stays `internal: true`.
 
@@ -136,7 +138,7 @@ Implementer must confirm no additional host is reached at runtime before calling
 - `docker compose -f deploy/compose.yaml config` is valid and shows the new network on mitmproxy only.
 - Containment invariants above hold.
 
-- [ ] **Unit 2: `WORKSPACE_EGRESS_HOSTS` env var + shared validation helper in `allowlist.py`**
+- [x] **Unit 2: `WORKSPACE_EGRESS_HOSTS` env var + shared validation helper in `allowlist.py`**
 
 **Goal:** A deployment can allowlist additional exact egress hosts (e.g. a self-hosted OpenCode proxy) via `WORKSPACE_EGRESS_HOSTS`, with identical security validation to `OBJECT_STORE_HOSTS`, implemented once.
 
@@ -172,7 +174,7 @@ Implementer must confirm no additional host is reached at runtime before calling
 **Verification:**
 - `pytest deploy/mitmproxy/test_allowlist.py` (or `python3 deploy/mitmproxy/test_allowlist.py`) is green, including the new and existing cases.
 
-- [ ] **Unit 3: DNS-rebinding defense — resolved-IP validation at enforcement time**
+- [x] **Unit 3: DNS-rebinding defense — resolved-IP validation at enforcement time**
 
 **Goal:** An operator-supplied allowlist host that resolves to a private/loopback/link-local/reserved IP is rejected at connect time, closing the DNS-rebinding gap for `OBJECT_STORE_HOSTS` and `WORKSPACE_EGRESS_HOSTS`.
 
@@ -206,7 +208,7 @@ Implementer must confirm no additional host is reached at runtime before calling
 **Verification:**
 - `python3 deploy/mitmproxy/test_allowlist.py` green including the new resolved-IP cases; the shared range helper backs both literal and resolved checks.
 
-- [ ] **Unit 4: CI regression guard — compose-topology invariant + run allowlist tests**
+- [x] **Unit 4: CI regression guard — compose-topology invariant + run allowlist tests**
 
 **Goal:** This defect class fails CI: a static assertion on the compose network topology, and the existing `test_allowlist.py` runs on deploy-touching changes.
 
@@ -237,7 +239,7 @@ Implementer must confirm no additional host is reached at runtime before calling
 **Verification:**
 - The `workspace-smoke` (or appropriate deploy) CI job runs the allowlist tests and the topology assertion and is green on the PR; both gates are present in `.github/workflows/ci.yaml`.
 
-- [ ] **Unit 5: Operator-facing docs — env var, topology, provider-proxy example**
+- [x] **Unit 5: Operator-facing docs — env var, topology, provider-proxy example**
 
 **Goal:** Deployers can discover and correctly use `WORKSPACE_EGRESS_HOSTS`, and the corrected egress topology is reflected in docs.
 

--- a/docs/plans/2026-06-03-002-feat-fro-bot-harness-plan.md
+++ b/docs/plans/2026-06-03-002-feat-fro-bot-harness-plan.md
@@ -1,10 +1,12 @@
 ---
 title: "feat: @fro.bot/harness — orw-embedded patched OpenCode (LLM-merge integration, default setup)"
 type: feat
-status: active
+status: superseded
 date: 2026-06-03
 origin: docs/brainstorms/2026-06-02-fro-bot-harness-patched-opencode-requirements.md
 ---
+
+> **Status: superseded.** The `@fro.bot/harness` package, integration engine, per-platform build/publish, and action cutover all shipped through the follow-on cycle plans (`2026-06-10-002`, `2026-06-12-001`, `2026-06-12-003`, `2026-06-13-001` action-pin-flip). Unit 5 (scheduled deliberate-bump pipeline) was never built — harness bumps remain manual/reviewed via the cycle-plan pattern, not a scheduled CI job.
 
 # feat: @fro.bot/harness — orw-embedded patched OpenCode
 

--- a/docs/plans/2026-06-03-003-fix-workspace-opencode-supervisor-readiness-plan.md
+++ b/docs/plans/2026-06-03-003-fix-workspace-opencode-supervisor-readiness-plan.md
@@ -1,10 +1,12 @@
 ---
 title: 'fix: workspace-agent OpenCode supervisor readiness + gateway readiness gate'
 type: fix
-status: active
+status: done
 date: 2026-06-03
 deepened: 2026-06-03
 ---
+
+> **Status: done.** All 6 units shipped: per-probe readiness timeout, `WORKSPACE_OPENCODE_READY_TIMEOUT_MS`, workspace-agent `/readyz`, gateway readiness gate before mention dispatch, bounded respawn/backoff, and process-group reaping — verified on `main` (`apps/workspace-agent/src/opencode-server.ts`, PR #755/#767).
 
 # fix: workspace-agent OpenCode supervisor readiness + gateway readiness gate
 
@@ -219,7 +221,7 @@ handleMention: thread guard → mention guard → auth → binding lookup
 
 ### Phase 1 — PR 1: deployment unblock (supervisor startup readiness)
 
-- [ ] **Unit 1: Per-probe readiness timeout in `defaultPollReady`**
+- [x] **Unit 1: Per-probe readiness timeout in `defaultPollReady`**
 
 **Goal:** A hung readiness connect can no longer stall the supervisor in `starting` forever.
 
@@ -254,7 +256,7 @@ handleMention: thread guard → mention guard → auth → binding lookup
 **Verification:** the stuck-probe test fails before the change and passes after; no test relies on fake timers; SIGTERM
 assertion on total-timeout still holds.
 
-- [ ] **Unit 2: Configurable readiness timeout via `WORKSPACE_OPENCODE_READY_TIMEOUT_MS`**
+- [x] **Unit 2: Configurable readiness timeout via `WORKSPACE_OPENCODE_READY_TIMEOUT_MS`**
 
 **Goal:** Operators can raise the readiness timeout; the default becomes a realistic 60s cold-boot value.
 
@@ -297,7 +299,7 @@ boot; `deploy/README.md` documents the variable.
 
 ### Phase 2 — PR 2: readiness contract + gateway gate
 
-- [ ] **Unit 3: workspace-agent `/readyz` endpoint**
+- [x] **Unit 3: workspace-agent `/readyz` endpoint**
 
 **Goal:** Expose OpenCode liveness as a dedicated readiness signal without regressing clone-only liveness.
 
@@ -330,7 +332,7 @@ boot; `deploy/README.md` documents the variable.
 
 **Verification:** `/readyz` flips with OpenCode status while `/healthz` stays 200.
 
-- [ ] **Unit 4: Gateway readiness gate before mention dispatch**
+- [x] **Unit 4: Gateway readiness gate before mention dispatch**
 
 **Goal:** The gateway refuses to route a mention run to a not-ready workspace, replying with a coarse message instead
 of creating a thread/lock/run-state.
@@ -378,7 +380,7 @@ message; with ready, dispatch proceeds unchanged.
 
 ### Phase 3 — PR 3: supervisor robustness (respawn + process-group reaping)
 
-- [ ] **Unit 5: Retry/respawn with bounded backoff + state machine**
+- [x] **Unit 5: Retry/respawn with bounded backoff + state machine**
 
 **Goal:** A transient startup failure no longer permanently disables the mention loop.
 
@@ -424,7 +426,7 @@ discipline from the resource-cleanup learning.
 **Verification:** induced transient failure recovers without container recreation; exhausted retries land in `degraded`
 and `/readyz` returns non-200.
 
-- [ ] **Unit 6: Process-group reaping on timeout/respawn**
+- [x] **Unit 6: Process-group reaping on timeout/respawn**
 
 **Goal:** No orphaned OpenCode child survives a timeout/respawn to confuse later `:54321` probes.
 

--- a/docs/plans/2026-06-04-001-fix-mention-loop-session-directory-plan.md
+++ b/docs/plans/2026-06-04-001-fix-mention-loop-session-directory-plan.md
@@ -1,9 +1,11 @@
 ---
 title: 'fix: thread directory to session.create so mention-loop events arrive'
 type: fix
-status: active
+status: done
 date: 2026-06-04
 ---
+
+> **Status: done.** `client.session.create()` threads `{query: {directory}}` matching `event.subscribe`/`promptAsync` — verified on `main` (`packages/gateway/src/execute/run-core.ts:319`).
 
 # fix: thread directory to session.create so mention-loop events arrive
 
@@ -103,7 +105,7 @@ threading" describe block tests `promptAsync` only), which is why the bug shippe
 
 ## Implementation Units
 
-- [ ] **Unit 1: Thread directory to session.create + regression test + comment**
+- [x] **Unit 1: Thread directory to session.create + regression test + comment**
 
 **Goal:** The mention run's session is rooted at the repo directory so the subdir-filtered event subscription receives
 its `message.part.delta` / `session.idle`, and the gateway posts the reply.

--- a/docs/plans/2026-06-05-002-feat-skip-integrate-empty-carry-plan.md
+++ b/docs/plans/2026-06-05-002-feat-skip-integrate-empty-carry-plan.md
@@ -1,9 +1,11 @@
 ---
 title: "feat: Skip integrate job for empty carry set + tune merge prompt for Sonnet 4.6"
 type: feat
-status: active
+status: done
 date: 2026-06-05
 ---
+
+> **Status: done.** All 5 units shipped: `has_refs` emitted from `prepare-integrate` and gating the `integrate` job, `build`'s dual-source clone, `publish` tolerating a skipped integrate, and the restructured merge prompt (`packages/harness/prompt.txt`) — verified on `main` (`.github/workflows/harness-release.yaml`, PR #788).
 
 # feat: Skip integrate job for empty carry set + tune merge prompt for Sonnet 4.6
 
@@ -112,7 +114,7 @@ publish (consumes needs.build.outputs.integration_commit; provenance = same SHA)
 
 ## Implementation Units
 
-- [ ] **Unit 1: Emit `has_refs` from `prepare-integrate`**
+- [x] **Unit 1: Emit `has_refs` from `prepare-integrate`**
 
 **Goal:** Make the empty/non-empty carry decision an explicit job output.
 
@@ -134,7 +136,7 @@ publish (consumes needs.build.outputs.integration_commit; provenance = same SHA)
 **Verification:**
 - actionlint clean; a dry-run logs `has_refs=false` for the current empty config.
 
-- [ ] **Unit 2: Gate the `integrate` job on `has_refs`**
+- [x] **Unit 2: Gate the `integrate` job on `has_refs`**
 
 **Goal:** Skip the agent run when there are no patches.
 
@@ -154,7 +156,7 @@ publish (consumes needs.build.outputs.integration_commit; provenance = same SHA)
 **Verification:**
 - Empty-carry dry-run shows `integrate` skipped; build still proceeds.
 
-- [ ] **Unit 3: `build` dual-source (fetch ref OR clone stock tag)**
+- [x] **Unit 3: `build` dual-source (fetch ref OR clone stock tag)**
 
 **Goal:** Make `build` produce the correct `integration_commit` in both paths and run even when `integrate` is skipped.
 
@@ -178,7 +180,7 @@ publish (consumes needs.build.outputs.integration_commit; provenance = same SHA)
 **Verification:**
 - Empty-carry dry-run: build clones the stock tag, resolves the tag SHA, builds all 4 platforms reporting `<base>+harness.<sha>`, emits `integration_commit` = tag SHA.
 
-- [ ] **Unit 4: `publish` tolerates skipped `integrate`**
+- [x] **Unit 4: `publish` tolerates skipped `integrate`**
 
 **Goal:** Ensure publish runs in the empty-carry path and records the correct commit.
 
@@ -199,7 +201,7 @@ publish (consumes needs.build.outputs.integration_commit; provenance = same SHA)
 **Verification:**
 - Empty-carry dry-run: publish job runs (skip-guards/dry-run as configured), provenance manifest has `integrationRefs: []` + tag SHA.
 
-- [ ] **Unit 5: Restructure the merge prompt for Sonnet 4.6**
+- [x] **Unit 5: Restructure the merge prompt for Sonnet 4.6**
 
 **Goal:** Make the (now merge-only) prompt a deterministic runbook; remove empty-carry conditionals.
 

--- a/docs/plans/2026-06-05-003-fix-gateway-approval-mode-787-plan.md
+++ b/docs/plans/2026-06-05-003-fix-gateway-approval-mode-787-plan.md
@@ -1,10 +1,12 @@
 ---
 title: "fix: Gateway approval waits for unattended tool permissions"
 type: fix
-status: active
+status: done
 date: 2026-06-05
 deepened: 2026-06-05
 ---
+
+> **Status: done.** All 4 units shipped: the approval-mode config guard (`GATEWAY_APPROVAL_MODE` in `packages/gateway/src/config.ts`), the coordinator-required core boundary, approval wait/timeout UX, and unsafe-fix regression guards — verified on `main`.
 
 # fix: Gateway approval waits for unattended tool permissions
 

--- a/docs/plans/2026-06-05-004-fix-workspace-repo-persistence-plan.md
+++ b/docs/plans/2026-06-05-004-fix-workspace-repo-persistence-plan.md
@@ -1,10 +1,12 @@
 ---
 title: "fix: Persist and rehydrate workspace repos"
 type: fix
-status: active
+status: done
 date: 2026-06-05
 origin: https://github.com/fro-bot/agent/issues/791
 ---
+
+> **Status: done.** All 4 units shipped: the `workspace-repos` named volume in `deploy/compose.yaml`, the gateway ensure-clone helper, rehydration before mention execution, and the already-bound recovery UX — verified on `main`.
 
 # fix: Persist and rehydrate workspace repos
 

--- a/docs/plans/2026-06-06-001-fix-discord-timeout-partial-output-plan.md
+++ b/docs/plans/2026-06-06-001-fix-discord-timeout-partial-output-plan.md
@@ -1,9 +1,11 @@
 ---
 title: fix: Improve Discord timeout messaging after partial output
 type: fix
-status: active
+status: done
 date: 2026-06-06
 ---
+
+> **Status: done.** All 3 units shipped: sink visible-output state exposure, timeout copy branching on visibility state, and the deferred-scope documentation — verified on `main` (`packages/gateway/src/discord/streaming.ts` `hasVisibleOutput`).
 
 # fix: Improve Discord timeout messaging after partial output
 

--- a/docs/plans/2026-06-07-001-feat-release-notes-narrative-plan.md
+++ b/docs/plans/2026-06-07-001-feat-release-notes-narrative-plan.md
@@ -1,11 +1,13 @@
 ---
 title: 'feat: LLM-narrated release notes for the multi-part release flow'
 type: feat
-status: active
+status: done
 date: 2026-06-07
 deepened: 2026-06-07
 origin: docs/brainstorms/2026-06-07-release-notes-narrative-requirements.md
 ---
+
+> **Status: done.** All 5 units shipped: `scripts/release/release-notes.ts` (pure narration logic), `scripts/release/dispatch-release-notes.ts` (CLI entry), the Vitest test port, `successCmd` wired in `.releaserc.yaml` + `fro-bot.yaml` inputs, and AGENTS.md documentation — verified on `main` and operating in production (the `RELEASE_NOTES_MODEL` operator-configurable variable per AGENTS.md).
 
 # LLM-narrated release notes
 
@@ -155,7 +157,7 @@ PR merge → `auto-release.yaml`) and its TypeScript-scripts convention
 
 ## Implementation Units
 
-- [ ] **Unit 1: Pure narration logic module**
+- [x] **Unit 1: Pure narration logic module**
 
 **Goal:** Tag validation, prompt construction, run selection, and outcome classification as pure
 functions.
@@ -213,7 +215,7 @@ direct unit testing).
 **Verification:** All classification branches and selection cases covered; `release-notes.test.ts`
 passes under Vitest.
 
-- [ ] **Unit 2: CLI entry (dispatch + poll + watch)**
+- [x] **Unit 2: CLI entry (dispatch + poll + watch)**
 
 **Goal:** Thin executable that wires the pure logic to `gh`.
 
@@ -252,7 +254,7 @@ subprocess test is explicitly out of scope given the pure-logic-first decision.)
 scripts/release/dispatch-release-notes.ts vX.Y.Z` runs the full flow; invalid tag exits 1 before
 any dispatch; a simulated `gh workflow run` failure exits 0 with a warning.
 
-- [ ] **Unit 3: Test port to Vitest**
+- [x] **Unit 3: Test port to Vitest**
 
 **Goal:** Port the 19 structural scenarios as direct unit tests of Unit 1's pure functions.
 
@@ -281,7 +283,7 @@ Unit 1.
 **Verification:** `pnpm test` (or the runtime-scoped vitest invocation) runs and passes the new
 file in CI; coverage spans all D4 branches.
 
-- [ ] **Unit 4: Wire successCmd + fro-bot.yaml inputs (correlation-id, model)**
+- [x] **Unit 4: Wire successCmd + fro-bot.yaml inputs (correlation-id, model)**
 
 **Goal:** Integrate into the release flow and add the dispatch inputs.
 
@@ -322,7 +324,7 @@ and the real release.
 `RELEASE_NOTES_DISPATCH_TOKEN` is set on the semantic-release step; `fro-bot.yaml` accepts
 `-f correlation-id=` and `-f model=` on dispatch (workflow lints clean).
 
-- [ ] **Unit 5: Documentation**
+- [x] **Unit 5: Documentation**
 
 **Goal:** Make the narration step and its contract discoverable.
 

--- a/docs/plans/2026-06-07-002-feat-gateway-daily-digest-event-plan.md
+++ b/docs/plans/2026-06-07-002-feat-gateway-daily-digest-event-plan.md
@@ -1,9 +1,11 @@
 ---
 title: "feat: Gateway daily_digest presence event"
 type: feat
-status: active
+status: done
 date: 2026-06-07
 ---
+
+> **Status: done.** Both units shipped: the `daily_digest` schema variant (`packages/gateway/src/http/announce-schema.ts`) and its embed rendering (`packages/gateway/src/http/templates.ts`) — verified on `main`.
 
 # Gateway daily_digest presence event
 

--- a/docs/plans/2026-06-09-001-fix-workspace-agent-build-entry-hermetic-plan.md
+++ b/docs/plans/2026-06-09-001-fix-workspace-agent-build-entry-hermetic-plan.md
@@ -1,9 +1,11 @@
 ---
 title: "fix: Make workspace-agent build entry hermetic"
 type: fix
-status: active
+status: done
 date: 2026-06-09
 ---
+
+> **Status: done.** All 3 units shipped: hermetic entry + scoped rootDir (`apps/workspace-agent/tsdown.config.ts`), the post-build symbol guard, and the CI repo-root build regression step — verified on `main` (PR #849).
 
 # fix: Make workspace-agent build entry hermetic
 

--- a/docs/plans/2026-06-10-002-feat-opencode-1.17.3-upgrade-plan.md
+++ b/docs/plans/2026-06-10-002-feat-opencode-1.17.3-upgrade-plan.md
@@ -1,10 +1,12 @@
 ---
 title: "feat: Upgrade OpenCode to 1.17.3 (action + gateway)"
 type: feat
-status: active
+status: done
 date: 2026-06-10
 reviewed: 2026-06-10
 ---
+
+> **Status: done.** Both units shipped (PR #865) — verified on `main`. Superseded by later cycles: base version has since advanced 1.17.3 → 1.17.6 → 1.17.9 → 1.17.13.
 
 # feat: Upgrade OpenCode to 1.17.3 (action + gateway)
 
@@ -56,7 +58,7 @@ Memory to update post-merge: 4729 (the OpenCode pin + Renovate cap memory) and 4
 
 ## Implementation Units
 
-- [ ] **Unit 1: bump pins + cap + commentary**
+- [x] **Unit 1: bump pins + cap + commentary**
   - `package.json` + `packages/runtime/package.json` → `@opencode-ai/sdk: 1.17.3`.
   - `constants.ts` → `DEFAULT_OPENCODE_VERSION = '1.17.3'`; refresh the comment block (1.17.3 validated; streaming contract unchanged; cap rationale retained).
   - `deploy/workspace.Dockerfile` → `ARG OPENCODE_VERSION=1.17.3`; refresh header comment.
@@ -66,7 +68,7 @@ Memory to update post-merge: 4729 (the OpenCode pin + Renovate cap memory) and 4
   - `pnpm install` (lockfile + licenses), `pnpm build` (dist).
   - Gate: `pnpm check-types`, `pnpm lint`, action + runtime + gateway test suites, `git diff dist/` reconciled.
 
-- [ ] **Unit 2: live 1.17.3 integration probe (merge gate)**
+- [x] **Unit 2: live 1.17.3 integration probe (merge gate)**
   - WRITE a fresh env-gated integration probe (no prior one exists) and run it against an isolated 1.17.3 server (isolation recipe: temp HOME/XDG, `--pure`, `opencode/big-pickle`, directory-scoped subscribe).
   - Assert: tool line (`| Bash`) rendered via `message.part.updated`, final assistant text rendered, directory-scoped SSE delivers events. Record raw evidence in the PR body, then delete the probe file before opening the PR.
   - Gateway permission-surface validation (closes the probe's gateway blind spot): take the RAW `permission.asked` / `permission.replied` event payloads captured from the live 1.17.3 server (the isolated permission probe produces these) and assert the gateway's actual parsers (`parsePermissionRequest` / `parsePermissionReply` in `packages/gateway/src/execute/run-core.ts` or their module) accept them — a payload-shape regression here would otherwise silently hang mention-loop approvals in production while the action-path probe passes.

--- a/docs/plans/2026-06-12-001-feat-harness-1.17.3-cycle-plan.md
+++ b/docs/plans/2026-06-12-001-feat-harness-1.17.3-cycle-plan.md
@@ -1,11 +1,13 @@
 ---
 title: "feat: Harness 1.17.3 cycle — eliminate version-source drift + carry 3 PRs"
 type: feat
-status: active
+status: done
 date: 2026-06-12
 reviewed: 2026-06-12
 deepened: 2026-06-12
 ---
+
+> **Status: done.** All 5 units shipped: the version-source drift eliminated (`base-version.ts` deleted, `harness.config.json` `base_version` is the sole source, Renovate retargeted), base bumped + carries added, the versioned-tool skill inventory fixed, dry-run, and real publish — verified on `main` (PR #867). Superseded by later cycles: base version has since advanced 1.17.3 → 1.17.6 → 1.17.9 → 1.17.13.
 
 # feat: Harness 1.17.3 cycle
 
@@ -73,7 +75,7 @@ Upgrade the `@fro.bot/harness` patched-OpenCode build from base 1.16.0 to 1.17.3
 
 ---
 
-- [ ] **Unit 1: eliminate version-source drift (the root-cause fix)**
+- [x] **Unit 1: eliminate version-source drift (the root-cause fix)**
 
   **Goal:** Delete the vestigial `base-version.ts` sentinel, retarget Renovate at the real config source, and add a drift-guard test that proves tracking is non-vacuous and cross-file agreement holds.
 
@@ -106,7 +108,7 @@ Upgrade the `@fro.bot/harness` patched-OpenCode build from base 1.16.0 to 1.17.3
 
 ---
 
-- [ ] **Unit 2: bump base + add carries in harness.config.json** (after Unit 1)
+- [x] **Unit 2: bump base + add carries in harness.config.json** (after Unit 1)
 
   **Goal:** Update `harness.config.json` to the new base version and the 3 carry refs; align any prose that enumerates refs.
 
@@ -131,7 +133,7 @@ Upgrade the `@fro.bot/harness` patched-OpenCode build from base 1.16.0 to 1.17.3
 
 ---
 
-- [ ] **Unit 3: versioned-tool skill inventory fix**
+- [x] **Unit 3: versioned-tool skill inventory fix**
 
   **Goal:** Close the skill-coverage gap by documenting the harness base-version site in the `versioned-tool` inventory.
 
@@ -154,7 +156,7 @@ Upgrade the `@fro.bot/harness` patched-OpenCode build from base 1.16.0 to 1.17.3
 
 ---
 
-- [ ] **Unit 4: dry-run the full pipeline (gate before real publish)**
+- [x] **Unit 4: dry-run the full pipeline (gate before real publish)**
 
   **Goal:** Validate the full integrate → build → publish path with `dry_run=true` before any real publish; confirm all 3 carries land via diff-scope assertion.
 
@@ -177,7 +179,7 @@ Upgrade the `@fro.bot/harness` patched-OpenCode build from base 1.16.0 to 1.17.3
 
 ---
 
-- [ ] **Unit 5: real publish** (after Unit 4 green + user approval)
+- [x] **Unit 5: real publish** (after Unit 4 green + user approval)
 
   **Goal:** Publish all 5 `@fro.bot/harness` packages at the new version; confirm the published binary runs a real session.
 

--- a/docs/plans/2026-06-12-003-feat-harness-github-release-action-cutover-plan.md
+++ b/docs/plans/2026-06-12-003-feat-harness-github-release-action-cutover-plan.md
@@ -1,11 +1,13 @@
 ---
 title: "feat: Harness GitHub Release + action cutover (C1)"
 type: feat
-status: active
+status: done
 date: 2026-06-12
 deepened: 2026-06-12
 origin: docs/brainstorms/2026-06-12-harness-github-release-and-action-cutover-requirements.md
 ---
+
+> **Status: done.** All 5 units shipped: harness version computation + npm prerelease versioning, the `release-binaries` job creating GitHub Releases with `SHA256SUMS`, the action's download-source swap + harness-aware `getLatestVersion()`, stock fallback + integrity verification, and the npm-publish environment/docs cleanup — verified on `main` (`src/services/setup/opencode.ts`, `.github/workflows/harness-release.yaml`).
 
 # feat: Harness GitHub Release + action cutover (C1)
 
@@ -96,7 +98,7 @@ The action runs **stock** OpenCode from `anomalyco/opencode` releases. The patch
 
 ## Implementation Units
 
-- [ ] **Unit 1: Compute harness version strings + fix npm prerelease versioning**
+- [x] **Unit 1: Compute harness version strings + fix npm prerelease versioning**
 
 **Goal:** Publish npm as the prerelease `<base>-harness.<short8>` across all 5 packages with the `latest` dist-tag set to it; expose the GitHub tag form `v<base>+harness.<short8>` for the release job.
 
@@ -123,7 +125,7 @@ The action runs **stock** OpenCode from `anomalyco/opencode` releases. The patch
 
 **Verification:** a dry-run publish names all 5 packages `1.17.3-harness.<sha>`; `latest` would resolve to it; harness tests pass.
 
-- [ ] **Unit 2: `release-binaries` job — package OpenCode-shaped assets + create the GitHub Release**
+- [x] **Unit 2: `release-binaries` job — package OpenCode-shaped assets + create the GitHub Release**
 
 **Goal:** A new isolated job that downloads the 4 build artifacts, repackages them into stock-shaped assets, verifies integrity, and creates the GitHub Release — all-or-nothing.
 
@@ -152,7 +154,7 @@ The action runs **stock** OpenCode from `anomalyco/opencode` releases. The patch
 
 **Verification:** dry-run produces 4 correctly-named, correctly-shaped assets + checksums; a simulated missing/4th asset fails the job; a real release lists all 4 + checksums.
 
-- [ ] **Unit 3: Action download source swap + `getLatestVersion()` harness-awareness**
+- [x] **Unit 3: Action download source swap + `getLatestVersion()` harness-awareness**
 
 **Goal:** The action downloads the harness binary from `fro-bot/agent` releases at `v<base>+harness.<short8>` and never misroutes a harness pin to stock latest.
 
@@ -179,7 +181,7 @@ The action runs **stock** OpenCode from `anomalyco/opencode` releases. The patch
 
 **Verification:** action tests pass; a manual/CI run downloads the real harness binary and `opencode --version` reports `1.17.3+harness.<sha>`.
 
-- [ ] **Unit 4: Stock fallback + download integrity verification in the action**
+- [x] **Unit 4: Stock fallback + download integrity verification in the action**
 
 **Goal:** A bad/missing harness release does not break runs (falls back to stock), and the downloaded binary is integrity-checked before execution.
 
@@ -202,7 +204,7 @@ The action runs **stock** OpenCode from `anomalyco/opencode` releases. The patch
 
 **Verification:** action tests cover fallback + integrity; injected bad-release path falls back cleanly.
 
-- [ ] **Unit 5: npm-publish environment removal (gated) + Windows/posture docs**
+- [x] **Unit 5: npm-publish environment removal (gated) + Windows/posture docs**
 
 **Goal:** Remove the redundant `environment: npm-publish` only if the npm trusted-publisher binding allows it; document harness as linux/darwin-only.
 

--- a/docs/plans/2026-06-13-001-feat-harness-action-pin-flip-plan.md
+++ b/docs/plans/2026-06-13-001-feat-harness-action-pin-flip-plan.md
@@ -1,10 +1,12 @@
 ---
 title: "feat: Flip the action default to the harness OpenCode binary"
 type: feat
-status: active
+status: done
 date: 2026-06-13
 deepened: 2026-06-13
 ---
+
+> **Status: done.** All 6 units shipped (PR #884) — `FALLBACK_VERSION`/`DEFAULT_OPENCODE_VERSION` decoupled, build-metadata-safe version compare, harness-aware tool-cache identity, retargeted Renovate manager, `sync-default-version` self-update job, and dist rebuild — verified on `main`.
 
 # feat: Flip the action default to the harness OpenCode binary
 
@@ -79,7 +81,7 @@ Flipping the default is not a single constant change. Two latent issues (surface
 
 ## Implementation Units
 
-- [ ] **Unit 1: Decouple FALLBACK_VERSION and introduce the harness default**
+- [x] **Unit 1: Decouple FALLBACK_VERSION and introduce the harness default**
 
 **Goal:** Make `FALLBACK_VERSION` an explicit stock constant and flip `DEFAULT_OPENCODE_VERSION` to the harness form, without the two aliasing.
 
@@ -104,7 +106,7 @@ Flipping the default is not a single constant change. Two latent issues (surface
 
 **Verification:** the existing fallback-is-semver test passes; default is the harness form.
 
-- [ ] **Unit 1b: Make compareVersions/isSqliteBackend build-metadata-safe**
+- [x] **Unit 1b: Make compareVersions/isSqliteBackend build-metadata-safe**
 
 **Goal:** Prevent the harness `+harness.<sha>` suffix from breaking OpenCode version comparison, which gates SQLite cache persistence.
 
@@ -129,7 +131,7 @@ Flipping the default is not a single constant change. Two latent issues (surface
 
 **Verification:** `isSqliteBackend` returns true for the harness default; SQLite cache paths are included; stock behavior unchanged.
 
-- [ ] **Unit 2: Tool-cache identity for harness versions**
+- [x] **Unit 2: Tool-cache identity for harness versions**
 
 **Goal:** Prevent harness/stock collision in `@actions/tool-cache` by using a `-harness` cache identity.
 
@@ -156,7 +158,7 @@ Flipping the default is not a single constant change. Two latent issues (surface
 
 **Verification:** all `toolCache.find`/`cacheDir` calls receive the `-harness` identity for harness versions; download/checksum/logs keep the raw `+harness` version.
 
-- [ ] **Unit 3: Retarget the existing Renovate manager to FALLBACK_VERSION**
+- [x] **Unit 3: Retarget the existing Renovate manager to FALLBACK_VERSION**
 
 **Goal:** Keep stock base tracking alive by pointing the existing customManager at `FALLBACK_VERSION`.
 
@@ -174,7 +176,7 @@ Flipping the default is not a single constant change. Two latent issues (surface
 
 **Verification:** the manager regex matches the new `FALLBACK_VERSION` literal.
 
-- [ ] **Unit 4: Self-update DEFAULT_OPENCODE_VERSION on successful harness release**
+- [x] **Unit 4: Self-update DEFAULT_OPENCODE_VERSION on successful harness release**
 
 **Goal:** Make the harness-release workflow open a PR that bumps `DEFAULT_OPENCODE_VERSION` (+ rebuilt `dist/`) when a publish succeeds, so future harness releases flow into the action default automatically — replacing any Renovate involvement for the harness version (Renovate cannot order `+harness.<sha>` tags).
 
@@ -198,7 +200,7 @@ Flipping the default is not a single constant change. Two latent issues (surface
 
 **Verification:** `actionlint` clean; the new step is gated on publish success + non-dry-run; opens a PR rather than pushing to main; rebuilds dist in the PR.
 
-- [ ] **Unit 5: Stale comments, dist rebuild, and config validation**
+- [x] **Unit 5: Stale comments, dist rebuild, and config validation**
 
 **Goal:** Clean up stale comments, rebuild `dist/`, and validate config.
 

--- a/docs/plans/2026-06-13-001-feat-workspace-harness-cutover-plan.md
+++ b/docs/plans/2026-06-13-001-feat-workspace-harness-cutover-plan.md
@@ -1,11 +1,13 @@
 ---
 title: "feat: Cut the workspace executor over to the harness OpenCode binary"
 type: feat
-status: active
+status: done
 date: 2026-06-13
 deepened: 2026-06-13
 origin: docs/brainstorms/2026-06-13-workspace-harness-cutover-requirements.md
 ---
+
+> **Status: done.** All 5 units shipped: the harness release publishes musl/baseline Linux assets, the release workflow checksums them, `deploy/workspace.Dockerfile` repoints to the harness release with SHA256SUMS verification, dry-run validation, and the workspace smoke test — verified on `main` (PR #887/#889).
 
 # feat: Cut the workspace executor over to the harness OpenCode binary
 
@@ -87,7 +89,7 @@ The workspace is Alpine-based and needs **musl** OpenCode binaries (`opencode-li
 
 ## Implementation Units
 
-- [ ] **Unit 1: Harness build emits musl/baseline Linux targets**
+- [x] **Unit 1: Harness build emits musl/baseline Linux targets**
 
 **Goal:** Make the harness Linux build produce `linux-x64-baseline-musl` and `linux-arm64-musl` binaries via an ephemeral `build.ts` target-selector patch + target-aware wrapper.
 
@@ -114,7 +116,7 @@ The workspace is Alpine-based and needs **musl** OpenCode binaries (`opencode-li
 
 **Verification:** a dry-run (Unit 4) produces musl/baseline binaries whose libc is verified musl and `--version` reports the harness version.
 
-- [ ] **Unit 2: Release workflow publishes + checksums the new assets**
+- [x] **Unit 2: Release workflow publishes + checksums the new assets**
 
 **Goal:** Expand Release Binaries asset handling from 4 to 6 so the musl/baseline assets are packaged, checksummed, and uploaded.
 
@@ -135,7 +137,7 @@ The workspace is Alpine-based and needs **musl** OpenCode binaries (`opencode-li
 
 **Verification:** dry-run release contains all 6 assets and `SHA256SUMS` lists the 2 new ones.
 
-- [ ] **Unit 3: Workspace Dockerfile repoint + checksum verification**
+- [x] **Unit 3: Workspace Dockerfile repoint + checksum verification**
 
 **Goal:** Point the workspace OpenCode bake at the harness release with fail-closed checksum verification and the harness version.
 
@@ -159,7 +161,7 @@ The workspace is Alpine-based and needs **musl** OpenCode binaries (`opencode-li
 
 **Verification:** the image builds, downloads the musl harness asset from `fro-bot/agent`, verifies the checksum, and boots; a tampered/missing checksum aborts the build.
 
-- [ ] **Unit 4: Dry-run validation (CI cost + asset correctness)**
+- [x] **Unit 4: Dry-run validation (CI cost + asset correctness)**
 
 **Goal:** Prove end-to-end via a real harness-release dry-run before any publish, and measure the added CI cost.
 
@@ -177,7 +179,7 @@ The workspace is Alpine-based and needs **musl** OpenCode binaries (`opencode-li
 
 **Verification:** dry-run succeeds, all 6 assets present + checksummed, musl confirmed via `file`/`ldd`, CI cost recorded against the abort threshold.
 
-- [ ] **Unit 5: Workspace smoke test (functional, beyond --version) + negative path**
+- [x] **Unit 5: Workspace smoke test (functional, beyond --version) + negative path**
 
 **Goal:** Prove the musl harness binary boots on Alpine and runs a real execution path, plus the fail-closed negative path.
 

--- a/docs/plans/2026-06-14-001-feat-opencode-1.17.6-upgrade-plan.md
+++ b/docs/plans/2026-06-14-001-feat-opencode-1.17.6-upgrade-plan.md
@@ -1,10 +1,12 @@
 ---
 title: "feat: Upgrade OpenCode to 1.17.6 (action/runtime + harness base)"
 type: feat
-status: active
+status: done
 date: 2026-06-14
 deepened: 2026-06-14
 ---
+
+> **Status: done.** All 5 units shipped (PR #893/#895) — verified on `main`. Superseded by later cycles: base version has since advanced 1.17.6 → 1.17.9 → 1.17.13 (`packages/harness/harness.config.json`).
 
 # Upgrade OpenCode to 1.17.6
 
@@ -82,7 +84,7 @@ The action/runtime and harness are pinned to OpenCode 1.17.3 (`1.17.3+harness.94
 
 ## Implementation Units
 
-- [ ] **Unit 1: Action/runtime SDK + FALLBACK → 1.17.6**
+- [x] **Unit 1: Action/runtime SDK + FALLBACK → 1.17.6**
 
 **Goal:** Action and runtime build against the OpenCode 1.17.6 SDK, with the stock fallback at 1.17.6.
 
@@ -108,7 +110,7 @@ The action/runtime and harness are pinned to OpenCode 1.17.3 (`1.17.3+harness.94
 
 **Verification:** `pnpm check-types` clean; `pnpm install` lockfile updated to SDK 1.17.6; opencode tests pass; `git diff` shows `DEFAULT_OPENCODE_VERSION` unchanged.
 
-- [ ] **Unit 2: Harness base_version → 1.17.6, carries retained**
+- [x] **Unit 2: Harness base_version → 1.17.6, carries retained**
 
 **Goal:** The harness builds on OpenCode 1.17.6 with the same three carries.
 
@@ -125,7 +127,7 @@ The action/runtime and harness are pinned to OpenCode 1.17.3 (`1.17.3+harness.94
 
 **Verification:** `harness.config.json` parses; harness unit tests still pass after Unit 5 test updates.
 
-- [ ] **Unit 3: Renovate cap + clonedeps + metadata → 1.17.6**
+- [x] **Unit 3: Renovate cap + clonedeps + metadata → 1.17.6**
 
 **Goal:** Renovate allows up to 1.17.6; cloned OpenCode source and docs reflect v1.17.6.
 
@@ -144,7 +146,7 @@ The action/runtime and harness are pinned to OpenCode 1.17.3 (`1.17.3+harness.94
 
 **Verification:** clonedeps.json points at v1.17.6; the cloned tree is at v1.17.6; AGENTS.md note updated; renovate.json5 valid.
 
-- [ ] **Unit 4: Live integration probe + v2 session.wait verification**
+- [x] **Unit 4: Live integration probe + v2 session.wait verification**
 
 **Goal:** Prove the real harness execution path streams + renders a tool under 1.17.6, and that v2 `session.wait` still works.
 
@@ -169,7 +171,7 @@ The action/runtime and harness are pinned to OpenCode 1.17.3 (`1.17.3+harness.94
 
 **Verification:** probe prints the tool line + completion marker against a 1.17.6 server; `session.wait` behaves; evidence captured for the PR.
 
-- [ ] **Unit 5: Version-string tests + dist rebuild**
+- [x] **Unit 5: Version-string tests + dist rebuild**
 
 **Goal:** Tests and bundled output reflect 1.17.6; nothing hard-asserts the old version.
 

--- a/docs/plans/2026-06-14-002-fix-egress-topology-guard-relay-plan.md
+++ b/docs/plans/2026-06-14-002-fix-egress-topology-guard-relay-plan.md
@@ -1,10 +1,12 @@
 ---
 title: "fix: Close egress-relay bypass in the compose topology guard (#814) + live egress smoke (#745)"
 type: fix
-status: active
+status: done
 date: 2026-06-14
 deepened: 2026-06-14
 ---
+
+> **Status: done.** All 4 units shipped: the global non-internal-attachment allowlist + drift check replacing Invariant 5, guard tests, the gateway TCB-exception docs + ingress pinning test, and the live workspace egress smoke — verified on `main` (`deploy/validate-stack.sh`, `deploy/egress-smoke.sh`, PR #901).
 
 # Close the egress-relay bypass in the topology guard (#814) + live egress smoke (#745)
 
@@ -79,7 +81,7 @@ Decision basis: Option B from issue #814, chosen after threat-model analysis con
 
 ## Implementation Units
 
-- [ ] **Unit 1: Replace Invariant 5 with a global non-internal-attachment allowlist + drift check**
+- [x] **Unit 1: Replace Invariant 5 with a global non-internal-attachment allowlist + drift check**
 
 **Goal:** The guard fails any non-allowlisted service on any non-internal network, and any unknown non-internal network declaration.
 
@@ -121,7 +123,7 @@ for net in sorted(non_internal_nets - {"egress-net", "gateway-net"}):
 
 **Verification:** running the guard against current `deploy/compose.yaml` exits 0; against each malicious fixture exits non-zero with the precise failing pair/network.
 
-- [ ] **Unit 2: Guard tests for the global invariant**
+- [x] **Unit 2: Guard tests for the global invariant**
 
 **Goal:** Lock the new invariant + drift check behavior with regression tests.
 
@@ -140,7 +142,7 @@ for net in sorted(non_internal_nets - {"egress-net", "gateway-net"}):
 
 **Verification:** the test suite passes; removing the Unit 1 fix makes the shadow-egress test fail (the test actually guards the bug); the multi-file override case runs through `docker compose config` (or is explicitly skipped, not silently raw-YAML'd).
 
-- [ ] **Unit 3: Document the gateway TCB exception + correct topology comments + pin the gateway ingress surface**
+- [x] **Unit 3: Document the gateway TCB exception + correct topology comments + pin the gateway ingress surface**
 
 **Goal:** Make the deliberate weaker-than-strict posture explicit and auditable; remove false "only mitmproxy reaches the internet" statements; back the TCB assumption with a pinning test so it can't silently erode.
 
@@ -162,7 +164,7 @@ for net in sorted(non_internal_nets - {"egress-net", "gateway-net"}):
 
 **Verification:** no remaining comment claims "only mitmproxy" reaches the internet; the gateway exception + constraint is stated in compose, guard header, and README; the gateway ingress pin passes for the current surface and would fail on an unreviewed new route.
 
-- [ ] **Unit 4: Live workspace egress smoke (#745)**
+- [x] **Unit 4: Live workspace egress smoke (#745)**
 
 **Goal:** Prove at runtime that the workspace's only internet path is mitmproxy.
 

--- a/docs/plans/2026-06-14-003-fix-egress-weakening-compose-keys-plan.md
+++ b/docs/plans/2026-06-14-003-fix-egress-weakening-compose-keys-plan.md
@@ -1,9 +1,11 @@
 ---
 title: "fix: Reject egress-weakening compose keys in the topology guard (#899)"
 type: fix
-status: active
+status: done
 date: 2026-06-14
 ---
+
+> **Status: done.** All 3 units shipped: the `extra_hosts`/`cap_add`/`/dev/net/tun` rejections (Invariants 1c-1f), guard tests, and docs — verified on `main` (`deploy/validate-stack.sh`, PR #909).
 
 # Reject egress-weakening compose keys in the topology guard (#899)
 
@@ -80,7 +82,7 @@ The inconsistency (the most obvious bypass banned, adjacent ones open) is the ga
 
 ## Implementation Units
 
-- [ ] **Unit 1: Add egress-weakening compose-key rejections to the guard**
+- [x] **Unit 1: Add egress-weakening compose-key rejections to the guard**
 
 **Goal:** The guard fails closed on `extra_hosts` host-gateway, `cap_add` NET_ADMIN/NET_RAW, and `/dev/net/tun` device mappings, on any service.
 
@@ -105,7 +107,7 @@ The inconsistency (the most obvious bypass banned, adjacent ones open) is the ga
 
 **Verification:** running the guard against current `deploy/compose.yaml` exits 0; against each malicious fixture exits non-zero naming the service + key.
 
-- [ ] **Unit 2: Guard tests for the new rejections**
+- [x] **Unit 2: Guard tests for the new rejections**
 
 **Goal:** Lock the three rejections + the real-stack-passes behavior with regression tests.
 
@@ -130,7 +132,7 @@ The inconsistency (the most obvious bypass banned, adjacent ones open) is the ga
 
 **Verification:** the suite passes; removing the Unit 1 checks makes the malicious fixtures pass (proving the tests guard the bug); benign `extra_hosts` is not falsely rejected.
 
-- [ ] **Unit 3: Document the additional rejected keys**
+- [x] **Unit 3: Document the additional rejected keys**
 
 **Goal:** Operators understand which compose keys the guard forbids and why.
 

--- a/docs/plans/2026-06-14-004-fix-egress-escalation-vectors-plan.md
+++ b/docs/plans/2026-06-14-004-fix-egress-escalation-vectors-plan.md
@@ -1,9 +1,11 @@
 ---
 title: "fix: Reject remaining egress-escalation compose keys in the topology guard (#908)"
 type: fix
-status: active
+status: done
 date: 2026-06-14
 ---
+
+> **Status: done.** All 7 units shipped: `cap_add: ALL`, `device_cgroup_rules`, `pid_mode: host`, IP-forwarding `sysctls`, confinement-disabling `security_opt`, guard tests, and docs — verified on `main` (`deploy/validate-stack.sh`, PR #911).
 
 # Reject remaining egress-escalation compose keys in the topology guard (#908)
 
@@ -93,7 +95,7 @@ These are not regressions introduced by #899; they are pre-existing vectors defe
 
 ## Implementation Units
 
-- [ ] **Unit 1: Add cap_add: ALL to the banned capability set**
+- [x] **Unit 1: Add cap_add: ALL to the banned capability set**
 
 **Goal:** `cap_add: ALL` / `CAP_ALL` is rejected by the existing capability invariant.
 
@@ -112,7 +114,7 @@ These are not regressions introduced by #899; they are pre-existing vectors defe
 
 **Verification:** a service with `cap_add: [ALL]` or `[CAP_ALL]` fails; real compose passes.
 
-- [ ] **Unit 2: Reject device_cgroup_rules that grant devices**
+- [x] **Unit 2: Reject device_cgroup_rules that grant devices**
 
 **Goal:** The guard fails any service declaring a `device_cgroup_rules` allow rule.
 
@@ -131,7 +133,7 @@ These are not regressions introduced by #899; they are pre-existing vectors defe
 
 **Verification:** a service with `device_cgroup_rules: ["c 10:200 rwm"]` fails; real compose passes.
 
-- [ ] **Unit 3: Reject pid_mode: host**
+- [x] **Unit 3: Reject pid_mode: host**
 
 **Goal:** The guard fails any service declaring `pid_mode: host`.
 
@@ -150,7 +152,7 @@ These are not regressions introduced by #899; they are pre-existing vectors defe
 
 **Verification:** `pid_mode: host` fails; `pid_mode: "service:foo"` passes; real compose passes.
 
-- [ ] **Unit 4: Reject IP-forwarding sysctls**
+- [x] **Unit 4: Reject IP-forwarding sysctls**
 
 **Goal:** The guard fails any service enabling IP forwarding via `sysctls`.
 
@@ -169,7 +171,7 @@ These are not regressions introduced by #899; they are pre-existing vectors defe
 
 **Verification:** `sysctls: {net.ipv4.ip_forward: 1}` fails; a benign sysctl (or forwarding=0) passes; real compose passes.
 
-- [ ] **Unit 5: Reject confinement-disabling security_opt**
+- [x] **Unit 5: Reject confinement-disabling security_opt**
 
 **Goal:** The guard fails any service that disables seccomp or AppArmor confinement.
 
@@ -188,7 +190,7 @@ These are not regressions introduced by #899; they are pre-existing vectors defe
 
 **Verification:** `security_opt: ["seccomp:unconfined"]` fails; `["no-new-privileges:true"]` passes; real compose passes.
 
-- [ ] **Unit 6: Guard tests for all five vectors**
+- [x] **Unit 6: Guard tests for all five vectors**
 
 **Goal:** Lock each rejection + benign/positive controls with regression tests.
 
@@ -217,7 +219,7 @@ These are not regressions introduced by #899; they are pre-existing vectors defe
 
 **Verification:** suite passes; removing each Unit 1-5 check makes its fixture pass (teeth); benign/positive controls pass; pre-existing PyYAML-absent failures unchanged.
 
-- [ ] **Unit 7: Document the additional rejected keys**
+- [x] **Unit 7: Document the additional rejected keys**
 
 **Goal:** Operators understand the full set of forbidden egress-weakening keys.
 

--- a/docs/plans/2026-06-14-005-fix-namespace-sharing-compose-keys-plan.md
+++ b/docs/plans/2026-06-14-005-fix-namespace-sharing-compose-keys-plan.md
@@ -1,9 +1,11 @@
 ---
 title: "fix: Reject host-namespace-sharing compose keys in the topology guard (#910)"
 type: fix
-status: active
+status: done
 date: 2026-06-14
 ---
+
+> **Status: done.** All 3 units shipped: `ipc: host` rejection + `SYS_PTRACE` added to the banned capability set, guard tests, and docs — verified on `main` (`deploy/validate-stack.sh`, PR #914).
 
 # Reject host-namespace-sharing compose keys in the topology guard (#910)
 
@@ -68,7 +70,7 @@ Different threat class from the egress work (lateral-movement / cross-container,
 
 ## Implementation Units
 
-- [ ] **Unit 1: Reject ipc: host and add SYS_PTRACE to the banned caps**
+- [x] **Unit 1: Reject ipc: host and add SYS_PTRACE to the banned caps**
 
 **Goal:** The guard fails any service declaring `ipc: host` or `cap_add: SYS_PTRACE`.
 
@@ -90,7 +92,7 @@ Different threat class from the egress work (lateral-movement / cross-container,
 
 **Verification:** `ipc: host` fails; `cap_add: [SYS_PTRACE]` fails; `ipc: "service:foo"` passes; real `deploy/compose.yaml` passes.
 
-- [ ] **Unit 2: Guard tests**
+- [x] **Unit 2: Guard tests**
 
 **Goal:** Lock the two rejections + positive controls.
 
@@ -112,7 +114,7 @@ Different threat class from the egress work (lateral-movement / cross-container,
 
 **Verification:** suite passes; removing the Unit 1 checks makes the fixtures pass (teeth); positive controls pass; pre-existing PyYAML-absent failures unchanged.
 
-- [ ] **Unit 3: Document the additional rejected keys**
+- [x] **Unit 3: Document the additional rejected keys**
 
 **Goal:** Operators understand `ipc: host` and `SYS_PTRACE` are forbidden.
 

--- a/docs/plans/2026-06-15-001-feat-gateway-control-surface-spine-phase-a-plan.md
+++ b/docs/plans/2026-06-15-001-feat-gateway-control-surface-spine-phase-a-plan.md
@@ -1,11 +1,13 @@
 ---
 title: 'feat: Gateway control surface spine — Phase A (transport-agnostic execution + approval extraction)'
 type: feat
-status: active
+status: done
 date: 2026-06-15
 deepened: 2026-06-15
 origin: docs/brainstorms/2026-06-15-gateway-control-surface-spine-requirements.md
 ---
+
+> **Status: done.** All 5 units shipped: characterization tests, `LaunchWorkRequest`/`StatusSink`/`ReplySink`, `launchWork` extracted from `startRun`, `runMention` as a thin Discord adapter, and the transport-neutral approval coordinator seam — verified on `main` (`packages/gateway/src/execute/launch-types.ts`, PR #920).
 
 # Gateway control surface spine — Phase A (transport-agnostic execution + approval extraction)
 
@@ -150,7 +152,7 @@ A future web caller (Phase B) will call `launchWork` directly with its own `Stat
 
 ## Implementation Units
 
-- [ ] **Unit 0: Characterization tests pinning current Discord behavior (mandatory)**
+- [x] **Unit 0: Characterization tests pinning current Discord behavior (mandatory)**
 
   **Goal:** Lock the current `runMention → startRun` and approval behaviors with tests that pass before AND after the refactor — the zero-regression gate. This is not optional; the engine has many edge behaviors (queue/cap, thread creation, live-status vs typing-only, reactions, approval waiting/timeout, empty-prompt) that a seam extraction can silently break.
 
@@ -170,7 +172,7 @@ A future web caller (Phase B) will call `launchWork` directly with its own `Stat
 
   **Verification:** the new characterization tests pass on current `main` before any refactor; they remain the regression gate through Units 2–4.
 
-- [ ] **Unit 1: Define transport-neutral types — `LaunchWorkRequest`, `StatusSink`, `ReplySink`**
+- [x] **Unit 1: Define transport-neutral types — `LaunchWorkRequest`, `StatusSink`, `ReplySink`**
 
   **Goal:** Establish the typed interface contract that the engine will accept and the Discord adapter will implement. No runtime behavior changes in this unit.
 
@@ -196,7 +198,7 @@ A future web caller (Phase B) will call `launchWork` directly with its own `Stat
 
   **Verification:** `pnpm --filter @fro-bot/gateway check-types` clean; the new types file exports `LaunchWorkRequest`, `StatusSink`, `ReplySink`; no `any` or `@ts-ignore`; the Discord `Message`-derived implementations in Unit 3 satisfy the interfaces structurally.
 
-- [ ] **Unit 2: Extract `launchWork` core from `startRun`**
+- [x] **Unit 2: Extract `launchWork` core from `startRun`**
 
   **Goal:** Move the execution engine to accept `LaunchWorkRequest` + sinks instead of `RunTask.message`. `startRun` is updated to bridge `RunTask` → `LaunchWorkRequest` (or `RunTask` carries `LaunchWorkRequest` directly). The engine runs against a fake/in-memory sink with no Discord dependency.
 
@@ -226,7 +228,7 @@ A future web caller (Phase B) will call `launchWork` directly with its own `Stat
 
   **Verification:** `pnpm --filter @fro-bot/gateway check-types` clean; `pnpm --filter @fro-bot/gateway test` passes (existing `run.test.ts` + new `launchWork` tests); `launchWork` is exported and accepts `LaunchWorkRequest` + in-memory sinks; no Discord import in `launchWork`'s own logic.
 
-- [ ] **Unit 3: Make `runMention` a thin Discord adapter**
+- [x] **Unit 3: Make `runMention` a thin Discord adapter**
 
   **Goal:** `runMention` maps a Discord `Message` → `LaunchWorkRequest`, constructs Discord `StatusSink`/`ReplySink` implementations over the existing live-status/typing message flow, and calls `launchWork`. Zero change to the Discord user experience.
 
@@ -257,7 +259,7 @@ A future web caller (Phase B) will call `launchWork` directly with its own `Stat
 
   **Verification:** `pnpm --filter @fro-bot/gateway check-types` clean; `pnpm --filter @fro-bot/gateway test` passes; `runMention` no longer passes a `Message` into `launchWork`/`startRun`; the Discord sink implementations satisfy `StatusSink`/`ReplySink` structurally; characterization tests pass.
 
-- [ ] **Unit 4: Generalize the approval coordinator seam**
+- [x] **Unit 4: Generalize the approval coordinator seam**
 
   **Goal:** Generalize the approval coordinator's transport callbacks (`onPending`, `onReplied`, `onDispose`) so a non-Discord transport can render+register an approval, settle a decision, and fail-close teardown via the same registry. The Discord embed+button flow becomes one set of implementations. The registry and fail-closed settlement are unchanged. A decision from a non-Discord source settles via the same gate.
 

--- a/docs/plans/2026-06-19-001-feat-operator-api-contract-plan.md
+++ b/docs/plans/2026-06-19-001-feat-operator-api-contract-plan.md
@@ -1,11 +1,13 @@
 ---
 title: "feat: Own and freeze the canonical operator API contract (S1 surface)"
 type: feat
-status: active
+status: done
 date: 2026-06-19
 deepened: 2026-06-19
 origin: https://github.com/fro-bot/agent/issues/949 (Fro Bot triage comment as requirements)
 ---
+
+> **Status: done.** All 6 units shipped as `packages/gateway/src/operator-contract/` (`version.ts`, `identity.ts`, `run-status.ts`, `approval.ts`, `responses.ts`/`parse.ts`, `redaction.ts`) — verified on `main` (PR #952).
 
 # Own and freeze the canonical operator API contract (S1 surface)
 
@@ -119,7 +121,7 @@ The gateway is gaining an inbound operator control surface (S1/S2, umbrella #907
 
 ## Implementation Units
 
-- [ ] **Unit 1: Contract version + module skeleton**
+- [x] **Unit 1: Contract version + module skeleton**
 
   **Goal:** Establish the module home, the pinned contract version, and the public barrel.
 
@@ -145,7 +147,7 @@ The gateway is gaining an inbound operator control surface (S1/S2, umbrella #907
 
   **Verification:** the version constant is pinned by test and exported from the barrel; type-check and lint clean.
 
-- [ ] **Unit 2: Canonical operator identity**
+- [x] **Unit 2: Canonical operator identity**
 
   **Goal:** Define one `OperatorIdentity` as the sole definer and collapse the duplicated identity sites onto it.
 
@@ -178,7 +180,7 @@ The gateway is gaining an inbound operator control surface (S1/S2, umbrella #907
 
   **Verification:** one structural definer of the operator identity; dependent sites reference it; all existing approval/launch tests pass.
 
-- [ ] **Unit 3: Run-status projection + lifecycle re-export**
+- [x] **Unit 3: Run-status projection + lifecycle re-export**
 
   **Goal:** Expose an operator-safe `OperatorRunStatus` projection and make the contract the operator-facing surface for `RunPhase`/`Surface`.
 
@@ -208,7 +210,7 @@ The gateway is gaining an inbound operator control surface (S1/S2, umbrella #907
 
   **Verification:** `OperatorRunStatus` excludes internal fields by construction, omits denylisted repos, and is covered by projection tests; field names match the Phase B table; `RunPhase`/`Surface` are re-exported from the barrel.
 
-- [ ] **Unit 4: Approval-decision contract + `PermissionReply` ownership**
+- [x] **Unit 4: Approval-decision contract + `PermissionReply` ownership**
 
   **Goal:** Make the contract the sole definer of `PermissionReply` and canonicalize the operator-facing decision-state set with an explicit mapping.
 
@@ -240,7 +242,7 @@ The gateway is gaining an inbound operator control surface (S1/S2, umbrella #907
 
   **Verification:** `PermissionReply` has one definer with a working re-export; the 5-variant mapping is correct and exhaustive; `DecisionInput` is exported and the no-`decidedBy` structural test passes; coordinator tests pass unchanged.
 
-- [ ] **Unit 5: Named operator response types + validators**
+- [x] **Unit 5: Named operator response types + validators**
 
   **Goal:** Publish named types for the already-shipped operator HTTP responses and provide Effect-free runtime validators.
 
@@ -269,7 +271,7 @@ The gateway is gaining an inbound operator control surface (S1/S2, umbrella #907
 
   **Verification:** named response types exported; validators return `Result` with no-oracle errors proven across all error paths; the session-info route uses the contract type; existing route tests pass.
 
-- [ ] **Unit 6: Redaction + authorization obligation clauses**
+- [x] **Unit 6: Redaction + authorization obligation clauses**
 
   **Goal:** Embed the #950 redaction obligation and the authorization obligation as normative contract clauses bound to the contract version.
 

--- a/docs/plans/2026-06-20-002-feat-web-launch-adapter-plan.md
+++ b/docs/plans/2026-06-20-002-feat-web-launch-adapter-plan.md
@@ -1,11 +1,13 @@
 ---
 title: 'feat: Gateway web launch adapter (Unit 5)'
 type: feat
-status: active
+status: done
 date: 2026-06-20
 origin: docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
 deepened: 2026-06-20
 ---
+
+> **Status: done.** Both units shipped: the scoped operator repo-list route (`GET /operator/repos`) and the web sinks + launch route (`POST /operator/runs`) — verified on `main` (`packages/gateway/src/web/operator/launch-route.ts`).
 
 # Gateway web launch adapter (Unit 5)
 

--- a/docs/plans/2026-06-20-003-fix-run-lifecycle-admission-plan.md
+++ b/docs/plans/2026-06-20-003-fix-run-lifecycle-admission-plan.md
@@ -1,10 +1,12 @@
 ---
 title: 'fix: Move run lifecycle admission into launchWork so queued/failed runs are observable'
 type: fix
-status: active
+status: done
 date: 2026-06-20
 deepened: 2026-06-20
 ---
+
+> **Status: done.** All 6 units shipped: the early-FAILED runtime transition table, `launchWork` admission ownership, `executeWorkOnHeldSlot` run-adoption, two-phase idempotency in the web launch route, shutdown queue-drop + recovery-sweep terminalization, and the operator read-surface verification — all verified on `main` (`packages/gateway/src/execute/run.ts`).
 
 # Move run lifecycle admission into launchWork so queued/failed runs are observable
 

--- a/docs/plans/2026-06-20-004-feat-stream-web-run-output-plan.md
+++ b/docs/plans/2026-06-20-004-feat-stream-web-run-output-plan.md
@@ -1,11 +1,13 @@
 ---
 title: "feat: Stream web-launched run output to the operator"
 type: feat
-status: active
+status: done
 date: 2026-06-20
 origin: docs/brainstorms/2026-06-20-stream-web-run-output-requirements.md
 issue: 965
 ---
+
+> **Status: done.** All 6 units shipped: the `OperatorOutputFrame` contract type + version bump, the manager `output` frame + `observeOutput` + terminal-output cache, the run-stream route `output` SSE mapping, the web `ReplySink` wired to push output, engine-side ordering, and the docs refresh — all verified on `main` (`packages/gateway/src/operator-contract/output.ts`, `packages/gateway/src/web/sse/manager.ts`). Closes #965.
 
 # feat: Stream web-launched run output to the operator
 

--- a/docs/plans/2026-06-21-001-refactor-third-party-notices-sbom-plan.md
+++ b/docs/plans/2026-06-21-001-refactor-third-party-notices-sbom-plan.md
@@ -1,9 +1,11 @@
 ---
 title: 'refactor: deterministic committed third-party notices + CI SBOM'
 type: refactor
-status: active
+status: done
 date: 2026-06-21
 ---
+
+> **Status: done.** All 4 units shipped: deterministic fail-closed notice generation + rename, the CI dist-diff carve-out removed, the CI CycloneDX SBOM artifact, and the renamed notice + docs committed — verified on `main` (`scripts/third-party-notices.ts`, PR #978).
 
 # Deterministic committed third-party notices + CI SBOM
 

--- a/docs/plans/2026-06-21-002-feat-harness-release-carry-fingerprint-plan.md
+++ b/docs/plans/2026-06-21-002-feat-harness-release-carry-fingerprint-plan.md
@@ -1,9 +1,11 @@
 ---
 title: 'feat: harness release carry fingerprint, notes, and non-latest'
 type: feat
-status: active
+status: done
 date: 2026-06-21
 ---
+
+> **Status: done.** Both units shipped: the carried refs squashed into one fingerprint commit (`packages/harness/prompt.txt` `git reset --soft` + single commit), and the carry list plumbed to the release job/notes in `harness-release.yaml` — verified on `main` (PR #982).
 
 # Harness release carry fingerprint, notes, and non-latest
 

--- a/docs/plans/2026-06-22-001-feat-opencode-1.17.9-upgrade-plan.md
+++ b/docs/plans/2026-06-22-001-feat-opencode-1.17.9-upgrade-plan.md
@@ -1,9 +1,11 @@
 ---
 title: 'feat: upgrade OpenCode to 1.17.9 + add SQLite-reliability carries'
 type: feat
-status: active
+status: done
 date: 2026-06-22
 ---
+
+> **Status: done.** Both units shipped: the action/runtime + harness pin bump to 1.17.9 with the 5-carry set, and the live 1.17.9 integration probe — verified on `main` (PR #984/#985). Since superseded by later cycles (1.17.13 is current per `packages/harness/harness.config.json`).
 
 # Upgrade OpenCode to 1.17.9 + add SQLite-reliability carries
 

--- a/docs/plans/2026-06-22-002-feat-web-tool-approval-plan.md
+++ b/docs/plans/2026-06-22-002-feat-web-tool-approval-plan.md
@@ -1,10 +1,12 @@
 ---
 title: 'feat: web tool-approval flow (gateway operator surface)'
 type: feat
-status: active
+status: done
 date: 2026-06-22
 origin: docs/brainstorms/2026-06-22-web-tool-approval-requirements.md
 ---
+
+> **Status: done.** All 6 units shipped: command/filepath surfaced on `PermissionRequest`, the SSE `ApprovalFrame` + `observeApproval` (operator-contract bump), write-level repo authz + audit enum, the web approval transport replacing auto-deny, the decision route, and the `GET` pending-approvals reconciliation endpoint — all verified on `main` (`packages/gateway/src/web/operator/web-approval.ts`, `packages/gateway/src/operator-contract/approval-frame.ts`).
 
 # Web Tool Approval Flow (Gateway Operator Surface)
 

--- a/docs/plans/2026-06-22-003-fix-license-collector-build-lifecycle-plan.md
+++ b/docs/plans/2026-06-22-003-fix-license-collector-build-lifecycle-plan.md
@@ -1,9 +1,11 @@
 ---
 title: "fix: Decouple license collection from the dist-escape build lifecycle"
 type: fix
-status: active
+status: done
 date: 2026-06-22
 ---
+
+> **Status: done.** All 4 units shipped: license-notice generation extracted to `scripts/third-party-notices.ts`, the `scripts/build-action-dist.ts` preflight→bundle→escape→writeNotice wrapper (escape runs in `finally`), the throwing license logic removed from the tsdown `writeBundle` hook, and the renovate.json5 comment fixed — verified on `main`.
 
 # fix: Decouple license collection from the dist-escape build lifecycle
 
@@ -76,7 +78,7 @@ Because the throw happens in a late, post-mutation hook and shares the plugin ar
 
 ## Implementation Units
 
-- [ ] **Unit 1: Extract license-notice generation into a shared, testable module**
+- [x] **Unit 1: Extract license-notice generation into a shared, testable module**
 
 **Goal:** Move the fallible license collection (`getProjectLicenses` + `getPnpmLicensesJson` + `formatThirdPartyNotices`) out of the tsdown `writeBundle` hook into a standalone module that produces the notice content (string) without writing to `dist/`.
 
@@ -102,7 +104,7 @@ Because the throw happens in a late, post-mutation hook and shares the plugin ar
 
 **Verification:** The notice-generation logic is importable and unit-tested; `tsdown.config.ts` no longer performs fallible license collection inside `writeBundle`.
 
-- [ ] **Unit 2: Add a build wrapper that preflights notices, bundles, and escapes in finally**
+- [x] **Unit 2: Add a build wrapper that preflights notices, bundles, and escapes in finally**
 
 **Goal:** Introduce a build-orchestration helper that runs the license preflight (fail-closed, before tsdown), then the tsdown action build, then the hidden-unicode escape in a `finally` that preserves the bundle's exit code, then writes the notice atomically on success.
 
@@ -131,7 +133,7 @@ Because the throw happens in a late, post-mutation hook and shares the plugin ar
 
 **Verification:** On success, `dist/` is byte-identical to current main and the notice is present; on a simulated license failure, the build exits non-zero without dropping the committed notice; on a simulated bundle failure, the escape has still run and the exit code is non-zero.
 
-- [ ] **Unit 3: Remove the throwing license logic from the tsdown writeBundle hook**
+- [x] **Unit 3: Remove the throwing license logic from the tsdown writeBundle hook**
 
 **Goal:** Ensure `tsdown.config.ts` no longer aborts the bundle from inside `writeBundle` due to license collection — the escape plugin and version-invariant plugin must not be blocked by a license failure.
 
@@ -151,7 +153,7 @@ Because the throw happens in a late, post-mutation hook and shares the plugin ar
 
 **Verification:** A simulated license failure no longer aborts the tsdown build; the escape plugin still runs in the normal build.
 
-- [ ] **Unit 4: Fix the stale renovate.json5 comment**
+- [x] **Unit 4: Fix the stale renovate.json5 comment**
 
 **Goal:** Correct the `.github/renovate.json5` comment that claims `ignorePaths` skips the hidden-unicode detector — it does not, and the claim actively misleads about this exact bug.
 

--- a/docs/plans/2026-06-23-001-refactor-pnpm-to-bun-migration-plan.md
+++ b/docs/plans/2026-06-23-001-refactor-pnpm-to-bun-migration-plan.md
@@ -1,10 +1,12 @@
 ---
 title: "refactor: Migrate the workspace from pnpm to Bun"
 type: refactor
-status: active
+status: done
 date: 2026-06-23
 origin: docs/brainstorms/2026-06-23-pnpm-to-bun-migration-requirements.md
 ---
+
+> **Status: done.** All 10 units shipped: the workspace runs on Bun (`bun.lock`, `bunfig.toml` on `main`, no `pnpm-lock.yaml`/`pnpm-workspace.yaml`), with CI, Dockerfiles, and the notice collector migrated — verified on `main` (PR #1002, follow-up hardening in `2026-06-24-001`/`2026-06-24-002`).
 
 # refactor: Migrate the workspace from pnpm to Bun
 
@@ -114,7 +116,7 @@ Migration phases and their gate relationship:
 
 ### Phase 1 — Spike (branch, no committed switch)
 
-- [ ] **Unit 1: Install + full workspace gate under Bun**
+- [x] **Unit 1: Install + full workspace gate under Bun**
 
 **Goal:** Prove `bun install` + build/test/lint/check-types succeed across all packages on a throwaway branch, with config relocated in-branch only.
 
@@ -140,7 +142,7 @@ Migration phases and their gate relationship:
 
 **Verification:** A captured gate transcript shows install + all four scripts' outcomes; any failure is recorded as a named blocker with its cause.
 
-- [ ] **Unit 2: Build-order and `--filter` parity**
+- [x] **Unit 2: Build-order and `--filter` parity**
 
 **Goal:** Confirm `bun --filter` reproduces per-package execution and the runtime → action/gateway/harness build order, including the `...` transitive syntax used by Dockerfiles and gateway-smoke.
 
@@ -160,7 +162,7 @@ Migration phases and their gate relationship:
 
 **Verification:** Build order and filter syntax confirmed (or a documented substitute), recorded in the decision artifact.
 
-- [ ] **Unit 3: tsdown + vitest under Bun**
+- [x] **Unit 3: tsdown + vitest under Bun**
 
 **Goal:** Validate the bundler and test runner work against Bun's install layout.
 
@@ -179,7 +181,7 @@ Migration phases and their gate relationship:
 
 **Verification:** tsdown + vitest pass under Bun with no resolution regressions; gateway build proves monorepo linking.
 
-- [ ] **Unit 4: THIRD_PARTY_NOTICES byte-diff**
+- [x] **Unit 4: THIRD_PARTY_NOTICES byte-diff**
 
 **Goal:** Prove the committed-dist attribution stays accurate under Bun's npm/arborist resolver path.
 
@@ -199,7 +201,7 @@ Migration phases and their gate relationship:
 
 **Verification:** A notices diff with zero unexplained differences; the attribution guarantee holds under Bun.
 
-- [ ] **Unit 5: Linker decision + spike decision artifact**
+- [x] **Unit 5: Linker decision + spike decision artifact**
 
 **Goal:** Choose isolated vs hoisted on evidence and record the consolidated go/no-go.
 
@@ -220,7 +222,7 @@ Migration phases and their gate relationship:
 
 ### Phase 2 — Cutover (spike GO confirmed; notice collector proven)
 
-- [ ] **Unit 6a: Bun-native notice collector (replaces generate-license-file)**
+- [x] **Unit 6a: Bun-native notice collector (replaces generate-license-file)**
 
 **Goal:** Replace the `generate-license-file` + `pnpm licenses list` path with a `bun.lock`-based collector that reproduces the committed `THIRD_PARTY_NOTICES.txt` package set. Proven in the sub-spike; this unit finalizes and reviews it.
 
@@ -241,7 +243,7 @@ Migration phases and their gate relationship:
 
 **Verification:** `bunx vitest run scripts/third-party-notices.test.ts` passes; name-level diff vs committed file shows zero missing committed packages.
 
-- [ ] **Unit 6: Config relocation + lockfile**
+- [x] **Unit 6: Config relocation + lockfile**
 
 **Goal:** Land the committed config: `package.json` workspaces/trustedDependencies/overrides, `bunfig.toml`, `bun.lock`, delete `pnpm-workspace.yaml`, move `minimumReleaseAgeExclude` to `renovate.json5`.
 
@@ -262,7 +264,7 @@ Migration phases and their gate relationship:
 
 **Verification:** Clean frozen install; `pnpm-workspace.yaml`/`pnpm-lock.yaml` gone; overrides enforced.
 
-- [ ] **Unit 7: Scripts rewrite (root + per-package)**
+- [x] **Unit 7: Scripts rewrite (root + per-package)**
 
 **Goal:** Rewrite all `pnpm` script invocations to Bun, preserving the build-ordering chain, the dist hidden-Unicode escape tail, and the `simple-git-hooks`/`lint-staged` config.
 
@@ -290,7 +292,7 @@ Migration phases and their gate relationship:
 
 **Verification:** All scripts run under Bun; `dist/` regenerates deterministically with notices + escape; hooks work.
 
-- [ ] **Unit 8: CI rewire (composite action + 6 workflows + dist regen)**
+- [x] **Unit 8: CI rewire (composite action + 6 workflows + dist regen)**
 
 **Goal:** Swap the shared composite action and all workflow pnpm references to Bun; commit the regenerated `dist/`.
 
@@ -316,7 +318,7 @@ Migration phases and their gate relationship:
 
 **Verification:** All CI jobs green under Bun; dist-diff gate passes; the action runs from the Bun-built bundle.
 
-- [ ] **Unit 9: Dockerfiles + Renovate manager + final gate**
+- [x] **Unit 9: Dockerfiles + Renovate manager + final gate**
 
 **Goal:** Update the deploy images and switch Renovate to the Bun manager; final end-to-end verification.
 

--- a/docs/plans/2026-06-24-001-fix-bun-migration-ci-hardening-plan.md
+++ b/docs/plans/2026-06-24-001-fix-bun-migration-ci-hardening-plan.md
@@ -1,9 +1,11 @@
 ---
 title: 'fix: Bun migration CI hardening — phantom-dep guard, bun cache, tools-cache version segment'
 type: fix
-status: active
+status: done
 date: 2026-06-24
 ---
+
+> **Status: done.** All 4 units shipped: the phantom-dependency ESLint guard (`eslint.config.ts` — "phantom-dependency guard"), Bun install cache in CI, Bun-version segment in the tools-cache key, and notice-collector polish — all verified on `main` (PR #1006).
 
 # Bun migration CI hardening
 

--- a/docs/plans/2026-06-24-002-fix-dockerfile-bun-hardening-plan.md
+++ b/docs/plans/2026-06-24-002-fix-dockerfile-bun-hardening-plan.md
@@ -1,9 +1,11 @@
 ---
 title: 'fix: harden Bun install in deploy Dockerfiles (verified binary) and trim runtime image'
 type: fix
-status: active
+status: done
 date: 2026-06-24
 ---
+
+> **Status: done.** All 4 units shipped: verified Bun binary install in `deploy/gateway.Dockerfile` and `deploy/workspace.Dockerfile` (checksum against `SHASUMS256.txt`, fail-closed), production-only runtime `node_modules`, and docs reconciliation — all verified on `main` (PR #1008).
 
 # Harden Bun install in deploy Dockerfiles + trim runtime image
 

--- a/docs/plans/2026-06-24-003-fix-backfill-deny-keys-runnable-entrypoint-plan.md
+++ b/docs/plans/2026-06-24-003-fix-backfill-deny-keys-runnable-entrypoint-plan.md
@@ -1,9 +1,11 @@
 ---
 title: "fix: ship a runnable deny-key backfill entrypoint with --dry-run"
 type: fix
-status: active
+status: done
 date: 2026-06-24
 ---
+
+> **Status: done.** All 5 units shipped: `--dry-run` on the backfill function, the daemon-free `backfill-runner.ts`, the `main-dispatch.ts` unconditional entrypoint + testable dispatch, the hermetic gateway tsdown build, and the docs runbook — all verified on `main` (`packages/gateway/src/bindings/backfill-runner.ts`, `packages/gateway/src/main-dispatch.ts`).
 
 # fix: ship a runnable deny-key backfill entrypoint with --dry-run
 

--- a/docs/plans/2026-06-25-001-feat-operator-surface-unit8-tail-plan.md
+++ b/docs/plans/2026-06-25-001-feat-operator-surface-unit8-tail-plan.md
@@ -1,9 +1,11 @@
 ---
 title: "feat: Operator web surface Unit 8 tail — image-level route smoke + deploy runbook"
 type: feat
-status: active
+status: done
 date: 2026-06-25
 ---
+
+> **Status: done.** Both units shipped: the image-level operator route-registration smoke (PR #1031) and the consolidated Operator Web Surface runbook in `deploy/README.md` (PR #996).
 
 # Operator web surface Unit 8 tail — image-level route smoke + deploy runbook
 

--- a/docs/plans/2026-06-25-002-fix-operator-launch-route-unmounted-plan.md
+++ b/docs/plans/2026-06-25-002-fix-operator-launch-route-unmounted-plan.md
@@ -1,9 +1,11 @@
 ---
 title: "fix: Operator launch route (POST /operator/runs) unmounted in production"
 type: fix
-status: active
+status: done
 date: 2026-06-25
 ---
+
+> **Status: done.** `getBindingByRepo` and `launchWorkDeps` are wired into `OperatorServerDeps` in `packages/gateway/src/program.ts` — the route mounts in production, verified on `main`.
 
 # Operator launch route (POST /operator/runs) unmounted in production
 
@@ -126,7 +128,7 @@ runtime dep is not wired).
 
 ## Implementation Units
 
-- [ ] **Unit 1: Wire getBindingByRepo + launchWorkDeps into the operator server deps**
+- [x] **Unit 1: Wire getBindingByRepo + launchWorkDeps into the operator server deps**
 
 **Goal:** `POST /operator/runs` registers in the running gateway; the launch route
 receives the same engine deps the Discord mention path uses.

--- a/docs/plans/2026-06-25-003-feat-operator-run-index-route-plan.md
+++ b/docs/plans/2026-06-25-003-feat-operator-run-index-route-plan.md
@@ -1,10 +1,12 @@
 ---
 title: 'feat: GET /operator/runs run-index route'
 type: feat
-status: active
+status: done
 date: 2026-06-25
 deepened: 2026-06-25
 ---
+
+> **Status: done.** All 4 units shipped: `RunIndex.listRunsForRepo` + `listWithMetadata` adapter, `RunSummary` contract + projector, `GET /operator/runs` route (`packages/gateway/src/web/operator/runs-route.ts`), and server wiring — all verified on `main`.
 
 # feat: GET /operator/runs run-index route
 

--- a/docs/plans/2026-06-30-001-feat-generating-project-docs-skill-plan.md
+++ b/docs/plans/2026-06-30-001-feat-generating-project-docs-skill-plan.md
@@ -1,10 +1,12 @@
 ---
 title: "feat: generating-project-docs skill + living-docs reconciliation"
 type: feat
-status: active
+status: done
 date: 2026-06-30
 origin: docs/brainstorms/2026-06-30-generating-project-docs-skill-requirements.md
 ---
+
+> **Status: done.** All 5 units shipped: PRD/FEATURES archived to `docs/product/` (#1071), the `generating-project-docs` skill authored (#1073), `ARCHITECTURE.md`/`STRUCTURE.md` generated and `AGENTS.md` slimmed (#1075), `CONTRIBUTING.md`/`SECURITY.md` added and `RULES.md` retired (#1076), and `README.md` refreshed as the canonical entry point (#1077) — all merged.
 
 # feat: generating-project-docs skill + living-docs reconciliation
 
@@ -126,7 +128,7 @@ Phase 3 (first generation run — uses the skill)
 
 ## Implementation Units
 
-- [ ] **Unit 1: Archive PRD.md and FEATURES.md to docs/product/**
+- [x] **Unit 1: Archive PRD.md and FEATURES.md to docs/product/**
 
 **Goal:** Move the two stale planning docs out of the repo root with a historical note, and repair every inbound reference and ignore-list entry so nothing dead-links.
 
@@ -152,7 +154,7 @@ Phase 3 (first generation run — uses the skill)
 
 **Verification:** No dead links to the old paths from `README.md`, `.github/`, or `.agents/`; `bun run lint` clean; `git grep -n "FEATURES.md\|PRD.md"` shows only intended targets.
 
-- [ ] **Unit 2: Author the generating-project-docs skill**
+- [x] **Unit 2: Author the generating-project-docs skill**
 
 **Goal:** Create `.agents/skills/generating-project-docs/SKILL.md` defining the living-doc set, per-document structures, style rules, first-run-vs-re-run generation flow, argument surface, and a verification checklist — adapted to this repo's monorepo shape.
 
@@ -178,7 +180,7 @@ Phase 3 (first generation run — uses the skill)
 
 **Verification:** The skill defines all five living docs with concrete structures, the bootstrap-vs-diff distinction, the argument surface, and a verification checklist; `.agents/skills/` lint exclusion means no lint gate, but the file parses as valid markdown + YAML frontmatter; a reviewer can follow it to produce each doc without inventing structure.
 
-- [ ] **Unit 3: Generate ARCHITECTURE.md and STRUCTURE.md; slim AGENTS.md**
+- [x] **Unit 3: Generate ARCHITECTURE.md and STRUCTURE.md; slim AGENTS.md**
 
 **Goal:** Run the skill to author the two canonical structural docs from `AGENTS.md`'s extracted content + live-repo facts, then slim `AGENTS.md` to its operational remainder with references to the new docs.
 
@@ -206,7 +208,7 @@ Phase 3 (first generation run — uses the skill)
 
 **Verification:** ARCHITECTURE.md + STRUCTURE.md exist with the defined structures and resolve all references; AGENTS.md is reduced to operational content + pointers and retains every convention/anti-pattern/command; no duplicate architecture/structure content across AGENTS.md and the new docs (one home per fact).
 
-- [ ] **Unit 4: Generate CONTRIBUTING.md (fold RULES.md) and SECURITY.md; retire RULES.md**
+- [x] **Unit 4: Generate CONTRIBUTING.md (fold RULES.md) and SECURITY.md; retire RULES.md**
 
 **Goal:** Partition `RULES.md` (1239 lines) by section into a written triage map, then author `CONTRIBUTING.md` from its contributor-facing buckets and `SECURITY.md` from scratch, then retire `RULES.md` and repair its remaining inbound references and ignore-lists. The partition is the load-bearing first step — produce it explicitly before authoring, not as an implicit byproduct.
 
@@ -240,7 +242,7 @@ Phase 3 (first generation run — uses the skill)
 
 **Verification:** CONTRIBUTING.md + SECURITY.md exist and resolve references; RULES.md is gone with no dead inbound links; `bun run lint` clean; the contributor content survived the fold without duplicating ARCHITECTURE/STRUCTURE.
 
-- [ ] **Unit 5: Refresh README.md as the canonical entry point**
+- [x] **Unit 5: Refresh README.md as the canonical entry point**
 
 **Goal:** Apply a bounded structural update to `README.md` — refresh stale body from live facts, add the picture header, flat-square badges, and `·` nav, and wire in the net-new navigation nodes (links to ARCHITECTURE/STRUCTURE/CONTRIBUTING/SECURITY and the wiki). Preserve the existing banner/TOC shape where still accurate; the doc graph changed, so this is a topology update, not a no-op diff.
 

--- a/docs/plans/2026-07-01-001-feat-harness-merge-credential-broker-plan.md
+++ b/docs/plans/2026-07-01-001-feat-harness-merge-credential-broker-plan.md
@@ -1,11 +1,13 @@
 ---
 title: "feat: Harness merge credential broker — consuming side"
 type: feat
-status: active
+status: done
 date: 2026-07-01
 deepened: 2026-07-01
 origin: docs/brainstorms/2026-07-01-harness-merge-credential-broker-requirements.md
 ---
+
+> **Status: done.** All 4 units shipped: `INPUT_AUTH_JSON` scrubbed from the harness process env (#1080), the testable broker-mint script (#1081), the `harness-integrate.yaml` reusable workflow (#1081/#1082), and the `harness-release.yaml` integrate job rewired onto broker-minted credentials (#1082) — merged and live end-to-end verified 2026-07-02 (broker mint + authenticated merge on harness-release run 28565737720). Residual: egress containment tracked in marcusrbrown/infra#725; R7 revocation is TTL/sweeper-only by design.
 
 # feat: Harness merge credential broker — consuming side
 
@@ -117,7 +119,7 @@ harness-release.yaml (integrate job)
 
 ## Implementation Units
 
-- [ ] **Unit 1: Scrub `INPUT_AUTH_JSON` from the harness process env**
+- [x] **Unit 1: Scrub `INPUT_AUTH_JSON` from the harness process env**
 
 **Goal:** Remove the durable `auth-json` secret from `process.env` after it is read and mask it, so it is not env-dumpable and not inherited by the OpenCode child.
 
@@ -146,7 +148,7 @@ harness-release.yaml (integrate job)
 
 **Verification:** `parseActionInputs` returns the same `authJson` value as before; `process.env.INPUT_AUTH_JSON` is gone after the call; `setSecret` masks it; existing 89 input-parsing tests still pass.
 
-- [ ] **Unit 2: Testable broker-mint script**
+- [x] **Unit 2: Testable broker-mint script**
 
 **Goal:** A self-contained, unit-tested module that mints the OIDC token, exchanges it at the broker, validates the response, emits the minted `auth.json` masked, and fails closed.
 
@@ -185,7 +187,7 @@ harness-release.yaml (integrate job)
 
 **Verification:** `bun run test:scripts` passes; the `Test Scripts Load` job accepts the file; every failure branch emits no credential; the OIDC token is masked before the first outbound call.
 
-- [ ] **Unit 3: `harness-integrate.yaml` reusable workflow**
+- [x] **Unit 3: `harness-integrate.yaml` reusable workflow**
 
 **Goal:** A dedicated reusable workflow that runs the merge on a broker-minted credential, with `id-token: write` scoped to it and no `AUTH_JSON`.
 
@@ -215,7 +217,7 @@ harness-release.yaml (integrate job)
 - The workflow parses (no YAML error); `id-token: write` is present only on this one job; `AUTH_JSON`/`secrets: inherit`/`continue-on-error` appear nowhere.
 - **Pre-allowlist fail-closed smoke test** (before the infra allowlist is un-placeholdered): dispatch the integrate path against the live broker and assert the run (1) reaches the mint step, (2) `core.getIDToken` returns a token (proves `id-token: write` propagates through `workflow_call`), (3) the placeholder allowlist returns 403 → the mint script exits non-zero, (4) no credential is emitted and the job fails (does not silently continue). A 403 here is success — it proves the OIDC plumbing, broker reachability, and fail-closed path independent of the infra allowlist.
 
-- [ ] **Unit 4: Rewire the `harness-release.yaml` integrate job**
+- [x] **Unit 4: Rewire the `harness-release.yaml` integrate job**
 
 **Goal:** Point the release integrate path at `harness-integrate.yaml` and stop inheriting the durable secret.
 


### PR DESCRIPTION
Reconciles the `docs/plans/` frontmatter with shipped reality. 52 plans carried `status: active` while their features had long since landed on `main` — the unit checkboxes were simply never ticked as work merged. This flips each to its verified state using the convention established in #1061 (frontmatter `status` + a `> **Status:** …` resolution note carrying on-main evidence).

## Outcome — 50 done, 1 superseded, 1 left active

Each flip was verified against `main` itself (named files/functions/workflows exist in the described shape, backed by the merged PR), not assumed from age. Highlights:

- **50 → done** — the gateway spine (operator contract, run lifecycle, web launch/stream/approval), the workspace executor + egress topology series, the pnpm→bun migration, the harness release pipeline and its OpenCode upgrade cycles, release-notes narration, and this-session's broker + docs-skill work.
- **1 → superseded** — `2026-06-03-002-feat-fro-bot-harness`: its scaffold/engine/build/cutover shipped through the follow-on cycle plans; only its Unit 5 (scheduled auto-bump pipeline) was never built, and harness bumps remain deliberately manual/reviewed.
- **1 left active** — `2026-04-18-001-fro-bot-gateway-discord-v1`: Units 1–6 shipped, but Unit 7 (cloud dispatch — `execute/cloud.ts`, `runtime/src/summaries/`) and Unit 8 (`docs/gateway/SETUP.md`) are genuinely unbuilt (none of the named files exist on `main`). Left untouched.

## Verification

`bun run check:md-links` → OK (185 links / 213 files), `bun run lint` exit 0. Frontmatter + checkbox + resolution-note edits only — no plan bodies rewritten.
