### PR TITLE
docs: capture run-cancellation learnings in docs/solutions

### DIFF
--- a/docs/solutions/best-practices/options-object-for-shared-signature-extension-2026-07-03.md
+++ b/docs/solutions/best-practices/options-object-for-shared-signature-extension-2026-07-03.md
@@ -1,0 +1,92 @@
+---
+title: Extend a shared function via an options object, not a positional optional, to survive cross-branch merges
+date: 2026-07-03
+category: best-practices
+module: runtime/coordination
+problem_type: best_practice
+component: assistant
+severity: medium
+applies_when:
+  - Two or more in-flight branches each need to add a parameter to the same shared function
+  - A widely-called function is accreting a tail of optional positional parameters
+  - A change adds an optional param to a signature that another branch also touches
+  - A shared runtime primitive is extended by feature work that will rebase onto sibling features
+tags:
+  - api-evolution
+  - options-object
+  - positional-params
+  - merge-hazard
+  - shared-signature
+  - telescoping-parameters
+---
+
+# Extend a shared function via an options object, not a positional optional, to survive cross-branch merges
+
+## Context
+
+Two independent feature branches each needed to extend the same shared runtime primitive, `transitionRun`. Branch A (a bugfix) appended `threadId?: string` as a trailing optional positional parameter; branch B (a feature) independently appended `detailsPatch?: Record<string, unknown>` as *its* trailing optional positional parameter. Both landed at the same argument position (arg 7). On rebase they collide into an ambiguous parameter order, and — because both are optional — TypeScript compiles either ordering without complaint. A caller passing only the second field would have to also pass the first, and the order becomes a silent coin-flip decided by merge order.
+
+## Guidance
+
+When a shared function needs a new optional parameter — especially when sibling branches also touch it — add a single **options object** as the one extension point, not a positional optional:
+
+```ts
+// packages/runtime/src/coordination/run-state.ts
+/**
+ * Extension point for fields atomically merged into a run-state write alongside
+ * the phase transition. Sibling additions (e.g. detailsPatch) should be appended
+ * as fields on this bag rather than as new positional params on transitionRun.
+ */
+export interface TransitionRunOptions {
+  readonly threadId?: string
+  readonly detailsPatch?: Record<string, unknown>
+}
+
+export async function transitionRun(
+  config: CoordinationConfig,
+  identity: string,
+  repo: string,
+  runId: string,
+  newPhase: RunPhase,
+  etag: string,
+  logger: CoordLogger,
+  options?: TransitionRunOptions, // ← one bag; both branches' fields fold in here
+): Promise<Result<{etag: string; state: RunState}, Error>>
+```
+
+Branch A adds `threadId?` to the interface; branch B adds `detailsPatch?` to the *same* interface. The two additions merge cleanly (different fields on one object), call sites read `{threadId}` / `{detailsPatch}` / `{threadId, detailsPatch}` self-documentingly, and there is no positional order to get wrong. Put a comment on the interface naming it the extension point so the next contributor appends a field instead of a positional param.
+
+## Why This Matters
+
+- **Positional optionals collide silently across branches.** Two branches each appending `arg[N]` produce a merge where the order is ambiguous and the type checker cannot catch it (both optional → any order compiles). An options object turns "which position?" into "which field name?" — order-free and merge-safe.
+- **It stops telescoping.** A function accreting `f(a, b, c, logger, opt1?, opt2?, opt3?)` becomes unreadable at call sites (`f(x, y, z, log, undefined, undefined, val)`). A bag keeps call sites legible (`f(x, y, z, log, {opt3: val})`).
+- **Self-documenting call sites.** `{detailsPatch: {cancelledBy}}` says what it is; `, undefined, {cancelledBy}` does not.
+
+## When to Apply
+
+- Any shared/widely-called function gaining an optional parameter when another branch is known to be in flight against it.
+- The moment a function would grow its *second* trailing optional positional param — refactor to a bag before the collision, not after.
+- Runtime primitives extended by feature branches that will rebase onto sibling features.
+
+Do **not** over-apply: a stable function with a single, long-lived optional positional and no sibling branches touching it does not need a bag. The trigger is *multiple extenders* or *a growing optional tail*, not every optional param.
+
+## Examples
+
+Before (positional — collides on rebase):
+```ts
+// branch A
+transitionRun(cfg, id, repo, runId, 'ACKNOWLEDGED', etag, logger, threadId)
+// branch B, independently
+transitionRun(cfg, id, repo, runId, 'CANCELLED', etag, logger, detailsPatch) // same arg slot!
+```
+
+After (options object — both fold into one bag):
+```ts
+transitionRun(cfg, id, repo, runId, 'ACKNOWLEDGED', etag, logger, {threadId})
+transitionRun(cfg, id, repo, runId, 'CANCELLED', etag, logger, {detailsPatch: {cancelledBy}})
+```
+
+## Related
+
+- fro-bot/agent#1109 (added `threadId`) and #1111 (added `detailsPatch`) — the two branches whose collision this pattern resolved; reconciled to `TransitionRunOptions` before the second merged.
+- [Centralize resource-key/identity construction](centralize-s3-key-identity-construction-2026-06-09.md) — related single-source-of-truth discipline for shared coordination shapes.

--- a/docs/solutions/logic-errors/abortsignal-any-reason-classification-race-2026-07-03.md
+++ b/docs/solutions/logic-errors/abortsignal-any-reason-classification-race-2026-07-03.md
@@ -1,0 +1,88 @@
+---
+title: Classifying an abort by AbortSignal.any's composite reason is racy — use a side-channel
+date: 2026-07-03
+category: logic-errors
+module: gateway/execute
+problem_type: logic_error
+component: assistant
+symptoms:
+  - A cancel and a timeout firing close together could be misclassified
+  - The composite signal's reason reflects whichever child aborted first, not which one you care about
+  - Reading combinedSignal.reason to decide cancel-vs-timeout is a data race
+root_cause: async_timing
+resolution_type: code_fix
+severity: high
+tags:
+  - abortsignal
+  - abortsignal-any
+  - race-condition
+  - cancel-vs-timeout
+  - side-channel-classification
+  - signal-composition
+---
+
+# Classifying an abort by AbortSignal.any's composite reason is racy — use a side-channel
+
+## Problem
+
+When several abort sources are composed with `AbortSignal.any([...])`, the resulting composite signal aborts with the **reason of whichever child fired first**. Deciding *why* the operation aborted (e.g. operator cancel vs. wall-clock timeout vs. inactivity) by inspecting the composite signal's `.reason` is therefore a race — if two sources fire in quick succession, the reason you read is a coin flip on scheduling order.
+
+## Symptoms
+
+- A run aborted by an operator cancel that also happened to be near its timeout ceiling could be classified as a `timeout` (or vice versa), driving the wrong terminal state and the wrong user-facing message.
+- `combinedSignal.reason` / `combinedSignal.aborted` tells you *that* it aborted and *the first* reason, not *which* of your sources you need to branch on.
+
+## What Didn't Work
+
+- **Inspecting the composite reason.** `AbortSignal.any([timeout, cancel])` yields one signal; reading its `.reason` to distinguish cancel from timeout assumes the source you care about is the one that won the race. It isn't guaranteed.
+- **Passing a custom reason into `abort(reason)`.** Even with distinct reasons per source, the composite still only surfaces the *first* fired source's reason — a distinguishable reason on the loser is invisible.
+
+## Solution
+
+Compose the signals for their *effect* (cancel the operation), but classify from an authoritative **side-channel** that records intent independently of scheduling order. Here, an abort registry whose `abort()` records the run and whose `isAborted(runId)` is queried in the catch handler:
+
+```ts
+// packages/gateway/src/execute/run.ts — compose for effect
+const effectiveSignal = AbortSignal.any([timeoutSignal, cancelSignal])
+// ... run under effectiveSignal ...
+
+// classify from the registry, NOT from the composite reason:
+const wasCancelled = abortRegistry.isAborted(runId)
+if (wasCancelled === true) {
+  // settle CANCELLED
+} else {
+  // settle FAILED/timeout
+}
+```
+
+```ts
+// packages/gateway/src/execute/abort-registry.ts — the side-channel ground truth
+function abort(runId: string, reason?: string, meta?: CancelledByMetadata): boolean {
+  const entry = controllers.get(runId)
+  if (entry === undefined) return false
+  entry.aborted = true          // ← recorded intent, order-independent
+  entry.controller.abort(reason)
+  return true
+}
+function isAborted(runId: string): boolean {
+  return controllers.get(runId)?.aborted === true
+}
+```
+
+`AbortSignal.any` still nests cleanly with any inner composition (e.g. run-core's own inactivity `AbortSignal.any`) — the fix is not about *how* to compose, it's about *not classifying from the composite*.
+
+## Why This Works
+
+The registry records the *cause* the moment it is requested, decoupled from the timing of when each signal's abort event propagates. Whichever signal wins the race to fire, the registry still knows the operator requested a cancel, so classification is deterministic. The composite signal is used only for its job — aborting the work — not as a source of truth about why.
+
+## Prevention
+
+- **Never branch behavior on `AbortSignal.any(...).reason`.** If you compose N signals and need to know which one fired, keep a per-source flag/registry and consult that.
+- **Separate "abort the operation" from "explain the abort."** Composition handles the former; a side-channel handles the latter.
+- **Test the near-simultaneous case.** A test where both the timeout and the cancel are armed and the cancel is requested must assert the classification comes out as cancel regardless — pin that the composite reason is *not* consulted.
+
+## Related Issues
+
+- fro-bot/agent#1111 — operator run cancellation; the settlement path classifies cancel-vs-timeout via the registry probe.
+- [Gateway OpenCode mention-loop best practices](../best-practices/gateway-opencode-mention-loop-best-practices-2026-05-30.md) — `AbortSignal.timeout` composition + bounded-execution discipline this builds on.
+- [Authenticated SSE run observation](../best-practices/authenticated-sse-run-observation-2026-06-20.md) — fail-closed teardown / lease timing in the same async-signal family.

--- a/docs/solutions/logic-errors/thread-id-persistence-gap-in-run-state-2026-07-03.md
+++ b/docs/solutions/logic-errors/thread-id-persistence-gap-in-run-state-2026-07-03.md
@@ -1,0 +1,81 @@
+---
+title: A coordination field written empty at creation and never updated silently breaks every reader
+date: 2026-07-03
+category: logic-errors
+module: gateway/coordination
+problem_type: logic_error
+component: assistant
+symptoms:
+  - Discord runs never surfaced waiting_for_approval on the operator SSE surface
+  - Startup recovery interruption thread-notes were never posted for real runs
+  - All unit tests passed despite the field being empty in production
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - run-state
+  - thread-id
+  - coordination-drift
+  - approval-scope
+  - test-fake-blind-spot
+  - persist-at-adoption
+---
+
+# A coordination field written empty at creation and never updated silently breaks every reader
+
+## Problem
+
+`RunState.thread_id` was written as the empty string at run admission and never written back after the Discord thread was created. Every consumer that resolved the discord approval scope or origin thread from run-state read an empty value, so operator-visible approval status and recovery thread-notes silently did nothing — while all unit tests passed.
+
+## Symptoms
+
+- `web/sse/projection.ts` `scopeIdFor` returned `''` for discord runs, so `hasPendingForScope('')` never matched a real approval → the operator SSE surface never showed `waiting_for_approval` for a discord run.
+- `execute/recovery.ts` posted interruption notes via `resolveThread(run.thread_id)` → `''` resolved nothing → recovery thread-notes effectively never posted.
+- The whole unit suite was green — the bug was invisible to tests.
+
+## What Didn't Work
+
+- **Trusting the tests.** Coverage looked thorough, but every test that touched `thread_id` hand-built a `RunState` fake with `thread_id: 'thread-1'` populated. The fakes encoded the *intended* state, not the *actual* admission shape (`thread_id: ''`), so they masked the write-path gap entirely.
+- **Reading the stale comment.** The adoption transition carried a comment asserting `thread_id` "is not load-bearing for run-state" — an assumption that was false the moment any consumer began resolving the approval scope from it.
+
+## Solution
+
+Persist the live thread id at run adoption. `threadFactory` produces the real thread id immediately before the `PENDING → ACKNOWLEDGED` transition, so fold it into that same conditional write — no extra round-trip, `ifMatch` etag gate unchanged:
+
+```ts
+// packages/gateway/src/execute/run.ts — the ACK transition
+const ackResult = await transitionRun(
+  coordinationConfig, identity, repo, runId, 'ACKNOWLEDGED', task.adoptionEtag, coordLogger,
+  {threadId}, // ← live thread id from threadFactory, persisted atomically with the phase
+)
+```
+
+```ts
+// packages/runtime/src/coordination/run-state.ts — merge only when non-empty
+const threadId = options?.threadId
+const nextState: RunState = {
+  ...parsedCurrent.data,
+  phase: newPhase,
+  ...(threadId !== undefined && threadId !== '' ? {thread_id: threadId} : {}),
+}
+```
+
+Runs with no thread (`threadFactory === undefined`, `threadId` stays `''`) keep an empty `thread_id`, which is correct. Web/GitHub surfaces scope on `run_id` and were never affected. Fixing the one missing write repaired discord approval-scope resolution *and* recovery thread-notes at the root.
+
+## Why This Works
+
+The failure was a **write-path gap, not a read-path bug**: readers were correct; the value they read was never populated. A field initialized empty at creation with an implicit "will be filled in later" that never happens is a silent-degradation trap — no error, no crash, just quietly wrong behavior in every consumer. Persisting at the first transition after the value becomes known closes the gap atomically with an already-required write.
+
+## Prevention
+
+- **When a feature depends on a persisted field, verify the write path, not just the declaration.** Grep for where the field is *written* with a real value, not only where it's typed or read.
+- **Distrust populated test fakes for persistence bugs.** A fake that hand-sets the field to a realistic value proves the reader works, not that production ever writes it. Add at least one test that exercises the *real* creation/admission path and asserts the stored value (via the store fake's written body), not a hand-built object.
+- **Treat "field X is not load-bearing" comments as expiry-dated.** The moment a new consumer resolves behavior from X, the comment is a lie. When adding such a consumer, audit the write path of the field it depends on.
+- **Prefer folding a newly-known value into an already-required conditional write** over a separate follow-up write (which needs its own etag round-trip and can race).
+
+## Related Issues
+
+- fro-bot/agent#1109 — the fix.
+- fro-bot/agent#1111 — the operator run-cancellation feature that exposed the gap (discord approval settlement + thread notice both read `thread_id`).
+- [Centralize resource-key/identity construction to prevent silent cross-signal drift](../best-practices/centralize-s3-key-identity-construction-2026-06-09.md) — sibling silent-coordination-drift pattern; that one is about the *key* being wrong, this one is about the *value* being empty.
+- [@actions/core input env-var mapping gotcha](actions-core-input-env-hyphen-mapping-2026-07-01.md) — same family: a silent gotcha that green tests miss because the fakes encode the intended shape.


### PR DESCRIPTION
## What

Captures three durable learnings from the operator run-cancellation work as `docs/solutions/` entries, so the next occurrence is a lookup instead of a re-derivation.

- **`logic-errors/thread-id-persistence-gap-in-run-state`** — a coordination field (`RunState.thread_id`) written empty at admission and never written back silently broke every consumer that read it (discord approval-scope resolution, recovery thread-notes), while all unit tests passed because the fakes hand-populated the field. Lesson: verify the write path, not just the declaration; distrust populated test fakes for persistence bugs.
- **`best-practices/options-object-for-shared-signature-extension`** — two branches each appending a positional optional param to the same shared function collide ambiguously on rebase (both land at the same arg slot; TypeScript can't catch it since both are optional). Extend via a single options object so sibling additions fold in by field name, not position.
- **`logic-errors/abortsignal-any-reason-classification-race`** — classifying an abort by `AbortSignal.any`'s composite `.reason` is a race (the composite carries whichever child fired first). Compose signals for their effect; classify from a side-channel (a registry probe) that records intent independently of scheduling order.

## Why

Each was non-obvious, cost real investigation this cycle, and generalizes beyond its origin. All three cross-link to the related existing solution docs.

## Verification

- Frontmatter validated against the solution schema (category dirs match `problem_type`, enums valid).
- `bun run check:md-links` passes — every cross-link resolves.
