### PR TITLE
chore(harness): bump base to OpenCode 1.17.14 and add SSE/leak stability carries

### DIFF
--- a/packages/harness/harness.config.json
+++ b/packages/harness/harness.config.json
@@ -1,14 +1,18 @@
 {
   "release_repo": "anomalyco/opencode",
   "source_repo": "https://github.com/anomalyco/opencode.git",
-  "base_version": "1.17.13",
+  "base_version": "1.17.14",
   "integrationRefs": [
     "https://github.com/anomalyco/opencode/pull/19961",
     "https://github.com/anomalyco/opencode/pull/31859",
     "https://github.com/anomalyco/opencode/pull/31638",
     "https://github.com/anomalyco/opencode/pull/33134",
     "https://github.com/anomalyco/opencode/pull/33159",
-    "https://github.com/anomalyco/opencode/pull/33444"
+    "https://github.com/anomalyco/opencode/pull/33444",
+    "https://github.com/anomalyco/opencode/pull/31922",
+    "https://github.com/anomalyco/opencode/pull/34975",
+    "https://github.com/anomalyco/opencode/pull/34977",
+    "https://github.com/anomalyco/opencode/pull/33713"
   ],
   "agent": "build",
   "model": "anthropic/claude-sonnet-4-6",

--- a/packages/harness/src/cli.test.ts
+++ b/packages/harness/src/cli.test.ts
@@ -13,7 +13,7 @@ describe('getProvenance', () => {
     const p = getProvenance()
 
     // #then
-    expect(p.baseVersion).toBe('1.17.13')
+    expect(p.baseVersion).toBe('1.17.14')
     expect(Array.isArray(p.integrationRefs)).toBe(true)
     expect(p.integrationCommit).toBeNull()
     expect(p.buildSha).toBe('dev')


### PR DESCRIPTION
Moves the harness base to OpenCode **v1.17.14** and adds four stability/performance carries.

## Base bump

`base_version` 1.17.13 → 1.17.14. Verified a safe drop-in against the two surfaces we consume: the release is overwhelmingly Desktop/TUI/stats work, and none of the load-bearing contracts changed — the SSE `/event` event shapes (`message.part.*`, `session.next.*`, `permission.asked/replied`, `session.idle/error`), the permission reply API, directory-scoping, and the V2 `findLast` permission evaluation are byte-identical to 1.17.13. `@opencode-ai/sdk` bumps to 1.17.14 version-only (no contract change). Code Mode ships gated off, so the standard tool path is unaffected. No gateway or action code changes are required.

`DEFAULT_OPENCODE_VERSION` is intentionally not touched here — the sync-default-version auto-PR bumps it after the harness release publishes. `cli.test.ts`'s live-config base assertion moves to 1.17.14 in lockstep.

## Carries

All six existing carries are kept — none were merged into 1.17.14, so none are redundant. The two highest-risk existing carries were re-verified against the v1.17.14 source:

- **#31859** — kept. The 409-reentry guard it adds is confirmed absent from the v1.17.14 plugin bootstrap; only the upstream active-listener bridge it preserves is present. Applies cleanly.
- **#19961** — kept. The session/prompt files it refactors barely changed 1.17.13→1.17.14, so rebase-conflict risk is low; the extra surface beyond the hook reorder is coupled to the contract change and worth keeping whole.

Four new carries added, prioritizing stability and performance on the surfaces our long-running/automated use depends on:

- **#31922** — bounds SSE event backlogs and disconnects stalled consumers. Patches the exact `/event` endpoint our event stream consumes; fixes an unbounded-queue leak on our hottest surface.
- **#33713** — evicts idle per-directory instances to bound serve memory. Targets the long-lived gateway daemon; flag-gated and test-covered.
- **#34975** — prevents an AbortSignal listener leak on a pre-aborted signal (two-char fix).
- **#34977** — prevents a pending-resolver leak on abandoned async iteration.

## Verification

- `bun run lint` clean; harness suite green (the live-config base assertion updated in lockstep).
- Config validated: `base_version: 1.17.14`, 10 integration refs (6 existing + 4 new), no other fields changed.

The actual harness release (build matrix + npm publish + GitHub Release) is dispatched separately after this merges.
