### PR TITLE
feat(gateway): operator-initiated run cancellation

### DIFF
--- a/docs/brainstorms/2026-07-03-operator-run-cancellation-requirements.md
+++ b/docs/brainstorms/2026-07-03-operator-run-cancellation-requirements.md
@@ -1,0 +1,163 @@
+---
+date: 2026-07-03
+topic: operator-run-cancellation
+---
+
+# Operator Run Cancellation
+
+## Summary
+
+Add operator-initiated run cancellation to the gateway web surface: a cancel action that stops a run whether it is still queued or actively executing, commits the existing `CANCELLED` terminal state, settles any pending tool approval, and posts a cancellation notice to the run's origin Discord thread.
+
+---
+
+## Problem Frame
+
+The operator web surface can launch a run, list runs, stream output, and decide tool approvals — but cannot stop a run. Once launched, a run holds its per-repo lock and consumes a global concurrency slot until it completes, fails, or times out (hard ceiling 30 minutes). An operator watching a run go wrong — wrong prompt, wrong repo, runaway output, or a tool-approval request that should never be granted — has no remedy except waiting out the timeout or denying approvals one at a time as they arrive.
+
+The `CANCELLED` terminal state already exists in the run-state machine and is reachable from every non-terminal phase, and the operator contract already models a `cancelled` run status — but nothing operator-facing can trigger the transition. The capability was deferred when the operator surface shipped (plan `2026-06-15-002`), leaving the surface launch-capable but stop-incapable.
+
+---
+
+## Actors
+
+- A1. Operator: an allowlisted human authenticated on the web operator surface who launches, observes, and now cancels runs.
+- A2. Thread watcher: anyone following the run's origin Discord thread (including the mention author for Discord-initiated runs).
+- A3. Gateway run machinery: the queue, concurrency registry, run-state store, SSE stream manager, and approval coordinator that a cancellation must leave consistent.
+
+---
+
+## Key Flows
+
+- F1. Cancel a queued run
+  - **Trigger:** A1 cancels a run still waiting in the per-channel FIFO queue (PENDING/ACKNOWLEDGED).
+  - **Actors:** A1, A3.
+  - **Steps:** Operator issues cancel → gateway removes the run from the queue before it starts → run-state transitions to CANCELLED → origin thread gets the cancellation notice → operator surface reflects `cancelled`.
+  - **Outcome:** The run never executes; no lock or concurrency slot is consumed; state and streams are terminal.
+  - **Covered by:** R1, R2, R3, R6, R7.
+
+- F2. Cancel an executing run
+  - **Trigger:** A1 cancels a run in EXECUTING.
+  - **Actors:** A1, A2, A3.
+  - **Steps:** Operator issues cancel → gateway aborts the in-flight execution → partial output already streamed stays visible → run-state transitions to CANCELLED → per-repo lock released and concurrency slot freed → origin thread gets the cancellation notice → SSE subscribers receive the terminal `cancelled` status.
+  - **Outcome:** Execution stops promptly; all coordination resources are released; every surface (web, Discord, run state) agrees the run was cancelled.
+  - **Covered by:** R1, R2, R4, R6, R7, R8.
+
+- F3. Cancel a run waiting on a tool approval
+  - **Trigger:** A1 cancels a run that is paused on a pending tool-approval request.
+  - **Actors:** A1, A2, A3.
+  - **Steps:** Operator issues cancel → the pending approval is settled as rejected (no dangling approval) → execution aborts → run-state transitions to CANCELLED → thread notice posted → approval UI on all transports reflects the settled state.
+  - **Outcome:** No orphaned approval remains on any transport; the run is terminal.
+  - **Covered by:** R1, R2, R4, R5, R6, R7.
+
+---
+
+## Requirements
+
+**Cancel action**
+
+- R1. An allowlisted operator can cancel a specific run from the web operator surface; the action passes the same authentication, allowlist, CSRF, browser-guard, repository-authorization, and rate-limit enforcement as existing mutating operator routes (an operator may cancel only runs in repos they are authorized to operate on).
+- R2. Cancelling a run in any non-terminal phase (queued or executing) transitions it to the existing `CANCELLED` terminal state; cancelling an already-terminal run is a no-op that reports the run's terminal state rather than an error.
+
+**Queued runs**
+
+- R3. Cancelling a queued run removes it from the queue before execution starts; it must not acquire the per-repo lock or a concurrency slot afterward. The queue→execution handoff window is covered: a cancel arriving after dequeue but before execution begins must still stop the run before any execution work starts, with the normal cancellation side effects.
+
+**Executing runs**
+
+- R4. Cancelling an executing run aborts the in-flight execution promptly and releases every coordination resource the run holds (per-repo lock, concurrency slot, stream subscriptions). Output already streamed remains visible; cancellation must not be reported as a generic failure.
+
+**Approvals**
+
+- R5. When a cancelled run has a pending tool-approval request, cancellation settles that approval as rejected before the run reaches terminal state; no approval may remain undecided for a terminal run on any transport (web or Discord). The rejection flows through the existing single fail-closed approval settlement gate — cancellation must not introduce a parallel settlement path.
+
+**Observability**
+
+- R6. The run's origin Discord thread receives a cancellation notice stating the run was cancelled by an operator, consistent with how the thread narrates other lifecycle transitions.
+- R7. The operator surface (run listing and run stream) reports the run as `cancelled` — the distinct existing terminal status, not `failed` — and SSE subscribers receive the terminal status frame.
+
+**Auditability**
+
+- R8. Cancellation is attributable: the gateway records which operator cancelled the run, consistent with how launch and approval decisions are attributed today.
+
+**Crash consistency**
+
+- R9. Cancellation is durable across gateway restarts: a crash between the `CANCELLED` transition and resource cleanup must not strand the per-repo lock — either cleanup is part of the same atomic path, or startup recovery reconciles terminal-`CANCELLED` runs still holding a live lock.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R2.** Given a run already in `COMPLETED`, when an operator cancels it, the response reports the run's terminal state, no state transition occurs, and no thread notice is posted.
+- AE2. **Covers R3.** Given a run queued behind an active run on the same channel, when an operator cancels the queued run, the active run is unaffected and the cancelled run never starts executing.
+- AE3. **Covers R4, R7.** Given a run mid-execution with output streaming, when an operator cancels it, streaming stops, previously streamed output remains visible in the web stream, and the terminal status is `cancelled`, not `failed`.
+- AE4. **Covers R5.** Given a run paused on a pending tool approval, when an operator cancels the run, the approval settles as rejected on both web and Discord surfaces and no approval prompt remains actionable.
+- AE5. **Covers R1.** Given a request without a valid operator session (or failing CSRF/origin checks), when it attempts a cancel, the request is denied by the same guard behavior as other mutating operator routes and no run state changes.
+- AE6. **Covers R2, R4.** Given a run that reaches natural completion concurrently with a cancel request, the run settles in exactly one terminal state; whichever transition commits first wins and the loser is a no-op.
+- AE7. **Covers R3.** Given a run cancelled in the instant between queue dequeue and execution start, the run never begins execution, settles as `CANCELLED`, and the operator response does not report a misleading no-op.
+
+---
+
+## Success Criteria
+
+- An operator can stop a wrong or runaway run from the web surface in seconds, instead of waiting out the timeout ceiling.
+- After any cancellation, no resource leaks: lock released, concurrency slot freed, queue entry removed, streams terminal, approvals settled.
+- Every surface agrees on the outcome: web status `cancelled`, Discord thread carries the notice, run state is `CANCELLED`.
+- Planning can proceed without inventing product behavior: cancel semantics per phase, approval settlement, and notification behavior are all pinned here.
+
+---
+
+## Scope Boundaries
+
+- Dashboard UI (the Cancel button) is dashboard-repo work; this feature ships the gateway capability the dashboard will consume.
+- Discord-side cancel initiation (command, button, or mention) is out of scope; cancellation is initiated from the web operator surface only.
+- Bulk cancellation (all runs for a repo/channel) is out of scope; the unit is a single run.
+- No new terminal state: `CANCELLED` already exists; this work makes it operator-reachable, not redefines it.
+- Run pause/resume is out of scope; cancel is terminal.
+
+---
+
+## Key Decisions
+
+- Full cancel (queued + executing) over queued-only: the primary operator need is stopping a run that is actively going wrong; a queued-only cancel would miss the main case.
+- Post a cancellation notice to the origin Discord thread rather than stopping silently: thread watchers must be able to distinguish a deliberately cancelled run from a stalled one, and the thread already narrates run lifecycle.
+- Auto-reject pending approvals on cancel rather than letting them dangle or expire: a terminal run with an undecided approval is an inconsistent state that confuses both transports.
+- Idempotent no-op on already-terminal runs rather than an error: cancel races with natural completion are expected and must not surface as operator-facing failures.
+
+---
+
+## Dependencies / Assumptions
+
+- The run-state machine already permits `CANCELLED` from PENDING, ACKNOWLEDGED, and EXECUTING — verified in `packages/runtime/src/coordination/run-state.ts`.
+- The operator contract already models `cancelled` as a terminal run status consumed by the SSE stream manager — verified in `packages/gateway/src/web/sse/manager.ts`.
+- Execution already runs under abort-signal control (timeout/inactivity), so an in-flight abort path exists to build on — verified in `packages/gateway/src/execute/run-core.ts`.
+- There is currently no runId→abort-handle registry for in-flight runs (`inFlightRuns` tracks bare promises) — cancellation of executing runs requires adding one.
+- `transitionRun` rejects transitions out of terminal phases (`VALID_TRANSITIONS` maps them to `[]`), so R2's terminal no-op requires a read-then-short-circuit before the transition call.
+- Startup recovery currently reaps only non-terminal runs (`packages/gateway/src/execute/recovery.ts`), so R9 requires either atomic cleanup or extending recovery to reconcile terminal-`CANCELLED` runs holding a live lock.
+- Adding an operator route touches the pinned route inventory (`packages/gateway/src/http/ingress-pin.test.ts`) and requires the deliberate security review that pin exists to force.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1][Technical] Operator-contract versioning: a new route and any new frame/DTO shapes interact with the dashboard's fail-closed contract-version drift gate; planning must decide bump-vs-no-bump and cross-repo sequencing so the deployed dashboard does not reject the gateway.
+- [Affects R4][Technical] Whether aborting the gateway-side execution also requires explicitly terminating the workspace-side OpenCode session (or whether abandoning the SSE stream suffices), and what teardown the workspace API offers.
+- [Affects R4][Technical] Cancel-vs-completion race semantics at the run-state store level (conditional-write loser handling) beyond the product-level "first commit wins" in AE6.
+- [Affects R6][Technical] Exact wording and mechanism of the thread notice (new message vs status-message edit) — follow existing thread-narration conventions.
+- [Affects R8][Technical] Where cancellation attribution lands (audit event, run-state metadata, or both), following the existing launch/approval attribution pattern.
+- [Affects R5, R7][Technical] Ordering guarantee across approval settlement, the `CANCELLED` state commit, and the SSE terminal broadcast, so no transport briefly shows a live approval on a terminal run.
+- [Affects R5][Technical] Whether cancel-triggered rejection reuses `registry.handleDecision` exactly or a dedicated internal helper with the same invariants, and what audit record the rejection emits.
+
+---
+
+## Sources / Research
+
+- `packages/runtime/src/coordination/run-state.ts` — VALID_TRANSITIONS: `CANCELLED` reachable from all non-terminal phases.
+- `packages/gateway/src/execute/run.ts` — queue admission, concurrency registry, `inFlightRuns` (no per-run abort handle today).
+- `packages/gateway/src/execute/run-core.ts` — existing AbortController wiring (ceiling + inactivity), the seam an operator-initiated abort would join.
+- `packages/gateway/src/web/sse/manager.ts` — terminal-status handling (`cancelled` in TERMINAL_STATUSES), `abortSubscription`, replay cache.
+- `packages/gateway/src/http/ingress-pin.test.ts` — pinned operator route inventory; adding the cancel route is a deliberate security-review event.
+- `docs/plans/2026-06-15-002` (operator surface deferred items) — where run cancellation was originally deferred.
+- Precedent for mutating-route shape: launch route + approval decision route (browser guard, CSRF, allowlist, audit attribution).

--- a/docs/plans/2026-07-03-001-feat-operator-run-cancellation-plan.md
+++ b/docs/plans/2026-07-03-001-feat-operator-run-cancellation-plan.md
@@ -1,0 +1,263 @@
+---
+title: 'feat: operator-initiated run cancellation'
+type: feat
+status: active
+date: 2026-07-03
+origin: docs/brainstorms/2026-07-03-operator-run-cancellation-requirements.md
+deepened: 2026-07-03
+---
+
+# feat: operator-initiated run cancellation
+
+## Overview
+
+Add a browser-guarded mutating operator route that cancels a run whether it is queued (PENDING/ACKNOWLEDGED in the per-channel FIFO) or executing (EXECUTING with a live OpenCode stream). Cancellation commits the existing `CANCELLED` terminal state, auto-rejects pending tool approvals through the existing fail-closed settlement gate, posts a cancellation notice to the origin Discord thread, emits the terminal `cancelled` SSE status, is idempotent on terminal runs, is attributable to the cancelling operator, and survives gateway crashes without stranding the per-repo lock.
+
+## Problem Frame
+
+The operator surface can launch, list, stream, and approve — but not stop. A run going wrong holds its per-repo lock and concurrency slot until completion or the 30-minute ceiling. `CANCELLED` already exists in the run-state machine (reachable from all three non-terminal phases) and the operator contract already models the `cancelled` status; nothing operator-facing can trigger it. See origin: `docs/brainstorms/2026-07-03-operator-run-cancellation-requirements.md`.
+
+## Requirements Trace
+
+Traceability to the origin doc's requirements:
+
+- R1 (authz/guard parity) → Unit 3
+- R2 (any non-terminal phase; idempotent terminal no-op) → Units 1, 2, 3
+- R3 (queued removal incl. dequeue-handoff window) → Unit 2
+- R4 (prompt abort + full resource release; partial output preserved) → Units 1, 2
+- R5 (approval auto-reject through the single settlement gate) → Unit 2
+- R6 (Discord thread notice) → Unit 2
+- R7 (SSE terminal `cancelled`, not `failed`) → Units 1, 3
+- R8 (operator attribution) → Units 2, 3
+- R9 (crash consistency — no stranded lock) → Unit 4
+
+## Scope Boundaries
+
+- Dashboard Cancel button/UI — dashboard-repo work consuming this route.
+- Discord-side cancel initiation — web operator surface only.
+- Bulk cancellation — single-run unit only.
+- Run pause/resume — cancel is terminal.
+- Cancel during gateway shutdown drain is a refused no-op; the startup recovery sweep owns terminalization (matches the existing shutdown-drain discipline).
+
+### Deferred to Separate Tasks
+
+- Dashboard contract-pin update to `1.6.0` + Cancel UI: `fro-bot/dashboard`, user-driven session after the gateway PR merges.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/gateway/src/web/operator/decision-route.ts` — the mutating-route template: gate ordering (session → repo-resolve → denylist → write-authz → parse → actor → settle → audit), uniform `notFoundResponse` denial (no oracle), rate-limit after authz, `WebOperatorActor` built server-side only.
+- `packages/gateway/src/web/operator/route-helpers.ts` — `resolveRepoFromRunIndex` + `checkDenylist`, shared by per-runId routes.
+- `packages/gateway/src/execute/run.ts` — run lifecycle: `AbortSignal.timeout` at ~:489 threaded into `runOpenCodeCore` (:592); error path (:668-779) maps `RunCoreError` kinds to transitions + coarse replies; `inFlightRuns` set (:911-919); atomic queue handoff (:823-885); `failAdmittedRun` (:1134-1143).
+- `packages/gateway/src/execute/run-core.ts` — inactivity controller + `AbortSignal.any` composition (:281-304); `RunCoreErrorKind` union (:36-44); abort checks at every loop iteration.
+- `packages/gateway/src/execute/queue.ts` — `ChannelQueue<T>` closure over `Map<string, T[]>`; `RunTask` entries carry `runId`; no remove-by-id primitive today.
+- `packages/gateway/src/approvals/registry.ts` — `handleDecision` (:214-219) single fail-closed settlement gate; `describePendingForScope` (:482-503); `confirmReply` cascade.
+- `packages/runtime/src/coordination/` — `transitionRun` (valid-transitions table rejects terminal→CANCELLED; conditional-write etags), `releaseLock` (ifMatch), `forceReleaseStaleLock` (dead-run-verified, checks lock `run_id` ownership), `heartbeat.stop()`.
+- `packages/gateway/src/execute/recovery.ts` — startup sweep; currently reaps only non-terminal runs to FAILED.
+- `packages/gateway/src/discord/io.ts` — `sendMessage` (hardcoded `SAFE_MENTIONS`, fail-soft); `discord/presence.ts` shows `client.channels.fetch` + `sendMessage`.
+- `packages/gateway/src/web/sse/manager.ts` — `cancelled` already in `TERMINAL_STATUSES`; terminal drain + replay cache need no changes; `PHASE_TO_WEB_STATUS` already maps `CANCELLED → 'cancelled'`.
+- `packages/gateway/src/web/audit.ts` — exhaustive audit-kind union + `LOG_LEVEL` compile-time guard.
+- `packages/gateway/src/http/ingress-pin.test.ts` (:114-127) and `packages/gateway/src/web/operator-route-smoke.ts` (:40-53) — dual route-inventory pins; both must gain the cancel route in the same PR.
+- Contract-bump precedent: every prior route addition bumped MINOR (1.0.0→…→1.5.0, commits `9fdaa1920`…`364033861`).
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/gateway-opencode-mention-loop-best-practices-2026-05-30.md` — abort composition via `AbortSignal.any`; dual-`finally` cleanup; lock release must verify lock `run_id` ownership (P0 class); failure-path partial-output flush.
+- `docs/solutions/best-practices/atomic-serial-channel-queue-handoff-2026-06-09.md` — handoff occurs with the slot held; queued runs hold no slot; cancel-removal must be race-checked against `takeNext`.
+- `docs/solutions/best-practices/web-operator-launch-surface-2026-06-20.md` — pre-acceptance denials collapse to one generic shape; per-operator idempotency reserve/commit/rollback; `createWebAutoDenyApproval` is prior art for auto-reject.
+- `docs/solutions/best-practices/sse-output-streaming-terminal-drain-2026-06-21.md` — terminal is a drain state; out-of-order projection guard (`terminalRuns`) is the active constraint for EXECUTING-after-CANCELLED.
+- `docs/solutions/best-practices/authenticated-sse-run-observation-2026-06-20.md` — no-oracle denials including throws; contract version on the ready frame (the dashboard drift-gate surface).
+- `docs/solutions/best-practices/dependency-gated-route-registration-guard-2026-06-25.md` — new route ⇒ update `EXPECTED_OPERATOR_ROUTES` + per-dep-omission smoke regression in the same PR.
+- `docs/solutions/best-practices/centralize-s3-key-identity-construction-2026-06-09.md` — run-state writes use `getRunKey(..., identity, ...)`, lock uses `getLockKey`; pin key strings in regression tests.
+- `docs/solutions/best-practices/signed-webhook-ingress-hardening-2026-05-29.md` — bound every outbound call; late-firing promises get `.catch` (the #1055 unhandled-rejection class).
+- `docs/solutions/best-practices/architectural-issues-type-safety-and-resource-cleanup.md` — reverse-order release, each step independently wrapped, cleanup never throws; force-test cleanup-failure paths.
+
+## Key Technical Decisions
+
+- **Cancel signal composes with existing signals via `AbortSignal.any`** — the run's effective signal becomes any-of(ceiling timeout, inactivity, operator cancel). No parallel abort mechanism; `run-core.ts` already checks the combined signal everywhere it must.
+- **Cancel classification happens in `run.ts`'s catch handler via an abort-registry probe** (`cancelRegistry.get(runId)?.signal.aborted`), not by inspecting the composite abort reason — `AbortSignal.any` propagates whichever child fired first, so reason inspection is racy; the registry's own signal is ground truth. The composed signal is built at the existing `run.ts:489` seam (nested `AbortSignal.any` with run-core's inactivity composition is well-defined; run-core's interface stays unchanged). A `'cancelled'` `RunCoreErrorKind` is added only if implementation finds run-core itself must behave differently on cancel; default is classification-at-run.ts with the existing kinds.
+- **runId→abort-handle registry lives in the execute layer** (small module beside `inFlightRuns`), registered after the EXECUTING transition, deleted in the run's existing `finally`. The route never reaches the inner execution primitive — it goes through a transport-neutral `cancelRun` orchestrator in `execute/`.
+- **Approval auto-reject enumerates pending entries and settles each through `registry.handleDecision` with `decision: 'reject'`** — reuses the single fail-closed gate verbatim (origin R5); no parallel settlement path, no new registry semantics.
+- **Idempotency by read-then-short-circuit** — `transitionRun` rejects terminal transitions by design; the orchestrator reads current state first and returns the terminal phase without attempting a transition (origin R2, AE1/AE6).
+- **Run-state rendezvous covers the registration window** — between queue dequeue and abort-registry registration (the pre-ACK gates: clone, readyz, threadFactory, lock), a cancel finds neither a queue entry nor an abort handle. The third path: `transitionRun(currentPhase → CANCELLED)` via conditional write. Either the cancel wins (the run's own next transition 412s, re-reads, sees CANCELLED, and exits cleanly) or the run advances first (cancel re-reads and retries/short-circuits). No polling, no early registration — the conditional-write chain is the rendezvous.
+- **Contract bump 1.5.0 → 1.6.0** (additive route + response type = MINOR, matching all 5 prior route-addition precedents). **Deploy sequencing is load-bearing:** the dashboard drift gate is exact-match fail-closed (`operator-sse-reader.ts:481-486` — `contractVersion !== pin` → `onError('contract-drift')` + immediate close; pin currently `1.5.0`, tests pin the behavior). Any version skew in either direction kills every operator run stream at the ready frame. Merging the gateway PR is safe; *deploying* a 1.6.0 gateway requires either a coordinated deploy with the dashboard's pin bump or a transitional dual-accept on the dashboard side — dashboard-side decision, surfaced at PR time (see Risks).
+- **Attribution in run-state `details.cancelledBy`** ({githubUserId, login, sessionCorrelationId, cancelledAt}) plus `run.cancel.*` audit events — mirrors launch/approval attribution. The `toRunSummary` projection must not leak it (verify in Unit 3 tests).
+- **Plain async, not Effect** — the launch/decision routes and `run.ts` orchestration are plain async; the cancel route and orchestrator follow suit.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Bump vs no-bump: bump to 1.6.0 (policy + 5 precedents; user-confirmed).
+- Error-kind reuse: new `'cancelled'` kind (user-confirmed).
+- Shutdown behavior: cancel during drain is refused; recovery owns it (user-confirmed).
+
+### Deferred to Implementation
+
+- Whether the queued-cancel path can reuse `failAdmittedRun` with a phase parameter or needs a sibling `cancelAdmittedRun` — depends on how much of its shape (observer notify, index touch) is phase-independent. (Note: on cancel-wins-adoption races, `failAdmittedRun` must be skipped entirely — see Unit 1 approach.)
+- Whether heartbeat's benign post-CANCELLED heartbeat write (terminal state gains a `last_heartbeat` update; harmless, doesn't resurrect the run) warrants suppression or just a comment — decide at the seam.
+- Thread-notice wording — follow existing thread-narration voice at implementation time.
+- Whether `runIndex.lookup` gains `thread_id` (additive) or the orchestrator reads run-state directly for the thread — pick whichever keeps the orchestrator single-read.
+
+## Implementation Units
+
+- [ ] **Unit 1: Cancel signal seam — abort registry + `'cancelled'` error kind + CANCELLED error path**
+
+**Goal:** An in-flight run can be aborted by runId, and the run lifecycle settles it as `CANCELLED` (not `FAILED`) with partial output preserved.
+
+**Requirements:** R2, R4, R7
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/gateway/src/execute/abort-registry.ts`
+- Create: `packages/gateway/src/execute/abort-registry.test.ts`
+- Modify: `packages/gateway/src/execute/run.ts`, `packages/gateway/src/execute/run-core.ts`
+- Test: `packages/gateway/src/execute/run-core.test.ts`, `packages/gateway/src/execute/run.test.ts`
+
+**Approach:**
+- Closure-based registry (`register/abort/delete` by runId) beside `inFlightRuns`; registered after the EXECUTING transition succeeds, removed in the run's existing outer `finally`.
+- Compose the cancel signal at the existing `run.ts:489` seam (`AbortSignal.any([timeout, cancel])` passed as the core's `signal`; run-core's internal inactivity composition nests cleanly — no run-core interface change).
+- Classify in run.ts's catch handler by probing the registry (`cancelRegistry.get(runId)?.signal.aborted`) — NOT by composite abort reason (racy under `AbortSignal.any`). The cancelled case: `heartbeat.stop()` FIRST (its `runEtag`/`lockEtag` are the authoritative conditional-write etags — a stale etag makes the lock release silently fail and TTL-orphan), flush partial output (existing best-effort flush), `transitionRun(CANCELLED)` with attribution details, notify SSE observer, release lock with the heartbeat-stop `lockEtag` + `run_id` ownership check, release slot in the outer finally (existing dual-`finally` shape). Suppress the user-facing failure reply for operator-initiated cancels (the thread notice from Unit 2 is the communication).
+- Etag-mismatch graceful losers: when the run's own `PENDING→ACKNOWLEDGED` or `ACKNOWLEDGED→EXECUTING` transition 412s, re-read the run-state; if `CANCELLED`, skip `failAdmittedRun` (its stale etag would 412 anyway and log a misleading error), suppress the user-facing "could not start" reply, release resources, exit cleanly.
+
+**Patterns to follow:** inactivity-controller composition in `run-core.ts:281-304`; the FAILED error path in `run.ts:668-779`; dual-`finally` cleanup (mention-loop learnings doc).
+
+**Test scenarios:**
+- Happy path: registered run aborted by runId → run-core exits with `RunCoreError('cancelled')` → run settles `CANCELLED`, SSE observer notified, lock released, slot released.
+- Edge: abort for an unknown/already-completed runId → registry no-op, no signal fired.
+- Edge: ceiling timeout and operator cancel racing → exactly one terminal state; classification via registry probe does not mislabel (composite reason is not consulted).
+- Edge: cancel wins the adoption race (PENDING→CANCELLED commits before PENDING→ACKNOWLEDGED) → the run's transition 412s, re-reads, sees CANCELLED, exits without `failAdmittedRun` noise or a user-facing failure reply.
+- Error path: lock release fails on cancel path → cleanup continues (slot still released), error logged, no throw from cleanup.
+- Error path (the #1055 class): OpenCode stream never settles after abort → the run's promise still resolves within the bounded window; no unhandled rejection from late-firing `.return()`.
+- Integration: partial output streamed before cancel remains flushed/visible after `CANCELLED` settles.
+
+**Verification:** gateway `tsc` + full gateway suite green; a simulated in-flight run cancelled via the registry lands `CANCELLED` with all resources released (asserted via fakes, not sleeps).
+
+- [ ] **Unit 2: Cancel orchestrator — queue removal, approval cascade, thread notice, attribution**
+
+**Goal:** A single transport-neutral `cancelRun(runId, actor, deps)` entry point that resolves the run's phase and executes the correct cancellation path.
+
+**Requirements:** R2, R3, R4, R5, R6, R8
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `packages/gateway/src/execute/cancel.ts`
+- Create: `packages/gateway/src/execute/cancel.test.ts`
+- Modify: `packages/gateway/src/execute/queue.ts` (add `removeByRunId`)
+- Test: `packages/gateway/src/execute/queue.test.ts`
+
+**Approach:**
+- Read run-state first (via `getRunKey` — never inline keys). Terminal phase → return `{outcome: 'already-terminal', phase}` (idempotent, origin AE1/AE6).
+- Queued (PENDING/ACKNOWLEDGED): `queue.removeByRunId(channelId, runId)`; on hit, terminalize to `CANCELLED` (no lock/slot held for queued runs — nothing to release). On miss, probe the abort registry; on registry hit, fire the abort (executing path). On double miss (the pre-ACK registration window, origin AE7): attempt `transitionRun(currentPhase → CANCELLED)` directly — the conditional write is the rendezvous (see Key Technical Decisions); on 412, re-read and retry once or short-circuit on terminal.
+- Executing: enumerate pending approvals for the run's scope (`describePendingForScope`) and settle each via `registry.handleDecision({decision:'reject', actor})`; then fire the abort handle. The Unit 1 error path owns the state transition and resource release.
+- Post the thread notice: resolve `thread_id` from run-state, `client.channels.fetch` → `sendMessage` (fail-soft, mention-safe, bounded); notice failure must not fail the cancellation.
+- Write attribution into the transition's `details.cancelledBy`.
+
+**Patterns to follow:** `presence.ts` channel-fetch + `sendMessage`; `createWebAutoDenyApproval` (web-launch learnings) for the reject cascade; reverse-order, independently-wrapped cleanup (resource-cleanup learnings).
+
+**Test scenarios:**
+- Happy path: queued run cancelled → removed from queue, `CANCELLED` committed, thread notice sent, active run on the same channel untouched (origin AE2).
+- Happy path: executing run cancelled → approvals rejected through `handleDecision` (asserted: no direct registry-state mutation), abort fired, notice sent.
+- Edge: cancel in the dequeue-handoff window (double miss) → run-state rendezvous commits CANCELLED; the run's own next transition 412s and exits cleanly; run never executes user work; response not a misleading no-op (origin AE7).
+- Edge: double-cancel (two concurrent cancels) → one wins the conditional write, the other re-reads and reports already-terminal; abort() on an aborted controller is a spec no-op.
+- Edge: already-terminal run → `already-terminal` outcome, no transition attempted, no notice posted (origin AE1).
+- Error path: pending-approval rejection fails for one entry → remaining entries still settled; cancellation proceeds fail-closed.
+- Error path: thread notice send fails → cancellation still completes; failure logged.
+- Integration: approval settle frames reach both web (`observeApproval`) and Discord render paths on cancel (origin AE4).
+
+**Verification:** every origin acceptance example AE1–AE7 that is orchestrator-scoped has a corresponding passing test; queue removal is race-checked against concurrent `takeNext` in a deterministic test.
+
+- [ ] **Unit 3: Operator cancel route + contract 1.6.0 + pins + audit**
+
+**Goal:** `POST /operator/runs/:runId/cancel` exposed on the operator surface with full guard parity, typed response, audit events, and the contract bump.
+
+**Requirements:** R1, R2, R7, R8
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Create: `packages/gateway/src/web/operator/cancel-route.ts`
+- Create: `packages/gateway/src/web/operator/cancel-route.test.ts`
+- Modify: `packages/gateway/src/web/server.ts` (registration tuple beside the decision route), `packages/gateway/src/operator-contract/responses.ts`, `packages/gateway/src/operator-contract/parse.ts`, `packages/gateway/src/operator-contract/index.ts`, `packages/gateway/src/operator-contract/version.ts` (1.5.0 → 1.6.0), `packages/gateway/src/web/audit.ts`, `packages/gateway/src/http/ingress-pin.test.ts`, `packages/gateway/src/web/operator-route-smoke.ts`
+- Test: `packages/gateway/src/operator-contract/version.test.ts`, `packages/gateway/src/web/server.test.ts`
+
+**Approach:**
+- Mirror `decision-route.ts` gate ordering exactly: session → `resolveRepoFromRunIndex` → `checkDenylist` → `checkRepoWriteAuthz` → rate limit (after authz, operator-keyed) → server-built `WebOperatorActor` → `cancelRun` → audit → typed response. All pre-acceptance denials return the identical `notFoundResponse` (no oracle), including throws.
+- Response type in the contract: success carries the resulting phase (`CANCELLED` or the pre-existing terminal phase for idempotent hits) so the dashboard can render "already completed" honestly.
+- New audit kinds (`run.cancel.requested` / `run.cancel.rejected` or a single kind with outcome) + `LOG_LEVEL` entries (compile-time exhaustive).
+- Update BOTH route pins + per-dep-omission smoke regression (dependency-gated-route learnings).
+- Verify `toRunSummary` / run-status projections do not leak `details.cancelledBy`.
+
+**Patterns to follow:** `decision-route.ts` (gates, try/catch split, response mapping); `launch-route.ts` (operator-keyed rate limiting); contract barrel + parse-helper conventions.
+
+**Test scenarios:**
+- Happy path: authorized operator cancels own-repo run → 200 with phase, audit event emitted with actor identity.
+- Error path: no session / bad CSRF / wrong origin / denylisted repo / no write authz → identical generic denial, zero state change (origin AE5); gate-throw degrades to the same denial.
+- Edge: cancel an already-terminal run → idempotent success carrying the terminal phase.
+- Edge: rate limit exceeded → limited response; unauthorized requests don't consume budget.
+- Integration: route inventory pins (ingress-pin + smoke) pass with the new route; contract version test asserts 1.6.0; projection tests prove `cancelledBy` never reaches summary/status DTOs.
+
+**Verification:** ingress-pin, smoke, and full gateway suite green; the SSE ready-frame carries 1.6.0.
+
+- [ ] **Unit 4: Crash-consistency recovery — reconcile CANCELLED runs holding live locks**
+
+**Goal:** A crash between the `CANCELLED` transition and resource cleanup cannot strand the per-repo lock (origin R9).
+
+**Requirements:** R9
+
+**Dependencies:** Units 1–2 (the cancel paths whose partial failure this reconciles)
+
+**Files:**
+- Modify: `packages/gateway/src/execute/recovery.ts`
+- Test: `packages/gateway/src/execute/recovery.test.ts`
+
+**Approach:**
+- `findStaleRuns` (`packages/runtime/src/coordination/run-state.ts`, phase filter around :214) currently skips CANCELLED entirely — a crash between the CANCELLED transition and lock release is invisible to the sweep. Extend the phase filter to include CANCELLED (gated on the staleness window) OR add a dedicated second pass listing CANCELLED-phase run-states; either way release via `forceReleaseStaleLock` (dead-run-verified — lock `run_id` ownership + lease/heartbeat staleness built in, protecting a newer run's lock from blind deletion).
+- Recovery-vs-cancel races are already safe (conditional writes: whichever transition commits first wins; the loser re-reads and skips) — pin with a test, no new machinery.
+- Emit a recovery audit/log line for each reconciled lock.
+
+**Patterns to follow:** existing `recoverStaleRuns`/`recoverOneRun` shape; `forceReleaseStaleLock` usage; lock-ownership P0 lesson (mention-loop learnings).
+
+**Test scenarios:**
+- Happy path: CANCELLED run + its own live lock at startup → lock released, logged.
+- Edge: CANCELLED run, lock since re-acquired by a NEWER run (`run_id` mismatch) → lock untouched.
+- Edge: CANCELLED run, no lock present → no-op.
+- Error path: release fails → sweep continues to other repos; failure logged, startup not blocked.
+
+**Verification:** recovery suite green; a simulated crash-mid-cancel (state committed, lock alive) reconciles on boot with no manual intervention.
+
+## System-Wide Impact
+
+- **Interaction graph:** cancel touches run lifecycle (`run.ts`/`run-core.ts`), queue, approvals registry, SSE manager (no code change — existing terminal handling), Discord io, recovery, and the operator contract. The SSE and Discord surfaces consume existing seams; no new fan-out paths.
+- **Error propagation:** cancellation is never reported as a generic failure — the `'cancelled'` kind keeps operator messaging and run-state honest. Cleanup steps are independently wrapped; a failing side effect (notice, one approval settle) degrades without aborting the cancellation.
+- **State lifecycle risks:** cancel-vs-completion and cancel-vs-handoff races settle to exactly one terminal state via conditional writes + read-then-short-circuit; the out-of-order SSE guard (`terminalRuns`) prevents a late EXECUTING projection from regressing a committed CANCELLED.
+- **API surface parity:** the route joins launch/decision as the third mutating operator route with identical guard shape. Dashboard gains the capability only after its own pin bump (deferred task).
+- **Integration coverage:** approval-settle frames on both transports; queue-removal race; recovery reconciliation — all pinned by tests above; the ingress pins force the deliberate-review event the security posture expects.
+- **Unchanged invariants:** `registry.handleDecision` remains the sole settlement gate; `OPERATOR_CONTRACT_VERSION` remains build-time pinned and never negotiated over the wire; the queue remains in-memory/lossy; `io.ts` remains the only Discord send boundary; no new listener or network surface.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Dashboard drift gate vs 1.6.0 bump | **Verified: exact-match fail-closed** (`fro-bot/dashboard` `operator-sse-reader.ts:481-486`; pin `1.5.0`; mismatch → `contract-drift` error + stream close, test-pinned). A 1.6.0 gateway deploy against a 1.5.0 dashboard kills every operator run stream at the ready frame — and vice versa. Mitigation: merge is safe, deploy is the gate — coordinate the dashboard pin bump to land in the same deploy window (user-driven dashboard session), or add transitional dual-accept dashboard-side first. Surface prominently at PR time. |
+| Blind lock release deleting a newer run's lock | Always `forceReleaseStaleLock` / ownership-checked release (`run_id` match) — never unconditional delete (documented P0 class). |
+| Hung OpenCode stream after abort pins the route or leaks an unhandled rejection (#1055 class) | Bound cancel propagation; `.catch` on late-firing promises; regression test with a never-settling stream. |
+| Queue removal racing `takeNext` handoff | Deterministic race test; miss falls through to abort-registry path so the window is covered either way (AE7). |
+| Cancel spam / abuse | Operator-keyed rate limit after authz; idempotent no-ops are cheap; audit trail per attempt. |
+| Approval reject cascade partially failing | Per-entry isolation; fail-closed continuation; integration test. |
+
+## Documentation / Operational Notes
+
+- `docs/wiki/` operator-surface page and `packages/gateway/AGENTS.md` route inventory mentions gain the cancel route (same PR).
+- The dashboard follow-up (pin 1.6.0 + Cancel UI) is a `fro-bot/dashboard` task; surface it clearly at PR time so the user can schedule the dashboard session.
+- No deploy/compose changes; no new env vars.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-07-03-operator-run-cancellation-requirements.md`
+- Related code: see Context & Research above.
+- Contract-bump precedent commits: `9fdaa1920`, `3d5fdcf19`, `5276272b0`, `1ad74fc04`, `364033861`.
+- Related plan: `docs/plans/2026-06-15-002` (operator surface — where cancellation was deferred).

--- a/packages/gateway/src/discord/cancel-notice.test.ts
+++ b/packages/gateway/src/discord/cancel-notice.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the Discord cancellation-notice dispatcher factory.
+ *
+ * BDD `// #given/#when/#then` per repo convention.
+ */
+
+import type {Client} from 'discord.js'
+import type {GatewayLogger} from './client.js'
+import {describe, expect, it, vi} from 'vitest'
+import {CANCELLED_NOTICE_TEXT, createCancelNoticeDispatcher} from './cancel-notice.js'
+
+type FakeClient = Pick<Client, 'channels'>
+
+function makeLogger(): GatewayLogger {
+  return {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+}
+
+function makeClient(sendMock = vi.fn().mockResolvedValue(undefined)): FakeClient {
+  const channel = {
+    isTextBased: (): boolean => true,
+    send: sendMock,
+  }
+  return {
+    channels: {
+      fetch: vi.fn().mockResolvedValue(channel),
+    } as unknown as FakeClient['channels'],
+  }
+}
+
+describe('createCancelNoticeDispatcher', () => {
+  it('skips (logs) when threadId is empty', async () => {
+    // #given
+    const client = makeClient()
+    const logger = makeLogger()
+    const dispatch = createCancelNoticeDispatcher(client, logger)
+
+    // #when
+    await dispatch('', 'run-1')
+
+    // #then
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- vi.fn() mock reference, not a real method
+    expect(client.channels.fetch).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith(
+      {runId: 'run-1'},
+      'cancelRun: no thread_id on run-state — skipping cancellation notice',
+    )
+  })
+
+  it('sends the cancellation notice for a resolved text-sendable channel', async () => {
+    // #given
+    const sendMock = vi.fn().mockResolvedValue(undefined)
+    const client = makeClient(sendMock)
+    const logger = makeLogger()
+    const dispatch = createCancelNoticeDispatcher(client, logger)
+
+    // #when
+    await dispatch('thread-1', 'run-1')
+
+    // #then
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- vi.fn() mock reference, not a real method
+    expect(client.channels.fetch).toHaveBeenCalledWith('thread-1')
+    expect(sendMock).toHaveBeenCalledWith(expect.objectContaining({content: CANCELLED_NOTICE_TEXT}))
+  })
+
+  it('skips (logs) when the channel cannot be resolved', async () => {
+    // #given
+    const client = {channels: {fetch: vi.fn().mockResolvedValue(null)}} as unknown as FakeClient
+    const logger = makeLogger()
+    const dispatch = createCancelNoticeDispatcher(client, logger)
+
+    // #when
+    await dispatch('thread-1', 'run-1')
+
+    // #then
+    expect(logger.warn).toHaveBeenCalledWith(
+      {runId: 'run-1', threadId: 'thread-1'},
+      'cancelRun: thread channel not found — skipping cancellation notice',
+    )
+  })
+
+  it('skips (logs) when the resolved channel is not text-sendable', async () => {
+    // #given
+    const channel = {isTextBased: () => false}
+    const client = {channels: {fetch: vi.fn().mockResolvedValue(channel)}} as unknown as FakeClient
+    const logger = makeLogger()
+    const dispatch = createCancelNoticeDispatcher(client, logger)
+
+    // #when
+    await dispatch('thread-1', 'run-1')
+
+    // #then
+    expect(logger.warn).toHaveBeenCalledWith(
+      {runId: 'run-1', threadId: 'thread-1'},
+      'cancelRun: resolved channel is not text-sendable — skipping cancellation notice',
+    )
+  })
+
+  it('logs (does not throw) when sendMessage returns a failure result', async () => {
+    // #given
+    const sendMock = vi.fn().mockRejectedValue(new Error('discord send failed'))
+    const client = makeClient(sendMock)
+    const logger = makeLogger()
+    const dispatch = createCancelNoticeDispatcher(client, logger)
+
+    // #when
+    await expect(dispatch('thread-1', 'run-1')).resolves.toBeUndefined()
+
+    // #then — io.ts's sendMessage catches the throw and returns err(...); logged, not thrown
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({runId: 'run-1', threadId: 'thread-1'}),
+      'cancelRun: cancellation notice send failed',
+    )
+  })
+
+  it('logs (does not throw) when channels.fetch itself throws', async () => {
+    // #given
+    const client = {
+      channels: {fetch: vi.fn().mockRejectedValue(new Error('discord unreachable'))},
+    } as unknown as FakeClient
+    const logger = makeLogger()
+    const dispatch = createCancelNoticeDispatcher(client, logger)
+
+    // #when
+    await expect(dispatch('thread-1', 'run-1')).resolves.toBeUndefined()
+
+    // #then
+    expect(logger.warn).toHaveBeenCalledWith(
+      {runId: 'run-1', threadId: 'thread-1', err: 'discord unreachable'},
+      'cancelRun: cancellation notice threw — continuing',
+    )
+  })
+})

--- a/packages/gateway/src/discord/cancel-notice.ts
+++ b/packages/gateway/src/discord/cancel-notice.ts
@@ -1,0 +1,59 @@
+/**
+ * Discord transport for the cancellation notice injected into `cancelRun`
+ * (`execute/cancel.ts`) via `CancelRunDeps.postCancelNotice`.
+ *
+ * `createCancelNoticeDispatcher` returns a `(threadId, runId) => Promise<void>`
+ * callback that resolves the run's thread and posts a fixed cancellation
+ * message. Always fail-soft: never throws, and every failure mode is logged,
+ * not propagated — the cancellation outcome never depends on this succeeding.
+ */
+
+import type {Client} from 'discord.js'
+import type {GatewayLogger} from './client.js'
+import {sendMessage} from './io.js'
+
+/** Fixed cancellation notice text posted to a run's origin thread. */
+export const CANCELLED_NOTICE_TEXT = 'Run cancelled by operator.'
+
+/**
+ * Build the Discord cancellation-notice callback for `CancelRunDeps.postCancelNotice`.
+ *
+ * Skips (logs) when `threadId` is empty, when the channel cannot be resolved,
+ * or when the resolved channel is not text-sendable. Logs (does not throw) on
+ * a `sendMessage` failure or any thrown error from `channels.fetch`.
+ */
+export function createCancelNoticeDispatcher(
+  client: Pick<Client, 'channels'>,
+  logger: GatewayLogger,
+): (threadId: string, runId: string) => Promise<void> {
+  return async (threadId: string, runId: string): Promise<void> => {
+    if (threadId === '') {
+      logger.info({runId}, 'cancelRun: no thread_id on run-state — skipping cancellation notice')
+      return
+    }
+    try {
+      const channel = await client.channels.fetch(threadId)
+      if (channel === null || channel === undefined) {
+        logger.warn({runId, threadId}, 'cancelRun: thread channel not found — skipping cancellation notice')
+        return
+      }
+      if (channel.isTextBased() === false || 'send' in channel === false) {
+        logger.warn(
+          {runId, threadId},
+          'cancelRun: resolved channel is not text-sendable — skipping cancellation notice',
+        )
+        return
+      }
+      const sendResult = await sendMessage(channel, {content: CANCELLED_NOTICE_TEXT}, logger)
+      if (sendResult.success === false) {
+        logger.warn({runId, threadId, err: sendResult.error.message}, 'cancelRun: cancellation notice send failed')
+      }
+    } catch (error: unknown) {
+      // sendMessage/io.ts never throws, but channels.fetch can — belt-and-suspenders.
+      logger.warn(
+        {runId, threadId, err: error instanceof Error ? error.message : String(error)},
+        'cancelRun: cancellation notice threw — continuing',
+      )
+    }
+  }
+}

--- a/packages/gateway/src/discord/commands/fro-bot.test.ts
+++ b/packages/gateway/src/discord/commands/fro-bot.test.ts
@@ -32,6 +32,7 @@ function makeQueue(clearReturnValue = 0): ChannelQueue<RunTask> {
     pendingCount: vi.fn().mockReturnValue(0),
     takeNext: vi.fn().mockReturnValue(undefined),
     clear: vi.fn().mockReturnValue(clearReturnValue),
+    removeBy: vi.fn().mockReturnValue(undefined),
   }
 }
 
@@ -434,6 +435,7 @@ describe('/fro-bot clear-queue — infra-failure path', () => {
       clear: vi.fn().mockImplementation(() => {
         throw infraError
       }),
+      removeBy: vi.fn().mockReturnValue(undefined),
     }
     const deps = makeDeps({queue})
     const cmd = createFroBotCommand(deps)

--- a/packages/gateway/src/discord/commands/index.test.ts
+++ b/packages/gateway/src/discord/commands/index.test.ts
@@ -40,6 +40,7 @@ function makeMockDeps(): FroBotDeps {
       pendingCount: vi.fn().mockReturnValue(0),
       takeNext: vi.fn().mockReturnValue(undefined),
       clear: vi.fn().mockReturnValue(0),
+      removeBy: vi.fn().mockReturnValue(undefined),
     },
     triggerRoleId: null,
     gatewayLogger: {

--- a/packages/gateway/src/discord/mentions.test.ts
+++ b/packages/gateway/src/discord/mentions.test.ts
@@ -130,6 +130,7 @@ function makeRunMentionDeps(): MentionDeps['run'] {
       pendingCount: vi.fn().mockReturnValue(0),
       takeNext: vi.fn().mockReturnValue(undefined),
       clear: vi.fn().mockReturnValue(0),
+      removeBy: vi.fn().mockReturnValue(undefined),
     },
     attachUrl: 'http://workspace:9200',
     attachToken: 'secret-token',

--- a/packages/gateway/src/execute/abort-registry.test.ts
+++ b/packages/gateway/src/execute/abort-registry.test.ts
@@ -1,0 +1,83 @@
+import {describe, expect, it} from 'vitest'
+import {createAbortRegistry} from './abort-registry.js'
+
+describe('abort-registry', () => {
+  it('register/abort/isAborted/delete lifecycle', () => {
+    // #given a fresh registry
+    const registry = createAbortRegistry()
+    const runId = 'run-1'
+
+    // #when registering the run
+    const signal = registry.register(runId)
+
+    // #then it is tracked, not yet aborted
+    expect(registry.has(runId)).toBe(true)
+    expect(registry.isAborted(runId)).toBe(false)
+    expect(signal.aborted).toBe(false)
+
+    // #when aborting the run
+    const aborted = registry.abort(runId, 'operator cancel')
+
+    // #then abort reports success and the signal/probe reflect it
+    expect(aborted).toBe(true)
+    expect(signal.aborted).toBe(true)
+    expect(registry.isAborted(runId)).toBe(true)
+
+    // #when deleting the entry
+    registry.delete(runId)
+
+    // #then the registry no longer tracks it
+    expect(registry.has(runId)).toBe(false)
+    expect(registry.isAborted(runId)).toBe(false)
+  })
+
+  it('abort on an unknown runId is a no-op returning false', () => {
+    // #given a fresh registry with no registrations
+    const registry = createAbortRegistry()
+
+    // #when aborting an unregistered runId
+    const result = registry.abort('never-registered')
+
+    // #then it reports false without throwing
+    expect(result).toBe(false)
+  })
+
+  it('double-abort on the same runId is a no-op (spec AbortController behavior)', () => {
+    // #given a registered, already-aborted run
+    const registry = createAbortRegistry()
+    const runId = 'run-2'
+    const signal = registry.register(runId)
+    expect(registry.abort(runId, 'first')).toBe(true)
+
+    // #when aborting again
+    const secondAbort = registry.abort(runId, 'second')
+
+    // #then it still reports true (controller found + abort() called), signal stays aborted once
+    expect(secondAbort).toBe(true)
+    expect(signal.aborted).toBe(true)
+    expect(registry.isAborted(runId)).toBe(true)
+  })
+
+  it('delete on an unknown runId is a no-op', () => {
+    // #given a fresh registry
+    const registry = createAbortRegistry()
+
+    // #when/#then deleting an unregistered runId does not throw
+    expect(() => {
+      registry.delete('never-registered')
+    }).not.toThrow()
+  })
+
+  it('register is idempotent — returns the same signal on repeat calls before delete', () => {
+    // #given a registered run
+    const registry = createAbortRegistry()
+    const runId = 'run-3'
+    const first = registry.register(runId)
+
+    // #when registering again without deleting
+    const second = registry.register(runId)
+
+    // #then the same signal/controller is reused (not reset)
+    expect(second).toBe(first)
+  })
+})

--- a/packages/gateway/src/execute/abort-registry.test.ts
+++ b/packages/gateway/src/execute/abort-registry.test.ts
@@ -58,6 +58,35 @@ describe('abort-registry', () => {
     expect(registry.isAborted(runId)).toBe(true)
   })
 
+  it('getMetadata returns stored CancelledByMetadata after abort with metadata; delete clears it', () => {
+    // #given a registered run
+    const registry = createAbortRegistry()
+    const runId = 'run-4'
+    registry.register(runId)
+    const metadata = {
+      githubUserId: 42,
+      login: 'octocat',
+      sessionCorrelationId: 'sess-1',
+      cancelledAt: '2026-07-03T00:00:00.000Z',
+    }
+
+    // #then no metadata before abort
+    expect(registry.getMetadata(runId)).toBeUndefined()
+
+    // #when aborting with metadata
+    const aborted = registry.abort(runId, 'operator cancel', metadata)
+
+    // #then metadata is retrievable
+    expect(aborted).toBe(true)
+    expect(registry.getMetadata(runId)).toEqual(metadata)
+
+    // #when deleting the entry
+    registry.delete(runId)
+
+    // #then metadata is cleared
+    expect(registry.getMetadata(runId)).toBeUndefined()
+  })
+
   it('delete on an unknown runId is a no-op', () => {
     // #given a fresh registry
     const registry = createAbortRegistry()

--- a/packages/gateway/src/execute/abort-registry.ts
+++ b/packages/gateway/src/execute/abort-registry.ts
@@ -21,6 +21,22 @@
  * entries for completed/failed/cancelled runs.
  */
 
+/**
+ * Attribution metadata for an operator-initiated cancel.
+ *
+ * Written by `cancelRun` (Unit 2) alongside `abort()` so the run's own
+ * settlement path in `run.ts` (the single writer of the CANCELLED transition)
+ * can read it back and thread `details.cancelledBy` onto the transition —
+ * without the orchestrator reaching into run.ts's private execution state.
+ */
+export interface CancelledByMetadata {
+  readonly githubUserId: number
+  readonly login: string
+  readonly sessionCorrelationId: string
+  /** ISO timestamp of the cancel request. */
+  readonly cancelledAt: string
+}
+
 export interface AbortRegistry {
   /**
    * Create (or return the existing) `AbortController` for `runId` and return
@@ -31,17 +47,28 @@ export interface AbortRegistry {
   /**
    * Abort the run's controller, if registered.
    *
+   * `metadata`, when provided, is stored retrievably via `getMetadata` — the
+   * run's own settlement path reads it back to attribute the CANCELLED
+   * transition's `details.cancelledBy` (single writer = the run's own
+   * settlement path, per the plan's Key Technical Decisions).
+   *
    * Returns `false` (no-op) for an unknown `runId` — the run may already have
    * completed and been deleted, or may not yet be registered (the pre-ACK
    * rendezvous window; a later unit's conditional-write path covers that case).
    * Returns `true` when a registered controller was aborted (or was already
    * aborted — `AbortController.abort()` is itself a spec no-op on a second call).
    */
-  readonly abort: (runId: string, reason?: unknown) => boolean
+  readonly abort: (runId: string, reason?: unknown, metadata?: CancelledByMetadata) => boolean
   /** Whether `runId` is currently registered. */
   readonly has: (runId: string) => boolean
   /** Whether `runId`'s registered controller has been aborted. `false` for an unknown `runId`. */
   readonly isAborted: (runId: string) => boolean
+  /**
+   * Retrieve the attribution metadata stored by `abort()`, if any.
+   * Returns `undefined` for an unknown `runId` or a run aborted without metadata
+   * (e.g. the ceiling timeout, which is not operator-attributed).
+   */
+  readonly getMetadata: (runId: string) => CancelledByMetadata | undefined
   /** Remove the registry entry for `runId`. No-op for an unknown `runId`. */
   readonly delete: (runId: string) => void
 }
@@ -49,6 +76,7 @@ export interface AbortRegistry {
 /** Closure-based factory — no classes, matches the project's functional-only convention. */
 export function createAbortRegistry(): AbortRegistry {
   const controllers = new Map<string, AbortController>()
+  const metadataByRunId = new Map<string, CancelledByMetadata>()
 
   return {
     register: (runId: string): AbortSignal => {
@@ -60,18 +88,23 @@ export function createAbortRegistry(): AbortRegistry {
       controllers.set(runId, controller)
       return controller.signal
     },
-    abort: (runId: string, reason?: unknown): boolean => {
+    abort: (runId: string, reason?: unknown, metadata?: CancelledByMetadata): boolean => {
       const controller = controllers.get(runId)
       if (controller === undefined) {
         return false
+      }
+      if (metadata !== undefined) {
+        metadataByRunId.set(runId, metadata)
       }
       controller.abort(reason)
       return true
     },
     has: (runId: string): boolean => controllers.has(runId),
     isAborted: (runId: string): boolean => controllers.get(runId)?.signal.aborted === true,
+    getMetadata: (runId: string): CancelledByMetadata | undefined => metadataByRunId.get(runId),
     delete: (runId: string): void => {
       controllers.delete(runId)
+      metadataByRunId.delete(runId)
     },
   }
 }

--- a/packages/gateway/src/execute/abort-registry.ts
+++ b/packages/gateway/src/execute/abort-registry.ts
@@ -1,0 +1,84 @@
+/**
+ * runId → abort-handle registry for operator-initiated run cancellation.
+ *
+ * Exists so a transport-neutral `cancelRun` orchestrator (a later unit) can
+ * abort an in-flight run by `runId` without reaching into `run.ts`'s private
+ * execution primitives. The registry is the sole handle: `abort()` fires the
+ * `AbortController` for the given run, and `run.ts`'s catch handler probes
+ * `isAborted()` to classify the failure as an operator cancel (→ `CANCELLED`)
+ * rather than a generic failure (→ `FAILED`).
+ *
+ * Classification via registry probe (not composite abort-reason inspection)
+ * is deliberate: the run's effective signal is `AbortSignal.any([timeoutSignal,
+ * cancelSignal])`, and `AbortSignal.any` propagates whichever child fired
+ * first — inspecting the composite signal's `reason` for "was this a cancel"
+ * is racy. The registry's own controller state is ground truth.
+ *
+ * Lifecycle: `register(runId)` is called after the EXECUTING transition
+ * succeeds (mirrors the `inFlightRuns` set precedent below) and the entry is
+ * always removed via `delete(runId)` in the run's existing outer `finally` —
+ * regardless of how the run settled. This keeps the registry from leaking
+ * entries for completed/failed/cancelled runs.
+ */
+
+export interface AbortRegistry {
+  /**
+   * Create (or return the existing) `AbortController` for `runId` and return
+   * its signal. Idempotent: calling `register` twice for the same `runId`
+   * returns the same signal without resetting an already-aborted controller.
+   */
+  readonly register: (runId: string) => AbortSignal
+  /**
+   * Abort the run's controller, if registered.
+   *
+   * Returns `false` (no-op) for an unknown `runId` — the run may already have
+   * completed and been deleted, or may not yet be registered (the pre-ACK
+   * rendezvous window; a later unit's conditional-write path covers that case).
+   * Returns `true` when a registered controller was aborted (or was already
+   * aborted — `AbortController.abort()` is itself a spec no-op on a second call).
+   */
+  readonly abort: (runId: string, reason?: unknown) => boolean
+  /** Whether `runId` is currently registered. */
+  readonly has: (runId: string) => boolean
+  /** Whether `runId`'s registered controller has been aborted. `false` for an unknown `runId`. */
+  readonly isAborted: (runId: string) => boolean
+  /** Remove the registry entry for `runId`. No-op for an unknown `runId`. */
+  readonly delete: (runId: string) => void
+}
+
+/** Closure-based factory — no classes, matches the project's functional-only convention. */
+export function createAbortRegistry(): AbortRegistry {
+  const controllers = new Map<string, AbortController>()
+
+  return {
+    register: (runId: string): AbortSignal => {
+      const existing = controllers.get(runId)
+      if (existing !== undefined) {
+        return existing.signal
+      }
+      const controller = new AbortController()
+      controllers.set(runId, controller)
+      return controller.signal
+    },
+    abort: (runId: string, reason?: unknown): boolean => {
+      const controller = controllers.get(runId)
+      if (controller === undefined) {
+        return false
+      }
+      controller.abort(reason)
+      return true
+    },
+    has: (runId: string): boolean => controllers.has(runId),
+    isAborted: (runId: string): boolean => controllers.get(runId)?.signal.aborted === true,
+    delete: (runId: string): void => {
+      controllers.delete(runId)
+    },
+  }
+}
+
+/**
+ * Module-scoped shared registry — mirrors the `inFlightRuns` module-level-singleton
+ * precedent in `run.ts`. `run.ts` registers/probes/deletes through this instance;
+ * the future `cancelRun` orchestrator calls `abort()` on the same instance.
+ */
+export const abortRegistry: AbortRegistry = createAbortRegistry()

--- a/packages/gateway/src/execute/cancel.test.ts
+++ b/packages/gateway/src/execute/cancel.test.ts
@@ -1,0 +1,443 @@
+/**
+ * Tests for the transport-neutral run-cancellation orchestrator.
+ *
+ * Deterministic fakes throughout — no real S3/Discord, no sleeps.
+ * BDD `// #given/#when/#then` per repo convention.
+ */
+
+import type {CoordinationConfig, RunState} from '@fro-bot/runtime'
+import type {ApprovalRegistry, PendingApprovalDTO} from '../approvals/registry.js'
+import type {GatewayLogger} from '../discord/client.js'
+import type {AbortRegistry} from './abort-registry.js'
+import type {CancelActorContext, CancelRunDeps} from './cancel.js'
+import type {ChannelQueue} from './queue.js'
+import type {RunIndex} from './run-index.js'
+import type {RunTask} from './run.js'
+
+import {err, ok} from '@fro-bot/runtime'
+import {describe, expect, it, vi} from 'vitest'
+import {cancelRun} from './cancel.js'
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+function makeLogger(): GatewayLogger {
+  return {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+}
+
+function makeActor(overrides: Partial<CancelActorContext> = {}): CancelActorContext {
+  return {githubUserId: 42, login: 'octocat', sessionCorrelationId: 'sess-1', ...overrides}
+}
+
+function makeRunState(overrides: Partial<RunState> = {}): RunState {
+  return {
+    run_id: 'run-1',
+    surface: 'discord',
+    thread_id: 'thread-1',
+    entity_ref: 'acme/widget',
+    phase: 'PENDING',
+    started_at: '2026-07-03T00:00:00.000Z',
+    last_heartbeat: '2026-07-03T00:00:00.000Z',
+    holder_id: 'gateway',
+    details: {channelId: 'ch-a'},
+    ...overrides,
+  }
+}
+
+/** In-memory getObject/conditionalPut fake so transitionRun's read-modify-write works end to end. */
+function makeCoordinationConfig(initialState: RunState, initialEtag = 'etag-1'): CoordinationConfig {
+  let stored = {state: initialState, etag: initialEtag}
+  return {
+    storeAdapter: {
+      upload: vi.fn(async () => ok(undefined)),
+      download: vi.fn(async () => ok(undefined)),
+      getObject: vi.fn(async () => ok({data: JSON.stringify(stored.state), etag: stored.etag})),
+      conditionalPut: vi.fn(async (_key: string, data: string, opts: {readonly ifMatch?: string}) => {
+        if (opts.ifMatch !== undefined && opts.ifMatch !== stored.etag) {
+          return err(new Error('etag mismatch (412)'))
+        }
+        const nextEtag = `etag-${Math.random().toString(36).slice(2)}`
+        stored = {state: JSON.parse(data) as RunState, etag: nextEtag}
+        return ok({etag: nextEtag})
+      }),
+      list: vi.fn(async () => ok([])),
+    },
+    storeConfig: {enabled: true, bucket: 'test-bucket', region: 'us-east-1', prefix: 'fro-bot-state'},
+    lockTtlSeconds: 900,
+    heartbeatIntervalMs: 30_000,
+    staleThresholdMs: 60_000,
+    pendingStaleThresholdMs: 30 * 60_000,
+  }
+}
+
+function makeRunIndex(repo = 'acme/widget'): Pick<RunIndex, 'lookup'> {
+  return {lookup: vi.fn(async () => ({repo, surface: 'discord' as const}))}
+}
+
+function makeQueue(overrides: Partial<ChannelQueue<RunTask>> = {}): ChannelQueue<RunTask> {
+  return {
+    enqueue: vi.fn().mockReturnValue('queued'),
+    pendingCount: vi.fn().mockReturnValue(0),
+    takeNext: vi.fn().mockReturnValue(undefined),
+    clear: vi.fn().mockReturnValue(0),
+    removeBy: vi.fn().mockReturnValue(undefined),
+    ...overrides,
+  }
+}
+
+function makeAbortRegistry(overrides: Partial<AbortRegistry> = {}): Pick<AbortRegistry, 'has' | 'abort'> {
+  return {
+    has: vi.fn().mockReturnValue(false),
+    abort: vi.fn().mockReturnValue(true),
+    ...overrides,
+  }
+}
+
+function makeApprovalRegistry(
+  overrides: Partial<Pick<ApprovalRegistry, 'describePendingForScope' | 'handleDecision'>> = {},
+): Pick<ApprovalRegistry, 'describePendingForScope' | 'handleDecision'> {
+  return {
+    describePendingForScope: vi.fn().mockReturnValue([]),
+    handleDecision: vi.fn().mockResolvedValue('ok'),
+    ...overrides,
+  }
+}
+
+function makeDiscordClient(sendMock = vi.fn().mockResolvedValue(undefined)): CancelRunDeps['discordClient'] {
+  const channel = {
+    isTextBased: () => true,
+    send: sendMock,
+  }
+  return {
+    channels: {
+      fetch: vi.fn().mockResolvedValue(channel),
+    } as unknown as CancelRunDeps['discordClient']['channels'],
+  }
+}
+
+function makeDeps(overrides: Partial<CancelRunDeps> & {readonly runState: RunState}): CancelRunDeps {
+  const {runState, ...rest} = overrides
+  return {
+    coordinationConfig: rest.coordinationConfig ?? makeCoordinationConfig(runState),
+    identity: rest.identity ?? 'discord-gateway',
+    runIndex: rest.runIndex ?? makeRunIndex(),
+    queue: rest.queue ?? makeQueue(),
+    abortRegistry: rest.abortRegistry ?? makeAbortRegistry(),
+    approvalRegistry: rest.approvalRegistry ?? makeApprovalRegistry(),
+    discordClient: rest.discordClient ?? makeDiscordClient(),
+    runObserver: rest.runObserver,
+    now: rest.now ?? (() => new Date('2026-07-03T12:00:00.000Z').getTime()),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// not-found
+// ---------------------------------------------------------------------------
+
+describe('cancelRun — not-found', () => {
+  it('returns not-found for an unknown runId', async () => {
+    // #given — runIndex.lookup misses
+    const deps = makeDeps({
+      runState: makeRunState(),
+      runIndex: {lookup: vi.fn().mockResolvedValue(undefined)},
+    })
+
+    // #when
+    const result = await cancelRun({runId: 'unknown-run', actor: makeActor(), logger: makeLogger()}, deps)
+
+    // #then
+    expect(result).toEqual({outcome: 'not-found'})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// already-terminal
+// ---------------------------------------------------------------------------
+
+describe('cancelRun — already-terminal', () => {
+  it('short-circuits on a terminal phase without a transition attempt or notice', async () => {
+    // #given — the run is already COMPLETED
+    const runState = makeRunState({phase: 'COMPLETED'})
+    const coordinationConfig = makeCoordinationConfig(runState)
+    const discordClient = makeDiscordClient()
+    const deps = makeDeps({runState, coordinationConfig, discordClient})
+
+    // #when
+    const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger: makeLogger()}, deps)
+
+    // #then — origin AE1: idempotent, no transition, no notice
+    expect(result).toEqual({outcome: 'already-terminal', phase: 'COMPLETED'})
+    expect(coordinationConfig.storeAdapter.conditionalPut).not.toHaveBeenCalled()
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- vi.fn() mock reference, not a real method
+    expect(discordClient.channels.fetch).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Queued cancel
+// ---------------------------------------------------------------------------
+
+describe('cancelRun — queued', () => {
+  it('removes from queue, commits CANCELLED with cancelledBy details, notifies observer, sends notice', async () => {
+    // #given — a PENDING run with a matching queue entry
+    const runState = makeRunState({phase: 'PENDING'})
+    const task = {runId: 'run-1'} as unknown as RunTask
+    const queue = makeQueue({removeBy: vi.fn().mockReturnValue(task)})
+    const observe = vi.fn().mockResolvedValue(undefined)
+    const sendMock = vi.fn().mockResolvedValue(undefined)
+    const discordClient = makeDiscordClient(sendMock)
+    const deps = makeDeps({runState, queue, runObserver: {observe}, discordClient})
+
+    // #when
+    const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger: makeLogger()}, deps)
+
+    // #then
+    expect(result).toEqual({outcome: 'cancelled', wasQueued: true})
+    expect(queue.removeBy).toHaveBeenCalledWith('ch-a', expect.any(Function))
+    expect(observe).toHaveBeenCalledWith(expect.objectContaining({phase: 'CANCELLED'}))
+    const observedState = observe.mock.calls[0]?.[0] as RunState
+    expect(observedState.details.cancelledBy).toMatchObject({
+      githubUserId: 42,
+      login: 'octocat',
+      sessionCorrelationId: 'sess-1',
+    })
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- vitest asymmetric matcher typing
+    expect(sendMock).toHaveBeenCalledWith(expect.objectContaining({content: expect.stringContaining('cancelled')}))
+  })
+
+  it('does not touch an active run on the same channel (other queue entries untouched)', async () => {
+    // #given — origin AE2: queue.removeBy is scoped by predicate/channel; only the target is affected
+    const runState = makeRunState({phase: 'PENDING'})
+    const task = {runId: 'run-1'} as unknown as RunTask
+    const removeBy = vi.fn().mockReturnValue(task)
+    const queue = makeQueue({removeBy})
+    const deps = makeDeps({runState, queue})
+
+    // #when
+    await cancelRun({runId: 'run-1', actor: makeActor(), logger: makeLogger()}, deps)
+
+    // #then — removeBy called once, scoped to the target channel; the predicate is
+    // responsible for matching only run-1 (verified indirectly: only one call made).
+    expect(removeBy).toHaveBeenCalledTimes(1)
+    expect(removeBy).toHaveBeenCalledWith('ch-a', expect.any(Function))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Executing cancel
+// ---------------------------------------------------------------------------
+
+describe('cancelRun — executing', () => {
+  it('settles approvals via handleDecision, aborts AFTER settlement, sends notice', async () => {
+    // #given — abort registry has the run; one pending approval
+    const runState = makeRunState({phase: 'EXECUTING'})
+    const pending: PendingApprovalDTO[] = [{requestID: 'req-1', permission: 'bash'}]
+    const callOrder: string[] = []
+    const handleDecision = vi.fn().mockImplementation(async () => {
+      callOrder.push('handleDecision')
+      return 'ok'
+    })
+    const abort = vi.fn().mockImplementation(() => {
+      callOrder.push('abort')
+      return true
+    })
+    const approvalRegistry = makeApprovalRegistry({
+      describePendingForScope: vi.fn().mockReturnValue(pending),
+      handleDecision,
+    })
+    const abortRegistry = makeAbortRegistry({has: vi.fn().mockReturnValue(true), abort})
+    const sendMock = vi.fn().mockResolvedValue(undefined)
+    const discordClient = makeDiscordClient(sendMock)
+    const deps = makeDeps({runState, approvalRegistry, abortRegistry, discordClient})
+
+    // #when
+    const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger: makeLogger()}, deps)
+
+    // #then
+    expect(result).toEqual({outcome: 'cancelled', wasQueued: false})
+    expect(handleDecision).toHaveBeenCalledWith({
+      requestID: 'req-1',
+      approvalScopeId: 'thread-1',
+      decision: 'reject',
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- vitest asymmetric matcher typing
+      actor: expect.objectContaining({kind: 'web-operator', githubUserId: 42}),
+    })
+    expect(abort).toHaveBeenCalledWith(
+      'run-1',
+      'operator cancel',
+      expect.objectContaining({githubUserId: 42, login: 'octocat'}),
+    )
+    // #and — settlement happens BEFORE the abort fires
+    expect(callOrder).toEqual(['handleDecision', 'abort'])
+    expect(sendMock).toHaveBeenCalled()
+  })
+
+  it('asserts no direct registry-state mutation — only handleDecision is called for settlement', async () => {
+    // #given
+    const runState = makeRunState({phase: 'EXECUTING'})
+    const pending: PendingApprovalDTO[] = [{requestID: 'req-1', permission: 'bash'}]
+    const handleDecision = vi.fn().mockResolvedValue('ok')
+    const approvalRegistry = makeApprovalRegistry({
+      describePendingForScope: vi.fn().mockReturnValue(pending),
+      handleDecision,
+    })
+    const abortRegistry = makeAbortRegistry({has: vi.fn().mockReturnValue(true)})
+    const deps = makeDeps({runState, approvalRegistry, abortRegistry})
+
+    // #when
+    await cancelRun({runId: 'run-1', actor: makeActor(), logger: makeLogger()}, deps)
+
+    // #then — the fake only exposes describePendingForScope + handleDecision; a call to
+    // any other mutator would be a TypeScript error at the mock construction site, and
+    // handleDecision is the sole settlement call observed.
+    expect(handleDecision).toHaveBeenCalledTimes(1)
+  })
+
+  it('partial failure: first entry rejection throws, second still settled, cancellation proceeds', async () => {
+    // #given — two pending approvals; the first handleDecision call throws
+    const runState = makeRunState({phase: 'EXECUTING'})
+    const pending: PendingApprovalDTO[] = [
+      {requestID: 'req-1', permission: 'bash'},
+      {requestID: 'req-2', permission: 'bash'},
+    ]
+    const handleDecision = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        throw new Error('postReply failed')
+      })
+      .mockImplementationOnce(async () => 'ok')
+    const approvalRegistry = makeApprovalRegistry({
+      describePendingForScope: vi.fn().mockReturnValue(pending),
+      handleDecision,
+    })
+    const abortRegistry = makeAbortRegistry({has: vi.fn().mockReturnValue(true)})
+    const deps = makeDeps({runState, approvalRegistry, abortRegistry})
+    const logger = makeLogger()
+
+    // #when
+    const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger}, deps)
+
+    // #then — both entries attempted despite the first throwing; cancellation still proceeds
+    expect(handleDecision).toHaveBeenCalledTimes(2)
+    expect(handleDecision).toHaveBeenNthCalledWith(1, expect.objectContaining({requestID: 'req-1'}))
+    expect(handleDecision).toHaveBeenNthCalledWith(2, expect.objectContaining({requestID: 'req-2'}))
+    expect(result).toEqual({outcome: 'cancelled', wasQueued: false})
+    expect(logger.warn).toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Double-miss rendezvous
+// ---------------------------------------------------------------------------
+
+describe('cancelRun — double-miss rendezvous', () => {
+  it('commits CANCELLED directly when no queue entry and no abort-registry entry exist', async () => {
+    // #given — origin AE7: pre-ACK window, queue miss AND registry miss
+    const runState = makeRunState({phase: 'ACKNOWLEDGED'})
+    const queue = makeQueue({removeBy: vi.fn().mockReturnValue(undefined)})
+    const abortRegistry = makeAbortRegistry({has: vi.fn().mockReturnValue(false)})
+    const observe = vi.fn().mockResolvedValue(undefined)
+    const deps = makeDeps({runState, queue, abortRegistry, runObserver: {observe}})
+
+    // #when
+    const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger: makeLogger()}, deps)
+
+    // #then
+    expect(result).toEqual({outcome: 'cancelled', wasQueued: false})
+    expect(observe).toHaveBeenCalledWith(expect.objectContaining({phase: 'CANCELLED'}))
+  })
+
+  it('412 then re-read terminal → already-terminal', async () => {
+    // #given — the coordination config's conditionalPut 412s once, then the re-read shows CANCELLED
+    // (i.e. the run's own transition won the race first).
+    const runState = makeRunState({phase: 'ACKNOWLEDGED'})
+    let getObjectCallCount = 0
+    const coordinationConfig: CoordinationConfig = {
+      storeAdapter: {
+        upload: vi.fn(async () => ok(undefined)),
+        download: vi.fn(async () => ok(undefined)),
+        getObject: vi.fn(async () => {
+          getObjectCallCount += 1
+          if (getObjectCallCount === 1) {
+            return ok({data: JSON.stringify(runState), etag: 'etag-1'})
+          }
+          // Second read (after 412) sees the run already CANCELLED by someone else.
+          return ok({data: JSON.stringify({...runState, phase: 'CANCELLED'}), etag: 'etag-99'})
+        }),
+        conditionalPut: vi.fn(async () => err(new Error('412'))),
+        list: vi.fn(async () => ok([])),
+      },
+      storeConfig: {enabled: true, bucket: 'test-bucket', region: 'us-east-1', prefix: 'fro-bot-state'},
+      lockTtlSeconds: 900,
+      heartbeatIntervalMs: 30_000,
+      staleThresholdMs: 60_000,
+      pendingStaleThresholdMs: 30 * 60_000,
+    }
+    const queue = makeQueue({removeBy: vi.fn().mockReturnValue(undefined)})
+    const abortRegistry = makeAbortRegistry({has: vi.fn().mockReturnValue(false)})
+    const deps = makeDeps({runState, coordinationConfig, queue, abortRegistry})
+
+    // #when
+    const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger: makeLogger()}, deps)
+
+    // #then
+    expect(result).toEqual({outcome: 'already-terminal', phase: 'CANCELLED'})
+  })
+
+  it('412 then re-read still EXECUTING → bounded retry then retry outcome', async () => {
+    // #given — every conditionalPut 412s and every re-read shows a non-terminal phase,
+    // simulating the run advancing faster than the rendezvous loop can observe stability.
+    const runState = makeRunState({phase: 'ACKNOWLEDGED'})
+    const coordinationConfig: CoordinationConfig = {
+      storeAdapter: {
+        upload: vi.fn(async () => ok(undefined)),
+        download: vi.fn(async () => ok(undefined)),
+        getObject: vi.fn(async () => ok({data: JSON.stringify({...runState, phase: 'EXECUTING'}), etag: 'etag-x'})),
+        conditionalPut: vi.fn(async () => err(new Error('412'))),
+        list: vi.fn(async () => ok([])),
+      },
+      storeConfig: {enabled: true, bucket: 'test-bucket', region: 'us-east-1', prefix: 'fro-bot-state'},
+      lockTtlSeconds: 900,
+      heartbeatIntervalMs: 30_000,
+      staleThresholdMs: 60_000,
+      pendingStaleThresholdMs: 30 * 60_000,
+    }
+    const queue = makeQueue({removeBy: vi.fn().mockReturnValue(undefined)})
+    const abortRegistry = makeAbortRegistry({has: vi.fn().mockReturnValue(false)})
+    const deps = makeDeps({runState, coordinationConfig, queue, abortRegistry})
+
+    // #when
+    const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger: makeLogger()}, deps)
+
+    // #then — bounded retry exhausted without a terminal resolution
+    expect(result).toEqual({outcome: 'retry'})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Thread notice failure
+// ---------------------------------------------------------------------------
+
+describe('cancelRun — thread notice failure', () => {
+  it('cancellation still succeeds when the notice send fails', async () => {
+    // #given — channels.fetch throws
+    const runState = makeRunState({phase: 'PENDING'})
+    const task = {runId: 'run-1'} as unknown as RunTask
+    const queue = makeQueue({removeBy: vi.fn().mockReturnValue(task)})
+    const discordClient: CancelRunDeps['discordClient'] = {
+      channels: {
+        fetch: vi.fn().mockRejectedValue(new Error('discord unreachable')),
+      } as unknown as CancelRunDeps['discordClient']['channels'],
+    }
+    const logger = makeLogger()
+    const deps = makeDeps({runState, queue, discordClient})
+
+    // #when
+    const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger}, deps)
+
+    // #then — outcome unaffected; failure logged
+    expect(result).toEqual({outcome: 'cancelled', wasQueued: true})
+    expect(logger.warn).toHaveBeenCalled()
+  })
+})

--- a/packages/gateway/src/execute/cancel.test.ts
+++ b/packages/gateway/src/execute/cancel.test.ts
@@ -440,4 +440,120 @@ describe('cancelRun — thread notice failure', () => {
     expect(result).toEqual({outcome: 'cancelled', wasQueued: true})
     expect(logger.warn).toHaveBeenCalled()
   })
+
+  it('does not delay cancelRun return when channels.fetch never resolves', async () => {
+    // #given — channels.fetch returns a promise that never resolves
+    const runState = makeRunState({phase: 'PENDING'})
+    const task = {runId: 'run-1'} as unknown as RunTask
+    const queue = makeQueue({removeBy: vi.fn().mockReturnValue(task)})
+    const discordClient: CancelRunDeps['discordClient'] = {
+      channels: {
+        fetch: vi.fn().mockReturnValue(new Promise(() => {})),
+      } as unknown as CancelRunDeps['discordClient']['channels'],
+    }
+    const logger = makeLogger()
+    const deps = makeDeps({runState, queue, discordClient})
+
+    // #when — cancelRun must resolve without waiting on the pending fetch
+    const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger}, deps)
+
+    // #then
+    expect(result).toEqual({outcome: 'cancelled', wasQueued: true})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F2: executing-path race — abort() returns false (run already left the registry)
+// ---------------------------------------------------------------------------
+
+describe('cancelRun — executing race: abort delivers to nothing', () => {
+  it('abortRegistry.has→true but abort→false with a COMPLETED run-state → already-terminal, no false cancelled', async () => {
+    // #given — the run left the registry between has() and abort() (settled naturally)
+    const runState = makeRunState({phase: 'EXECUTING'})
+    const abortRegistry = makeAbortRegistry({has: vi.fn().mockReturnValue(true), abort: vi.fn().mockReturnValue(false)})
+    const sendMock = vi.fn().mockResolvedValue(undefined)
+    const discordClient = makeDiscordClient(sendMock)
+
+    // Coordination config whose re-read reflects the run having settled to COMPLETED.
+    const coordinationConfig: CoordinationConfig = {
+      storeAdapter: {
+        upload: vi.fn(async () => ok(undefined)),
+        download: vi.fn(async () => ok(undefined)),
+        getObject: vi.fn(async () => ok({data: JSON.stringify({...runState, phase: 'COMPLETED'}), etag: 'etag-2'})),
+        conditionalPut: vi.fn(async () => err(new Error('should not be called'))),
+        list: vi.fn(async () => ok([])),
+      },
+      storeConfig: {enabled: true, bucket: 'test-bucket', region: 'us-east-1', prefix: 'fro-bot-state'},
+      lockTtlSeconds: 900,
+      heartbeatIntervalMs: 30_000,
+      staleThresholdMs: 60_000,
+      pendingStaleThresholdMs: 30 * 60_000,
+    }
+    const deps = makeDeps({runState, coordinationConfig, abortRegistry, discordClient})
+
+    // #when
+    const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger: makeLogger()}, deps)
+
+    // #then — accurate already-terminal outcome, no thread notice, no false 'cancelled'
+    expect(result).toEqual({outcome: 'already-terminal', phase: 'COMPLETED'})
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// readRunState failure modes → not-found
+// ---------------------------------------------------------------------------
+
+describe('cancelRun — readRunState failure modes', () => {
+  it('returns not-found when getObject fails', async () => {
+    // #given
+    const runState = makeRunState({phase: 'PENDING'})
+    const coordinationConfig: CoordinationConfig = {
+      storeAdapter: {
+        upload: vi.fn(async () => ok(undefined)),
+        download: vi.fn(async () => ok(undefined)),
+        getObject: vi.fn(async () => err(new Error('S3 unreachable'))),
+        conditionalPut: vi.fn(async () => err(new Error('should not be called'))),
+        list: vi.fn(async () => ok([])),
+      },
+      storeConfig: {enabled: true, bucket: 'test-bucket', region: 'us-east-1', prefix: 'fro-bot-state'},
+      lockTtlSeconds: 900,
+      heartbeatIntervalMs: 30_000,
+      staleThresholdMs: 60_000,
+      pendingStaleThresholdMs: 30 * 60_000,
+    }
+    const deps = makeDeps({runState, coordinationConfig})
+
+    // #when
+    const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger: makeLogger()}, deps)
+
+    // #then
+    expect(result).toEqual({outcome: 'not-found'})
+  })
+
+  it('returns not-found when the stored run-state JSON is malformed', async () => {
+    // #given
+    const runState = makeRunState({phase: 'PENDING'})
+    const coordinationConfig: CoordinationConfig = {
+      storeAdapter: {
+        upload: vi.fn(async () => ok(undefined)),
+        download: vi.fn(async () => ok(undefined)),
+        getObject: vi.fn(async () => ok({data: 'not valid json {{{', etag: 'etag-1'})),
+        conditionalPut: vi.fn(async () => err(new Error('should not be called'))),
+        list: vi.fn(async () => ok([])),
+      },
+      storeConfig: {enabled: true, bucket: 'test-bucket', region: 'us-east-1', prefix: 'fro-bot-state'},
+      lockTtlSeconds: 900,
+      heartbeatIntervalMs: 30_000,
+      staleThresholdMs: 60_000,
+      pendingStaleThresholdMs: 30 * 60_000,
+    }
+    const deps = makeDeps({runState, coordinationConfig})
+
+    // #when
+    const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger: makeLogger()}, deps)
+
+    // #then
+    expect(result).toEqual({outcome: 'not-found'})
+  })
 })

--- a/packages/gateway/src/execute/cancel.test.ts
+++ b/packages/gateway/src/execute/cancel.test.ts
@@ -104,18 +104,6 @@ function makeApprovalRegistry(
   }
 }
 
-function makeDiscordClient(sendMock = vi.fn().mockResolvedValue(undefined)): CancelRunDeps['discordClient'] {
-  const channel = {
-    isTextBased: () => true,
-    send: sendMock,
-  }
-  return {
-    channels: {
-      fetch: vi.fn().mockResolvedValue(channel),
-    } as unknown as CancelRunDeps['discordClient']['channels'],
-  }
-}
-
 function makeDeps(overrides: Partial<CancelRunDeps> & {readonly runState: RunState}): CancelRunDeps {
   const {runState, ...rest} = overrides
   return {
@@ -125,7 +113,7 @@ function makeDeps(overrides: Partial<CancelRunDeps> & {readonly runState: RunSta
     queue: rest.queue ?? makeQueue(),
     abortRegistry: rest.abortRegistry ?? makeAbortRegistry(),
     approvalRegistry: rest.approvalRegistry ?? makeApprovalRegistry(),
-    discordClient: rest.discordClient ?? makeDiscordClient(),
+    postCancelNotice: rest.postCancelNotice ?? vi.fn().mockResolvedValue(undefined),
     runObserver: rest.runObserver,
     now: rest.now ?? (() => new Date('2026-07-03T12:00:00.000Z').getTime()),
   }
@@ -160,8 +148,8 @@ describe('cancelRun — already-terminal', () => {
     // #given — the run is already COMPLETED
     const runState = makeRunState({phase: 'COMPLETED'})
     const coordinationConfig = makeCoordinationConfig(runState)
-    const discordClient = makeDiscordClient()
-    const deps = makeDeps({runState, coordinationConfig, discordClient})
+    const postCancelNotice = vi.fn().mockResolvedValue(undefined)
+    const deps = makeDeps({runState, coordinationConfig, postCancelNotice})
 
     // #when
     const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger: makeLogger()}, deps)
@@ -169,8 +157,7 @@ describe('cancelRun — already-terminal', () => {
     // #then — origin AE1: idempotent, no transition, no notice
     expect(result).toEqual({outcome: 'already-terminal', phase: 'COMPLETED'})
     expect(coordinationConfig.storeAdapter.conditionalPut).not.toHaveBeenCalled()
-    // eslint-disable-next-line @typescript-eslint/unbound-method -- vi.fn() mock reference, not a real method
-    expect(discordClient.channels.fetch).not.toHaveBeenCalled()
+    expect(postCancelNotice).not.toHaveBeenCalled()
   })
 })
 
@@ -185,9 +172,8 @@ describe('cancelRun — queued', () => {
     const task = {runId: 'run-1'} as unknown as RunTask
     const queue = makeQueue({removeBy: vi.fn().mockReturnValue(task)})
     const observe = vi.fn().mockResolvedValue(undefined)
-    const sendMock = vi.fn().mockResolvedValue(undefined)
-    const discordClient = makeDiscordClient(sendMock)
-    const deps = makeDeps({runState, queue, runObserver: {observe}, discordClient})
+    const postCancelNotice = vi.fn().mockResolvedValue(undefined)
+    const deps = makeDeps({runState, queue, runObserver: {observe}, postCancelNotice})
 
     // #when
     const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger: makeLogger()}, deps)
@@ -202,8 +188,7 @@ describe('cancelRun — queued', () => {
       login: 'octocat',
       sessionCorrelationId: 'sess-1',
     })
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- vitest asymmetric matcher typing
-    expect(sendMock).toHaveBeenCalledWith(expect.objectContaining({content: expect.stringContaining('cancelled')}))
+    expect(postCancelNotice).toHaveBeenCalledWith('thread-1', 'run-1')
   })
 
   it('does not touch an active run on the same channel (other queue entries untouched)', async () => {
@@ -247,9 +232,8 @@ describe('cancelRun — executing', () => {
       handleDecision,
     })
     const abortRegistry = makeAbortRegistry({has: vi.fn().mockReturnValue(true), abort})
-    const sendMock = vi.fn().mockResolvedValue(undefined)
-    const discordClient = makeDiscordClient(sendMock)
-    const deps = makeDeps({runState, approvalRegistry, abortRegistry, discordClient})
+    const postCancelNotice = vi.fn().mockResolvedValue(undefined)
+    const deps = makeDeps({runState, approvalRegistry, abortRegistry, postCancelNotice})
 
     // #when
     const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger: makeLogger()}, deps)
@@ -270,7 +254,7 @@ describe('cancelRun — executing', () => {
     )
     // #and — settlement happens BEFORE the abort fires
     expect(callOrder).toEqual(['handleDecision', 'abort'])
-    expect(sendMock).toHaveBeenCalled()
+    expect(postCancelNotice).toHaveBeenCalledWith('thread-1', 'run-1')
   })
 
   it('asserts no direct registry-state mutation — only handleDecision is called for settlement', async () => {
@@ -420,41 +404,33 @@ describe('cancelRun — double-miss rendezvous', () => {
 // ---------------------------------------------------------------------------
 
 describe('cancelRun — thread notice failure', () => {
-  it('cancellation still succeeds when the notice send fails', async () => {
-    // #given — channels.fetch throws
+  it('cancellation still succeeds when postCancelNotice rejects', async () => {
+    // #given — the injected notice callback rejects (belt-and-suspenders .catch in cancel.ts)
     const runState = makeRunState({phase: 'PENDING'})
     const task = {runId: 'run-1'} as unknown as RunTask
     const queue = makeQueue({removeBy: vi.fn().mockReturnValue(task)})
-    const discordClient: CancelRunDeps['discordClient'] = {
-      channels: {
-        fetch: vi.fn().mockRejectedValue(new Error('discord unreachable')),
-      } as unknown as CancelRunDeps['discordClient']['channels'],
-    }
+    const postCancelNotice = vi.fn().mockRejectedValue(new Error('discord unreachable'))
     const logger = makeLogger()
-    const deps = makeDeps({runState, queue, discordClient})
+    const deps = makeDeps({runState, queue, postCancelNotice})
 
     // #when
     const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger}, deps)
 
-    // #then — outcome unaffected; failure logged
+    // #then — outcome unaffected
     expect(result).toEqual({outcome: 'cancelled', wasQueued: true})
-    expect(logger.warn).toHaveBeenCalled()
+    expect(postCancelNotice).toHaveBeenCalledWith('thread-1', 'run-1')
   })
 
-  it('does not delay cancelRun return when channels.fetch never resolves', async () => {
-    // #given — channels.fetch returns a promise that never resolves
+  it('does not delay cancelRun return when postCancelNotice never resolves', async () => {
+    // #given — postCancelNotice returns a promise that never resolves
     const runState = makeRunState({phase: 'PENDING'})
     const task = {runId: 'run-1'} as unknown as RunTask
     const queue = makeQueue({removeBy: vi.fn().mockReturnValue(task)})
-    const discordClient: CancelRunDeps['discordClient'] = {
-      channels: {
-        fetch: vi.fn().mockReturnValue(new Promise(() => {})),
-      } as unknown as CancelRunDeps['discordClient']['channels'],
-    }
+    const postCancelNotice = vi.fn().mockReturnValue(new Promise(() => {}))
     const logger = makeLogger()
-    const deps = makeDeps({runState, queue, discordClient})
+    const deps = makeDeps({runState, queue, postCancelNotice})
 
-    // #when — cancelRun must resolve without waiting on the pending fetch
+    // #when — cancelRun must resolve without waiting on the pending notice
     const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger}, deps)
 
     // #then
@@ -471,8 +447,7 @@ describe('cancelRun — executing race: abort delivers to nothing', () => {
     // #given — the run left the registry between has() and abort() (settled naturally)
     const runState = makeRunState({phase: 'EXECUTING'})
     const abortRegistry = makeAbortRegistry({has: vi.fn().mockReturnValue(true), abort: vi.fn().mockReturnValue(false)})
-    const sendMock = vi.fn().mockResolvedValue(undefined)
-    const discordClient = makeDiscordClient(sendMock)
+    const postCancelNotice = vi.fn().mockResolvedValue(undefined)
 
     // Coordination config whose re-read reflects the run having settled to COMPLETED.
     const coordinationConfig: CoordinationConfig = {
@@ -489,14 +464,14 @@ describe('cancelRun — executing race: abort delivers to nothing', () => {
       staleThresholdMs: 60_000,
       pendingStaleThresholdMs: 30 * 60_000,
     }
-    const deps = makeDeps({runState, coordinationConfig, abortRegistry, discordClient})
+    const deps = makeDeps({runState, coordinationConfig, abortRegistry, postCancelNotice})
 
     // #when
     const result = await cancelRun({runId: 'run-1', actor: makeActor(), logger: makeLogger()}, deps)
 
     // #then — accurate already-terminal outcome, no thread notice, no false 'cancelled'
     expect(result).toEqual({outcome: 'already-terminal', phase: 'COMPLETED'})
-    expect(sendMock).not.toHaveBeenCalled()
+    expect(postCancelNotice).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/gateway/src/execute/cancel.ts
+++ b/packages/gateway/src/execute/cancel.ts
@@ -27,7 +27,7 @@
  * the cancellation outcome, only logs.
  */
 
-import type {CoordinationConfig, RunPhase, RunState} from '@fro-bot/runtime'
+import type {CoordinationConfig, RunPhase, RunState, TerminalPhase} from '@fro-bot/runtime'
 import type {ApprovalActor, ApprovalRegistry} from '../approvals/registry.js'
 import type {GatewayLogger} from '../discord/client.js'
 import type {AbortRegistry, CancelledByMetadata} from './abort-registry.js'
@@ -58,7 +58,7 @@ export interface CancelActorContext {
 
 export type CancelOutcome =
   | {readonly outcome: 'not-found'}
-  | {readonly outcome: 'already-terminal'; readonly phase: RunPhase}
+  | {readonly outcome: 'already-terminal'; readonly phase: TerminalPhase}
   | {readonly outcome: 'cancelled'; readonly wasQueued: boolean}
   /**
    * The bounded rendezvous retry (see `attemptRendezvousCancel`) was
@@ -151,7 +151,7 @@ async function readRunState(
 
 const TERMINAL_PHASES: ReadonlySet<RunPhase> = new Set(['COMPLETED', 'FAILED', 'CANCELLED'])
 
-function isTerminalPhase(phase: RunPhase): boolean {
+function isTerminalPhase(phase: RunPhase): phase is TerminalPhase {
   return TERMINAL_PHASES.has(phase)
 }
 
@@ -381,6 +381,15 @@ export async function cancelRun(params: CancelRunParams, deps: CancelRunDeps): P
       return attemptRendezvousCancel(deps, repo, runId, actor, logger)
     }
 
+    // ACCEPTED: this notice fires as soon as abort() confirms delivery — it means
+    // "cancel requested and delivered to the run", not "settled as CANCELLED". The
+    // actual terminal transition happens asynchronously in run.ts's catch handler,
+    // which may rarely fall back to FAILED if the CANCELLED conditional write fails
+    // (see run.ts's cancel-path fallback). In that narrow window the thread can show
+    // "cancelled" while the run settles FAILED — state is always correct, only this
+    // best-effort message can be briefly stale. Do NOT make this conditional on the
+    // eventual terminal state: that would couple this fire-and-forget orchestrator to
+    // the async settlement and defeat the point of firing eagerly.
     // eslint-disable-next-line no-void
     void deps.postCancelNotice(initialRead.state.thread_id, runId).catch(() => {})
     return {outcome: 'cancelled', wasQueued: false}

--- a/packages/gateway/src/execute/cancel.ts
+++ b/packages/gateway/src/execute/cancel.ts
@@ -31,13 +31,14 @@ import type {CoordinationConfig, RunPhase, RunState} from '@fro-bot/runtime'
 import type {Client} from 'discord.js'
 import type {ApprovalActor, ApprovalRegistry} from '../approvals/registry.js'
 import type {GatewayLogger} from '../discord/client.js'
-import type {AbortRegistry} from './abort-registry.js'
+import type {AbortRegistry, CancelledByMetadata} from './abort-registry.js'
 import type {ChannelQueue} from './queue.js'
 import type {RunIndex} from './run-index.js'
 import type {RunTask} from './run.js'
 
 import {getRunKey, parseRunState, transitionRun} from '@fro-bot/runtime'
 import {sendMessage} from '../discord/io.js'
+import {toCoordLogger} from './run.js'
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -150,6 +151,16 @@ const TERMINAL_PHASES: ReadonlySet<RunPhase> = new Set(['COMPLETED', 'FAILED', '
 
 function isTerminalPhase(phase: RunPhase): boolean {
   return TERMINAL_PHASES.has(phase)
+}
+
+/** Build the `cancelledBy` attribution metadata attached to a CANCELLED transition. */
+function makeCancelledBy(actor: CancelActorContext, now?: () => number): CancelledByMetadata {
+  return {
+    githubUserId: actor.githubUserId,
+    login: actor.login,
+    sessionCorrelationId: actor.sessionCorrelationId,
+    cancelledAt: new Date(now?.() ?? Date.now()).toISOString(),
+  }
 }
 
 /** Fire-and-forget SSE observer notification — mirrors run.ts's notifyObserverBestEffort. */
@@ -273,7 +284,7 @@ async function attemptRendezvousCancel(
   logger: GatewayLogger,
 ): Promise<CancelOutcome> {
   const {coordinationConfig, identity} = deps
-  const coordLogger = {debug: (msg: string, ctx?: Record<string, unknown>) => logger.debug(ctx ?? {}, msg)}
+  const coordLogger = toCoordLogger(logger)
 
   let read = await readRunState(deps, repo, runId, logger)
   if (read === undefined) {
@@ -285,12 +296,7 @@ async function attemptRendezvousCancel(
       return {outcome: 'already-terminal', phase: read.state.phase}
     }
 
-    const cancelledBy = {
-      githubUserId: actor.githubUserId,
-      login: actor.login,
-      sessionCorrelationId: actor.sessionCorrelationId,
-      cancelledAt: new Date(deps.now?.() ?? Date.now()).toISOString(),
-    }
+    const cancelledBy = makeCancelledBy(actor, deps.now)
 
     const result = await transitionRun(coordinationConfig, identity, repo, runId, 'CANCELLED', read.etag, coordLogger, {
       detailsPatch: {cancelledBy},
@@ -298,7 +304,8 @@ async function attemptRendezvousCancel(
 
     if (result.success === true) {
       notifyObserverBestEffort(deps, result.data.state, logger)
-      await postCancellationNotice(deps, runId, result.data.state.thread_id, logger)
+      // eslint-disable-next-line no-void
+      void postCancellationNotice(deps, runId, result.data.state.thread_id, logger).catch(() => {})
       return {outcome: 'cancelled', wasQueued: false}
     }
 
@@ -348,13 +355,8 @@ export async function cancelRun(params: CancelRunParams, deps: CancelRunDeps): P
   if (channelId !== '') {
     const removed = deps.queue.removeBy(channelId, task => task.runId === runId)
     if (removed !== undefined) {
-      const coordLogger = {debug: (msg: string, ctx?: Record<string, unknown>) => logger.debug(ctx ?? {}, msg)}
-      const cancelledBy = {
-        githubUserId: actor.githubUserId,
-        login: actor.login,
-        sessionCorrelationId: actor.sessionCorrelationId,
-        cancelledAt: new Date(deps.now?.() ?? Date.now()).toISOString(),
-      }
+      const coordLogger = toCoordLogger(logger)
+      const cancelledBy = makeCancelledBy(actor, deps.now)
       const transitionResult = await transitionRun(
         deps.coordinationConfig,
         deps.identity,
@@ -377,7 +379,8 @@ export async function cancelRun(params: CancelRunParams, deps: CancelRunDeps): P
         return attemptRendezvousCancel(deps, repo, runId, actor, logger)
       }
       notifyObserverBestEffort(deps, transitionResult.data.state, logger)
-      await postCancellationNotice(deps, runId, transitionResult.data.state.thread_id, logger)
+      // eslint-disable-next-line no-void
+      void postCancellationNotice(deps, runId, transitionResult.data.state.thread_id, logger).catch(() => {})
       return {outcome: 'cancelled', wasQueued: true}
     }
   }
@@ -397,15 +400,25 @@ export async function cancelRun(params: CancelRunParams, deps: CancelRunDeps): P
     // a still-open approval against the cancel.
     await settlePendingApprovals(deps, initialRead.state, approvalActor, logger)
 
-    const cancelledBy = {
-      githubUserId: actor.githubUserId,
-      login: actor.login,
-      sessionCorrelationId: actor.sessionCorrelationId,
-      cancelledAt: new Date(deps.now?.() ?? Date.now()).toISOString(),
-    }
-    deps.abortRegistry.abort(runId, 'operator cancel', cancelledBy)
+    const cancelledBy = makeCancelledBy(actor, deps.now)
+    const delivered = deps.abortRegistry.abort(runId, 'operator cancel', cancelledBy)
 
-    await postCancellationNotice(deps, runId, initialRead.state.thread_id, logger)
+    if (delivered === false) {
+      // The run left the registry between `has()` and `abort()` (run.ts's finally
+      // deletes the entry on settlement) — the abort signal reached nothing. Re-read
+      // run-state to report an accurate outcome instead of falsely claiming 'cancelled'.
+      const reread = await readRunState(deps, repo, runId, logger)
+      if (reread === undefined) {
+        return {outcome: 'not-found'}
+      }
+      if (isTerminalPhase(reread.state.phase)) {
+        return {outcome: 'already-terminal', phase: reread.state.phase}
+      }
+      return attemptRendezvousCancel(deps, repo, runId, actor, logger)
+    }
+
+    // eslint-disable-next-line no-void
+    void postCancellationNotice(deps, runId, initialRead.state.thread_id, logger).catch(() => {})
     return {outcome: 'cancelled', wasQueued: false}
   }
 

--- a/packages/gateway/src/execute/cancel.ts
+++ b/packages/gateway/src/execute/cancel.ts
@@ -28,7 +28,6 @@
  */
 
 import type {CoordinationConfig, RunPhase, RunState} from '@fro-bot/runtime'
-import type {Client} from 'discord.js'
 import type {ApprovalActor, ApprovalRegistry} from '../approvals/registry.js'
 import type {GatewayLogger} from '../discord/client.js'
 import type {AbortRegistry, CancelledByMetadata} from './abort-registry.js'
@@ -37,7 +36,6 @@ import type {RunIndex} from './run-index.js'
 import type {RunTask} from './run.js'
 
 import {getRunKey, parseRunState, transitionRun} from '@fro-bot/runtime'
-import {sendMessage} from '../discord/io.js'
 import {toCoordLogger} from './run.js'
 
 // ---------------------------------------------------------------------------
@@ -83,7 +81,13 @@ export interface CancelRunDeps {
   readonly queue: ChannelQueue<RunTask>
   readonly abortRegistry: Pick<AbortRegistry, 'has' | 'abort'>
   readonly approvalRegistry: Pick<ApprovalRegistry, 'describePendingForScope' | 'handleDecision'>
-  readonly discordClient: Pick<Client, 'channels'>
+  /**
+   * Post the cancellation notice for a run to its origin surface. Transport-specific
+   * (Discord thread, etc.) — injected by the composition root so this orchestrator
+   * stays transport-neutral. Must be fail-soft: never throw. Called fire-and-forget.
+   * `threadId` is the run-state thread_id ('' when the run has no thread).
+   */
+  readonly postCancelNotice: (threadId: string, runId: string) => Promise<void>
   readonly runObserver?: {readonly observe: (runState: RunState) => Promise<void>}
   /** Wall-clock provider — injectable for deterministic tests. Defaults to `Date.now`. */
   readonly now?: () => number
@@ -104,8 +108,6 @@ export interface CancelRunDeps {
  * safely re-issue the cancel request.
  */
 const RENDEZVOUS_MAX_ATTEMPTS = 2
-
-const CANCELLED_NOTICE_TEXT = 'Run cancelled by operator.'
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -171,44 +173,6 @@ function notifyObserverBestEffort(deps: CancelRunDeps, state: RunState, logger: 
     })
   } catch (error: unknown) {
     logger.warn({err: String(error)}, 'cancelRun: runObserver.observe threw synchronously')
-  }
-}
-
-/**
- * Post the thread cancellation notice. Always fail-soft: never throws, and
- * failure is logged, not propagated — the cancellation outcome does not
- * depend on this succeeding. Skips (logs) when `thread_id` is absent.
- */
-async function postCancellationNotice(
-  deps: CancelRunDeps,
-  runId: string,
-  threadId: string,
-  logger: GatewayLogger,
-): Promise<void> {
-  if (threadId === '') {
-    logger.info({runId}, 'cancelRun: no thread_id on run-state — skipping cancellation notice')
-    return
-  }
-  try {
-    const channel = await deps.discordClient.channels.fetch(threadId)
-    if (channel === null || channel === undefined) {
-      logger.warn({runId, threadId}, 'cancelRun: thread channel not found — skipping cancellation notice')
-      return
-    }
-    if (channel.isTextBased() === false || 'send' in channel === false) {
-      logger.warn({runId, threadId}, 'cancelRun: resolved channel is not text-sendable — skipping cancellation notice')
-      return
-    }
-    const sendResult = await sendMessage(channel, {content: CANCELLED_NOTICE_TEXT}, logger)
-    if (sendResult.success === false) {
-      logger.warn({runId, threadId, err: sendResult.error.message}, 'cancelRun: cancellation notice send failed')
-    }
-  } catch (error: unknown) {
-    // sendMessage/io.ts never throws, but channels.fetch can — belt-and-suspenders.
-    logger.warn(
-      {runId, threadId, err: error instanceof Error ? error.message : String(error)},
-      'cancelRun: cancellation notice threw — continuing',
-    )
   }
 }
 
@@ -305,7 +269,7 @@ async function attemptRendezvousCancel(
     if (result.success === true) {
       notifyObserverBestEffort(deps, result.data.state, logger)
       // eslint-disable-next-line no-void
-      void postCancellationNotice(deps, runId, result.data.state.thread_id, logger).catch(() => {})
+      void deps.postCancelNotice(result.data.state.thread_id, runId).catch(() => {})
       return {outcome: 'cancelled', wasQueued: false}
     }
 
@@ -380,7 +344,7 @@ export async function cancelRun(params: CancelRunParams, deps: CancelRunDeps): P
       }
       notifyObserverBestEffort(deps, transitionResult.data.state, logger)
       // eslint-disable-next-line no-void
-      void postCancellationNotice(deps, runId, transitionResult.data.state.thread_id, logger).catch(() => {})
+      void deps.postCancelNotice(transitionResult.data.state.thread_id, runId).catch(() => {})
       return {outcome: 'cancelled', wasQueued: true}
     }
   }
@@ -418,7 +382,7 @@ export async function cancelRun(params: CancelRunParams, deps: CancelRunDeps): P
     }
 
     // eslint-disable-next-line no-void
-    void postCancellationNotice(deps, runId, initialRead.state.thread_id, logger).catch(() => {})
+    void deps.postCancelNotice(initialRead.state.thread_id, runId).catch(() => {})
     return {outcome: 'cancelled', wasQueued: false}
   }
 

--- a/packages/gateway/src/execute/cancel.ts
+++ b/packages/gateway/src/execute/cancel.ts
@@ -1,0 +1,414 @@
+/**
+ * Transport-neutral run-cancellation orchestrator.
+ *
+ * `cancelRun(params, deps)` resolves a run's current phase and executes the
+ * correct cancellation path:
+ *
+ *  - **Queued** (PENDING/ACKNOWLEDGED, in the per-channel FIFO): removed via
+ *    `queue.removeBy`, terminalized directly (no lock/slot held — nothing to
+ *    release).
+ *  - **Executing** (abort-registry hit): pending approvals for the run's scope
+ *    are rejected through the single fail-closed settlement gate
+ *    (`registry.handleDecision`), then the abort handle fires. Unit 1's error
+ *    path in `run.ts` owns the CANCELLED transition and resource release.
+ *  - **Pre-ACK rendezvous** (double miss — the registration window between
+ *    dequeue and abort-registry registration): a direct conditional-write
+ *    `transitionRun(currentPhase → CANCELLED)` IS the rendezvous. Either the
+ *    cancel wins (the run's own next transition 412s, re-reads, sees
+ *    CANCELLED, exits cleanly) or the run advances first (this call 412s,
+ *    re-reads, and resolves via a single bounded retry — see
+ *    `attemptRendezvousCancel` below).
+ *
+ * Already-terminal runs are idempotent no-ops (read-then-short-circuit —
+ * `transitionRun` rejects terminal transitions by design, so the orchestrator
+ * never attempts one). Unknown runIds resolve to `not-found`.
+ *
+ * The Discord thread notice is always fail-soft: notice failure never fails
+ * the cancellation outcome, only logs.
+ */
+
+import type {CoordinationConfig, RunPhase, RunState} from '@fro-bot/runtime'
+import type {Client} from 'discord.js'
+import type {ApprovalActor, ApprovalRegistry} from '../approvals/registry.js'
+import type {GatewayLogger} from '../discord/client.js'
+import type {AbortRegistry} from './abort-registry.js'
+import type {ChannelQueue} from './queue.js'
+import type {RunIndex} from './run-index.js'
+import type {RunTask} from './run.js'
+
+import {getRunKey, parseRunState, transitionRun} from '@fro-bot/runtime'
+import {sendMessage} from '../discord/io.js'
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal, readonly actor-attribution shape accepted by `cancelRun`.
+ *
+ * Structurally compatible with `OperatorIdentity`/`WebOperatorActor` — the
+ * Unit 3 web route passes those fields directly. Kept as its own type here so
+ * `cancel.ts` (execute-layer, transport-neutral) does not import the web
+ * operator-contract module.
+ */
+export interface CancelActorContext {
+  readonly githubUserId: number
+  readonly login: string
+  readonly sessionCorrelationId: string
+}
+
+export type CancelOutcome =
+  | {readonly outcome: 'not-found'}
+  | {readonly outcome: 'already-terminal'; readonly phase: RunPhase}
+  | {readonly outcome: 'cancelled'; readonly wasQueued: boolean}
+  /**
+   * The bounded rendezvous retry (see `attemptRendezvousCancel`) was
+   * exhausted without resolving to a terminal outcome — the run advanced to
+   * EXECUTING on every observed attempt. The caller should treat this as
+   * "cancel not yet applied, safe to retry" rather than a failure.
+   */
+  | {readonly outcome: 'retry'}
+
+export interface CancelRunParams {
+  readonly runId: string
+  readonly actor: CancelActorContext
+  readonly logger: GatewayLogger
+}
+
+export interface CancelRunDeps {
+  readonly coordinationConfig: CoordinationConfig
+  readonly identity: string
+  readonly runIndex: Pick<RunIndex, 'lookup'>
+  readonly queue: ChannelQueue<RunTask>
+  readonly abortRegistry: Pick<AbortRegistry, 'has' | 'abort'>
+  readonly approvalRegistry: Pick<ApprovalRegistry, 'describePendingForScope' | 'handleDecision'>
+  readonly discordClient: Pick<Client, 'channels'>
+  readonly runObserver?: {readonly observe: (runState: RunState) => Promise<void>}
+  /** Wall-clock provider — injectable for deterministic tests. Defaults to `Date.now`. */
+  readonly now?: () => number
+}
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Bounded strategy for the pre-ACK rendezvous retry: a single retry after the
+ * first 412 resolves to EXECUTING. One retry is sufficient because the
+ * registration window (dequeue → abort-registry registration) is short and
+ * bounded by the pipeline's own gates (ensureClone/readyz/threadFactory/lock);
+ * a run cannot cycle between "not yet registered" and "EXECUTING" more than
+ * once within that window. Exceeding the bound returns `{outcome:'retry'}`
+ * rather than looping unboundedly — the caller (a future web route) can
+ * safely re-issue the cancel request.
+ */
+const RENDEZVOUS_MAX_ATTEMPTS = 2
+
+const CANCELLED_NOTICE_TEXT = 'Run cancelled by operator.'
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface RunStateRead {
+  readonly state: RunState
+  readonly etag: string
+}
+
+/** Read the current run-state for `repo`/`runId`. Returns `undefined` on any read/parse failure. */
+async function readRunState(
+  deps: CancelRunDeps,
+  repo: string,
+  runId: string,
+  logger: GatewayLogger,
+): Promise<RunStateRead | undefined> {
+  const {coordinationConfig, identity} = deps
+  const keyResult = getRunKey(coordinationConfig, identity, repo, runId)
+  if (keyResult.success === false) {
+    logger.warn({repo, runId, err: keyResult.error.message}, 'cancelRun: getRunKey failed')
+    return undefined
+  }
+  const getObject = coordinationConfig.storeAdapter.getObject
+  if (getObject == null) {
+    logger.warn({repo, runId}, 'cancelRun: store adapter does not support getObject')
+    return undefined
+  }
+  const fetched = await getObject(keyResult.data)
+  if (fetched.success === false) {
+    logger.warn({repo, runId, err: fetched.error.message}, 'cancelRun: getObject failed')
+    return undefined
+  }
+  const parsed = parseRunState(fetched.data.data)
+  if (parsed.success === false) {
+    logger.warn({repo, runId, err: parsed.error.message}, 'cancelRun: parseRunState failed')
+    return undefined
+  }
+  return {state: parsed.data, etag: fetched.data.etag}
+}
+
+const TERMINAL_PHASES: ReadonlySet<RunPhase> = new Set(['COMPLETED', 'FAILED', 'CANCELLED'])
+
+function isTerminalPhase(phase: RunPhase): boolean {
+  return TERMINAL_PHASES.has(phase)
+}
+
+/** Fire-and-forget SSE observer notification — mirrors run.ts's notifyObserverBestEffort. */
+function notifyObserverBestEffort(deps: CancelRunDeps, state: RunState, logger: GatewayLogger): void {
+  try {
+    deps.runObserver?.observe(state)?.catch((error: unknown) => {
+      logger.warn({err: String(error)}, 'cancelRun: runObserver.observe failed')
+    })
+  } catch (error: unknown) {
+    logger.warn({err: String(error)}, 'cancelRun: runObserver.observe threw synchronously')
+  }
+}
+
+/**
+ * Post the thread cancellation notice. Always fail-soft: never throws, and
+ * failure is logged, not propagated — the cancellation outcome does not
+ * depend on this succeeding. Skips (logs) when `thread_id` is absent.
+ */
+async function postCancellationNotice(
+  deps: CancelRunDeps,
+  runId: string,
+  threadId: string,
+  logger: GatewayLogger,
+): Promise<void> {
+  if (threadId === '') {
+    logger.info({runId}, 'cancelRun: no thread_id on run-state — skipping cancellation notice')
+    return
+  }
+  try {
+    const channel = await deps.discordClient.channels.fetch(threadId)
+    if (channel === null || channel === undefined) {
+      logger.warn({runId, threadId}, 'cancelRun: thread channel not found — skipping cancellation notice')
+      return
+    }
+    if (channel.isTextBased() === false || 'send' in channel === false) {
+      logger.warn({runId, threadId}, 'cancelRun: resolved channel is not text-sendable — skipping cancellation notice')
+      return
+    }
+    const sendResult = await sendMessage(channel, {content: CANCELLED_NOTICE_TEXT}, logger)
+    if (sendResult.success === false) {
+      logger.warn({runId, threadId, err: sendResult.error.message}, 'cancelRun: cancellation notice send failed')
+    }
+  } catch (error: unknown) {
+    // sendMessage/io.ts never throws, but channels.fetch can — belt-and-suspenders.
+    logger.warn(
+      {runId, threadId, err: error instanceof Error ? error.message : String(error)},
+      'cancelRun: cancellation notice threw — continuing',
+    )
+  }
+}
+
+/**
+ * Settle every pending approval for the run's scope via the single fail-closed
+ * gate (`registry.handleDecision`), rejecting each. Per-entry isolation: one
+ * entry's failure (thrown or a non-'ok' `DecisionOutcome`) is logged and the
+ * remaining entries are still attempted — cancellation proceeds regardless.
+ *
+ * Scope resolution: `approvalScopeId` is the Discord thread id for `surface
+ * === 'discord'` runs (mirrors `scopeIdFor` in `web/sse/projection.ts`) and
+ * the run id otherwise (mirrors `web/operator/web-approval.ts`'s
+ * `approvalScopeId: ctx.runId` and `decision-route.ts`'s
+ * `approvalScopeId: run.run_id`).
+ */
+async function settlePendingApprovals(
+  deps: CancelRunDeps,
+  runState: RunState,
+  actor: ApprovalActor,
+  logger: GatewayLogger,
+): Promise<void> {
+  const approvalScopeId = runState.surface === 'discord' ? runState.thread_id : runState.run_id
+  const pending = deps.approvalRegistry.describePendingForScope(approvalScopeId)
+  for (const entry of pending) {
+    try {
+      const outcome = await deps.approvalRegistry.handleDecision({
+        requestID: entry.requestID,
+        approvalScopeId,
+        decision: 'reject',
+        actor,
+      })
+      if (outcome !== 'ok') {
+        logger.warn(
+          {runId: runState.run_id, requestID: entry.requestID, outcome},
+          'cancelRun: approval settle did not return ok — continuing with remaining entries',
+        )
+      }
+    } catch (error: unknown) {
+      logger.warn(
+        {
+          runId: runState.run_id,
+          requestID: entry.requestID,
+          err: error instanceof Error ? error.message : String(error),
+        },
+        'cancelRun: approval settle threw — continuing with remaining entries',
+      )
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rendezvous: pre-ACK / pre-registration double-miss path
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt the direct conditional-write rendezvous: `transitionRun(currentPhase
+ * → CANCELLED)`. This is used only on a double miss (no queue entry, no abort
+ * registry entry) — the window between `queue.takeNext` and the abort
+ * registry's `register()` call in `run.ts`.
+ *
+ * Bounded retry strategy (see `RENDEZVOUS_MAX_ATTEMPTS`): on a 412 etag
+ * mismatch, re-read the run-state.
+ *   - Terminal phase → `{outcome:'already-terminal', phase}` (the run's own
+ *     transition won the race).
+ *   - Non-terminal (still advancing, e.g. now EXECUTING) → retry once more.
+ *   - Retries exhausted → `{outcome:'retry'}` (never loop unboundedly).
+ */
+async function attemptRendezvousCancel(
+  deps: CancelRunDeps,
+  repo: string,
+  runId: string,
+  actor: CancelActorContext,
+  logger: GatewayLogger,
+): Promise<CancelOutcome> {
+  const {coordinationConfig, identity} = deps
+  const coordLogger = {debug: (msg: string, ctx?: Record<string, unknown>) => logger.debug(ctx ?? {}, msg)}
+
+  let read = await readRunState(deps, repo, runId, logger)
+  if (read === undefined) {
+    return {outcome: 'not-found'}
+  }
+
+  for (let attempt = 0; attempt < RENDEZVOUS_MAX_ATTEMPTS; attempt += 1) {
+    if (isTerminalPhase(read.state.phase)) {
+      return {outcome: 'already-terminal', phase: read.state.phase}
+    }
+
+    const cancelledBy = {
+      githubUserId: actor.githubUserId,
+      login: actor.login,
+      sessionCorrelationId: actor.sessionCorrelationId,
+      cancelledAt: new Date(deps.now?.() ?? Date.now()).toISOString(),
+    }
+
+    const result = await transitionRun(coordinationConfig, identity, repo, runId, 'CANCELLED', read.etag, coordLogger, {
+      detailsPatch: {cancelledBy},
+    })
+
+    if (result.success === true) {
+      notifyObserverBestEffort(deps, result.data.state, logger)
+      await postCancellationNotice(deps, runId, result.data.state.thread_id, logger)
+      return {outcome: 'cancelled', wasQueued: false}
+    }
+
+    // 412 (or another conditional-write failure) — re-read before deciding.
+    const reread = await readRunState(deps, repo, runId, logger)
+    if (reread === undefined) {
+      // Could not confirm the current state — do not claim success or terminality.
+      return {outcome: 'retry'}
+    }
+    read = reread
+  }
+
+  // Bound exhausted without resolving — the run kept advancing (e.g. to EXECUTING)
+  // faster than this loop could observe a stable state. Safe to retry later:
+  // by the time this returns, either the abort registry now has the entry
+  // (a subsequent cancelRun call will hit the executing path) or the run
+  // reached a terminal state on its own.
+  return {outcome: 'retry'}
+}
+
+// ---------------------------------------------------------------------------
+// cancelRun
+// ---------------------------------------------------------------------------
+
+export async function cancelRun(params: CancelRunParams, deps: CancelRunDeps): Promise<CancelOutcome> {
+  const {runId, actor, logger} = params
+
+  const location = await deps.runIndex.lookup(runId)
+  if (location === undefined) {
+    return {outcome: 'not-found'}
+  }
+  const {repo} = location
+
+  const initialRead = await readRunState(deps, repo, runId, logger)
+  if (initialRead === undefined) {
+    return {outcome: 'not-found'}
+  }
+
+  // ── Idempotent short-circuit — read-then-short-circuit, never attempt a
+  // terminal transition (transitionRun rejects it by design anyway). ──────
+  if (isTerminalPhase(initialRead.state.phase)) {
+    return {outcome: 'already-terminal', phase: initialRead.state.phase}
+  }
+
+  // ── Queued path: PENDING/ACKNOWLEDGED with a matching queue entry ───────
+  const channelId = typeof initialRead.state.details.channelId === 'string' ? initialRead.state.details.channelId : ''
+  if (channelId !== '') {
+    const removed = deps.queue.removeBy(channelId, task => task.runId === runId)
+    if (removed !== undefined) {
+      const coordLogger = {debug: (msg: string, ctx?: Record<string, unknown>) => logger.debug(ctx ?? {}, msg)}
+      const cancelledBy = {
+        githubUserId: actor.githubUserId,
+        login: actor.login,
+        sessionCorrelationId: actor.sessionCorrelationId,
+        cancelledAt: new Date(deps.now?.() ?? Date.now()).toISOString(),
+      }
+      const transitionResult = await transitionRun(
+        deps.coordinationConfig,
+        deps.identity,
+        repo,
+        runId,
+        'CANCELLED',
+        initialRead.etag,
+        coordLogger,
+        {detailsPatch: {cancelledBy}},
+      )
+      if (transitionResult.success === false) {
+        logger.error(
+          {repo, runId, err: transitionResult.error.message},
+          'cancelRun: transitionRun CANCELLED failed for a queued run',
+        )
+        // The run was already dequeued — it cannot be re-enqueued safely (order would
+        // be lost). Fall through to the rendezvous path: the run-state read there will
+        // reflect whatever won, and the caller gets an accurate outcome rather than a
+        // silent no-op.
+        return attemptRendezvousCancel(deps, repo, runId, actor, logger)
+      }
+      notifyObserverBestEffort(deps, transitionResult.data.state, logger)
+      await postCancellationNotice(deps, runId, transitionResult.data.state.thread_id, logger)
+      return {outcome: 'cancelled', wasQueued: true}
+    }
+  }
+
+  // ── Executing path: abort-registry hit ───────────────────────────────────
+  if (deps.abortRegistry.has(runId)) {
+    const approvalActor: ApprovalActor = {
+      kind: 'web-operator',
+      githubUserId: actor.githubUserId,
+      login: actor.login,
+      sessionCorrelationId: actor.sessionCorrelationId,
+    }
+
+    // Settle pending approvals FIRST — Unit 1's error path (triggered by the
+    // abort below) owns the run-state transition/cleanup; approvals must be
+    // rejected before the abort so the run's own catch handler doesn't race
+    // a still-open approval against the cancel.
+    await settlePendingApprovals(deps, initialRead.state, approvalActor, logger)
+
+    const cancelledBy = {
+      githubUserId: actor.githubUserId,
+      login: actor.login,
+      sessionCorrelationId: actor.sessionCorrelationId,
+      cancelledAt: new Date(deps.now?.() ?? Date.now()).toISOString(),
+    }
+    deps.abortRegistry.abort(runId, 'operator cancel', cancelledBy)
+
+    await postCancellationNotice(deps, runId, initialRead.state.thread_id, logger)
+    return {outcome: 'cancelled', wasQueued: false}
+  }
+
+  // ── Double miss: pre-ACK / pre-registration rendezvous window ───────────
+  return attemptRendezvousCancel(deps, repo, runId, actor, logger)
+}

--- a/packages/gateway/src/execute/queue.test.ts
+++ b/packages/gateway/src/execute/queue.test.ts
@@ -10,7 +10,7 @@ describe('createChannelQueue', () => {
   describe('happy path — FIFO enqueue and takeNext', () => {
     it('enqueues two tasks and returns them in FIFO order', () => {
       // #given
-      const queue = createChannelQueue(5)
+      const queue = createChannelQueue<{id: string}>(5)
       const task1 = {id: 'task-1'}
       const task2 = {id: 'task-2'}
 
@@ -27,7 +27,7 @@ describe('createChannelQueue', () => {
 
     it('pendingCount reflects depth and decrements on each takeNext', () => {
       // #given
-      const queue = createChannelQueue(5)
+      const queue = createChannelQueue<{id: string}>(5)
       const task1 = {id: 'task-1'}
       const task2 = {id: 'task-2'}
 
@@ -55,7 +55,7 @@ describe('createChannelQueue', () => {
   describe('edge cases — empty / unknown channel', () => {
     it('takeNext on an empty channel returns undefined', () => {
       // #given
-      const queue = createChannelQueue(5)
+      const queue = createChannelQueue<{id: string}>(5)
 
       // #when / #then
       expect(queue.takeNext('ch-unknown')).toBeUndefined()
@@ -63,7 +63,7 @@ describe('createChannelQueue', () => {
 
     it('takeNext on a channel that was drained returns undefined', () => {
       // #given
-      const queue = createChannelQueue(5)
+      const queue = createChannelQueue<{id: string}>(5)
       queue.enqueue('ch-a', {id: 'task-1'})
       queue.takeNext('ch-a')
 
@@ -73,7 +73,7 @@ describe('createChannelQueue', () => {
 
     it('pendingCount on an unknown channel returns 0', () => {
       // #given
-      const queue = createChannelQueue(5)
+      const queue = createChannelQueue<{id: string}>(5)
 
       // #when / #then
       expect(queue.pendingCount('ch-unknown')).toBe(0)
@@ -81,7 +81,7 @@ describe('createChannelQueue', () => {
 
     it('clear on an empty / unknown channel returns 0', () => {
       // #given
-      const queue = createChannelQueue(5)
+      const queue = createChannelQueue<{id: string}>(5)
 
       // #when / #then
       expect(queue.clear('ch-unknown')).toBe(0)
@@ -89,7 +89,7 @@ describe('createChannelQueue', () => {
 
     it('clear on a drained channel returns 0', () => {
       // #given
-      const queue = createChannelQueue(5)
+      const queue = createChannelQueue<{id: string}>(5)
       queue.enqueue('ch-a', {id: 'task-1'})
       queue.takeNext('ch-a')
 
@@ -101,7 +101,7 @@ describe('createChannelQueue', () => {
   describe('channel isolation', () => {
     it('enqueue on channel A does not affect pendingCount for channel B', () => {
       // #given
-      const queue = createChannelQueue(5)
+      const queue = createChannelQueue<{id: string}>(5)
 
       // #when
       queue.enqueue('ch-a', {id: 'task-1'})
@@ -113,7 +113,7 @@ describe('createChannelQueue', () => {
 
     it('takeNext on channel A does not affect channel B', () => {
       // #given
-      const queue = createChannelQueue(5)
+      const queue = createChannelQueue<{id: string}>(5)
       const taskA = {id: 'task-a'}
       const taskB = {id: 'task-b'}
       queue.enqueue('ch-a', taskA)
@@ -129,7 +129,7 @@ describe('createChannelQueue', () => {
 
     it('clear on channel A does not affect channel B', () => {
       // #given
-      const queue = createChannelQueue(5)
+      const queue = createChannelQueue<{id: string}>(5)
       const taskA = {id: 'task-a'}
       const taskB = {id: 'task-b'}
       queue.enqueue('ch-a', taskA)
@@ -213,10 +213,153 @@ describe('createChannelQueue', () => {
     })
   })
 
+  describe('removeBy', () => {
+    it('removes a task matching the predicate from the head', () => {
+      // #given
+      const queue = createChannelQueue<{id: string}>(5)
+      const task1 = {id: 'task-1'}
+      const task2 = {id: 'task-2'}
+      const task3 = {id: 'task-3'}
+      queue.enqueue('ch-a', task1)
+      queue.enqueue('ch-a', task2)
+      queue.enqueue('ch-a', task3)
+
+      // #when
+      const removed = queue.removeBy('ch-a', t => t.id === 'task-1')
+
+      // #then — removed the head; remaining order preserved
+      expect(removed).toBe(task1)
+      expect(queue.pendingCount('ch-a')).toBe(2)
+      expect(queue.takeNext('ch-a')).toBe(task2)
+      expect(queue.takeNext('ch-a')).toBe(task3)
+    })
+
+    it('removes a task matching the predicate from the middle, preserving order of the rest', () => {
+      // #given
+      const queue = createChannelQueue<{id: string}>(5)
+      const task1 = {id: 'task-1'}
+      const task2 = {id: 'task-2'}
+      const task3 = {id: 'task-3'}
+      queue.enqueue('ch-a', task1)
+      queue.enqueue('ch-a', task2)
+      queue.enqueue('ch-a', task3)
+
+      // #when
+      const removed = queue.removeBy('ch-a', t => t.id === 'task-2')
+
+      // #then
+      expect(removed).toBe(task2)
+      expect(queue.pendingCount('ch-a')).toBe(2)
+      expect(queue.takeNext('ch-a')).toBe(task1)
+      expect(queue.takeNext('ch-a')).toBe(task3)
+    })
+
+    it('removes a task matching the predicate from the tail', () => {
+      // #given
+      const queue = createChannelQueue<{id: string}>(5)
+      const task1 = {id: 'task-1'}
+      const task2 = {id: 'task-2'}
+      const task3 = {id: 'task-3'}
+      queue.enqueue('ch-a', task1)
+      queue.enqueue('ch-a', task2)
+      queue.enqueue('ch-a', task3)
+
+      // #when
+      const removed = queue.removeBy('ch-a', t => t.id === 'task-3')
+
+      // #then — removing the tail cleans up correctly and pendingCount is accurate
+      expect(removed).toBe(task3)
+      expect(queue.pendingCount('ch-a')).toBe(2)
+      expect(queue.takeNext('ch-a')).toBe(task1)
+      expect(queue.takeNext('ch-a')).toBe(task2)
+      expect(queue.takeNext('ch-a')).toBeUndefined()
+    })
+
+    it('returns undefined on a miss without disturbing the queue', () => {
+      // #given
+      const queue = createChannelQueue<{id: string}>(5)
+      const task1 = {id: 'task-1'}
+      queue.enqueue('ch-a', task1)
+
+      // #when
+      const removed = queue.removeBy('ch-a', t => t.id === 'nonexistent')
+
+      // #then
+      expect(removed).toBeUndefined()
+      expect(queue.pendingCount('ch-a')).toBe(1)
+      expect(queue.takeNext('ch-a')).toBe(task1)
+    })
+
+    it('returns undefined for an unknown channel', () => {
+      // #given
+      const queue = createChannelQueue<{id: string}>(5)
+
+      // #when / #then
+      expect(queue.removeBy('ch-unknown', () => true)).toBeUndefined()
+    })
+
+    it('returns undefined for an already-drained channel', () => {
+      // #given
+      const queue = createChannelQueue<{id: string}>(5)
+      queue.enqueue('ch-a', {id: 'task-1'})
+      queue.takeNext('ch-a')
+
+      // #when / #then
+      expect(queue.removeBy('ch-a', () => true)).toBeUndefined()
+    })
+
+    it('removing the last remaining task cleans up the channel entry (pendingCount stays accurate)', () => {
+      // #given
+      const queue = createChannelQueue<{id: string}>(5)
+      const task1 = {id: 'task-1'}
+      queue.enqueue('ch-a', task1)
+
+      // #when
+      const removed = queue.removeBy('ch-a', t => t.id === 'task-1')
+
+      // #then
+      expect(removed).toBe(task1)
+      expect(queue.pendingCount('ch-a')).toBe(0)
+      // Re-enqueue to prove the channel entry was cleaned up, not left as a stale empty array.
+      expect(queue.enqueue('ch-a', {id: 'task-2'})).toBe('queued')
+    })
+
+    it('removeBy on channel A does not affect channel B', () => {
+      // #given
+      const queue = createChannelQueue<{id: string}>(5)
+      const taskA = {id: 'task-a'}
+      const taskB = {id: 'task-b'}
+      queue.enqueue('ch-a', taskA)
+      queue.enqueue('ch-b', taskB)
+
+      // #when
+      queue.removeBy('ch-a', t => t.id === 'task-a')
+
+      // #then
+      expect(queue.pendingCount('ch-b')).toBe(1)
+      expect(queue.takeNext('ch-b')).toBe(taskB)
+    })
+
+    it('race-adjacent: after takeNext consumes the target task, removeBy misses deterministically', () => {
+      // #given — simulates the dequeue-handoff window: takeNext already drained the task
+      // that a concurrent cancel is targeting by runId.
+      const queue = createChannelQueue<{id: string}>(5)
+      const task1 = {id: 'task-1'}
+      queue.enqueue('ch-a', task1)
+
+      // #when — takeNext wins the race first
+      const taken = queue.takeNext('ch-a')
+
+      // #then — the subsequent removeBy for the same task deterministically misses
+      expect(taken).toBe(task1)
+      expect(queue.removeBy('ch-a', t => t.id === 'task-1')).toBeUndefined()
+    })
+  })
+
   describe('atomicity and FIFO correctness', () => {
     it('two sequential takeNext calls never return the same task object', () => {
       // #given
-      const queue = createChannelQueue(5)
+      const queue = createChannelQueue<{id: string}>(5)
       const task1 = {id: 'task-1'}
       const task2 = {id: 'task-2'}
       queue.enqueue('ch-a', task1)
@@ -234,7 +377,7 @@ describe('createChannelQueue', () => {
 
     it('interleaved enqueue + takeNext preserves FIFO and loses no task', () => {
       // #given
-      const queue = createChannelQueue(5)
+      const queue = createChannelQueue<{id: string}>(5)
       const task1 = {id: 'task-1'}
       const task2 = {id: 'task-2'}
       const task3 = {id: 'task-3'}
@@ -257,7 +400,7 @@ describe('createChannelQueue', () => {
 
     it('clear after a takeNext drops only the remaining tasks', () => {
       // #given
-      const queue = createChannelQueue(5)
+      const queue = createChannelQueue<{id: string}>(5)
       const task1 = {id: 'task-1'}
       const task2 = {id: 'task-2'}
       const task3 = {id: 'task-3'}
@@ -276,7 +419,7 @@ describe('createChannelQueue', () => {
 
     it('clear returns the exact count of dropped tasks', () => {
       // #given
-      const queue = createChannelQueue(5)
+      const queue = createChannelQueue<{id: string}>(5)
       queue.enqueue('ch-a', {id: 'task-1'})
       queue.enqueue('ch-a', {id: 'task-2'})
       queue.enqueue('ch-a', {id: 'task-3'})
@@ -291,7 +434,7 @@ describe('createChannelQueue', () => {
 
     it('takeNext after clear returns undefined — no stale empty array', () => {
       // #given
-      const queue = createChannelQueue(5)
+      const queue = createChannelQueue<{id: string}>(5)
       queue.enqueue('ch-a', {id: 'task-1'})
       queue.clear('ch-a')
 

--- a/packages/gateway/src/execute/queue.ts
+++ b/packages/gateway/src/execute/queue.ts
@@ -48,6 +48,22 @@ export interface ChannelQueue<T> {
    * Does not affect the in-flight run (which holds the concurrency slot, not the queue).
    */
   readonly clear: (channelId: string) => number
+  /**
+   * Remove the FIRST pending task for the channel matching `predicate`
+   * (head/middle/tail — the whole array is searched) and return it.
+   *
+   * Returns `undefined` when no pending task matches (unknown channel, empty
+   * channel, or no match) — including the race where `takeNext` already
+   * consumed the target task before this call runs.
+   *
+   * Preserves FIFO order for the remaining tasks. Removing the last remaining
+   * task cleans up the channel's entry (mirrors `takeNext`'s empty-array cleanup)
+   * so `pendingCount` stays accurate.
+   *
+   * Generic predicate (rather than a `removeByRunId`-specific method) so this
+   * primitive is reusable for any `T` shape without a `runId` type constraint.
+   */
+  readonly removeBy: (channelId: string, predicate: (task: T) => boolean) => T | undefined
 }
 
 /**
@@ -94,6 +110,20 @@ export function createChannelQueue<T>(maxDepth: number = DEFAULT_MAX_QUEUE_DEPTH
       const count = existing.length
       queues.delete(channelId)
       return count
+    },
+
+    removeBy: (channelId: string, predicate: (task: T) => boolean): T | undefined => {
+      const existing = queues.get(channelId)
+      if (existing === undefined || existing.length === 0) return undefined
+      const index = existing.findIndex(predicate)
+      if (index === -1) return undefined
+      const [removed] = existing.splice(index, 1)
+      // Clean up the entry when the array is drained so pendingCount stays accurate
+      // and we don't accumulate stale empty arrays — mirrors takeNext's cleanup.
+      if (existing.length === 0) {
+        queues.delete(channelId)
+      }
+      return removed
     },
   }
 }

--- a/packages/gateway/src/execute/recovery.test.ts
+++ b/packages/gateway/src/execute/recovery.test.ts
@@ -12,13 +12,19 @@ import {recoverStaleRuns} from './recovery.js'
 // Mock @fro-bot/runtime
 // ---------------------------------------------------------------------------
 
-vi.mock('@fro-bot/runtime', () => ({
-  getRunKey: vi.fn(),
-  getLockKey: vi.fn(),
-  findStaleRuns: vi.fn(),
-  transitionRun: vi.fn(),
-  releaseLock: vi.fn(),
-}))
+vi.mock('@fro-bot/runtime', async () => {
+  const actual = await vi.importActual<typeof import('@fro-bot/runtime')>('@fro-bot/runtime')
+  return {
+    getRunKey: vi.fn(),
+    getLockKey: vi.fn(),
+    findStaleRuns: vi.fn(),
+    transitionRun: vi.fn(),
+    releaseLock: vi.fn(),
+    forceReleaseStaleLock: vi.fn(),
+    // parseRunState is pure JSON-shape validation — use the real implementation.
+    parseRunState: actual.parseRunState,
+  }
+})
 
 // ---------------------------------------------------------------------------
 // Typed mock accessors
@@ -29,6 +35,7 @@ const mockGetLockKey = vi.mocked(runtimeModule.getLockKey)
 const mockFindStaleRuns = vi.mocked(runtimeModule.findStaleRuns)
 const mockTransitionRun = vi.mocked(runtimeModule.transitionRun)
 const mockReleaseLock = vi.mocked(runtimeModule.releaseLock)
+const mockForceReleaseStaleLock = vi.mocked(runtimeModule.forceReleaseStaleLock)
 
 // ---------------------------------------------------------------------------
 // Test constants
@@ -116,6 +123,37 @@ function makeThread(): SinkThread {
   return {send: vi.fn().mockResolvedValue(undefined)}
 }
 
+function makeCancelledLockFixture(overrides: {lockRunId?: string} = {}): CoordinationConfig {
+  const runStateJson = JSON.stringify({
+    run_id: RUN_ID,
+    surface: 'discord',
+    thread_id: THREAD_ID,
+    entity_ref: REPO_SLUG,
+    phase: 'CANCELLED',
+    started_at: new Date().toISOString(),
+    last_heartbeat: new Date().toISOString(),
+    holder_id: 'discord-gateway',
+    details: {},
+  })
+
+  const getObjectFn = vi.fn().mockImplementation(async (key: string) => {
+    if (key === RUN_KEY) return {success: true, data: {data: runStateJson, etag: RUN_ETAG}}
+    if (key === LOCK_KEY) {
+      return {
+        success: true,
+        data: {data: JSON.stringify({run_id: overrides.lockRunId ?? RUN_ID}), etag: LOCK_ETAG},
+      }
+    }
+    return {success: false, error: new Error('not found')}
+  })
+
+  const base = makeCoordinationConfig()
+  return {
+    ...base,
+    storeAdapter: {...base.storeAdapter, getObject: getObjectFn},
+  }
+}
+
 function makeDeps(overrides: Partial<RecoverStaleRunsDeps> = {}): RecoverStaleRunsDeps {
   return {
     coordinationConfig: overrides.coordinationConfig ?? makeCoordinationConfig(),
@@ -165,6 +203,10 @@ beforeEach(() => {
     data: {etag: 'etag-run-2', state: makeStaleRun({phase: 'FAILED'})},
   })
   mockReleaseLock.mockResolvedValue({success: true, data: undefined})
+  mockForceReleaseStaleLock.mockResolvedValue({
+    success: true,
+    data: {outcome: 'no-lock', holderId: null, runId: null, lockAgeMs: null, heartbeatAgeMs: null},
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -499,6 +541,139 @@ describe('recoverStaleRuns', () => {
       )
       expect(mockReleaseLock).toHaveBeenCalledWith(expect.anything(), REPO_SLUG, LOCK_ETAG, expect.anything())
       expect(thread.send).toHaveBeenCalled()
+    })
+  })
+
+  describe('cancelled-run lock reconciliation', () => {
+    it('releases the lock via forceReleaseStaleLock when it is still held by a CANCELLED run', async () => {
+      // #given — no other stale runs; a CANCELLED run whose own lock is still live
+      mockFindStaleRuns.mockResolvedValue({success: true, data: []})
+      const coordinationConfig = makeCancelledLockFixture()
+      mockForceReleaseStaleLock.mockResolvedValue({
+        success: true,
+        data: {
+          outcome: 'released',
+          holderId: 'discord-gateway',
+          runId: RUN_ID,
+          lockAgeMs: 999_999,
+          heartbeatAgeMs: 999_999,
+        },
+      })
+      const logger = makeLogger()
+      const deps = makeDeps({coordinationConfig, logger})
+
+      // #when
+      await recoverStaleRuns(deps)
+
+      // #then — release goes through the dead-run-verified path, not a raw releaseLock
+      expect(mockForceReleaseStaleLock).toHaveBeenCalledWith(
+        coordinationConfig,
+        REPO_SLUG,
+        'discord-gateway',
+        expect.anything(),
+      )
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({repo: REPO_SLUG, runId: RUN_ID}),
+        expect.stringContaining('released repo lock stranded'),
+      )
+    })
+
+    it('leaves the lock untouched when it was re-acquired by a newer run (ownership mismatch)', async () => {
+      // #given — the lock's run_id no longer matches the CANCELLED run that originally held it
+      mockFindStaleRuns.mockResolvedValue({success: true, data: []})
+      const coordinationConfig = makeCancelledLockFixture({lockRunId: 'run-newer-999'})
+      const deps = makeDeps({coordinationConfig})
+
+      // #when
+      await recoverStaleRuns(deps)
+
+      // #then — reconciliation reads run-state for the LOCK's run_id (run-newer-999), which is
+      // not the CANCELLED fixture (RUN_ID) — forceReleaseStaleLock must not even be attempted
+      expect(mockForceReleaseStaleLock).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when the CANCELLED run holds no lock', async () => {
+      // #given — CANCELLED run-state exists, but no lock object for the repo
+      mockFindStaleRuns.mockResolvedValue({success: true, data: []})
+      const getObjectFn = vi.fn().mockImplementation(async (key: string) => {
+        if (key === LOCK_KEY) return {success: false, error: new Error('not found')}
+        return {success: false, error: new Error('not found')}
+      })
+      const base = makeCoordinationConfig()
+      const coordinationConfig = {...base, storeAdapter: {...base.storeAdapter, getObject: getObjectFn}}
+      const deps = makeDeps({coordinationConfig})
+
+      // #when
+      await expect(recoverStaleRuns(deps)).resolves.toBeUndefined()
+
+      // #then
+      expect(mockForceReleaseStaleLock).not.toHaveBeenCalled()
+    })
+
+    it('continues the sweep when forceReleaseStaleLock errors (fail-soft)', async () => {
+      // #given
+      mockFindStaleRuns.mockResolvedValue({success: true, data: []})
+      const coordinationConfig = makeCancelledLockFixture()
+      mockForceReleaseStaleLock.mockResolvedValue({success: false, error: new Error('conditional delete boom')})
+      const logger = makeLogger()
+      const deps = makeDeps({coordinationConfig, logger})
+
+      // #when — must not throw; startup sweep completes
+      await expect(recoverStaleRuns(deps)).resolves.toBeUndefined()
+
+      // #then
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({repo: REPO_SLUG, runId: RUN_ID}),
+        expect.stringContaining('forceReleaseStaleLock errored'),
+      )
+    })
+
+    it('does not attempt reconciliation for a non-CANCELLED terminal run (FAILED) holding the lock', async () => {
+      // #given — a lock owned by a FAILED (not CANCELLED) run
+      mockFindStaleRuns.mockResolvedValue({success: true, data: []})
+      const runStateJson = JSON.stringify({
+        run_id: RUN_ID,
+        surface: 'discord',
+        thread_id: THREAD_ID,
+        entity_ref: REPO_SLUG,
+        phase: 'FAILED',
+        started_at: new Date().toISOString(),
+        last_heartbeat: new Date().toISOString(),
+        holder_id: 'discord-gateway',
+        details: {},
+      })
+      const getObjectFn = vi.fn().mockImplementation(async (key: string) => {
+        if (key === RUN_KEY) return {success: true, data: {data: runStateJson, etag: RUN_ETAG}}
+        if (key === LOCK_KEY) return {success: true, data: {data: JSON.stringify({run_id: RUN_ID}), etag: LOCK_ETAG}}
+        return {success: false, error: new Error('not found')}
+      })
+      const base = makeCoordinationConfig()
+      const coordinationConfig = {...base, storeAdapter: {...base.storeAdapter, getObject: getObjectFn}}
+      const deps = makeDeps({coordinationConfig})
+
+      // #when
+      await recoverStaleRuns(deps)
+
+      // #then — only CANCELLED-held locks are reconciled by this pass
+      expect(mockForceReleaseStaleLock).not.toHaveBeenCalled()
+    })
+
+    it('does not disturb existing EXECUTING/PENDING/ACKNOWLEDGED recovery when a separate CANCELLED lock is also reconciled', async () => {
+      // #given — one stale EXECUTING run (existing path) plus a CANCELLED run's lock is NOT
+      // the one held (findStaleRuns path exercises the same repo scan already covered above);
+      // here we assert the two passes coexist without interference.
+      const staleExecuting = makeStaleRun({phase: 'EXECUTING'})
+      mockFindStaleRuns.mockResolvedValue({success: true, data: [staleExecuting]})
+      const coordinationConfig = makeCoordinationConfig() // lock owned by RUN_ID, run-state is '{}' (not CANCELLED)
+      const deps = makeDeps({coordinationConfig})
+
+      // #when
+      await recoverStaleRuns(deps)
+
+      // #then — existing EXECUTING recovery still fires; cancelled-lock pass is a no-op (parse fails)
+      expect(mockTransitionRun).toHaveBeenCalled()
+      expect(mockReleaseLock).toHaveBeenCalled()
+      expect(mockForceReleaseStaleLock).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/gateway/src/execute/recovery.test.ts
+++ b/packages/gateway/src/execute/recovery.test.ts
@@ -398,6 +398,80 @@ describe('recoverStaleRuns', () => {
       )
     })
 
+    it('continues to the next repo when recoverOneRun throws unexpectedly for a prior repo', async () => {
+      // #given — two repos, each with one stale EXECUTING run; repo A's recovery throws unexpectedly
+      const bindingA = {owner: 'acme', repo: 'widget', channelId: 'ch-1', workspacePath: '/w/widget'}
+      const bindingB = {owner: 'acme', repo: 'other', channelId: 'ch-2', workspacePath: '/w/other'}
+      const bindingsStore = makeBindingsStore({
+        listBindings: vi.fn().mockResolvedValue({success: true, data: [bindingA, bindingB]}),
+      })
+
+      const staleRun = makeStaleRun()
+      mockFindStaleRuns.mockResolvedValue({success: true, data: [staleRun]})
+
+      // getRunKey throws (unexpected, not a Result failure) only for repo A
+      mockGetRunKey.mockImplementation((_config, _identity, repo, runId) => {
+        if (repo === 'acme/widget') {
+          throw new Error('unexpected boom in repo A')
+        }
+        if (runId === RUN_ID) return okKey(RUN_KEY)
+        return errKey('unexpected run key')
+      })
+
+      const logger = makeLogger()
+      const deps = makeDeps({bindingsStore, logger})
+
+      // #when — must not throw
+      await expect(recoverStaleRuns(deps)).resolves.toBeUndefined()
+
+      // #then — repo B is still swept (its transitionRun/reconcile still ran)
+      expect(mockTransitionRun).toHaveBeenCalledWith(
+        expect.anything(),
+        'discord-gateway',
+        'acme/other',
+        RUN_ID,
+        'FAILED',
+        RUN_ETAG,
+        expect.anything(),
+      )
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({repo: 'acme/widget', err: 'unexpected boom in repo A'}),
+        expect.stringContaining('unexpected error recovering repo'),
+      )
+    })
+
+    it('continues to the next repo when reconcileCancelledLock throws unexpectedly for a prior repo', async () => {
+      // #given — two repos, no stale runs; repo A's cancelled-lock reconciliation throws unexpectedly
+      const bindingA = {owner: 'acme', repo: 'widget', channelId: 'ch-1', workspacePath: '/w/widget'}
+      const bindingB = {owner: 'acme', repo: 'other', channelId: 'ch-2', workspacePath: '/w/other'}
+      const bindingsStore = makeBindingsStore({
+        listBindings: vi.fn().mockResolvedValue({success: true, data: [bindingA, bindingB]}),
+      })
+
+      mockFindStaleRuns.mockResolvedValue({success: true, data: []})
+
+      // getLockKey throws (unexpected) only for repo A
+      mockGetLockKey.mockImplementation((_config, repo) => {
+        if (repo === 'acme/widget') {
+          throw new Error('unexpected boom reconciling repo A')
+        }
+        return okKey(LOCK_KEY)
+      })
+
+      const logger = makeLogger()
+      const deps = makeDeps({bindingsStore, logger})
+
+      // #when — must not throw
+      await expect(recoverStaleRuns(deps)).resolves.toBeUndefined()
+
+      // #then — repo B's reconciliation still attempted (getLockKey called for it)
+      expect(mockGetLockKey).toHaveBeenCalledWith(expect.anything(), 'acme/other')
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({repo: 'acme/widget', err: 'unexpected boom reconciling repo A'}),
+        expect.stringContaining('unexpected error recovering repo'),
+      )
+    })
+
     it('logs an error and returns early when listBindings fails', async () => {
       // #given
       const bindingsStore = makeBindingsStore({

--- a/packages/gateway/src/execute/recovery.ts
+++ b/packages/gateway/src/execute/recovery.ts
@@ -23,7 +23,15 @@ import type {CoordinationConfig} from '@fro-bot/runtime'
 import type {BindingsStore} from '../bindings/store.js'
 import type {GatewayLogger} from '../discord/client.js'
 import type {SinkThread} from '../discord/streaming.js'
-import {findStaleRuns, getLockKey, getRunKey, releaseLock, transitionRun} from '@fro-bot/runtime'
+import {
+  findStaleRuns,
+  forceReleaseStaleLock,
+  getLockKey,
+  getRunKey,
+  parseRunState,
+  releaseLock,
+  transitionRun,
+} from '@fro-bot/runtime'
 
 // ---------------------------------------------------------------------------
 // Public interface
@@ -166,18 +174,126 @@ export async function recoverStaleRuns(deps: RecoverStaleRunsDeps): Promise<void
     }
 
     const staleRuns = staleResult.data
-    if (staleRuns.length === 0) {
-      continue
+    if (staleRuns.length > 0) {
+      logger.info({repo, count: staleRuns.length}, 'recovery: found stale runs')
+
+      for (const run of staleRuns) {
+        await recoverOneRun({run, repo, coordinationConfig, identity, resolveThread, coordLogger, logger})
+      }
     }
 
-    logger.info({repo, count: staleRuns.length}, 'recovery: found stale runs')
-
-    for (const run of staleRuns) {
-      await recoverOneRun({run, repo, coordinationConfig, identity, resolveThread, coordLogger, logger})
-    }
+    // A crash between committing the CANCELLED transition and releasing the repo
+    // lock is invisible to findStaleRuns (its phase filter only matches
+    // EXECUTING/PENDING/ACKNOWLEDGED — CANCELLED is terminal and intentionally
+    // skipped there). Reconcile separately: if the repo's lock is still held by
+    // a run whose committed state is CANCELLED, release it. The run itself is
+    // already terminal and must NOT be re-transitioned.
+    await reconcileCancelledLock({repo, coordinationConfig, identity, coordLogger, logger})
   }
 
   logger.info({}, 'recovery: stale-run sweep complete')
+}
+
+// ---------------------------------------------------------------------------
+// Cancelled-run lock reconciliation
+// ---------------------------------------------------------------------------
+
+interface ReconcileCancelledLockOpts {
+  readonly repo: string
+  readonly coordinationConfig: CoordinationConfig
+  readonly identity: string
+  readonly coordLogger: {debug: (message: string, context?: Record<string, unknown>) => void}
+  readonly logger: GatewayLogger
+}
+
+/**
+ * Release a repo's lock when it is still held by a run whose committed
+ * run-state phase is CANCELLED.
+ *
+ * The run itself is terminal and is never re-transitioned — only the lock is
+ * reconciled. Release goes through `forceReleaseStaleLock`, which independently
+ * re-verifies both dead-run signals (lease + heartbeat staleness) and performs
+ * an `IfMatch`-conditional delete, so a newer run that re-acquired the lock
+ * after this one's lease expired is never clobbered.
+ *
+ * No-ops (logged at debug) when: no lock exists, the lock belongs to a
+ * different run_id, the owning run-state cannot be read, or the owning run's
+ * phase is not CANCELLED. Any error is logged and swallowed — one repo's
+ * failure must not block the rest of the startup sweep.
+ */
+async function reconcileCancelledLock(opts: ReconcileCancelledLockOpts): Promise<void> {
+  const {repo, coordinationConfig, identity, coordLogger, logger} = opts
+
+  const lockKeyResult = getLockKey(coordinationConfig, repo)
+  if (lockKeyResult.success === false) {
+    logger.warn(
+      {repo, err: lockKeyResult.error.message},
+      'recovery: could not build lock key — skipping cancelled-lock reconciliation',
+    )
+    return
+  }
+
+  const lockFetch = await fetchLockRecord(coordinationConfig, lockKeyResult.data, logger)
+  if (lockFetch === null || lockFetch.runId === null) {
+    // No lock, or lock content unreadable/lacks run_id — nothing to reconcile.
+    return
+  }
+
+  const runKeyResult = getRunKey(coordinationConfig, identity, repo, lockFetch.runId)
+  if (runKeyResult.success === false) {
+    logger.warn(
+      {repo, runId: lockFetch.runId, err: runKeyResult.error.message},
+      'recovery: could not build run key — skipping cancelled-lock reconciliation',
+    )
+    return
+  }
+
+  if (coordinationConfig.storeAdapter.getObject == null) {
+    logger.warn({repo}, 'recovery: store adapter does not support getObject — skipping cancelled-lock reconciliation')
+    return
+  }
+
+  const runResult = await coordinationConfig.storeAdapter.getObject(runKeyResult.data)
+  if (runResult.success === false) {
+    // Absent or unreadable run-state for the lock's run_id — not this reconciliation's
+    // concern (forceReleaseStaleLock's own dead-run check handles absence separately).
+    return
+  }
+
+  const parsedRun = parseRunState(runResult.data.data)
+  if (parsedRun.success === false || parsedRun.data.phase !== 'CANCELLED') {
+    // Only CANCELLED-held locks are in scope for this pass — live/other-terminal
+    // runs are left alone (EXECUTING is handled by the stale-run sweep above;
+    // COMPLETED/FAILED runs release their own lock before reaching that phase).
+    return
+  }
+
+  const releaseResult = await forceReleaseStaleLock(coordinationConfig, repo, identity, coordLogger)
+  if (releaseResult.success === false) {
+    logger.warn(
+      {repo, runId: lockFetch.runId, err: releaseResult.error.message},
+      'recovery: forceReleaseStaleLock errored while reconciling cancelled-run lock — continuing',
+    )
+    return
+  }
+
+  const outcome = releaseResult.data
+  if (outcome.outcome === 'released') {
+    logger.info(
+      {repo, runId: lockFetch.runId},
+      'recovery: released repo lock stranded by a crash between CANCELLED commit and lock release',
+    )
+  } else if (outcome.outcome === 'live-holder' || outcome.outcome === 'conflict') {
+    logger.info(
+      {repo, runId: lockFetch.runId, outcome: outcome.outcome},
+      'recovery: cancelled-lock reconciliation skipped release — lock is live or was re-acquired by a newer run',
+    )
+  } else {
+    logger.debug(
+      {repo, runId: lockFetch.runId, outcome: outcome.outcome},
+      'recovery: cancelled-lock reconciliation outcome',
+    )
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/execute/recovery.ts
+++ b/packages/gateway/src/execute/recovery.ts
@@ -167,28 +167,37 @@ export async function recoverStaleRuns(deps: RecoverStaleRunsDeps): Promise<void
   for (const binding of bindings) {
     const repo = `${binding.owner}/${binding.repo}`
 
-    const staleResult = await findStaleRuns(coordinationConfig, identity, repo, coordLogger)
-    if (staleResult.success === false) {
-      logger.warn({repo, err: staleResult.error.message}, 'recovery: findStaleRuns failed — skipping repo')
-      continue
-    }
-
-    const staleRuns = staleResult.data
-    if (staleRuns.length > 0) {
-      logger.info({repo, count: staleRuns.length}, 'recovery: found stale runs')
-
-      for (const run of staleRuns) {
-        await recoverOneRun({run, repo, coordinationConfig, identity, resolveThread, coordLogger, logger})
+    try {
+      const staleResult = await findStaleRuns(coordinationConfig, identity, repo, coordLogger)
+      if (staleResult.success === false) {
+        logger.warn({repo, err: staleResult.error.message}, 'recovery: findStaleRuns failed — skipping repo')
+        continue
       }
-    }
 
-    // A crash between committing the CANCELLED transition and releasing the repo
-    // lock is invisible to findStaleRuns (its phase filter only matches
-    // EXECUTING/PENDING/ACKNOWLEDGED — CANCELLED is terminal and intentionally
-    // skipped there). Reconcile separately: if the repo's lock is still held by
-    // a run whose committed state is CANCELLED, release it. The run itself is
-    // already terminal and must NOT be re-transitioned.
-    await reconcileCancelledLock({repo, coordinationConfig, identity, coordLogger, logger})
+      const staleRuns = staleResult.data
+      if (staleRuns.length > 0) {
+        logger.info({repo, count: staleRuns.length}, 'recovery: found stale runs')
+
+        for (const run of staleRuns) {
+          await recoverOneRun({run, repo, coordinationConfig, identity, resolveThread, coordLogger, logger})
+        }
+      }
+
+      // A crash between committing the CANCELLED transition and releasing the repo
+      // lock is invisible to findStaleRuns (its phase filter only matches
+      // EXECUTING/PENDING/ACKNOWLEDGED — CANCELLED is terminal and intentionally
+      // skipped there). Reconcile separately: if the repo's lock is still held by
+      // a run whose committed state is CANCELLED, release it. The run itself is
+      // already terminal and must NOT be re-transitioned.
+      await reconcileCancelledLock({repo, coordinationConfig, identity, coordLogger, logger})
+    } catch (error: unknown) {
+      // Fail-soft per the module docstring: an unexpected throw from either helper
+      // must not abort recovery for the remaining repos.
+      logger.warn(
+        {repo, err: error instanceof Error ? error.message : String(error)},
+        'recovery: unexpected error recovering repo — continuing to next repo',
+      )
+    }
   }
 
   logger.info({}, 'recovery: stale-run sweep complete')

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -7121,6 +7121,76 @@ describe('operator cancel — abort-registry integration', () => {
     abortRegistry.delete(CANCEL_FALLBACK_RUN_ID)
   })
 
+  it('cancelled→failed fallback reaches a terminal state without throwing (accepted notice-vs-settlement interleaving)', async () => {
+    // #given — same CANCELLED-transition-fails/FAILED-fallback-succeeds setup as above.
+    // ACCEPTED BEHAVIOR: cancelRun (execute/cancel.ts) posts the "cancelled" thread
+    // notice fire-and-forget as soon as abort() confirms delivery — before this async
+    // settlement runs. In this rare fallback window the thread may show "cancelled"
+    // while the run actually settles FAILED. State is always correct; only the
+    // best-effort notice can be briefly stale. This test pins the FAILED-fallback
+    // side: the run must still reach a terminal state and must not throw or hang.
+    // The notice side (fire-and-forget post on abort delivery) is covered separately
+    // by cancel.test.ts's "abort delivered → notice posted" test.
+    const {launchWork} = await import('./run.js')
+    const failedState = buildMockRunState({phase: 'FAILED', run_id: 'cancel-fallback-pin-run-id'})
+
+    mockRuntime.releaseLock.mockResolvedValue({success: true as const, data: undefined})
+    mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'run-etag-v1'}})
+    mockRuntime.transitionRun.mockImplementation(
+      async (_config: unknown, _identity: unknown, _repo: unknown, _runId: unknown, phase: string) => {
+        if (phase === 'CANCELLED') {
+          return {success: false as const, error: new Error('CANCELLED conditional write conflict')}
+        }
+        if (phase === 'FAILED') {
+          return {success: true as const, data: {etag: 'failed-etag', state: failedState}}
+        }
+        return {success: true as const, data: {etag: 'admit-etag', state: failedState}}
+      },
+    )
+    const heartbeatStop = vi.fn().mockResolvedValue({
+      success: true,
+      data: {runEtag: 'run-etag-after-heartbeat', lockEtag: 'lock-etag-after-heartbeat', runState: failedState},
+    })
+    mockRuntime.createHeartbeatController.mockReturnValue({
+      start: vi.fn(),
+      stop: heartbeatStop,
+      isRunning: false,
+    })
+    vi.mocked(attachModule.attachOpencode).mockReturnValue({
+      server: {url: 'http://workspace:9200'},
+      session: {create: vi.fn(), prompt: vi.fn()},
+    } as unknown as ReturnType<typeof attachModule.attachOpencode>)
+    vi.mocked(promptModule.buildDiscordPrompt).mockReturnValue('Repository: acme/widget\n\ndo the thing')
+
+    const PIN_RUN_ID = 'cancel-fallback-pin-run-id'
+    mockRunOpenCodeCoreAbortedBy(() => {
+      abortRegistry.abort(PIN_RUN_ID, 'operator cancel')
+    })
+
+    const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+    const request = makeInMemoryRequest()
+    ;(request as {runId?: string}).runId = PIN_RUN_ID
+    const deps = makeDeps({logger})
+
+    // #when — the run must resolve (not throw, not hang) despite the CANCELLED
+    // transition failing.
+    await expect(awaitLaunchWorkRun(launchWork, request, deps)).resolves.toBeDefined()
+
+    // #then — the run reached a terminal state via the FAILED fallback.
+    const transitionCalls = mockRuntime.transitionRun.mock.calls.filter(
+      (c: unknown[]) => c[4] === 'CANCELLED' || c[4] === 'FAILED',
+    )
+    expect(transitionCalls.map((c: unknown[]) => c[4] as string)).toEqual(
+      expect.arrayContaining(['CANCELLED', 'FAILED']),
+    )
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({runId: PIN_RUN_ID}),
+      expect.stringContaining('fell back to FAILED'),
+    )
+
+    abortRegistry.delete(PIN_RUN_ID)
+  })
+
   it('timeout-vs-cancel race: classification uses registry probe, not composite abort reason', async () => {
     // #given — a pure ceiling-timeout failure where the registry entry exists but was
     // never aborted. The run must still land FAILED with timeout messaging.

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -212,6 +212,7 @@ function makeDefaultQueue(): ChannelQueue<RunTask> {
     pendingCount: vi.fn().mockReturnValue(0),
     takeNext: vi.fn().mockReturnValue(undefined),
     clear: vi.fn().mockReturnValue(0),
+    removeBy: vi.fn().mockReturnValue(undefined),
   }
 }
 

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -6933,8 +6933,14 @@ describe('operator cancel — abort-registry integration', () => {
     } as unknown as ReturnType<typeof attachModule.attachOpencode>)
     vi.mocked(promptModule.buildDiscordPrompt).mockReturnValue('Repository: acme/widget\n\ndo the thing')
 
+    const cancelledByMetadata = {
+      githubUserId: 42,
+      login: 'octocat',
+      sessionCorrelationId: 'sess-1',
+      cancelledAt: '2026-07-03T00:00:00.000Z',
+    }
     mockRunOpenCodeCoreAbortedBy(() => {
-      abortRegistry.abort(CANCEL_RUN_ID, 'operator cancel')
+      abortRegistry.abort(CANCEL_RUN_ID, 'operator cancel', cancelledByMetadata)
     })
 
     const observeFn = vi.fn().mockResolvedValue(undefined)
@@ -6959,6 +6965,12 @@ describe('operator cancel — abort-registry integration', () => {
     expect(transitionPhases).toContain('CANCELLED')
     expect(transitionPhases).not.toContain('FAILED')
 
+    // #and — the CANCELLED transitionRun call carries the registry's cancelledBy attribution
+    // (the only end-to-end check of the getMetadata → transitionRun attribution seam)
+    const cancelledCall = mockRuntime.transitionRun.mock.calls.find((c: unknown[]) => c[4] === 'CANCELLED')
+    const cancelledCallOptions = cancelledCall?.[7] as {detailsPatch: {cancelledBy: unknown}}
+    expect(cancelledCallOptions.detailsPatch.cancelledBy).toEqual(cancelledByMetadata)
+
     // #and — SSE observer notified with the CANCELLED state
     const observedPhases = observeFn.mock.calls.map((c: unknown[]) => (c[0] as {phase?: string}).phase)
     expect(observedPhases).toContain('CANCELLED')
@@ -6980,6 +6992,133 @@ describe('operator cancel — abort-registry integration', () => {
 
     // #and — registry entry deleted (a later abort() is now a no-op)
     expect(abortRegistry.has(CANCEL_RUN_ID)).toBe(false)
+  })
+
+  it('heartbeat.stop() failure on the cancel path — CANCELLED still settles using last-known etags, warning logged', async () => {
+    // #given — heartbeat.stop() fails on the cancel path
+    const {launchWork} = await import('./run.js')
+    const cancelledState = buildMockRunState({phase: 'CANCELLED', run_id: 'hb-fail-cancel-run-id'})
+    const stopError = new Error('heartbeat stop S3 error on cancel path')
+
+    mockRuntime.acquireLock.mockResolvedValue({
+      success: true as const,
+      data: {acquired: true as const, etag: 'lock-etag-v1', holder: null},
+    })
+    mockRuntime.releaseLock.mockResolvedValue({success: true as const, data: undefined})
+    mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'run-etag-v1'}})
+    mockRuntime.transitionRun.mockResolvedValue({
+      success: true as const,
+      data: {etag: 'cancelled-etag', state: cancelledState},
+    })
+    const heartbeatStop = vi.fn().mockResolvedValue({success: false, error: stopError})
+    mockRuntime.createHeartbeatController.mockReturnValue({
+      start: vi.fn(),
+      stop: heartbeatStop,
+      isRunning: false,
+    })
+    vi.mocked(attachModule.attachOpencode).mockReturnValue({
+      server: {url: 'http://workspace:9200'},
+      session: {create: vi.fn(), prompt: vi.fn()},
+    } as unknown as ReturnType<typeof attachModule.attachOpencode>)
+    vi.mocked(promptModule.buildDiscordPrompt).mockReturnValue('Repository: acme/widget\n\ndo the thing')
+
+    const HB_FAIL_CANCEL_RUN_ID = 'hb-fail-cancel-run-id'
+    mockRunOpenCodeCoreAbortedBy(() => {
+      abortRegistry.abort(HB_FAIL_CANCEL_RUN_ID, 'operator cancel')
+    })
+
+    const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+    const request = makeInMemoryRequest()
+    ;(request as {runId?: string}).runId = HB_FAIL_CANCEL_RUN_ID
+    const deps = makeDeps({logger})
+
+    // #when — must not throw
+    await expect(awaitLaunchWorkRun(launchWork, request, deps)).resolves.toBeDefined()
+
+    // #then — CANCELLED still settled despite the heartbeat-stop failure
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).toContain('CANCELLED')
+
+    // #and — warning logged for the heartbeat-stop failure on the cancel path
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({err: stopError.message}),
+      expect.stringContaining('heartbeat stop failed on cancel path'),
+    )
+
+    abortRegistry.delete(HB_FAIL_CANCEL_RUN_ID)
+  })
+
+  it('cancelled transition failure falls back to FAILED terminalization — run does not remain EXECUTING', async () => {
+    // #given — the CANCELLED transitionRun call fails; a subsequent FAILED transitionRun succeeds
+    const {launchWork} = await import('./run.js')
+    const failedState = buildMockRunState({phase: 'FAILED', run_id: 'cancel-fallback-run-id'})
+
+    mockRuntime.acquireLock.mockResolvedValue({
+      success: true as const,
+      data: {acquired: true as const, etag: 'lock-etag-v1', holder: null},
+    })
+    mockRuntime.releaseLock.mockResolvedValue({success: true as const, data: undefined})
+    mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'run-etag-v1'}})
+    mockRuntime.transitionRun.mockImplementation(
+      async (_config: unknown, _identity: unknown, _repo: unknown, _runId: unknown, phase: string) => {
+        if (phase === 'CANCELLED') {
+          return {success: false as const, error: new Error('CANCELLED conditional write conflict')}
+        }
+        if (phase === 'FAILED') {
+          return {success: true as const, data: {etag: 'failed-etag', state: failedState}}
+        }
+        // ACKNOWLEDGED / EXECUTING admission transitions
+        return {success: true as const, data: {etag: 'admit-etag', state: failedState}}
+      },
+    )
+    const heartbeatStop = vi.fn().mockResolvedValue({
+      success: true,
+      data: {runEtag: 'run-etag-after-heartbeat', lockEtag: 'lock-etag-after-heartbeat', runState: failedState},
+    })
+    mockRuntime.createHeartbeatController.mockReturnValue({
+      start: vi.fn(),
+      stop: heartbeatStop,
+      isRunning: false,
+    })
+    vi.mocked(attachModule.attachOpencode).mockReturnValue({
+      server: {url: 'http://workspace:9200'},
+      session: {create: vi.fn(), prompt: vi.fn()},
+    } as unknown as ReturnType<typeof attachModule.attachOpencode>)
+    vi.mocked(promptModule.buildDiscordPrompt).mockReturnValue('Repository: acme/widget\n\ndo the thing')
+
+    const CANCEL_FALLBACK_RUN_ID = 'cancel-fallback-run-id'
+    mockRunOpenCodeCoreAbortedBy(() => {
+      abortRegistry.abort(CANCEL_FALLBACK_RUN_ID, 'operator cancel')
+    })
+
+    const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+    const request = makeInMemoryRequest()
+    ;(request as {runId?: string}).runId = CANCEL_FALLBACK_RUN_ID
+    const deps = makeDeps({logger})
+
+    // #when — must not throw
+    await expect(awaitLaunchWorkRun(launchWork, request, deps)).resolves.toBeDefined()
+
+    // #then — both a CANCELLED attempt (failed) and a FAILED fallback attempt (succeeded) observed
+    const transitionCalls = mockRuntime.transitionRun.mock.calls.filter(
+      (c: unknown[]) => c[4] === 'CANCELLED' || c[4] === 'FAILED',
+    )
+    const observedPhases = transitionCalls.map((c: unknown[]) => c[4] as string)
+    expect(observedPhases).toContain('CANCELLED')
+    expect(observedPhases).toContain('FAILED')
+
+    // #and — the run does not remain EXECUTING: the FAILED fallback call is the last
+    // observed terminal-settlement attempt for this run, confirming it did not stay open.
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({runId: CANCEL_FALLBACK_RUN_ID}),
+      expect.stringContaining('transitionRun CANCELLED failed'),
+    )
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({runId: CANCEL_FALLBACK_RUN_ID}),
+      expect.stringContaining('fell back to FAILED'),
+    )
+
+    abortRegistry.delete(CANCEL_FALLBACK_RUN_ID)
   })
 
   it('timeout-vs-cancel race: classification uses registry probe, not composite abort reason', async () => {

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -15,6 +15,7 @@ import * as discordApprovalsModule from '../discord/approvals.js'
 import * as reactionsModule from '../discord/reactions.js'
 import * as statusMessageModule from '../discord/status-message.js'
 import * as streamingModule from '../discord/streaming.js'
+import {abortRegistry} from './abort-registry.js'
 import * as attachModule from './opencode-attach.js'
 import * as promptModule from './prompt.js'
 import * as runCoreModule from './run-core.js'
@@ -6868,5 +6869,345 @@ describe('early-abort gates terminalize to FAILED', () => {
 
     // #and — execution happened
     expect(mockRunOpenCodeCore).toHaveBeenCalledOnce()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Operator cancel — abort-registry integration (Unit 1)
+// ---------------------------------------------------------------------------
+
+const CANCEL_RUN_ID = 'cancel-run-id-1'
+
+/**
+ * Simulate `runOpenCodeCore` observing the cancel signal fire and throwing
+ * the same way the real implementation would once its combined signal aborts:
+ * a `RunCoreError('timeout', ...)` (run-core does not add a distinct
+ * 'cancelled' kind — classification happens in run.ts via registry probe).
+ */
+function mockRunOpenCodeCoreAbortedBy(viaRegistryAbort: () => void) {
+  mockRunOpenCodeCore.mockImplementation(async () => {
+    viaRegistryAbort()
+    throw new runCoreModule.RunCoreError('timeout', 'run-core: signal aborted')
+  })
+}
+
+describe('operator cancel — abort-registry integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // The registry is a module-level singleton shared with run.ts (mirrors
+    // inFlightRuns). Clear any leaked entries between tests.
+    abortRegistry.delete(CANCEL_RUN_ID)
+  })
+
+  it('registered run aborted via registry settles CANCELLED (not FAILED), notifies SSE observer, releases lock+slot, deletes registry entry', async () => {
+    // #given — happy-path runtime mocks, but runOpenCodeCore aborts the run's own
+    // registry entry mid-flight (simulating an operator cancel firing during execution)
+    const {launchWork} = await import('./run.js')
+    const ackState = buildMockRunState({phase: 'ACKNOWLEDGED', run_id: CANCEL_RUN_ID})
+    const execState = buildMockRunState({phase: 'EXECUTING', run_id: CANCEL_RUN_ID})
+    const cancelledState = buildMockRunState({phase: 'CANCELLED', run_id: CANCEL_RUN_ID})
+
+    mockRuntime.acquireLock.mockResolvedValue({
+      success: true as const,
+      data: {acquired: true as const, etag: 'lock-etag-v1', holder: null},
+    })
+    mockRuntime.releaseLock.mockResolvedValue({success: true as const, data: undefined})
+    mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'run-etag-v1'}})
+    mockRuntime.transitionRun
+      .mockResolvedValueOnce({success: true as const, data: {etag: 'ack-etag', state: ackState}})
+      .mockResolvedValueOnce({success: true as const, data: {etag: 'exec-etag', state: execState}})
+      .mockResolvedValueOnce({success: true as const, data: {etag: 'cancelled-etag', state: cancelledState}})
+    const heartbeatStop = vi.fn().mockResolvedValue({
+      success: true,
+      data: {runEtag: 'run-etag-after-heartbeat', lockEtag: 'lock-etag-after-heartbeat', runState: cancelledState},
+    })
+    mockRuntime.createHeartbeatController.mockReturnValue({
+      start: vi.fn(),
+      stop: heartbeatStop,
+      isRunning: false,
+    })
+    vi.mocked(attachModule.attachOpencode).mockReturnValue({
+      server: {url: 'http://workspace:9200'},
+      session: {create: vi.fn(), prompt: vi.fn()},
+    } as unknown as ReturnType<typeof attachModule.attachOpencode>)
+    vi.mocked(promptModule.buildDiscordPrompt).mockReturnValue('Repository: acme/widget\n\ndo the thing')
+
+    mockRunOpenCodeCoreAbortedBy(() => {
+      abortRegistry.abort(CANCEL_RUN_ID, 'operator cancel')
+    })
+
+    const observeFn = vi.fn().mockResolvedValue(undefined)
+    const releaseFn = vi.fn()
+    const request = makeInMemoryRequest()
+    ;(request as {runId?: string}).runId = CANCEL_RUN_ID
+    const deps = makeDeps({
+      runObserver: {observe: observeFn},
+      concurrency: {
+        tryAcquire: vi.fn().mockReturnValue('ok'),
+        release: releaseFn,
+        activeCount: vi.fn().mockReturnValue(1),
+        max: 3,
+      },
+    })
+
+    // #when
+    await awaitLaunchWorkRun(launchWork, request, deps)
+
+    // #then — settled CANCELLED, not FAILED
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).toContain('CANCELLED')
+    expect(transitionPhases).not.toContain('FAILED')
+
+    // #and — SSE observer notified with the CANCELLED state
+    const observedPhases = observeFn.mock.calls.map((c: unknown[]) => (c[0] as {phase?: string}).phase)
+    expect(observedPhases).toContain('CANCELLED')
+
+    // #and — lock released using the heartbeat-stop lockEtag
+    expect(mockRuntime.releaseLock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'lock-etag-after-heartbeat',
+      expect.anything(),
+    )
+
+    // #and — concurrency slot released
+    expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
+
+    // #and — no user-facing failure reply was sent to the thread
+    const sends = request._replySink._sends
+    expect(sends.some(s => s.content.toLowerCase().includes('failed'))).toBe(false)
+
+    // #and — registry entry deleted (a later abort() is now a no-op)
+    expect(abortRegistry.has(CANCEL_RUN_ID)).toBe(false)
+  })
+
+  it('timeout-vs-cancel race: classification uses registry probe, not composite abort reason', async () => {
+    // #given — a pure ceiling-timeout failure where the registry entry exists but was
+    // never aborted. The run must still land FAILED with timeout messaging.
+    const {launchWork} = await import('./run.js')
+    setupHappyPath()
+    mockRunOpenCodeCore.mockRejectedValue(new runCoreModule.RunCoreError('timeout', 'wall-clock timeout'))
+
+    const request = makeInMemoryRequest()
+    const TIMEOUT_RUN_ID = 'timeout-run-id-1'
+    ;(request as {runId?: string}).runId = TIMEOUT_RUN_ID
+    const deps = makeDeps()
+
+    // #when
+    await awaitLaunchWorkRun(launchWork, request, deps)
+
+    // #then — settled FAILED (registry was never aborted for this runId)
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).toContain('FAILED')
+    expect(transitionPhases).not.toContain('CANCELLED')
+
+    // #and — the coarse timeout message was sent (existing FAILED-path messaging)
+    const sends = request._replySink._sends
+    expect(sends.some(s => s.content.includes('time limit'))).toBe(true)
+
+    abortRegistry.delete(TIMEOUT_RUN_ID)
+  })
+
+  it('timeout-vs-cancel race: a cancel-flagged abort lands CANCELLED even with a timeout-kind RunCoreError', async () => {
+    // #given — the registry entry IS aborted (operator cancel won the race), even though
+    // run-core still surfaces a 'timeout' kind (it has no distinct 'cancelled' kind).
+    const {launchWork} = await import('./run.js')
+    setupHappyPath()
+
+    const RACE_RUN_ID = 'race-run-id-1'
+    mockRunOpenCodeCore.mockImplementation(async () => {
+      abortRegistry.abort(RACE_RUN_ID, 'operator cancel wins the race')
+      throw new runCoreModule.RunCoreError('timeout', 'combined signal aborted')
+    })
+
+    const request = makeInMemoryRequest()
+    ;(request as {runId?: string}).runId = RACE_RUN_ID
+    const deps = makeDeps()
+
+    // #when
+    await awaitLaunchWorkRun(launchWork, request, deps)
+
+    // #then — settled CANCELLED despite the 'timeout' RunCoreError kind
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).toContain('CANCELLED')
+    expect(transitionPhases).not.toContain('FAILED')
+
+    abortRegistry.delete(RACE_RUN_ID)
+  })
+
+  it('lock-release failure on the cancelled path — cleanup continues, no throw', async () => {
+    // #given — cancelled run whose lock release fails
+    const {launchWork} = await import('./run.js')
+    setupHappyPath()
+    mockRuntime.releaseLock.mockResolvedValue({success: false as const, error: new Error('release failed')})
+
+    const LOCK_FAIL_RUN_ID = 'lock-fail-run-id-1'
+    mockRunOpenCodeCore.mockImplementation(async () => {
+      abortRegistry.abort(LOCK_FAIL_RUN_ID, 'operator cancel')
+      throw new runCoreModule.RunCoreError('timeout', 'combined signal aborted')
+    })
+
+    const releaseFn = vi.fn()
+    const request = makeInMemoryRequest()
+    ;(request as {runId?: string}).runId = LOCK_FAIL_RUN_ID
+    const deps = makeDeps({
+      concurrency: {
+        tryAcquire: vi.fn().mockReturnValue('ok'),
+        release: releaseFn,
+        activeCount: vi.fn().mockReturnValue(1),
+        max: 3,
+      },
+    })
+
+    // #when — must not throw despite the lock-release failure
+    await expect(awaitLaunchWorkRun(launchWork, request, deps)).resolves.toBeDefined()
+
+    // #then — the run still settled CANCELLED and the concurrency slot was still released
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).toContain('CANCELLED')
+    expect(releaseFn).toHaveBeenCalledWith(CHANNEL_ID)
+
+    abortRegistry.delete(LOCK_FAIL_RUN_ID)
+  })
+
+  it('#1055 class: stream never settles after abort — run promise still resolves bounded, no unhandled rejection', async () => {
+    // #given — runOpenCodeCore that hangs unless it observes the abort, then rejects
+    // (mirrors run-core's makeAbortableStream: the abort signal races the hung iterator
+    // rather than waiting on it forever).
+    const {launchWork} = await import('./run.js')
+    setupHappyPath()
+
+    const NEVER_SETTLE_RUN_ID = 'never-settle-run-id-1'
+    mockRunOpenCodeCore.mockImplementation(async () => {
+      abortRegistry.abort(NEVER_SETTLE_RUN_ID, 'operator cancel')
+      // Simulate run-core's abort-aware race resolving promptly instead of hanging
+      // on a stream that never emits again.
+      throw new runCoreModule.RunCoreError('timeout', 'aborted while stream was hung')
+    })
+
+    const request = makeInMemoryRequest()
+    ;(request as {runId?: string}).runId = NEVER_SETTLE_RUN_ID
+    const deps = makeDeps()
+
+    // #when — the run promise must resolve (not hang, not reject) within this test's
+    // normal timeout budget
+    await expect(awaitLaunchWorkRun(launchWork, request, deps)).resolves.toBeDefined()
+
+    // #then — settled CANCELLED
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).toContain('CANCELLED')
+
+    abortRegistry.delete(NEVER_SETTLE_RUN_ID)
+  })
+
+  it('partial output flushed before cancel remains flushed after CANCELLED settles', async () => {
+    // #given — a reply sink that has visible/appended output before the abort fires
+    const {launchWork} = await import('./run.js')
+    setupHappyPath()
+
+    const PARTIAL_OUTPUT_RUN_ID = 'partial-output-run-id-1'
+    mockRunOpenCodeCore.mockImplementation(async () => {
+      abortRegistry.abort(PARTIAL_OUTPUT_RUN_ID, 'operator cancel')
+      throw new runCoreModule.RunCoreError('timeout', 'combined signal aborted')
+    })
+
+    const replySink = makeInMemoryReplySink()
+    replySink.append('partial output streamed before cancel')
+    const request = makeInMemoryRequest({replySink})
+    ;(request as {runId?: string}).runId = PARTIAL_OUTPUT_RUN_ID
+    const deps = makeDeps()
+
+    // #when
+    await awaitLaunchWorkRun(launchWork, request, deps)
+
+    // #then — flush was called on the cancel path (partial output preserved)
+    expect(replySink.flush).toHaveBeenCalled()
+    expect(replySink.buffered()).toBe('partial output streamed before cancel')
+
+    abortRegistry.delete(PARTIAL_OUTPUT_RUN_ID)
+  })
+
+  it('abort for an unknown/already-completed runId is a registry no-op — no signal fired, run unaffected', async () => {
+    // #given — a happy-path run whose registry entry is untouched; abort a DIFFERENT,
+    // never-registered runId concurrently
+    const {launchWork} = await import('./run.js')
+    setupHappyPath()
+
+    const HAPPY_RUN_ID = 'happy-run-id-1'
+    const request = makeInMemoryRequest()
+    ;(request as {runId?: string}).runId = HAPPY_RUN_ID
+    const deps = makeDeps()
+
+    // #when — abort an unrelated, unregistered runId; then run the happy-path task
+    const noopResult = abortRegistry.abort('never-registered-run-id')
+    await awaitLaunchWorkRun(launchWork, request, deps)
+
+    // #then — the unrelated abort was a no-op
+    expect(noopResult).toBe(false)
+    // #and — the happy-path run completed normally (COMPLETED, not CANCELLED)
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).toContain('COMPLETED')
+    expect(transitionPhases).not.toContain('CANCELLED')
+
+    abortRegistry.delete(HAPPY_RUN_ID)
+  })
+
+  it('cancel-wins-adoption race: PENDING→ACKNOWLEDGED 412s, re-read shows CANCELLED → no failAdmittedRun noise, no user-facing reply, clean exit', async () => {
+    // #given — the ACK transition fails (etag mismatch), and a re-read of the run-state
+    // shows CANCELLED (an operator cancel committed PENDING→CANCELLED first)
+    const {launchWork} = await import('./run.js')
+    const releaseFn = vi.fn()
+
+    mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'run-etag-v1'}})
+    mockRuntime.acquireLock.mockResolvedValue({
+      success: true as const,
+      data: {acquired: true as const, etag: 'lock-etag-v1', holder: null},
+    })
+    mockRuntime.releaseLock.mockResolvedValue({success: true as const, data: undefined})
+    // ACK transition 412s.
+    mockRuntime.transitionRun.mockResolvedValueOnce({
+      success: false as const,
+      error: new Error('412 precondition failed'),
+    })
+
+    const cancelledRunState = buildMockRunState({phase: 'CANCELLED'})
+    const getObjectMock = vi.fn().mockResolvedValue({
+      success: true as const,
+      data: {data: JSON.stringify(cancelledRunState), etag: 'cancelled-etag'},
+    })
+    const coordinationConfig = {
+      storeAdapter: {upload: vi.fn(), download: vi.fn(), list: vi.fn(), getObject: getObjectMock},
+      storeConfig: {enabled: true, bucket: 'test', region: 'us-east-1', prefix: 'state'},
+      lockTtlSeconds: 900,
+      heartbeatIntervalMs: 30_000,
+      staleThresholdMs: 60_000,
+      pendingStaleThresholdMs: 30 * 60_000,
+    } as unknown as CoordinationConfig
+
+    const request = makeInMemoryRequest()
+    const deps = makeDeps({
+      coordinationConfig,
+      concurrency: {
+        tryAcquire: vi.fn().mockReturnValue('ok'),
+        release: releaseFn,
+        activeCount: vi.fn().mockReturnValue(1),
+        max: 3,
+      },
+    })
+
+    // #when
+    await awaitLaunchWorkRun(launchWork, request, deps)
+
+    // #then — failAdmittedRun (a second FAILED transitionRun call) was never attempted
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).not.toContain('FAILED')
+
+    // #and — no user-facing "could not start" reply was sent
+    const sends = request._replySink._sends
+    expect(sends.some(s => s.content.includes('Could not start'))).toBe(false)
+
+    // #and — lock released, execution never attempted, clean exit
+    expect(mockRuntime.releaseLock).toHaveBeenCalled()
+    expect(mockRunOpenCodeCore).not.toHaveBeenCalled()
   })
 })

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -12,7 +12,15 @@ import type {LaunchAdmission, LaunchWorkRequest, PostReplyFactory, ReplySink, St
 import type {ChannelQueue} from './queue.js'
 import type {RunIndex} from './run-index.js'
 
-import {acquireLock, createHeartbeatController, createRun, releaseLock, transitionRun} from '@fro-bot/runtime'
+import {
+  acquireLock,
+  createHeartbeatController,
+  createRun,
+  getRunKey,
+  parseRunState,
+  releaseLock,
+  transitionRun,
+} from '@fro-bot/runtime'
 
 import {createPermissionCoordinator} from '../approvals/coordinator.js'
 import {createDiscordApprovalOnPending} from '../approvals/discord-transport.js'
@@ -20,6 +28,7 @@ import {sendMessage} from '../discord/io.js'
 import {setRunReaction} from '../discord/reactions.js'
 import {createStatusController} from '../discord/status-message.js'
 import {createDiscordStreamSink} from '../discord/streaming.js'
+import {abortRegistry} from './abort-registry.js'
 import {attachOpencode} from './opencode-attach.js'
 import {buildDiscordPrompt, EmptyPromptError} from './prompt.js'
 import {RunCoreError, runOpenCodeCore} from './run-core.js'
@@ -179,6 +188,53 @@ export function formatTimeoutDuration(ms: number): string {
 function toCoordLogger(logger: GatewayLogger): {debug: (message: string, context?: Record<string, unknown>) => void} {
   return {
     debug: (msg, ctx) => logger.debug(ctx ?? {}, msg),
+  }
+}
+
+/**
+ * Re-read the run-state's current phase.
+ *
+ * Used by the ACK/EXECUTING adoption-race graceful-loser path: when a
+ * `transitionRun` call 412s, this determines whether the run lost the race to
+ * an operator cancel (phase === 'CANCELLED') so the caller can skip
+ * `failAdmittedRun` (whose stale etag would 412 too, logging a misleading
+ * error) and exit cleanly instead. Returns `null` on any read/parse failure —
+ * callers fall back to the pre-existing failure-path behavior in that case.
+ */
+async function readCurrentRunPhase(
+  deps: RunMentionDeps,
+  repo: string,
+  runId: string,
+): Promise<RunState['phase'] | null> {
+  const {coordinationConfig, identity, logger} = deps
+  try {
+    const keyResult = getRunKey(coordinationConfig, identity, repo, runId)
+    if (keyResult.success === false) {
+      logger.warn({repo, runId, err: keyResult.error.message}, 'run: readCurrentRunPhase — could not build run key')
+      return null
+    }
+    const getObject = coordinationConfig.storeAdapter?.getObject
+    if (getObject == null) {
+      logger.warn({repo, runId}, 'run: readCurrentRunPhase — store adapter does not support getObject')
+      return null
+    }
+    const fetched = await getObject(keyResult.data)
+    if (fetched.success === false) {
+      logger.warn({repo, runId, err: fetched.error.message}, 'run: readCurrentRunPhase — getObject failed')
+      return null
+    }
+    const parsed = parseRunState(fetched.data.data)
+    if (parsed.success === false) {
+      logger.warn({repo, runId, err: parsed.error.message}, 'run: readCurrentRunPhase — parseRunState failed')
+      return null
+    }
+    return parsed.data.phase
+  } catch (error) {
+    logger.warn(
+      {repo, runId, err: error instanceof Error ? error.message : String(error)},
+      'run: readCurrentRunPhase threw — treating as not-CANCELLED',
+    )
+    return null
   }
 }
 
@@ -419,6 +475,17 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       {threadId},
     )
     if (ackResult.success === false) {
+      // ── Graceful loser: cancel-wins-adoption race ──────────────────────────────────
+      // The etag mismatch may mean an operator cancel committed PENDING → CANCELLED
+      // before this ACK transition. Re-read to distinguish that from a genuine failure:
+      // a stale-etag failAdmittedRun call would 412 anyway and log a misleading error.
+      const currentPhase = await readCurrentRunPhase(deps, repo, runId)
+      if (currentPhase === 'CANCELLED') {
+        logger.info({repo, runId}, 'run: ACK lost the adoption race to an operator cancel — exiting cleanly')
+        await releaseLock(coordinationConfig, repo, lockEtag, coordLogger)
+        return
+      }
+
       logger.error({repo, runId, err: ackResult.error.message}, 'run: transitionRun ACKNOWLEDGED failed')
       // Gate 5 (ACK fail): run is still PENDING; terminalize to FAILED using adoptionEtag.
       await failAdmittedRun(deps, repo, runId, task.adoptionEtag)
@@ -453,12 +520,38 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
         coordLogger,
       )
       if (execResult.success === false) {
+        // ── Graceful loser: cancel-wins-adoption race (ACKNOWLEDGED → EXECUTING) ──────
+        // Same rendezvous as the ACK case above: an operator cancel may have committed
+        // ACKNOWLEDGED → CANCELLED before this transition. Re-read before treating the
+        // etag mismatch as a genuine failure.
+        const currentPhase = await readCurrentRunPhase(deps, repo, runId)
+        if (currentPhase === 'CANCELLED') {
+          logger.info({repo, runId}, 'run: EXECUTING lost the adoption race to an operator cancel — exiting cleanly')
+          // Registration happens only after EXECUTING succeeds (below), so there is no
+          // abort-registry entry to delete here — the outer finally's unconditional
+          // delete() is still a safe no-op for this runId.
+          if (heartbeatStopped === false) {
+            await heartbeat.stop().catch(() => {
+              /* best-effort */
+            })
+            heartbeatStopped = true
+          }
+          return
+        }
         throw new Error(`transitionRun EXECUTING failed: ${execResult.error.message}`)
       }
       runEtag = execResult.data.etag
 
       // Push the EXECUTING state to the observation pipeline (best-effort, fire-and-forget).
       notifyObserverBestEffort(deps, execResult.data.state)
+
+      // ── Operator-cancel registration ──────────────────────────────────────────
+      // Registered only after EXECUTING commits — the pre-ACK/pre-EXECUTING window is
+      // covered by the run-state conditional-write rendezvous (see the ACK/EXECUTING
+      // etag-mismatch handling above and Unit 2's orchestrator), not by this registry.
+      // Always deleted in the outer finally below, regardless of settlement outcome.
+      // The returned signal is composed into effectiveSignal at the timeout seam below.
+      const cancelSignal = abortRegistry.register(runId)
 
       // ── Working reaction — best-effort, fire-and-forget ───────────────────────────────────────────────────────────────────
       statusSink.setReaction('working')
@@ -489,6 +582,12 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       const elapsedMs = Date.now() - runStartMs
       const remainingBudgetMs = Math.max(0, runTimeoutMs - elapsedMs)
       const timeoutSignal = AbortSignal.timeout(remainingBudgetMs)
+
+      // ── Cancel signal composition ───────────────────────────────────────────────
+      // The run's effective signal is any-of(ceiling timeout, operator cancel). No
+      // parallel abort mechanism: run-core's own internal AbortSignal.any (inactivity
+      // composition) nests cleanly on top of this — run-core's interface is unchanged.
+      const effectiveSignal = AbortSignal.any([timeoutSignal, cancelSignal])
 
       // ── Approval coordinator — per-run, wired to the program-scoped registry ──
       const approvalDeadlineMs = computeApprovalDeadlineMs(remainingBudgetMs)
@@ -591,7 +690,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
           directory: bindingWithEnsuredPath.workspacePath,
           promptText,
           sink: replySink,
-          signal: timeoutSignal,
+          signal: effectiveSignal,
           logger,
           coordinator,
           approvalMode,
@@ -677,109 +776,186 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       const isReachability = isCoreError && (execError.kind === 'unreachable' || execError.kind === 'auth')
       const isEmptyPrompt = execError instanceof EmptyPromptError
 
+      // ── Cancel classification — registry probe, NOT composite abort-reason inspection ──
+      // AbortSignal.any([timeoutSignal, cancelSignal]) propagates whichever child fired
+      // first; reading the composite signal's `.reason` to decide "was this a cancel" is
+      // racy. The registry's own controller state is ground truth (see abort-registry.ts).
+      const wasCancelled = abortRegistry.isAborted(runId)
+
       logger.error(
         {
           repo,
           runId,
           kind: isCoreError ? execError.kind : 'unknown',
+          cancelled: wasCancelled,
           err: execError instanceof Error ? execError.message : String(execError),
         },
-        'run: execution failed',
+        wasCancelled === true ? 'run: execution aborted by operator cancel' : 'run: execution failed',
       )
 
-      // ── Failed reaction — best-effort, fire-and-forget ────────────────────────────────────────
-      // Replaces the working/awaiting reaction with the failed cue.
-      statusSink.setReaction('failed')
+      if (wasCancelled === true) {
+        // ── Operator-cancel settlement path ──────────────────────────────────────────
+        // Distinct from the generic FAILED path below: settles CANCELLED, suppresses the
+        // user-facing failure reply (Unit 2's thread notice is the communication), and
+        // still flushes partial output.
 
-      // Stop heartbeat (best-effort) if not already stopped
-      if (heartbeatStopped === false) {
-        const stopResult = await heartbeat.stop()
-        heartbeatStopped = true
-        if (stopResult.success === true) {
-          runEtag = stopResult.data.runEtag
-          lockEtag = stopResult.data.lockEtag
-        } else {
-          logger.warn(
-            {repo, runId, err: stopResult.error.message},
-            'run: heartbeat stop failed; using last known etags',
-          )
+        // Replaces the working/awaiting reaction with the failed cue — no distinct
+        // "cancelled" reaction exists yet; reusing 'failed' here is a UX nit, not a
+        // correctness issue (the thread notice, added in Unit 2, carries the real signal).
+        statusSink.setReaction('failed')
+
+        // heartbeat.stop() FIRST — its runEtag/lockEtag are the authoritative
+        // conditional-write etags. A stale etag on the subsequent transitionRun/releaseLock
+        // calls makes those conditional writes silently 412 (releaseLock) or fail the
+        // transition; a 412'd lock release TTL-orphans the lock rather than failing loudly.
+        // This ordering discipline mirrors the COMPLETED/FAILED paths above.
+        if (heartbeatStopped === false) {
+          const stopResult = await heartbeat.stop()
+          heartbeatStopped = true
+          if (stopResult.success === true) {
+            runEtag = stopResult.data.runEtag
+            lockEtag = stopResult.data.lockEtag
+          } else {
+            logger.warn(
+              {repo, runId, err: stopResult.error.message},
+              'run: heartbeat stop failed on cancel path; using last known etags',
+            )
+          }
         }
-      }
 
-      // Transition to FAILED (best-effort)
-      const failedResult = await transitionRun(
-        coordinationConfig,
-        identity,
-        repo,
-        runId,
-        'FAILED',
-        runEtag,
-        coordLogger,
-      )
-      // Capture the FAILED state now so we can notify AFTER the partial-output flush.
-      // The notify is deferred to guarantee the web sink's flush() → final output frame
-      // is pushed before observe(terminalState) fans the terminal status frame (which
-      // closes run subscribers). For Discord, the reorder is inert.
-      let failedStateForNotify: RunState | undefined
-      if (failedResult.success === false) {
-        logger.error({repo, runId, err: failedResult.error.message}, 'run: transitionRun FAILED failed')
+        // Best-effort flush of partial output BEFORE the transition/observer notify —
+        // mirrors the existing failure-path ordering so the user's streamed output is
+        // never lost on cancel.
+        await replySink.flush().catch((flushError: unknown) => {
+          logger.warn({repo, runId, err: String(flushError)}, 'run: sink.flush failed in cancel path')
+        })
+
+        // Transition to CANCELLED (best-effort) with the fresh heartbeat-stop etag.
+        // Unit 2: `details.cancelledBy` attribution lands on this transition once the
+        // orchestrator threads actor context through the abort call.
+        const cancelledResult = await transitionRun(
+          coordinationConfig,
+          identity,
+          repo,
+          runId,
+          'CANCELLED',
+          runEtag,
+          coordLogger,
+        )
+        if (cancelledResult.success === false) {
+          logger.error({repo, runId, err: cancelledResult.error.message}, 'run: transitionRun CANCELLED failed')
+        } else {
+          notifyObserverBestEffort(deps, cancelledResult.data.state)
+        }
+
+        // Release lock with the heartbeat-stop lockEtag via the existing ownership-checked
+        // release path (outer finally, below) — no separate release call here; lockEtag
+        // was already updated above so the outer finally's releaseLock uses the fresh value.
+
+        // Suppress the user-facing failure reply for operator-initiated cancels — no
+        // "task failed" message to the thread. Unit 2 posts the cancellation notice.
+        // Log instead so the suppression is observable in gateway logs.
+        logger.info({repo, runId}, 'run: cancelled — suppressing user-facing failure reply')
       } else {
-        failedStateForNotify = failedResult.data.state
-      }
+        // ── Failed reaction — best-effort, fire-and-forget ────────────────────────────────────────
+        // Replaces the working/awaiting reaction with the failed cue.
+        statusSink.setReaction('failed')
 
-      // Flush partial output (best-effort) so the user sees whatever streamed before the failure.
-      // Wrapped in its own try/catch so a flush failure does not mask the original error.
-      await replySink.flush().catch((flushError: unknown) => {
-        logger.warn({repo, runId, err: String(flushError)}, 'run: sink.flush failed in error path')
-      })
+        // Stop heartbeat (best-effort) if not already stopped
+        if (heartbeatStopped === false) {
+          const stopResult = await heartbeat.stop()
+          heartbeatStopped = true
+          if (stopResult.success === true) {
+            runEtag = stopResult.data.runEtag
+            lockEtag = stopResult.data.lockEtag
+          } else {
+            logger.warn(
+              {repo, runId, err: stopResult.error.message},
+              'run: heartbeat stop failed; using last known etags',
+            )
+          }
+        }
 
-      // Push the FAILED state to the observation pipeline AFTER the partial-output flush.
-      // This guarantees the web sink's final output frame is delivered before the terminal
-      // status frame (which closes run subscribers). Best-effort, fire-and-forget.
-      if (failedStateForNotify !== undefined) {
-        notifyObserverBestEffort(deps, failedStateForNotify)
-      }
+        // Transition to FAILED (best-effort)
+        const failedResult = await transitionRun(
+          coordinationConfig,
+          identity,
+          repo,
+          runId,
+          'FAILED',
+          runEtag,
+          coordLogger,
+        )
+        // Capture the FAILED state now so we can notify AFTER the partial-output flush.
+        // The notify is deferred to guarantee the web sink's flush() → final output frame
+        // is pushed before observe(terminalState) fans the terminal status frame (which
+        // closes run subscribers). For Discord, the reorder is inert.
+        let failedStateForNotify: RunState | undefined
+        if (failedResult.success === false) {
+          logger.error({repo, runId, err: failedResult.error.message}, 'run: transitionRun FAILED failed')
+        } else {
+          failedStateForNotify = failedResult.data.state
+        }
 
-      // Coarse user message — no internal detail
-      const timeoutDuration = formatTimeoutDuration(runTimeoutMs)
-      const inactivityDuration = formatTimeoutDuration(runInactivityTimeoutMs)
-      const hasVisibleOutput = replySink.hasVisibleOutput() === true
-      const userMessage =
-        isTimeout === true
-          ? hasVisibleOutput === true
-            ? `The task reached the ${timeoutDuration} time limit after posting updates above. Start a new @fro-bot request with what to do next and include any needed context from the output above.`
-            : `The task reached the ${timeoutDuration} time limit. Please try again.`
-          : isInactivityTimeout === true
+        // Flush partial output (best-effort) so the user sees whatever streamed before the failure.
+        // Wrapped in its own try/catch so a flush failure does not mask the original error.
+        await replySink.flush().catch((flushError: unknown) => {
+          logger.warn({repo, runId, err: String(flushError)}, 'run: sink.flush failed in error path')
+        })
+
+        // Push the FAILED state to the observation pipeline AFTER the partial-output flush.
+        // This guarantees the web sink's final output frame is delivered before the terminal
+        // status frame (which closes run subscribers). Best-effort, fire-and-forget.
+        if (failedStateForNotify !== undefined) {
+          notifyObserverBestEffort(deps, failedStateForNotify)
+        }
+
+        // Coarse user message — no internal detail
+        const timeoutDuration = formatTimeoutDuration(runTimeoutMs)
+        const inactivityDuration = formatTimeoutDuration(runInactivityTimeoutMs)
+        const hasVisibleOutput = replySink.hasVisibleOutput() === true
+        const userMessage =
+          isTimeout === true
             ? hasVisibleOutput === true
-              ? `The task stopped producing output for ${inactivityDuration} after posting updates above. Start a new @fro-bot request with what to do next and include any needed context from the output above.`
-              : `The task stopped producing output for ${inactivityDuration}. Please try again.`
-            : isReachability === true
-              ? 'The workspace is not reachable right now. Please try again later.'
-              : isEmptyPrompt === true
-                ? 'Nothing to do — please include a task in your message.'
-                : isStreamEnded === true
-                  ? 'The task stream closed unexpectedly. Please try again.'
-                  : 'The task failed. Please try again.'
+              ? `The task reached the ${timeoutDuration} time limit after posting updates above. Start a new @fro-bot request with what to do next and include any needed context from the output above.`
+              : `The task reached the ${timeoutDuration} time limit. Please try again.`
+            : isInactivityTimeout === true
+              ? hasVisibleOutput === true
+                ? `The task stopped producing output for ${inactivityDuration} after posting updates above. Start a new @fro-bot request with what to do next and include any needed context from the output above.`
+                : `The task stopped producing output for ${inactivityDuration}. Please try again.`
+              : isReachability === true
+                ? 'The workspace is not reachable right now. Please try again later.'
+                : isEmptyPrompt === true
+                  ? 'Nothing to do — please include a task in your message.'
+                  : isStreamEnded === true
+                    ? 'The task stream closed unexpectedly. Please try again.'
+                    : 'The task failed. Please try again.'
 
-      // ── Status controller failure transition ──────────────────────────────────────────────────
-      // resolveToFailure returns:
-      //   'handled'   → controller edited the status message into the failure note; skip sendMessage.
-      //   'delegated' → no status to edit (or typing-only); post via sendMessage as normal.
-      // Never both — single owner for the failure message.
-      const failureResult = await statusSink.resolveToFailure(userMessage).catch((error: unknown) => {
-        logger.warn({repo, runId, err: String(error)}, 'run: statusController.resolveToFailure failed — delegating')
-        return {transition: 'delegated' as const}
-      })
-      if (failureResult.transition === 'delegated') {
-        const failureSendResult = await replySink.send('thread', {content: userMessage})
-        if (failureSendResult !== undefined) {
-          const result = failureSendResult as {success?: boolean; error?: {message: string}}
-          if (result.success === false && result.error !== undefined) {
-            logger.warn({repo, runId, err: result.error.message}, 'run: failed to send error reply to thread')
+        // ── Status controller failure transition ──────────────────────────────────────────────────
+        // resolveToFailure returns:
+        //   'handled'   → controller edited the status message into the failure note; skip sendMessage.
+        //   'delegated' → no status to edit (or typing-only); post via sendMessage as normal.
+        // Never both — single owner for the failure message.
+        const failureResult = await statusSink.resolveToFailure(userMessage).catch((error: unknown) => {
+          logger.warn({repo, runId, err: String(error)}, 'run: statusController.resolveToFailure failed — delegating')
+          return {transition: 'delegated' as const}
+        })
+        if (failureResult.transition === 'delegated') {
+          const failureSendResult = await replySink.send('thread', {content: userMessage})
+          if (failureSendResult !== undefined) {
+            const result = failureSendResult as {success?: boolean; error?: {message: string}}
+            if (result.success === false && result.error !== undefined) {
+              logger.warn({repo, runId, err: result.error.message}, 'run: failed to send error reply to thread')
+            }
           }
         }
       }
     } finally {
+      // Delete the abort-registry entry unconditionally — the run is settling one way or
+      // another (COMPLETED/FAILED/CANCELLED). Prevents leaking registry entries; a stray
+      // abort() call after this point becomes the documented unknown-runId no-op.
+      abortRegistry.delete(runId)
+
       // Stop heartbeat if not yet stopped (defensive — should not normally happen)
       if (heartbeatStopped === false) {
         await heartbeat.stop().catch(() => {

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -831,8 +831,14 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
         })
 
         // Transition to CANCELLED (best-effort) with the fresh heartbeat-stop etag.
-        // Unit 2: `details.cancelledBy` attribution lands on this transition once the
-        // orchestrator threads actor context through the abort call.
+        // Attribution: the abort-registry entry may carry `cancelledBy` metadata,
+        // written by `cancelRun` (Unit 2) alongside its `abort()` call. This is the
+        // single writer of the CANCELLED transition, so reading it back here (rather
+        // than a follow-up write from the orchestrator) keeps attribution atomic with
+        // the phase write and avoids a second etag round-trip.
+        const cancelledByMetadata = abortRegistry.getMetadata(runId)
+        const cancelledOptions =
+          cancelledByMetadata === undefined ? undefined : {detailsPatch: {cancelledBy: cancelledByMetadata}}
         const cancelledResult = await transitionRun(
           coordinationConfig,
           identity,
@@ -841,6 +847,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
           'CANCELLED',
           runEtag,
           coordLogger,
+          cancelledOptions,
         )
         if (cancelledResult.success === false) {
           logger.error({repo, runId, err: cancelledResult.error.message}, 'run: transitionRun CANCELLED failed')

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -185,7 +185,9 @@ export function formatTimeoutDuration(ms: number): string {
 }
 
 /** Narrow logger adapter for runtime coordination functions. */
-function toCoordLogger(logger: GatewayLogger): {debug: (message: string, context?: Record<string, unknown>) => void} {
+export function toCoordLogger(logger: GatewayLogger): {
+  debug: (message: string, context?: Record<string, unknown>) => void
+} {
   return {
     debug: (msg, ctx) => logger.debug(ctx ?? {}, msg),
   }
@@ -851,6 +853,29 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
         )
         if (cancelledResult.success === false) {
           logger.error({repo, runId, err: cancelledResult.error.message}, 'run: transitionRun CANCELLED failed')
+
+          // Fallback: leaving the run non-terminal (EXECUTING) with the lock about to be
+          // released by the outer finally is an inconsistent state until the next recovery
+          // sweep. Attempt a best-effort FAILED terminalization with the same etag (FAILED
+          // is a valid transition from EXECUTING) rather than leaving this to recovery alone.
+          const failedFallbackResult = await transitionRun(
+            coordinationConfig,
+            identity,
+            repo,
+            runId,
+            'FAILED',
+            runEtag,
+            coordLogger,
+          )
+          if (failedFallbackResult.success === false) {
+            logger.error(
+              {repo, runId, err: failedFallbackResult.error.message},
+              'run: FAILED fallback after CANCELLED transition failure also failed — leaving for recovery sweep',
+            )
+          } else {
+            logger.warn({repo, runId}, 'run: CANCELLED transition failed — fell back to FAILED terminalization')
+            notifyObserverBestEffort(deps, failedFallbackResult.data.state)
+          }
         } else {
           notifyObserverBestEffort(deps, cancelledResult.data.state)
         }

--- a/packages/gateway/src/http/ingress-pin.test.ts
+++ b/packages/gateway/src/http/ingress-pin.test.ts
@@ -123,6 +123,7 @@ const EXPECTED_OPERATOR_ROUTES_WITH_BROWSER_GUARD: readonly {method: string; pat
   {method: 'GET', path: '/operator/runs'},
   {method: 'POST', path: '/operator/runs'},
   {method: 'POST', path: '/operator/runs/:runId/approvals/:requestId/decision'},
+  {method: 'POST', path: '/operator/runs/:runId/cancel'},
   {method: 'GET', path: '/operator/runs/:runId/approvals'},
 ]
 
@@ -278,6 +279,8 @@ function makeBrowserGuardStubDeps(): OperatorServerDeps {
       ensureClone: vi.fn(async () => ({success: true as const, data: '/workspace'})),
       readyz: vi.fn(async () => ({success: true as const, data: {ready: true as const, opencode: 'ready' as const}})),
     },
+    // Provide cancelRunDeps so the cancel route is registered in the pinned inventory.
+    cancelRunDeps: {} as unknown as OperatorServerDeps['cancelRunDeps'],
   }
 }
 

--- a/packages/gateway/src/http/ingress-pin.test.ts
+++ b/packages/gateway/src/http/ingress-pin.test.ts
@@ -250,6 +250,7 @@ function makeBrowserGuardStubDeps(): OperatorServerDeps {
         takeNext: vi.fn(() => undefined),
         pendingCount: vi.fn(() => 0),
         clear: vi.fn(() => 0),
+        removeBy: vi.fn(() => undefined),
       },
       attachUrl: 'http://localhost:3000',
       attachToken: 'stub-token',

--- a/packages/gateway/src/operator-contract/index.ts
+++ b/packages/gateway/src/operator-contract/index.ts
@@ -20,12 +20,24 @@ export type {DecisionInput, OperatorDecisionState, PermissionReply} from './appr
 export {toOperatorDecisionState} from './approval.js'
 export type {OperatorIdentity} from './identity.js'
 export type {OperatorOutputFrame} from './output.js'
-export {parseOperatorCsrfToken, parseOperatorError, parseOperatorOk, parseOperatorSessionInfo} from './parse.js'
+export {
+  parseOperatorCancelResponse,
+  parseOperatorCsrfToken,
+  parseOperatorError,
+  parseOperatorOk,
+  parseOperatorSessionInfo,
+} from './parse.js'
 export {assertRedactionApplied, AUTHORIZATION_OBLIGATION, REDACTION_OBLIGATION} from './redaction.js'
 export type {RedactionContext} from './redaction.js'
 export type {RepoSummary} from './repo-summary.js'
 export {toRepoSummary} from './repo-summary.js'
-export type {OperatorCsrfToken, OperatorError, OperatorOk, OperatorSessionInfo} from './responses.js'
+export type {
+  OperatorCancelResponse,
+  OperatorCsrfToken,
+  OperatorError,
+  OperatorOk,
+  OperatorSessionInfo,
+} from './responses.js'
 export type {OperatorRunStatus, OperatorWebStatus, RunPhase, RunStatusRepoKey, Surface} from './run-status.js'
 export {toOperatorRunStatus} from './run-status.js'
 export type {RunSummary, RunSummaryStatus} from './run-summary.js'

--- a/packages/gateway/src/operator-contract/parse.ts
+++ b/packages/gateway/src/operator-contract/parse.ts
@@ -16,7 +16,13 @@
  */
 
 import type {Result} from '@fro-bot/runtime'
-import type {OperatorCsrfToken, OperatorError, OperatorOk, OperatorSessionInfo} from './responses.js'
+import type {
+  OperatorCancelResponse,
+  OperatorCsrfToken,
+  OperatorError,
+  OperatorOk,
+  OperatorSessionInfo,
+} from './responses.js'
 
 import {err, ok} from '@fro-bot/runtime'
 
@@ -133,6 +139,41 @@ function hasValidOperatorErrorShape(value: unknown): value is OperatorError {
 export function parseOperatorError(input: unknown): Result<OperatorError, Error> {
   if (hasValidOperatorErrorShape(input) === false) {
     return err(new Error('invalid operator error shape'))
+  }
+
+  return ok(input)
+}
+
+// ---------------------------------------------------------------------------
+// OperatorCancelResponse
+// ---------------------------------------------------------------------------
+
+const VALID_CANCEL_PHASES: ReadonlySet<string> = new Set(['CANCELLED', 'COMPLETED', 'FAILED'])
+
+function hasValidOperatorCancelResponseShape(value: unknown): value is OperatorCancelResponse {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const candidate = value as Record<string, unknown>
+  return (
+    candidate.ok === true &&
+    typeof candidate.runId === 'string' &&
+    typeof candidate.phase === 'string' &&
+    VALID_CANCEL_PHASES.has(candidate.phase)
+  )
+}
+
+/**
+ * Parse an unknown value as OperatorCancelResponse.
+ *
+ * Returns ok(value) when the input has the required shape.
+ * Returns err(Error) with a FIXED reason string when validation fails —
+ * the error message never echoes any part of the input.
+ */
+export function parseOperatorCancelResponse(input: unknown): Result<OperatorCancelResponse, Error> {
+  if (hasValidOperatorCancelResponseShape(input) === false) {
+    return err(new Error('invalid operator cancel response shape'))
   }
 
   return ok(input)

--- a/packages/gateway/src/operator-contract/responses.ts
+++ b/packages/gateway/src/operator-contract/responses.ts
@@ -10,6 +10,8 @@
  * - camelCase keys match the shipped JSON literals exactly.
  */
 
+import type {TerminalPhase} from '@fro-bot/runtime'
+
 /**
  * Canonical response shape for GET /operator/session.
  *
@@ -69,5 +71,5 @@ export interface OperatorError {
 export interface OperatorCancelResponse {
   readonly ok: true
   readonly runId: string
-  readonly phase: 'CANCELLED' | 'COMPLETED' | 'FAILED'
+  readonly phase: TerminalPhase
 }

--- a/packages/gateway/src/operator-contract/responses.ts
+++ b/packages/gateway/src/operator-contract/responses.ts
@@ -54,3 +54,20 @@ export interface OperatorOk {
 export interface OperatorError {
   readonly error: string
 }
+
+/**
+ * Canonical success response shape for POST /operator/runs/:runId/cancel.
+ *
+ * Carries the resulting phase so the dashboard can render honestly whether the
+ * cancel actually transitioned the run ('CANCELLED') or the run was already
+ * terminal (the pre-existing terminal phase — an idempotent no-op, still a
+ * 200, never an error). `runId` echoes the path param for client convenience.
+ *
+ * Internal attribution (`details.cancelledBy`) and coordination fields
+ * (`thread_id`, etc.) are excluded by construction — they never appear here.
+ */
+export interface OperatorCancelResponse {
+  readonly ok: true
+  readonly runId: string
+  readonly phase: 'CANCELLED' | 'COMPLETED' | 'FAILED'
+}

--- a/packages/gateway/src/operator-contract/version.test.ts
+++ b/packages/gateway/src/operator-contract/version.test.ts
@@ -2,11 +2,11 @@ import {describe, expect, it} from 'vitest'
 import {OPERATOR_CONTRACT_VERSION} from './version.js'
 
 describe('OPERATOR_CONTRACT_VERSION', () => {
-  it('is pinned to 1.5.0', () => {
+  it('is pinned to 1.6.0', () => {
     // #given the contract version constant
     // #when read at import time
     // #then it is exactly the pinned literal
-    expect(OPERATOR_CONTRACT_VERSION).toBe('1.5.0')
+    expect(OPERATOR_CONTRACT_VERSION).toBe('1.6.0')
   })
 
   it('is importable from the contract barrel', async () => {

--- a/packages/gateway/src/operator-contract/version.ts
+++ b/packages/gateway/src/operator-contract/version.ts
@@ -12,4 +12,4 @@
 // Security constraint: the version is BUILD-TIME pinned and is never supplied or
 // negotiated over the wire. Any endpoint reading a version header must reject
 // unrecognized versions fail-closed.
-export const OPERATOR_CONTRACT_VERSION = '1.5.0'
+export const OPERATOR_CONTRACT_VERSION = '1.6.0'

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -23,6 +23,7 @@ import {Effect} from 'effect'
 import {createApprovalRegistry} from './approvals/registry.js'
 import {createBindingsStore} from './bindings/store.js'
 import {parseApprovalCustomId} from './discord/approvals.js'
+import {createCancelNoticeDispatcher} from './discord/cancel-notice.js'
 import {createDiscordClient, withLogContext} from './discord/client.js'
 import {dispatchCommand, getCommandRegistry, registerSlashCommands} from './discord/commands/index.js'
 import {editInteractionAsync} from './discord/io.js'
@@ -687,7 +688,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           queue: channelQueue,
           abortRegistry,
           approvalRegistry,
-          discordClient: client,
+          postCancelNotice: createCancelNoticeDispatcher(client, logger),
           runObserver: runObservationManager,
         },
         launchWorkDeps: runEngineDeps,

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -27,6 +27,7 @@ import {createDiscordClient, withLogContext} from './discord/client.js'
 import {dispatchCommand, getCommandRegistry, registerSlashCommands} from './discord/commands/index.js'
 import {editInteractionAsync} from './discord/io.js'
 import {handleMention, userIsAuthorized} from './discord/mentions.js'
+import {abortRegistry} from './execute/abort-registry.js'
 import {createConcurrencyRegistry} from './execute/concurrency.js'
 import {createChannelQueue, DEFAULT_MAX_QUEUE_DEPTH} from './execute/queue.js'
 import {recoverStaleRuns} from './execute/recovery.js'
@@ -140,6 +141,12 @@ export interface BuildOperatorServerInputs {
    */
   readonly approvalRegistry?: NonNullable<OperatorServerDeps['approvalRegistry']>
   /**
+   * Cancel-run engine dependencies for the cancel route's `cancelRun` orchestrator call.
+   * Optional — omit (or pass undefined) to simulate a missing dep in tests,
+   * which causes POST /operator/runs/:runId/cancel to be absent from app.routes.
+   */
+  readonly cancelRunDeps?: NonNullable<OperatorServerDeps['cancelRunDeps']>
+  /**
    * Engine dependencies for the launch route's launchWork call.
    * Required for POST /operator/runs to be registered — the route gate checks
    * deps.launchWorkDeps !== undefined. Pass runEngineDeps from the program scope.
@@ -189,6 +196,7 @@ export function buildOperatorServerInputs(inputs: BuildOperatorServerInputs): {
     runObservationManager,
     runIndex,
     approvalRegistry,
+    cancelRunDeps,
     launchWorkDeps,
     operatorWebConfig,
   } = inputs
@@ -258,6 +266,7 @@ export function buildOperatorServerInputs(inputs: BuildOperatorServerInputs): {
     runObservationManager,
     runIndex,
     approvalRegistry,
+    cancelRunDeps,
   }
 
   const config: OperatorServerConfig = {
@@ -671,6 +680,16 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
         runObservationManager,
         runIndex,
         approvalRegistry,
+        cancelRunDeps: {
+          coordinationConfig: makeCoordinationConfig(s3Adapter, config),
+          identity: config.identity,
+          runIndex,
+          queue: channelQueue,
+          abortRegistry,
+          approvalRegistry,
+          discordClient: client,
+          runObserver: runObservationManager,
+        },
         launchWorkDeps: runEngineDeps,
         operatorWebConfig: config.operatorWeb,
       })

--- a/packages/gateway/src/web/audit.ts
+++ b/packages/gateway/src/web/audit.ts
@@ -36,6 +36,9 @@ export type LaunchRejectedReason = 'binding_not_found' | 'concurrency_cap' | 'au
 /** Safe reasons for approval rejection. */
 export type ApprovalRejectedReason = 'already_claimed' | 'not_found' | 'deadline_expired' | 'scope_mismatch' | 'unknown'
 
+/** Safe reasons for cancel-request rejection (pre-acceptance denial). */
+export type CancelRejectedReason = 'not_found' | 'authz_denied' | 'unknown'
+
 /** Safe reasons for bearer token rejection. */
 export type BearerRejectedReason = 'missing_token' | 'invalid_signature' | 'expired' | 'unknown'
 
@@ -141,6 +144,27 @@ export interface ApprovalRejectedEvent {
   readonly reason: ApprovalRejectedReason
 }
 
+/**
+ * Operator cancel request accepted and processed (regardless of outcome —
+ * 'cancelled' or the idempotent 'already-terminal' hit). The resulting phase
+ * is carried so the audit trail records what actually happened.
+ */
+export interface RunCancelRequestedEvent {
+  readonly kind: 'run.cancel.requested'
+  readonly correlationId: string
+  readonly githubUserId: number
+  readonly runId: string
+  readonly phase: 'CANCELLED' | 'COMPLETED' | 'FAILED'
+}
+
+/** Operator cancel request denied at a pre-acceptance gate (no state change). */
+export interface RunCancelRejectedEvent {
+  readonly kind: 'run.cancel.rejected'
+  readonly correlationId: string
+  readonly githubUserId: number
+  readonly reason: CancelRejectedReason
+}
+
 /** Operator read a repo binding. */
 export interface BindingReadEvent {
   readonly kind: 'binding.read'
@@ -186,6 +210,8 @@ export type AuditEvent =
   | BindingReadEvent
   | BearerRejectedEvent
   | BrowserGuardRejectedEvent
+  | RunCancelRequestedEvent
+  | RunCancelRejectedEvent
 
 // ---------------------------------------------------------------------------
 // Redaction
@@ -256,6 +282,8 @@ const LOG_LEVEL: Record<Exclude<AuditEvent['kind'], 'approval.rejected'>, 'info'
   'binding.read': 'info',
   'bearer.rejected': 'warn',
   'browser.guard.rejected': 'warn',
+  'run.cancel.requested': 'info',
+  'run.cancel.rejected': 'warn',
 }
 
 /**
@@ -308,6 +336,9 @@ export function emitAudit(event: AuditEvent, logger: AuditLogger): void {
     case 'approval.rejected':
       ctx.requestId = redactIfSensitive(event.requestId)
       break
+    case 'run.cancel.requested':
+      ctx.runId = redactIfSensitive(event.runId)
+      break
     case 'auth.start':
     case 'auth.callback.failure':
     case 'auth.logout':
@@ -316,6 +347,7 @@ export function emitAudit(event: AuditEvent, logger: AuditLogger): void {
     case 'launch.rejected':
     case 'bearer.rejected':
     case 'browser.guard.rejected':
+    case 'run.cancel.rejected':
       // No additional caller-controlled string fields on these variants.
       break
     default:

--- a/packages/gateway/src/web/operator-route-smoke.ts
+++ b/packages/gateway/src/web/operator-route-smoke.ts
@@ -50,6 +50,7 @@ export const EXPECTED_OPERATOR_ROUTES: readonly {readonly method: string; readon
   {method: 'GET', path: '/operator/runs/:runId/stream'},
   {method: 'POST', path: '/operator/runs/:runId/approvals/:requestId/decision'},
   {method: 'GET', path: '/operator/runs/:runId/approvals'},
+  {method: 'POST', path: '/operator/runs/:runId/cancel'},
 ]
 
 // ---------------------------------------------------------------------------
@@ -107,6 +108,12 @@ function makeStubApprovalRegistry() {
   }
 }
 
+function makeStubCancelRunDeps() {
+  // Registration only checks `deps.cancelRunDeps !== undefined`; the actual
+  // shape is not inspected at construction time.
+  return {} as NonNullable<Parameters<typeof buildOperatorApp>[0]['cancelRunDeps']>
+}
+
 function makeStubLaunchWorkDeps() {
   // Registration only checks `deps.launchWorkDeps !== undefined`; the actual
   // shape is not inspected at construction time.
@@ -130,8 +137,7 @@ export interface OperatorRouteSmokeOptions {
    * undefined here flows through the helper and causes the run-stream route to be absent.
    */
   readonly runObservationManagerOverride?:
-    | Parameters<typeof buildOperatorServerInputs>[0]['runObservationManager']
-    | undefined
+    Parameters<typeof buildOperatorServerInputs>[0]['runObservationManager'] | undefined
   /**
    * Override the launchWorkDeps passed to buildOperatorServerInputs.
    * Used in regression-guard tests to simulate a missing launch dep (POST /operator/runs absent).
@@ -152,6 +158,13 @@ export interface OperatorRouteSmokeOptions {
    * flows through the helper and causes the runs listing route to be absent.
    */
   readonly runIndexOverride?: Parameters<typeof buildOperatorServerInputs>[0]['runIndex'] | undefined
+  /**
+   * Override the cancelRunDeps passed to buildOperatorServerInputs.
+   * Pass undefined to simulate a missing cancel-run dep (cancel route absent).
+   * Because cancelRunDeps is optional in BuildOperatorServerInputs, passing
+   * undefined here flows through the helper and causes the cancel route to be absent.
+   */
+  readonly cancelRunDepsOverride?: Parameters<typeof buildOperatorServerInputs>[0]['cancelRunDeps'] | undefined
   /**
    * Whether to suppress log output. Defaults to false (logs to stdout).
    */
@@ -237,6 +250,13 @@ export async function runOperatorRouteSmoke(options?: OperatorRouteSmokeOptions)
   const hasRunIndexOverride = options !== undefined && 'runIndexOverride' in options
   const runIndex = hasRunIndexOverride ? options.runIndexOverride : makeStubRunIndex()
 
+  // Resolve cancelRunDeps — use the override if provided, else the default stub.
+  // When the override is explicitly undefined, POST /operator/runs/:runId/cancel
+  // will not register because buildOperatorServerInputs passes it through to
+  // deps.cancelRunDeps, and server.ts gates the cancel route on that dep being present.
+  const hasCancelRunDepsOverride = options !== undefined && 'cancelRunDepsOverride' in options
+  const cancelRunDeps = hasCancelRunDepsOverride ? options.cancelRunDepsOverride : makeStubCancelRunDeps()
+
   // Build the operator server inputs via the shared production helper.
   // This is the seam that makes the diagnostic catch wiring gaps: if a dep is
   // dropped from buildOperatorServerInputs, both production and this diagnostic
@@ -256,6 +276,10 @@ export async function runOperatorRouteSmoke(options?: OperatorRouteSmokeOptions)
     // sees the same value as production. When undefined (regression test), the
     // helper passes undefined to deps.approvalRegistry and the approval routes are absent.
     approvalRegistry,
+    // cancelRunDeps flows through the helper so the route gate in server.ts
+    // sees the same value as production. When undefined (regression test), the
+    // helper passes undefined to deps.cancelRunDeps and the cancel route is absent.
+    cancelRunDeps,
     // launchWorkDeps flows through the helper so the route gate in server.ts
     // sees the same value as production. When undefined (regression test), the
     // helper passes undefined to deps.launchWorkDeps and POST /operator/runs is absent.

--- a/packages/gateway/src/web/operator/cancel-route.test.ts
+++ b/packages/gateway/src/web/operator/cancel-route.test.ts
@@ -379,6 +379,7 @@ describe('POST cancel — CancelOutcome mapping', () => {
     expect(response.status).toBe(503)
     const body = (await response.json()) as {error: string}
     expect(body.error).toBe('unavailable')
+    expect(response.headers.get('Retry-After')).toBe('2')
   })
 })
 

--- a/packages/gateway/src/web/operator/cancel-route.test.ts
+++ b/packages/gateway/src/web/operator/cancel-route.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Tests for the authenticated cancel route: POST /operator/runs/:runId/cancel
+ *
+ * All tests go through the REAL HTTP route (with auth guard, denylist, middleware)
+ * — not a direct cancelRun call. The execute/cancel.js module is mocked so route
+ * tests don't need real S3/registry/queue instances; cancel.ts's own orchestrator
+ * behavior is covered by cancel.test.ts.
+ *
+ * Load-bearing tests:
+ *   1. Happy path: authorized operator cancels own-repo run → 200 with phase.
+ *   2. NO-ORACLE DENIAL: every pre-acceptance gate failure returns the identical
+ *      notFoundResponse shape, with zero cancelRun invocation.
+ *   3. IDEMPOTENT: already-terminal outcome → 200 carrying the terminal phase.
+ *   4. NOT-FOUND: cancelRun's own not-found outcome → notFoundResponse.
+ *   5. RETRY: rendezvous-exhausted outcome → coarse transient response.
+ *   6. RATE LIMIT: exceeded → limited; unauthorized requests don't consume budget.
+ *   7. DTO: response never carries cancelledBy/thread_id.
+ */
+
+import type {CancelOutcome} from '../../execute/cancel.js'
+import type {RunLocation} from '../../execute/run-index.js'
+import type {RepoKey} from '../../redaction/denylist.js'
+import type {AuditLogger} from '../audit.js'
+import type {RepoAuthzDeps} from '../auth/repo-authz.js'
+import type {CancelRouteDeps} from './cancel-route.js'
+import {Hono} from 'hono'
+import {describe, expect, it, vi} from 'vitest'
+import {setOperatorRouteGuard} from '../operator-route.js'
+import {buildCancelRoute} from './cancel-route.js'
+
+// ---------------------------------------------------------------------------
+// Mock execute/cancel.js — route tests exercise gate wiring, not orchestrator logic.
+// ---------------------------------------------------------------------------
+
+const {cancelRunMock} = vi.hoisted(() => ({cancelRunMock: vi.fn()}))
+
+vi.mock('../../execute/cancel.js', () => ({
+  cancelRun: cancelRunMock,
+}))
+
+// ---------------------------------------------------------------------------
+// Stub factories (mirrors decision-route.test.ts)
+// ---------------------------------------------------------------------------
+
+function makeSessionStore(overrides?: {
+  getOperatorToken?: (sessionId: string, nowMs: number) => string | undefined
+  get?: (
+    sessionId: string,
+    nowMs: number,
+  ) =>
+    | {
+        readonly githubUserId: number
+        readonly login: string
+        readonly issuedAt: number
+        readonly lastAccessedAt: number
+        readonly revoked: boolean
+      }
+    | undefined
+}): CancelRouteDeps['sessionStore'] {
+  return {
+    getOperatorToken: vi.fn((_sessionId: string, _nowMs: number) => 'oauth-token-stub'),
+    get: vi.fn((_sessionId: string, _nowMs: number) => ({
+      githubUserId: 1001,
+      login: 'alice',
+      issuedAt: 0,
+      lastAccessedAt: 0,
+      revoked: false,
+    })),
+    ...overrides,
+  }
+}
+
+function makeRunIndex(location?: RunLocation): CancelRouteDeps['runIndex'] {
+  return {
+    lookup: vi.fn(async (_runId: string) => location ?? {repo: 'acme/widget', surface: 'web' as const}),
+  }
+}
+
+function makeDenylistCache(denied = false): CancelRouteDeps['denylistCache'] {
+  return {
+    getDenylistState: vi.fn(async () => undefined),
+    isRepoDenied: vi.fn((_keys: RepoKey) => denied),
+  }
+}
+
+function makeBindingsLookup(): CancelRouteDeps['bindingsLookup'] {
+  return {
+    getBindingByRepo: vi.fn(async (_owner: string, _repo: string) => ({
+      success: true as const,
+      data: {
+        owner: 'acme',
+        repo: 'widget',
+        channelId: 'ch-123',
+        channelName: 'widget-dev',
+        workspacePath: '/workspace/acme/widget',
+        createdAt: '2026-01-01T00:00:00Z',
+        createdByDiscordId: 'discord-user-1',
+        databaseId: 42,
+        nodeId: 'R_node_42',
+      },
+    })),
+  }
+}
+
+function makeWriteRepoAuthzDeps(): RepoAuthzDeps {
+  return {
+    allowlist: {isAuthorized: vi.fn(() => true), size: 1},
+    fetch: vi.fn(
+      async () =>
+        new Response(JSON.stringify({permissions: {push: true, admin: false}}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+    ),
+    clock: () => 0,
+    random: () => 0.5,
+    auditLogger: {info: vi.fn(), warn: vi.fn()},
+    logger: {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()},
+    cache: {
+      get: vi.fn(() => undefined),
+      set: vi.fn(),
+      getInFlight: vi.fn(() => undefined),
+      setInFlight: vi.fn(),
+      deleteInFlight: vi.fn(),
+      tokenIdentityFor: vi.fn(() => 'stub-token-identity'),
+    },
+  }
+}
+
+function makeReadOnlyRepoAuthzDeps(): RepoAuthzDeps {
+  return {
+    ...makeWriteRepoAuthzDeps(),
+    fetch: vi.fn(
+      async () =>
+        new Response(JSON.stringify({permissions: {pull: true, push: false, admin: false}}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+    ),
+  }
+}
+
+function makeAuditLogger(): AuditLogger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+  }
+}
+
+function makeDeps(overrides?: Partial<CancelRouteDeps>): CancelRouteDeps {
+  return {
+    sessionStore: makeSessionStore(),
+    runIndex: makeRunIndex(),
+    denylistCache: makeDenylistCache(),
+    bindingsLookup: makeBindingsLookup(),
+    repoAuthzDeps: makeWriteRepoAuthzDeps(),
+    cancelRunDeps: {} as CancelRouteDeps['cancelRunDeps'],
+    auditLogger: makeAuditLogger(),
+    logger: {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()},
+    now: () => 0,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// App builder helpers
+// ---------------------------------------------------------------------------
+
+function buildApp(deps: CancelRouteDeps, guardUserId = 1001, guardSessionId = 'sess-abc'): Hono {
+  const app = new Hono()
+  setOperatorRouteGuard(app, async (_c, _method, _path) => ({
+    ok: true as const,
+    githubUserId: guardUserId,
+    sessionId: guardSessionId,
+  }))
+  buildCancelRoute(app, deps)
+  return app
+}
+
+function buildAppWithGuardResult(
+  guardResult: {ok: true; githubUserId: number; sessionId: string} | {ok: false; response: Response},
+  deps: CancelRouteDeps,
+): Hono {
+  const app = new Hono()
+  setOperatorRouteGuard(app, async () => guardResult)
+  buildCancelRoute(app, deps)
+  return app
+}
+
+async function postCancel(app: Hono, runId: string): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost/operator/runs/${runId}/cancel`, {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+    }),
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe('POST cancel — happy path', () => {
+  it('authorized operator cancels own-repo run → 200 with phase; audit emitted; actor built server-side', async () => {
+    const outcome: CancelOutcome = {outcome: 'cancelled', wasQueued: false}
+    cancelRunMock.mockReset().mockResolvedValue(outcome)
+    const auditLogger = makeAuditLogger()
+    const deps = makeDeps({auditLogger})
+    const app = buildApp(deps)
+
+    const response = await postCancel(app, 'run-abc')
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {ok: boolean; runId: string; phase: string}
+    expect(body).toEqual({ok: true, runId: 'run-abc', phase: 'CANCELLED'})
+
+    expect(cancelRunMock).toHaveBeenCalledTimes(1)
+    const call = cancelRunMock.mock.calls[0] as unknown as [
+      {runId: string; actor: {githubUserId: number; login: string; sessionCorrelationId: string}},
+      unknown,
+    ]
+    expect(call[0].runId).toBe('run-abc')
+    expect(call[0].actor).toEqual({githubUserId: 1001, login: 'alice', sessionCorrelationId: 'sess-abc'})
+
+    expect(vi.mocked(auditLogger.info)).toHaveBeenCalledWith(
+      expect.objectContaining({githubUserId: 1001, runId: 'run-abc', phase: 'CANCELLED'}),
+      'audit: run.cancel.requested',
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// No-oracle denials
+// ---------------------------------------------------------------------------
+
+describe('POST cancel — no-oracle denials (load-bearing)', () => {
+  it('no session (guard rejects) → identical notFoundResponse, zero cancelRun calls', async () => {
+    cancelRunMock.mockReset()
+    const deps = makeDeps()
+    const app = buildAppWithGuardResult(
+      {ok: false, response: new Response(JSON.stringify({error: 'not-found'}), {status: 404})},
+      deps,
+    )
+
+    const response = await postCancel(app, 'run-abc')
+
+    expect(response.status).toBe(404)
+    const body = (await response.json()) as {error: string}
+    expect(body.error).toBe('not-found')
+    expect(cancelRunMock).not.toHaveBeenCalled()
+  })
+
+  it('no token → notFoundResponse, zero cancelRun calls', async () => {
+    cancelRunMock.mockReset()
+    const deps = makeDeps({sessionStore: makeSessionStore({getOperatorToken: () => undefined})})
+    const app = buildApp(deps)
+
+    const response = await postCancel(app, 'run-abc')
+
+    expect(response.status).toBe(404)
+    expect(cancelRunMock).not.toHaveBeenCalled()
+  })
+
+  it('runIndex miss → notFoundResponse, zero cancelRun calls', async () => {
+    cancelRunMock.mockReset()
+    const deps = makeDeps({runIndex: {lookup: vi.fn(async () => undefined)}})
+    const app = buildApp(deps)
+
+    const response = await postCancel(app, 'run-abc')
+
+    expect(response.status).toBe(404)
+    const body = (await response.json()) as {error: string}
+    expect(body.error).toBe('not-found')
+    expect(cancelRunMock).not.toHaveBeenCalled()
+  })
+
+  it('denylisted repo → notFoundResponse, zero cancelRun calls', async () => {
+    cancelRunMock.mockReset()
+    const deps = makeDeps({denylistCache: makeDenylistCache(true)})
+    const app = buildApp(deps)
+
+    const response = await postCancel(app, 'run-abc')
+
+    expect(response.status).toBe(404)
+    expect(cancelRunMock).not.toHaveBeenCalled()
+  })
+
+  it('read-only operator (insufficient_permission) → notFoundResponse, zero cancelRun calls', async () => {
+    cancelRunMock.mockReset()
+    const deps = makeDeps({repoAuthzDeps: makeReadOnlyRepoAuthzDeps()})
+    const app = buildApp(deps)
+
+    const response = await postCancel(app, 'run-abc')
+
+    expect(response.status).toBe(404)
+    const body = (await response.json()) as {error: string}
+    expect(body.error).toBe('not-found')
+    expect(cancelRunMock).not.toHaveBeenCalled()
+  })
+
+  it('gate throw → identical notFoundResponse (no-oracle), zero cancelRun calls', async () => {
+    cancelRunMock.mockReset()
+    const deps = makeDeps({
+      runIndex: {
+        lookup: vi.fn(async () => {
+          throw new Error('boom')
+        }),
+      },
+    })
+    const app = buildApp(deps)
+
+    const response = await postCancel(app, 'run-abc')
+
+    expect(response.status).toBe(404)
+    const body = (await response.json()) as {error: string}
+    expect(body.error).toBe('not-found')
+    expect(cancelRunMock).not.toHaveBeenCalled()
+  })
+
+  it('all denial shapes are identical (same status + body)', async () => {
+    const missDeps = makeDeps({runIndex: {lookup: vi.fn(async () => undefined)}})
+    const deniedDeps = makeDeps({denylistCache: makeDenylistCache(true)})
+    const readOnlyDeps = makeDeps({repoAuthzDeps: makeReadOnlyRepoAuthzDeps()})
+
+    cancelRunMock.mockReset()
+    const missResp = await postCancel(buildApp(missDeps), 'run-abc')
+    const deniedResp = await postCancel(buildApp(deniedDeps), 'run-abc')
+    const readOnlyResp = await postCancel(buildApp(readOnlyDeps), 'run-abc')
+
+    expect(missResp.status).toBe(deniedResp.status)
+    expect(deniedResp.status).toBe(readOnlyResp.status)
+    const missBody = (await missResp.json()) as {error: string}
+    const deniedBody = (await deniedResp.json()) as {error: string}
+    const readOnlyBody = (await readOnlyResp.json()) as {error: string}
+    expect(missBody.error).toBe(deniedBody.error)
+    expect(deniedBody.error).toBe(readOnlyBody.error)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Outcome mapping
+// ---------------------------------------------------------------------------
+
+describe('POST cancel — CancelOutcome mapping', () => {
+  it('already-terminal → 200 carrying the terminal phase (idempotent, not an error)', async () => {
+    const outcome: CancelOutcome = {outcome: 'already-terminal', phase: 'COMPLETED'}
+    cancelRunMock.mockReset().mockResolvedValue(outcome)
+    const deps = makeDeps()
+    const app = buildApp(deps)
+
+    const response = await postCancel(app, 'run-abc')
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {ok: boolean; runId: string; phase: string}
+    expect(body).toEqual({ok: true, runId: 'run-abc', phase: 'COMPLETED'})
+  })
+
+  it('not-found (from cancelRun itself) → notFoundResponse', async () => {
+    const outcome: CancelOutcome = {outcome: 'not-found'}
+    cancelRunMock.mockReset().mockResolvedValue(outcome)
+    const deps = makeDeps()
+    const app = buildApp(deps)
+
+    const response = await postCancel(app, 'run-abc')
+
+    expect(response.status).toBe(404)
+    const body = (await response.json()) as {error: string}
+    expect(body.error).toBe('not-found')
+  })
+
+  it('retry (rendezvous exhausted) → coarse transient response, not success or a distinguishable error', async () => {
+    const outcome: CancelOutcome = {outcome: 'retry'}
+    cancelRunMock.mockReset().mockResolvedValue(outcome)
+    const deps = makeDeps()
+    const app = buildApp(deps)
+
+    const response = await postCancel(app, 'run-abc')
+
+    expect(response.status).toBe(503)
+    const body = (await response.json()) as {error: string}
+    expect(body.error).toBe('unavailable')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Rate limiting
+// ---------------------------------------------------------------------------
+
+describe('POST cancel — rate limiting', () => {
+  it('exceeded → limited response; unauthorized requests do not consume budget', async () => {
+    const outcome: CancelOutcome = {outcome: 'cancelled', wasQueued: false}
+    cancelRunMock.mockReset().mockResolvedValue(outcome)
+
+    // Limiter of 1/window shared across both apps to prove unauthorized requests
+    // (which fail before the limiter is consulted) don't eat the budget.
+    let allowCount = 0
+    const rateLimiter = {
+      allow: vi.fn(() => {
+        allowCount += 1
+        return allowCount <= 1
+      }),
+    }
+
+    const deniedDeps = makeDeps({denylistCache: makeDenylistCache(true), rateLimiter})
+    const deniedApp = buildApp(deniedDeps)
+    // Denied at gate 5 (denylist) — before rate limiting — must not consume budget.
+    const deniedResponse = await postCancel(deniedApp, 'run-abc')
+    expect(deniedResponse.status).toBe(404)
+    expect(rateLimiter.allow).not.toHaveBeenCalled()
+
+    const okDeps = makeDeps({rateLimiter})
+    const okApp = buildApp(okDeps)
+    const firstResponse = await postCancel(okApp, 'run-abc')
+    expect(firstResponse.status).toBe(200)
+
+    const secondResponse = await postCancel(okApp, 'run-abc')
+    expect(secondResponse.status).toBe(429)
+    const body = (await secondResponse.json()) as {error: string}
+    expect(body.error).toBe('rate limited')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DTO leak check
+// ---------------------------------------------------------------------------
+
+describe('POST cancel — DTO leak check', () => {
+  it('success response never carries cancelledBy or thread_id', async () => {
+    const outcome: CancelOutcome = {outcome: 'cancelled', wasQueued: false}
+    cancelRunMock.mockReset().mockResolvedValue(outcome)
+    const deps = makeDeps()
+    const app = buildApp(deps)
+
+    const response = await postCancel(app, 'run-abc')
+    const body = (await response.json()) as Record<string, unknown>
+
+    expect(Object.keys(body).sort()).toEqual(['ok', 'phase', 'runId'])
+    expect(JSON.stringify(body)).not.toContain('cancelledBy')
+    expect(JSON.stringify(body)).not.toContain('thread_id')
+  })
+})

--- a/packages/gateway/src/web/operator/cancel-route.ts
+++ b/packages/gateway/src/web/operator/cancel-route.ts
@@ -1,0 +1,297 @@
+/**
+ * Authenticated cancel route: POST /operator/runs/:runId/cancel
+ *
+ * Cancels a run whether it is queued (PENDING/ACKNOWLEDGED in the per-channel
+ * FIFO) or executing, through the transport-neutral `cancelRun` orchestrator.
+ * This is the write-gated cancellation path for the web operator surface.
+ *
+ * Gate ordering (mirrors decision-route.ts exactly):
+ *   1. Guard (browser/session/allowlist/CSRF) — installed by buildOperatorApp
+ *   2. Resolve session + OAuth token by sessionId
+ *   3. Resolve runId → repo via RunIndex (server-owned; never client-supplied)
+ *   4. Split owner/repo from the resolved location
+ *   5. Resolve binding deny-keys; prime denylist; check isRepoDenied
+ *   6. checkRepoWriteAuthz (WRITE-level — not read; insufficient_permission → denial)
+ *   7. Operator-keyed rate limit (AFTER authz — unauthorized requests don't consume budget)
+ *   8. Build CancelActorContext from the operator auth context (server-side only)
+ *   9. cancelRun(params, deps)
+ *  10. Emit run.cancel.* audit record
+ *  11. Map CancelOutcome → JSON response
+ *
+ * Security invariants:
+ *   - The repo is resolved server-side via resolveRepoFromRunIndex — NEVER from the client.
+ *   - Every denial at gates 2–6 returns the identical no-oracle notFoundResponse.
+ *   - A gate throw degrades to the same no-oracle denial, not a distinguishable 500.
+ *   - Read-only operators (insufficient_permission) are denied at gate 6.
+ *   - CSRF/Origin middleware covers this POST route (write route).
+ */
+
+import type {Hono} from 'hono'
+import type {CancelActorContext, CancelOutcome, CancelRunDeps} from '../../execute/cancel.js'
+import type {RunIndex} from '../../execute/run-index.js'
+import type {RateLimiter} from '../../http/rate-limit.js'
+import type {DenylistCache} from '../../redaction/denylist.js'
+import type {BindingsLookup} from '../../redaction/surface-gate.js'
+import type {AuditLogger} from '../audit.js'
+import type {RepoAuthzDeps} from '../auth/repo-authz.js'
+import type {SessionStore} from '../auth/session.js'
+import type {OperatorLogger} from '../server.js'
+import {cancelRun} from '../../execute/cancel.js'
+import {createRateLimiter} from '../../http/rate-limit.js'
+import {emitAudit} from '../audit.js'
+import {checkRepoWriteAuthz} from '../auth/repo-authz.js'
+import {getOperatorAuthContext, registerOperatorRoute} from '../operator-route.js'
+import {notFoundResponse, rateLimitedResponse, unavailableResponse} from '../safe-response.js'
+import {checkDenylist, resolveRepoFromRunIndex} from './route-helpers.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Per-operator cancel rate limit: 10 requests per minute (cheap idempotent no-ops, but bound abuse). */
+const CANCEL_RATE_LIMIT_PER_MIN = 10
+const CANCEL_RATE_WINDOW_MIN_MS = 60_000
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Dependencies for the cancel route. */
+export interface CancelRouteDeps {
+  /** Session store for token retrieval. */
+  readonly sessionStore: Pick<SessionStore, 'getOperatorToken' | 'get'>
+  /** Server-owned run index for runId → repo resolution. */
+  readonly runIndex: Pick<RunIndex, 'lookup'>
+  /** Denylist cache for pre-cancel redaction check. */
+  readonly denylistCache: DenylistCache
+  /** Bindings lookup for deny-key resolution. */
+  readonly bindingsLookup: BindingsLookup
+  /** Repo authorization dependencies (write-level). */
+  readonly repoAuthzDeps: RepoAuthzDeps
+  /** Cancel-run engine dependencies (queue, abort registry, approvals, etc.). */
+  readonly cancelRunDeps: CancelRunDeps
+  /** Audit logger for security events. */
+  readonly auditLogger: AuditLogger
+  /** Structured logger. */
+  readonly logger: OperatorLogger
+  /** Injectable clock. */
+  readonly now: () => number
+  /**
+   * Optional injectable per-minute rate limiter (operator-keyed).
+   * When absent, a fresh limiter is created with CANCEL_RATE_LIMIT_PER_MIN.
+   */
+  readonly rateLimiter?: RateLimiter
+}
+
+// ---------------------------------------------------------------------------
+// Route builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Register POST /operator/runs/:runId/cancel on the given Hono app.
+ *
+ * Must be called after setOperatorRouteGuard is installed in buildOperatorApp.
+ * The guard runs first (browser/session/allowlist/CSRF); this handler runs only
+ * if the guard allows the request.
+ *
+ * Response body: OperatorCancelResponse {ok:true, runId, phase} on success
+ * (both an active cancel and an idempotent already-terminal hit are 200s).
+ */
+export function buildCancelRoute(app: Hono, deps: CancelRouteDeps): void {
+  // Per-operator rate limiter (operator-keyed, not socket-keyed), AFTER authz —
+  // unauthorized requests must not consume budget.
+  const rateLimiter =
+    deps.rateLimiter ??
+    createRateLimiter({limit: CANCEL_RATE_LIMIT_PER_MIN, windowMs: CANCEL_RATE_WINDOW_MIN_MS, clock: deps.now})
+
+  registerOperatorRoute(app, 'POST', '/operator/runs/:runId/cancel', async c => {
+    const nowMs = deps.now()
+
+    // ── Gate 1: Read authenticated context set by the guard ──────────────────
+    // In production the guard always sets this; undefined is unreachable.
+    // Return not-found as a safe fallback (no oracle — same shape as all denials).
+    const authCtx = getOperatorAuthContext(c)
+    if (authCtx === undefined) {
+      deps.logger.warn({gate: 'no-auth-ctx'}, 'cancel: denied')
+      return notFoundResponse(c)
+    }
+
+    const {githubUserId, sessionId} = authCtx
+
+    // ── Gates 2–6: Pre-acceptance authorization gates ─────────────────────────
+    // Wrapped in try/catch so any unexpected throw returns the uniform not-found
+    // shape rather than propagating to Hono as a 500 (no-oracle property).
+    let runId: string
+    let owner: string
+    let repo: string
+
+    try {
+      // ── Gate 2: Resolve OAuth token ──────────────────────────────────────
+      const token = deps.sessionStore.getOperatorToken(sessionId, nowMs)
+      if (token === undefined) {
+        deps.logger.warn({githubUserId, gate: 'no-token'}, 'cancel: denied')
+        emitAudit(
+          {kind: 'run.cancel.rejected', correlationId: `cancel:${githubUserId}`, githubUserId, reason: 'not_found'},
+          deps.auditLogger,
+        )
+        return notFoundResponse(c)
+      }
+
+      // ── Gates 3–4: Resolve runId → {owner, repo} (server-owned) ────────────
+      // The repo is NEVER taken from the client. RunIndex.lookup is the sole authority.
+      runId = c.req.param('runId') ?? ''
+      const resolved = await resolveRepoFromRunIndex(runId, deps.runIndex)
+      if (resolved === null) {
+        deps.logger.warn({githubUserId, runId, gate: 'runIndex-miss-or-malformed'}, 'cancel: denied')
+        emitAudit(
+          {
+            kind: 'run.cancel.rejected',
+            correlationId: `cancel:${githubUserId}:${runId}`,
+            githubUserId,
+            reason: 'not_found',
+          },
+          deps.auditLogger,
+        )
+        return notFoundResponse(c)
+      }
+      owner = resolved.owner
+      repo = resolved.repo
+
+      // ── Gate 5: Redaction check (denylist before authz, fail-closed) ─────
+      const isDenied = await checkDenylist(owner, repo, deps.bindingsLookup, deps.denylistCache)
+      if (isDenied === true) {
+        deps.logger.warn({githubUserId, runId, gate: 'denylisted'}, 'cancel: denied')
+        emitAudit(
+          {
+            kind: 'run.cancel.rejected',
+            correlationId: `cancel:${githubUserId}:${runId}`,
+            githubUserId,
+            reason: 'not_found',
+          },
+          deps.auditLogger,
+        )
+        return notFoundResponse(c)
+      }
+
+      // ── Gate 6: Write-level repo authorization ───────────────────────────
+      const authzResult = await checkRepoWriteAuthz(githubUserId, owner, repo, token, deps.repoAuthzDeps)
+      if (authzResult.authorized === false) {
+        deps.logger.warn({githubUserId, runId, gate: 'write-authz-denied'}, 'cancel: denied')
+        emitAudit(
+          {
+            kind: 'run.cancel.rejected',
+            correlationId: `cancel:${githubUserId}:${runId}`,
+            githubUserId,
+            reason: 'authz_denied',
+          },
+          deps.auditLogger,
+        )
+        return notFoundResponse(c)
+      }
+    } catch (error: unknown) {
+      deps.logger.warn({runId: c.req.param('runId') ?? '', githubUserId, error}, 'cancel: gate threw — denying')
+      emitAudit(
+        {kind: 'run.cancel.rejected', correlationId: `cancel:${githubUserId}`, githubUserId, reason: 'unknown'},
+        deps.auditLogger,
+      )
+      return notFoundResponse(c)
+    }
+
+    // ── Gate 7: Operator rate limit — AFTER authz so unauthorized requests
+    // don't consume budget. Operator-keyed, not socket-keyed. ─────────────────
+    const operatorKey = String(githubUserId)
+    if (rateLimiter.allow(operatorKey) === false) {
+      deps.logger.warn({githubUserId, runId, gate: 'rate-limited'}, 'cancel: rate limited')
+      return rateLimitedResponse(c)
+    }
+
+    // ── Gates 8–11: Post-authz settlement gates ───────────────────────────────
+    // Wrapped in try/catch so any unexpected throw returns the uniform not-found
+    // shape rather than propagating to Hono as a distinguishable 500.
+    try {
+      // ── Gate 8: Build CancelActorContext from the operator auth context ────
+      const sessionEntry = deps.sessionStore.get(sessionId, nowMs)
+      if (sessionEntry === undefined) {
+        deps.logger.warn({githubUserId, runId, gate: 'no-session'}, 'cancel: denied — session missing')
+        emitAudit(
+          {
+            kind: 'run.cancel.rejected',
+            correlationId: `cancel:${githubUserId}:${runId}`,
+            githubUserId,
+            reason: 'not_found',
+          },
+          deps.auditLogger,
+        )
+        return notFoundResponse(c)
+      }
+
+      const actor: CancelActorContext = {
+        githubUserId,
+        login: sessionEntry.login,
+        sessionCorrelationId: sessionId,
+      }
+
+      // ── Gate 9: Cancel through the transport-neutral orchestrator ───────────
+      const outcome: CancelOutcome = await cancelRun({runId, actor, logger: deps.logger}, deps.cancelRunDeps)
+
+      // ── Gates 10–11: Map outcome → audit + JSON response ─────────────────────
+      switch (outcome.outcome) {
+        case 'cancelled': {
+          emitAudit(
+            {
+              kind: 'run.cancel.requested',
+              correlationId: `cancel:${githubUserId}:${runId}`,
+              githubUserId,
+              runId,
+              phase: 'CANCELLED',
+            },
+            deps.auditLogger,
+          )
+          return c.json({ok: true, runId, phase: 'CANCELLED'}, 200)
+        }
+        case 'already-terminal': {
+          // cancelRun's TERMINAL_PHASES set guarantees outcome.phase is one of
+          // CANCELLED/COMPLETED/FAILED here — narrow the wider RunPhase type
+          // to match OperatorCancelResponse's closed phase union.
+          const terminalPhase = outcome.phase as 'CANCELLED' | 'COMPLETED' | 'FAILED'
+          emitAudit(
+            {
+              kind: 'run.cancel.requested',
+              correlationId: `cancel:${githubUserId}:${runId}`,
+              githubUserId,
+              runId,
+              phase: terminalPhase,
+            },
+            deps.auditLogger,
+          )
+          return c.json({ok: true, runId, phase: terminalPhase}, 200)
+        }
+        case 'not-found': {
+          deps.logger.warn({githubUserId, runId, gate: 'cancelRun-not-found'}, 'cancel: denied')
+          emitAudit(
+            {
+              kind: 'run.cancel.rejected',
+              correlationId: `cancel:${githubUserId}:${runId}`,
+              githubUserId,
+              reason: 'not_found',
+            },
+            deps.auditLogger,
+          )
+          return notFoundResponse(c)
+        }
+        case 'retry': {
+          // The bounded rendezvous retry was exhausted without resolving to a
+          // terminal outcome. Safe to retry — the run either advanced to
+          // EXECUTING (a subsequent cancel hits the abort-registry path) or
+          // reached a terminal state on its own. Return a coarse transient
+          // 503 rather than a misleading success or a distinguishable error.
+          deps.logger.warn({githubUserId, runId, gate: 'cancelRun-retry'}, 'cancel: transient — retry')
+          return unavailableResponse(c)
+        }
+      }
+    } catch (error: unknown) {
+      deps.logger.warn({runId, githubUserId, error}, 'cancel: post-authz gate threw — denying (no-oracle)')
+      return notFoundResponse(c)
+    }
+  })
+}

--- a/packages/gateway/src/web/operator/cancel-route.ts
+++ b/packages/gateway/src/web/operator/cancel-route.ts
@@ -250,21 +250,20 @@ export function buildCancelRoute(app: Hono, deps: CancelRouteDeps): void {
           return c.json({ok: true, runId, phase: 'CANCELLED'}, 200)
         }
         case 'already-terminal': {
-          // cancelRun's TERMINAL_PHASES set guarantees outcome.phase is one of
-          // CANCELLED/COMPLETED/FAILED here — narrow the wider RunPhase type
-          // to match OperatorCancelResponse's closed phase union.
-          const terminalPhase = outcome.phase as 'CANCELLED' | 'COMPLETED' | 'FAILED'
+          // outcome.phase is already TerminalPhase — CancelOutcome's already-terminal
+          // variant is typed as such (see execute/cancel.ts), so it matches
+          // OperatorCancelResponse's phase field with no narrowing needed.
           emitAudit(
             {
               kind: 'run.cancel.requested',
               correlationId: `cancel:${githubUserId}:${runId}`,
               githubUserId,
               runId,
-              phase: terminalPhase,
+              phase: outcome.phase,
             },
             deps.auditLogger,
           )
-          return c.json({ok: true, runId, phase: terminalPhase}, 200)
+          return c.json({ok: true, runId, phase: outcome.phase}, 200)
         }
         case 'not-found': {
           deps.logger.warn({githubUserId, runId, gate: 'cancelRun-not-found'}, 'cancel: denied')
@@ -285,8 +284,10 @@ export function buildCancelRoute(app: Hono, deps: CancelRouteDeps): void {
           // EXECUTING (a subsequent cancel hits the abort-registry path) or
           // reached a terminal state on its own. Return a coarse transient
           // 503 rather than a misleading success or a distinguishable error.
+          // The rendezvous window is short — bounded by ensureClone/readyz/
+          // threadFactory/lock — so a 2s Retry-After is a reasonable hint.
           deps.logger.warn({githubUserId, runId, gate: 'cancelRun-retry'}, 'cancel: transient — retry')
-          return unavailableResponse(c)
+          return unavailableResponse(c, 2)
         }
       }
     } catch (error: unknown) {

--- a/packages/gateway/src/web/operator/launch-route.test.ts
+++ b/packages/gateway/src/web/operator/launch-route.test.ts
@@ -33,12 +33,10 @@ vi.mock('../../execute/run.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../../execute/run.js')>()
   return {
     ...actual,
-    launchWork: vi.fn(
-      async (request: {readonly runId?: string}): Promise<LaunchAdmission> => ({
-        accepted: true,
-        runId: request.runId ?? 'mock-run-id',
-      }),
-    ),
+    launchWork: vi.fn(async (request: {readonly runId?: string}): Promise<LaunchAdmission> => ({
+      accepted: true,
+      runId: request.runId ?? 'mock-run-id',
+    })),
   }
 })
 
@@ -49,12 +47,10 @@ const mockLaunchWork = vi.mocked(launchWork)
 beforeEach(() => {
   mockLaunchWork.mockClear()
   // Restore the default implementation (accepted:true, echoes request.runId).
-  mockLaunchWork.mockImplementation(
-    async (request: {readonly runId?: string}): Promise<LaunchAdmission> => ({
-      accepted: true,
-      runId: request.runId ?? 'mock-run-id',
-    }),
-  )
+  mockLaunchWork.mockImplementation(async (request: {readonly runId?: string}): Promise<LaunchAdmission> => ({
+    accepted: true,
+    runId: request.runId ?? 'mock-run-id',
+  }))
 })
 
 // ---------------------------------------------------------------------------
@@ -146,6 +142,7 @@ function makeLaunchWorkDeps(): RunMentionDeps {
       takeNext: vi.fn(() => undefined),
       pendingCount: vi.fn(() => 0),
       clear: vi.fn(() => 0),
+      removeBy: vi.fn(() => undefined),
     },
     attachUrl: 'http://localhost:3000',
     attachToken: 'attach-token',

--- a/packages/gateway/src/web/server.test.ts
+++ b/packages/gateway/src/web/server.test.ts
@@ -1730,6 +1730,13 @@ function makeStubApprovalRegistry(): NonNullable<OperatorServerDeps['approvalReg
   }
 }
 
+/** Shared stub for cancelRunDeps — opaque sentinel for registration tests only. */
+function makeStubCancelRunDeps(): NonNullable<OperatorServerDeps['cancelRunDeps']> {
+  // Registration only checks `deps.cancelRunDeps !== undefined`; the actual
+  // shape is not inspected at construction time. Cast to satisfy the type.
+  return {} as unknown as NonNullable<OperatorServerDeps['cancelRunDeps']>
+}
+
 /** Shared stub for launchWorkDeps — opaque sentinel for registration tests only. */
 function makeStubLaunchWorkDeps(): NonNullable<OperatorServerDeps['launchWorkDeps']> {
   // Registration only checks `deps.launchWorkDeps !== undefined`; the actual
@@ -1756,6 +1763,7 @@ function makeFullPrivilegedDeps(sessionStore: ReturnType<typeof createInMemorySe
     getBindingByRepo: async () => ({success: true, data: null}),
     launchWorkDeps: makeStubLaunchWorkDeps(),
     approvalRegistry: makeStubApprovalRegistry(),
+    cancelRunDeps: makeStubCancelRunDeps(),
     rateLimiter: {allow: () => true},
   })
 }
@@ -1829,6 +1837,7 @@ describe('buildOperatorApp — v1.5.0 full route-registration smoke (drift guard
     expect(routePaths).not.toContain('GET:/operator/runs/:runId/stream')
     expect(routePaths).not.toContain('POST:/operator/runs/:runId/approvals/:requestId/decision')
     expect(routePaths).not.toContain('GET:/operator/runs/:runId/approvals')
+    expect(routePaths).not.toContain('POST:/operator/runs/:runId/cancel')
 
     // #and — health, auth, session routes ARE registered
     expect(routePaths).toContain('GET:/operator/health')

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -24,6 +24,7 @@
 import type {ServerType} from '@hono/node-server'
 import type {ApprovalRegistry} from '../approvals/registry.js'
 import type {RepoBinding} from '../bindings/types.js'
+import type {CancelRunDeps} from '../execute/cancel.js'
 import type {RunIndex} from '../execute/run-index.js'
 import type {RunMentionDeps} from '../execute/run.js'
 import type {DenylistCache} from '../redaction/denylist.js'
@@ -48,6 +49,7 @@ import {createRepoAuthzCache} from './auth/repo-authz.js'
 import {buildSessionInfoRoute} from './auth/session-info-route.js'
 import {buildLogoutRoutes} from './auth/session.js'
 import {assertAllPrivilegedRoutesWrapped, registerPublicRoute, setOperatorRouteGuard} from './operator-route.js'
+import {buildCancelRoute} from './operator/cancel-route.js'
 import {buildDecisionRoute} from './operator/decision-route.js'
 import {createIdempotencyGuard} from './operator/idempotency.js'
 import {buildLaunchRoute} from './operator/launch-route.js'
@@ -213,6 +215,18 @@ export interface OperatorServerDeps {
    * When absent, neither route is registered (opt-in).
    */
   readonly approvalRegistry?: Pick<ApprovalRegistry, 'handleDecision' | 'describePendingForScope'>
+  /**
+   * Cancel-run engine dependencies (queue, abort registry, approvals, Discord
+   * client, coordination config/identity) for the cancel route's `cancelRun`
+   * orchestrator call.
+   *
+   * When present (alongside the browser guard, sessionStore, denylistCache,
+   * bindingsLookup, runIndex, approvalRegistry, and auditLogger), the following
+   * route is registered:
+   *   - POST /operator/runs/:runId/cancel (write-gated)
+   * When absent, the route is not registered (opt-in).
+   */
+  readonly cancelRunDeps?: CancelRunDeps
 }
 
 export interface OperatorServerConfig {
@@ -824,6 +838,61 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
         cache: deps.repoAuthzCache ?? createRepoAuthzCache(),
       },
       registry: deps.approvalRegistry,
+      auditLogger: deps.auditLogger,
+      logger: deps.logger,
+      now: clock,
+    })
+  }
+
+  // ── Cancel route ───────────────────────────────────────────────────────────
+  //
+  // Registered only when the full browser guard is present AND the cancel-run
+  // engine deps, runIndex, denylistCache, bindingsLookup, and auditLogger are
+  // provided. Route: POST /operator/runs/:runId/cancel — privileged
+  //   (requires session + allowlist + CSRF; write-level repo authz).
+  //
+  // Gate ordering (mirrors the decision route):
+  //   1. Guard (browser/session/allowlist/CSRF) — installed above (POST → requireCsrf=true)
+  //   2. Session token resolution
+  //   3. RunIndex.lookup (server-owned runId → repo resolution)
+  //   4. Split owner/repo
+  //   5. Denylist check (before authz, no oracle)
+  //   6. checkRepoWriteAuthz (WRITE-level — not read)
+  //   7. Operator-keyed rate limit (AFTER authz)
+  //   8. Build CancelActorContext from session
+  //   9. cancelRun(params, deps) — transport-neutral orchestrator
+  //  10. Emit run.cancel.* audit record
+  //  11. Map CancelOutcome → JSON response
+  //
+  // Every failure at gates 2–6 returns the identical no-oracle notFoundResponse.
+  // A gate throw degrades to the same denial, not a distinguishable 500.
+  if (
+    browserGuardDeps !== undefined &&
+    deps.sessionStore !== undefined &&
+    deps.denylistCache !== undefined &&
+    deps.bindingsLookup !== undefined &&
+    deps.runIndex !== undefined &&
+    deps.approvalRegistry !== undefined &&
+    deps.allowlist !== undefined &&
+    deps.auditLogger !== undefined &&
+    deps.cancelRunDeps !== undefined
+  ) {
+    const clock = deps.sessionDeps?.clock ?? (() => Date.now())
+    buildCancelRoute(app, {
+      sessionStore: deps.sessionStore,
+      runIndex: deps.runIndex,
+      denylistCache: deps.denylistCache,
+      bindingsLookup: deps.bindingsLookup,
+      repoAuthzDeps: {
+        allowlist: deps.allowlist,
+        fetch: globalThis.fetch,
+        clock,
+        random: Math.random.bind(Math),
+        auditLogger: deps.auditLogger,
+        logger: deps.logger,
+        cache: deps.repoAuthzCache ?? createRepoAuthzCache(),
+      },
+      cancelRunDeps: deps.cancelRunDeps,
       auditLogger: deps.auditLogger,
       logger: deps.logger,
       now: clock,

--- a/packages/runtime/src/coordination/run-state.ts
+++ b/packages/runtime/src/coordination/run-state.ts
@@ -112,6 +112,14 @@ export async function createRun(
 export interface TransitionRunOptions {
   /** When provided and non-empty, atomically persists the live thread id alongside the phase write. Absent/empty leaves the existing thread_id untouched. */
   readonly threadId?: string
+  /**
+   * Optional shallow patch merged into `details` alongside the phase change.
+   * Used by operator-attributed transitions (e.g. `details.cancelledBy`) so
+   * attribution lands atomically with the phase write instead of a separate
+   * follow-up write (which would need its own etag round-trip). Absent by
+   * default — existing callers are unaffected.
+   */
+  readonly detailsPatch?: Record<string, unknown>
 }
 
 export async function transitionRun(
@@ -156,10 +164,14 @@ export async function transitionRun(
   // The caller-supplied etag is the single concurrency gate. S3's IfMatch enforces atomicity —
   // a 412 here means another writer modified the object since the caller's last fetch.
   const threadId = options?.threadId
+  const detailsPatch = options?.detailsPatch
+  const mergedDetails =
+    detailsPatch === undefined ? undefined : {details: {...parsedCurrent.data.details, ...detailsPatch}}
   const nextState: RunState = {
     ...parsedCurrent.data,
     phase: newPhase,
     ...(threadId !== undefined && threadId !== '' ? {thread_id: threadId} : {}),
+    ...mergedDetails,
   }
   logger.debug('Transitioning run-state', {
     key: key.data,

--- a/packages/runtime/src/coordination/types.ts
+++ b/packages/runtime/src/coordination/types.ts
@@ -2,6 +2,14 @@ import type {ObjectStoreAdapter, ObjectStoreConfig} from '../object-store/types.
 
 export type RunPhase = 'PENDING' | 'ACKNOWLEDGED' | 'EXECUTING' | 'COMPLETED' | 'FAILED' | 'CANCELLED'
 
+/**
+ * The subset of `RunPhase` that is terminal (no further transitions possible).
+ * Shared by `cancelRun`'s already-terminal outcome and the operator cancel
+ * route's response DTO so both agree on one closed union instead of each
+ * hand-writing the same three literals.
+ */
+export type TerminalPhase = Extract<RunPhase, 'COMPLETED' | 'FAILED' | 'CANCELLED'>
+
 export type Surface = 'github' | 'discord' | 'web'
 
 export interface RunState {


### PR DESCRIPTION
## What

Adds operator-initiated run cancellation to the gateway web surface. An operator can now stop a run — whether it is still queued or actively executing — instead of waiting out the timeout ceiling.

`POST /operator/runs/:runId/cancel`:
- Cancels a queued run (dequeue) or an executing run (abort the in-flight OpenCode stream).
- Auto-rejects any pending tool approval through the existing single settlement gate.
- Transitions run-state to the existing `CANCELLED` terminal phase, attributed to the cancelling operator.
- Posts a cancellation notice to the run's origin Discord thread.
- Emits the terminal `cancelled` status to SSE subscribers.
- Is idempotent on already-terminal runs (returns the terminal phase, no error).

## Why

The operator surface could launch, list, stream, and approve — but not stop. A run going wrong held its per-repo lock and concurrency slot until natural completion or the 30-minute ceiling, with no operator remedy. `CANCELLED` already existed in the run-state machine and the operator contract; nothing operator-facing could trigger it (deferred when the operator surface first shipped).

## How

Four layers, each an atomic commit:

- **Abort registry + settlement path** — a `runId → AbortController` registry composed into the run's existing timeout/inactivity signals via `AbortSignal.any`. Cancellation is classified by a registry probe (not the composite abort reason, which is racy), and the run's error path settles `CANCELLED` (not `FAILED`) with heartbeat-first etag discipline so the lock release never uses a stale etag.
- **Transport-neutral orchestrator** — `cancelRun` resolves the run's phase and takes the right path: dequeue a queued run, abort an executing one, or use a run-state conditional-write rendezvous for the narrow window between dequeue and abort-registration. Pending approvals are rejected only through the existing `handleDecision` gate. The cancellation notice is delivered via an injected callback, keeping the orchestrator free of any Discord dependency.
- **Operator route** — gate ordering identical to the existing decision route (session → server-resolved repo → denylist → write authz → rate limit after authz → server-built actor → cancel → audit); every pre-acceptance denial and gate throw returns the uniform no-oracle response. New audit events carry operator attribution. The route is pinned in both route inventories.
- **Crash-consistency recovery** — startup reconciles a per-repo lock stranded by a crash between the `CANCELLED` commit and the lock release, using the dead-run-verified release so a newer run's lock is never clobbered.

Internal coordination fields (`thread_id`, `details.cancelledBy`) stay excluded from operator DTOs by construction.

## Contract / deploy ordering

`OPERATOR_CONTRACT_VERSION` bumps `1.5.0 → 1.6.0` (additive route + response type = MINOR). The dashboard pins this version with an exact-match, fail-closed drift gate, so the gateway deploy and the dashboard's `1.6.0` pin bump must land in the same deploy window — the dashboard-side change is a separate follow-up. Merging this PR does not affect the running deployment on its own.

## Verification

- `bun run lint`, `bun run build` — clean, no `dist/` diff
- runtime + gateway type-check clean
- runtime (459) and gateway (2859) suites green
- Coverage spans the plan's acceptance examples: idempotent-terminal, queued-cancel-leaves-active-run, executing-cancel-preserves-partial-output, approval-settled, denial-no-state-change, cancel-vs-completion single-winner, and the dequeue-handoff window — plus crash-recovery reconciliation (ownership guard, fail-soft), race accuracy, and the attribution seam.
