### PR TITLE
chore: drop @opencode-ai/sdk age-gate fast-track now that 1.17.13 has cleared the window

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -12,7 +12,3 @@ linker = "hoisted"
 # Supply-chain age gate: refuse dependency versions published within this window.
 # Mirrors the prior pnpm minimumReleaseAge policy. Seconds (3 days).
 minimumReleaseAge = 259200
-
-# Temporarily fast-track the deliberate OpenCode 1.17.13 SDK bump before the
-# 3-day supply-chain age gate clears; remove once 1.17.13 is older than the window.
-minimumReleaseAgeExcludes = ["@opencode-ai/sdk"]


### PR DESCRIPTION
## What

Removes the temporary `minimumReleaseAgeExcludes = ["@opencode-ai/sdk"]` fast-track from `bunfig.toml`.

## Why

The exclusion was added to fast-track the deliberate `@opencode-ai/sdk@1.17.13` bump past the 3-day `minimumReleaseAge` supply-chain gate. `1.17.13` was published `2026-07-01T15:17:43Z` and cleared the 3-day window at `2026-07-04T15:17:43Z`, so the fast-track is no longer needed and the SDK is back under the standard age gate. Same cleanup #1066 did for `1.17.11`.

## Verification

- `bun install` — clean, `bun.lock` unchanged (the pinned `1.17.13` now satisfies the age gate without the exclusion).
- `bun run lint` — clean.
