### PR TITLE
fix(ci): checkout before harden-runner so the egress block does not drop github.com

### DIFF
--- a/.github/workflows/harness-integrate.yaml
+++ b/.github/workflows/harness-integrate.yaml
@@ -28,7 +28,7 @@ on:
         required: false
     secrets:
       FRO_BOT_PAT:
-        description: PAT used for checkout and as the action's github-token. Required.
+        description: PAT used as the action's github-token. Required.
         required: true
       OPENCODE_CONFIG:
         description: JSON merged into the OpenCode config (OPENCODE_CONFIG_CONTENT). Optional.
@@ -55,6 +55,15 @@ jobs:
       contents: read
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          # No token: this runs before egress hardening and only needs to read
+          # this repo, so the default job-scoped GITHUB_TOKEN suffices.
+          # FRO_BOT_PAT is only needed later, by the Run Fro Bot step.
+
       - name: Harden runner egress
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -73,13 +82,6 @@ jobs:
             registry.npmjs.org:443
             *.actions.githubusercontent.com:443
             *.githubusercontent.com:443
-
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-          token: ${{ secrets.FRO_BOT_PAT }}
 
       - name: Setup Node.js and Bun
         uses: ./.github/actions/setup


### PR DESCRIPTION
Fixes the harness release, which has been broken at `actions/checkout` since #1108 added the harden-runner egress block.

## Root cause

harden-runner block mode enforces at the **IP layer**, not the domain string — it authorizes the IPs it observed being resolved for allowed domains through its own DNS proxy. In the integrate job, `git-remote-http` (inside `actions/checkout`) connected to a `github.com` edge IP that harden-runner had not correlated to an allowed domain, so it dropped the packet with `Failed to connect to github.com port 443 after 1 ms` — even though `github.com:443` is in `allowed-endpoints`. This is a documented harden-runner failure class (step-security/harden-runner#144 and an identical public `actions/checkout`/`git-remote-http`/raw-IP case); it is **not** fixable by adding endpoints, because the domain is already allowlisted.

The first release dispatches since #1108 merged both failed identically here (fail-closed — nothing was published). CI on #1108 never exercised `harness-release.yaml`, so the config shipped latent.

## Fix

Run `actions/checkout` **before** the harden-runner step, so the clone happens before harden-runner's iptables rules exist. Checkout also drops `FRO_BOT_PAT` and uses the job-scoped `GITHUB_TOKEN` — it only needs to read this repo, and the PAT is needed later by the agent step (after hardening is active), which shrinks the PAT's exposure window.

The egress block is unchanged and still covers every step that matters to #1108's threat model: the broker credential mint and the untrusted LLM merge (`Run Fro Bot`). The one-job invariant, `permissions`, and the full `allowed-endpoints` list are byte-preserved.

## Residual risk

One unmonitored network window for a pinned, trusted `actions/checkout` cloning **this repo** — before any broker credential is minted and before any untrusted upstream code is fetched or executed. The only meaningful risk there is supply-chain compromise of `actions/checkout` or GitHub infra, which is outside #1108's threat model (containing the untrusted merge + protecting the model credential). This weakens StepSecurity's generic "harden-runner first" guidance on paper without weakening the actual boundary. Diagnosis and this tradeoff were independently reviewed.

## Verification

- `bun run lint` clean; YAML parses; step order confirmed `[Checkout, Harden runner egress, Setup, Mint broker credential, Run Fro Bot]`, exactly one job, `egress-policy: block` intact.
- End-to-end proof is the next release dispatch reaching past checkout into the broker mint + merge (done after merge).
