### PR TITLE
fix(gateway): persist thread_id to run-state at run adoption

### DIFF
--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -1915,8 +1915,7 @@ describe('runMention', () => {
 
       // Extract the onDeadlineSettled callback from the register call
       const registerCall = (approvalRegistry.register as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
-        | {onDeadlineSettled?: () => void | Promise<void>}
-        | undefined
+        {onDeadlineSettled?: () => void | Promise<void>} | undefined
       expect(registerCall?.onDeadlineSettled).toBeDefined()
 
       // #when — simulate deadline firing
@@ -2629,8 +2628,7 @@ describe('runMention', () => {
 
       // Extract the onDeadlineSettled callback from the register call
       const registerCall = (approvalRegistry.register as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
-        | {onDeadlineSettled?: () => void | Promise<void>}
-        | undefined
+        {onDeadlineSettled?: () => void | Promise<void>} | undefined
       expect(registerCall).toBeDefined()
       expect(registerCall?.onDeadlineSettled).toBeDefined()
 
@@ -2714,8 +2712,7 @@ describe('runMention', () => {
 
       // Extract the deadlineMs from the register call
       const registerCall = (approvalRegistry.register as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
-        | {deadlineMs?: number}
-        | undefined
+        {deadlineMs?: number} | undefined
       expect(registerCall).toBeDefined()
 
       // The deadline must equal computeApprovalDeadlineMs(runTimeoutMs - elapsedMs).
@@ -6544,6 +6541,46 @@ describe('early-abort gates terminalize to FAILED', () => {
 
     // #and — acquireLock NOT called
     expect(mockRuntime.acquireLock).not.toHaveBeenCalled()
+  })
+
+  // ── thread_id persistence at ACK (bug fix) ────────────────────────────────
+
+  it('persists the live thread_id to run-state at PENDING → ACKNOWLEDGED when threadFactory succeeds', async () => {
+    // #given — a discord run with a threadFactory that resolves a real thread id
+    const {launchWork} = await import('./run.js')
+    mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'adoption-etag-thread'}})
+    setupHappyPath()
+
+    const request = makeInMemoryRequest()
+    const threadFactory = vi.fn().mockResolvedValue({ok: true as const, threadId: 'live-thread-999'})
+    const requestWithFactory = {...request, threadFactory}
+    const deps = makeDeps()
+
+    // #when
+    await awaitLaunchWorkRun(launchWork, requestWithFactory, deps)
+
+    // #then — the ACKNOWLEDGED transitionRun call carries the live thread id in the options bag
+    const ackCall = mockRuntime.transitionRun.mock.calls.find((c: unknown[]) => c[4] === 'ACKNOWLEDGED')
+    expect(ackCall).toBeDefined()
+    expect((ackCall as unknown[])[7]).toEqual({threadId: 'live-thread-999'})
+  })
+
+  it('leaves thread_id empty at ACK when there is no threadFactory (non-discord/no-thread path)', async () => {
+    // #given — a run with no threadFactory (e.g. in-memory/no-thread transport)
+    const {launchWork} = await import('./run.js')
+    mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'adoption-etag-nothread'}})
+    setupHappyPath()
+
+    const request = makeInMemoryRequest()
+    const deps = makeDeps()
+
+    // #when
+    await awaitLaunchWorkRun(launchWork, request, deps)
+
+    // #then — the ACKNOWLEDGED transitionRun call passes {threadId: ''} (no-op in transitionRun)
+    const ackCall = mockRuntime.transitionRun.mock.calls.find((c: unknown[]) => c[4] === 'ACKNOWLEDGED')
+    expect(ackCall).toBeDefined()
+    expect((ackCall as unknown[])[7]).toEqual({threadId: ''})
   })
 
   // ── Gate 4a: lock acquisition error ───────────────────────────────────────

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -404,9 +404,10 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
     // The run was already created (PENDING) by launchWork during admission.
     // Adopt it here by transitioning PENDING → ACKNOWLEDGED using the adoption etag.
     // This is the seam between admission (launchWork) and execution (here).
-    // The thread_id is updated via the transition so the run-state reflects the actual thread.
-    // NOTE: transitionRun does not update thread_id — the thread_id was set at createRun time
-    // with an empty string (pre-thread). This is acceptable — the thread_id is not load-bearing for run-state.
+    // thread_id IS now persisted at adoption: it's load-bearing for discord approval-scope
+    // resolution (projection.ts scopeIdFor) and recovery thread-notes (recovery.ts resolveThread).
+    // The thread_id was set at createRun time to an empty string (pre-thread); once threadFactory
+    // resolves a live thread id above, fold it into this same conditional write.
     const ackResult = await transitionRun(
       coordinationConfig,
       identity,
@@ -415,6 +416,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       'ACKNOWLEDGED',
       task.adoptionEtag,
       coordLogger,
+      {threadId},
     )
     if (ackResult.success === false) {
       logger.error({repo, runId, err: ackResult.error.message}, 'run: transitionRun ACKNOWLEDGED failed')

--- a/packages/gateway/src/runtime-effect.ts
+++ b/packages/gateway/src/runtime-effect.ts
@@ -16,6 +16,7 @@ import type {
   RunPhase,
   RunState,
   Surface,
+  TransitionRunOptions,
 } from '@fro-bot/runtime'
 
 import {
@@ -131,9 +132,10 @@ export const transitionRunEffect = (
   newPhase: RunPhase,
   etag: string,
   logger: CoordinationLogger,
+  options?: TransitionRunOptions,
 ): Effect.Effect<{etag: string; state: RunState}, Error> =>
   Effect.tryPromise({
-    try: async () => transitionRun(config, identity, repo, runId, newPhase, etag, logger),
+    try: async () => transitionRun(config, identity, repo, runId, newPhase, etag, logger, options),
     catch: error => (error instanceof Error ? error : new Error(String(error))),
   }).pipe(Effect.flatMap(result => (result.success === true ? Effect.succeed(result.data) : Effect.fail(result.error))))
 

--- a/packages/runtime/src/coordination/run-state.test.ts
+++ b/packages/runtime/src/coordination/run-state.test.ts
@@ -233,6 +233,146 @@ describe('run-state coordination', () => {
     expect(executingToCompleted).toEqual(ok({etag: 'etag-4', state: completed}))
   })
 
+  it('persists thread_id atomically with the phase write when threadId is provided', async () => {
+    // #given a PENDING run with an empty thread_id, and a live thread id resolved by threadFactory
+    const pending = createRunState({phase: 'PENDING', thread_id: ''})
+    const getObject = vi
+      .fn<Required<ObjectStoreAdapter>['getObject']>()
+      .mockResolvedValueOnce(ok({data: JSON.stringify(pending), etag: 'etag-1'}))
+    const conditionalPut = vi
+      .fn<Required<ObjectStoreAdapter>['conditionalPut']>()
+      .mockResolvedValueOnce(ok({etag: 'etag-2'}))
+    const storeAdapter = createStoreAdapter({getObject, conditionalPut})
+    const config = createCoordinationConfig(storeAdapter)
+    const logger = createLogger()
+
+    // #when transitioning PENDING -> ACKNOWLEDGED with a non-empty threadId
+    const result = await transitionRun(
+      config,
+      'coordination',
+      'owner/repo',
+      'run-1',
+      'ACKNOWLEDGED',
+      'etag-1',
+      logger,
+      {threadId: 'live-thread-123'},
+    )
+
+    // #then the written state carries the live thread_id alongside the new phase
+    expect(result).toEqual(
+      ok({etag: 'etag-2', state: {...pending, phase: 'ACKNOWLEDGED', thread_id: 'live-thread-123'}}),
+    )
+    const [, writtenBody] = conditionalPut.mock.calls[0] as [string, string, unknown]
+    expect(JSON.parse(writtenBody)).toMatchObject({thread_id: 'live-thread-123', phase: 'ACKNOWLEDGED'})
+  })
+
+  it('preserves the existing thread_id when threadId is omitted', async () => {
+    // #given a run with an existing thread_id
+    const pending = createRunState({phase: 'PENDING', thread_id: 'existing-thread'})
+    const getObject = vi
+      .fn<Required<ObjectStoreAdapter>['getObject']>()
+      .mockResolvedValueOnce(ok({data: JSON.stringify(pending), etag: 'etag-1'}))
+    const conditionalPut = vi
+      .fn<Required<ObjectStoreAdapter>['conditionalPut']>()
+      .mockResolvedValueOnce(ok({etag: 'etag-2'}))
+    const storeAdapter = createStoreAdapter({getObject, conditionalPut})
+    const config = createCoordinationConfig(storeAdapter)
+    const logger = createLogger()
+
+    // #when transitioning without passing threadId
+    const result = await transitionRun(config, 'coordination', 'owner/repo', 'run-1', 'ACKNOWLEDGED', 'etag-1', logger)
+
+    // #then thread_id is unchanged from current state
+    expect(result).toEqual(ok({etag: 'etag-2', state: {...pending, phase: 'ACKNOWLEDGED'}}))
+  })
+
+  it('treats an empty-string threadId as a no-op (does not clobber existing thread_id)', async () => {
+    // #given a run with an existing thread_id
+    const pending = createRunState({phase: 'PENDING', thread_id: 'existing-thread'})
+    const getObject = vi
+      .fn<Required<ObjectStoreAdapter>['getObject']>()
+      .mockResolvedValueOnce(ok({data: JSON.stringify(pending), etag: 'etag-1'}))
+    const conditionalPut = vi
+      .fn<Required<ObjectStoreAdapter>['conditionalPut']>()
+      .mockResolvedValueOnce(ok({etag: 'etag-2'}))
+    const storeAdapter = createStoreAdapter({getObject, conditionalPut})
+    const config = createCoordinationConfig(storeAdapter)
+    const logger = createLogger()
+
+    // #when transitioning with an explicit empty-string threadId (no thread exists on this path)
+    const result = await transitionRun(
+      config,
+      'coordination',
+      'owner/repo',
+      'run-1',
+      'ACKNOWLEDGED',
+      'etag-1',
+      logger,
+      {threadId: ''},
+    )
+
+    // #then thread_id is unchanged — empty string never overwrites an existing value
+    expect(result).toEqual(ok({etag: 'etag-2', state: {...pending, phase: 'ACKNOWLEDGED'}}))
+  })
+
+  it('carries a thread_id persisted at ACKNOWLEDGED through later transitions without options (no clobber)', async () => {
+    // #given a PENDING run with an empty thread_id, progressing PENDING -> ACKNOWLEDGED (with threadId)
+    // -> EXECUTING (no options) -> COMPLETED (no options)
+    const pending = createRunState({phase: 'PENDING', thread_id: ''})
+    const acknowledged = {...pending, phase: 'ACKNOWLEDGED' as const, thread_id: 'live-thread'}
+    const executing = {...acknowledged, phase: 'EXECUTING' as const}
+    const getObject = vi
+      .fn<Required<ObjectStoreAdapter>['getObject']>()
+      .mockResolvedValueOnce(ok({data: JSON.stringify(pending), etag: 'etag-1'}))
+      .mockResolvedValueOnce(ok({data: JSON.stringify(acknowledged), etag: 'etag-2'}))
+      .mockResolvedValueOnce(ok({data: JSON.stringify(executing), etag: 'etag-3'}))
+    const conditionalPut = vi
+      .fn<Required<ObjectStoreAdapter>['conditionalPut']>()
+      .mockResolvedValueOnce(ok({etag: 'etag-2'}))
+      .mockResolvedValueOnce(ok({etag: 'etag-3'}))
+      .mockResolvedValueOnce(ok({etag: 'etag-4'}))
+    const storeAdapter = createStoreAdapter({getObject, conditionalPut})
+    const config = createCoordinationConfig(storeAdapter)
+    const logger = createLogger()
+
+    // #when
+    const toAcknowledged = await transitionRun(
+      config,
+      'coordination',
+      'owner/repo',
+      'run-1',
+      'ACKNOWLEDGED',
+      'etag-1',
+      logger,
+      {threadId: 'live-thread'},
+    )
+    const toExecuting = await transitionRun(
+      config,
+      'coordination',
+      'owner/repo',
+      'run-1',
+      'EXECUTING',
+      'etag-2',
+      logger,
+    )
+    const toCompleted = await transitionRun(
+      config,
+      'coordination',
+      'owner/repo',
+      'run-1',
+      'COMPLETED',
+      'etag-3',
+      logger,
+    )
+
+    // #then thread_id set at ACKNOWLEDGED survives EXECUTING and COMPLETED transitions made without options
+    expect(toAcknowledged).toEqual(ok({etag: 'etag-2', state: acknowledged}))
+    expect(toExecuting).toEqual(ok({etag: 'etag-3', state: executing}))
+    expect(toExecuting.success === true ? toExecuting.data.state.thread_id : '').toBe('live-thread')
+    expect(toCompleted.success === true ? toCompleted.data.state.thread_id : '').toBe('live-thread')
+    expect(toCompleted.success === true ? toCompleted.data.state.phase : '').toBe('COMPLETED')
+  })
+
   it('rejects an invalid completed to executing transition', async () => {
     // #given
     const storeAdapter = createStoreAdapter({

--- a/packages/runtime/src/coordination/run-state.ts
+++ b/packages/runtime/src/coordination/run-state.ts
@@ -103,6 +103,17 @@ export async function createRun(
   return conditionalPut.data(key.data, JSON.stringify(runState), {ifNoneMatch: '*'})
 }
 
+/**
+ * Extension point for fields that must be atomically merged into a run-state write
+ * alongside the phase transition. Sibling additions (e.g. detailsPatch) should be
+ * appended as additional optional fields on this bag rather than as new positional
+ * params on transitionRun.
+ */
+export interface TransitionRunOptions {
+  /** When provided and non-empty, atomically persists the live thread id alongside the phase write. Absent/empty leaves the existing thread_id untouched. */
+  readonly threadId?: string
+}
+
 export async function transitionRun(
   config: CoordinationConfig,
   identity: string,
@@ -111,6 +122,7 @@ export async function transitionRun(
   newPhase: RunPhase,
   etag: string,
   logger: {debug: (message: string, context?: Record<string, unknown>) => void},
+  options?: TransitionRunOptions,
 ): Promise<Result<{etag: string; state: RunState}, Error>> {
   const key = getRunKey(config, identity, repo, runId)
   if (key.success === false) {
@@ -143,7 +155,12 @@ export async function transitionRun(
 
   // The caller-supplied etag is the single concurrency gate. S3's IfMatch enforces atomicity —
   // a 412 here means another writer modified the object since the caller's last fetch.
-  const nextState: RunState = {...parsedCurrent.data, phase: newPhase}
+  const threadId = options?.threadId
+  const nextState: RunState = {
+    ...parsedCurrent.data,
+    phase: newPhase,
+    ...(threadId !== undefined && threadId !== '' ? {thread_id: threadId} : {}),
+  }
   logger.debug('Transitioning run-state', {
     key: key.data,
     from: parsedCurrent.data.phase,


### PR DESCRIPTION
## What

Persist the Discord thread id into run-state at run adoption (PENDING → ACKNOWLEDGED), instead of leaving it as the empty string it was written with at admission.

## Why

Discord tool-approval requests register under the **live** thread id (`discord-transport.ts` — `approvalScopeId: threadId`), but run-state stored `thread_id: ''` and nothing ever wrote the real value back. Every consumer that resolves the discord approval scope from run-state therefore read an empty scope:

- **Operator SSE surface** — `scopeIdFor()` returns `runState.thread_id` for discord runs, so `hasPendingForScope('')` never matched a real approval. Discord runs never surfaced `waiting_for_approval` on the operator view.
- **Startup recovery** — `recovery.ts` posts interruption notes via `resolveThread(run.thread_id)`; an empty id silently resolves nothing, so recovery thread-notes effectively never posted.

Web/GitHub surfaces are unaffected — they scope on `run_id`.

The `threadFactory` already produces the real thread id immediately before the adoption transition, so the fix folds it into that same conditional write — no extra round-trip, and the `ifMatch` etag gate is unchanged. Runs without a thread (`threadFactory` undefined) keep an empty `thread_id`, which is correct.

`thread_id` remains an internal coordination field — it stays excluded from the operator DTOs by construction.

## Shape

`transitionRun` gains a `TransitionRunOptions` bag (`{ threadId? }`) rather than a positional parameter, so atomically-merged fields have one self-documenting extension point instead of a growing tail of positional optionals. The adoption call passes `{ threadId }`; later transitions omit it and preserve the persisted value via the state read-merge.

## Verification

- `bun run lint`, `bun run build` — clean, no `dist/` diff
- runtime + gateway type-check clean
- runtime (459) and gateway (2792) suites green
- New coverage: `transitionRun` persists/omits `thread_id` per the options bag; a chained ACK → EXECUTING → COMPLETED test proves a persisted `thread_id` survives later option-less transitions; adoption passes the live thread id when a thread exists and stays empty when it does not.
