### PR TITLE
ci: update CI workflow dependencies and required status checks

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -34,12 +34,14 @@ branches:
           - Build
           - CodeQL
           - Dependency Review
+          - Gateway Image Smoke Test
           - Lint
           - Release
           - Test
           - Test GitHub Action
           - Setup
           - Renovate / Renovate
+          - Workspace Image Smoke Test
       restrictions: null
 
   - name: v0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,7 +128,7 @@ jobs:
 
   test:
     name: Test
-    needs: [setup, build]
+    needs: [setup]
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -736,7 +736,7 @@ jobs:
       DRY_RUN: ${{ github.ref_name != github.event.repository.default_branch }}
       RELEASE_BRANCH: release
     name: Release
-    needs: [setup, lint, test, build]
+    needs: [lint, test, build]
     outputs:
       commit: ${{ steps.merge.outputs.commit }}
       version: ${{ steps.release-preview.outputs.next_version }}


### PR DESCRIPTION
- Added 'Gateway Image Smoke Test' and 'Workspace Image Smoke Test' to the list of required status checks.
- Modified 'Test' job to only depend on 'setup'.
- Adjusted 'Release' job dependencies to include only 'lint', 'test', and 'build'.