### PR TITLE
fix(ci): fold harden-runner allowed-endpoints so all endpoints parse

### DIFF
--- a/.github/workflows/harness-integrate.yaml
+++ b/.github/workflows/harness-integrate.yaml
@@ -28,7 +28,7 @@ on:
         required: false
     secrets:
       FRO_BOT_PAT:
-        description: PAT used as the action's github-token. Required.
+        description: PAT used for checkout and as the action's github-token. Required.
         required: true
       OPENCODE_CONFIG:
         description: JSON merged into the OpenCode config (OPENCODE_CONFIG_CONTENT). Optional.
@@ -55,15 +55,6 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-          # No token: this runs before egress hardening and only needs to read
-          # this repo, so the default job-scoped GITHUB_TOKEN suffices.
-          # FRO_BOT_PAT is only needed later, by the Run Fro Bot step.
-
       - name: Harden runner egress
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -82,6 +73,13 @@ jobs:
             registry.npmjs.org:443
             *.actions.githubusercontent.com:443
             *.githubusercontent.com:443
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.FRO_BOT_PAT }}
 
       - name: Setup Node.js and Bun
         uses: ./.github/actions/setup

--- a/.github/workflows/harness-integrate.yaml
+++ b/.github/workflows/harness-integrate.yaml
@@ -70,7 +70,7 @@ jobs:
           egress-policy: block
           disable-telemetry: true
           disable-sudo-and-containers: true
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             broker.fro.bot:443
             bun.sh:443


### PR DESCRIPTION
Fixes the release-blocking harness-integrate checkout failure at its real root cause, and reverts the ineffective step-reorder from #1137.

## Root cause (verified from the harden-runner agent's own parsed-config log)

`step-security/harden-runner` parses `allowed-endpoints` by splitting on **spaces only**, not all whitespace. The step used a YAML **literal** block scalar (`allowed-endpoints: |`), which preserves newlines — so the newline-separated list collapsed into one malformed token and only the **first** entry parsed. The agent log confirms it:

```
Allowed domains:map[api.github.com.:[{api.github.com. 0}] ...]
```

Only `api.github.com` made it into the allow map (note the malformed `port: 0`). `github.com`, `codeload.github.com`, `broker.fro.bot`, `cliproxy.fro.bot`, `registry.npmjs.org`, and the rest were silently dropped. So `actions/checkout`'s connection to `github.com` was sinkholed to harden-runner's decoy IP (`54.185.253.63`) and blocked — and the broker/cliproxy mint would have failed next for the same reason.

## Fix

Change the block scalar from literal `|` to **folded `>-`**, so YAML collapses the newlines into spaces and harden-runner's space-split parser sees all 11 endpoints. `egress-policy: block` and the endpoint list are unchanged. Verified: the parser now reads all 11 endpoints including `github.com`, `broker.fro.bot`, `cliproxy.fro.bot`, and `registry.npmjs.org`.

## Also reverts #1137

#1137 had reordered `actions/checkout` before the harden-runner step under a wrong premise — harden-runner enforces egress via a **pre-job hook** (`Pre Harden runner egress` runs before every regular step), so step order never changed when the block activates; the reorder was ineffective and the checkout still failed identically. With the real cause fixed, this restores harden-runner as the first step and returns checkout to using `FRO_BOT_PAT`.

## Verification

- harden-runner allowed-endpoints now parses all 11 endpoints (folded scalar → space-split).
- Net change vs `main`: the `|`→`>-` scalar fix; the step order, checkout token, and secret description return to their pre-#1137 state.
- End-to-end proof is the next release dispatch reaching past checkout into the broker mint + LLM merge (after merge).
