### PR TITLE
test(gateway): run gateway suite in the root test lane

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fix": "bun run --filter @fro-bot/runtime fix && bun run --filter @fro-bot/action fix && bun run --filter @fro.bot/harness fix",
     "postinstall": "simple-git-hooks",
     "lint": "bun run --filter @fro-bot/runtime lint && bun run --filter @fro-bot/action lint && bun run --filter @fro.bot/harness lint && bun run dist:check-hidden-unicode && bun run check:md-links",
-    "test": "bun run --filter @fro-bot/runtime test && bun run --filter @fro-bot/action test && bun run --filter @fro.bot/harness test",
+    "test": "bun run --filter @fro-bot/runtime test && bun run --filter @fro-bot/action test && bun run --filter @fro.bot/harness test && bun run --filter @fro-bot/gateway test",
     "test:scripts": "vitest run scripts/"
   },
   "simple-git-hooks": {

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
   ],
   "scripts": {
     "bootstrap": "bun install",
-    "build": "bun run --filter @fro-bot/runtime build && bun run --filter @fro-bot/action build && bun run --filter @fro.bot/harness build && bun run dist:escape-hidden-unicode",
-    "check-types": "bun run --filter @fro-bot/runtime check-types && bun run --filter @fro-bot/action check-types && bun run --filter @fro.bot/harness check-types",
+    "build": "bun run --filter @fro-bot/runtime build && bun run --filter @fro-bot/action build && bun run --filter @fro.bot/harness build && bun run --filter @fro-bot/gateway build && bun run dist:escape-hidden-unicode",
+    "check-types": "bun run --filter @fro-bot/runtime check-types && bun run --filter @fro-bot/action check-types && bun run --filter @fro.bot/harness check-types && bun run --filter @fro-bot/gateway check-types",
     "check:md-links": "node --experimental-strip-types scripts/check-md-links.ts",
     "dist:check-hidden-unicode": "node --experimental-strip-types scripts/check-dist-hidden-unicode.ts",
     "dist:escape-hidden-unicode": "node --experimental-strip-types scripts/escape-dist-hidden-unicode.ts",
-    "fix": "bun run --filter @fro-bot/runtime fix && bun run --filter @fro-bot/action fix && bun run --filter @fro.bot/harness fix",
+    "fix": "bun run --filter @fro-bot/runtime fix && bun run --filter @fro-bot/action fix && bun run --filter @fro.bot/harness fix && bun run --filter @fro-bot/gateway fix",
     "postinstall": "simple-git-hooks",
-    "lint": "bun run --filter @fro-bot/runtime lint && bun run --filter @fro-bot/action lint && bun run --filter @fro.bot/harness lint && bun run dist:check-hidden-unicode && bun run check:md-links",
+    "lint": "bun run --filter @fro-bot/runtime lint && bun run --filter @fro-bot/action lint && bun run --filter @fro.bot/harness lint && bun run --filter @fro-bot/gateway lint && bun run dist:check-hidden-unicode && bun run check:md-links",
     "test": "bun run --filter @fro-bot/runtime test && bun run --filter @fro-bot/action test && bun run --filter @fro.bot/harness test && bun run --filter @fro-bot/gateway test",
     "test:scripts": "vitest run scripts/"
   },

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -575,8 +575,7 @@ export function loadGatewayConfig(): GatewayConfig {
   }
 
   let announce:
-    | {readonly webhookSecret: string; readonly presenceChannelId: string; readonly httpPort: number}
-    | undefined
+    {readonly webhookSecret: string; readonly presenceChannelId: string; readonly httpPort: number} | undefined
 
   if (gatewayWebhookSecret !== null && gatewayPresenceChannelId !== null) {
     const rawHttpPort = readOptionalSecret('GATEWAY_HTTP_PORT') ?? '3000'

--- a/packages/gateway/src/operator-contract/approval.ts
+++ b/packages/gateway/src/operator-contract/approval.ts
@@ -44,12 +44,7 @@ export type PermissionReply = 'once' | 'always' | 'reject'
  * it is derived separately from the deadline path, not from this mapping.
  */
 export type OperatorDecisionState =
-  | 'pending'
-  | 'claimed'
-  | 'already_claimed'
-  | 'scope_mismatch'
-  | 'failed_to_settle'
-  | 'unavailable'
+  'pending' | 'claimed' | 'already_claimed' | 'scope_mismatch' | 'failed_to_settle' | 'unavailable'
 
 /**
  * Map a `DecisionOutcome` (registry-internal) to the operator-facing `OperatorDecisionState`.

--- a/packages/gateway/src/web/auth/allowlist.ts
+++ b/packages/gateway/src/web/auth/allowlist.ts
@@ -27,8 +27,7 @@ export interface AllowlistLogger {
 
 /** Parse result for allowlist text. */
 export type ParseAllowlistResult =
-  | {readonly ok: true; readonly ids: ReadonlySet<number>}
-  | {readonly ok: false; readonly reason: string}
+  {readonly ok: true; readonly ids: ReadonlySet<number>} | {readonly ok: false; readonly reason: string}
 
 /** An operator allowlist — a set of authorized numeric GitHub user IDs. */
 export interface OperatorAllowlist {

--- a/packages/gateway/src/web/auth/repo-authz.ts
+++ b/packages/gateway/src/web/auth/repo-authz.ts
@@ -39,8 +39,7 @@ export interface RepoAuthzLogger {
 
 /** Result of a repo authorization check. */
 export type RepoAuthzResult =
-  | {readonly authorized: true}
-  | {readonly authorized: false; readonly reason: RepoAuthzDeniedReason}
+  {readonly authorized: true} | {readonly authorized: false; readonly reason: RepoAuthzDeniedReason}
 
 /** Result of a write-level repo authorization check. */
 export type RepoWriteAuthzResult =


### PR DESCRIPTION
The root `test` script ran only the runtime, action, and harness suites. `packages/gateway` — the largest package, covering the approval gate, redaction, and operator auth — had no unit-test coverage in CI; its only signal was the `gateway-smoke` build (type-check + bundle). A regression in that package could ship green.

This appends `bun run --filter @fro-bot/gateway test` to the root lane so the gateway suite runs on every PR.

## Why the root lane, not a separate job

The gateway suite runs in **11.5s** (89 files, 2911 tests). A dedicated job would pay ~30–60s of runner setup to parallelize away ~12s — net negative. Appended to the existing serial Test lane, it adds ~12s wall and no new runner minutes. Resolution is clean on a fresh runner: `@fro-bot/runtime` resolves to its `src` entry, so no build artifact is required.

## Verification

- `bun run --filter @fro-bot/gateway test` → 89 files, 2911 tests, all passing, 11.54s.