### PR TITLE
feat(gateway): emit contractVersion on the operator health body

### DIFF
--- a/packages/gateway/src/web/server.test.ts
+++ b/packages/gateway/src/web/server.test.ts
@@ -6,7 +6,7 @@
  *   - Error path: partial config fails closed during startup.
  *   - Security: unauthenticated floods hit socket-keyed rate limits and bounded body handling.
  *   - Shutdown: closing the Gateway closes the operator server without hanging active handles.
- *   - Health route: GET /operator/health returns 200 {ok:true}.
+ *   - Health route: GET /operator/health returns 200 {ok:true, contractVersion}.
  *   - Rate limiter: limit enforcement, window reset, key isolation.
  *   - Forwarded headers: no headers, only host, only proto, proto=http, host with port, comma-separated.
  *   - Drain gate: returns 503 before body-limit (drain fires first).
@@ -26,6 +26,7 @@ import {createServer} from 'node:http'
 
 import {describe, expect, it, vi} from 'vitest'
 import {createRateLimiter} from '../http/rate-limit.js'
+import {OPERATOR_CONTRACT_VERSION} from '../operator-contract/index.js'
 import {loadAllowlistFromText} from './auth/allowlist.js'
 import {generateCsrfToken} from './auth/csrf.js'
 import {createInMemoryStateStore} from './auth/github.js'
@@ -248,7 +249,7 @@ describe('buildOperatorApp — partial OAuth config programming error', () => {
 // ---------------------------------------------------------------------------
 
 describe('GET /operator/health — happy path', () => {
-  it('returns 200 {ok:true} when the listener is running', async () => {
+  it('returns 200 {ok:true, contractVersion} when the listener is running', async () => {
     // #given
     const port = await findFreePort()
     const server = createOperatorServer(makeStubDeps(), makeStubConfig({bindPort: port}))
@@ -260,7 +261,7 @@ describe('GET /operator/health — happy path', () => {
 
       // #then
       expect(res.status).toBe(200)
-      expect(body).toEqual({ok: true})
+      expect(body).toEqual({ok: true, contractVersion: OPERATOR_CONTRACT_VERSION})
     } finally {
       await closeServer(server)
     }
@@ -450,7 +451,7 @@ describe('operator server — trusted origin enforcement', () => {
 
       // #then — accepted (health route is not privileged)
       expect(res.status).toBe(200)
-      expect(body).toEqual({ok: true})
+      expect(body).toEqual({ok: true, contractVersion: OPERATOR_CONTRACT_VERSION})
     } finally {
       await new Promise<void>(resolve => server.close(() => resolve()))
     }

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -421,7 +421,8 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
    * GET /operator/health
    *
    * Unauthenticated health check for the operator listener.
-   * Returns 200 {ok:true} when the listener is running and not draining.
+   * Returns 200 {ok:true, contractVersion} when the listener is running and not
+   * draining. contractVersion is emit-only (never read/negotiated over the wire).
    * (Drain gate above returns 503 before this handler is reached.)
    *
    * Registered as a public route via registerPublicRoute — explicitly unauthenticated.

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -40,6 +40,7 @@ import {getConnInfo} from '@hono/node-server/conninfo'
 import {Hono} from 'hono'
 import {bodyLimit} from 'hono/body-limit'
 import {createRateLimiter} from '../http/rate-limit.js'
+import {OPERATOR_CONTRACT_VERSION} from '../operator-contract/index.js'
 import {buildCsrfRoute} from './auth/csrf-route.js'
 import {applyBrowserGuard} from './auth/csrf.js'
 import {buildGitHubOAuthRoutes} from './auth/github.js'
@@ -56,7 +57,6 @@ import {buildRunsRoute} from './operator/runs-route.js'
 import {
   badRequestResponse,
   notFoundResponse,
-  okResponse,
   payloadTooLargeResponse,
   rateLimitedResponse,
   unavailableResponse,
@@ -448,7 +448,7 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
       deps.logger.warn({}, 'operator request rate limited (unauthenticated)')
       return rateLimitedResponse(c)
     }
-    return okResponse(c)
+    return c.json({ok: true, contractVersion: OPERATOR_CONTRACT_VERSION})
   })
 
   // ── GitHub OAuth routes ────────────────────────────────────────────────────


### PR DESCRIPTION
Adds an emit-only `contractVersion` field to the `GET /operator/health` response so operators can verify the deployed operator contract with a one-line probe (the follow-up noted in `fro-bot/.github#3512`, where the deployed-version gate currently relies on a deploy-side digest chain because the health body carries no version).

## Change

```diff
-    return okResponse(c)
+    return c.json({ok: true, contractVersion: OPERATOR_CONTRACT_VERSION})
```

Route-local to the health handler only. The rate-limit logic and route path/method are unchanged.

## Deliberate constraints

- **Emit-only.** The version is never read or negotiated over the wire — consistent with the build-time-pinned contract constraint (`operator-contract/redaction.ts`). This endpoint only *emits* it.
- **No contract bump.** `OPERATOR_CONTRACT_VERSION` stays `1.5.0`. Adding an emit-only health field is not a structural contract change, and the dashboard enforces a fail-closed drift gate on the SSE ready-frame `contractVersion` — a bump could break the deployed dashboard. `version.ts` is untouched.
- **`okResponse` untouched.** The shared coarse-success helper is not modified (that would leak `contractVersion` onto every ok route); it's simply no longer this handler's return path.

## Verification

Gateway `tsc --noEmit` exit 0, `bunx eslint` exit 0, full gateway suite 2790/2790. The one test that exercises the real production route (`server.test.ts`) asserts the new field against the `OPERATOR_CONTRACT_VERSION` constant (so it tracks future bumps); the ingress-pin route inventory is unchanged.
