### PR TITLE
fix(gateway): re-read for a fresh etag before the cancel-to-FAILED fallback

### DIFF
--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -7049,9 +7049,23 @@ describe('operator cancel — abort-registry integration', () => {
   })
 
   it('cancelled transition failure falls back to FAILED terminalization — run does not remain EXECUTING', async () => {
-    // #given — the CANCELLED transitionRun call fails; a subsequent FAILED transitionRun succeeds
+    // #given — the CANCELLED transitionRun call fails; a re-read shows the run still
+    // EXECUTING with a fresh etag; the FAILED fallback uses that fresh etag and succeeds
     const {launchWork} = await import('./run.js')
     const failedState = buildMockRunState({phase: 'FAILED', run_id: 'cancel-fallback-run-id'})
+    const executingState = buildMockRunState({phase: 'EXECUTING', run_id: 'cancel-fallback-run-id'})
+    const getObjectMock = vi.fn().mockResolvedValue({
+      success: true as const,
+      data: {data: JSON.stringify(executingState), etag: 'fresh-etag-after-cancel-412'},
+    })
+    const coordinationConfig = {
+      storeAdapter: {upload: vi.fn(), download: vi.fn(), list: vi.fn(), getObject: getObjectMock},
+      storeConfig: {enabled: true, bucket: 'test', region: 'us-east-1', prefix: 'state'},
+      lockTtlSeconds: 900,
+      heartbeatIntervalMs: 30_000,
+      staleThresholdMs: 60_000,
+      pendingStaleThresholdMs: 30 * 60_000,
+    } as unknown as CoordinationConfig
 
     mockRuntime.acquireLock.mockResolvedValue({
       success: true as const,
@@ -7094,7 +7108,7 @@ describe('operator cancel — abort-registry integration', () => {
     const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
     const request = makeInMemoryRequest()
     ;(request as {runId?: string}).runId = CANCEL_FALLBACK_RUN_ID
-    const deps = makeDeps({logger})
+    const deps = makeDeps({logger, coordinationConfig})
 
     // #when — must not throw
     await expect(awaitLaunchWorkRun(launchWork, request, deps)).resolves.toBeDefined()
@@ -7106,6 +7120,12 @@ describe('operator cancel — abort-registry integration', () => {
     const observedPhases = transitionCalls.map((c: unknown[]) => c[4] as string)
     expect(observedPhases).toContain('CANCELLED')
     expect(observedPhases).toContain('FAILED')
+
+    // #and — the re-read happened, and the FAILED fallback used the FRESH etag from the
+    // re-read (not the stale runEtag the CANCELLED write was rejected with).
+    expect(getObjectMock).toHaveBeenCalled()
+    const failedCall = mockRuntime.transitionRun.mock.calls.find((c: unknown[]) => c[4] === 'FAILED')
+    expect(failedCall?.[5]).toBe('fresh-etag-after-cancel-412')
 
     // #and — the run does not remain EXECUTING: the FAILED fallback call is the last
     // observed terminal-settlement attempt for this run, confirming it did not stay open.
@@ -7121,6 +7141,194 @@ describe('operator cancel — abort-registry integration', () => {
     abortRegistry.delete(CANCEL_FALLBACK_RUN_ID)
   })
 
+  it('cancelled transition failure + re-read shows run ALREADY TERMINAL (concurrent writer landed CANCELLED) — no FAILED fallback attempted', async () => {
+    // #given — the CANCELLED transitionRun call fails, but a re-read shows a concurrent
+    // writer already landed CANCELLED (a valid, terminal phase) — the FAILED fallback
+    // must be skipped (FAILED is not a valid transition from CANCELLED)
+    const {launchWork} = await import('./run.js')
+    const cancelledState = buildMockRunState({phase: 'CANCELLED', run_id: 'cancel-fallback-terminal-run-id'})
+    const getObjectMock = vi.fn().mockResolvedValue({
+      success: true as const,
+      data: {data: JSON.stringify(cancelledState), etag: 'cancelled-etag'},
+    })
+    const coordinationConfig = {
+      storeAdapter: {upload: vi.fn(), download: vi.fn(), list: vi.fn(), getObject: getObjectMock},
+      storeConfig: {enabled: true, bucket: 'test', region: 'us-east-1', prefix: 'state'},
+      lockTtlSeconds: 900,
+      heartbeatIntervalMs: 30_000,
+      staleThresholdMs: 60_000,
+      pendingStaleThresholdMs: 30 * 60_000,
+    } as unknown as CoordinationConfig
+
+    mockRuntime.acquireLock.mockResolvedValue({
+      success: true as const,
+      data: {acquired: true as const, etag: 'lock-etag-v1', holder: null},
+    })
+    mockRuntime.releaseLock.mockResolvedValue({success: true as const, data: undefined})
+    mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'run-etag-v1'}})
+    mockRuntime.transitionRun.mockImplementation(
+      async (_config: unknown, _identity: unknown, _repo: unknown, _runId: unknown, phase: string) => {
+        if (phase === 'CANCELLED') {
+          return {success: false as const, error: new Error('CANCELLED conditional write conflict')}
+        }
+        // ACKNOWLEDGED / EXECUTING admission transitions
+        return {success: true as const, data: {etag: 'admit-etag', state: cancelledState}}
+      },
+    )
+    const heartbeatStop = vi.fn().mockResolvedValue({
+      success: true,
+      data: {runEtag: 'run-etag-after-heartbeat', lockEtag: 'lock-etag-after-heartbeat', runState: cancelledState},
+    })
+    mockRuntime.createHeartbeatController.mockReturnValue({
+      start: vi.fn(),
+      stop: heartbeatStop,
+      isRunning: false,
+    })
+    vi.mocked(attachModule.attachOpencode).mockReturnValue({
+      server: {url: 'http://workspace:9200'},
+      session: {create: vi.fn(), prompt: vi.fn()},
+    } as unknown as ReturnType<typeof attachModule.attachOpencode>)
+    vi.mocked(promptModule.buildDiscordPrompt).mockReturnValue('Repository: acme/widget\n\ndo the thing')
+
+    const TERMINAL_RUN_ID = 'cancel-fallback-terminal-run-id'
+    mockRunOpenCodeCoreAbortedBy(() => {
+      abortRegistry.abort(TERMINAL_RUN_ID, 'operator cancel')
+    })
+
+    const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+    const request = makeInMemoryRequest()
+    ;(request as {runId?: string}).runId = TERMINAL_RUN_ID
+    const deps = makeDeps({logger, coordinationConfig})
+
+    // #when — must not throw
+    await expect(awaitLaunchWorkRun(launchWork, request, deps)).resolves.toBeDefined()
+
+    // #then — the FAILED fallback transitionRun was NEVER attempted
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).not.toContain('FAILED')
+
+    // #and — a log records the concurrent terminalization
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({runId: TERMINAL_RUN_ID, phase: 'CANCELLED'}),
+      expect.stringContaining('already terminalized'),
+    )
+
+    abortRegistry.delete(TERMINAL_RUN_ID)
+  })
+
+  it('cancelled transition failure + re-read fails (read error) — no fallback write, warn logged, no throw', async () => {
+    // #given — the CANCELLED transitionRun call fails, and the subsequent re-read also
+    // fails (e.g. getObject error) — the fallback must be skipped fail-soft, no throw
+    const {launchWork} = await import('./run.js')
+    const executingState = buildMockRunState({phase: 'EXECUTING', run_id: 'cancel-fallback-readfail-run-id'})
+    const getObjectMock = vi.fn().mockResolvedValue({
+      success: false as const,
+      error: new Error('getObject transient failure'),
+    })
+    const coordinationConfig = {
+      storeAdapter: {upload: vi.fn(), download: vi.fn(), list: vi.fn(), getObject: getObjectMock},
+      storeConfig: {enabled: true, bucket: 'test', region: 'us-east-1', prefix: 'state'},
+      lockTtlSeconds: 900,
+      heartbeatIntervalMs: 30_000,
+      staleThresholdMs: 60_000,
+      pendingStaleThresholdMs: 30 * 60_000,
+    } as unknown as CoordinationConfig
+
+    mockRuntime.acquireLock.mockResolvedValue({
+      success: true as const,
+      data: {acquired: true as const, etag: 'lock-etag-v1', holder: null},
+    })
+    mockRuntime.releaseLock.mockResolvedValue({success: true as const, data: undefined})
+    mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'run-etag-v1'}})
+    mockRuntime.transitionRun.mockImplementation(
+      async (_config: unknown, _identity: unknown, _repo: unknown, _runId: unknown, phase: string) => {
+        if (phase === 'CANCELLED') {
+          return {success: false as const, error: new Error('CANCELLED conditional write conflict')}
+        }
+        return {success: true as const, data: {etag: 'admit-etag', state: executingState}}
+      },
+    )
+    const heartbeatStop = vi.fn().mockResolvedValue({
+      success: true,
+      data: {runEtag: 'run-etag-after-heartbeat', lockEtag: 'lock-etag-after-heartbeat', runState: executingState},
+    })
+    mockRuntime.createHeartbeatController.mockReturnValue({
+      start: vi.fn(),
+      stop: heartbeatStop,
+      isRunning: false,
+    })
+    vi.mocked(attachModule.attachOpencode).mockReturnValue({
+      server: {url: 'http://workspace:9200'},
+      session: {create: vi.fn(), prompt: vi.fn()},
+    } as unknown as ReturnType<typeof attachModule.attachOpencode>)
+    vi.mocked(promptModule.buildDiscordPrompt).mockReturnValue('Repository: acme/widget\n\ndo the thing')
+
+    const READFAIL_RUN_ID = 'cancel-fallback-readfail-run-id'
+    mockRunOpenCodeCoreAbortedBy(() => {
+      abortRegistry.abort(READFAIL_RUN_ID, 'operator cancel')
+    })
+
+    const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+    const request = makeInMemoryRequest()
+    ;(request as {runId?: string}).runId = READFAIL_RUN_ID
+    const deps = makeDeps({logger, coordinationConfig})
+
+    // #when — must not throw
+    await expect(awaitLaunchWorkRun(launchWork, request, deps)).resolves.toBeDefined()
+
+    // #then — the FAILED fallback transitionRun was NEVER attempted
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).not.toContain('FAILED')
+
+    // #and — a warn log records the skipped fallback (fail-soft; recovery reconciles)
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({runId: READFAIL_RUN_ID}),
+      expect.stringContaining('skipping FAILED fallback'),
+    )
+
+    abortRegistry.delete(READFAIL_RUN_ID)
+  })
+
+  it('happy cancel path (CANCELLED transition succeeds) — no re-read, no fallback attempted', async () => {
+    // #given — the CANCELLED transitionRun call succeeds outright
+    const {launchWork} = await import('./run.js')
+    setupHappyPath()
+    const cancelledState = buildMockRunState({phase: 'CANCELLED', run_id: 'cancel-happy-run-id'})
+    const getObjectMock = vi.fn()
+    const coordinationConfig = {
+      storeAdapter: {upload: vi.fn(), download: vi.fn(), list: vi.fn(), getObject: getObjectMock},
+    } as unknown as CoordinationConfig
+
+    mockRuntime.transitionRun.mockImplementation(
+      async (_config: unknown, _identity: unknown, _repo: unknown, _runId: unknown, phase: string) => {
+        if (phase === 'CANCELLED') {
+          return {success: true as const, data: {etag: 'cancelled-etag', state: cancelledState}}
+        }
+        return {success: true as const, data: {etag: 'admit-etag', state: cancelledState}}
+      },
+    )
+
+    const HAPPY_CANCEL_RUN_ID = 'cancel-happy-run-id'
+    mockRunOpenCodeCoreAbortedBy(() => {
+      abortRegistry.abort(HAPPY_CANCEL_RUN_ID, 'operator cancel')
+    })
+
+    const request = makeInMemoryRequest()
+    ;(request as {runId?: string}).runId = HAPPY_CANCEL_RUN_ID
+    const deps = makeDeps({coordinationConfig})
+
+    // #when — must not throw
+    await expect(awaitLaunchWorkRun(launchWork, request, deps)).resolves.toBeDefined()
+
+    // #then — the CANCELLED transition succeeded; no re-read (getObject) was ever needed
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).toContain('CANCELLED')
+    expect(transitionPhases).not.toContain('FAILED')
+    expect(getObjectMock).not.toHaveBeenCalled()
+
+    abortRegistry.delete(HAPPY_CANCEL_RUN_ID)
+  })
+
   it('cancelled→failed fallback reaches a terminal state without throwing (accepted notice-vs-settlement interleaving)', async () => {
     // #given — same CANCELLED-transition-fails/FAILED-fallback-succeeds setup as above.
     // ACCEPTED BEHAVIOR: cancelRun (execute/cancel.ts) posts the "cancelled" thread
@@ -7133,6 +7341,19 @@ describe('operator cancel — abort-registry integration', () => {
     // by cancel.test.ts's "abort delivered → notice posted" test.
     const {launchWork} = await import('./run.js')
     const failedState = buildMockRunState({phase: 'FAILED', run_id: 'cancel-fallback-pin-run-id'})
+    const executingState = buildMockRunState({phase: 'EXECUTING', run_id: 'cancel-fallback-pin-run-id'})
+    const getObjectMock = vi.fn().mockResolvedValue({
+      success: true as const,
+      data: {data: JSON.stringify(executingState), etag: 'fresh-etag-pin'},
+    })
+    const coordinationConfig = {
+      storeAdapter: {upload: vi.fn(), download: vi.fn(), list: vi.fn(), getObject: getObjectMock},
+      storeConfig: {enabled: true, bucket: 'test', region: 'us-east-1', prefix: 'state'},
+      lockTtlSeconds: 900,
+      heartbeatIntervalMs: 30_000,
+      staleThresholdMs: 60_000,
+      pendingStaleThresholdMs: 30 * 60_000,
+    } as unknown as CoordinationConfig
 
     mockRuntime.releaseLock.mockResolvedValue({success: true as const, data: undefined})
     mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'run-etag-v1'}})
@@ -7170,7 +7391,7 @@ describe('operator cancel — abort-registry integration', () => {
     const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
     const request = makeInMemoryRequest()
     ;(request as {runId?: string}).runId = PIN_RUN_ID
-    const deps = makeDeps({logger})
+    const deps = makeDeps({logger, coordinationConfig})
 
     // #when — the run must resolve (not throw, not hang) despite the CANCELLED
     // transition failing.
@@ -7561,6 +7782,19 @@ describe('failureKind persistence on FAILED transitions', () => {
     const FALLBACK_RUN_ID = 'fallback-cancel-run-id'
     setupHappyPath()
     const failedFallbackState = buildMockRunState({phase: 'FAILED', run_id: FALLBACK_RUN_ID})
+    const executingState = buildMockRunState({phase: 'EXECUTING', run_id: FALLBACK_RUN_ID})
+    const getObjectMock = vi.fn().mockResolvedValue({
+      success: true as const,
+      data: {data: JSON.stringify(executingState), etag: 'fresh-etag-failurekind'},
+    })
+    const coordinationConfig = {
+      storeAdapter: {upload: vi.fn(), download: vi.fn(), list: vi.fn(), getObject: getObjectMock},
+      storeConfig: {enabled: true, bucket: 'test', region: 'us-east-1', prefix: 'state'},
+      lockTtlSeconds: 900,
+      heartbeatIntervalMs: 30_000,
+      staleThresholdMs: 60_000,
+      pendingStaleThresholdMs: 30 * 60_000,
+    } as unknown as CoordinationConfig
     mockRuntime.transitionRun
       .mockResolvedValueOnce({
         success: true as const,
@@ -7581,7 +7815,7 @@ describe('failureKind persistence on FAILED transitions', () => {
 
     const request = makeInMemoryRequest()
     ;(request as {runId?: string}).runId = FALLBACK_RUN_ID
-    const deps = makeDeps()
+    const deps = makeDeps({coordinationConfig})
 
     // #when
     await awaitLaunchWorkRun(launchWork, request, deps)

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -7141,80 +7141,85 @@ describe('operator cancel — abort-registry integration', () => {
     abortRegistry.delete(CANCEL_FALLBACK_RUN_ID)
   })
 
-  it('cancelled transition failure + re-read shows run ALREADY TERMINAL (concurrent writer landed CANCELLED) — no FAILED fallback attempted', async () => {
-    // #given — the CANCELLED transitionRun call fails, but a re-read shows a concurrent
-    // writer already landed CANCELLED (a valid, terminal phase) — the FAILED fallback
-    // must be skipped (FAILED is not a valid transition from CANCELLED)
-    const {launchWork} = await import('./run.js')
-    const cancelledState = buildMockRunState({phase: 'CANCELLED', run_id: 'cancel-fallback-terminal-run-id'})
-    const getObjectMock = vi.fn().mockResolvedValue({
-      success: true as const,
-      data: {data: JSON.stringify(cancelledState), etag: 'cancelled-etag'},
+  for (const terminalPhase of ['COMPLETED', 'FAILED', 'CANCELLED'] as const) {
+    it(`cancelled transition failure + re-read shows run ALREADY TERMINAL (concurrent writer landed ${terminalPhase}) — no FAILED fallback attempted`, async () => {
+      // #given — the CANCELLED transitionRun call fails, but a re-read shows a concurrent
+      // writer already landed on a terminal phase — the FAILED fallback must be skipped
+      // (FAILED is not a valid transition from any terminal phase)
+      const {launchWork} = await import('./run.js')
+      const terminalState = buildMockRunState({
+        phase: terminalPhase,
+        run_id: `cancel-fallback-terminal-run-id-${terminalPhase}`,
+      })
+      const getObjectMock = vi.fn().mockResolvedValue({
+        success: true as const,
+        data: {data: JSON.stringify(terminalState), etag: 'terminal-etag'},
+      })
+      const coordinationConfig = {
+        storeAdapter: {upload: vi.fn(), download: vi.fn(), list: vi.fn(), getObject: getObjectMock},
+        storeConfig: {enabled: true, bucket: 'test', region: 'us-east-1', prefix: 'state'},
+        lockTtlSeconds: 900,
+        heartbeatIntervalMs: 30_000,
+        staleThresholdMs: 60_000,
+        pendingStaleThresholdMs: 30 * 60_000,
+      } as unknown as CoordinationConfig
+
+      mockRuntime.acquireLock.mockResolvedValue({
+        success: true as const,
+        data: {acquired: true as const, etag: 'lock-etag-v1', holder: null},
+      })
+      mockRuntime.releaseLock.mockResolvedValue({success: true as const, data: undefined})
+      mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'run-etag-v1'}})
+      mockRuntime.transitionRun.mockImplementation(
+        async (_config: unknown, _identity: unknown, _repo: unknown, _runId: unknown, phase: string) => {
+          if (phase === 'CANCELLED') {
+            return {success: false as const, error: new Error('CANCELLED conditional write conflict')}
+          }
+          // ACKNOWLEDGED / EXECUTING admission transitions
+          return {success: true as const, data: {etag: 'admit-etag', state: terminalState}}
+        },
+      )
+      const heartbeatStop = vi.fn().mockResolvedValue({
+        success: true,
+        data: {runEtag: 'run-etag-after-heartbeat', lockEtag: 'lock-etag-after-heartbeat', runState: terminalState},
+      })
+      mockRuntime.createHeartbeatController.mockReturnValue({
+        start: vi.fn(),
+        stop: heartbeatStop,
+        isRunning: false,
+      })
+      vi.mocked(attachModule.attachOpencode).mockReturnValue({
+        server: {url: 'http://workspace:9200'},
+        session: {create: vi.fn(), prompt: vi.fn()},
+      } as unknown as ReturnType<typeof attachModule.attachOpencode>)
+      vi.mocked(promptModule.buildDiscordPrompt).mockReturnValue('Repository: acme/widget\n\ndo the thing')
+
+      const TERMINAL_RUN_ID = `cancel-fallback-terminal-run-id-${terminalPhase}`
+      mockRunOpenCodeCoreAbortedBy(() => {
+        abortRegistry.abort(TERMINAL_RUN_ID, 'operator cancel')
+      })
+
+      const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+      const request = makeInMemoryRequest()
+      ;(request as {runId?: string}).runId = TERMINAL_RUN_ID
+      const deps = makeDeps({logger, coordinationConfig})
+
+      // #when — must not throw
+      await expect(awaitLaunchWorkRun(launchWork, request, deps)).resolves.toBeDefined()
+
+      // #then — the FAILED fallback transitionRun was NEVER attempted
+      const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+      expect(transitionPhases).not.toContain('FAILED')
+
+      // #and — a log records the concurrent terminalization with the observed phase
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({runId: TERMINAL_RUN_ID, phase: terminalPhase}),
+        expect.stringContaining('already terminalized'),
+      )
+
+      abortRegistry.delete(TERMINAL_RUN_ID)
     })
-    const coordinationConfig = {
-      storeAdapter: {upload: vi.fn(), download: vi.fn(), list: vi.fn(), getObject: getObjectMock},
-      storeConfig: {enabled: true, bucket: 'test', region: 'us-east-1', prefix: 'state'},
-      lockTtlSeconds: 900,
-      heartbeatIntervalMs: 30_000,
-      staleThresholdMs: 60_000,
-      pendingStaleThresholdMs: 30 * 60_000,
-    } as unknown as CoordinationConfig
-
-    mockRuntime.acquireLock.mockResolvedValue({
-      success: true as const,
-      data: {acquired: true as const, etag: 'lock-etag-v1', holder: null},
-    })
-    mockRuntime.releaseLock.mockResolvedValue({success: true as const, data: undefined})
-    mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'run-etag-v1'}})
-    mockRuntime.transitionRun.mockImplementation(
-      async (_config: unknown, _identity: unknown, _repo: unknown, _runId: unknown, phase: string) => {
-        if (phase === 'CANCELLED') {
-          return {success: false as const, error: new Error('CANCELLED conditional write conflict')}
-        }
-        // ACKNOWLEDGED / EXECUTING admission transitions
-        return {success: true as const, data: {etag: 'admit-etag', state: cancelledState}}
-      },
-    )
-    const heartbeatStop = vi.fn().mockResolvedValue({
-      success: true,
-      data: {runEtag: 'run-etag-after-heartbeat', lockEtag: 'lock-etag-after-heartbeat', runState: cancelledState},
-    })
-    mockRuntime.createHeartbeatController.mockReturnValue({
-      start: vi.fn(),
-      stop: heartbeatStop,
-      isRunning: false,
-    })
-    vi.mocked(attachModule.attachOpencode).mockReturnValue({
-      server: {url: 'http://workspace:9200'},
-      session: {create: vi.fn(), prompt: vi.fn()},
-    } as unknown as ReturnType<typeof attachModule.attachOpencode>)
-    vi.mocked(promptModule.buildDiscordPrompt).mockReturnValue('Repository: acme/widget\n\ndo the thing')
-
-    const TERMINAL_RUN_ID = 'cancel-fallback-terminal-run-id'
-    mockRunOpenCodeCoreAbortedBy(() => {
-      abortRegistry.abort(TERMINAL_RUN_ID, 'operator cancel')
-    })
-
-    const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
-    const request = makeInMemoryRequest()
-    ;(request as {runId?: string}).runId = TERMINAL_RUN_ID
-    const deps = makeDeps({logger, coordinationConfig})
-
-    // #when — must not throw
-    await expect(awaitLaunchWorkRun(launchWork, request, deps)).resolves.toBeDefined()
-
-    // #then — the FAILED fallback transitionRun was NEVER attempted
-    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
-    expect(transitionPhases).not.toContain('FAILED')
-
-    // #and — a log records the concurrent terminalization
-    expect(logger.info).toHaveBeenCalledWith(
-      expect.objectContaining({runId: TERMINAL_RUN_ID, phase: 'CANCELLED'}),
-      expect.stringContaining('already terminalized'),
-    )
-
-    abortRegistry.delete(TERMINAL_RUN_ID)
-  })
+  }
 
   it('cancelled transition failure + re-read fails (read error) — no fallback write, warn logged, no throw', async () => {
     // #given — the CANCELLED transitionRun call fails, and the subsequent re-read also
@@ -7287,6 +7292,150 @@ describe('operator cancel — abort-registry integration', () => {
     )
 
     abortRegistry.delete(READFAIL_RUN_ID)
+  })
+
+  it('cancelled transition failure + re-read data is unparseable — no fallback write, warn logged, no throw', async () => {
+    // #given — the CANCELLED transitionRun call fails, and the subsequent re-read's stored
+    // data fails to parse (corrupt/malformed run state) — parseRunState failure inside
+    // readCurrentRunStateWithEtag must be treated as fail-soft and skip the fallback write
+    const {launchWork} = await import('./run.js')
+    const getObjectMock = vi.fn().mockResolvedValue({
+      success: true as const,
+      data: {data: '{not-valid-json', etag: 'corrupt-etag'},
+    })
+    const coordinationConfig = {
+      storeAdapter: {upload: vi.fn(), download: vi.fn(), list: vi.fn(), getObject: getObjectMock},
+      storeConfig: {enabled: true, bucket: 'test', region: 'us-east-1', prefix: 'state'},
+      lockTtlSeconds: 900,
+      heartbeatIntervalMs: 30_000,
+      staleThresholdMs: 60_000,
+      pendingStaleThresholdMs: 30 * 60_000,
+    } as unknown as CoordinationConfig
+
+    const executingState = buildMockRunState({phase: 'EXECUTING', run_id: 'cancel-fallback-parsefail-run-id'})
+    mockRuntime.acquireLock.mockResolvedValue({
+      success: true as const,
+      data: {acquired: true as const, etag: 'lock-etag-v1', holder: null},
+    })
+    mockRuntime.releaseLock.mockResolvedValue({success: true as const, data: undefined})
+    mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'run-etag-v1'}})
+    mockRuntime.transitionRun.mockImplementation(
+      async (_config: unknown, _identity: unknown, _repo: unknown, _runId: unknown, phase: string) => {
+        if (phase === 'CANCELLED') {
+          return {success: false as const, error: new Error('CANCELLED conditional write conflict')}
+        }
+        return {success: true as const, data: {etag: 'admit-etag', state: executingState}}
+      },
+    )
+    const heartbeatStop = vi.fn().mockResolvedValue({
+      success: true,
+      data: {runEtag: 'run-etag-after-heartbeat', lockEtag: 'lock-etag-after-heartbeat', runState: executingState},
+    })
+    mockRuntime.createHeartbeatController.mockReturnValue({
+      start: vi.fn(),
+      stop: heartbeatStop,
+      isRunning: false,
+    })
+    vi.mocked(attachModule.attachOpencode).mockReturnValue({
+      server: {url: 'http://workspace:9200'},
+      session: {create: vi.fn(), prompt: vi.fn()},
+    } as unknown as ReturnType<typeof attachModule.attachOpencode>)
+    vi.mocked(promptModule.buildDiscordPrompt).mockReturnValue('Repository: acme/widget\n\ndo the thing')
+
+    const PARSEFAIL_RUN_ID = 'cancel-fallback-parsefail-run-id'
+    mockRunOpenCodeCoreAbortedBy(() => {
+      abortRegistry.abort(PARSEFAIL_RUN_ID, 'operator cancel')
+    })
+
+    const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+    const request = makeInMemoryRequest()
+    ;(request as {runId?: string}).runId = PARSEFAIL_RUN_ID
+    const deps = makeDeps({logger, coordinationConfig})
+
+    // #when — must not throw
+    await expect(awaitLaunchWorkRun(launchWork, request, deps)).resolves.toBeDefined()
+
+    // #then — the FAILED fallback transitionRun was NEVER attempted
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).not.toContain('FAILED')
+
+    // #and — a warn log records the skipped fallback (fail-soft; recovery reconciles)
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({runId: PARSEFAIL_RUN_ID}),
+      expect.stringContaining('skipping FAILED fallback'),
+    )
+
+    abortRegistry.delete(PARSEFAIL_RUN_ID)
+  })
+
+  it('cancelled transition failure + no getObject adapter — re-read unsupported, no fallback write, warn logged, no throw', async () => {
+    // #given — the CANCELLED transitionRun call fails, and the store adapter does not
+    // support getObject at all — readCurrentRunStateWithEtag must return null without
+    // throwing and the fallback write must be skipped fail-soft
+    const {launchWork} = await import('./run.js')
+    const coordinationConfig = {
+      storeAdapter: {upload: vi.fn(), download: vi.fn(), list: vi.fn()},
+      storeConfig: {enabled: true, bucket: 'test', region: 'us-east-1', prefix: 'state'},
+      lockTtlSeconds: 900,
+      heartbeatIntervalMs: 30_000,
+      staleThresholdMs: 60_000,
+      pendingStaleThresholdMs: 30 * 60_000,
+    } as unknown as CoordinationConfig
+
+    const executingState = buildMockRunState({phase: 'EXECUTING', run_id: 'cancel-fallback-noadapter-run-id'})
+    mockRuntime.acquireLock.mockResolvedValue({
+      success: true as const,
+      data: {acquired: true as const, etag: 'lock-etag-v1', holder: null},
+    })
+    mockRuntime.releaseLock.mockResolvedValue({success: true as const, data: undefined})
+    mockRuntime.createRun.mockResolvedValue({success: true as const, data: {etag: 'run-etag-v1'}})
+    mockRuntime.transitionRun.mockImplementation(
+      async (_config: unknown, _identity: unknown, _repo: unknown, _runId: unknown, phase: string) => {
+        if (phase === 'CANCELLED') {
+          return {success: false as const, error: new Error('CANCELLED conditional write conflict')}
+        }
+        return {success: true as const, data: {etag: 'admit-etag', state: executingState}}
+      },
+    )
+    const heartbeatStop = vi.fn().mockResolvedValue({
+      success: true,
+      data: {runEtag: 'run-etag-after-heartbeat', lockEtag: 'lock-etag-after-heartbeat', runState: executingState},
+    })
+    mockRuntime.createHeartbeatController.mockReturnValue({
+      start: vi.fn(),
+      stop: heartbeatStop,
+      isRunning: false,
+    })
+    vi.mocked(attachModule.attachOpencode).mockReturnValue({
+      server: {url: 'http://workspace:9200'},
+      session: {create: vi.fn(), prompt: vi.fn()},
+    } as unknown as ReturnType<typeof attachModule.attachOpencode>)
+    vi.mocked(promptModule.buildDiscordPrompt).mockReturnValue('Repository: acme/widget\n\ndo the thing')
+
+    const NOADAPTER_RUN_ID = 'cancel-fallback-noadapter-run-id'
+    mockRunOpenCodeCoreAbortedBy(() => {
+      abortRegistry.abort(NOADAPTER_RUN_ID, 'operator cancel')
+    })
+
+    const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+    const request = makeInMemoryRequest()
+    ;(request as {runId?: string}).runId = NOADAPTER_RUN_ID
+    const deps = makeDeps({logger, coordinationConfig})
+
+    // #when — must not throw
+    await expect(awaitLaunchWorkRun(launchWork, request, deps)).resolves.toBeDefined()
+
+    // #then — the FAILED fallback transitionRun was NEVER attempted
+    const transitionPhases = mockRuntime.transitionRun.mock.calls.map((c: unknown[]) => c[4] as string)
+    expect(transitionPhases).not.toContain('FAILED')
+
+    // #and — a warn log records the skipped fallback (fail-soft; recovery reconciles)
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({runId: NOADAPTER_RUN_ID}),
+      expect.stringContaining('skipping FAILED fallback'),
+    )
+
+    abortRegistry.delete(NOADAPTER_RUN_ID)
   })
 
   it('happy cancel path (CANCELLED transition succeeds) — no re-read, no fallback attempted', async () => {

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -240,6 +240,60 @@ async function readCurrentRunPhase(
   }
 }
 
+/**
+ * Re-read the run-state's current phase AND etag together.
+ *
+ * Used by the CANCELLED→FAILED fallback path: when the CANCELLED
+ * `transitionRun` call fails (commonly a 412 on a stale etag), the fallback
+ * FAILED write must not reuse that same stale etag — it is guaranteed to
+ * 412 again. This re-read gets a fresh etag for the fallback attempt, and
+ * also lets the caller detect that a concurrent writer already
+ * terminalized the run (in which case no fallback write should be
+ * attempted at all — FAILED is not a valid transition from a terminal
+ * phase). Returns `null` on any read/parse failure — callers should treat
+ * that as fail-soft and skip the fallback write, leaving it to the
+ * recovery sweep.
+ */
+async function readCurrentRunStateWithEtag(
+  deps: RunMentionDeps,
+  repo: string,
+  runId: string,
+): Promise<{readonly phase: RunState['phase']; readonly etag: string} | null> {
+  const {coordinationConfig, identity, logger} = deps
+  try {
+    const keyResult = getRunKey(coordinationConfig, identity, repo, runId)
+    if (keyResult.success === false) {
+      logger.warn(
+        {repo, runId, err: keyResult.error.message},
+        'run: readCurrentRunStateWithEtag — could not build run key',
+      )
+      return null
+    }
+    const getObject = coordinationConfig.storeAdapter?.getObject
+    if (getObject == null) {
+      logger.warn({repo, runId}, 'run: readCurrentRunStateWithEtag — store adapter does not support getObject')
+      return null
+    }
+    const fetched = await getObject(keyResult.data)
+    if (fetched.success === false) {
+      logger.warn({repo, runId, err: fetched.error.message}, 'run: readCurrentRunStateWithEtag — getObject failed')
+      return null
+    }
+    const parsed = parseRunState(fetched.data.data)
+    if (parsed.success === false) {
+      logger.warn({repo, runId, err: parsed.error.message}, 'run: readCurrentRunStateWithEtag — parseRunState failed')
+      return null
+    }
+    return {phase: parsed.data.phase, etag: fetched.data.etag}
+  } catch (error) {
+    logger.warn(
+      {repo, runId, err: error instanceof Error ? error.message : String(error)},
+      'run: readCurrentRunStateWithEtag threw',
+    )
+    return null
+  }
+}
+
 // ---------------------------------------------------------------------------
 // computeApprovalDeadlineMs
 // ---------------------------------------------------------------------------
@@ -876,32 +930,53 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
 
           // Fallback: leaving the run non-terminal (EXECUTING) with the lock about to be
           // released by the outer finally is an inconsistent state until the next recovery
-          // sweep. Attempt a best-effort FAILED terminalization with the same etag (FAILED
-          // is a valid transition from EXECUTING) rather than leaving this to recovery alone.
-          // The cancel path was entered via the wasCancelled registry check; execError is
-          // still the caught throw and is classified here for the rare CANCELLED→FAILED
-          // fallback (usually an AbortError → no RunCoreError.kind → failureKind omitted).
-          const fallbackFailureKind = extractRunCoreKind(execError)
-          const fallbackOptions =
-            fallbackFailureKind === undefined ? undefined : {detailsPatch: {failureKind: fallbackFailureKind}}
-          const failedFallbackResult = await transitionRun(
-            coordinationConfig,
-            identity,
-            repo,
-            runId,
-            'FAILED',
-            runEtag,
-            coordLogger,
-            fallbackOptions,
-          )
-          if (failedFallbackResult.success === false) {
-            logger.error(
-              {repo, runId, err: failedFallbackResult.error.message},
-              'run: FAILED fallback after CANCELLED transition failure also failed — leaving for recovery sweep',
+          // sweep. Attempt a best-effort FAILED terminalization rather than leaving this to
+          // recovery alone. The CANCELLED failure above is commonly a 412 on a stale etag —
+          // reusing that same etag for the FAILED write would 412 again, so re-read the
+          // run-state first to get a fresh etag and to detect whether a concurrent writer
+          // already landed a terminal phase (in which case FAILED is an invalid transition
+          // and no fallback write should be attempted).
+          const reReadResult = await readCurrentRunStateWithEtag(deps, repo, runId)
+          if (reReadResult === null) {
+            logger.warn(
+              {repo, runId},
+              'run: CANCELLED transition failed and run-state re-read also failed — skipping FAILED fallback; recovery sweep will reconcile',
+            )
+          } else if (
+            reReadResult.phase === 'COMPLETED' ||
+            reReadResult.phase === 'FAILED' ||
+            reReadResult.phase === 'CANCELLED'
+          ) {
+            logger.info(
+              {repo, runId, phase: reReadResult.phase},
+              'run: CANCELLED transition failed but a concurrent writer already terminalized the run — skipping FAILED fallback',
             )
           } else {
-            logger.warn({repo, runId}, 'run: CANCELLED transition failed — fell back to FAILED terminalization')
-            notifyObserverBestEffort(deps, failedFallbackResult.data.state)
+            // The cancel path was entered via the wasCancelled registry check; execError is
+            // still the caught throw and is classified here for the rare CANCELLED→FAILED
+            // fallback (usually an AbortError → no RunCoreError.kind → failureKind omitted).
+            const fallbackFailureKind = extractRunCoreKind(execError)
+            const fallbackOptions =
+              fallbackFailureKind === undefined ? undefined : {detailsPatch: {failureKind: fallbackFailureKind}}
+            const failedFallbackResult = await transitionRun(
+              coordinationConfig,
+              identity,
+              repo,
+              runId,
+              'FAILED',
+              reReadResult.etag,
+              coordLogger,
+              fallbackOptions,
+            )
+            if (failedFallbackResult.success === false) {
+              logger.error(
+                {repo, runId, err: failedFallbackResult.error.message},
+                'run: FAILED fallback after CANCELLED transition failure also failed — leaving for recovery sweep',
+              )
+            } else {
+              logger.warn({repo, runId}, 'run: CANCELLED transition failed — fell back to FAILED terminalization')
+              notifyObserverBestEffort(deps, failedFallbackResult.data.state)
+            }
           }
         } else {
           notifyObserverBestEffort(deps, cancelledResult.data.state)


### PR DESCRIPTION
Closes #1114.

## What

Fixes the operator run-cancellation settlement path so the `CANCELLED → FAILED` fallback re-reads run-state for a fresh etag before writing, and skips the write entirely when a concurrent path already terminalized the run.

## Why

When the `CANCELLED` transition failed, the `FAILED` fallback reused the **same** etag the `CANCELLED` write was just rejected with. A `CANCELLED` failure is most commonly a 412 (stale etag), so retrying `FAILED` with that identical etag was guaranteed to 412 again — the fallback did nothing for the exact failure mode it existed to handle. And if a concurrent writer had already landed `CANCELLED` (terminal), the fallback `FAILED` write was an invalid transition, logged at `error` as misleading noise.

## How

- New `readCurrentRunStateWithEtag` helper (sibling to `readCurrentRunPhase`, same fail-soft null-on-error discipline) returns `{phase, etag}`.
- On a `CANCELLED` transition failure, re-read before the fallback:
  - **read fails** → skip the fallback, warn, no throw — recovery reconciles.
  - **already terminal** (`COMPLETED`/`FAILED`/`CANCELLED`) → skip the fallback, info-log the concurrent terminalization (no more invalid-transition error noise).
  - **still `EXECUTING`** → attempt `FAILED` with the **fresh** etag, carrying the same failure-kind attribution.

The primary `CANCELLED` settlement path (heartbeat-first etag discipline) is unchanged; only the fallback sub-branch changes. The re-read adds one `getObject` only on the rare `CANCELLED`-failure path — never on the happy path.

## Scope

Low severity, self-healing: even before this fix the startup recovery sweep reconciled a stranded `EXECUTING` run. This makes the immediate fallback actually succeed in the common case and removes the misleading error log. A narrow race remains between the re-read and the `FAILED` write (a concurrent terminalizer can still 412 it), but that path is fail-soft and covered by recovery — strictly better than the prior deterministic double-412.

## Verification

- `bun run lint`, `bun run build` — clean, no `dist/` diff
- gateway type-check clean, suite green (2911)
- Tests: `CANCELLED` 412 → re-read yields a **distinct** fresh etag + `EXECUTING` → `FAILED` succeeds against the fresh etag (asserts the new etag, not the stale one); `CANCELLED` fails → re-read already-terminal (`COMPLETED`/`FAILED`/`CANCELLED`) → no fallback write, info log; re-read null (getObject failure, parse failure, missing adapter) → no fallback write, warn, no throw; happy `CANCELLED`-succeeds path → no re-read (no extra round-trip).
