### PR TITLE
docs: capture credential-isolation learnings from the #1107 arc

### DIFF
--- a/docs/solutions/best-practices/same-job-phase-split-not-a-security-boundary-2026-07-04.md
+++ b/docs/solutions/best-practices/same-job-phase-split-not-a-security-boundary-2026-07-04.md
@@ -1,0 +1,109 @@
+---
+title: Sequential steps in one GitHub Actions job are not a security boundary
+date: 2026-07-04
+category: best-practices
+module: ci security
+problem_type: best_practice
+component: development_workflow
+severity: high
+applies_when:
+  - A prompt-injectable or untrusted step runs before a trusted credential-holding step in the same job
+  - You are relying on step ORDER to isolate trust while preserving a one-job constraint
+  - An earlier step can influence env, workspace files, git config, hooks, or shell startup files
+tags:
+  - github-actions
+  - security-boundary
+  - prompt-injection
+  - step-order
+  - credential-isolation
+  - github-env
+---
+
+# Sequential steps in one GitHub Actions job are not a security boundary
+
+## Context
+
+To keep an agent from holding a write credential while still doing a privileged push, a tempting design is a same-job "phase split": run the prompt-injectable agent in one step with no write token, then a later "trusted" step holds the token and does the push — all in one job (e.g. to preserve `harness-integrate.yaml`'s one-job security invariant). Evaluated (and rejected) while scoping #1107.
+
+## Guidance
+
+Same-job sequential steps are **not** a trust boundary. Steps in one job share a runner, a filesystem, and a shell environment, and an earlier step can poison every later step. If the earlier step runs untrusted/prompt-injectable code, a later step in the same job cannot be treated as trusted relative to it.
+
+Poisoning vectors an earlier step controls:
+
+- **`GITHUB_ENV`** — append env vars (`GIT_ASKPASS`, `PATH`, `BASH_ENV`, `GH_TOKEN`, `GIT_CONFIG_*`) that later steps silently inherit.
+- **Workspace files** — write scripts/configs a later step reads or executes.
+- **`.git/config` and git hooks** — later `git` invocations pick up attacker-controlled config (`core.hooksPath`, `core.sshCommand`, remotes).
+- **`BASH_ENV`** — a file sourced by every non-interactive bash step.
+- **`PATH` / shims** — shadow real binaries a later step calls.
+
+`git --no-verify` disables hooks but does **not** make the later step trusted — it closes one vector of many.
+
+Real isolation requires either:
+- a **separate job** (fresh runner, explicit `needs.*`/outputs hand-off, no shared filesystem or env), or — better for credentials —
+- **credential minimization**: give the untrusted step only a short-lived, narrowly-scoped token so there is little worth protecting from it, rather than trying to withhold a broad one until "later" in the same job.
+
+If a same-job split is unavoidable, the later step needs aggressive hardening (clean env, `BASH_ENV=/dev/null`, safe `PATH`, ignore workspace git config, hardcoded remote/ref) — and even then it is defense-in-depth, not a boundary.
+
+## Why This Matters
+
+Same-job phase splits look neat and preserve one-job constraints, so teams reach for them believing they isolate. They don't. Designing security around step order gives a false sense of a boundary that an injected earlier step walks straight through. Naming this prevents shipping a design whose "trusted step" is trusting attacker-influenced state.
+
+## When to Apply
+
+- Designing any agent-vs-privileged-operation split in CI ("run the untrusted thing, then do the privileged thing").
+- Any attempt to keep one job while pretending its steps are mutually isolated.
+- Reviewing a workflow that runs untrusted/agent code and later consumes a credential or pushes.
+
+## Examples
+
+Poisoning via `GITHUB_ENV` (earlier untrusted step):
+
+```bash
+echo "GIT_ASKPASS=$PWD/evil-askpass.sh" >> "$GITHUB_ENV"
+echo "PATH=$PWD/bin:$PATH" >> "$GITHUB_ENV"
+# a later "trusted" push step now uses attacker-controlled askpass + PATH
+```
+
+Poisoning via `BASH_ENV`:
+
+```bash
+echo 'export GH_TOKEN=exfil' > /tmp/be
+echo "BASH_ENV=/tmp/be" >> "$GITHUB_ENV"
+# every later non-interactive bash step sources /tmp/be automatically
+```
+
+Better — separate jobs (real hand-off):
+
+```yaml
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.out.outputs.ref }}
+    steps:
+      - id: out
+        run: echo "ref=refs/harness-integrate/v1" >> "$GITHUB_OUTPUT"
+  push:
+    needs: agent
+    runs-on: ubuntu-latest # fresh runner — no shared fs/env with `agent`
+    permissions:
+      contents: write
+    steps:
+      - run: git push origin "${{ needs.agent.outputs.ref }}"
+```
+
+Better still for credentials — minimize instead of "trust later":
+
+```yaml
+# give the agent only a short-lived, contents:write-scoped token;
+# there is nothing broad left to protect from it, so no boundary is needed
+env:
+  GH_TOKEN: ${{ steps.mint.outputs.token }}
+```
+
+## Related
+
+- `docs/solutions/workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md` — credential minimization via broker-mint (the real fix for #1107), and why credential-lifetime/process boundaries matter more than agent config.
+- `docs/solutions/workflow-issues/create-github-app-token-caller-mint-invalid-2026-07-04.md` — the reusable-workflow constraint that pushes this design toward mint-in-workflow or broker-mint.
+- Issue #1107; PR #1119 (interim hygiene); #1124 + `marcusrbrown/infra#771` (the broker-mint fix).

--- a/docs/solutions/workflow-issues/create-github-app-token-caller-mint-invalid-2026-07-04.md
+++ b/docs/solutions/workflow-issues/create-github-app-token-caller-mint-invalid-2026-07-04.md
@@ -1,0 +1,116 @@
+---
+title: You cannot caller-mint a GitHub App token and pass it into a reusable workflow
+date: 2026-07-04
+category: workflow-issues
+module: harness/release pipeline
+problem_type: workflow_issue
+component: development_workflow
+severity: high
+applies_when:
+  - A caller job invokes a reusable workflow via jobs.<id>.uses
+  - You want a freshly minted credential (e.g. a GitHub App token) available inside the called workflow
+  - You expect to mint in the caller job and pass the token down through the secrets block
+tags:
+  - github-actions
+  - reusable-workflow
+  - create-github-app-token
+  - job-outputs
+  - secrets
+  - credential-minting
+---
+
+# You cannot caller-mint a GitHub App token and pass it into a reusable workflow
+
+## Context
+
+Removing a durable PAT from a reusable workflow (`harness-integrate.yaml`, which runs a prompt-injectable merge agent) by minting a short-lived GitHub App token in the **caller** (`harness-release.yaml`'s `integrate` job) and passing it into the called workflow via `secrets:`. This is the intuitive design — and it is invalid GitHub Actions. Surfaced while scoping #1107.
+
+## Guidance
+
+Two independent constraints block caller-mint:
+
+1. **A job that calls a reusable workflow (`jobs.<id>.uses:`) cannot also have `steps:`.** The reusable-workflow-calling job supports only job-level keys (`uses`, `with`, `secrets`, `needs`, `permissions`, `strategy`, `if`). So you cannot run `actions/create-github-app-token` before the `uses:` call in the same job.
+2. **Reusable-workflow `secrets:` values cannot reference `steps.*`.** A `jobs.<id>.secrets.<name>` expression may only read `github`, `needs`, `inputs`, `vars`, and `secrets` contexts — not `steps`. So even if you could run a mint step, `secrets: { TOKEN: ${{ steps.mint.outputs.token }} }` would not resolve.
+
+So the whole "mint in the caller, hand the token down" shape is not implementable. Choose one of the valid alternatives instead — each with a distinct tradeoff.
+
+## Why This Matters
+
+Caller-mint reads as the obvious way to keep an App private key out of a prompt-injectable reusable workflow while still giving it a scoped token. It silently doesn't work — the workflow won't even parse. Knowing the constraint upfront avoids designing (and half-implementing) a token handoff GitHub Actions will reject, and points you at the real options early.
+
+## When to Apply
+
+- Any time you want a freshly minted credential available *inside* a reusable workflow.
+- Any "mint a scoped token, then call the reusable workflow with it" design.
+- Reviewing a workflow PR that appears to mint-and-pass into a `uses:` job.
+
+## Examples
+
+Invalid — mint in the same job that calls the reusable workflow:
+
+```yaml
+jobs:
+  integrate:
+    uses: ./.github/workflows/harness-integrate.yaml
+    steps: # ← illegal: a `uses:` job cannot have `steps:`
+      - id: mint
+        uses: actions/create-github-app-token@v3
+    secrets:
+      TOKEN: ${{ steps.mint.outputs.token }} # ← illegal: secrets: cannot read steps.*
+```
+
+Valid alternative 1 — producer job + `needs.*` (brittle):
+
+```yaml
+jobs:
+  mint:
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.mint.outputs.token }}
+    steps:
+      - id: mint
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          skip-token-revoke: true # ← required, else the token is revoked at job end
+  integrate:
+    needs: mint
+    uses: ./.github/workflows/harness-integrate.yaml
+    secrets:
+      TOKEN: ${{ needs.mint.outputs.token }}
+```
+
+Caveat: `actions/create-github-app-token` revokes its token at the minting job's end unless `skip-token-revoke: true`, so a cross-job hand-off is brittle and keeps the token alive longer than one job.
+
+Valid alternative 2 — mint inside the called workflow:
+
+```yaml
+# inside harness-integrate.yaml
+steps:
+  - uses: actions/create-github-app-token@v3
+    with:
+      app-id: ${{ secrets.APP_ID }}
+      private-key: ${{ secrets.APP_PRIVATE_KEY }}
+```
+
+Tradeoff: the App **private key** now lives in the called workflow's job — and if that job runs a prompt-injectable agent, the key (which mints the App's full installation scope) is in the untrusted blast radius. Worse than a scoped PAT for that case.
+
+Valid alternative 3 — broker-mint off OIDC (keeps the App key out of CI entirely):
+
+```yaml
+# inside the called workflow
+permissions:
+  id-token: write
+steps:
+  - run: node scripts/harness/mint-broker-credential.ts # OIDC → broker → scoped short-lived token
+```
+
+Tradeoff: needs a broker that holds the App key server-side. This is the chosen direction for #1107 (see the broker doc below).
+
+## Related
+
+- `docs/solutions/workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md` — the broker-mint pattern (alternative 3), the real fix for #1107's integrate path.
+- `docs/solutions/best-practices/reusable-workflow-permissions-replace-not-merge-2026-07-01.md` — a *different* reusable-workflow trap (permissions REPLACE, not merge). Adjacent but distinct: that one is about the `permissions:` ceiling; this one is about `steps`/`secrets`-context invalidity.
+- `docs/solutions/best-practices/same-job-phase-split-not-a-security-boundary-2026-07-04.md` — why mint-inside-the-workflow (alternative 2) doesn't isolate the key from a same-job agent step.
+- Issue #1107; in-repo wiring tracked at #1124, broker change at `marcusrbrown/infra#771`.

--- a/docs/solutions/workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md
+++ b/docs/solutions/workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md
@@ -1,6 +1,7 @@
 ---
 title: Isolate a CI credential from an autonomous agent via an OIDC broker
 date: 2026-07-01
+last_updated: 2026-07-04
 category: workflow-issues
 module: harness/release pipeline
 problem_type: workflow_issue
@@ -62,6 +63,8 @@ A dedicated reusable workflow requests a GitHub OIDC token and exchanges it at a
 
 The paths that still use the durable key should scrub it from `process.env` after reading it, so it is not inherited by the agent's child process (which the OpenCode SDK spawns with `{ ...process.env }`). Note `@actions/core` maps input names replacing **spaces** only with underscores — `auth-json` reads from `INPUT_AUTH-JSON`, not `INPUT_AUTH_JSON` (PR #1080).
 
+**A scrub removes one copy, not the credential — enumerate every env copy before claiming isolation.** Scrubbing a single `INPUT_*` var is credential *hygiene*, not *isolation*, when the same secret value is exported again under a different name that the agent genuinely needs. The `github-token` case (#1107 / PR #1119) is the cautionary example: masking + `delete process.env['INPUT_GITHUB-TOKEN']` removes the input copy, but the same PAT is still exported as `GH_TOKEN` (`src/services/setup/setup.ts` `core.exportVariable`, `src/services/setup/gh-auth.ts` `process.env.GH_TOKEN = token`) — and the integrate agent *needs* `GH_TOKEN` to `git push` its result. So the scrub cannot isolate the token; it only shrinks the log/leak surface (`core.setSecret` masks by **value**, so it does cover all copies of the string in logs). When a prompt-injectable child genuinely needs the credential, the only real fix is credential **minimization** — give it a short-lived, narrowly-scoped, mint-per-run token so the durable one never reaches it — not a scrub. Before asserting "the agent can't read secret X," grep for X's value origin and every `core.exportVariable` / `process.env.X =` that re-creates it.
+
 ## Why This Matters
 
 The durable model key is the highest-value secret on the runner. Removing it entirely (broker path) shrinks the credential's value and lifetime; a stolen minted token is cliproxy-scoped and expires. The two halves are load-bearing together: dropping `secrets: inherit` without the broker leaves the merge with no credential; minting without dropping `secrets: inherit` leaves the durable key inherited into the called workflow's env, making the isolation fake.
@@ -89,6 +92,8 @@ Fail-closed verified in practice: a dry-run `harness-release` dispatch whose bro
 ## Related
 
 - `docs/solutions/best-practices/reusable-workflow-permissions-replace-not-merge-2026-07-01.md` — the permissions trap this work hit (a caller job needs `id-token: write` for the broker mint; getting the `permissions:` block wrong fails the run at startup).
+- `docs/solutions/workflow-issues/create-github-app-token-caller-mint-invalid-2026-07-04.md` — why you cannot mint a scoped App token in the caller and pass it into the reusable workflow (the intuitive alternative to broker-mint), and the valid alternatives.
+- `docs/solutions/best-practices/same-job-phase-split-not-a-security-boundary-2026-07-04.md` — why splitting the agent and the privileged push into sequential steps of one job does not isolate them (the reason broker-mint / credential minimization is the real fix, not intra-job ordering).
 - `docs/solutions/best-practices/workspace-executor-opencode-provisioning-best-practices-2026-06-01.md` — the sibling `auth-json` surface (workspace container entrypoint). This doc is the harness-CI producer side; that doc is the container consumer side.
 - `docs/solutions/workflow-issues/build-pipeline-fallible-preflight-and-finally-cleanup-2026-06-22.md` — the preflight → mutator → finally lifecycle the mint script follows.
 - `docs/solutions/best-practices/release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md` — the `scripts/`-as-testable-module precedent for the mint script.


### PR DESCRIPTION
## What

Captures three credential-isolation learnings from the #1107 harness-integrate hardening arc.

- **Updated `isolate-ci-credential-via-oidc-broker`** — folds in "a scrub removes one copy, not the credential": masking + `delete process.env['INPUT_GITHUB-TOKEN']` is credential *hygiene*, not *isolation*, when the same value is exported again as `GH_TOKEN` (which the integrate agent needs to push). Enumerate every env copy before claiming isolation; the real fix for a credential a child genuinely needs is minimization (short-lived scoped token), not a scrub.
- **New `create-github-app-token-caller-mint-invalid`** — you cannot mint a GitHub App token in a caller job and pass it into a reusable workflow: a `uses:` job can't also have `steps:`, and reusable-workflow `secrets:` can't reference `steps.*`. Documents the three valid alternatives and their tradeoffs.
- **New `same-job-phase-split-not-a-security-boundary`** — sequential steps in one GitHub Actions job aren't a trust boundary: an earlier prompt-injectable step poisons later steps via `GITHUB_ENV`, workspace files, `.git/config`, `BASH_ENV`, `PATH`. Real isolation needs a separate job or credential minimization.

## Why

Each was non-obvious, cost real investigation (and an Oracle pass) this cycle, and generalizes beyond #1107. The first was folded into the existing broker doc rather than duplicated (high overlap); the other two are distinct and stand alone. All three cross-link.

## Verification

- Frontmatter matches the repo's local `docs/solutions` conventions (component values in actual use here, not the Rails template defaults); `category` matches directory.
- `bun run check:md-links` passes — all cross-links resolve.
