### PR TITLE
docs: capture time-gate and triage-staleness workflow learnings

### DIFF
--- a/docs/solutions/workflow-issues/time-gated-smart-note-surfaced-ready-early-2026-07-04.md
+++ b/docs/solutions/workflow-issues/time-gated-smart-note-surfaced-ready-early-2026-07-04.md
@@ -1,0 +1,92 @@
+---
+title: 'A time-gated "ready" signal can fire before the real boundary — verify the timestamp, not the date'
+date: 2026-07-04
+category: workflow-issues
+module: development-workflow
+problem_type: workflow_issue
+component: assistant
+severity: medium
+applies_when:
+  - A smart note, reminder, or CI gate is conditioned on an age window, embargo, or release-timing rule
+  - A background checker marks something "ready" on or near the boundary date
+  - Acting early would remove a temporary workaround or fast-track before its precondition actually holds
+tags:
+  - smart-notes
+  - time-gate
+  - minimum-release-age
+  - bunfig
+  - date-granularity
+  - verify-before-act
+---
+
+# A time-gated "ready" signal can fire before the real boundary
+
+## Context
+
+A magic-context smart note said: *remove the temporary `minimumReleaseAgeExcludes = ["@opencode-ai/sdk"]` fast-track from `bunfig.toml` once `@opencode-ai/sdk@1.17.13` clears the 3-day `minimumReleaseAge` window.* The background checker surfaced it **ready** on 2026-07-04. Acting on it would have been wrong.
+
+`bunfig.toml` gates installs on package age:
+
+```toml
+[install]
+# Supply-chain age gate: refuse dependency versions published within this window (3 days).
+minimumReleaseAge = 259200
+# Temporary fast-track for the deliberate 1.17.13 SDK bump; remove once it clears the window.
+minimumReleaseAgeExcludes = ["@opencode-ai/sdk"]
+```
+
+The empirical check showed the version was still **inside** the window when the note surfaced:
+
+```
+$ npm view @opencode-ai/sdk@1.17.13 time --json   # → "1.17.13": "2026-07-01T15:17:43.240Z"
+published: 2026-07-01T15:17:43Z
+age(days): 2.77
+window(days): 3
+cleared: false          # clears at ~15:17Z on 2026-07-04, ~5h after the note surfaced
+```
+
+Removing the exclusion with the package still in-window makes `bun install` refuse the pinned version — breaking the frozen-lockfile install in CI — for no reason.
+
+## Guidance
+
+Before acting on any time/age-gated "ready" signal, compute the boundary from the authoritative timestamp rather than trusting the flag's date resolution:
+
+```bash
+npm view <pkg>@<ver> time --json
+```
+
+```bash
+node -e 'const pub=new Date("2026-07-01T15:17:43.240Z").getTime();
+const ageMs=Date.now()-pub; const cleared=ageMs>=259200000;
+console.log({ageDays:(ageMs/86400000).toFixed(2), cleared});'
+```
+
+If `cleared` is false, the precondition does not hold — leave the note pending and pivot to other work rather than idle-waiting; it will still be valid after the true boundary.
+
+## Why This Matters
+
+A readiness signal whose condition is evaluated at **calendar-date** granularity can fire up to a day before the real **timestamp** boundary. For an age gate, "the date matches" is not "the window cleared." Acting on the early flag removes a workaround while its precondition is still false — here, breaking the CI install. The flag answers "is it roughly time?"; the timestamp answers "is it actually time?" — and only the second one is safe to act on.
+
+## When to Apply
+
+- Removing any `minimumReleaseAge` / supply-chain age-gate exclusion or fast-track.
+- Any smart note, reminder, or automation whose surface condition is time-, age-, or deadline-based.
+- Any "the embargo has lifted / the window has passed" claim — verify the exact boundary before the irreversible step.
+
+## Examples
+
+Before (trusting the ready flag):
+```
+note: "ready" → remove minimumReleaseAgeExcludes → bun install refuses in-window version → CI breaks
+```
+
+After (verify-then-act):
+```
+note: "ready" → npm view <pkg>@<ver> time → age 2.77d < 3d window → NOT cleared → hold the note, pivot
+```
+
+Rule: verify-then-act on any time-gated condition; a "ready" flag is a prompt to check the clock, not permission to act.
+
+## Related
+
+- [Migrating a pnpm workspace to Bun](migrate-pnpm-to-bun-monorepo-2026-06-24.md) — where `minimumReleaseAge` moved into `bunfig.toml` (§3c); this is the operational hazard of acting on that gate too early.

--- a/docs/solutions/workflow-issues/triage-comment-goes-stale-reverify-against-main-2026-07-04.md
+++ b/docs/solutions/workflow-issues/triage-comment-goes-stale-reverify-against-main-2026-07-04.md
@@ -1,0 +1,70 @@
+---
+title: 'A triage comment can go stale within an hour — re-verify its claims against current main'
+date: 2026-07-04
+category: workflow-issues
+module: development-workflow
+problem_type: workflow_issue
+component: assistant
+severity: medium
+applies_when:
+  - The newest signal on an issue is an older triage, analysis, or "current state" comment
+  - That comment's claims (issue state, PR merge status, code presence) are being used as implementation input
+  - A closing PR may have merged shortly after the comment was written
+tags:
+  - triage
+  - stale-context
+  - verify-against-main
+  - merge-timing
+  - github
+  - re-triage
+---
+
+# A triage comment can go stale within an hour — re-verify against current main
+
+## Context
+
+Issue #1069's triage comment (posted 2026-06-30 **02:26Z**) claimed the gateway "does not yet have the inactivity timer" and that "#1055 is an open issue." Both were overtaken ~1h later: PR #1068 merged at **03:26Z**, closing #1055 and shipping the gateway inactivity model. A later session that took the triage at face value would have built the *wrong* thing — "build the gateway inactivity model" — when the real remaining work was the inverse: "extract the now-existing model to a shared primitive and adopt it in the action."
+
+The model was verifiably present on current `main`:
+
+- `packages/gateway/src/execute/run-core.ts` — `RunCoreErrorKind` includes `'inactivity-timeout'` (~:42); the inactivity controller composes with the run signal via `AbortSignal.any([signal, inactivityController.signal])` (~:304).
+- `packages/gateway/src/execute/run.ts` — `isInactivityTimeout = isCoreError && execError.kind === 'inactivity-timeout'` (~:796).
+
+## Guidance
+
+Before acting on any triage / analysis / "current state" comment — human or bot — re-verify its load-bearing claims against current `main`:
+
+- **Issue/PR state**: `gh issue view <n> --json state,closedAt` / `gh pr view <n> --json state,mergedAt` — is it actually still open?
+- **Merge timing by timestamp, not date**: compare the comment's `createdAt` against the closing PR's `mergedAt`. A comment written at 02:26Z is stale if the fix merged at 03:26Z the same day — same date, opposite reality.
+- **Code presence**: grep/read the claimed-missing (or claimed-present) code on `main`.
+
+If the comment is stale, post a corrected re-triage that cites the evidence and reframes the actual remaining work, so the next actor doesn't inherit the inverted framing.
+
+## Why This Matters
+
+Issue threads are append-only, but reality is not — a triage comment is a snapshot of `main` at the instant it was written, and a PR merging minutes later can invert its core claims without editing the comment. Trusting the newest *comment* instead of the newest *state* leads you to rebuild something that already exists, or to skip something that was reverted. Date-level reasoning ("the triage is from today") is not enough; a fix can land an hour after the triage on the same day.
+
+## When to Apply
+
+- Picking up any issue whose freshest signal is an older triage or analysis comment.
+- Any "the code currently does X / feature Y is not built yet" claim in an issue body or comment.
+- Reconciling a tracker or status doc that summarizes cross-repo state — re-derive from live state, not from the last narrative.
+
+## Examples
+
+Before (trusting stale triage):
+```
+triage (02:26Z): "gateway has no inactivity timer; #1055 open" → plan: build the model
+```
+
+After (re-verified against main):
+```
+gh: #1055 CLOSED by #1068 (merged 03:26Z); run-core.ts:304 has the inactivity AbortSignal.any
+→ plan: extract the existing model to a shared primitive, adopt in the action
+```
+
+Rule: act on the newest *state*, not the newest *comment* — and check merge timestamps, not just dates.
+
+## Related
+
+- [A coordination field written empty at creation and never updated silently breaks every reader](../logic-errors/thread-id-persistence-gap-in-run-state-2026-07-03.md) — the sibling "a stale comment/assumption misleads a green-looking situation" lesson, on persisted state rather than issue threads.


### PR DESCRIPTION
## What

Two `docs/solutions/` workflow learnings from this session:

- **`workflow-issues/time-gated-smart-note-surfaced-ready-early`** — a time/age-gated "ready" signal can fire before the real boundary. A note to remove a temporary `bunfig.toml` `minimumReleaseAgeExcludes` fast-track surfaced "ready," but the package was still 2.77 days into a 3-day age gate — removing the exclusion then would have made `bun install` refuse the in-window version and break the frozen-lockfile CI. Lesson: verify the timestamp boundary (`npm view <pkg>@<ver> time`) before acting, not the date the flag fired.
- **`workflow-issues/triage-comment-goes-stale-reverify-against-main`** — a triage/analysis comment can be overtaken within the hour by a merge that lands right after it. An issue's triage claimed a feature was unbuilt and its tracking issue open; the closing PR merged ~1h later, inverting both claims. Lesson: act on the newest *state*, not the newest *comment* — check issue/PR state and merge *timestamps* (not just dates) against current main before building on a comment.

## Why

Both cost real investigation this cycle and generalize beyond their origin. Each cross-links the nearest existing solution doc.

## Verification

- Frontmatter validated against the solution schema (knowledge track, `category` matches `problem_type`).
- `bun run check:md-links` passes — cross-links resolve.
