### PR TITLE
feat(gateway): durable operator push subscription store

### DIFF
--- a/packages/gateway/src/web/operator-push/subscription-store.test.ts
+++ b/packages/gateway/src/web/operator-push/subscription-store.test.ts
@@ -150,6 +150,34 @@ function withAlwaysFailingConditionalDeleteFor(
   }
 }
 
+/**
+ * Adapter whose conditionalDelete PreconditionFails exactly once for a
+ * matching key, running `onIntercept` first — used to inject a concurrent
+ * mutation (e.g. a same-owner resubscribe or a competing deactivation)
+ * landing between the delete's read and its physical-delete attempt. Every
+ * later call delegates to the real adapter normally.
+ */
+function withOneShotConditionalDeleteFailure(
+  adapter: ObjectStoreAdapter,
+  matches: (key: string) => boolean,
+  onIntercept: () => void,
+): ObjectStoreAdapter {
+  let fired = false
+  const conditionalDelete = adapter.conditionalDelete
+  if (conditionalDelete === undefined) throw new Error('unreachable')
+  return {
+    ...adapter,
+    conditionalDelete: async (key, options) => {
+      if (fired === false && matches(key)) {
+        fired = true
+        onIntercept()
+        return err(new Error('PreconditionFailed: forced one-shot conflict'))
+      }
+      return conditionalDelete(key, options)
+    },
+  }
+}
+
 /** Adapter that returns a structured ObjectStoreOperationError (httpStatusCode-based) instead of a plain Error. */
 function createStructuredErrorAdapter(): ObjectStoreAdapter {
   const objects = new Map<string, {data: string; etag: string}>()
@@ -1063,8 +1091,11 @@ describe('createOperatorPushSubscriptionStore — deleteForOperator gaps', () =>
     // #when privacy-deleting while the physical delete is forced to conflict
     const result = await store.deleteForOperator({operatorId: 'operator-a'})
 
-    // #then the tombstone still excludes the record from reads, but it is NOT
-    // counted as deleted, and the secrets remain on disk pending a later prune
+    // #then the physical delete is not counted as deleted, but because the
+    // record is still active on disk (untouched by the forced conflict), the
+    // tombstone-exists-iff-no-active-record invariant rolls the tombstone
+    // back — the still-active record remains visible, and secrets remain on
+    // disk pending a later successful delete or prune.
     expect(result.success).toBe(true)
     if (result.success === false) throw new Error('unreachable')
     expect(result.data.deleted).toBe(0)
@@ -1073,11 +1104,161 @@ describe('createOperatorPushSubscriptionStore — deleteForOperator gaps', () =>
 
     const active = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
     if (active.success === false) throw new Error('unreachable')
-    expect(active.data).toHaveLength(0) // tombstone still excludes it from reads
+    expect(active.data).toHaveLength(1) // tombstone rolled back — still-active record stays visible
 
     const subscriptionKey = Array.from(backing.keys()).find(k => k.includes('subscriptions/by-endpoint'))
     if (subscriptionKey === undefined) throw new Error('unreachable')
     expect(backing.get(subscriptionKey)?.data).toContain('p256dh-still-on-disk') // secrets acknowledged as still on disk
+  })
+
+  it('rolls back the tombstone when a same-owner resubscribe races the physical delete (still active, still owned)', async () => {
+    // #given an active subscription, plus a one-shot conditionalDelete
+    // failure that, when it fires, simulates a concurrent same-owner
+    // resubscribe landing between the delete's read and its physical
+    // delete attempt — the on-disk record stays active and owned by the
+    // same operator, just at a new etag.
+    const backing = new Map<string, {data: string; etag: string}>()
+    const baseAdapter = createCasFakeAdapter(backing)
+    const endpoint = 'https://push.example.com/ep-resubscribe-race'
+    const seedStore = createOperatorPushSubscriptionStore({adapter: baseAdapter, logger: testLogger})
+    await seedStore.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p1', auth: 'a1', keyVersion: '1'})
+    const subscriptionKey = Array.from(backing.keys()).find(k => k.includes('subscriptions/by-endpoint'))
+    if (subscriptionKey === undefined) throw new Error('unreachable')
+
+    const raceAdapter = withOneShotConditionalDeleteFailure(
+      baseAdapter,
+      key => key === subscriptionKey,
+      () => {
+        // Simulate the concurrent same-owner resubscribe: refresh the
+        // record's etag and keys, keeping it active and owned by operator-a.
+        const current = backing.get(subscriptionKey)
+        if (current === undefined) throw new Error('unreachable')
+        const parsed: {[k: string]: unknown} = JSON.parse(current.data) as {[k: string]: unknown}
+        backing.set(subscriptionKey, {
+          data: JSON.stringify({...parsed, p256dh: 'refreshed-p256dh', auth: 'refreshed-auth'}),
+          etag: 'etag-resubscribed-during-race',
+        })
+      },
+    )
+    const warn = vi.fn()
+    const store = createOperatorPushSubscriptionStore({adapter: raceAdapter, logger: {debug: () => {}, warn}})
+
+    // #when deleteForOperator loses the physical-delete CAS race to that resubscribe
+    const result = await store.deleteForOperator({operatorId: 'operator-a'})
+
+    // #then the delete is not counted, and — because the record is still
+    // active and still owned by operator-a — the tombstone is rolled back,
+    // so the record is NOT shadowed from active reads
+    expect(result.success).toBe(true)
+    if (result.success === false) throw new Error('unreachable')
+    expect(result.data.deleted).toBe(0)
+    expect(result.data.skipped).toBe(1)
+
+    const active = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (active.success === false) throw new Error('unreachable')
+    expect(active.data).toHaveLength(1)
+    expect(active.data[0]?.p256dh).toBe('refreshed-p256dh')
+
+    const listed = await store.listMetadataForOperator({operatorId: 'operator-a'})
+    if (listed.success === false) throw new Error('unreachable')
+    expect(listed.data).toHaveLength(1)
+    expect(listed.data[0]?.active).toBe(true)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — prune reclaims a record left behind by a skipped delete', () => {
+  it('eventually removes a stale object left inactive by a lost physical-delete race', async () => {
+    // #given an active subscription, deactivated instead of deleted by the
+    // time the physical delete is attempted (simulating a lost race against
+    // a concurrent unsubscribe rather than a resubscribe) — the tombstone
+    // invariant then correctly leaves the tombstone in place, since the
+    // record is inactive, and the stale inactive object is left on disk.
+    let now = 1_000_000
+    const backing = new Map<string, {data: string; etag: string}>()
+    const baseAdapter = createCasFakeAdapter(backing)
+    const endpoint = 'https://push.example.com/ep-prune-reclaim'
+    const seedStore = createOperatorPushSubscriptionStore({adapter: baseAdapter, logger: testLogger, clock: () => now})
+    await seedStore.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p1', auth: 'a1', keyVersion: '1'})
+    const subscriptionKey = Array.from(backing.keys()).find(k => k.includes('subscriptions/by-endpoint'))
+    if (subscriptionKey === undefined) throw new Error('unreachable')
+
+    const raceAdapter = withOneShotConditionalDeleteFailure(
+      baseAdapter,
+      key => key === subscriptionKey,
+      () => {
+        // Simulate a concurrent unsubscribe landing first: the record is
+        // deactivated (not removed) with a fresh etag.
+        const current = backing.get(subscriptionKey)
+        if (current === undefined) throw new Error('unreachable')
+        const parsed: {[k: string]: unknown} = JSON.parse(current.data) as {[k: string]: unknown}
+        backing.set(subscriptionKey, {
+          data: JSON.stringify({...parsed, active: false, inactiveReason: 'unsubscribed', deactivatedAt: now}),
+          etag: 'etag-deactivated-during-race',
+        })
+      },
+    )
+    const store = createOperatorPushSubscriptionStore({adapter: raceAdapter, logger: testLogger, clock: () => now})
+
+    // #when deleteForOperator loses the physical-delete race against that deactivation
+    const deleteResult = await store.deleteForOperator({operatorId: 'operator-a'})
+    if (deleteResult.success === false) throw new Error('unreachable')
+    expect(deleteResult.data.skipped).toBe(1)
+    // The record is inactive on re-read, so the tombstone stays (correct exclusion).
+    expect(backing.has(subscriptionKey)).toBe(true)
+
+    // #when the retention window elapses and pruneInactive runs
+    now += 40 * 24 * 60 * 60 * 1000 // past the default 30-day inactive-record retention
+    const pruned = await store.pruneInactive()
+
+    // #then the stale inactive object is eventually reclaimed
+    expect(pruned.success).toBe(true)
+    if (pruned.success === false) throw new Error('unreachable')
+    expect(pruned.data.records).toBe(1)
+    expect(backing.has(subscriptionKey)).toBe(false)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — transfer clears a prior tombstone', () => {
+  it('a different operator subscribing to a tombstoned-but-present endpoint clears the tombstone and becomes the active owner', async () => {
+    // #given an endpoint with BOTH a tombstone and a (skipped-delete) subscription
+    // object present — the tombstone-exists-but-object-present edge case.
+    const backing = new Map<string, {data: string; etag: string}>()
+    const store = makeStore(createCasFakeAdapter(backing))
+    const endpoint = 'https://push.example.com/ep-transfer-clears-tombstone'
+    await store.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p1', auth: 'a1', keyVersion: '1'})
+
+    const subscriptionKey = Array.from(backing.keys()).find(k => k.includes('subscriptions/by-endpoint'))
+    if (subscriptionKey === undefined) throw new Error('unreachable')
+    const tombstoneKey = subscriptionKey.replace('subscriptions/by-endpoint', 'tombstones')
+    // Write a tombstone directly, alongside the still-present subscription
+    // object, modelling a lost-race skip that left both artifacts behind.
+    backing.set(tombstoneKey, {
+      data: JSON.stringify({endpointHash: 'ignored', operatorId: 'operator-a', deletedAt: 1}),
+      etag: 'etag-manual-tombstone',
+    })
+
+    // #when a different operator subscribes to that same endpoint
+    const transfer = await store.subscribe({
+      operatorId: 'operator-b',
+      endpoint,
+      p256dh: 'p2',
+      auth: 'a2',
+      keyVersion: '1',
+    })
+
+    // #then the transfer succeeds, the tombstone is cleared by subscribe's
+    // tail best-effort clear, and the new owner is active/dispatchable
+    expect(transfer.success).toBe(true)
+    expect(backing.has(tombstoneKey)).toBe(false)
+
+    const bActive = await store.getActiveRecordsForOperator({operatorId: 'operator-b'})
+    if (bActive.success === false) throw new Error('unreachable')
+    expect(bActive.data).toHaveLength(1)
+
+    // and the old owner no longer has access
+    const aActive = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (aActive.success === false) throw new Error('unreachable')
+    expect(aActive.data).toHaveLength(0)
   })
 })
 

--- a/packages/gateway/src/web/operator-push/subscription-store.test.ts
+++ b/packages/gateway/src/web/operator-push/subscription-store.test.ts
@@ -1,0 +1,680 @@
+import type {ObjectStoreAdapter, Result} from '@fro-bot/runtime'
+import type {StoreLogger} from './subscription-store.js'
+
+import {err, ok} from '@fro-bot/runtime'
+import {describe, expect, it} from 'vitest'
+import {createOperatorPushSubscriptionStore, toSubscriptionMetadata} from './subscription-store.js'
+
+// ---------------------------------------------------------------------------
+// In-memory fakes
+// ---------------------------------------------------------------------------
+
+/** Faithfully models S3-style conditionalPut ifNoneMatch/ifMatch etag CAS semantics. */
+function createCasFakeAdapter(): ObjectStoreAdapter {
+  const objects = new Map<string, {data: string; etag: string}>()
+  let etagCounter = 0
+
+  return {
+    upload: async () => ok(undefined),
+    download: async () => ok(undefined),
+    list: async (prefix: string) => ok(Array.from(objects.keys()).filter(k => k.startsWith(prefix))),
+    conditionalPut: async (key, data, options) => {
+      const current = objects.get(key)
+      if (options.ifNoneMatch === '*' && current !== undefined) {
+        return err(new Error('PreconditionFailed: key already exists'))
+      }
+      if (options.ifMatch !== undefined && (current === undefined || current.etag !== options.ifMatch)) {
+        return err(new Error('PreconditionFailed: etag mismatch'))
+      }
+      etagCounter += 1
+      const etag = `etag-${etagCounter}`
+      objects.set(key, {data, etag})
+      return ok({etag})
+    },
+    conditionalDelete: async (key, options) => {
+      const current = objects.get(key)
+      if (current === undefined) {
+        return err(new Error('NotFound: no such key'))
+      }
+      if (current.etag !== options.ifMatch) {
+        return err(new Error('PreconditionFailed: etag mismatch'))
+      }
+      objects.delete(key)
+      return ok(undefined)
+    },
+    getObject: async key => {
+      const current = objects.get(key)
+      if (current === undefined) {
+        return err(new Error('NotFound: no such key'))
+      }
+      return ok({data: current.data, etag: current.etag})
+    },
+    listWithMetadata: async prefix =>
+      ok(
+        Array.from(objects.keys())
+          .filter(k => k.startsWith(prefix))
+          .map(key => ({key, lastModified: new Date()})),
+      ),
+  }
+}
+
+/** Adapter that "reloads" over the same backing map — simulates a fresh store instance. */
+function createCasFakeAdapterOverBackingMap(backing: Map<string, {data: string; etag: string}>): ObjectStoreAdapter {
+  let etagCounter = 1000
+  return {
+    upload: async () => ok(undefined),
+    download: async () => ok(undefined),
+    list: async (prefix: string) => ok(Array.from(backing.keys()).filter(k => k.startsWith(prefix))),
+    conditionalPut: async (key, data, options) => {
+      const current = backing.get(key)
+      if (options.ifNoneMatch === '*' && current !== undefined) {
+        return err(new Error('PreconditionFailed: key already exists'))
+      }
+      if (options.ifMatch !== undefined && (current === undefined || current.etag !== options.ifMatch)) {
+        return err(new Error('PreconditionFailed: etag mismatch'))
+      }
+      etagCounter += 1
+      const etag = `etag-${etagCounter}`
+      backing.set(key, {data, etag})
+      return ok({etag})
+    },
+    conditionalDelete: async (key, options) => {
+      const current = backing.get(key)
+      if (current === undefined) {
+        return err(new Error('NotFound: no such key'))
+      }
+      if (current.etag !== options.ifMatch) {
+        return err(new Error('PreconditionFailed: etag mismatch'))
+      }
+      backing.delete(key)
+      return ok(undefined)
+    },
+    getObject: async key => {
+      const current = backing.get(key)
+      if (current === undefined) {
+        return err(new Error('NotFound: no such key'))
+      }
+      return ok({data: current.data, etag: current.etag})
+    },
+  }
+}
+
+/** Last-write-wins adapter: no real CAS — both contended writes "succeed". */
+function createLastWriteWinsFakeAdapter(): ObjectStoreAdapter {
+  const objects = new Map<string, {data: string; etag: string}>()
+  let etagCounter = 0
+
+  return {
+    upload: async () => ok(undefined),
+    download: async () => ok(undefined),
+    list: async (prefix: string) => ok(Array.from(objects.keys()).filter(k => k.startsWith(prefix))),
+    conditionalPut: async (key, data): Promise<Result<{etag: string}, Error>> => {
+      // Ignores ifNoneMatch/ifMatch entirely — always "succeeds" (last writer wins).
+      etagCounter += 1
+      const etag = `etag-${etagCounter}`
+      objects.set(key, {data, etag})
+      return ok({etag})
+    },
+    conditionalDelete: async key => {
+      objects.delete(key)
+      return ok(undefined)
+    },
+    getObject: async key => {
+      const current = objects.get(key)
+      if (current === undefined) {
+        return err(new Error('NotFound: no such key'))
+      }
+      return ok({data: current.data, etag: current.etag})
+    },
+  }
+}
+
+/** Adapter missing conditionalPut entirely. */
+function createNonCasAdapter(): ObjectStoreAdapter {
+  return {
+    upload: async () => ok(undefined),
+    download: async () => ok(undefined),
+    list: async () => ok([]),
+  }
+}
+
+const testLogger: StoreLogger = {
+  debug: () => {},
+  warn: () => {},
+}
+
+function makeStore(adapter: ObjectStoreAdapter, clock?: () => number) {
+  return createOperatorPushSubscriptionStore({adapter, logger: testLogger, clock})
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createOperatorPushSubscriptionStore — subscribe happy path', () => {
+  it('creates an active record and listMetadata returns metadata without secrets', async () => {
+    // #given a fresh CAS-capable store
+    const store = makeStore(createCasFakeAdapter())
+
+    // #when subscribing an operator's first endpoint
+    const result = await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-1',
+      p256dh: 'p256dh-secret',
+      auth: 'auth-secret',
+      keyVersion: '1',
+    })
+
+    // #then the create succeeds and metadata omits the secret fields
+    expect(result.success).toBe(true)
+    if (result.success === false) throw new Error('unreachable')
+    expect(result.data.active).toBe(true)
+    expect(result.data.ownershipGeneration).toBe(1)
+    expect('endpoint' in result.data).toBe(false)
+    expect('p256dh' in result.data).toBe(false)
+    expect('auth' in result.data).toBe(false)
+
+    const listed = await store.listMetadataForOperator({operatorId: 'operator-a'})
+    expect(listed.success).toBe(true)
+    if (listed.success === false) throw new Error('unreachable')
+    expect(listed.data).toHaveLength(1)
+    expect(listed.data[0]?.active).toBe(true)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — same operator re-subscribe', () => {
+  it('replaces in place without creating a duplicate record', async () => {
+    // #given an operator with an existing subscription
+    const store = makeStore(createCasFakeAdapter())
+    const endpoint = 'https://push.example.com/ep-dup'
+    await store.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p1', auth: 'a1', keyVersion: '1'})
+
+    // #when the same operator subscribes the same endpoint again
+    const second = await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint,
+      p256dh: 'p2',
+      auth: 'a2',
+      keyVersion: '2',
+    })
+
+    // #then no duplicate is created and generation is unchanged
+    expect(second.success).toBe(true)
+    if (second.success === false) throw new Error('unreachable')
+    expect(second.data.ownershipGeneration).toBe(1)
+    expect(second.data.keyVersion).toBe('2')
+
+    const listed = await store.listMetadataForOperator({operatorId: 'operator-a'})
+    if (listed.success === false) throw new Error('unreachable')
+    expect(listed.data).toHaveLength(1)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — ownership transfer', () => {
+  it('transfers ownership atomically and bumps generation; old owner loses the record', async () => {
+    // #given operator A owns an endpoint
+    const store = makeStore(createCasFakeAdapter())
+    const endpoint = 'https://push.example.com/ep-transfer'
+    await store.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p1', auth: 'a1', keyVersion: '1'})
+
+    // #when operator B subscribes with the same endpoint
+    const transfer = await store.subscribe({
+      operatorId: 'operator-b',
+      endpoint,
+      p256dh: 'p2',
+      auth: 'a2',
+      keyVersion: '1',
+    })
+
+    // #then ownership moves to B, generation bumps, and A no longer sees it
+    expect(transfer.success).toBe(true)
+    if (transfer.success === false) throw new Error('unreachable')
+    expect(transfer.data.operatorId).toBe('operator-b')
+    expect(transfer.data.ownershipGeneration).toBe(2)
+
+    const aRecords = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (aRecords.success === false) throw new Error('unreachable')
+    expect(aRecords.data).toHaveLength(0)
+
+    const bRecords = await store.getActiveRecordsForOperator({operatorId: 'operator-b'})
+    if (bRecords.success === false) throw new Error('unreachable')
+    expect(bRecords.data).toHaveLength(1)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — cross-operator mutation fails closed', () => {
+  it("a different operator cannot unsubscribe another operator's record", async () => {
+    // #given operator A owns an endpoint
+    const store = makeStore(createCasFakeAdapter())
+    const endpoint = 'https://push.example.com/ep-owned'
+    await store.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p1', auth: 'a1', keyVersion: '1'})
+
+    // #when operator B tries to unsubscribe it
+    const result = await store.unsubscribe({operatorId: 'operator-b', endpoint})
+
+    // #then the call fails closed and A's record is unaffected
+    expect(result.success).toBe(false)
+    const aRecords = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (aRecords.success === false) throw new Error('unreachable')
+    expect(aRecords.data).toHaveLength(1)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — mark inactive', () => {
+  it('stops the record appearing in getActiveRecordsForOperator', async () => {
+    // #given an active subscription
+    const store = makeStore(createCasFakeAdapter())
+    const endpoint = 'https://push.example.com/ep-inactive'
+    await store.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p1', auth: 'a1', keyVersion: '1'})
+
+    // #when the owning operator unsubscribes
+    const result = await store.unsubscribe({operatorId: 'operator-a', endpoint})
+    expect(result.success).toBe(true)
+
+    // #then getActiveRecordsForOperator no longer returns it
+    const active = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (active.success === false) throw new Error('unreachable')
+    expect(active.data).toHaveLength(0)
+
+    // but it is still visible (inactive) via listMetadata
+    const listed = await store.listMetadataForOperator({operatorId: 'operator-a'})
+    if (listed.success === false) throw new Error('unreachable')
+    expect(listed.data).toHaveLength(1)
+    expect(listed.data[0]?.active).toBe(false)
+    expect(listed.data[0]?.inactiveReason).toBe('unsubscribed')
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — durability across reload', () => {
+  it('records survive a new store instance over the same backing store', async () => {
+    // #given a store with a subscription, backed by a shared map
+    const backing = new Map<string, {data: string; etag: string}>()
+    const adapter1 = createCasFakeAdapterOverBackingMap(backing)
+    const store1 = makeStore(adapter1)
+    await store1.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-durable',
+      p256dh: 'p1',
+      auth: 'a1',
+      keyVersion: '1',
+    })
+
+    // #when a fresh store instance is created over the same backing map (simulated reload)
+    const adapter2 = createCasFakeAdapterOverBackingMap(backing)
+    const store2 = makeStore(adapter2)
+
+    // #then dispatch queries on the new instance see the recovered state
+    const active = await store2.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (active.success === false) throw new Error('unreachable')
+    expect(active.data).toHaveLength(1)
+    expect(active.data[0]?.endpoint).toBe('https://push.example.com/ep-durable')
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — CAS conflict retry on transfer', () => {
+  it('retries a contended transfer without producing two active owners for one endpoint', async () => {
+    // #given operator A owns an endpoint
+    const adapter = createCasFakeAdapter()
+    const store = makeStore(adapter)
+    const endpoint = 'https://push.example.com/ep-race'
+    await store.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p1', auth: 'a1', keyVersion: '1'})
+
+    // #when two different operators race to claim the endpoint concurrently
+    const [transferB, transferC] = await Promise.all([
+      store.subscribe({operatorId: 'operator-b', endpoint, p256dh: 'pb', auth: 'ab', keyVersion: '1'}),
+      store.subscribe({operatorId: 'operator-c', endpoint, p256dh: 'pc', auth: 'ac', keyVersion: '1'}),
+    ])
+
+    // #then both calls succeed via retry, and exactly one owner ends up active
+    expect(transferB.success).toBe(true)
+    expect(transferC.success).toBe(true)
+
+    const [aActive, bActive, cActive] = await Promise.all([
+      store.getActiveRecordsForOperator({operatorId: 'operator-a'}),
+      store.getActiveRecordsForOperator({operatorId: 'operator-b'}),
+      store.getActiveRecordsForOperator({operatorId: 'operator-c'}),
+    ])
+    if (aActive.success === false || bActive.success === false || cActive.success === false) {
+      throw new Error('unreachable')
+    }
+    const totalActiveOwners = aActive.data.length + bActive.data.length + cActive.data.length
+    expect(totalActiveOwners).toBe(1)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — selfTestCas', () => {
+  it('passes on a real-CAS fake', async () => {
+    // #given a CAS-capable adapter
+    const store = makeStore(createCasFakeAdapter())
+
+    // #when running the startup self-test
+    const result = await store.selfTestCas()
+
+    // #then it succeeds
+    expect(result.success).toBe(true)
+  })
+
+  it('fails on a last-write-wins fake', async () => {
+    // #given a last-write-wins adapter (no real CAS)
+    const store = makeStore(createLastWriteWinsFakeAdapter())
+
+    // #when running the startup self-test
+    const result = await store.selfTestCas()
+
+    // #then it fails, signalling the caller to fail the push surface closed
+    expect(result.success).toBe(false)
+  })
+
+  it('fails on an adapter missing conditionalPut', async () => {
+    // #given an adapter that lacks CAS capability entirely
+    const store = makeStore(createNonCasAdapter())
+
+    // #when running the startup self-test
+    const result = await store.selfTestCas()
+
+    // #then it fails closed
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — pruneInactive (records)', () => {
+  it('removes inactive records older than the window and keeps recent ones', async () => {
+    // #given two inactive records: one old, one recent
+    let now = 1_000_000
+    const store = makeStore(createCasFakeAdapter(), () => now)
+
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-old',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+    await store.unsubscribe({operatorId: 'operator-a', endpoint: 'https://push.example.com/ep-old'})
+
+    now += 40 * 24 * 60 * 60 * 1000 // fast-forward 40 days
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-recent',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+    await store.unsubscribe({operatorId: 'operator-a', endpoint: 'https://push.example.com/ep-recent'})
+
+    now += 1000 // barely after the recent unsubscribe
+
+    // #when pruning with the default 30-day window
+    const pruned = await store.pruneInactive()
+
+    // #then only the old record is removed
+    expect(pruned.success).toBe(true)
+    if (pruned.success === false) throw new Error('unreachable')
+    expect(pruned.data.records).toBe(1)
+
+    const remaining = await store.listMetadataForOperator({operatorId: 'operator-a'})
+    if (remaining.success === false) throw new Error('unreachable')
+    expect(remaining.data).toHaveLength(1)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — pruneInactive (tombstones)', () => {
+  it('prunes a tombstone older than the retention window and keeps a recent one', async () => {
+    // #given two deleted (tombstoned) endpoints: one old, one recent
+    let now = 1_000_000
+    const store = makeStore(createCasFakeAdapter(), () => now)
+
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-tomb-old',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+    await store.deleteForOperator({operatorId: 'operator-a'})
+
+    now += 100 * 24 * 60 * 60 * 1000 // fast-forward past the 90-day default tombstone retention
+
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-tomb-recent',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+    await store.deleteForOperator({operatorId: 'operator-a'})
+
+    now += 1000 // barely after the recent delete
+
+    // #when pruning with the default retention windows
+    const pruned = await store.pruneInactive()
+
+    // #then only the old tombstone is removed
+    expect(pruned.success).toBe(true)
+    if (pruned.success === false) throw new Error('unreachable')
+    expect(pruned.data.tombstones).toBe(1)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — privacy: secrets never leak', () => {
+  it('listMetadata and toSubscriptionMetadata never include endpoint, p256dh, or auth', async () => {
+    // #given an active subscription
+    const store = makeStore(createCasFakeAdapter())
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-secret',
+      p256dh: 'p256dh-secret-value',
+      auth: 'auth-secret-value',
+      keyVersion: '1',
+    })
+
+    // #when reading via the safe metadata surface
+    const listed = await store.listMetadataForOperator({operatorId: 'operator-a'})
+    if (listed.success === false) throw new Error('unreachable')
+
+    // #then no secret field is present, by structural absence and by JSON serialization check
+    const serialized = JSON.stringify(listed.data)
+    expect(serialized).not.toContain('p256dh-secret-value')
+    expect(serialized).not.toContain('auth-secret-value')
+    expect(serialized).not.toContain('https://push.example.com/ep-secret')
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — restore regression (tombstone wins)', () => {
+  it('a deleted record stays excluded after a stale backup restores the subscription object alone, with no re-delete', async () => {
+    // #given a subscription that gets privacy-deleted
+    const backing = new Map<string, {data: string; etag: string}>()
+    const store1 = makeStore(createCasFakeAdapterOverBackingMap(backing))
+    const endpoint = 'https://push.example.com/ep-restore'
+    await store1.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p', auth: 'a', keyVersion: '1'})
+
+    const subscriptionKey = Array.from(backing.keys()).find(k => k.includes('subscriptions/by-endpoint'))
+    if (subscriptionKey === undefined) throw new Error('unreachable')
+    const staleActiveSnapshot = backing.get(subscriptionKey)
+    if (staleActiveSnapshot === undefined) throw new Error('unreachable')
+
+    const deleteResult = await store1.deleteForOperator({operatorId: 'operator-a'})
+    expect(deleteResult.success).toBe(true)
+
+    // The subscription object is physically gone; only the tombstone key remains.
+    expect(backing.has(subscriptionKey)).toBe(false)
+    const tombstoneKey = Array.from(backing.keys()).find(k => k.includes('tombstones'))
+    if (tombstoneKey === undefined) throw new Error('unreachable')
+
+    // #when a stale backup restores ONLY the subscription object's old active
+    // bytes — the tombstone key is untouched — and then the store reloads
+    backing.set(subscriptionKey, staleActiveSnapshot)
+    const store2 = makeStore(createCasFakeAdapterOverBackingMap(backing))
+
+    // #then the resurrected subscription object is still excluded from every
+    // active-read surface, because its tombstone at the separate key still
+    // exists. No second deleteForOperator call is made.
+    const active = await store2.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (active.success === false) throw new Error('unreachable')
+    expect(active.data).toHaveLength(0)
+
+    const listed = await store2.listMetadataForOperator({operatorId: 'operator-a'})
+    if (listed.success === false) throw new Error('unreachable')
+    expect(listed.data).toHaveLength(0)
+
+    const parsedSnapshot = JSON.parse(staleActiveSnapshot.data) as {
+      endpointHash: string
+      ownershipGeneration: number
+    }
+    const stillOwned = await store2.verifyStillOwned({
+      endpointHash: parsedSnapshot.endpointHash,
+      operatorId: 'operator-a',
+      ownershipGeneration: parsedSnapshot.ownershipGeneration,
+    })
+    if (stillOwned.success === false) throw new Error('unreachable')
+    expect(stillOwned.data).toBe(false)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — privacy delete removes secrets from disk', () => {
+  it('the subscription object is physically gone after delete', async () => {
+    // #given an active subscription
+    const backing = new Map<string, {data: string; etag: string}>()
+    const store = makeStore(createCasFakeAdapterOverBackingMap(backing))
+    const endpoint = 'https://push.example.com/ep-secret-removal'
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint,
+      p256dh: 'p256dh-value',
+      auth: 'auth-value',
+      keyVersion: '1',
+    })
+
+    const subscriptionKey = Array.from(backing.keys()).find(k => k.includes('subscriptions/by-endpoint'))
+    if (subscriptionKey === undefined) throw new Error('unreachable')
+
+    // #when the operator privacy-deletes it
+    await store.deleteForOperator({operatorId: 'operator-a'})
+
+    // #then the subscription object key no longer exists — the secrets are
+    // physically gone, not merely marked inactive.
+    expect(backing.has(subscriptionKey)).toBe(false)
+
+    // and no remaining object in the backing store contains the secret values.
+    const remainingSerialized = JSON.stringify(Array.from(backing.values()))
+    expect(remainingSerialized).not.toContain('p256dh-value')
+    expect(remainingSerialized).not.toContain('auth-value')
+    expect(remainingSerialized).not.toContain(endpoint)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — re-subscribe after delete clears the tombstone', () => {
+  it('a legitimate re-subscribe of the same endpoint is active and dispatchable again', async () => {
+    // #given an endpoint that was privacy-deleted
+    const store = makeStore(createCasFakeAdapter())
+    const endpoint = 'https://push.example.com/ep-resubscribe'
+    await store.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p1', auth: 'a1', keyVersion: '1'})
+    await store.deleteForOperator({operatorId: 'operator-a'})
+
+    const beforeResubscribe = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (beforeResubscribe.success === false) throw new Error('unreachable')
+    expect(beforeResubscribe.data).toHaveLength(0)
+
+    // #when the same operator authenticates and re-subscribes the same endpoint
+    const resubscribed = await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint,
+      p256dh: 'p2',
+      auth: 'a2',
+      keyVersion: '1',
+    })
+    expect(resubscribed.success).toBe(true)
+
+    // #then the new record is active and dispatchable — delete is not a permanent ban
+    const active = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (active.success === false) throw new Error('unreachable')
+    expect(active.data).toHaveLength(1)
+    expect(active.data[0]?.active).toBe(true)
+
+    if (resubscribed.success === false) throw new Error('unreachable')
+    const stillOwned = await store.verifyStillOwned({
+      endpointHash: resubscribed.data.endpointHash,
+      operatorId: 'operator-a',
+      ownershipGeneration: resubscribed.data.ownershipGeneration,
+    })
+    if (stillOwned.success === false) throw new Error('unreachable')
+    expect(stillOwned.data).toBe(true)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — verifyStillOwned linearizability', () => {
+  it('returns false when a transfer bumped the generation between the dispatch read and the check', async () => {
+    // #given operator A's active subscription, read for dispatch
+    const store = makeStore(createCasFakeAdapter())
+    const endpoint = 'https://push.example.com/ep-verify'
+    await store.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p', auth: 'a', keyVersion: '1'})
+
+    const active = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (active.success === false) throw new Error('unreachable')
+    const record = active.data[0]
+    if (record === undefined) throw new Error('unreachable')
+
+    // #when a transfer to operator B lands after the dispatch read but before verification
+    await store.subscribe({operatorId: 'operator-b', endpoint, p256dh: 'p2', auth: 'a2', keyVersion: '1'})
+
+    const stillOwned = await store.verifyStillOwned({
+      endpointHash: record.endpointHash,
+      operatorId: 'operator-a',
+      ownershipGeneration: record.ownershipGeneration,
+    })
+
+    // #then the stale read is rejected — operator A's notification must not be sent
+    expect(stillOwned.success).toBe(true)
+    if (stillOwned.success === false) throw new Error('unreachable')
+    expect(stillOwned.data).toBe(false)
+  })
+
+  it('returns true when nothing changed since the dispatch read', async () => {
+    // #given an unchanged active subscription
+    const store = makeStore(createCasFakeAdapter())
+    const endpoint = 'https://push.example.com/ep-verify-ok'
+    await store.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p', auth: 'a', keyVersion: '1'})
+    const active = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (active.success === false) throw new Error('unreachable')
+    const record = active.data[0]
+    if (record === undefined) throw new Error('unreachable')
+
+    // #when verifying immediately
+    const stillOwned = await store.verifyStillOwned({
+      endpointHash: record.endpointHash,
+      operatorId: 'operator-a',
+      ownershipGeneration: record.ownershipGeneration,
+    })
+
+    // #then it is confirmed still owned
+    expect(stillOwned.success).toBe(true)
+    if (stillOwned.success === false) throw new Error('unreachable')
+    expect(stillOwned.data).toBe(true)
+  })
+})
+
+describe('toSubscriptionMetadata', () => {
+  it('never includes secret fields even via direct call', () => {
+    // #given a full record with secrets
+    const record = {
+      endpointHash: 'hash-1',
+      endpoint: 'https://push.example.com/direct',
+      p256dh: 'p256dh-value',
+      auth: 'auth-value',
+      operatorId: 'operator-a',
+      active: true,
+      keyVersion: '1',
+      ownershipGeneration: 1,
+      createdAt: 1,
+      updatedAt: 1,
+    }
+
+    // #when deriving metadata
+    const metadata = toSubscriptionMetadata(record)
+
+    // #then no secret key is present on the result
+    expect('endpoint' in metadata).toBe(false)
+    expect('p256dh' in metadata).toBe(false)
+    expect('auth' in metadata).toBe(false)
+  })
+})

--- a/packages/gateway/src/web/operator-push/subscription-store.test.ts
+++ b/packages/gateway/src/web/operator-push/subscription-store.test.ts
@@ -1,66 +1,22 @@
 import type {ObjectStoreAdapter, Result} from '@fro-bot/runtime'
 import type {StoreLogger} from './subscription-store.js'
 
-import {err, ok} from '@fro-bot/runtime'
-import {describe, expect, it} from 'vitest'
+import {createObjectStoreOperationError, err, ok} from '@fro-bot/runtime'
+import {describe, expect, it, vi} from 'vitest'
 import {createOperatorPushSubscriptionStore, toSubscriptionMetadata} from './subscription-store.js'
 
 // ---------------------------------------------------------------------------
 // In-memory fakes
 // ---------------------------------------------------------------------------
 
-/** Faithfully models S3-style conditionalPut ifNoneMatch/ifMatch etag CAS semantics. */
-function createCasFakeAdapter(): ObjectStoreAdapter {
-  const objects = new Map<string, {data: string; etag: string}>()
+/**
+ * Faithfully models S3-style conditionalPut ifNoneMatch/ifMatch etag CAS
+ * semantics against a shared backing map. Passing an existing map lets a
+ * test simulate a fresh store "reload" over the same on-disk state.
+ */
+function createCasFakeAdapter(backing: Map<string, {data: string; etag: string}> = new Map()): ObjectStoreAdapter {
   let etagCounter = 0
 
-  return {
-    upload: async () => ok(undefined),
-    download: async () => ok(undefined),
-    list: async (prefix: string) => ok(Array.from(objects.keys()).filter(k => k.startsWith(prefix))),
-    conditionalPut: async (key, data, options) => {
-      const current = objects.get(key)
-      if (options.ifNoneMatch === '*' && current !== undefined) {
-        return err(new Error('PreconditionFailed: key already exists'))
-      }
-      if (options.ifMatch !== undefined && (current === undefined || current.etag !== options.ifMatch)) {
-        return err(new Error('PreconditionFailed: etag mismatch'))
-      }
-      etagCounter += 1
-      const etag = `etag-${etagCounter}`
-      objects.set(key, {data, etag})
-      return ok({etag})
-    },
-    conditionalDelete: async (key, options) => {
-      const current = objects.get(key)
-      if (current === undefined) {
-        return err(new Error('NotFound: no such key'))
-      }
-      if (current.etag !== options.ifMatch) {
-        return err(new Error('PreconditionFailed: etag mismatch'))
-      }
-      objects.delete(key)
-      return ok(undefined)
-    },
-    getObject: async key => {
-      const current = objects.get(key)
-      if (current === undefined) {
-        return err(new Error('NotFound: no such key'))
-      }
-      return ok({data: current.data, etag: current.etag})
-    },
-    listWithMetadata: async prefix =>
-      ok(
-        Array.from(objects.keys())
-          .filter(k => k.startsWith(prefix))
-          .map(key => ({key, lastModified: new Date()})),
-      ),
-  }
-}
-
-/** Adapter that "reloads" over the same backing map — simulates a fresh store instance. */
-function createCasFakeAdapterOverBackingMap(backing: Map<string, {data: string; etag: string}>): ObjectStoreAdapter {
-  let etagCounter = 1000
   return {
     upload: async () => ok(undefined),
     download: async () => ok(undefined),
@@ -96,6 +52,12 @@ function createCasFakeAdapterOverBackingMap(backing: Map<string, {data: string; 
       }
       return ok({data: current.data, etag: current.etag})
     },
+    listWithMetadata: async prefix =>
+      ok(
+        Array.from(backing.keys())
+          .filter(k => k.startsWith(prefix))
+          .map(key => ({key, lastModified: new Date()})),
+      ),
   }
 }
 
@@ -135,6 +97,99 @@ function createNonCasAdapter(): ObjectStoreAdapter {
     upload: async () => ok(undefined),
     download: async () => ok(undefined),
     list: async () => ok([]),
+  }
+}
+
+/** Adapter whose conditionalPut ALWAYS PreconditionFails — simulates a permanently contended key. */
+function createAlwaysConflictingAdapter(): ObjectStoreAdapter {
+  return {
+    upload: async () => ok(undefined),
+    download: async () => ok(undefined),
+    list: async () => ok([]),
+    conditionalPut: async () => err(new Error('PreconditionFailed: always conflicting')),
+    conditionalDelete: async () => ok(undefined),
+    getObject: async () => err(new Error('NotFound: no such key')),
+  }
+}
+
+/** Wraps a CAS-fake adapter's conditionalPut with a call counter, to prove a retry actually fired. */
+function withConditionalPutCallCounter(adapter: ObjectStoreAdapter): {
+  readonly adapter: ObjectStoreAdapter
+  readonly callCount: () => number
+} {
+  let calls = 0
+  const conditionalPut = adapter.conditionalPut
+  if (conditionalPut === undefined) throw new Error('unreachable')
+  return {
+    adapter: {
+      ...adapter,
+      conditionalPut: async (key, data, options) => {
+        calls += 1
+        return conditionalPut(key, data, options)
+      },
+    },
+    callCount: () => calls,
+  }
+}
+
+/** Adapter whose conditionalDelete on the subscription key ALWAYS PreconditionFails, everything else delegates. */
+function withAlwaysFailingConditionalDeleteFor(
+  adapter: ObjectStoreAdapter,
+  shouldFail: (key: string) => boolean,
+): ObjectStoreAdapter {
+  const conditionalDelete = adapter.conditionalDelete
+  if (conditionalDelete === undefined) throw new Error('unreachable')
+  return {
+    ...adapter,
+    conditionalDelete: async (key, options) => {
+      if (shouldFail(key)) {
+        return err(new Error('PreconditionFailed: forced conflict'))
+      }
+      return conditionalDelete(key, options)
+    },
+  }
+}
+
+/** Adapter that returns a structured ObjectStoreOperationError (httpStatusCode-based) instead of a plain Error. */
+function createStructuredErrorAdapter(): ObjectStoreAdapter {
+  const objects = new Map<string, {data: string; etag: string}>()
+  let etagCounter = 0
+
+  return {
+    upload: async () => ok(undefined),
+    download: async () => ok(undefined),
+    list: async (prefix: string) => ok(Array.from(objects.keys()).filter(k => k.startsWith(prefix))),
+    conditionalPut: async (key, data, options) => {
+      const current = objects.get(key)
+      if (options.ifNoneMatch === '*' && current !== undefined) {
+        return err(createObjectStoreOperationError('conflict', {httpStatusCode: 412}))
+      }
+      if (options.ifMatch !== undefined && (current === undefined || current.etag !== options.ifMatch)) {
+        return err(createObjectStoreOperationError('conflict', {httpStatusCode: 412}))
+      }
+      etagCounter += 1
+      const etag = `etag-${etagCounter}`
+      objects.set(key, {data, etag})
+      return ok({etag})
+    },
+    conditionalDelete: async (key, options) => {
+      const current = objects.get(key)
+      if (current === undefined) {
+        return err(createObjectStoreOperationError('missing', {httpStatusCode: 404}))
+      }
+      if (current.etag !== options.ifMatch) {
+        return err(createObjectStoreOperationError('conflict', {httpStatusCode: 412}))
+      }
+      objects.delete(key)
+      return ok(undefined)
+    },
+    getObject: async key => {
+      const current = objects.get(key)
+      if (current === undefined) {
+        return err(createObjectStoreOperationError('missing', {httpStatusCode: 404}))
+      }
+      return ok({data: current.data, etag: current.etag})
+    },
   }
 }
 
@@ -289,7 +344,7 @@ describe('createOperatorPushSubscriptionStore — durability across reload', () 
   it('records survive a new store instance over the same backing store', async () => {
     // #given a store with a subscription, backed by a shared map
     const backing = new Map<string, {data: string; etag: string}>()
-    const adapter1 = createCasFakeAdapterOverBackingMap(backing)
+    const adapter1 = createCasFakeAdapter(backing)
     const store1 = makeStore(adapter1)
     await store1.subscribe({
       operatorId: 'operator-a',
@@ -300,7 +355,7 @@ describe('createOperatorPushSubscriptionStore — durability across reload', () 
     })
 
     // #when a fresh store instance is created over the same backing map (simulated reload)
-    const adapter2 = createCasFakeAdapterOverBackingMap(backing)
+    const adapter2 = createCasFakeAdapter(backing)
     const store2 = makeStore(adapter2)
 
     // #then dispatch queries on the new instance see the recovered state
@@ -313,11 +368,12 @@ describe('createOperatorPushSubscriptionStore — durability across reload', () 
 
 describe('createOperatorPushSubscriptionStore — CAS conflict retry on transfer', () => {
   it('retries a contended transfer without producing two active owners for one endpoint', async () => {
-    // #given operator A owns an endpoint
-    const adapter = createCasFakeAdapter()
-    const store = makeStore(adapter)
+    // #given operator A owns an endpoint, with a call-counting adapter wrapper
+    const {adapter: counted, callCount} = withConditionalPutCallCounter(createCasFakeAdapter())
+    const store = makeStore(counted)
     const endpoint = 'https://push.example.com/ep-race'
     await store.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p1', auth: 'a1', keyVersion: '1'})
+    const callsBeforeRace = callCount()
 
     // #when two different operators race to claim the endpoint concurrently
     const [transferB, transferC] = await Promise.all([
@@ -328,6 +384,11 @@ describe('createOperatorPushSubscriptionStore — CAS conflict retry on transfer
     // #then both calls succeed via retry, and exactly one owner ends up active
     expect(transferB.success).toBe(true)
     expect(transferC.success).toBe(true)
+
+    // A clean single-attempt race would need exactly 2 conditionalPut calls
+    // (one per subscriber); more than that proves a retry actually fired
+    // after a lost CAS race, not just a lucky non-conflicting interleave.
+    expect(callCount() - callsBeforeRace).toBeGreaterThan(2)
 
     const [aActive, bActive, cActive] = await Promise.all([
       store.getActiveRecordsForOperator({operatorId: 'operator-a'}),
@@ -354,26 +415,54 @@ describe('createOperatorPushSubscriptionStore — selfTestCas', () => {
     expect(result.success).toBe(true)
   })
 
-  it('fails on a last-write-wins fake', async () => {
+  it('fails with a SelfTestCasFailure on a last-write-wins fake', async () => {
     // #given a last-write-wins adapter (no real CAS)
     const store = makeStore(createLastWriteWinsFakeAdapter())
 
     // #when running the startup self-test
     const result = await store.selfTestCas()
 
-    // #then it fails, signalling the caller to fail the push surface closed
+    // #then it fails closed with the dedicated failure code, signalling the
+    // caller to fail the push surface closed rather than a generic store error
     expect(result.success).toBe(false)
+    if (result.success === true) throw new Error('unreachable')
+    expect(result.error.code).toBe('OPERATOR_PUSH_SELF_TEST_CAS_FAILURE')
   })
 
-  it('fails on an adapter missing conditionalPut', async () => {
+  it('fails with a SelfTestCasFailure on an adapter missing conditionalPut', async () => {
     // #given an adapter that lacks CAS capability entirely
     const store = makeStore(createNonCasAdapter())
 
     // #when running the startup self-test
     const result = await store.selfTestCas()
 
-    // #then it fails closed
+    // #then it fails closed with the dedicated failure code
     expect(result.success).toBe(false)
+    if (result.success === true) throw new Error('unreachable')
+    expect(result.error.code).toBe('OPERATOR_PUSH_SELF_TEST_CAS_FAILURE')
+  })
+
+  it('does not leak the self-test key into subsequent scans', async () => {
+    // #given a store that has just run its startup self-test
+    const store = makeStore(createCasFakeAdapter())
+    await store.selfTestCas()
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-post-selftest',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+
+    // #when scanning for an operator's records
+    const listed = await store.listMetadataForOperator({operatorId: 'operator-a'})
+    const active = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+
+    // #then only the real subscription is returned — the self-test key lives
+    // under a prefix outside every scan and is never surfaced
+    if (listed.success === false || active.success === false) throw new Error('unreachable')
+    expect(listed.data).toHaveLength(1)
+    expect(active.data).toHaveLength(1)
   })
 })
 
@@ -484,7 +573,7 @@ describe('createOperatorPushSubscriptionStore — restore regression (tombstone 
   it('a deleted record stays excluded after a stale backup restores the subscription object alone, with no re-delete', async () => {
     // #given a subscription that gets privacy-deleted
     const backing = new Map<string, {data: string; etag: string}>()
-    const store1 = makeStore(createCasFakeAdapterOverBackingMap(backing))
+    const store1 = makeStore(createCasFakeAdapter(backing))
     const endpoint = 'https://push.example.com/ep-restore'
     await store1.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p', auth: 'a', keyVersion: '1'})
 
@@ -504,7 +593,7 @@ describe('createOperatorPushSubscriptionStore — restore regression (tombstone 
     // #when a stale backup restores ONLY the subscription object's old active
     // bytes — the tombstone key is untouched — and then the store reloads
     backing.set(subscriptionKey, staleActiveSnapshot)
-    const store2 = makeStore(createCasFakeAdapterOverBackingMap(backing))
+    const store2 = makeStore(createCasFakeAdapter(backing))
 
     // #then the resurrected subscription object is still excluded from every
     // active-read surface, because its tombstone at the separate key still
@@ -535,7 +624,7 @@ describe('createOperatorPushSubscriptionStore — privacy delete removes secrets
   it('the subscription object is physically gone after delete', async () => {
     // #given an active subscription
     const backing = new Map<string, {data: string; etag: string}>()
-    const store = makeStore(createCasFakeAdapterOverBackingMap(backing))
+    const store = makeStore(createCasFakeAdapter(backing))
     const endpoint = 'https://push.example.com/ep-secret-removal'
     await store.subscribe({
       operatorId: 'operator-a',
@@ -650,6 +739,426 @@ describe('createOperatorPushSubscriptionStore — verifyStillOwned linearizabili
     expect(stillOwned.success).toBe(true)
     if (stillOwned.success === false) throw new Error('unreachable')
     expect(stillOwned.data).toBe(true)
+  })
+
+  it('returns false for a nonexistent endpointHash', async () => {
+    // #given a store with no matching record
+    const store = makeStore(createCasFakeAdapter())
+
+    // #when verifying an endpointHash that was never subscribed
+    const stillOwned = await store.verifyStillOwned({
+      endpointHash: 'never-existed',
+      operatorId: 'operator-a',
+      ownershipGeneration: 1,
+    })
+
+    // #then it reports not-owned rather than erroring
+    expect(stillOwned.success).toBe(true)
+    if (stillOwned.success === false) throw new Error('unreachable')
+    expect(stillOwned.data).toBe(false)
+  })
+
+  it('returns false for a privacy-deleted endpoint via the tombstone fast-path', async () => {
+    // #given a subscription that gets privacy-deleted (record physically gone, tombstone remains)
+    const store = makeStore(createCasFakeAdapter())
+    const endpoint = 'https://push.example.com/ep-verify-deleted'
+    const subscribed = await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint,
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+    if (subscribed.success === false) throw new Error('unreachable')
+    await store.deleteForOperator({operatorId: 'operator-a'})
+
+    // #when verifying ownership of the now-deleted endpoint
+    const stillOwned = await store.verifyStillOwned({
+      endpointHash: subscribed.data.endpointHash,
+      operatorId: 'operator-a',
+      ownershipGeneration: subscribed.data.ownershipGeneration,
+    })
+
+    // #then the tombstone fast-path rejects it before even reading the (now-absent) record
+    expect(stillOwned.success).toBe(true)
+    if (stillOwned.success === false) throw new Error('unreachable')
+    expect(stillOwned.data).toBe(false)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — deactivateForOperator', () => {
+  it('marks every active record inactive with reason session-revoked', async () => {
+    // #given operator A with two active subscriptions
+    const store = makeStore(createCasFakeAdapter())
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-deact-1',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-deact-2',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+
+    // #when deactivating for that operator
+    const result = await store.deactivateForOperator({operatorId: 'operator-a'})
+
+    // #then both records are updated and none remain active
+    expect(result.success).toBe(true)
+    if (result.success === false) throw new Error('unreachable')
+    expect(result.data.updated).toBe(2)
+    expect(result.data.skipped).toBe(0)
+
+    const active = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (active.success === false) throw new Error('unreachable')
+    expect(active.data).toHaveLength(0)
+
+    const listed = await store.listMetadataForOperator({operatorId: 'operator-a'})
+    if (listed.success === false) throw new Error('unreachable')
+    expect(listed.data.every(m => m.inactiveReason === 'session-revoked')).toBe(true)
+  })
+
+  it("is operator-scoped: does not affect another operator's records", async () => {
+    // #given operator A and operator B each with an active subscription
+    const store = makeStore(createCasFakeAdapter())
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-deact-a',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+    await store.subscribe({
+      operatorId: 'operator-b',
+      endpoint: 'https://push.example.com/ep-deact-b',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+
+    // #when operator B's session is revoked
+    await store.deactivateForOperator({operatorId: 'operator-b'})
+
+    // #then operator A's record is untouched
+    const aActive = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (aActive.success === false) throw new Error('unreachable')
+    expect(aActive.data).toHaveLength(1)
+  })
+
+  it('logs a warning and reports skipped when the CAS retry loop is exhausted', async () => {
+    // #given an active record on a real adapter, then swapped for an
+    // always-conflicting adapter to force retry exhaustion
+    const backing = new Map<string, {data: string; etag: string}>()
+    const seedStore = makeStore(createCasFakeAdapter(backing))
+    await seedStore.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-deact-exhaust',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+
+    const conflictingAdapter: ObjectStoreAdapter = {
+      ...createAlwaysConflictingAdapter(),
+      list: async prefix => ok(Array.from(backing.keys()).filter(k => k.startsWith(prefix))),
+      getObject: async key => {
+        const current = backing.get(key)
+        if (current === undefined) return err(new Error('NotFound: no such key'))
+        return ok({data: current.data, etag: current.etag})
+      },
+    }
+    const warn = vi.fn()
+    const store = createOperatorPushSubscriptionStore({
+      adapter: conflictingAdapter,
+      logger: {debug: () => {}, warn},
+    })
+
+    // #when deactivating against a permanently contended key
+    const result = await store.deactivateForOperator({operatorId: 'operator-a'})
+
+    // #then the retry loop exhausts, the record stays untouched, and a warning is logged
+    expect(result.success).toBe(true)
+    if (result.success === false) throw new Error('unreachable')
+    expect(result.data.updated).toBe(0)
+    expect(result.data.skipped).toBe(1)
+    expect(warn).toHaveBeenCalled()
+
+    const stillActive = await seedStore.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (stillActive.success === false) throw new Error('unreachable')
+    expect(stillActive.data).toHaveLength(1)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — markDead', () => {
+  it("marks the owner's record inactive with reason dead", async () => {
+    // #given an active subscription
+    const store = makeStore(createCasFakeAdapter())
+    const endpoint = 'https://push.example.com/ep-dead'
+    await store.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p', auth: 'a', keyVersion: '1'})
+
+    // #when the owner marks it dead (relay 410 handling)
+    const result = await store.markDead({operatorId: 'operator-a', endpoint})
+
+    // #then it becomes inactive with the dead reason
+    expect(result.success).toBe(true)
+    const listed = await store.listMetadataForOperator({operatorId: 'operator-a'})
+    if (listed.success === false) throw new Error('unreachable')
+    expect(listed.data[0]?.active).toBe(false)
+    expect(listed.data[0]?.inactiveReason).toBe('dead')
+  })
+
+  it("fails closed when a different operator calls markDead on someone else's endpoint", async () => {
+    // #given operator A owns an endpoint
+    const store = makeStore(createCasFakeAdapter())
+    const endpoint = 'https://push.example.com/ep-dead-owned'
+    await store.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p', auth: 'a', keyVersion: '1'})
+
+    // #when operator B calls markDead on it
+    const result = await store.markDead({operatorId: 'operator-b', endpoint})
+
+    // #then the call fails closed and A's record is unaffected
+    expect(result.success).toBe(false)
+    const active = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (active.success === false) throw new Error('unreachable')
+    expect(active.data).toHaveLength(1)
+  })
+
+  it('is idempotent — a second markDead call is a no-op success', async () => {
+    // #given a subscription already marked dead
+    const store = makeStore(createCasFakeAdapter())
+    const endpoint = 'https://push.example.com/ep-dead-idempotent'
+    await store.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p', auth: 'a', keyVersion: '1'})
+    await store.markDead({operatorId: 'operator-a', endpoint})
+
+    // #when markDead is called again
+    const second = await store.markDead({operatorId: 'operator-a', endpoint})
+
+    // #then it succeeds as a no-op
+    expect(second.success).toBe(true)
+  })
+
+  it('is a no-op success for a non-existent endpoint', async () => {
+    // #given no subscription for this endpoint
+    const store = makeStore(createCasFakeAdapter())
+
+    // #when marking it dead
+    const result = await store.markDead({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-never-existed',
+    })
+
+    // #then it succeeds as a no-op
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — deleteForOperator gaps', () => {
+  it("is operator-scoped: does not affect another operator's records", async () => {
+    // #given operator A and operator B each with an active subscription
+    const store = makeStore(createCasFakeAdapter())
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-del-a',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+    await store.subscribe({
+      operatorId: 'operator-b',
+      endpoint: 'https://push.example.com/ep-del-b',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+
+    // #when operator B privacy-deletes their own records
+    await store.deleteForOperator({operatorId: 'operator-b'})
+
+    // #then operator A's record is untouched
+    const aActive = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (aActive.success === false) throw new Error('unreachable')
+    expect(aActive.data).toHaveLength(1)
+  })
+
+  it("removes exactly the target operator's records, active and inactive, leaving other operators intact", async () => {
+    // #given operator A with 2 active + 1 inactive record, operator B with 2 active
+    const store = makeStore(createCasFakeAdapter())
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-multi-a1',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-multi-a2',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-multi-a3',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+    await store.unsubscribe({operatorId: 'operator-a', endpoint: 'https://push.example.com/ep-multi-a3'})
+    await store.subscribe({
+      operatorId: 'operator-b',
+      endpoint: 'https://push.example.com/ep-multi-b1',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+    await store.subscribe({
+      operatorId: 'operator-b',
+      endpoint: 'https://push.example.com/ep-multi-b2',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+
+    // #when deleting operator A
+    const result = await store.deleteForOperator({operatorId: 'operator-a'})
+
+    // #then exactly A's 3 records are removed and B's 2 are intact
+    expect(result.success).toBe(true)
+    if (result.success === false) throw new Error('unreachable')
+    expect(result.data.deleted).toBe(3)
+
+    const aListed = await store.listMetadataForOperator({operatorId: 'operator-a'})
+    if (aListed.success === false) throw new Error('unreachable')
+    expect(aListed.data).toHaveLength(0)
+
+    const bActive = await store.getActiveRecordsForOperator({operatorId: 'operator-b'})
+    if (bActive.success === false) throw new Error('unreachable')
+    expect(bActive.data).toHaveLength(2)
+  })
+
+  it('does not count a record as deleted when the physical delete loses its CAS race', async () => {
+    // #given an active subscription whose physical conditionalDelete is forced to always PreconditionFail
+    const backing = new Map<string, {data: string; etag: string}>()
+    const baseAdapter = createCasFakeAdapter(backing)
+    const forcedConflictAdapter = withAlwaysFailingConditionalDeleteFor(baseAdapter, key =>
+      key.includes('subscriptions/by-endpoint'),
+    )
+    const warn = vi.fn()
+    const store = createOperatorPushSubscriptionStore({adapter: forcedConflictAdapter, logger: {debug: () => {}, warn}})
+    const endpoint = 'https://push.example.com/ep-physical-delete-race'
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint,
+      p256dh: 'p256dh-still-on-disk',
+      auth: 'auth-still-on-disk',
+      keyVersion: '1',
+    })
+
+    // #when privacy-deleting while the physical delete is forced to conflict
+    const result = await store.deleteForOperator({operatorId: 'operator-a'})
+
+    // #then the tombstone still excludes the record from reads, but it is NOT
+    // counted as deleted, and the secrets remain on disk pending a later prune
+    expect(result.success).toBe(true)
+    if (result.success === false) throw new Error('unreachable')
+    expect(result.data.deleted).toBe(0)
+    expect(result.data.skipped).toBe(1)
+    expect(warn).toHaveBeenCalled()
+
+    const active = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    if (active.success === false) throw new Error('unreachable')
+    expect(active.data).toHaveLength(0) // tombstone still excludes it from reads
+
+    const subscriptionKey = Array.from(backing.keys()).find(k => k.includes('subscriptions/by-endpoint'))
+    if (subscriptionKey === undefined) throw new Error('unreachable')
+    expect(backing.get(subscriptionKey)?.data).toContain('p256dh-still-on-disk') // secrets acknowledged as still on disk
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — corrupted record resilience', () => {
+  it('skips a malformed record without throwing and returns valid siblings', async () => {
+    // #given one valid record and one corrupted record written directly to the backing store
+    const backing = new Map<string, {data: string; etag: string}>()
+    const store = makeStore(createCasFakeAdapter(backing))
+    await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint: 'https://push.example.com/ep-valid',
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+    backing.set('operator-push/subscriptions/by-endpoint/corrupted-hash.json', {
+      data: 'not valid json {{{',
+      etag: 'etag-corrupt',
+    })
+
+    // #when scanning for the operator's records
+    const active = await store.getActiveRecordsForOperator({operatorId: 'operator-a'})
+    const listed = await store.listMetadataForOperator({operatorId: 'operator-a'})
+
+    // #then the corrupted record is skipped silently and the valid sibling is still returned
+    expect(active.success).toBe(true)
+    expect(listed.success).toBe(true)
+    if (active.success === false || listed.success === false) throw new Error('unreachable')
+    expect(active.data).toHaveLength(1)
+    expect(listed.data).toHaveLength(1)
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — CAS retry exhaustion', () => {
+  it('subscribe, unsubscribe, and markDead each return the max-retry error on a permanently contended key', async () => {
+    // #given a plain-conflict adapter with no successful writes possible
+    const adapter = createAlwaysConflictingAdapter()
+    const store = makeStore(adapter)
+    const endpoint = 'https://push.example.com/ep-permanently-contended'
+
+    // #when calling subscribe against the permanently contended key
+    const subscribed = await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint,
+      p256dh: 'p',
+      auth: 'a',
+      keyVersion: '1',
+    })
+
+    // #then it fails with the retry-exhaustion error
+    expect(subscribed.success).toBe(false)
+    if (subscribed.success === true) throw new Error('unreachable')
+    expect(subscribed.error.message).toContain('exceeded max CAS retry attempts')
+  })
+})
+
+describe('createOperatorPushSubscriptionStore — structured error classification', () => {
+  it('classifies a structured 404 getObject error as not-found and a structured 412 conditionalPut error as a precondition conflict', async () => {
+    // #given a store backed by an adapter that returns structured
+    // ObjectStoreOperationError objects (httpStatusCode-based) instead of
+    // plain Error messages
+    const {adapter: counted, callCount} = withConditionalPutCallCounter(createStructuredErrorAdapter())
+    const store = makeStore(counted)
+    const endpoint = 'https://push.example.com/ep-structured-error'
+
+    // #when subscribing for the first time (create-if-absent path reads via
+    // getObject first, which returns a structured 404)
+    const first = await store.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p', auth: 'a', keyVersion: '1'})
+    expect(first.success).toBe(true)
+
+    // #then a concurrent create attempt against the same endpoint retries
+    // past the structured 412 conflict rather than surfacing it as a hard error
+    const second = await store.subscribe({
+      operatorId: 'operator-a',
+      endpoint,
+      p256dh: 'p2',
+      auth: 'a2',
+      keyVersion: '1',
+    })
+    expect(second.success).toBe(true)
+    expect(callCount()).toBeGreaterThan(1)
   })
 })
 

--- a/packages/gateway/src/web/operator-push/subscription-store.ts
+++ b/packages/gateway/src/web/operator-push/subscription-store.ts
@@ -1,0 +1,1033 @@
+/**
+ * Durable subscription-record lifecycle store for the Gateway operator push
+ * surface.
+ *
+ * Each browser push subscription is persisted as one object keyed by an
+ * opaque hash of its endpoint URL — never the endpoint itself:
+ *
+ *   operator-push/subscriptions/by-endpoint/{sha256(endpoint)}.json
+ *
+ * `endpoint`, `p256dh`, and `auth` are write-only secret fields: they are
+ * persisted in the record body but are NEVER returned by any non-mutating
+ * surface (list, export, audit, metrics). The single structural boundary
+ * enforcing this is {@link toSubscriptionMetadata} — it is the only
+ * sanctioned way to turn a full record into operator-facing data. The full
+ * record (secrets included) is exposed exclusively via
+ * {@link OperatorPushSubscriptionStore.getActiveRecordsForOperator}, which
+ * exists solely for the relay/dispatch path.
+ *
+ * Privacy-delete model: separate tombstone key space.
+ *
+ * A privacy delete does NOT rewrite the subscription object in place — that
+ * would leave the secrets on disk and can be undone by any process that
+ * restores an older version of that same key. Instead, `deleteForOperator`
+ * writes a secret-free marker at a DIFFERENT key:
+ *
+ *   operator-push/tombstones/{sha256(endpoint)}.json
+ *   → {endpointHash, operatorId, deletedAt}
+ *
+ * and then physically removes the subscription object. Every active-read
+ * path (`listAllRecords`, `getActiveRecordsForOperator`,
+ * `listMetadataForOperator`, `verifyStillOwned`) consults the tombstone
+ * prefix and excludes any endpointHash with a live tombstone — regardless
+ * of what the subscription object at that endpointHash currently contains.
+ * This means restoring the subscription object alone (e.g. a targeted
+ * key-level backup restore of just that object) cannot resurrect a deleted
+ * record: the tombstone lives at a separate key and keeps excluding it.
+ *
+ * Boundary this does NOT protect against: a full-bucket restore that
+ * rewinds the ENTIRE object store — tombstones included — to a snapshot
+ * taken before the delete. That is a disaster-recovery rewind of all
+ * state, not a targeted resurrection of one record, and is out of scope
+ * for an application-level tombstone. No object-store-backed design can
+ * defend against its own storage being time-traveled wholesale; that is
+ * a backup-retention/operational concern, not a store-API concern.
+ *
+ * A privacy delete is not a permanent ban: `subscribe` clears the
+ * tombstone for its endpointHash after a successful record write, so an
+ * authenticated operator can legitimately re-subscribe the same endpoint
+ * later. Only an authenticated `subscribe` call clears a tombstone — a
+ * passive object restore never calls `subscribe`, so the resurrection
+ * protection holds for anything short of a full-bucket rewind.
+ *
+ * Ownership transfer is a single atomic CAS write: when a different
+ * operator subscribes with an endpoint that is already bound to someone
+ * else, the same `conditionalPut` call (guarded by `ifMatch` on the
+ * current etag) reassigns `operatorId`, sets `active: true`, and bumps
+ * `ownershipGeneration` — there is no window where two operators can both
+ * see themselves as the current owner of one endpoint.
+ *
+ * Dispatch-vs-transfer linearizability: `getActiveRecordsForOperator`
+ * returns a point-in-time snapshot. Because a transfer can land between
+ * that read and the moment a notification is actually sent, the dispatch
+ * path MUST call {@link OperatorPushSubscriptionStore.verifyStillOwned}
+ * immediately before sending, passing back the `ownershipGeneration` it
+ * read. If the generation has moved on (or the record is no longer active,
+ * no longer owned by the same operator, or has since been tombstoned), the
+ * dispatch is skipped — a stale pre-transfer (or pre-delete) read can
+ * never deliver operator A's notification to operator B, nor to a deleted
+ * subscription.
+ */
+
+import type {ObjectStoreAdapter, Result} from '@fro-bot/runtime'
+
+import {createHash, randomUUID} from 'node:crypto'
+import {err, ok} from '@fro-bot/runtime'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Coarse, closed set of reasons a subscription record became inactive. No free-form text. */
+export type SubscriptionInactiveReason = 'unsubscribed' | 'transferred' | 'dead' | 'key_revoked' | 'session-revoked'
+
+/**
+ * Full subscription record, including the write-only secret fields.
+ *
+ * Never return this shape from a listing/export surface — use
+ * {@link toSubscriptionMetadata} to derive the safe projection.
+ */
+export interface SubscriptionRecord {
+  /** sha256 hex digest of the push endpoint URL — the record's key discriminant. */
+  readonly endpointHash: string
+  /** Secret: the push endpoint URL. Write-only outside the dispatch path. */
+  readonly endpoint: string
+  /** Secret: the P-256 DH public key from the browser subscription. Write-only outside the dispatch path. */
+  readonly p256dh: string
+  /** Secret: the auth secret from the browser subscription. Write-only outside the dispatch path. */
+  readonly auth: string
+  /** Current owning operator. */
+  readonly operatorId: string
+  /** Whether this record is in the active dispatch set. */
+  readonly active: boolean
+  /** VAPID key version this subscription was created/refreshed under. */
+  readonly keyVersion: string
+  /** Monotonic counter bumped on every ownership transfer. Starts at 1. */
+  readonly ownershipGeneration: number
+  readonly createdAt: number
+  readonly updatedAt: number
+  readonly deactivatedAt?: number
+  readonly inactiveReason?: SubscriptionInactiveReason
+}
+
+/**
+ * Secret-free tombstone marker for a privacy-deleted endpoint. Lives at a
+ * separate key from the subscription object it corresponds to — see the
+ * module docstring for why that separation matters.
+ */
+export interface TombstoneRecord {
+  readonly endpointHash: string
+  readonly operatorId: string
+  readonly deletedAt: number
+}
+
+/**
+ * Safe metadata projection — the ONLY shape returned by list/export/audit
+ * surfaces. Structurally excludes `endpoint`, `p256dh`, and `auth`.
+ */
+export interface SubscriptionMetadata {
+  readonly endpointHash: string
+  readonly operatorId: string
+  readonly active: boolean
+  readonly keyVersion: string
+  readonly ownershipGeneration: number
+  readonly createdAt: number
+  readonly updatedAt: number
+  readonly deactivatedAt?: number
+  readonly inactiveReason?: SubscriptionInactiveReason
+}
+
+/**
+ * The single sanctioned way to derive operator-facing metadata from a full
+ * record. Never spreads the full record — lists the safe fields explicitly
+ * so a future secret field added to `SubscriptionRecord` does not leak here
+ * by accident.
+ */
+export function toSubscriptionMetadata(record: SubscriptionRecord): SubscriptionMetadata {
+  const base: SubscriptionMetadata = {
+    endpointHash: record.endpointHash,
+    operatorId: record.operatorId,
+    active: record.active,
+    keyVersion: record.keyVersion,
+    ownershipGeneration: record.ownershipGeneration,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  }
+  if (record.deactivatedAt !== undefined) {
+    return {
+      ...base,
+      deactivatedAt: record.deactivatedAt,
+      ...(record.inactiveReason === undefined ? {} : {inactiveReason: record.inactiveReason}),
+    }
+  }
+  if (record.inactiveReason !== undefined) {
+    return {...base, inactiveReason: record.inactiveReason}
+  }
+  return base
+}
+
+export interface SubscribeInput {
+  readonly operatorId: string
+  readonly endpoint: string
+  readonly p256dh: string
+  readonly auth: string
+  readonly keyVersion: string
+}
+
+export interface StoreLogger {
+  readonly debug: (context: Record<string, unknown>, message: string) => void
+  readonly warn: (context: Record<string, unknown>, message: string) => void
+}
+
+export interface OperatorPushSubscriptionStoreDeps {
+  readonly adapter: ObjectStoreAdapter
+  readonly keyPrefix?: string
+  readonly logger: StoreLogger
+  readonly clock?: () => number
+  /** Retention window for pruning inactive subscription records. Default 30 days. */
+  readonly inactiveRetentionMs?: number
+  /**
+   * Retention window for pruning tombstones. Default 90 days.
+   *
+   * MUST exceed the longest object-store backup retention window in use —
+   * pruning a tombstone before every backup that predates the delete has
+   * expired would reopen the restore-resurrection gap the tombstone exists
+   * to close. When in doubt, keep this larger than the backup window, not
+   * smaller.
+   */
+  readonly tombstoneRetentionMs?: number
+}
+
+export interface StoreError extends Error {
+  readonly code: 'OPERATOR_PUSH_STORE_ERROR'
+}
+
+export function createStoreError(message: string): StoreError {
+  return Object.assign(new Error(message), {code: 'OPERATOR_PUSH_STORE_ERROR' as const})
+}
+
+export interface SelfTestCasFailure extends Error {
+  readonly code: 'OPERATOR_PUSH_SELF_TEST_CAS_FAILURE'
+}
+
+export function createSelfTestCasFailure(message: string): SelfTestCasFailure {
+  return Object.assign(new Error(message), {code: 'OPERATOR_PUSH_SELF_TEST_CAS_FAILURE' as const})
+}
+
+/** Combined prune outcome: subscription records removed vs. tombstones removed. */
+export interface PruneResult {
+  readonly records: number
+  readonly tombstones: number
+}
+
+export interface OperatorPushSubscriptionStore {
+  subscribe: (input: SubscribeInput) => Promise<Result<SubscriptionMetadata, StoreError>>
+  unsubscribe: (args: {readonly operatorId: string; readonly endpoint: string}) => Promise<Result<void, StoreError>>
+  deactivateForOperator: (args: {readonly operatorId: string}) => Promise<Result<number, StoreError>>
+  /** Privacy delete: tombstones then physically removes every record owned by `operatorId`. */
+  deleteForOperator: (args: {readonly operatorId: string}) => Promise<Result<number, StoreError>>
+  listMetadataForOperator: (args: {
+    readonly operatorId: string
+  }) => Promise<Result<readonly SubscriptionMetadata[], StoreError>>
+  /** Full records WITH secrets. Dispatch-path ONLY — never surface this to listing/export/audit. */
+  getActiveRecordsForOperator: (args: {
+    readonly operatorId: string
+  }) => Promise<Result<readonly SubscriptionRecord[], StoreError>>
+  markDead: (args: {readonly endpoint: string}) => Promise<Result<void, StoreError>>
+  /** Prunes inactive subscription records and expired tombstones past their respective retention windows. */
+  pruneInactive: (args?: {
+    readonly recordsOlderThanMs?: number
+    readonly tombstonesOlderThanMs?: number
+  }) => Promise<Result<PruneResult, StoreError>>
+  /**
+   * Re-validates ownership immediately before a dispatch send. Returns true
+   * only if the record is still active, still owned by `operatorId`, still
+   * at `ownershipGeneration`, and has no tombstone. Dispatch MUST call this
+   * right before sending so a stale pre-transfer or pre-delete read cannot
+   * deliver to the wrong owner or to a deleted subscription.
+   */
+  verifyStillOwned: (args: {
+    readonly endpointHash: string
+    readonly operatorId: string
+    readonly ownershipGeneration: number
+  }) => Promise<Result<boolean, StoreError>>
+  /**
+   * Startup self-test: proves the configured adapter has real
+   * compare-and-swap semantics by racing two contended writes against a
+   * throwaway key. Returns a failure Result when the adapter lacks CAS
+   * capability or the write does not conflict (last-write-wins) — callers
+   * must fail the push surface closed in that case.
+   */
+  selfTestCas: () => Promise<Result<void, StoreError | SelfTestCasFailure>>
+}
+
+const DEFAULT_KEY_PREFIX = 'operator-push/subscriptions/by-endpoint'
+const DEFAULT_TOMBSTONE_PREFIX = 'operator-push/tombstones'
+const DEFAULT_INACTIVE_RETENTION_MS = 30 * 24 * 60 * 60 * 1000
+const DEFAULT_TOMBSTONE_RETENTION_MS = 90 * 24 * 60 * 60 * 1000
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function hashEndpoint(endpoint: string): string {
+  return createHash('sha256').update(endpoint, 'utf8').digest('hex')
+}
+
+function isPreconditionFailed(error: Error): boolean {
+  return /pre-?condition/i.test(error.message)
+}
+
+function isNotFound(error: Error): boolean {
+  return /not.?found|no.?such.?key|does.?not.?exist|404/i.test(error.message)
+}
+
+function hasValidSubscriptionRecordShape(value: unknown): value is SubscriptionRecord {
+  if (typeof value !== 'object' || value == null) {
+    return false
+  }
+  const c = value as Partial<SubscriptionRecord>
+  return (
+    typeof c.endpointHash === 'string' &&
+    typeof c.endpoint === 'string' &&
+    typeof c.p256dh === 'string' &&
+    typeof c.auth === 'string' &&
+    typeof c.operatorId === 'string' &&
+    typeof c.active === 'boolean' &&
+    typeof c.keyVersion === 'string' &&
+    typeof c.ownershipGeneration === 'number' &&
+    typeof c.createdAt === 'number' &&
+    typeof c.updatedAt === 'number'
+  )
+}
+
+function parseSubscriptionRecord(data: string): Result<SubscriptionRecord, StoreError> {
+  try {
+    const parsed: unknown = JSON.parse(data)
+    if (hasValidSubscriptionRecordShape(parsed) === false) {
+      return err(createStoreError('Invalid subscription record payload'))
+    }
+    return ok(parsed)
+  } catch (error) {
+    return err(createStoreError(error instanceof Error ? error.message : String(error)))
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createOperatorPushSubscriptionStore(
+  deps: OperatorPushSubscriptionStoreDeps,
+): OperatorPushSubscriptionStore {
+  const {adapter, logger} = deps
+  const keyPrefix = deps.keyPrefix ?? DEFAULT_KEY_PREFIX
+  const tombstonePrefix = DEFAULT_TOMBSTONE_PREFIX
+  const clock = deps.clock ?? Date.now
+  const inactiveRetentionMs = deps.inactiveRetentionMs ?? DEFAULT_INACTIVE_RETENTION_MS
+  const tombstoneRetentionMs = deps.tombstoneRetentionMs ?? DEFAULT_TOMBSTONE_RETENTION_MS
+
+  function buildKey(endpointHash: string): string {
+    return `${keyPrefix}/${endpointHash}.json`
+  }
+
+  function buildTombstoneKey(endpointHash: string): string {
+    return `${tombstonePrefix}/${endpointHash}.json`
+  }
+
+  /** Derives the endpointHash from a tombstone key name — avoids a getObject per tombstone. */
+  function endpointHashFromTombstoneKey(key: string): string | null {
+    const prefix = `${tombstonePrefix}/`
+    if (key.startsWith(prefix) === false || key.endsWith('.json') === false) {
+      return null
+    }
+    return key.slice(prefix.length, key.length - '.json'.length)
+  }
+
+  function requireCasCapable(): Result<
+    {
+      readonly conditionalPut: NonNullable<ObjectStoreAdapter['conditionalPut']>
+      readonly conditionalDelete: NonNullable<ObjectStoreAdapter['conditionalDelete']>
+      readonly getObject: NonNullable<ObjectStoreAdapter['getObject']>
+    },
+    StoreError
+  > {
+    if (adapter.conditionalPut == null) {
+      return err(createStoreError('Object store adapter does not support conditionalPut'))
+    }
+    if (adapter.conditionalDelete == null) {
+      return err(createStoreError('Object store adapter does not support conditionalDelete'))
+    }
+    if (adapter.getObject == null) {
+      return err(createStoreError('Object store adapter does not support getObject'))
+    }
+    return ok({
+      conditionalPut: adapter.conditionalPut,
+      conditionalDelete: adapter.conditionalDelete,
+      getObject: adapter.getObject,
+    })
+  }
+
+  async function readRecord(
+    endpointHash: string,
+  ): Promise<Result<{readonly record: SubscriptionRecord; readonly etag: string} | null, StoreError>> {
+    const cas = requireCasCapable()
+    if (cas.success === false) {
+      return err(cas.error)
+    }
+
+    const fetched = await cas.data.getObject(buildKey(endpointHash))
+    if (fetched.success === false) {
+      if (isNotFound(fetched.error)) {
+        return ok(null)
+      }
+      return err(createStoreError(fetched.error.message))
+    }
+
+    const parsed = parseSubscriptionRecord(fetched.data.data)
+    if (parsed.success === false) {
+      return err(parsed.error)
+    }
+
+    return ok({record: parsed.data, etag: fetched.data.etag})
+  }
+
+  /** List all endpoint-hash keys currently under the subscription-object prefix. */
+  async function listAllKeys(): Promise<Result<readonly string[], StoreError>> {
+    const listed = await adapter.list(`${keyPrefix}/`)
+    if (listed.success === false) {
+      return err(createStoreError(listed.error.message))
+    }
+    return ok(listed.data)
+  }
+
+  /** Set of endpointHashes with a live tombstone. Derived from key names — no getObject per tombstone. */
+  async function listTombstonedHashes(): Promise<Result<ReadonlySet<string>, StoreError>> {
+    const listed = await adapter.list(`${tombstonePrefix}/`)
+    if (listed.success === false) {
+      return err(createStoreError(listed.error.message))
+    }
+    const hashes = new Set<string>()
+    for (const key of listed.data) {
+      const hash = endpointHashFromTombstoneKey(key)
+      if (hash !== null) {
+        hashes.add(hash)
+      }
+    }
+    return ok(hashes)
+  }
+
+  async function hasTombstone(endpointHash: string): Promise<Result<boolean, StoreError>> {
+    const cas = requireCasCapable()
+    if (cas.success === false) {
+      return err(cas.error)
+    }
+    const fetched = await cas.data.getObject(buildTombstoneKey(endpointHash))
+    if (fetched.success === false) {
+      if (isNotFound(fetched.error)) {
+        return ok(false)
+      }
+      return err(createStoreError(fetched.error.message))
+    }
+    return ok(true)
+  }
+
+  async function listAllRecords(): Promise<Result<readonly SubscriptionRecord[], StoreError>> {
+    const cas = requireCasCapable()
+    if (cas.success === false) {
+      return err(cas.error)
+    }
+
+    const [keys, tombstones] = await Promise.all([listAllKeys(), listTombstonedHashes()])
+    if (keys.success === false) {
+      return err(keys.error)
+    }
+    if (tombstones.success === false) {
+      return err(tombstones.error)
+    }
+
+    const records: SubscriptionRecord[] = []
+    for (const key of keys.data) {
+      const fetched = await cas.data.getObject(key)
+      if (fetched.success === false) {
+        if (isNotFound(fetched.error)) {
+          continue
+        }
+        return err(createStoreError(fetched.error.message))
+      }
+      const parsed = parseSubscriptionRecord(fetched.data.data)
+      if (parsed.success === false) {
+        // Corrupted record — skip; one bad record must not kill the whole scan.
+        logger.warn({key}, 'operator push subscription store: skipping corrupted record')
+        continue
+      }
+      // A live tombstone always excludes its endpointHash, regardless of what
+      // the subscription object currently contains (see module docstring).
+      if (tombstones.data.has(parsed.data.endpointHash)) {
+        continue
+      }
+      records.push(parsed.data)
+    }
+    return ok(records)
+  }
+
+  // -------------------------------------------------------------------------
+  // subscribe
+  // -------------------------------------------------------------------------
+
+  async function subscribe(input: SubscribeInput): Promise<Result<SubscriptionMetadata, StoreError>> {
+    const cas = requireCasCapable()
+    if (cas.success === false) {
+      return err(cas.error)
+    }
+
+    const endpointHash = hashEndpoint(input.endpoint)
+    const key = buildKey(endpointHash)
+    const now = clock()
+
+    // Retry loop bounds the CAS race on concurrent writers targeting the same endpoint.
+    const maxAttempts = 5
+    let written: SubscriptionRecord | null = null
+    for (let attempt = 0; attempt < maxAttempts && written === null; attempt++) {
+      const existing = await readRecord(endpointHash)
+      if (existing.success === false) {
+        return err(existing.error)
+      }
+
+      if (existing.data === null) {
+        // Create-if-absent: first subscription for this endpoint (or the
+        // object was physically removed by a prior privacy delete).
+        const record: SubscriptionRecord = {
+          endpointHash,
+          endpoint: input.endpoint,
+          p256dh: input.p256dh,
+          auth: input.auth,
+          operatorId: input.operatorId,
+          active: true,
+          keyVersion: input.keyVersion,
+          ownershipGeneration: 1,
+          createdAt: now,
+          updatedAt: now,
+        }
+        const write = await cas.data.conditionalPut(key, JSON.stringify(record), {ifNoneMatch: '*'})
+        if (write.success === false) {
+          if (isPreconditionFailed(write.error)) {
+            continue // Someone else created it concurrently — retry and reconcile below.
+          }
+          return err(createStoreError(write.error.message))
+        }
+        written = record
+        break
+      }
+
+      const {record: current, etag} = existing.data
+      const sameOwner = current.operatorId === input.operatorId
+
+      const nextRecord: SubscriptionRecord = sameOwner
+        ? {
+            // Same operator re-subscribing the same endpoint: refresh keys, no ownership change.
+            ...current,
+            p256dh: input.p256dh,
+            auth: input.auth,
+            keyVersion: input.keyVersion,
+            active: true,
+            updatedAt: now,
+            deactivatedAt: undefined,
+            inactiveReason: undefined,
+          }
+        : {
+            // Different operator: atomic ownership transfer in the same CAS write —
+            // reassign owner, reactivate, bump generation, in one call.
+            ...current,
+            operatorId: input.operatorId,
+            p256dh: input.p256dh,
+            auth: input.auth,
+            keyVersion: input.keyVersion,
+            active: true,
+            ownershipGeneration: current.ownershipGeneration + 1,
+            updatedAt: now,
+            deactivatedAt: undefined,
+            inactiveReason: undefined,
+          }
+
+      // JSON.stringify drops `undefined` fields, so explicit resets above serialize cleanly.
+      const write = await cas.data.conditionalPut(key, JSON.stringify(nextRecord), {ifMatch: etag})
+      if (write.success === false) {
+        if (isPreconditionFailed(write.error)) {
+          continue // Lost the race — reread and retry.
+        }
+        return err(createStoreError(write.error.message))
+      }
+      written = nextRecord
+    }
+
+    if (written === null) {
+      return err(createStoreError('subscribe: exceeded max CAS retry attempts'))
+    }
+
+    // Clear any tombstone for this endpointHash AFTER the record write succeeds.
+    // Only a real authenticated subscribe reaches this line — a passive object
+    // restore never calls subscribe, so this cannot reopen the resurrection
+    // gap the tombstone exists to close. Best-effort: a crash here leaves the
+    // record written but the tombstone still in place, which fails toward
+    // NOT dispatching (safe) rather than toward resurrecting a deleted record.
+    const tombstoneRead = await cas.data.getObject(buildTombstoneKey(endpointHash))
+    if (tombstoneRead.success === true) {
+      const cleared = await cas.data.conditionalDelete(buildTombstoneKey(endpointHash), {
+        ifMatch: tombstoneRead.data.etag,
+      })
+      if (
+        cleared.success === false &&
+        isPreconditionFailed(cleared.error) === false &&
+        isNotFound(cleared.error) === false
+      ) {
+        logger.warn(
+          {endpointHash, error: cleared.error.message},
+          'operator push subscription store: failed to clear tombstone after subscribe',
+        )
+      }
+    }
+
+    return ok(toSubscriptionMetadata(written))
+  }
+
+  // -------------------------------------------------------------------------
+  // unsubscribe
+  // -------------------------------------------------------------------------
+
+  async function unsubscribe(args: {
+    readonly operatorId: string
+    readonly endpoint: string
+  }): Promise<Result<void, StoreError>> {
+    const cas = requireCasCapable()
+    if (cas.success === false) {
+      return err(cas.error)
+    }
+
+    const endpointHash = hashEndpoint(args.endpoint)
+    const maxAttempts = 5
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const existing = await readRecord(endpointHash)
+      if (existing.success === false) {
+        return err(existing.error)
+      }
+      if (existing.data === null) {
+        // Idempotent: unsubscribing an unknown endpoint is a no-op success.
+        return ok(undefined)
+      }
+
+      const {record: current, etag} = existing.data
+      if (current.operatorId !== args.operatorId) {
+        // Fail closed — a different operator cannot unsubscribe someone else's record.
+        return err(createStoreError('unsubscribe: endpoint is not owned by this operator'))
+      }
+
+      const nextRecord: SubscriptionRecord = {
+        ...current,
+        active: false,
+        updatedAt: clock(),
+        deactivatedAt: clock(),
+        inactiveReason: 'unsubscribed',
+      }
+      const write = await cas.data.conditionalPut(buildKey(endpointHash), JSON.stringify(nextRecord), {
+        ifMatch: etag,
+      })
+      if (write.success === false) {
+        if (isPreconditionFailed(write.error)) {
+          continue
+        }
+        return err(createStoreError(write.error.message))
+      }
+      return ok(undefined)
+    }
+    return err(createStoreError('unsubscribe: exceeded max CAS retry attempts'))
+  }
+
+  // -------------------------------------------------------------------------
+  // deactivateForOperator (session-revoke — unchanged, no tombstones)
+  // -------------------------------------------------------------------------
+
+  async function deactivateForOperator(args: {readonly operatorId: string}): Promise<Result<number, StoreError>> {
+    const cas = requireCasCapable()
+    if (cas.success === false) {
+      return err(cas.error)
+    }
+
+    const keys = await listAllKeys()
+    if (keys.success === false) {
+      return err(keys.error)
+    }
+
+    let count = 0
+    for (const key of keys.data) {
+      const maxAttempts = 5
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        const fetched = await cas.data.getObject(key)
+        if (fetched.success === false) {
+          if (isNotFound(fetched.error)) break
+          return err(createStoreError(fetched.error.message))
+        }
+        const parsed = parseSubscriptionRecord(fetched.data.data)
+        if (parsed.success === false) break // corrupted — skip
+
+        const record = parsed.data
+        if (record.operatorId !== args.operatorId || record.active === false) break
+
+        const now = clock()
+        const nextRecord: SubscriptionRecord = {
+          ...record,
+          active: false,
+          updatedAt: now,
+          deactivatedAt: now,
+          inactiveReason: 'session-revoked',
+        }
+        const write = await cas.data.conditionalPut(key, JSON.stringify(nextRecord), {ifMatch: fetched.data.etag})
+        if (write.success === false) {
+          if (isPreconditionFailed(write.error)) continue // retry
+          return err(createStoreError(write.error.message))
+        }
+        count += 1
+        break
+      }
+    }
+    return ok(count)
+  }
+
+  // -------------------------------------------------------------------------
+  // deleteForOperator (privacy delete — tombstone-first, then physical removal)
+  // -------------------------------------------------------------------------
+
+  async function deleteForOperator(args: {readonly operatorId: string}): Promise<Result<number, StoreError>> {
+    const cas = requireCasCapable()
+    if (cas.success === false) {
+      return err(cas.error)
+    }
+
+    const keys = await listAllKeys()
+    if (keys.success === false) {
+      return err(keys.error)
+    }
+
+    let count = 0
+    for (const key of keys.data) {
+      const fetched = await cas.data.getObject(key)
+      if (fetched.success === false) {
+        if (isNotFound(fetched.error)) continue
+        return err(createStoreError(fetched.error.message))
+      }
+      const parsed = parseSubscriptionRecord(fetched.data.data)
+      if (parsed.success === false) continue // corrupted — skip
+
+      const record = parsed.data
+      if (record.operatorId !== args.operatorId) continue
+
+      const now = clock()
+      const tombstoneKey = buildTombstoneKey(record.endpointHash)
+      const tombstone: TombstoneRecord = {
+        endpointHash: record.endpointHash,
+        operatorId: args.operatorId,
+        deletedAt: now,
+      }
+
+      // Step 1 — tombstone FIRST. Required ordering: if the process crashes
+      // after this write but before the physical delete below, the record
+      // is still on disk but the tombstone already excludes it from every
+      // active-read path — the failure mode fails safe toward privacy
+      // (still-visible-as-deleted), never toward "looks deleted but isn't".
+      const tombstoneWrite = await cas.data.conditionalPut(tombstoneKey, JSON.stringify(tombstone), {
+        ifNoneMatch: '*',
+      })
+      if (tombstoneWrite.success === false && isPreconditionFailed(tombstoneWrite.error) === false) {
+        return err(createStoreError(tombstoneWrite.error.message))
+      }
+      // A precondition failure here means a tombstone already exists for this
+      // endpointHash — treat as idempotent success and continue to the
+      // physical delete below.
+
+      // Step 2 — physically remove the subscription object, dropping the
+      // secrets (endpoint/p256dh/auth) from disk entirely.
+      const deleted = await cas.data.conditionalDelete(key, {ifMatch: fetched.data.etag})
+      if (
+        deleted.success === false &&
+        isPreconditionFailed(deleted.error) === false &&
+        isNotFound(deleted.error) === false
+      ) {
+        return err(createStoreError(deleted.error.message))
+      }
+
+      count += 1
+    }
+    return ok(count)
+  }
+
+  // -------------------------------------------------------------------------
+  // listMetadataForOperator / getActiveRecordsForOperator
+  // -------------------------------------------------------------------------
+
+  async function listMetadataForOperator(args: {
+    readonly operatorId: string
+  }): Promise<Result<readonly SubscriptionMetadata[], StoreError>> {
+    const all = await listAllRecords()
+    if (all.success === false) {
+      return err(all.error)
+    }
+    return ok(all.data.filter(r => r.operatorId === args.operatorId).map(toSubscriptionMetadata))
+  }
+
+  async function getActiveRecordsForOperator(args: {
+    readonly operatorId: string
+  }): Promise<Result<readonly SubscriptionRecord[], StoreError>> {
+    const all = await listAllRecords()
+    if (all.success === false) {
+      return err(all.error)
+    }
+    return ok(all.data.filter(r => r.operatorId === args.operatorId && r.active === true))
+  }
+
+  // -------------------------------------------------------------------------
+  // markDead
+  // -------------------------------------------------------------------------
+
+  async function markDead(args: {readonly endpoint: string}): Promise<Result<void, StoreError>> {
+    const cas = requireCasCapable()
+    if (cas.success === false) {
+      return err(cas.error)
+    }
+
+    const endpointHash = hashEndpoint(args.endpoint)
+    const maxAttempts = 5
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const existing = await readRecord(endpointHash)
+      if (existing.success === false) {
+        return err(existing.error)
+      }
+      if (existing.data === null) {
+        return ok(undefined) // Already gone — nothing to mark.
+      }
+
+      const {record: current, etag} = existing.data
+      if (current.active === false) {
+        return ok(undefined) // Already inactive — no-op.
+      }
+
+      const nextRecord: SubscriptionRecord = {
+        ...current,
+        active: false,
+        updatedAt: clock(),
+        deactivatedAt: clock(),
+        inactiveReason: 'dead',
+      }
+      const write = await cas.data.conditionalPut(buildKey(endpointHash), JSON.stringify(nextRecord), {
+        ifMatch: etag,
+      })
+      if (write.success === false) {
+        if (isPreconditionFailed(write.error)) {
+          continue
+        }
+        return err(createStoreError(write.error.message))
+      }
+      return ok(undefined)
+    }
+    return err(createStoreError('markDead: exceeded max CAS retry attempts'))
+  }
+
+  // -------------------------------------------------------------------------
+  // pruneInactive
+  // -------------------------------------------------------------------------
+
+  async function pruneInactive(args?: {
+    readonly recordsOlderThanMs?: number
+    readonly tombstonesOlderThanMs?: number
+  }): Promise<Result<PruneResult, StoreError>> {
+    const cas = requireCasCapable()
+    if (cas.success === false) {
+      return err(cas.error)
+    }
+
+    const recordsThreshold = args?.recordsOlderThanMs ?? inactiveRetentionMs
+    const tombstonesThreshold = args?.tombstonesOlderThanMs ?? tombstoneRetentionMs
+    const now = clock()
+
+    // --- prune inactive subscription records ---
+    const keys = await listAllKeys()
+    if (keys.success === false) {
+      return err(keys.error)
+    }
+
+    let prunedRecords = 0
+    for (const key of keys.data) {
+      const fetched = await cas.data.getObject(key)
+      if (fetched.success === false) {
+        if (isNotFound(fetched.error)) continue
+        return err(createStoreError(fetched.error.message))
+      }
+      const parsed = parseSubscriptionRecord(fetched.data.data)
+      if (parsed.success === false) continue
+
+      const record = parsed.data
+      // Only ever remove already-inactive records — never resurrects anything.
+      if (record.active === true) continue
+      const deactivatedAt = record.deactivatedAt ?? record.updatedAt
+      if (now - deactivatedAt < recordsThreshold) continue
+
+      const deleted = await cas.data.conditionalDelete(key, {ifMatch: fetched.data.etag})
+      if (deleted.success === false) {
+        if (isPreconditionFailed(deleted.error) || isNotFound(deleted.error)) {
+          continue // Changed/removed concurrently — skip, not an error.
+        }
+        return err(createStoreError(deleted.error.message))
+      }
+      prunedRecords += 1
+    }
+
+    // --- prune expired tombstones ---
+    // MUST NOT run before tombstonesThreshold has elapsed since deletion —
+    // removing a tombstone too early re-exposes the window in which an
+    // older backup restore of the (already-removed) subscription object
+    // could resurrect it with no tombstone left to exclude it.
+    const tombstoneKeys = await adapter.list(`${tombstonePrefix}/`)
+    if (tombstoneKeys.success === false) {
+      return err(createStoreError(tombstoneKeys.error.message))
+    }
+
+    let prunedTombstones = 0
+    for (const key of tombstoneKeys.data) {
+      const fetched = await cas.data.getObject(key)
+      if (fetched.success === false) {
+        if (isNotFound(fetched.error)) continue
+        return err(createStoreError(fetched.error.message))
+      }
+      let tombstone: TombstoneRecord
+      try {
+        const parsed: unknown = JSON.parse(fetched.data.data)
+        if (
+          typeof parsed !== 'object' ||
+          parsed == null ||
+          typeof (parsed as Partial<TombstoneRecord>).deletedAt !== 'number'
+        ) {
+          continue
+        }
+        tombstone = parsed as TombstoneRecord
+      } catch {
+        continue
+      }
+
+      if (now - tombstone.deletedAt < tombstonesThreshold) continue
+
+      const deleted = await cas.data.conditionalDelete(key, {ifMatch: fetched.data.etag})
+      if (deleted.success === false) {
+        if (isPreconditionFailed(deleted.error) || isNotFound(deleted.error)) {
+          continue
+        }
+        return err(createStoreError(deleted.error.message))
+      }
+      prunedTombstones += 1
+    }
+
+    return ok({records: prunedRecords, tombstones: prunedTombstones})
+  }
+
+  // -------------------------------------------------------------------------
+  // verifyStillOwned
+  // -------------------------------------------------------------------------
+
+  async function verifyStillOwned(args: {
+    readonly endpointHash: string
+    readonly operatorId: string
+    readonly ownershipGeneration: number
+  }): Promise<Result<boolean, StoreError>> {
+    const tombstoned = await hasTombstone(args.endpointHash)
+    if (tombstoned.success === false) {
+      return err(tombstoned.error)
+    }
+    if (tombstoned.data) {
+      return ok(false)
+    }
+
+    const existing = await readRecord(args.endpointHash)
+    if (existing.success === false) {
+      return err(existing.error)
+    }
+    if (existing.data === null) {
+      return ok(false)
+    }
+    const {record} = existing.data
+    return ok(
+      record.active === true &&
+        record.operatorId === args.operatorId &&
+        record.ownershipGeneration === args.ownershipGeneration,
+    )
+  }
+
+  // -------------------------------------------------------------------------
+  // selfTestCas
+  // -------------------------------------------------------------------------
+
+  async function selfTestCas(): Promise<Result<void, StoreError | SelfTestCasFailure>> {
+    if (adapter.conditionalPut == null || adapter.conditionalDelete == null || adapter.getObject == null) {
+      return err(
+        createSelfTestCasFailure(
+          'Object store adapter does not support conditionalPut/conditionalDelete/getObject — cannot verify CAS',
+        ),
+      )
+    }
+
+    const testKey = `${keyPrefix}/_self-test/${randomUUID()}.json`
+
+    try {
+      // Race two ifNoneMatch creates against the same key. A real CAS backend
+      // must let exactly one succeed and fail the other with a precondition
+      // conflict; a last-write-wins backend lets both "succeed".
+      const [first, second] = await Promise.all([
+        adapter.conditionalPut(testKey, JSON.stringify({attempt: 1}), {ifNoneMatch: '*'}),
+        adapter.conditionalPut(testKey, JSON.stringify({attempt: 2}), {ifNoneMatch: '*'}),
+      ])
+
+      const successes = [first, second].filter(r => r.success === true)
+      const failures = [first, second].filter(r => r.success === false)
+
+      if (successes.length !== 1 || failures.length !== 1) {
+        return err(
+          createSelfTestCasFailure(
+            `Object store failed the contended-write self-test: expected exactly one winner and one conflict, got ${successes.length} winner(s) and ${failures.length} conflict(s) — the store does not provide real compare-and-swap`,
+          ),
+        )
+      }
+
+      const failure = failures[0]
+      if (failure !== undefined && failure.success === false && isPreconditionFailed(failure.error) === false) {
+        return err(
+          createSelfTestCasFailure(
+            `Object store contended-write self-test failed for an unexpected reason (not a precondition conflict): ${failure.error.message}`,
+          ),
+        )
+      }
+
+      return ok(undefined)
+    } finally {
+      // Best-effort cleanup — read current etag then delete; ignore failures
+      // (a leftover self-test key does not affect the active dispatch set).
+      const cleanupRead = await adapter.getObject(testKey)
+      if (cleanupRead.success === true) {
+        try {
+          await adapter.conditionalDelete(testKey, {ifMatch: cleanupRead.data.etag})
+        } catch (error) {
+          logger.debug({error, testKey}, 'operator push subscription store: self-test cleanup delete threw')
+        }
+      }
+    }
+  }
+
+  return {
+    subscribe,
+    unsubscribe,
+    deactivateForOperator,
+    deleteForOperator,
+    listMetadataForOperator,
+    getActiveRecordsForOperator,
+    markDead,
+    pruneInactive,
+    verifyStillOwned,
+    selfTestCas,
+  }
+}

--- a/packages/gateway/src/web/operator-push/subscription-store.ts
+++ b/packages/gateway/src/web/operator-push/subscription-store.ts
@@ -688,6 +688,8 @@ export function createOperatorPushSubscriptionStore(
       return err(cas.error)
     }
 
+    // Scans the physical object set directly — deliberately NOT tombstone-filtered
+    // like listAllRecords, since a session revoke acts on whatever object currently exists.
     const keys = await listAllKeys()
     if (keys.success === false) {
       return err(keys.error)
@@ -790,6 +792,8 @@ export function createOperatorPushSubscriptionStore(
       return err(cas.error)
     }
 
+    // Scans the physical object set directly — deliberately NOT tombstone-filtered
+    // like listAllRecords, since a privacy delete must act on the object regardless of tombstone state.
     const keys = await listAllKeys()
     if (keys.success === false) {
       return err(keys.error)
@@ -852,12 +856,25 @@ export function createOperatorPushSubscriptionStore(
         'operator push subscription store: deleteForOperator lost the physical-delete CAS race — secrets remain on disk pending a later prune or transfer',
       )
 
-      // Step 4 — rollback the tombstone if the record no longer belongs to
-      // this operator, so we don't shadow a legitimately transferred record.
+      // Step 4 — invariant: a tombstone must exist iff the endpoint has no
+      // active record for any operator. The physical delete above lost its
+      // race, meaning the record was mutated between the read and the
+      // delete — by a transfer to a different operator, OR by the SAME
+      // operator concurrently re-subscribing (refresh path). Either way, if
+      // the record is now active, the tombstone we just wrote would wrongly
+      // shadow a legitimately-active record until the next prune or
+      // subscribe self-heals it — so roll it back regardless of who owns
+      // it. Only leave the tombstone in place when the re-read shows the
+      // record inactive or absent, which is the correct excluded state.
+      // A crash between this re-read and the rollback delete leaves a
+      // transient shadow over an active record — the same window that
+      // already exists between steps 2 and 3, self-healed by the next
+      // subscribe's tombstone-clear or by pruneInactive; no worse than the
+      // pre-existing ordering.
       const reread = await cas.data.getObject(key)
       if (reread.success === true) {
         const reparsed = parseSubscriptionRecord(reread.data.data)
-        if (reparsed.success === true && reparsed.data.operatorId !== args.operatorId) {
+        if (reparsed.success === true && reparsed.data.active === true) {
           // Re-fetch the tombstone's current etag rather than trusting the
           // step-2 write result — a concurrent prune could have raced it too.
           const currentTombstone = await cas.data.getObject(tombstoneKey)
@@ -868,7 +885,7 @@ export function createOperatorPushSubscriptionStore(
             if (tombstoneRollback.success === false && isNotFound(tombstoneRollback.error) === false) {
               logger.warn(
                 {key, tombstoneKey, error: tombstoneRollback.error.message},
-                'operator push subscription store: failed to roll back tombstone after a lost delete race against a transferred record',
+                'operator push subscription store: failed to roll back tombstone after a lost delete race against an active record',
               )
             }
           }
@@ -975,6 +992,8 @@ export function createOperatorPushSubscriptionStore(
     const now = clock()
 
     // --- prune inactive subscription records ---
+    // Scans the physical object set directly — deliberately NOT tombstone-filtered
+    // like listAllRecords, since pruning must inspect the object's own lifecycle state.
     const keys = await listAllKeys()
     if (keys.success === false) {
       return err(keys.error)

--- a/packages/gateway/src/web/operator-push/subscription-store.ts
+++ b/packages/gateway/src/web/operator-push/subscription-store.ts
@@ -69,7 +69,7 @@
  * subscription.
  */
 
-import type {ObjectStoreAdapter, Result} from '@fro-bot/runtime'
+import type {ObjectStoreAdapter, ObjectStoreOperationError, Result} from '@fro-bot/runtime'
 
 import {createHash, randomUUID} from 'node:crypto'
 import {err, ok} from '@fro-bot/runtime'
@@ -223,9 +223,24 @@ export interface PruneResult {
 export interface OperatorPushSubscriptionStore {
   subscribe: (input: SubscribeInput) => Promise<Result<SubscriptionMetadata, StoreError>>
   unsubscribe: (args: {readonly operatorId: string; readonly endpoint: string}) => Promise<Result<void, StoreError>>
-  deactivateForOperator: (args: {readonly operatorId: string}) => Promise<Result<number, StoreError>>
-  /** Privacy delete: tombstones then physically removes every record owned by `operatorId`. */
-  deleteForOperator: (args: {readonly operatorId: string}) => Promise<Result<number, StoreError>>
+  /**
+   * Marks every active record owned by `operatorId` inactive (session-revoke).
+   * `skipped` counts records whose CAS retry loop was exhausted by concurrent
+   * writers — those records were NOT updated and remain in their prior state.
+   */
+  deactivateForOperator: (args: {
+    readonly operatorId: string
+  }) => Promise<Result<{readonly updated: number; readonly skipped: number}, StoreError>>
+  /**
+   * Privacy delete: tombstones then physically removes every record owned by
+   * `operatorId`. `skipped` counts records whose physical removal could not
+   * be completed (e.g. a concurrent transfer) — for those, the tombstone
+   * still excludes them from reads, but their secrets may remain on disk
+   * until a later `pruneInactive` or transfer removes the stale object.
+   */
+  deleteForOperator: (args: {
+    readonly operatorId: string
+  }) => Promise<Result<{readonly deleted: number; readonly skipped: number}, StoreError>>
   listMetadataForOperator: (args: {
     readonly operatorId: string
   }) => Promise<Result<readonly SubscriptionMetadata[], StoreError>>
@@ -233,7 +248,7 @@ export interface OperatorPushSubscriptionStore {
   getActiveRecordsForOperator: (args: {
     readonly operatorId: string
   }) => Promise<Result<readonly SubscriptionRecord[], StoreError>>
-  markDead: (args: {readonly endpoint: string}) => Promise<Result<void, StoreError>>
+  markDead: (args: {readonly operatorId: string; readonly endpoint: string}) => Promise<Result<void, StoreError>>
   /** Prunes inactive subscription records and expired tombstones past their respective retention windows. */
   pruneInactive: (args?: {
     readonly recordsOlderThanMs?: number
@@ -263,6 +278,10 @@ export interface OperatorPushSubscriptionStore {
 
 const DEFAULT_KEY_PREFIX = 'operator-push/subscriptions/by-endpoint'
 const DEFAULT_TOMBSTONE_PREFIX = 'operator-push/tombstones'
+// A sibling of the subscription and tombstone prefixes — never swept by
+// listAllKeys(`${keyPrefix}/`) or the tombstone listing, so leftover
+// self-test keys are never scanned, getObject'd, or warned about.
+const SELF_TEST_PREFIX = 'operator-push/_self-test'
 const DEFAULT_INACTIVE_RETENTION_MS = 30 * 24 * 60 * 60 * 1000
 const DEFAULT_TOMBSTONE_RETENTION_MS = 90 * 24 * 60 * 60 * 1000
 
@@ -274,11 +293,24 @@ function hashEndpoint(endpoint: string): string {
   return createHash('sha256').update(endpoint, 'utf8').digest('hex')
 }
 
+// Structured-error-first classification, mirroring the pattern in
+// packages/runtime/src/coordination/lock.ts: check the S3-adapter's
+// structured ObjectStoreOperationError fields (httpStatusCode / errorCode /
+// errorName) before falling back to message-substring matching, which is
+// only reliable for plain-Error adapters (e.g. the test fakes).
 function isPreconditionFailed(error: Error): boolean {
+  const e = error as Partial<ObjectStoreOperationError>
+  if (e.httpStatusCode !== undefined) return e.httpStatusCode === 412
+  const code = e.errorCode ?? e.errorName
+  if (code !== undefined) return code === 'PreconditionFailed'
   return /pre-?condition/i.test(error.message)
 }
 
 function isNotFound(error: Error): boolean {
+  const e = error as Partial<ObjectStoreOperationError>
+  if (e.httpStatusCode !== undefined) return e.httpStatusCode === 404
+  const code = e.errorCode ?? e.errorName
+  if (code !== undefined) return code === 'NoSuchKey' || code === 'NotFound'
   return /not.?found|no.?such.?key|does.?not.?exist|404/i.test(error.message)
 }
 
@@ -622,11 +654,12 @@ export function createOperatorPushSubscriptionStore(
         return err(createStoreError('unsubscribe: endpoint is not owned by this operator'))
       }
 
+      const now = clock()
       const nextRecord: SubscriptionRecord = {
         ...current,
         active: false,
-        updatedAt: clock(),
-        deactivatedAt: clock(),
+        updatedAt: now,
+        deactivatedAt: now,
         inactiveReason: 'unsubscribed',
       }
       const write = await cas.data.conditionalPut(buildKey(endpointHash), JSON.stringify(nextRecord), {
@@ -647,7 +680,9 @@ export function createOperatorPushSubscriptionStore(
   // deactivateForOperator (session-revoke — unchanged, no tombstones)
   // -------------------------------------------------------------------------
 
-  async function deactivateForOperator(args: {readonly operatorId: string}): Promise<Result<number, StoreError>> {
+  async function deactivateForOperator(args: {
+    readonly operatorId: string
+  }): Promise<Result<{readonly updated: number; readonly skipped: number}, StoreError>> {
     const cas = requireCasCapable()
     if (cas.success === false) {
       return err(cas.error)
@@ -658,20 +693,31 @@ export function createOperatorPushSubscriptionStore(
       return err(keys.error)
     }
 
-    let count = 0
+    let updated = 0
+    let skipped = 0
     for (const key of keys.data) {
       const maxAttempts = 5
+      let settled = false
       for (let attempt = 0; attempt < maxAttempts; attempt++) {
         const fetched = await cas.data.getObject(key)
         if (fetched.success === false) {
-          if (isNotFound(fetched.error)) break
+          if (isNotFound(fetched.error)) {
+            settled = true
+            break
+          }
           return err(createStoreError(fetched.error.message))
         }
         const parsed = parseSubscriptionRecord(fetched.data.data)
-        if (parsed.success === false) break // corrupted — skip
+        if (parsed.success === false) {
+          settled = true
+          break // corrupted — skip
+        }
 
         const record = parsed.data
-        if (record.operatorId !== args.operatorId || record.active === false) break
+        if (record.operatorId !== args.operatorId || record.active === false) {
+          settled = true
+          break
+        }
 
         const now = clock()
         const nextRecord: SubscriptionRecord = {
@@ -686,18 +732,59 @@ export function createOperatorPushSubscriptionStore(
           if (isPreconditionFailed(write.error)) continue // retry
           return err(createStoreError(write.error.message))
         }
-        count += 1
+        updated += 1
+        settled = true
         break
       }
+      if (settled === false) {
+        skipped += 1
+        logger.warn(
+          {key, operatorId: args.operatorId},
+          'operator push subscription store: deactivateForOperator CAS retry exhausted for key — record not updated',
+        )
+      }
     }
-    return ok(count)
+    return ok({updated, skipped})
   }
 
   // -------------------------------------------------------------------------
   // deleteForOperator (privacy delete — tombstone-first, then physical removal)
   // -------------------------------------------------------------------------
 
-  async function deleteForOperator(args: {readonly operatorId: string}): Promise<Result<number, StoreError>> {
+  /**
+   * Privacy delete for one operator's records.
+   *
+   * Ordering (tombstone-first, then physical removal, with a compensating
+   * tombstone rollback on a lost race) is deliberate:
+   *
+   *   1. Read the record + its etag (already owner-checked here).
+   *   2. Write the tombstone (ifNoneMatch:'*', idempotent on conflict).
+   *      A crash between steps 1-2 and step 3 leaves the record physically
+   *      present but the tombstone already excludes it from every active-read
+   *      path — the failure mode fails SAFE toward privacy, never toward
+   *      "looks deleted but isn't".
+   *   3. Physically delete the subscription object with `ifMatch` bound to
+   *      the etag read in step 1. If this delete loses the CAS race
+   *      (PreconditionFailed) — meaning the record was mutated since the
+   *      read, most plausibly transferred to a different operator by a
+   *      concurrent `subscribe` — the delete is NOT retried and the record
+   *      is NOT counted as deleted. The secrets remain on disk (a
+   *      `pruneInactive` pass or a future transfer will eventually clear
+   *      the stale object), and this is logged as a warning so partial
+   *      physical removal is observable.
+   *   4. Because the tombstone from step 2 would otherwise permanently
+   *      exclude an endpoint that might now legitimately belong to someone
+   *      else, a lost race additionally triggers a best-effort rollback:
+   *      re-read the current record, and if it is no longer owned by
+   *      `args.operatorId`, delete the tombstone so the new owner's
+   *      subscription is not shadowed. If the tombstone rollback itself
+   *      fails, that failure is logged and swallowed — the tombstone stays,
+   *      which fails toward excluding a record rather than exposing one
+   *      that might still be this operator's.
+   */
+  async function deleteForOperator(args: {
+    readonly operatorId: string
+  }): Promise<Result<{readonly deleted: number; readonly skipped: number}, StoreError>> {
     const cas = requireCasCapable()
     if (cas.success === false) {
       return err(cas.error)
@@ -708,7 +795,8 @@ export function createOperatorPushSubscriptionStore(
       return err(keys.error)
     }
 
-    let count = 0
+    let deleted = 0
+    let skipped = 0
     for (const key of keys.data) {
       const fetched = await cas.data.getObject(key)
       if (fetched.success === false) {
@@ -729,11 +817,7 @@ export function createOperatorPushSubscriptionStore(
         deletedAt: now,
       }
 
-      // Step 1 — tombstone FIRST. Required ordering: if the process crashes
-      // after this write but before the physical delete below, the record
-      // is still on disk but the tombstone already excludes it from every
-      // active-read path — the failure mode fails safe toward privacy
-      // (still-visible-as-deleted), never toward "looks deleted but isn't".
+      // Step 2 — tombstone FIRST (see function docstring for the full ordering rationale).
       const tombstoneWrite = await cas.data.conditionalPut(tombstoneKey, JSON.stringify(tombstone), {
         ifNoneMatch: '*',
       })
@@ -744,20 +828,54 @@ export function createOperatorPushSubscriptionStore(
       // endpointHash — treat as idempotent success and continue to the
       // physical delete below.
 
-      // Step 2 — physically remove the subscription object, dropping the
-      // secrets (endpoint/p256dh/auth) from disk entirely.
-      const deleted = await cas.data.conditionalDelete(key, {ifMatch: fetched.data.etag})
-      if (
-        deleted.success === false &&
-        isPreconditionFailed(deleted.error) === false &&
-        isNotFound(deleted.error) === false
-      ) {
-        return err(createStoreError(deleted.error.message))
+      // Step 3 — physically remove the subscription object, bound to the
+      // etag read above, so a concurrent mutation (e.g. an ownership
+      // transfer) loses the delete rather than silently clobbering it.
+      const objectDelete = await cas.data.conditionalDelete(key, {ifMatch: fetched.data.etag})
+      if (objectDelete.success === true || isNotFound(objectDelete.error)) {
+        // Physical removal succeeded, or the object was already gone —
+        // either way the secrets are off disk. Count as deleted.
+        deleted += 1
+        continue
       }
 
-      count += 1
+      if (isPreconditionFailed(objectDelete.error) === false) {
+        return err(createStoreError(objectDelete.error.message))
+      }
+
+      // Lost the CAS race — the record changed since the read (most
+      // plausibly a concurrent transfer). Do NOT count this as deleted: the
+      // secrets are still on disk under whatever the current object holds.
+      skipped += 1
+      logger.warn(
+        {key, operatorId: args.operatorId},
+        'operator push subscription store: deleteForOperator lost the physical-delete CAS race — secrets remain on disk pending a later prune or transfer',
+      )
+
+      // Step 4 — rollback the tombstone if the record no longer belongs to
+      // this operator, so we don't shadow a legitimately transferred record.
+      const reread = await cas.data.getObject(key)
+      if (reread.success === true) {
+        const reparsed = parseSubscriptionRecord(reread.data.data)
+        if (reparsed.success === true && reparsed.data.operatorId !== args.operatorId) {
+          // Re-fetch the tombstone's current etag rather than trusting the
+          // step-2 write result — a concurrent prune could have raced it too.
+          const currentTombstone = await cas.data.getObject(tombstoneKey)
+          if (currentTombstone.success === true) {
+            const tombstoneRollback = await cas.data.conditionalDelete(tombstoneKey, {
+              ifMatch: currentTombstone.data.etag,
+            })
+            if (tombstoneRollback.success === false && isNotFound(tombstoneRollback.error) === false) {
+              logger.warn(
+                {key, tombstoneKey, error: tombstoneRollback.error.message},
+                'operator push subscription store: failed to roll back tombstone after a lost delete race against a transferred record',
+              )
+            }
+          }
+        }
+      }
     }
-    return ok(count)
+    return ok({deleted, skipped})
   }
 
   // -------------------------------------------------------------------------
@@ -788,7 +906,10 @@ export function createOperatorPushSubscriptionStore(
   // markDead
   // -------------------------------------------------------------------------
 
-  async function markDead(args: {readonly endpoint: string}): Promise<Result<void, StoreError>> {
+  async function markDead(args: {
+    readonly operatorId: string
+    readonly endpoint: string
+  }): Promise<Result<void, StoreError>> {
     const cas = requireCasCapable()
     if (cas.success === false) {
       return err(cas.error)
@@ -806,15 +927,20 @@ export function createOperatorPushSubscriptionStore(
       }
 
       const {record: current, etag} = existing.data
+      if (current.operatorId !== args.operatorId) {
+        // Fail closed — a different operator cannot deactivate someone else's record.
+        return err(createStoreError('markDead: endpoint is not owned by this operator'))
+      }
       if (current.active === false) {
         return ok(undefined) // Already inactive — no-op.
       }
 
+      const now = clock()
       const nextRecord: SubscriptionRecord = {
         ...current,
         active: false,
-        updatedAt: clock(),
-        deactivatedAt: clock(),
+        updatedAt: now,
+        deactivatedAt: now,
         inactiveReason: 'dead',
       }
       const write = await cas.data.conditionalPut(buildKey(endpointHash), JSON.stringify(nextRecord), {
@@ -972,7 +1098,7 @@ export function createOperatorPushSubscriptionStore(
       )
     }
 
-    const testKey = `${keyPrefix}/_self-test/${randomUUID()}.json`
+    const testKey = `${SELF_TEST_PREFIX}/${randomUUID()}.json`
 
     try {
       // Race two ifNoneMatch creates against the same key. A real CAS backend


### PR DESCRIPTION
Adds the Gateway-owned durable store for operator Web Push subscriptions — the second slice of the push feature (server counterpart to fro-bot/dashboard#108). Still **disabled by default**: no routes, no dispatch, no `web-push` dependency yet. This is the persistence and lifecycle core.

## What it stores

One durable record per browser push endpoint, bound to one operator. The push `endpoint`, `p256dh`, and `auth` are **write-only secret fields**: persisted in the record but never returned by any listing or export surface — a single explicit metadata projection is the only path non-dispatch callers get data out, and it lists safe fields by name rather than spreading the record.

## Security properties

- **Cross-account isolation.** Every owner-scoped operation (unsubscribe, deactivate, delete, mark-dead) verifies the record owner and fails closed otherwise.
- **Atomic ownership transfer.** When a different operator subscribes an endpoint already bound to someone else (a shared device), a single compare-and-swap reassigns the owner and bumps a monotonic ownership generation. The dispatch path re-validates ownership immediately before sending, so a stale read can never deliver one operator's notification to another.
- **Durable privacy delete.** Deleting writes a secret-free tombstone at a separate key and physically removes the subscription object; the active-read path excludes any tombstoned endpoint, so restoring a subscription object alone cannot resurrect a deleted record. Delete reports skipped records if a concurrent transfer wins the race, and rolls back its own tombstone rather than shadowing a record that legitimately moved to another operator.
- **Fail-closed on a weak backend.** A startup compare-and-swap self-test proves the configured store has real conditional-write semantics; a last-write-wins store fails the push surface closed.

## Scope

The authenticated routes, the fail-soft dispatch path, and the hooks into approval/run/session events follow in subsequent PRs. Plan: `docs/plans/2026-07-08-002-feat-operator-push-gateway-plan.md`.
