### PR TITLE
feat(harness): carry OpenCode #33444 to restore session summary

### DIFF
--- a/packages/harness/harness.config.json
+++ b/packages/harness/harness.config.json
@@ -7,7 +7,8 @@
     "https://github.com/anomalyco/opencode/pull/31859",
     "https://github.com/anomalyco/opencode/pull/31638",
     "https://github.com/anomalyco/opencode/pull/33134",
-    "https://github.com/anomalyco/opencode/pull/33159"
+    "https://github.com/anomalyco/opencode/pull/33159",
+    "https://github.com/anomalyco/opencode/pull/33444"
   ],
   "agent": "build",
   "model": "anthropic/claude-sonnet-4-6",


### PR DESCRIPTION
Adds `anomalyco/opencode#33444` as the sixth harness integration ref, restoring the session summary that upstream lost in v1.16.0.

## Why

Upstream #30127 (v1.16.0) removed full-session snapshot diffs for performance, which also zeroes `session.summary`. The fallout: `GET /session/{id}/diff` returns `[]`, the TUI "Modified Files" sidebar renders blank, and the session-summary payload that space-bus consumes over the server API is empty. Upstream tracks this as #30877, #32852, and #34620.

#33444 re-aggregates `session.summary` from the already-computed per-turn diffs — no return to the expensive full-session snapshot. It touches a single file, `packages/opencode/src/session/summary.ts`.

## Carry policy

- **Reason:** open upstream fix for Fro-Bot-critical behavior (blank sidebar + empty space-bus summaries), with reproducible upstream incidents.
- **Upstream status:** open (#33444).
- **Drop condition:** an upstream stable release that includes it.

It appends last in the carry order and touches only `summary.ts`, which no other carried ref modifies, so it integrates without overlap. `base_version` stays at 1.17.13; the harness-build default is untouched and moves when the release pipeline's `sync-default-version` publishes the new integration commit.