### PR TITLE
feat(gateway): expose sanitized operator failure reason on run status

### DIFF
--- a/docs/plans/2026-07-04-001-feat-operator-failure-reason-plan.md
+++ b/docs/plans/2026-07-04-001-feat-operator-failure-reason-plan.md
@@ -1,0 +1,234 @@
+---
+title: 'feat: expose sanitized operator failure reason on the run status contract'
+type: feat
+status: active
+date: 2026-07-04
+deepened: 2026-07-04
+---
+
+# feat: expose sanitized operator failure reason on the run status contract
+
+## Overview
+
+Add an optional, allowlisted `failureKind` enum to the operator run-status contract so the dashboard can distinguish *why* a run failed (e.g. inactivity timeout vs. workspace unreachable vs. generic failure) instead of seeing only `status: failed`. The gateway already classifies failures internally; this feature persists that classification onto run-state and maps it — through a closed allowlist — onto both operator-facing run projections. Additive change, folded into the unreleased contract `1.6.0`.
+
+## Problem Frame
+
+A dashboard-launched run can end `failed` while the gateway knows the sanitized failure class (a live case failed after ~6m15s with gateway log reason `inactivity-timeout`), but `OperatorRunStatus` exposes only `phase`/`status`, so the operator UI cannot tell an inactivity timeout from any other failure. The failure kind is computed in the run lifecycle's error path and turned into a Discord message, then discarded — it is never persisted to run-state, so no operator projection can read it back. Source: fro-bot/agent#1099.
+
+## Requirements Trace
+
+- R1. Expose a sanitized failure reason for terminal `FAILED` operator runs, present only when `phase === 'FAILED'`. → Units 1, 2, 3
+- R2. Values are an allowlisted closed enum, never raw error strings / model output / repo-private data / stack traces / internal URLs / tokens. → Unit 1
+- R3. Available on both the live SSE status frame and the recent-runs/index projection. → Unit 2
+- R4. Preserve all redaction invariants: denylisted-repo records still return null; no other `details` key leaks through the new field. → Units 1, 2
+- R5. The internal failure classification is persisted to run-state so a projection can read it. → Units 3, 4
+- R6. Pre-ACK workspace-startup failures (clone/readyz) surface as `workspace-unreachable`; other pre-ACK failures render without a `failureKind`. → Unit 4
+- R7. A regression proves an inactivity-timeout failure exposes the sanitized reason without leaking raw details. → Units 2, 3
+
+## Scope Boundaries
+
+- No `failureMessage` — the gateway ships the allowlisted enum only; the dashboard owns user-facing copy. (Keeps the redaction story airtight: an enum literally cannot leak.)
+- No dashboard rendering — that is `fro-bot/dashboard` work.
+- No contract version bump — additive optional field is MINOR; `OPERATOR_CONTRACT_VERSION` stays `1.6.0` (grown, not bumped).
+- `failureKind` is never set on non-`FAILED` phases (including `CANCELLED`, which takes its own path and carries `cancelledBy`, not `failureKind`).
+
+### Deferred to Separate Tasks
+
+- Full pre-ACK failure-kind coverage (lock-held, threadFactory failure, ACK-race, generic gate throw → distinct kinds): deferred; these render with no `failureKind` for v1. A follow-up can refine if the dashboard needs them.
+- Dashboard consumption (render distinct copy for each kind) + the dashboard's `1.6.0` pin bump: `fro-bot/dashboard`, user-driven, in the same deploy window as the cancellation work (smart note #198).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/gateway/src/execute/run-core.ts` — `RunCoreErrorKind` union (`unreachable`/`auth`/`session-error`/`prompt-error`/`timeout`/`inactivity-timeout`/`stream-ended`/`missing-coordinator`), the internal classification source.
+- `packages/gateway/src/execute/run.ts` — the error-path `is*` classification (`isTimeout`/`isInactivityTimeout`/`isStreamEnded`/`isReachability`), the FAILED transition (no `detailsPatch` today — the seam to add persistence), the `failAdmittedRun` helper called by ~7 pre-ACK gate paths.
+- `packages/gateway/src/operator-contract/run-status.ts` — `OperatorRunStatus` (closed DTO), `PHASE_TO_WEB_STATUS`, `toOperatorRunStatus` (live-SSE projector; reads only whitelisted fields, never `details`). Natural home for `OperatorFailureKind` + the allowlist mapping, beside `PHASE_TO_WEB_STATUS`.
+- `packages/gateway/src/operator-contract/run-summary.ts` — `RunSummary` + `toRunSummary` (recent-runs projector); the `updatedAt?` conditional-spread is the exact pattern `failureKind?` mirrors.
+- `packages/gateway/src/web/sse/projection.ts` — `projectRunObservation` re-copies the DTO field-by-field (the approval overlay path); must copy `failureKind` through from the bridge result (not from run-state directly, preserving the deny-gate).
+- `packages/runtime/src/coordination/run-state.ts` — `TransitionRunOptions.detailsPatch` (added by the cancellation work #1111); the `detailsPatch: {failureKind}` write is atomic with the FAILED phase write (one S3 IfMatch, no extra round-trip). Precedent: `detailsPatch: {cancelledBy}` in `cancel.ts`/`run.ts`.
+- `packages/gateway/src/operator-contract/version.ts` — `OPERATOR_CONTRACT_VERSION = '1.6.0'`; MINOR policy means additive fields do not bump it.
+
+### Institutional Learnings
+
+- `docs/solutions/best-practices/options-object-for-shared-signature-extension-2026-07-03.md` — the `detailsPatch` bag this feature writes through is the extension point that doc established; add `failureKind` as a detail, not a new signature param.
+- Closed-DTO discipline: `projection.test.ts` asserts the operator DTO has *exactly* its whitelisted key set — the structural regression guard. Adding a field means adding it to that set (a deliberate contract-commit), and adding an assertion that no *other* `details` key leaks.
+
+## Key Technical Decisions
+
+- **Enum only, no message** (confirmed): `OperatorFailureKind` is a closed union; the dashboard owns copy. Redaction is trivially safe — the projection maps an internal kind to an allowlisted enum value, so nothing else can pass through.
+- **Grow 1.6.0, don't bump** (confirmed): additive optional field = MINOR; `1.6.0` is unreleased/undeployed and the dashboard pins it once for both cancellation and this. Version test stays `1.6.0`.
+- **The `RunCoreErrorKind → OperatorFailureKind` mapping IS the allowlist** and lives in `run-status.ts`: a `Record<...>` plus an `'unknown'` default so any unrecognized/adversarial `details.failureKind` value becomes `'unknown'` — never a raw passthrough. `missing-coordinator` (and any future internal kind) has no `Record` entry and therefore resolves to `'unknown'` — no new internal kind can leak without an explicit mapping.
+- **The mapper takes the value, not the whole `details` dict** (defense-in-depth): signature is `toOperatorFailureKind(failureKind: unknown): OperatorFailureKind | undefined`, and the caller passes `runState.details.failureKind`. This makes the single-key-read constraint structural in the type signature rather than test-enforced — the mapper physically cannot read any other `details` key.
+- **`OperatorFailureKind` = `'inactivity-timeout' | 'max-duration-timeout' | 'stream-ended' | 'workspace-unreachable' | 'session-error' | 'unknown'`.** Mapping: `timeout`→`max-duration-timeout` (operator-facing rename); `inactivity-timeout`/`stream-ended` direct; `unreachable`+`auth`→`workspace-unreachable` (coarsened deliberately — no network-vs-credential oracle for the operator); `session-error`+`prompt-error`→`session-error` (both upstream-of-tool failures, folded); `missing-coordinator`/empty-prompt/anything else→`unknown`.
+- **Persist on the FAILED transition** via `detailsPatch: {failureKind}` — the classification must land on run-state or no projection can read it. A small `classifyOperatorFailureKind` helper in `run.ts` maps the existing `is*` flags to the internal kind string; the contract module maps that to the operator enum. This includes the rare CANCELLED→FAILED fallback path (when a CANCELLED transition itself fails and the run falls back to FAILED) — the error is already classified there, so the fallback transition must also carry `detailsPatch: {failureKind}`.
+- **Guard against the #1109 write-path trap** (deepen finding): Unit 2's projection tests use hand-built run-state fakes with `details.failureKind` populated — they prove the *reader* works, not that production ever *writes* it. This is the exact pattern that made the thread_id bug (#1109) invisible to a green suite. Mandate at least one end-to-end test that drives a real `transitionRun(FAILED, {detailsPatch:{failureKind}})` and feeds the returned state into `toOperatorRunStatus`/`toRunSummary`, asserting the reason surfaces — tying the write to the read through the real seam.
+- **Present only on `phase === 'FAILED'`**, populated via conditional spread (mirrors `updatedAt?`), so the closed DTO stays honest for every other phase.
+- **Pre-ACK: `workspace-unreachable` only** (confirmed): thread an optional `failureKind` param through `failAdmittedRun`; populate it for clone/readyz gate failures, leave it `undefined` (field omitted) for lock-held/thread-fail/ACK-race/generic gate throw. (Note: lock-held IS terminalized to FAILED — it is just not a *workspace-startup* failure, so it omits the kind.) Verified call-site inventory: 7 pre-ACK `failAdmittedRun` sites (clone/readyz populate; threadFactory×2, lock-error, lock-held, ACK-412 omit) plus a pre-ACK catch-all (omit); the 3 `launchWork` admission sites are out of pre-ACK scope.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Enum vs message: enum only (user-confirmed).
+- Version: grow 1.6.0, no bump (user-confirmed; matches additive MINOR policy).
+- `prompt-error` has no operator enum entry: fold into `session-error` (user-confirmed).
+- Pre-ACK coverage: `workspace-unreachable` for clone/readyz, omit the rest (user-confirmed).
+- `EmptyPromptError` reaching FAILED: front-door guard short-circuits it before run-state exists; if it somehow reaches FAILED, map to `unknown`/omit (defensive).
+
+### Deferred to Implementation
+
+- Whether `classifyOperatorFailureKind` lives inline in `run.ts` or a tiny adjacent `failure-classify.ts` — decide by whether it keeps `run.ts` readable; single consumer either way.
+- Exact `EnsureCloneFailureKind → workspace-unreachable` wiring (ensure-clone uses its own kind namespace) — map at the `failAdmittedRun` call site, don't introduce a parallel enum.
+
+## Implementation Units
+
+- [ ] **Unit 1: Contract type + allowlist mapping**
+
+**Goal:** Define `OperatorFailureKind` and the closed `RunCoreErrorKind → OperatorFailureKind` allowlist gate; export from the contract barrel. No projection changes yet.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/gateway/src/operator-contract/run-status.ts`, `packages/gateway/src/operator-contract/index.ts`
+- Test: `packages/gateway/src/operator-contract/run-status.test.ts`
+
+**Approach:**
+- Add `export type OperatorFailureKind = 'inactivity-timeout' | 'max-duration-timeout' | 'stream-ended' | 'workspace-unreachable' | 'session-error' | 'unknown'`.
+- Add `toOperatorFailureKind(failureKind: unknown): OperatorFailureKind | undefined` beside `PHASE_TO_WEB_STATUS`: takes the value (NOT the `details` dict — the narrow signature makes single-key-read structural), maps a known internal-kind string through a `Record` to the operator enum, returns `'unknown'` for any non-`undefined` value not in the map, and `undefined` when the value is absent. Callers pass `runState.details.failureKind`.
+- Export both from the barrel.
+
+**Patterns to follow:** `PHASE_TO_WEB_STATUS` (the sibling closed mapping); the `?? 'failed'` defaulting style.
+
+**Test scenarios:**
+- Happy path: each known internal kind maps to its operator enum (table-driven: `timeout`→`max-duration-timeout`, `inactivity-timeout`→same, `stream-ended`→same, `unreachable`→`workspace-unreachable`, `auth`→`workspace-unreachable`, `session-error`→same, `prompt-error`→`session-error`).
+- Edge: `details.failureKind` absent → `undefined`.
+- Edge/security: an unrecognized string (`'lol-raw-error'`, `missing-coordinator`) → `'unknown'` (allowlist gate holds).
+- Edge: a non-string value (object/number/null) → `'unknown'` (present) or `undefined` (absent) — never coerced into a raw value.
+- Structural: the mapper's signature takes only the value, so it physically cannot read another `details` key (defense-in-depth over the test guard).
+
+**Verification:** the mapping is total over `RunCoreErrorKind`, falls back to `'unknown'` for everything else, and reads no other detail.
+
+- [ ] **Unit 2: Populate both projections + closed-DTO tests**
+
+**Goal:** Add `failureKind?` to `OperatorRunStatus` and `RunSummary`, populate it (FAILED-only) in both projectors and the SSE copy-through, and update the closed-DTO guards.
+
+**Requirements:** R1, R3, R4, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/gateway/src/operator-contract/run-status.ts` (`OperatorRunStatus` + `toOperatorRunStatus`), `packages/gateway/src/operator-contract/run-summary.ts` (`RunSummary` + `toRunSummary`), `packages/gateway/src/web/sse/projection.ts` (`projectRunObservation` copy-through)
+- Test: `packages/gateway/src/operator-contract/run-status.test.ts`, `packages/gateway/src/operator-contract/run-summary.test.ts`, `packages/gateway/src/web/sse/projection.test.ts`
+
+**Approach:**
+- Add `readonly failureKind?: OperatorFailureKind` to both DTOs.
+- In `toOperatorRunStatus` and `toRunSummary`: conditional spread gated on `phase === 'FAILED'` that calls `toOperatorFailureKind(runState.details.failureKind)` and omits the field when it returns `undefined` (mirrors `updatedAt?`). Read `runState.details.failureKind` ONLY inside this FAILED branch.
+- In `projectRunObservation`: copy `base.failureKind` through from the bridge result (NOT from run-state) so the deny-gate/overlay path stays intact.
+- Update the exact-key-set assertions (`projection.test.ts` `contractFields`, `run-status.test.ts`, `run-summary.test.ts`) to include `failureKind`; add an explicit assertion that no other `details` key (rawOutput, workspacePath, toolArgs, internalUrl) leaks. NOTE: `run-status.test.ts` currently has only a *negative* check (asserts `holder_id`/`thread_id`/`details` absent) — upgrade it to a full exact-key-set assertion so a future sibling-field leak is caught structurally, matching the `projection.test.ts` guard.
+
+**Patterns to follow:** `updatedAt?` conditional spread in `run-summary.ts`; the closed-DTO key-set test in `projection.test.ts`.
+
+**Test scenarios:**
+- Happy path: a FAILED run-state with `details.failureKind = 'inactivity-timeout'` → both projections carry `failureKind: 'inactivity-timeout'` (R7).
+- Edge: a non-FAILED run (running/succeeded/cancelled) → `failureKind` absent from both DTOs.
+- Edge: FAILED run with no `details.failureKind` → field omitted (not `null`, not `'unknown'`).
+- Security/R4: FAILED run whose `details` also contains `rawOutput`/`internalUrl`/`workspacePath` → only `failureKind` surfaces; the closed-key-set test proves no leak.
+- Security: denylisted-repo FAILED run → projection returns null (deny-gate unaffected by the new field).
+- Integration: SSE `projectRunObservation` carries `failureKind` through with the approval overlay applied.
+
+**Verification:** both operator DTOs expose `failureKind` only on FAILED runs; the exact-key-set guards pass with the field added and prove no other detail leaks.
+
+> Write-path caveat (deepen/#1109): these tests use populated run-state fakes and prove only the *reader*. The write is proven in Unit 3's end-to-end scenario — do not treat a green Unit 2 as evidence production populates the field.
+
+- [ ] **Unit 3: Persist the failure kind on the in-flight FAILED transition**
+
+**Goal:** Classify the in-flight run failure and write it to run-state so the projections (Unit 2) can read it.
+
+**Requirements:** R5, R7
+
+**Dependencies:** Unit 1 (needs the internal-kind vocabulary)
+
+**Files:**
+- Modify: `packages/gateway/src/execute/run.ts`
+- Test: `packages/gateway/src/execute/run.test.ts`
+
+**Approach:**
+- Add a `classifyOperatorFailureKind(...)` helper mapping the existing error-path `is*` flags (`isTimeout`/`isInactivityTimeout`/`isStreamEnded`/`isReachability`, plus the `RunCoreError.kind` for `session-error`/`prompt-error`) to the internal kind string; catch-all → the value that maps to `'unknown'`.
+- On the in-flight FAILED `transitionRun` call, pass `detailsPatch: {failureKind: <internal-kind-string>}` (atomic with the phase write). Do NOT set `failureKind` on the CANCELLED path (it carries `cancelledBy`, not `failureKind`). DO cover the CANCELLED→FAILED fallback path (when the CANCELLED transition fails and the run falls back to FAILED): the error is already classified there, so that fallback `transitionRun` must also carry `detailsPatch: {failureKind}` — otherwise the rare fallback surfaces `failed` with no reason.
+- `details.failureKind` is additive-safe: verified no gateway/runtime consumer iterates `details` keys or asserts a closed shape (only `cancel.ts` reads `details.channelId`, `run-state.ts` validates the container type). `cancelledBy` and `failureKind` never coexist (mutually exclusive by phase), so the `{...details, ...detailsPatch}` merge cannot collide.
+
+**Patterns to follow:** the `detailsPatch: {cancelledBy}` write in `run.ts`/`cancel.ts` (#1111); the existing `is*` classification block.
+
+**Test scenarios:**
+- **End-to-end (the #1109 guard — required):** drive a real `transitionRun(FAILED, {detailsPatch:{failureKind:'inactivity-timeout'}})` and feed the RETURNED run-state into `toOperatorRunStatus`/`toRunSummary`, asserting the projection carries `failureKind:'inactivity-timeout'`. This ties the write to the read through the real seam — a green Unit 2 alone does not prove production writes the field.
+- Happy path: an inactivity-timeout failure → FAILED transition called with `detailsPatch.failureKind` = the inactivity kind.
+- Happy path: a wall-clock timeout → `detailsPatch.failureKind` maps to `max-duration-timeout` at the projection.
+- Edge: a generic/uncategorized failure → `failureKind` maps to `'unknown'` (or is omitted per the classify helper's contract — pick one and assert it).
+- Edge: reachability failure (`unreachable`/`auth`) → persisted kind projects to `workspace-unreachable`.
+- Regression: the CANCELLED path still writes `cancelledBy` and NOT `failureKind`.
+- Fallback: a run whose CANCELLED transition fails and falls back to FAILED persists `detailsPatch.failureKind` (reason survives the fallback).
+
+**Verification:** the FAILED transition persists the classified kind; a full inactivity-timeout path surfaces the sanitized reason on the operator contract with no raw detail leak.
+
+- [ ] **Unit 4: Pre-ACK workspace-unreachable coverage**
+
+**Goal:** Surface `workspace-unreachable` for pre-ACK workspace-startup failures; leave other pre-ACK failures without a `failureKind`.
+
+**Requirements:** R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `packages/gateway/src/execute/run.ts` (`failAdmittedRun` + its clone/readyz call sites)
+- Test: `packages/gateway/src/execute/run.test.ts`
+
+**Approach:**
+- Add an optional `failureKind?` param to `failAdmittedRun`; when present, thread it into the FAILED `transitionRun` via `detailsPatch: {failureKind}`.
+- At the clone-failure and readyz-failure call sites, pass the workspace-unreachable internal kind (map the ensure-clone kind namespace at the call site — do not add a parallel enum). Leave lock-held/threadFactory-fail/ACK-race/generic-gate-throw call sites passing nothing (field omitted).
+
+**Patterns to follow:** the existing `failAdmittedRun` call sites; Unit 3's `detailsPatch` write.
+
+**Test scenarios:**
+- Happy path: workspace clone failure pre-ACK → run-state FAILED carries the workspace-unreachable kind → projection exposes `workspace-unreachable`.
+- Happy path: readyz failure pre-ACK → same.
+- Edge: lock-held path (an expected non-failure) → no `failureKind` written; projection omits the field.
+- Edge: threadFactory failure / ACK-race → FAILED with no `failureKind` (omitted).
+
+**Verification:** clone/readyz pre-ACK failures are operator-distinguishable as `workspace-unreachable`; other pre-ACK terminalizations render without a failure reason.
+
+## System-Wide Impact
+
+- **Interaction graph:** touches the two operator projections, the SSE observation copy-through, the in-flight + pre-ACK FAILED transitions, and the run-state `details` write. No new routes, no new frames, no version bump.
+- **Error propagation:** the failure kind now travels run.ts classification → run-state `details` → projection → operator DTO, instead of dying at the Discord message. The Discord user-message path is unchanged.
+- **State lifecycle risks:** `failureKind` is written atomically with the FAILED phase (single conditional write). The `terminalReplayCache` carries the enriched DTO to late subscribers automatically. `terminalRuns` out-of-order guard is inert to an added field.
+- **API surface parity:** both operator run projections (`toOperatorRunStatus`, `toRunSummary`) gain the field in lockstep; the SSE overlay path copies it through. Missing one would make the surfaces disagree.
+- **Integration coverage:** the closed-DTO key-set tests are the structural guard that the field is exposed *and* that no sibling `details` key leaks.
+- **Unchanged invariants:** `OPERATOR_CONTRACT_VERSION` stays `1.6.0`; denylist gate still returns null for denied repos; internal fields (`holder_id`/`thread_id`/`details`) remain excluded by construction; `registry.handleDecision`/cancellation paths untouched; the ready/health frames still emit `1.6.0`.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| A raw internal string leaks through `failureKind` | The projection maps through a closed `Record` with `'unknown'` default — the mapping IS the allowlist; the mapper's signature takes only the value (cannot read another `details` key); a table-driven test + the closed-key-set test prove no passthrough. |
+| **Green Unit 2 masks a missing/wrong Unit 3 write** (the #1109 thread_id-fake trap) | Unit 2 fakes populate `details.failureKind`, proving only the reader. Unit 3 mandates an end-to-end `transitionRun`→projection test that ties write to read through the real seam. |
+| `RunSummary` denylist filtering is caller-level (not built into `toRunSummary`) | Adding `failureKind` does not change this — callers must keep filtering denied records before projection (existing `filterDeniedRecords` in the runs route). Noted so a future caller doesn't assume `toRunSummary` self-guards. |
+| Presence-vs-absence of `failureKind` on FAILED runs is a coarse oracle (pre-ACK-non-workspace vs `unknown`) | Accepted for v1: the operator can already infer pre-ACK timing, and writing `'unknown'` on every path would thread an extra param through all pre-ACK sites. Revisit if it proves exploitable. |
+| Projections drift (one surface gains the field, the other doesn't) | Units 2 covers both `toOperatorRunStatus` and `toRunSummary` in one unit with parity tests. |
+| Growing `1.6.0` post-merge confuses anyone reasoning from the merged cancellation PR | Nothing consumes `1.6.0` yet (unreleased, dashboard unpinned); documented that this and cancellation ship as one `1.6.0` the dashboard pins once. |
+| Pre-ACK threading balloons scope | Scoped to `workspace-unreachable` on clone/readyz only; other call sites pass nothing (field omitted). |
+| `failureKind` accidentally set on non-FAILED (esp. CANCELLED) | Population is gated on `phase === 'FAILED'` in the projection and only written on FAILED transitions; a regression asserts CANCELLED carries `cancelledBy`, not `failureKind`. |
+
+## Documentation / Operational Notes
+
+- Dashboard follow-up (render per-kind copy + pin `1.6.0`) is tracked in smart note #198; surface it at PR time so the dashboard consumes both cancellation and failure-reason in one pin bump.
+- No deploy/compose/env changes.
+
+## Sources & References
+
+- Origin issue: fro-bot/agent#1099.
+- Related: #1055 (inactivity-timeout policy, shipped — the failure class this exposes), #1111 (contract `1.6.0` + the `detailsPatch` seam this writes through), #1101 (lost-event vs hung diagnostics — complementary; once this ships the dashboard can at least name the reason).
+- Related code: see Context & Research.

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -7421,3 +7421,240 @@ describe('operator cancel — abort-registry integration', () => {
     expect(mockRunOpenCodeCore).not.toHaveBeenCalled()
   })
 })
+
+// ---------------------------------------------------------------------------
+// failureKind persistence on the FAILED transition (Unit 3)
+// ---------------------------------------------------------------------------
+
+describe('failureKind persistence on FAILED transitions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('inactivity-timeout failure: FAILED transitionRun called with detailsPatch.failureKind = internal kind', async () => {
+    // #given
+    const {runMention} = await import('./run.js')
+    const {RunCoreError} = runCoreModule
+    setupHappyPath()
+    mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('inactivity-timeout', 'no progress'))
+
+    const deps = makeDeps()
+    const message = makeMessage()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then
+    const failedCall = mockRuntime.transitionRun.mock.calls.find((c: unknown[]) => c[4] === 'FAILED')
+    const failedOptions = failedCall?.[7] as {detailsPatch: {failureKind: unknown}} | undefined
+    expect(failedOptions?.detailsPatch.failureKind).toBe('inactivity-timeout')
+  })
+
+  it('wall-clock timeout failure: detailsPatch.failureKind = internal "timeout" kind (projects to max-duration-timeout)', async () => {
+    // #given
+    const {runMention} = await import('./run.js')
+    const {RunCoreError} = runCoreModule
+    setupHappyPath()
+    mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('timeout', 'timed out'))
+
+    const deps = makeDeps()
+    const message = makeMessage()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then
+    const failedCall = mockRuntime.transitionRun.mock.calls.find((c: unknown[]) => c[4] === 'FAILED')
+    const failedOptions = failedCall?.[7] as {detailsPatch: {failureKind: unknown}} | undefined
+    expect(failedOptions?.detailsPatch.failureKind).toBe('timeout')
+
+    const {toOperatorFailureKind} = await import('../operator-contract/run-status.js')
+    expect(toOperatorFailureKind(failedOptions?.detailsPatch.failureKind)).toBe('max-duration-timeout')
+  })
+
+  it('reachability failure (unreachable/auth): persisted kind projects to workspace-unreachable', async () => {
+    // #given
+    const {runMention} = await import('./run.js')
+    const {RunCoreError} = runCoreModule
+    setupHappyPath()
+    mockRunOpenCodeCore.mockRejectedValue(new RunCoreError('unreachable', 'network error'))
+
+    const deps = makeDeps()
+    const message = makeMessage()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then
+    const failedCall = mockRuntime.transitionRun.mock.calls.find((c: unknown[]) => c[4] === 'FAILED')
+    const failedOptions = failedCall?.[7] as {detailsPatch: {failureKind: unknown}} | undefined
+    expect(failedOptions?.detailsPatch.failureKind).toBe('unreachable')
+
+    const {toOperatorFailureKind} = await import('../operator-contract/run-status.js')
+    expect(toOperatorFailureKind(failedOptions?.detailsPatch.failureKind)).toBe('workspace-unreachable')
+  })
+
+  it('generic/uncategorized failure: failureKind omitted from detailsPatch (no options object, or options without failureKind)', async () => {
+    // #given — a plain Error, not a RunCoreError
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+    mockRunOpenCodeCore.mockRejectedValue(new Error('boom'))
+
+    const deps = makeDeps()
+    const message = makeMessage()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — the FAILED transitionRun call carries no detailsPatch.failureKind
+    const failedCall = mockRuntime.transitionRun.mock.calls.find((c: unknown[]) => c[4] === 'FAILED')
+    const failedOptions = failedCall?.[7]
+    expect(failedOptions?.detailsPatch?.failureKind).toBeUndefined()
+  })
+
+  it('regression: the CANCELLED path still writes cancelledBy and NOT failureKind', async () => {
+    // #given — a run whose registry entry is aborted mid-flight (operator cancel)
+    const {launchWork} = await import('./run.js')
+    const REGRESSION_CANCEL_RUN_ID = 'regression-cancel-run-id'
+    setupHappyPath()
+    const cancelledState = buildMockRunState({phase: 'CANCELLED', run_id: REGRESSION_CANCEL_RUN_ID})
+    mockRuntime.transitionRun
+      .mockResolvedValueOnce({
+        success: true as const,
+        data: {etag: 'ack-etag', state: buildMockRunState({phase: 'ACKNOWLEDGED', run_id: REGRESSION_CANCEL_RUN_ID})},
+      })
+      .mockResolvedValueOnce({
+        success: true as const,
+        data: {etag: 'exec-etag', state: buildMockRunState({phase: 'EXECUTING', run_id: REGRESSION_CANCEL_RUN_ID})},
+      })
+      .mockResolvedValueOnce({success: true as const, data: {etag: 'cancelled-etag', state: cancelledState}})
+
+    const cancelledByMetadata = {
+      githubUserId: 1,
+      login: 'someone',
+      sessionCorrelationId: 'sess-x',
+      cancelledAt: '2026-07-04T00:00:00.000Z',
+    }
+    mockRunOpenCodeCoreAbortedBy(() => {
+      abortRegistry.abort(REGRESSION_CANCEL_RUN_ID, 'operator cancel', cancelledByMetadata)
+    })
+
+    const request = makeInMemoryRequest()
+    ;(request as {runId?: string}).runId = REGRESSION_CANCEL_RUN_ID
+    const deps = makeDeps()
+
+    // #when
+    await awaitLaunchWorkRun(launchWork, request, deps)
+
+    // #then — CANCELLED transition carries cancelledBy, not failureKind
+    const cancelledCall = mockRuntime.transitionRun.mock.calls.find((c: unknown[]) => c[4] === 'CANCELLED')
+    const cancelledOptions = cancelledCall?.[7] as {detailsPatch: Record<string, unknown>} | undefined
+    expect(cancelledOptions?.detailsPatch.cancelledBy).toEqual(cancelledByMetadata)
+    expect(cancelledOptions?.detailsPatch.failureKind).toBeUndefined()
+
+    abortRegistry.delete(REGRESSION_CANCEL_RUN_ID)
+  })
+
+  it('fallback: CANCELLED transition returns success:false → FAILED fallback persists detailsPatch.failureKind', async () => {
+    // #given — the CANCELLED transitionRun call itself fails; the run falls back to FAILED
+    const {launchWork} = await import('./run.js')
+    const FALLBACK_RUN_ID = 'fallback-cancel-run-id'
+    setupHappyPath()
+    const failedFallbackState = buildMockRunState({phase: 'FAILED', run_id: FALLBACK_RUN_ID})
+    mockRuntime.transitionRun
+      .mockResolvedValueOnce({
+        success: true as const,
+        data: {etag: 'ack-etag', state: buildMockRunState({phase: 'ACKNOWLEDGED', run_id: FALLBACK_RUN_ID})},
+      })
+      .mockResolvedValueOnce({
+        success: true as const,
+        data: {etag: 'exec-etag', state: buildMockRunState({phase: 'EXECUTING', run_id: FALLBACK_RUN_ID})},
+      })
+      .mockResolvedValueOnce({success: false as const, error: new Error('CANCELLED transition failed')})
+      .mockResolvedValueOnce({success: true as const, data: {etag: 'failed-etag', state: failedFallbackState}})
+
+    const {RunCoreError} = runCoreModule
+    mockRunOpenCodeCore.mockImplementation(async () => {
+      abortRegistry.abort(FALLBACK_RUN_ID, 'operator cancel')
+      throw new RunCoreError('inactivity-timeout', 'no progress')
+    })
+
+    const request = makeInMemoryRequest()
+    ;(request as {runId?: string}).runId = FALLBACK_RUN_ID
+    const deps = makeDeps()
+
+    // #when
+    await awaitLaunchWorkRun(launchWork, request, deps)
+
+    // #then — the CANCELLED call was attempted, then the FAILED fallback carries failureKind
+    const transitionCalls = mockRuntime.transitionRun.mock.calls
+    const cancelledCall = transitionCalls.find((c: unknown[]) => c[4] === 'CANCELLED')
+    expect(cancelledCall).toBeDefined()
+    const failedFallbackCall = transitionCalls.find((c: unknown[]) => c[4] === 'FAILED')
+    const failedFallbackOptions = failedFallbackCall?.[7] as {detailsPatch: {failureKind: unknown}} | undefined
+    expect(failedFallbackOptions?.detailsPatch.failureKind).toBe('inactivity-timeout')
+
+    abortRegistry.delete(FALLBACK_RUN_ID)
+  })
+
+  it('end-to-end (#1109 guard): a real transitionRun(FAILED, {detailsPatch:{failureKind}}) round-trip through the coordination store projects to the operator enum on both surfaces', async () => {
+    // #given — the REAL transitionRun (unmocked for this test) against a fake store adapter,
+    // driving a PENDING run through FAILED with detailsPatch.failureKind, then feeding the
+    // RETURNED state into both operator projections. This ties the write to the read through
+    // the real seam (not a hand-built run-state fake) per the #1109 write-path-trap guard.
+    const {transitionRun: realTransitionRun} =
+      await vi.importActual<typeof import('@fro-bot/runtime')>('@fro-bot/runtime')
+    const {toOperatorRunStatus} = await import('../operator-contract/run-status.js')
+    const {toRunSummary} = await import('../operator-contract/run-summary.js')
+
+    const initialState = buildMockRunState({phase: 'EXECUTING', run_id: 'e2e-run-1', entity_ref: 'acme/widget#1'})
+    let stored = JSON.stringify(initialState)
+    const storeAdapter = {
+      upload: vi.fn(),
+      download: vi.fn(),
+      list: vi.fn(),
+      conditionalPut: vi.fn(async (_key: unknown, data: string) => {
+        stored = data
+        return {success: true as const, data: {etag: 'etag-2'}}
+      }),
+      conditionalDelete: vi.fn(),
+      getObject: vi.fn(async () => ({success: true as const, data: {data: stored, etag: 'etag-1'}})),
+      listWithMetadata: vi.fn(),
+    }
+    const coordinationConfig = {
+      storeAdapter,
+      storeConfig: {enabled: true, bucket: 'test-bucket', region: 'us-east-1', prefix: 'fro-bot-state'},
+      lockTtlSeconds: 900,
+      heartbeatIntervalMs: 30_000,
+      staleThresholdMs: 60_000,
+      pendingStaleThresholdMs: 30 * 60_000,
+    } as unknown as CoordinationConfig
+    const logger = {debug: vi.fn()}
+
+    // #when — the real seam: transitionRun with detailsPatch.failureKind
+    const result = await realTransitionRun(
+      coordinationConfig,
+      'discord-gateway',
+      'acme/widget',
+      'e2e-run-1',
+      'FAILED',
+      'etag-1',
+      logger,
+      {detailsPatch: {failureKind: 'inactivity-timeout'}},
+    )
+    expect(result.success).toBe(true)
+    if (result.success === false) return
+
+    // #then — the RETURNED run-state projects failureKind on both operator surfaces
+    const operatorStatus = toOperatorRunStatus(result.data.state, {
+      nowMs: Date.now(),
+      staleThresholdMs: 60_000,
+      repoKey: {databaseId: 123, nodeId: 'node-123'},
+      isRepoDenylisted: () => false,
+    })
+    expect(operatorStatus?.failureKind).toBe('inactivity-timeout')
+
+    const summary = toRunSummary(result.data.state, {owner: 'acme', repo: 'widget'})
+    expect(summary?.failureKind).toBe('inactivity-timeout')
+  })
+})

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -7658,3 +7658,109 @@ describe('failureKind persistence on FAILED transitions', () => {
     expect(summary?.failureKind).toBe('inactivity-timeout')
   })
 })
+
+// ---------------------------------------------------------------------------
+// failAdmittedRun failureKind threading (Unit 4) — pre-ACK gates
+// ---------------------------------------------------------------------------
+
+describe('failAdmittedRun failureKind threading (pre-ACK gates)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('workspace clone failure: FAILED transitionRun carries detailsPatch.failureKind = "unreachable"', async () => {
+    // #given — ensureClone fails before ACK
+    const {runMention} = await import('./run.js')
+    const ensureClone = makeEnsureCloneFn('failure')
+    const message = makeMessage()
+    const deps = makeDeps({ensureClone})
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — the FAILED transitionRun call persists the internal 'unreachable' kind
+    const failedCall = mockRuntime.transitionRun.mock.calls.find((c: unknown[]) => c[4] === 'FAILED')
+    const failedOptions = failedCall?.[7] as {detailsPatch: {failureKind: unknown}} | undefined
+    expect(failedOptions?.detailsPatch.failureKind).toBe('unreachable')
+
+    // #and — this projects to 'workspace-unreachable' via the operator mapping (Unit 1)
+    const {toOperatorFailureKind} = await import('../operator-contract/run-status.js')
+    expect(toOperatorFailureKind(failedOptions?.detailsPatch.failureKind)).toBe('workspace-unreachable')
+  })
+
+  it('readyz failure: FAILED transitionRun carries detailsPatch.failureKind = "unreachable"', async () => {
+    // #given — readyz reports not-ready before ACK
+    const {runMention} = await import('./run.js')
+    const readyz = makeReadyzFn('not-ready')
+    const message = makeMessage()
+    const deps = makeDeps({readyz})
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — the FAILED transitionRun call persists the internal 'unreachable' kind
+    const failedCall = mockRuntime.transitionRun.mock.calls.find((c: unknown[]) => c[4] === 'FAILED')
+    const failedOptions = failedCall?.[7] as {detailsPatch: {failureKind: unknown}} | undefined
+    expect(failedOptions?.detailsPatch.failureKind).toBe('unreachable')
+
+    const {toOperatorFailureKind} = await import('../operator-contract/run-status.js')
+    expect(toOperatorFailureKind(failedOptions?.detailsPatch.failureKind)).toBe('workspace-unreachable')
+  })
+
+  it('lock held: FAILED transitionRun omits detailsPatch.failureKind (contention, not a workspace-startup failure)', async () => {
+    // #given — lock is held by another gateway
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+    const message = makeMessage()
+    const deps = makeDeps()
+
+    mockRuntime.acquireLock.mockResolvedValue({
+      success: true as const,
+      data: {acquired: false as const, etag: null, holder: {holder_id: 'other-gateway', etag: 'abc'} as unknown},
+    } as Awaited<ReturnType<typeof runtimeModule.acquireLock>>)
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — the FAILED transitionRun call carries no detailsPatch.failureKind
+    const failedCall = mockRuntime.transitionRun.mock.calls.find((c: unknown[]) => c[4] === 'FAILED')
+    const failedOptions = failedCall?.[7] as {detailsPatch?: {failureKind?: unknown}}
+    expect(failedOptions?.detailsPatch?.failureKind).toBeUndefined()
+  })
+
+  it('threadFactory throws: FAILED transitionRun omits detailsPatch.failureKind', async () => {
+    // #given — threadFactory (message.startThread) rejects before ACK
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+    const thread = makeThread()
+    const message = makeMessage(thread)
+    ;(message.startThread as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Discord thread creation failed'))
+    const deps = makeDeps()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then
+    const failedCall = mockRuntime.transitionRun.mock.calls.find((c: unknown[]) => c[4] === 'FAILED')
+    const failedOptions = failedCall?.[7] as {detailsPatch?: {failureKind?: unknown}}
+    expect(failedOptions?.detailsPatch?.failureKind).toBeUndefined()
+  })
+
+  it('regression: omit call sites still call failAdmittedRun with the same signature (no behavior change)', async () => {
+    // #given — a plain Error from the core run (generic failure, not a pre-ACK gate)
+    const {runMention} = await import('./run.js')
+    setupHappyPath()
+    mockRunOpenCodeCore.mockRejectedValue(new Error('boom'))
+
+    const deps = makeDeps()
+    const message = makeMessage()
+
+    // #when
+    await runMention(message, makeBinding(), deps)
+
+    // #then — FAILED transition still occurs with no failureKind (this failure is post-ACK, Unit 3's path)
+    const failedCall = mockRuntime.transitionRun.mock.calls.find((c: unknown[]) => c[4] === 'FAILED')
+    const failedOptions = failedCall?.[7] as {detailsPatch?: {failureKind?: unknown}}
+    expect(failedOptions?.detailsPatch?.failureKind).toBeUndefined()
+  })
+})

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -270,6 +270,24 @@ export function computeApprovalDeadlineMs(remainingBudgetMs: number): number | u
 
 // DiscordAdapterBridge was removed — thread creation now lives in the adapter via threadFactory
 
+/**
+ * Classify an in-flight execution failure to the internal failure-kind string
+ * persisted on the FAILED run-state (`details.failureKind`).
+ *
+ * Returns the internal `RunCoreErrorKind` verbatim when `execError` is a
+ * `RunCoreError` (e.g. `'timeout'`, `'inactivity-timeout'`, `'unreachable'`) —
+ * the operator-contract projection (`toOperatorFailureKind`) owns mapping
+ * these internal kinds to the closed operator enum.
+ *
+ * Returns `undefined` for any non-`RunCoreError` failure (generic JS error,
+ * a stray `EmptyPromptError`, etc.) so `details.failureKind` is omitted
+ * rather than persisting a synthetic 'unknown' string — the projection
+ * already renders an absent field as no failure reason.
+ */
+function classifyOperatorFailureKind(execError: unknown): string | undefined {
+  return execError instanceof RunCoreError ? execError.kind : undefined
+}
+
 // ---------------------------------------------------------------------------
 // executeWorkOnHeldSlot — the private slot-holding execution pipeline
 // ---------------------------------------------------------------------------
@@ -858,6 +876,11 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
           // released by the outer finally is an inconsistent state until the next recovery
           // sweep. Attempt a best-effort FAILED terminalization with the same etag (FAILED
           // is a valid transition from EXECUTING) rather than leaving this to recovery alone.
+          // The error is already classified above (the cancel path itself was entered via
+          // execError) — carry it through so the rare fallback still surfaces a reason.
+          const fallbackFailureKind = classifyOperatorFailureKind(execError)
+          const fallbackOptions =
+            fallbackFailureKind === undefined ? undefined : {detailsPatch: {failureKind: fallbackFailureKind}}
           const failedFallbackResult = await transitionRun(
             coordinationConfig,
             identity,
@@ -866,6 +889,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
             'FAILED',
             runEtag,
             coordLogger,
+            fallbackOptions,
           )
           if (failedFallbackResult.success === false) {
             logger.error(
@@ -908,7 +932,11 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
           }
         }
 
-        // Transition to FAILED (best-effort)
+        // Transition to FAILED (best-effort), carrying the classified failure kind
+        // atomically with the phase write so the operator projections can read it back.
+        const inFlightFailureKind = classifyOperatorFailureKind(execError)
+        const inFlightFailedOptions =
+          inFlightFailureKind === undefined ? undefined : {detailsPatch: {failureKind: inFlightFailureKind}}
         const failedResult = await transitionRun(
           coordinationConfig,
           identity,
@@ -917,6 +945,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
           'FAILED',
           runEtag,
           coordLogger,
+          inFlightFailedOptions,
         )
         // Capture the FAILED state now so we can notify AFTER the partial-output flush.
         // The notify is deferred to guarantee the web sink's flush() → final output frame

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -372,7 +372,8 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
         'run: workspace clone unavailable — aborting',
       )
       // Gate 1 failure: terminalize the admitted run to FAILED before replying.
-      await failAdmittedRun(deps, repo, runId, task.adoptionEtag)
+      // 'unreachable' maps to 'workspace-unreachable' via the operator projection.
+      await failAdmittedRun(deps, repo, runId, task.adoptionEtag, 'unreachable')
       await request.replySink.send('source', {
         content: 'The workspace is not available right now. Please try again later.',
       })
@@ -399,7 +400,8 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
     if (workspaceReady === false) {
       logger.warn({channelId, repo}, 'run: workspace not ready — aborting')
       // Gate 2 failure: terminalize the admitted run to FAILED before replying.
-      await failAdmittedRun(deps, repo, runId, task.adoptionEtag)
+      // 'unreachable' maps to 'workspace-unreachable' via the operator projection.
+      await failAdmittedRun(deps, repo, runId, task.adoptionEtag, 'unreachable')
       await request.replySink.send('source', {
         content: 'The workspace is not reachable right now. Please try again later.',
       })
@@ -1369,11 +1371,31 @@ function notifyObserverBestEffort(deps: RunMentionDeps, state: RunState): void {
  * Uses the provided etag (the latest known etag for this run). Best-effort:
  * a failure to transition is logged but not propagated — the caller's error
  * takes precedence.
+ *
+ * `failureKind`, when provided, is persisted as `details.failureKind` on the
+ * FAILED transition — used by the workspace-startup gates (clone/readyz) so
+ * the operator projection can surface `workspace-unreachable`. Omitted for
+ * all other pre-ACK failure paths (contention, transport, admission races).
  */
-async function failAdmittedRun(deps: RunMentionDeps, repo: string, runId: string, currentEtag: string): Promise<void> {
+async function failAdmittedRun(
+  deps: RunMentionDeps,
+  repo: string,
+  runId: string,
+  currentEtag: string,
+  failureKind?: string,
+): Promise<void> {
   const {coordinationConfig, identity, logger} = deps
   const coordLogger = toCoordLogger(logger)
-  const failResult = await transitionRun(coordinationConfig, identity, repo, runId, 'FAILED', currentEtag, coordLogger)
+  const failResult = await transitionRun(
+    coordinationConfig,
+    identity,
+    repo,
+    runId,
+    'FAILED',
+    currentEtag,
+    coordLogger,
+    failureKind === undefined ? undefined : {detailsPatch: {failureKind}},
+  )
   if (failResult.success === false) {
     logger.error({repo, runId, err: failResult.error.message}, 'run: failAdmittedRun — transitionRun FAILED failed')
   } else {

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -284,7 +284,7 @@ export function computeApprovalDeadlineMs(remainingBudgetMs: number): number | u
  * rather than persisting a synthetic 'unknown' string — the projection
  * already renders an absent field as no failure reason.
  */
-function classifyOperatorFailureKind(execError: unknown): string | undefined {
+function extractRunCoreKind(execError: unknown): string | undefined {
   return execError instanceof RunCoreError ? execError.kind : undefined
 }
 
@@ -878,9 +878,10 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
           // released by the outer finally is an inconsistent state until the next recovery
           // sweep. Attempt a best-effort FAILED terminalization with the same etag (FAILED
           // is a valid transition from EXECUTING) rather than leaving this to recovery alone.
-          // The error is already classified above (the cancel path itself was entered via
-          // execError) — carry it through so the rare fallback still surfaces a reason.
-          const fallbackFailureKind = classifyOperatorFailureKind(execError)
+          // The cancel path was entered via the wasCancelled registry check; execError is
+          // still the caught throw and is classified here for the rare CANCELLED→FAILED
+          // fallback (usually an AbortError → no RunCoreError.kind → failureKind omitted).
+          const fallbackFailureKind = extractRunCoreKind(execError)
           const fallbackOptions =
             fallbackFailureKind === undefined ? undefined : {detailsPatch: {failureKind: fallbackFailureKind}}
           const failedFallbackResult = await transitionRun(
@@ -936,7 +937,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
 
         // Transition to FAILED (best-effort), carrying the classified failure kind
         // atomically with the phase write so the operator projections can read it back.
-        const inFlightFailureKind = classifyOperatorFailureKind(execError)
+        const inFlightFailureKind = extractRunCoreKind(execError)
         const inFlightFailedOptions =
           inFlightFailureKind === undefined ? undefined : {detailsPatch: {failureKind: inFlightFailureKind}}
         const failedResult = await transitionRun(

--- a/packages/gateway/src/operator-contract/index.ts
+++ b/packages/gateway/src/operator-contract/index.ts
@@ -38,8 +38,15 @@ export type {
   OperatorOk,
   OperatorSessionInfo,
 } from './responses.js'
-export type {OperatorRunStatus, OperatorWebStatus, RunPhase, RunStatusRepoKey, Surface} from './run-status.js'
-export {toOperatorRunStatus} from './run-status.js'
+export type {
+  OperatorFailureKind,
+  OperatorRunStatus,
+  OperatorWebStatus,
+  RunPhase,
+  RunStatusRepoKey,
+  Surface,
+} from './run-status.js'
+export {toOperatorFailureKind, toOperatorRunStatus} from './run-status.js'
 export type {RunSummary, RunSummaryStatus} from './run-summary.js'
 export {toRunSummary} from './run-summary.js'
 export {OPERATOR_CONTRACT_VERSION} from './version.js'

--- a/packages/gateway/src/operator-contract/run-status.test.ts
+++ b/packages/gateway/src/operator-contract/run-status.test.ts
@@ -461,6 +461,51 @@ describe('toOperatorFailureKind — allowlist mapping', () => {
       expect(result).toBe('unknown')
     },
   )
+
+  it("(edge) empty string '' maps to 'unknown' (not undefined — present but unrecognized)", () => {
+    // #given an empty-string failure-kind value (distinct from absent/undefined)
+    // #when mapped
+    const result = toOperatorFailureKind('')
+
+    // #then it is treated as an unrecognized string and falls back to 'unknown'
+    expect(result).toBe('unknown')
+  })
+})
+
+describe('RUN_CORE_ERROR_KIND_TO_OPERATOR_FAILURE_KIND — exhaustive over RunCoreErrorKind', () => {
+  it('every RunCoreErrorKind member maps to a valid OperatorFailureKind via toOperatorFailureKind', () => {
+    // #given every member of the internal RunCoreErrorKind union
+    const allRunCoreErrorKinds = [
+      'unreachable',
+      'auth',
+      'session-error',
+      'prompt-error',
+      'timeout',
+      'inactivity-timeout',
+      'stream-ended',
+      'missing-coordinator',
+    ] as const
+
+    const validOperatorFailureKinds = new Set<OperatorFailureKind>([
+      'inactivity-timeout',
+      'max-duration-timeout',
+      'stream-ended',
+      'workspace-unreachable',
+      'session-error',
+      'unknown',
+    ])
+
+    for (const kind of allRunCoreErrorKinds) {
+      // #when mapped through the operator-safe gate
+      const result = toOperatorFailureKind(kind)
+
+      // #then it resolves to one of the six closed OperatorFailureKind values
+      // (including 'unknown' for kinds with no operator-meaningful mapping, e.g.
+      // 'missing-coordinator')
+      assert(result !== undefined, `expected ${kind} to map to a defined OperatorFailureKind`)
+      expect(validOperatorFailureKinds.has(result)).toBe(true)
+    }
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/operator-contract/run-status.test.ts
+++ b/packages/gateway/src/operator-contract/run-status.test.ts
@@ -1,8 +1,8 @@
 import type {RunState} from '@fro-bot/runtime'
-import type {OperatorRunStatus, OperatorWebStatus} from './run-status.js'
+import type {OperatorFailureKind, OperatorRunStatus, OperatorWebStatus} from './run-status.js'
 
 import {assert, describe, expect, expectTypeOf, it} from 'vitest'
-import {toOperatorRunStatus} from './run-status.js'
+import {toOperatorFailureKind, toOperatorRunStatus} from './run-status.js'
 
 // ---------------------------------------------------------------------------
 // Shared fixture helpers
@@ -329,6 +329,71 @@ describe('toOperatorRunStatus — unknown phase fallback (fail-closed)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// toOperatorFailureKind — internal→operator failure-kind mapping
+//
+// Structural note: toOperatorFailureKind(failureKind: unknown) takes only the single
+// candidate VALUE — never a details/context object — so it is structurally impossible
+// for this function to read any other key off a details dict.
+// ---------------------------------------------------------------------------
+
+describe('toOperatorFailureKind — allowlist mapping', () => {
+  const cases: [string, OperatorFailureKind][] = [
+    ['timeout', 'max-duration-timeout'],
+    ['inactivity-timeout', 'inactivity-timeout'],
+    ['stream-ended', 'stream-ended'],
+    ['unreachable', 'workspace-unreachable'],
+    ['auth', 'workspace-unreachable'],
+    ['session-error', 'session-error'],
+    ['prompt-error', 'session-error'],
+  ]
+
+  for (const [internalKind, expected] of cases) {
+    it(`maps internal kind '${internalKind}' → '${expected}'`, () => {
+      // #given an internal RunCoreErrorKind value
+      // #when mapped to the operator-safe enum
+      const result = toOperatorFailureKind(internalKind)
+
+      // #then it resolves to the expected OperatorFailureKind
+      expect(result).toBe(expected)
+    })
+  }
+
+  it('absent failureKind (undefined) maps to undefined (field omitted)', () => {
+    // #given no failure-kind value at all
+    // #when mapped
+    const result = toOperatorFailureKind(undefined)
+
+    // #then undefined — the operator field is omitted, not defaulted to 'unknown'
+    expect(result).toBeUndefined()
+  })
+
+  it.each(['lol-raw-error', 'missing-coordinator', 'DROP TABLE'])(
+    "(security) unrecognized string '%s' maps to 'unknown' (allowlist gate)",
+    unrecognizedKind => {
+      // #given a string that is not in the closed allowlist (including the internal
+      // 'missing-coordinator' kind, which is deliberately unmapped)
+      // #when mapped
+      const result = toOperatorFailureKind(unrecognizedKind)
+
+      // #then it falls back to 'unknown' — never coerced/passed through raw
+      expect(result).toBe('unknown')
+    },
+  )
+
+  it.each([{}, 42, null, true])(
+    "(security) non-string value %j maps to 'unknown' (never coerced to a raw value)",
+    nonStringValue => {
+      // #given a non-string candidate value (object, number, null, boolean)
+      // #when mapped
+      const result = toOperatorFailureKind(nonStringValue)
+
+      // #then it falls back to 'unknown'
+      expect(result).toBe('unknown')
+    },
+  )
+})
+
+// ---------------------------------------------------------------------------
 // Barrel re-export smoke test
 // ---------------------------------------------------------------------------
 
@@ -340,5 +405,14 @@ describe('barrel re-exports', () => {
     // #when the projection function is accessed
     // #then it is present and callable
     expect(typeof barrel.toOperatorRunStatus).toBe('function')
+  })
+
+  it('toOperatorFailureKind is re-exported from the contract barrel', async () => {
+    // #given the public barrel for the operator-contract module
+    const barrel = await import('./index.js')
+
+    // #when the failure-kind mapper is accessed
+    // #then it is present and callable
+    expect(typeof barrel.toOperatorFailureKind).toBe('function')
   })
 })

--- a/packages/gateway/src/operator-contract/run-status.test.ts
+++ b/packages/gateway/src/operator-contract/run-status.test.ts
@@ -104,6 +104,76 @@ describe('toOperatorRunStatus — operator-safe fields', () => {
     expect(keys).not.toContain('details')
   })
 
+  it('(r5) exact key-set for a non-FAILED run — no failureKind, no sibling leak', () => {
+    // #given a non-FAILED run
+    const runState = makeRunState({phase: 'EXECUTING'})
+
+    // #when projected
+    const result = toOperatorRunStatus(runState, BASE_OPTS)
+
+    // #then the output has exactly the 7 declared keys, no more, no less
+    assert(result !== null, 'expected a populated status for a non-denylisted repo')
+    const keys = new Set(Object.keys(result))
+    expect(keys).toEqual(new Set(['runId', 'entityRef', 'surface', 'phase', 'status', 'startedAt', 'stale']))
+  })
+
+  it('(r5/r7) exact key-set for a FAILED run with details.failureKind — field present+mapped', () => {
+    // #given a FAILED run with a classified failureKind in details
+    const runState = makeRunState({phase: 'FAILED', details: {failureKind: 'inactivity-timeout'}})
+
+    // #when projected
+    const result = toOperatorRunStatus(runState, BASE_OPTS)
+
+    // #then failureKind is present and mapped, with exactly the 8 declared keys
+    assert(result !== null, 'expected a populated status for a non-denylisted repo')
+    const keys = new Set(Object.keys(result))
+    expect(keys).toEqual(
+      new Set(['runId', 'entityRef', 'surface', 'phase', 'status', 'startedAt', 'stale', 'failureKind']),
+    )
+    expect(result.failureKind).toBe('inactivity-timeout')
+  })
+
+  it('(r5) exact key-set for a FAILED run with no details.failureKind — field omitted', () => {
+    // #given a FAILED run with no failureKind in details
+    const runState = makeRunState({phase: 'FAILED', details: {}})
+
+    // #when projected
+    const result = toOperatorRunStatus(runState, BASE_OPTS)
+
+    // #then the output has exactly the 7 declared keys — no failureKind key at all
+    assert(result !== null, 'expected a populated status for a non-denylisted repo')
+    const keys = new Set(Object.keys(result))
+    expect(keys).toEqual(new Set(['runId', 'entityRef', 'surface', 'phase', 'status', 'startedAt', 'stale']))
+  })
+
+  it('(r4/r5) FAILED run whose details also carries rawOutput/workspacePath/internalUrl — only failureKind surfaces', () => {
+    // #given a FAILED run with sensitive sibling detail keys alongside failureKind
+    const runState = makeRunState({
+      phase: 'FAILED',
+      details: {
+        failureKind: 'stream-ended',
+        rawOutput: 'secret tool output',
+        workspacePath: '/home/runner/workspace/acme/widget',
+        internalUrl: 'http://internal.corp/api',
+      },
+    })
+
+    // #when projected
+    const result = toOperatorRunStatus(runState, BASE_OPTS)
+
+    // #then only failureKind surfaces — no sibling detail key leaks
+    assert(result !== null, 'expected a populated status for a non-denylisted repo')
+    const keys = new Set(Object.keys(result))
+    expect(keys).toEqual(
+      new Set(['runId', 'entityRef', 'surface', 'phase', 'status', 'startedAt', 'stale', 'failureKind']),
+    )
+    expect(result.failureKind).toBe('stream-ended')
+    const serialized = JSON.stringify(result)
+    expect(serialized).not.toContain('rawOutput')
+    expect(serialized).not.toContain('workspacePath')
+    expect(serialized).not.toContain('internalUrl')
+  })
+
   it('(r5) OperatorRunStatus type cannot carry holder_id, thread_id, or details', () => {
     // #given the OperatorRunStatus type
     // #when inspected at the type level

--- a/packages/gateway/src/operator-contract/run-status.ts
+++ b/packages/gateway/src/operator-contract/run-status.ts
@@ -40,13 +40,7 @@ export type {RunPhase, Surface} from '@fro-bot/runtime'
  * RunPhase only). The snapshot endpoint layers them on top after projection.
  */
 export type OperatorWebStatus =
-  | 'queued'
-  | 'blocked'
-  | 'running'
-  | 'waiting_for_approval'
-  | 'succeeded'
-  | 'failed'
-  | 'cancelled'
+  'queued' | 'blocked' | 'running' | 'waiting_for_approval' | 'succeeded' | 'failed' | 'cancelled'
 
 /**
  * Operator-safe projection of a run's status.
@@ -82,6 +76,61 @@ export const PHASE_TO_WEB_STATUS: Record<RunPhase, OperatorWebStatus> = {
   COMPLETED: 'succeeded',
   FAILED: 'failed',
   CANCELLED: 'cancelled',
+}
+
+/**
+ * The operator-facing failure-reason enum.
+ *
+ * A closed allowlist derived from RunCoreErrorKind (execute/run-core.ts) — the internal
+ * error-kind vocabulary. 'unknown' is the fallback for any internal kind with no mapping
+ * entry (defense-in-depth: unmapped/future/unrecognized kinds never leak past this gate).
+ */
+export type OperatorFailureKind =
+  'inactivity-timeout' | 'max-duration-timeout' | 'stream-ended' | 'workspace-unreachable' | 'session-error' | 'unknown'
+
+/**
+ * Closed allowlist mapping RunCoreErrorKind (internal) → OperatorFailureKind (operator-safe).
+ *
+ * Deliberately a `Partial`-shaped Record via index access with `?? 'unknown'` in
+ * toOperatorFailureKind — kinds with no entry here (e.g. 'missing-coordinator') fall
+ * through to 'unknown' rather than being a type error, since the input is untyped `unknown`.
+ *
+ * Exported so sibling projectors can reuse the mapping without re-declaring it.
+ */
+export const RUN_CORE_ERROR_KIND_TO_OPERATOR_FAILURE_KIND: Record<string, OperatorFailureKind> = {
+  timeout: 'max-duration-timeout',
+  'inactivity-timeout': 'inactivity-timeout',
+  'stream-ended': 'stream-ended',
+  unreachable: 'workspace-unreachable',
+  auth: 'workspace-unreachable',
+  'session-error': 'session-error',
+  'prompt-error': 'session-error',
+  // 'missing-coordinator' has no entry — falls through to 'unknown' via the default.
+}
+
+/**
+ * Maps a raw failure-kind value to the operator-safe OperatorFailureKind enum.
+ *
+ * Structural defense-in-depth: this function's signature accepts only the single
+ * candidate VALUE, never a details/context object — it is impossible for this function
+ * to read any other property, because it never receives one.
+ *
+ * - `undefined` (field absent) → `undefined` (the operator field will be omitted).
+ * - Any recognized internal kind string → its mapped OperatorFailureKind.
+ * - Any other value (unrecognized string, object, number, null, boolean) → `'unknown'`.
+ *   This is a closed allowlist gate: nothing but the six known enum values can escape
+ *   this function, regardless of what raw value flows in.
+ */
+export function toOperatorFailureKind(failureKind: unknown): OperatorFailureKind | undefined {
+  if (failureKind === undefined) {
+    return undefined
+  }
+
+  if (typeof failureKind === 'string') {
+    return RUN_CORE_ERROR_KIND_TO_OPERATOR_FAILURE_KIND[failureKind] ?? 'unknown'
+  }
+
+  return 'unknown'
 }
 
 /**

--- a/packages/gateway/src/operator-contract/run-status.ts
+++ b/packages/gateway/src/operator-contract/run-status.ts
@@ -57,6 +57,7 @@ export interface OperatorRunStatus {
   readonly status: OperatorWebStatus
   readonly startedAt: string
   readonly stale: boolean
+  readonly failureKind?: OperatorFailureKind
 }
 
 /**
@@ -203,5 +204,11 @@ export const toOperatorRunStatus = (
     status: PHASE_TO_WEB_STATUS[runState.phase] ?? 'failed',
     startedAt: runState.started_at,
     stale,
+    // failureKind is populated ONLY for FAILED runs, mapped through the closed
+    // allowlist (never a raw passthrough). Read runState.details.failureKind
+    // solely within this branch — never elsewhere.
+    ...(runState.phase === 'FAILED' && toOperatorFailureKind(runState.details.failureKind) !== undefined
+      ? {failureKind: toOperatorFailureKind(runState.details.failureKind)}
+      : {}),
   }
 }

--- a/packages/gateway/src/operator-contract/run-status.ts
+++ b/packages/gateway/src/operator-contract/run-status.ts
@@ -29,6 +29,7 @@
  */
 
 import type {RunPhase, RunState, Surface} from '@fro-bot/runtime'
+import type {RunCoreErrorKind} from '../execute/run-core.js'
 
 export type {RunPhase, Surface} from '@fro-bot/runtime'
 
@@ -92,13 +93,16 @@ export type OperatorFailureKind =
 /**
  * Closed allowlist mapping RunCoreErrorKind (internal) → OperatorFailureKind (operator-safe).
  *
- * Deliberately a `Partial`-shaped Record via index access with `?? 'unknown'` in
- * toOperatorFailureKind — kinds with no entry here (e.g. 'missing-coordinator') fall
- * through to 'unknown' rather than being a type error, since the input is untyped `unknown`.
+ * `satisfies Record<RunCoreErrorKind, OperatorFailureKind | undefined>` makes this
+ * exhaustive over the RunCoreErrorKind union at compile time — adding a new
+ * RunCoreErrorKind member in run-core.ts without adding an entry here is a compile
+ * error. `undefined` is an explicit, intentional "maps to 'unknown'" entry (e.g.
+ * 'missing-coordinator' has no operator-meaningful mapping), distinct from an
+ * omitted key (which `satisfies` would reject).
  *
  * Exported so sibling projectors can reuse the mapping without re-declaring it.
  */
-export const RUN_CORE_ERROR_KIND_TO_OPERATOR_FAILURE_KIND: Record<string, OperatorFailureKind> = {
+export const RUN_CORE_ERROR_KIND_TO_OPERATOR_FAILURE_KIND = {
   timeout: 'max-duration-timeout',
   'inactivity-timeout': 'inactivity-timeout',
   'stream-ended': 'stream-ended',
@@ -106,8 +110,8 @@ export const RUN_CORE_ERROR_KIND_TO_OPERATOR_FAILURE_KIND: Record<string, Operat
   auth: 'workspace-unreachable',
   'session-error': 'session-error',
   'prompt-error': 'session-error',
-  // 'missing-coordinator' has no entry — falls through to 'unknown' via the default.
-}
+  'missing-coordinator': undefined, // → 'unknown' at the projection (no operator-meaningful mapping)
+} satisfies Record<RunCoreErrorKind, OperatorFailureKind | undefined>
 
 /**
  * Maps a raw failure-kind value to the operator-safe OperatorFailureKind enum.
@@ -128,7 +132,13 @@ export function toOperatorFailureKind(failureKind: unknown): OperatorFailureKind
   }
 
   if (typeof failureKind === 'string') {
-    return RUN_CORE_ERROR_KIND_TO_OPERATOR_FAILURE_KIND[failureKind] ?? 'unknown'
+    // Widening cast (not a suppression): `satisfies` narrows the object's key type to
+    // RunCoreErrorKind, but the lookup key here is an arbitrary runtime string (untyped
+    // `unknown` input) that may not be a RunCoreErrorKind member. Widen the lookup type
+    // to accept any string so the index access type-checks; the `?? 'unknown'` fallback
+    // below still handles unrecognized keys safely at runtime.
+    const lookup = RUN_CORE_ERROR_KIND_TO_OPERATOR_FAILURE_KIND as Record<string, OperatorFailureKind | undefined>
+    return lookup[failureKind] ?? 'unknown'
   }
 
   return 'unknown'
@@ -193,6 +203,11 @@ export const toOperatorRunStatus = (
   const heartbeatMs = Date.parse(runState.last_heartbeat)
   const stale = Number.isNaN(heartbeatMs) || heartbeatMs <= opts.nowMs - opts.staleThresholdMs
 
+  // failureKind is populated ONLY for FAILED runs, mapped through the closed
+  // allowlist (never a raw passthrough). Read runState.details.failureKind
+  // solely within this branch — never elsewhere.
+  const failureKind = runState.phase === 'FAILED' ? toOperatorFailureKind(runState.details.failureKind) : undefined
+
   // #when projecting — map only operator-safe fields; internal fields are never read
   return {
     runId: runState.run_id,
@@ -204,11 +219,6 @@ export const toOperatorRunStatus = (
     status: PHASE_TO_WEB_STATUS[runState.phase] ?? 'failed',
     startedAt: runState.started_at,
     stale,
-    // failureKind is populated ONLY for FAILED runs, mapped through the closed
-    // allowlist (never a raw passthrough). Read runState.details.failureKind
-    // solely within this branch — never elsewhere.
-    ...(runState.phase === 'FAILED' && toOperatorFailureKind(runState.details.failureKind) !== undefined
-      ? {failureKind: toOperatorFailureKind(runState.details.failureKind)}
-      : {}),
+    ...(failureKind === undefined ? {} : {failureKind}),
   }
 }

--- a/packages/gateway/src/operator-contract/run-summary.test.ts
+++ b/packages/gateway/src/operator-contract/run-summary.test.ts
@@ -202,6 +202,34 @@ describe('toRunSummary — closed-DTO key set', () => {
     expect(keys).not.toContain('details')
   })
 
+  it('output has failureKind + exactly 6 keys for a FAILED run with details.failureKind', () => {
+    // #given a FAILED run with a classified failureKind and no valid heartbeat
+    const runState = makeRunState({phase: 'FAILED', last_heartbeat: '', details: {failureKind: 'session-error'}})
+
+    // #when projected
+    const result = toRunSummary(runState, BINDING_A)
+
+    // #then failureKind is present, updatedAt is absent
+    assert(result !== null, 'expected a non-null summary')
+    const keys = new Set(Object.keys(result))
+    expect(keys).toEqual(new Set(['runId', 'repo', 'status', 'createdAt', 'failureKind']))
+    expect(result.failureKind).toBe('session-error')
+  })
+
+  it('output has no failureKind for a non-FAILED run even with details.failureKind set', () => {
+    // #given a non-FAILED run whose details happen to carry a failureKind value
+    const runState = makeRunState({phase: 'EXECUTING', last_heartbeat: '', details: {failureKind: 'session-error'}})
+
+    // #when projected
+    const result = toRunSummary(runState, BINDING_A)
+
+    // #then failureKind is absent — population is gated on FAILED phase
+    assert(result !== null, 'expected a non-null summary')
+    const keys = new Set(Object.keys(result))
+    expect(keys).toEqual(new Set(['runId', 'repo', 'status', 'createdAt']))
+    expect(Object.prototype.hasOwnProperty.call(result, 'failureKind')).toBe(false)
+  })
+
   it('runSummary type does not carry entityRef, surface, phase, stale, or internal fields', () => {
     // #given the RunSummary type
     // #when inspected at the type level

--- a/packages/gateway/src/operator-contract/run-summary.test.ts
+++ b/packages/gateway/src/operator-contract/run-summary.test.ts
@@ -182,6 +182,25 @@ describe('toRunSummary — closed-DTO key set', () => {
     expect(keys).toEqual(new Set(['runId', 'repo', 'status', 'createdAt', 'updatedAt']))
   })
 
+  it('output has exactly 6 keys (runId, repo, status, createdAt, updatedAt, failureKind) for a FAILED run with both a valid heartbeat and details.failureKind', () => {
+    // #given a FAILED run with a valid last_heartbeat AND a classified failureKind
+    const runState = makeRunState({
+      phase: 'FAILED',
+      last_heartbeat: '2024-06-15T10:30:00.000Z',
+      details: {failureKind: 'session-error'},
+    })
+
+    // #when projected
+    const result = toRunSummary(runState, BINDING_A)
+
+    // #then both optional fields are present, and no extra keys leak in
+    assert(result !== null, 'expected a non-null summary')
+    const keys = new Set(Object.keys(result))
+    expect(keys).toEqual(new Set(['runId', 'repo', 'status', 'createdAt', 'updatedAt', 'failureKind']))
+    expect(result.updatedAt).toBe('2024-06-15T10:30:00.000Z')
+    expect(result.failureKind).toBe('session-error')
+  })
+
   it('output has no entityRef, surface, phase, stale, thread_id, holder_id, or details keys', () => {
     // #given a fully-populated RunState with all internal fields
     const runState = makeRunState()

--- a/packages/gateway/src/operator-contract/run-summary.ts
+++ b/packages/gateway/src/operator-contract/run-summary.ts
@@ -18,8 +18,9 @@
  */
 
 import type {RunState} from '@fro-bot/runtime'
+import type {OperatorFailureKind} from './run-status.js'
 
-import {PHASE_TO_WEB_STATUS} from './run-status.js'
+import {PHASE_TO_WEB_STATUS, toOperatorFailureKind} from './run-status.js'
 
 /**
  * The 5-value status set producible by toRunSummary via PHASE_TO_WEB_STATUS.
@@ -51,6 +52,7 @@ export interface RunSummary {
   readonly status: RunSummaryStatus
   readonly createdAt: string
   readonly updatedAt?: string
+  readonly failureKind?: OperatorFailureKind
 }
 
 /**
@@ -135,6 +137,12 @@ export function toRunSummary(
     status,
     createdAt: runState.started_at,
     ...(hasValidHeartbeat ? {updatedAt: runState.last_heartbeat} : {}),
+    // failureKind is populated ONLY for FAILED runs, mapped through the closed
+    // allowlist (never a raw passthrough). Read runState.details.failureKind
+    // solely within this branch — never elsewhere.
+    ...(runState.phase === 'FAILED' && toOperatorFailureKind(runState.details.failureKind) !== undefined
+      ? {failureKind: toOperatorFailureKind(runState.details.failureKind)}
+      : {}),
   }
 
   return summary

--- a/packages/gateway/src/operator-contract/run-summary.ts
+++ b/packages/gateway/src/operator-contract/run-summary.ts
@@ -129,6 +129,11 @@ export function toRunSummary(
   const heartbeatMs = runState.last_heartbeat.length === 0 ? Number.NaN : Date.parse(runState.last_heartbeat)
   const hasValidHeartbeat = Number.isNaN(heartbeatMs) === false
 
+  // failureKind is populated ONLY for FAILED runs, mapped through the closed
+  // allowlist (never a raw passthrough). Read runState.details.failureKind
+  // solely within this branch — never elsewhere.
+  const failureKind = runState.phase === 'FAILED' ? toOperatorFailureKind(runState.details.failureKind) : undefined
+
   // Build the closed DTO — copy only declared safe fields, never spread runState.
   // repo comes from the binding (the authorization anchor), not entity_ref.
   const summary: RunSummary = {
@@ -137,12 +142,7 @@ export function toRunSummary(
     status,
     createdAt: runState.started_at,
     ...(hasValidHeartbeat ? {updatedAt: runState.last_heartbeat} : {}),
-    // failureKind is populated ONLY for FAILED runs, mapped through the closed
-    // allowlist (never a raw passthrough). Read runState.details.failureKind
-    // solely within this branch — never elsewhere.
-    ...(runState.phase === 'FAILED' && toOperatorFailureKind(runState.details.failureKind) !== undefined
-      ? {failureKind: toOperatorFailureKind(runState.details.failureKind)}
-      : {}),
+    ...(failureKind === undefined ? {} : {failureKind}),
   }
 
   return summary

--- a/packages/gateway/src/web/sse/projection.test.ts
+++ b/packages/gateway/src/web/sse/projection.test.ts
@@ -332,6 +332,34 @@ describe('projectRunObservation — closed DTO safety', () => {
     expect(resultKeys).toEqual(contractFields)
   })
 
+  it('carries failureKind through from the bridge result when present (FAILED)', async () => {
+    // #given a FAILED base status carrying a failureKind from the bridge
+    const runState = makeRunState({phase: 'FAILED'})
+    const baseStatus = makeBaseStatus({phase: 'FAILED', status: 'failed', failureKind: 'inactivity-timeout'})
+    const deps = makeDeps(baseStatus)
+
+    // #when projecting
+    const result = await projectRunObservation(runState, deps)
+
+    // #then failureKind is copied through from base
+    expect(result).not.toBeNull()
+    expect(result?.failureKind).toBe('inactivity-timeout')
+  })
+
+  it('omits failureKind when absent from the bridge result (non-FAILED)', async () => {
+    // #given a non-FAILED base status with no failureKind
+    const runState = makeRunState({phase: 'EXECUTING'})
+    const baseStatus = makeBaseStatus({phase: 'EXECUTING', status: 'running'})
+    const deps = makeDeps(baseStatus)
+
+    // #when projecting
+    const result = await projectRunObservation(runState, deps)
+
+    // #then failureKind is absent (not undefined-valued key, structurally omitted)
+    expect(result).not.toBeNull()
+    expect(Object.prototype.hasOwnProperty.call(result as object, 'failureKind')).toBe(false)
+  })
+
   it('does not spread runState — holder_id and thread_id are absent from output', async () => {
     // #given a run with holder_id and thread_id
     const runState = makeRunState({holder_id: 'holder-secret', thread_id: 'thread-secret'})

--- a/packages/gateway/src/web/sse/projection.ts
+++ b/packages/gateway/src/web/sse/projection.ts
@@ -85,6 +85,9 @@ export async function projectRunObservation(
     status: overlaidStatus,
     startedAt: base.startedAt,
     stale: base.stale,
+    // Copy from the deny-gated bridge result (base), never from runState —
+    // preserves the deny-gate (a denied repo's base is null before any field).
+    ...(base.failureKind === undefined ? {} : {failureKind: base.failureKind}),
   }
 
   return result


### PR DESCRIPTION
Closes #1099.

## What

Adds an optional, allowlisted `failureKind` to the operator run-status contract so the dashboard can tell *why* a run failed instead of seeing only `status: failed`.

`OperatorRunStatus` and `RunSummary` gain `failureKind?: OperatorFailureKind`, present only on terminal `FAILED` runs:

```
'inactivity-timeout' | 'max-duration-timeout' | 'stream-ended' | 'workspace-unreachable' | 'session-error' | 'unknown'
```

## Why

A dashboard-launched run can fail with the gateway *knowing* the sanitized failure class — a live case failed after ~6m15s with gateway reason `inactivity-timeout` — but the operator contract exposed only `phase`/`status`, so the UI couldn't distinguish an inactivity timeout from any other failure. The failure kind was classified internally, turned into a Discord message, and then discarded — never persisted, so no operator projection could read it back.

## How

- **Classify + persist.** The in-flight FAILED transition (and the rare CANCELLED→FAILED fallback) now persists the internal error kind onto run-state `details.failureKind`, atomically with the phase write — no extra round-trip.
- **Map through a closed allowlist.** The projection maps the internal kind to the operator enum through a total `Record` with an `'unknown'` fallback. The mapping *is* the allowlist: no raw error string, model output, stack trace, internal URL, or repo-private value can reach the operator surface — an unrecognized or future internal kind resolves to `'unknown'`, never a passthrough. The mapper takes only the candidate value, so it structurally cannot read any other `details` key.
- **FAILED-only, both surfaces.** The field appears only when `phase === 'FAILED'`, on both the live SSE status frame and the recent-runs projection. The SSE path copies it from the deny-gated bridge result, so a denylisted repo still returns null before any field is read.
- **Pre-ACK coverage.** Workspace-startup failures (clone/readyz) surface as `workspace-unreachable`; other pre-ACK terminalizations render without a `failureKind`.

Internal fields (`details`, `thread_id`, `cancelledBy`) remain excluded from operator DTOs by construction; the exact-key-set projection tests prove no sibling detail leaks.

## Contract / deploy ordering

Additive optional field — MINOR — so `OPERATOR_CONTRACT_VERSION` stays `1.6.0` (grown, not bumped). `1.6.0` is unreleased and undeployed, and the dashboard hasn't bumped its pin yet, so this ships in the same `1.6.0` the dashboard pins **once** — alongside run cancellation. The dashboard pins the contract with an exact-match, fail-closed drift gate, so a gateway release carrying `1.6.0` and the dashboard's `1.6.0` pin (+ the per-kind copy) must land in the same deploy window. Merging this does not affect the running deployment.

## Verification

- `bun run lint`, `bun run build` — clean, no `dist/` diff
- runtime + gateway type-check clean
- gateway suite green (2899)
- The mapping is exhaustive over the internal error-kind union at compile time (`satisfies`), so a future kind cannot silently degrade to `'unknown'` without an explicit decision.
- End-to-end coverage drives the real run-state write through to the real projections (proving production populates the field, not just that the reader works); plus allowlist, hostile-`details` no-leak, denylist-null, FAILED-only, and per-kind classification cases.
