### PR TITLE
feat(gateway): count events in run-core to distinguish hang from lost-event timeout

### DIFF
--- a/packages/gateway/src/execute/run-core.test.ts
+++ b/packages/gateway/src/execute/run-core.test.ts
@@ -2239,6 +2239,140 @@ describe('runOpenCodeCore', () => {
       await expect(runOpenCodeCore(params)).resolves.toBeUndefined()
     })
 
+    it('event counters: zero events on inactivity timeout signal the silent-workspace case', async () => {
+      // #given — a completely silent stream (no events at all) and a short inactivity window
+      const logger = makeLogger()
+      const handle = makeHandle({
+        subscribe: async () =>
+          Promise.resolve({
+            stream: (async function* () {
+              await new Promise<void>(() => {
+                /* never resolves */
+              })
+            })(),
+          }),
+      })
+      const params = {
+        ...buildParams(handle),
+        logger,
+        coordinator: makeCoordinator(),
+        inactivityTimeoutMs: 10,
+      }
+
+      // #when
+      const err = await runOpenCodeCore(params).catch((error: unknown) => error)
+
+      // #then — inactivity-timeout thrown with totalEvents:0, activityEvents:0 (silent hang signature)
+      expect(err).toBeInstanceOf(RunCoreError)
+      expect((err as RunCoreError).kind).toBe('inactivity-timeout')
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({sessionId: 'sess-123', totalEvents: 0, activityEvents: 0}),
+        'run-core: stream ended due to inactivity timeout',
+      )
+    }, 10_000)
+
+    it('event counters: events arriving without activity signal the lost-event/routing-gap case', async () => {
+      // #given — events arrive (a foreign-session delta and an unrecognized event type) but
+      // none of them reset the inactivity timer, since none is a recognized same-session activity event.
+      const logger = makeLogger()
+      const handle = makeHandle({
+        subscribe: async () =>
+          Promise.resolve({
+            stream: (async function* () {
+              yield partDeltaObjectEvent('should be ignored', 'other-session')
+              yield {type: 'some.unrecognized.event', properties: {sessionID: 'sess-123'}}
+              await new Promise<void>(() => {
+                /* never resolves */
+              })
+            })(),
+          }),
+      })
+      const params = {
+        ...buildParams(handle),
+        logger,
+        coordinator: makeCoordinator(),
+        inactivityTimeoutMs: 10,
+      }
+
+      // #when
+      const err = await runOpenCodeCore(params).catch((error: unknown) => error)
+
+      // #then — totalEvents > 0 but activityEvents stays 0; lastEventType reflects the last processed event
+      expect(err).toBeInstanceOf(RunCoreError)
+      expect((err as RunCoreError).kind).toBe('inactivity-timeout')
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: 'sess-123',
+          activityEvents: 0,
+          lastEventType: 'some.unrecognized.event',
+        }),
+        'run-core: stream ended due to inactivity timeout',
+      )
+      const warnCall = (logger.warn as ReturnType<typeof vi.fn>).mock.calls.find(
+        (call: unknown[]) => call[1] === 'run-core: stream ended due to inactivity timeout',
+      )
+      expect((warnCall?.[0] as {totalEvents: number}).totalEvents).toBeGreaterThan(0)
+    }, 10_000)
+
+    it('event counters: unrecognized event type logs at debug and increments totalEvents', async () => {
+      // #given — a stream with one unrecognized event type followed by session.idle
+      const logger = makeLogger()
+      const handle = makeHandle({
+        subscribe: async () =>
+          subscribeOk([
+            {type: 'some.unrecognized.event', properties: {sessionID: 'sess-123'}},
+            sessionIdleEvent('sess-123'),
+          ]),
+      })
+      const params = {
+        ...buildParams(handle),
+        logger,
+        coordinator: makeCoordinator(),
+      }
+
+      // #when
+      await expect(runOpenCodeCore(params)).resolves.toBeUndefined()
+
+      // #then — debug log fired for the unrecognized event type
+      expect(logger.debug).toHaveBeenCalledWith(
+        {eventType: 'some.unrecognized.event', sessionId: 'sess-123'},
+        'run-core: unrecognized event type',
+      )
+      // session.idle log carries totalEvents > 0 (counts the unrecognized event + session.idle itself)
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({sessionId: 'sess-123', totalEvents: 2}),
+        'run-core: session.idle received — stream complete',
+      )
+    })
+
+    it('event counters: a normal run reaching session.idle after activity has totalEvents and activityEvents > 0', async () => {
+      // #given — a normal run with text delta activity before session.idle
+      const logger = makeLogger()
+      const handle = makeHandle({
+        subscribe: async () => subscribeOk([partDeltaObjectEvent('Hello'), sessionIdleEvent('sess-123')]),
+      })
+      const params = {
+        ...buildParams(handle),
+        logger,
+        coordinator: makeCoordinator(),
+      }
+
+      // #when
+      await expect(runOpenCodeCore(params)).resolves.toBeUndefined()
+
+      // #then — healthy-baseline signature: both counters > 0
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({sessionId: 'sess-123'}),
+        'run-core: session.idle received — stream complete',
+      )
+      const idleCall = (logger.info as ReturnType<typeof vi.fn>).mock.calls.find(
+        (call: unknown[]) => call[1] === 'run-core: session.idle received — stream complete',
+      )
+      const ctx = idleCall?.[0] as {totalEvents: number; activityEvents: number}
+      expect(ctx.totalEvents).toBeGreaterThan(0)
+      expect(ctx.activityEvents).toBeGreaterThan(0)
+    })
+
     it('inactivity timeout does not fire when inactivityTimeoutMs is absent', async () => {
       // #given — no inactivityTimeoutMs; silent stream that never yields
       // Without inactivity timeout, the run would hang forever on a silent stream.

--- a/packages/gateway/src/execute/run-core.test.ts
+++ b/packages/gateway/src/execute/run-core.test.ts
@@ -1040,6 +1040,43 @@ describe('runOpenCodeCore', () => {
       expect(err).toBeInstanceOf(RunCoreError)
       expect((err as RunCoreError).kind).toBe('timeout')
     })
+
+    it('event counters: hard-ceiling timeout signal carries counters when at least one event was processed', async () => {
+      // #given — no inactivityTimeoutMs (so only the outer wall-clock signal can abort), a
+      // stream that yields one activity event and then hangs, and an outer signal aborted
+      // via a real timer AFTER that first event has already been processed. This exercises
+      // the `combinedSignal.aborted && !inactivityController.signal.aborted` branch (here
+      // inactivityController is null entirely) that logs 'stream ended due to timeout signal'.
+      const controller = new AbortController()
+      const logger = makeLogger()
+      const handle = makeHandle({
+        subscribe: async () =>
+          Promise.resolve({
+            stream: hangingStreamAfterFirst(partDeltaObjectEvent('hi')),
+          }),
+      })
+      const params = {...buildParams(handle), signal: controller.signal, logger, coordinator: makeCoordinator()}
+      // Abort on a real timer tick — the first event (yielded synchronously by the async
+      // generator) is processed well before this fires, since the generator only blocks
+      // on its *second* `next()` call.
+      setTimeout(() => controller.abort(), 5)
+
+      // #when
+      const err = await runOpenCodeCore(params).catch((error: unknown) => error)
+
+      // #then — timeout kind (not inactivity-timeout, since no inactivity controller exists)
+      expect(err).toBeInstanceOf(RunCoreError)
+      expect((err as RunCoreError).kind).toBe('timeout')
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: 'sess-123',
+          totalEvents: 1,
+          activityEvents: 1,
+          lastEventType: 'message.part.delta',
+        }),
+        'run-core: stream ended due to timeout signal',
+      )
+    })
   })
 
   describe('isAuthError classification', () => {
@@ -1824,6 +1861,7 @@ describe('runOpenCodeCore', () => {
 
     it('throws RunCoreError with kind "stream-ended" when stream closes after some events but before session.idle', async () => {
       // #given — stream yields some text deltas then closes without session.idle
+      const logger = makeLogger()
       const handle = makeHandle({
         subscribe: async () =>
           subscribeOk([
@@ -1831,12 +1869,21 @@ describe('runOpenCodeCore', () => {
             // No sessionIdleEvent — stream ends prematurely
           ]),
       })
-      const params = {...buildParams(handle), coordinator: makeCoordinator()}
+      const params = {...buildParams(handle), logger, coordinator: makeCoordinator()}
 
       // #when / #then
       const err = await runOpenCodeCore(params).catch((error: unknown) => error)
       expect(err).toBeInstanceOf(RunCoreError)
       expect((err as RunCoreError).kind).toBe('stream-ended')
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: 'sess-123',
+          totalEvents: 1,
+          activityEvents: 1,
+          lastEventType: 'message.part.delta',
+        }),
+        'run-core: event stream closed before session.idle',
+      )
     })
 
     it('stream-ended error is NOT thrown when signal is aborted (timeout takes precedence)', async () => {

--- a/packages/gateway/src/execute/run-core.ts
+++ b/packages/gateway/src/execute/run-core.ts
@@ -421,6 +421,21 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
   // the loop exits promptly even when the SSE server is silent.
   const abortableStream = makeAbortableStream(eventStream, combinedSignal)
 
+  // Observability counters (#1101): disambiguate a genuine workspace hang (zero events
+  // observed) from an event-delivery/routing gap (events arrived but none reset the
+  // inactivity timer, e.g. session-mismatched or unrecognized event types).
+  let totalEvents = 0
+  let activityEvents = 0
+  let lastEventType: string | undefined
+
+  // Marks a real run-activity event: bumps the activity counter and re-arms the
+  // inactivity timer. Kept as a thin wrapper so resetInactivity() semantics are
+  // untouched — this does not change when/why the timer resets, only adds counting.
+  function markActivity(): void {
+    activityEvents += 1
+    resetInactivity()
+  }
+
   try {
     for await (const rawEvent of abortableStream) {
       // Check abort at the top of each iteration so we exit as soon as the signal
@@ -429,6 +444,13 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
 
       const eventType = getEventKind(rawEvent)
       const eventPayload = getEventPayload(rawEvent)
+
+      // totalEvents counts every event the loop PROCESSES (post-getEventKind), including
+      // events dropped by a session-mismatch guard below, by design — a foreign-session
+      // event that arrives but is dropped still increments totalEvents, so
+      // `totalEvents > 0, activityEvents: 0` reveals the session-mismatch/routing case.
+      totalEvents += 1
+      lastEventType = eventType ?? undefined
 
       if (eventType === 'message.part.delta') {
         // New SDK shape: streaming text delta events.
@@ -445,10 +467,10 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
             const deltaText = getStringProperty(delta, 'text')
             if (deltaType === 'text' && deltaText != null) {
               sink.append(deltaText)
-              resetInactivity()
+              markActivity()
             } else if (typeof delta === 'string' && getStringProperty(eventPayload, 'field') === 'text') {
               sink.append(delta)
-              resetInactivity()
+              markActivity()
             }
           }
         }
@@ -461,7 +483,7 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
           const deltaText = typeof deltaRaw === 'string' ? deltaRaw : (getStringProperty(deltaRaw, 'text') ?? null)
           if (deltaText != null) {
             sink.append(deltaText)
-            resetInactivity()
+            markActivity()
           }
         }
       } else if (eventType === 'message.part.updated') {
@@ -505,7 +527,7 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
                 logger,
                 onActivity,
               )
-              resetInactivity()
+              markActivity()
             }
           }
         }
@@ -550,7 +572,7 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
                 logger,
                 onActivity,
               )
-              resetInactivity()
+              markActivity()
             }
           }
         }
@@ -585,7 +607,7 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
           } else {
             // Approval resolved — resume typing if the run continues.
             onBusy?.(true)
-            resetInactivity() // Re-arm inactivity now that the run is unblocked.
+            markActivity() // Re-arm inactivity now that the run is unblocked.
             coordinator.onPermissionReplied(ev)
             logger.info(
               {requestID: ev.requestID, reply: ev.reply},
@@ -596,7 +618,10 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
       } else if (eventType === 'session.idle') {
         const eventSessionID = getEventSessionID(rawEvent)
         if (eventSessionID === sessionId) {
-          logger.info({sessionId}, 'run-core: session.idle received — stream complete')
+          logger.info(
+            {sessionId, totalEvents, activityEvents, lastEventType},
+            'run-core: session.idle received — stream complete',
+          )
           // Signal not-busy: work is done.
           onBusy?.(false)
           clearInactivity()
@@ -610,6 +635,10 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
           clearInactivity()
           throw new RunCoreError('session-error', `Session error: ${errorDetail}`)
         }
+      } else {
+        // Unrecognized event type — log at debug so a lost-event/routing gap (events arriving
+        // as types we do not handle) is visible rather than silently falling through.
+        logger.debug({eventType, sessionId}, 'run-core: unrecognized event type')
       }
     }
   } finally {
@@ -625,16 +654,22 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
     // Inactivity is the tighter bound (always < hard ceiling), so on the rare both-aborted
     // tick we attribute to inactivity-timeout deliberately.
     if (inactivityController !== null && inactivityController.signal.aborted) {
-      logger.warn({sessionId}, 'run-core: stream ended due to inactivity timeout')
+      logger.warn(
+        {sessionId, totalEvents, activityEvents, lastEventType},
+        'run-core: stream ended due to inactivity timeout',
+      )
       throw new RunCoreError('inactivity-timeout', 'Run timed out: no activity within the inactivity window')
     }
-    logger.warn({sessionId}, 'run-core: stream ended due to timeout signal')
+    logger.warn({sessionId, totalEvents, activityEvents, lastEventType}, 'run-core: stream ended due to timeout signal')
     throw new RunCoreError('timeout', 'Run timed out: event stream aborted by timeout signal')
   }
 
   // Stream closed without session.idle and not aborted by us → OpenCode
   // may still be working; mark as failed so the run is not silently completed.
-  logger.error({sessionId}, 'run-core: event stream closed before session.idle')
+  logger.error(
+    {sessionId, totalEvents, activityEvents, lastEventType},
+    'run-core: event stream closed before session.idle',
+  )
   throw new RunCoreError('stream-ended', 'Event stream closed before session.idle was received')
 }
 


### PR DESCRIPTION
Closes #1101.

## What

Adds event counters to the gateway run-core event loop so an inactivity-timeout log line reveals whether any events were seen — distinguishing a genuine workspace hang from an event-delivery/routing gap.

The inactivity-timeout, hard-ceiling timeout, stream-ended, and session.idle log lines now carry `totalEvents`, `activityEvents`, and `lastEventType`. A terminal `else` on the event dispatch logs any unrecognized event type at debug.

## Why

A dashboard-launched run produced zero observable activity for its whole lifetime and was killed by the inactivity timeout — with no way to tell from the outside whether the workspace genuinely hung or whether events were produced but never reached run-core. The inactivity timer only resets on text deltas, tool completions, and `permission.replied`, so a run whose events are lost (or arrive on a mismatched session id, or as unhandled types) is observationally identical to a run that's stuck: both emit the same terminal log and state.

## How

- `totalEvents` counts every event the loop processes — **including** events later dropped by the `eventSessionID === sessionId` guard, by design — so a foreign-session or otherwise-non-resetting event still registers.
- `activityEvents` increments only on genuine run activity, via a small `markActivity()` wrapper around the existing `resetInactivity()` (timer semantics unchanged; the wrapper only adds counting).
- The two signatures at timeout: `totalEvents: 0, activityEvents: 0` = silent workspace / hang; `totalEvents > 0, activityEvents: 0` = events arrived but none were activity, pointing at a subscription/routing gap rather than a model hang.
- The terminal `else` surfaces the "events arriving as unhandled types" case that previously fell through silently.

No control flow, timer timing, or error kinds change — counters and logging only. Complements #1099 (which exposes the sanitized `inactivity-timeout` kind on the operator surface): #1099 tells the operator *that* it timed out; this tells a maintainer reading gateway logs *why*.

## Verification

- `bun run lint`, `bun run build` — clean, no `dist/` diff
- gateway type-check clean, suite green (2904)
- Tests assert the actual counter values on every enriched log path: zero-events hang (`0/0`), events-but-no-activity gap (`>0/0` with `lastEventType` populated), healthy `session.idle` baseline (`>0/>0`), unrecognized-type debug log, and the hard-ceiling-timeout and stream-ended paths.
