### PR TITLE
feat(gateway): authenticated operator push routes behind a fail-closed self-test

### DIFF
--- a/packages/gateway/src/http/ingress-pin.test.ts
+++ b/packages/gateway/src/http/ingress-pin.test.ts
@@ -125,6 +125,10 @@ const EXPECTED_OPERATOR_ROUTES_WITH_BROWSER_GUARD: readonly {method: string; pat
   {method: 'POST', path: '/operator/runs/:runId/approvals/:requestId/decision'},
   {method: 'POST', path: '/operator/runs/:runId/cancel'},
   {method: 'GET', path: '/operator/runs/:runId/approvals'},
+  {method: 'GET', path: '/operator/push/vapid-key'},
+  {method: 'POST', path: '/operator/push/subscriptions'},
+  {method: 'POST', path: '/operator/push/subscriptions/unsubscribe'},
+  {method: 'GET', path: '/operator/push/subscriptions'},
 ]
 
 // ---------------------------------------------------------------------------
@@ -281,6 +285,28 @@ function makeBrowserGuardStubDeps(): OperatorServerDeps {
     },
     // Provide cancelRunDeps so the cancel route is registered in the pinned inventory.
     cancelRunDeps: {} as unknown as OperatorServerDeps['cancelRunDeps'],
+    // Provide operatorPushStore/operatorPushVapidKeyInfo so the push routes are
+    // registered in the pinned inventory.
+    operatorPushStore: {
+      subscribe: vi.fn(async () => ({
+        success: true as const,
+        data: {
+          endpointHash: 'stub-hash',
+          operatorId: 'stub-operator',
+          active: true,
+          keyVersion: '1',
+          ownershipGeneration: 1,
+          createdAt: 0,
+          updatedAt: 0,
+        },
+      })),
+      unsubscribe: vi.fn(async () => ({success: true as const, data: undefined})),
+      listMetadataForOperator: vi.fn(async () => ({success: true as const, data: []})),
+    },
+    operatorPushVapidKeyInfo: {
+      publicKey: 'BOb1EqJOpvFSxr2XOPIr82Ktdxl6AibGOAiPmrkjbsv0mpr9In09mLbskqVAgLPIDjb0UIb7mZpU0SJKWWsVazc',
+      keyVersion: '1',
+    },
   }
 }
 

--- a/packages/gateway/src/operator-contract/index.ts
+++ b/packages/gateway/src/operator-contract/index.ts
@@ -26,6 +26,7 @@ export {
   parseOperatorError,
   parseOperatorOk,
   parseOperatorPushSubscribeRequest,
+  parseOperatorPushUnsubscribeRequest,
   parseOperatorPushVapidKeyResponse,
   parseOperatorSessionInfo,
 } from './parse.js'

--- a/packages/gateway/src/operator-contract/parse.test.ts
+++ b/packages/gateway/src/operator-contract/parse.test.ts
@@ -23,6 +23,7 @@ import {
   parseOperatorError,
   parseOperatorOk,
   parseOperatorPushSubscribeRequest,
+  parseOperatorPushUnsubscribeRequest,
   parseOperatorPushVapidKeyResponse,
   parseOperatorSessionInfo,
 } from './parse.js'
@@ -650,5 +651,56 @@ describe('parseOperatorPushSubscribeRequest — error paths', () => {
       keys: {p256dh: 'p256dh-key-value', auth: ''},
     }
     expect(parseOperatorPushSubscribeRequest(input).success).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseOperatorPushUnsubscribeRequest — happy path
+// ---------------------------------------------------------------------------
+
+describe('parseOperatorPushUnsubscribeRequest — happy path', () => {
+  it('returns ok(value) for a valid {endpoint} payload', () => {
+    // #given
+    const input = {endpoint: 'https://push.example.com/subscription/abc123'}
+
+    // #when
+    const result = parseOperatorPushUnsubscribeRequest(input)
+
+    // #then
+    expect(result.success).toBe(true)
+    expect(result.success && result.data).toEqual(input)
+  })
+
+  it('ignores extra fields (permissive structural subtyping)', () => {
+    // #given
+    const input = {endpoint: 'https://push.example.com/subscription/abc123', extra: 'field'}
+
+    // #when
+    const result = parseOperatorPushUnsubscribeRequest(input)
+
+    // #then
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('parseOperatorPushUnsubscribeRequest — error paths', () => {
+  it('returns err for null input', () => {
+    expect(parseOperatorPushUnsubscribeRequest(null).success).toBe(false)
+  })
+
+  it('returns err for array input', () => {
+    expect(parseOperatorPushUnsubscribeRequest([]).success).toBe(false)
+  })
+
+  it('returns err when endpoint is missing', () => {
+    expect(parseOperatorPushUnsubscribeRequest({}).success).toBe(false)
+  })
+
+  it('returns err when endpoint is non-string', () => {
+    expect(parseOperatorPushUnsubscribeRequest({endpoint: 42}).success).toBe(false)
+  })
+
+  it('returns err when endpoint is an empty string', () => {
+    expect(parseOperatorPushUnsubscribeRequest({endpoint: ''}).success).toBe(false)
   })
 })

--- a/packages/gateway/src/operator-contract/parse.ts
+++ b/packages/gateway/src/operator-contract/parse.ts
@@ -22,6 +22,7 @@ import type {
   OperatorError,
   OperatorOk,
   OperatorPushSubscribeRequest,
+  OperatorPushUnsubscribeRequest,
   OperatorPushVapidKeyResponse,
   OperatorSessionInfo,
 } from './responses.js'
@@ -252,6 +253,38 @@ function hasValidOperatorPushSubscribeRequestShape(value: unknown): value is Ope
 export function parseOperatorPushSubscribeRequest(input: unknown): Result<OperatorPushSubscribeRequest, Error> {
   if (hasValidOperatorPushSubscribeRequestShape(input) === false) {
     return err(new Error('invalid operator push subscribe request shape'))
+  }
+
+  return ok(input)
+}
+
+// ---------------------------------------------------------------------------
+// OperatorPushUnsubscribeRequest
+// ---------------------------------------------------------------------------
+//
+// Accepts `{endpoint}` — the same shape the browser's push subscription
+// endpoint is registered under.
+
+function hasValidOperatorPushUnsubscribeRequestShape(value: unknown): value is OperatorPushUnsubscribeRequest {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const candidate = value as Record<string, unknown>
+  return typeof candidate.endpoint === 'string' && candidate.endpoint.length > 0
+}
+
+/**
+ * Parse an unknown value as OperatorPushUnsubscribeRequest.
+ *
+ * Accepts only `{endpoint: string}` with a non-empty endpoint. Returns
+ * err(Error) with a FIXED reason string when validation fails — the error
+ * message never echoes any part of the input (the endpoint must never
+ * appear in a parse error).
+ */
+export function parseOperatorPushUnsubscribeRequest(input: unknown): Result<OperatorPushUnsubscribeRequest, Error> {
+  if (hasValidOperatorPushUnsubscribeRequestShape(input) === false) {
+    return err(new Error('invalid operator push unsubscribe request shape'))
   }
 
   return ok(input)

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -86,6 +86,34 @@ vi.mock('./redaction/denylist.js', async importOriginal => {
   }
 })
 
+// Mockable seam for the operator push self-test gate. Each test controls
+// selfTestCasMock's resolved/rejected value to exercise the CAS self-test
+// success, Result-typed-failure, and throw branches independently of the
+// real object-store adapter.
+const selfTestCasMock = vi.fn(
+  async (): Promise<
+    {readonly success: true; readonly data: undefined} | {readonly success: false; readonly error: Error}
+  > => ({success: true, data: undefined}) as const,
+)
+vi.mock('./web/operator-push/subscription-store.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./web/operator-push/subscription-store.js')>()
+  return {
+    ...actual,
+    createOperatorPushSubscriptionStore: vi.fn(() => ({
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      deactivateForOperator: vi.fn(),
+      deleteForOperator: vi.fn(),
+      listMetadataForOperator: vi.fn(),
+      getActiveRecordsForOperator: vi.fn(),
+      markDead: vi.fn(),
+      pruneInactive: vi.fn(),
+      verifyStillOwned: vi.fn(),
+      selfTestCas: selfTestCasMock,
+    })),
+  }
+})
+
 const {makeDiscordClientFromConfig, makeGatewayProgram} = await import('./program.js')
 const {createDiscordClient} = await import('./discord/client.js')
 const createDiscordClientSpy = vi.mocked(createDiscordClient)
@@ -178,6 +206,20 @@ function makeFakeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
       httpPort: 3000,
     },
     ...overrides,
+  }
+}
+
+/** Full operatorPush config block for tests — includes all required VAPID fields. */
+function makeOperatorPushConfig(): NonNullable<GatewayConfig['operatorPush']> {
+  return {
+    current: {
+      publicKey: 'test-public-key',
+      privateKey: 'test-private-key',
+      subject: 'mailto:test@example.com',
+      keyVersion: 'v1',
+    },
+    vapidPublicKeyInfo: {publicKey: 'test-public-key', keyVersion: 'v1'},
+    dedupeWindowMs: 300_000,
   }
 }
 
@@ -1056,6 +1098,144 @@ describe('button interaction handler (approval flow)', () => {
 
     // #then — operator server was never started
     expect(startOperatorServerSpy).not.toHaveBeenCalled()
+  })
+
+  it('operator push self-test success: push deps are present in the operator server inputs', async () => {
+    // #given — operatorWeb and operatorPush are both configured, self-test succeeds
+    selfTestCasMock.mockResolvedValueOnce({success: true, data: undefined})
+    const fakeConfig = makeFakeConfig({
+      announce: undefined,
+      operatorWeb: makeOperatorWebConfig(),
+      operatorPush: makeOperatorPushConfig(),
+    })
+    const fakeClient = makeFakeClient()
+    const startOperatorServerSpy = vi.fn().mockReturnValue(makeFakeServerHandle())
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: startOperatorServerSpy,
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    // #when
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then — push deps present, no disabled-push warning
+    const [serverDeps] = startOperatorServerSpy.mock.calls[0] as [
+      import('./web/server.js').OperatorServerDeps,
+      import('./web/server.js').OperatorServerConfig,
+    ]
+    expect(serverDeps.operatorPushStore).toBeDefined()
+    expect(serverDeps.operatorPushVapidKeyInfo).toBeDefined()
+    const warnedPushDisabled = consoleWarnSpy.mock.calls.some(([line]) =>
+      String(line).includes('operator push disabled'),
+    )
+    expect(warnedPushDisabled).toBe(false)
+    consoleWarnSpy.mockRestore()
+  })
+
+  it('operator push self-test failure (Result err): push omitted, warn logged, gateway still starts', async () => {
+    // #given — self-test resolves a failed Result (not a throw)
+    selfTestCasMock.mockResolvedValueOnce({
+      success: false,
+      error: Object.assign(new Error('cas contended-write self-test failed'), {
+        code: 'OPERATOR_PUSH_SELF_TEST_CAS_FAILURE' as const,
+      }),
+    })
+    const fakeConfig = makeFakeConfig({
+      announce: undefined,
+      operatorWeb: makeOperatorWebConfig(),
+      operatorPush: makeOperatorPushConfig(),
+    })
+    const fakeClient = makeFakeClient()
+    const startOperatorServerSpy = vi.fn().mockReturnValue(makeFakeServerHandle())
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: startOperatorServerSpy,
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    // #when — the program still completes (gateway starts)
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then — push omitted, operator server still started
+    expect(startOperatorServerSpy).toHaveBeenCalledOnce()
+    const [serverDeps] = startOperatorServerSpy.mock.calls[0] as [
+      import('./web/server.js').OperatorServerDeps,
+      import('./web/server.js').OperatorServerConfig,
+    ]
+    expect(serverDeps.operatorPushStore).toBeUndefined()
+  })
+
+  it('operator push self-test throws: degrades to the same push-omitted graceful path as a Result failure', async () => {
+    // #given — the adapter throws instead of returning a failed Result
+    selfTestCasMock.mockRejectedValueOnce(new Error('adapter connection refused'))
+    const fakeConfig = makeFakeConfig({
+      announce: undefined,
+      operatorWeb: makeOperatorWebConfig(),
+      operatorPush: makeOperatorPushConfig(),
+    })
+    const fakeClient = makeFakeClient()
+    const startOperatorServerSpy = vi.fn().mockReturnValue(makeFakeServerHandle())
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: startOperatorServerSpy,
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    // #when — the throw must NOT propagate as an unrecoverable defect; the
+    // gateway must still start (Discord + operator web), just without push.
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then
+    expect(startOperatorServerSpy).toHaveBeenCalledOnce()
+    const [serverDeps] = startOperatorServerSpy.mock.calls[0] as [
+      import('./web/server.js').OperatorServerDeps,
+      import('./web/server.js').OperatorServerConfig,
+    ]
+    expect(serverDeps.operatorPushStore).toBeUndefined()
+  })
+
+  it('operator push absent from config: push omitted, self-test never called', async () => {
+    // #given — no operatorPush block in config
+    const fakeConfig = makeFakeConfig({
+      announce: undefined,
+      operatorWeb: makeOperatorWebConfig(),
+    })
+    const fakeClient = makeFakeClient()
+    const startOperatorServerSpy = vi.fn().mockReturnValue(makeFakeServerHandle())
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: startOperatorServerSpy,
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    // #when
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then
+    expect(selfTestCasMock).not.toHaveBeenCalled()
+    const [serverDeps] = startOperatorServerSpy.mock.calls[0] as [
+      import('./web/server.js').OperatorServerDeps,
+      import('./web/server.js').OperatorServerConfig,
+    ]
+    expect(serverDeps.operatorPushStore).toBeUndefined()
   })
 
   it('composite close closes both announce and operator handles', async () => {

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -10,6 +10,8 @@ import type {AnnounceServerConfig, AnnounceServerDeps} from './http/server.js'
 import type {CoordinationLogger} from './runtime-effect.js'
 import type {CloseableServer} from './shutdown.js'
 import type {OperatorAllowlist} from './web/auth/allowlist.js'
+import type {OperatorPushSubscriptionStore} from './web/operator-push/subscription-store.js'
+import type {VapidPublicKeyInfo} from './web/operator-push/vapid.js'
 import type {OperatorServerConfig, OperatorServerDeps} from './web/server.js'
 import {
   createS3Adapter,
@@ -42,6 +44,7 @@ import {forceReleaseStaleLockEffect} from './runtime-effect.js'
 import {DEFAULT_DRAIN_MS, installShutdownHandlers, isShuttingDown} from './shutdown.js'
 import {buildGitHubOAuthDeps} from './web/auth/github.js'
 import {createInMemorySessionStore} from './web/auth/session.js'
+import {createOperatorPushSubscriptionStore} from './web/operator-push/subscription-store.js'
 import {createRunObservationManager} from './web/sse/manager.js'
 import {projectRunObservation} from './web/sse/projection.js'
 import {createWorkspaceClient} from './workspace-api/client.js'
@@ -155,6 +158,15 @@ export interface BuildOperatorServerInputs {
    * a missing dep and verify the launch route is absent.
    */
   readonly launchWorkDeps?: NonNullable<OperatorServerDeps['launchWorkDeps']>
+  /**
+   * Operator push subscription deps — threaded through only when push is
+   * enabled AND the object store passed its startup CAS self-test. When
+   * absent, the /operator/push/* routes are not registered (fail-closed).
+   */
+  readonly operatorPush?: {
+    readonly store: NonNullable<OperatorServerDeps['operatorPushStore']>
+    readonly vapidPublicKeyInfo: VapidPublicKeyInfo
+  }
   readonly operatorWebConfig: {
     readonly bindHost: string
     readonly bindPort: number
@@ -199,6 +211,7 @@ export function buildOperatorServerInputs(inputs: BuildOperatorServerInputs): {
     approvalRegistry,
     cancelRunDeps,
     launchWorkDeps,
+    operatorPush,
     operatorWebConfig,
   } = inputs
 
@@ -268,6 +281,11 @@ export function buildOperatorServerInputs(inputs: BuildOperatorServerInputs): {
     runIndex,
     approvalRegistry,
     cancelRunDeps,
+    // operatorPushStore/operatorPushVapidKeyInfo: server.ts gates the
+    // /operator/push/* routes on both being present. Threaded only when the
+    // caller passed operatorPush (push enabled + self-test passed upstream).
+    operatorPushStore: operatorPush?.store,
+    operatorPushVapidKeyInfo: operatorPush?.vapidPublicKeyInfo,
   }
 
   const config: OperatorServerConfig = {
@@ -667,6 +685,32 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
     if (config.operatorWeb === undefined || deps.startOperatorServer === undefined) {
       logger.info({}, 'operator web endpoint disabled — no operator web config set')
     } else {
+      // Operator push — opt-in via config.operatorPush (presence means enabled).
+      // Before threading push deps into the operator server, prove the configured
+      // object store has real compare-and-swap semantics by running the
+      // subscription store's startup self-test. A self-test failure does NOT
+      // crash gateway startup — it only disables the push surface (the rest of
+      // the operator server still starts) so a misconfigured/incompatible object
+      // store can never silently corrupt subscription ownership transfers.
+      let operatorPush:
+        | {
+            readonly store: OperatorPushSubscriptionStore
+            readonly vapidPublicKeyInfo: VapidPublicKeyInfo
+          }
+        | undefined
+      if (config.operatorPush !== undefined) {
+        const pushStore = createOperatorPushSubscriptionStore({
+          adapter: s3Adapter,
+          logger,
+        })
+        const selfTest = yield* Effect.promise(async () => pushStore.selfTestCas())
+        if (selfTest.success === true) {
+          operatorPush = {store: pushStore, vapidPublicKeyInfo: config.operatorPush.vapidPublicKeyInfo}
+        } else {
+          logger.warn({err: selfTest.error.message}, 'operator push disabled — object store failed CAS self-test')
+        }
+      }
+
       // Build the operator server deps and config via the shared helper.
       // The helper constructs operator-local pieces (rate limiter, session store,
       // OAuth deps, getSourceKey) and wires the program-scoped instances.
@@ -692,6 +736,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           runObserver: runObservationManager,
         },
         launchWorkDeps: runEngineDeps,
+        operatorPush,
         operatorWebConfig: config.operatorWeb,
       })
 

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_LOCK_TTL_SECONDS,
   DEFAULT_PENDING_STALE_THRESHOLD_MS,
   DEFAULT_STALE_THRESHOLD_MS,
+  err,
 } from '@fro-bot/runtime'
 import {getConnInfo} from '@hono/node-server/conninfo'
 import {Effect} from 'effect'
@@ -703,7 +704,15 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
           adapter: s3Adapter,
           logger,
         })
-        const selfTest = yield* Effect.promise(async () => pushStore.selfTestCas())
+        // Effect.tryPromise (not Effect.promise) so a throwing adapter — not
+        // just a Result-typed failure — is caught here and degrades to
+        // "push disabled" rather than becoming an unrecoverable defect that
+        // crashes the whole gateway (Discord + operator web + announce)
+        // at startup.
+        const selfTest = yield* Effect.tryPromise({
+          try: async () => pushStore.selfTestCas(),
+          catch: error => (error instanceof Error ? error : new Error(String(error))),
+        }).pipe(Effect.catchAll(error => Effect.succeed(err(error))))
         if (selfTest.success === true) {
           operatorPush = {store: pushStore, vapidPublicKeyInfo: config.operatorPush.vapidPublicKeyInfo}
         } else {

--- a/packages/gateway/src/web/operator-push/subscription-route.test.ts
+++ b/packages/gateway/src/web/operator-push/subscription-route.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for the authenticated operator push subscription routes:
+ *   - POST /operator/push/subscriptions
+ *   - POST /operator/push/subscriptions/unsubscribe
+ *   - GET  /operator/push/subscriptions
+ *
+ * All tests go through the REAL HTTP route (with the operator route guard
+ * installed) — not a handler-only or store-only call.
+ */
+
+import type {SubscriptionRouteDeps} from './subscription-route.js'
+import type {SubscriptionMetadata} from './subscription-store.js'
+import {err, ok} from '@fro-bot/runtime'
+import {Hono} from 'hono'
+import {describe, expect, it, vi} from 'vitest'
+import {createRateLimiter} from '../../http/rate-limit.js'
+import {setOperatorRouteGuard} from '../operator-route.js'
+import {buildSubscriptionRoutes} from './subscription-route.js'
+import {createStoreError} from './subscription-store.js'
+
+const VALID_ENDPOINT = 'https://fcm.googleapis.com/fcm/send/abc123'
+const OPERATOR_A_ID = '1001'
+
+function makeMetadata(overrides?: Partial<SubscriptionMetadata>): SubscriptionMetadata {
+  return {
+    endpointHash: 'hash-1',
+    operatorId: OPERATOR_A_ID,
+    active: true,
+    keyVersion: '1',
+    ownershipGeneration: 1,
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  }
+}
+
+function makeStore(overrides?: Partial<SubscriptionRouteDeps['store']>): SubscriptionRouteDeps['store'] {
+  return {
+    subscribe: vi.fn(async () => ok(makeMetadata())),
+    unsubscribe: vi.fn(async () => ok(undefined)),
+    listMetadataForOperator: vi.fn(async () => ok([makeMetadata()])),
+    ...overrides,
+  }
+}
+
+function makeSessionStore(): SubscriptionRouteDeps['sessionStore'] {
+  return {
+    get: vi.fn((_sessionId: string, _nowMs: number) => ({githubUserId: 1001, login: 'alice'})),
+  }
+}
+
+function makeDeps(overrides?: Partial<SubscriptionRouteDeps>): SubscriptionRouteDeps {
+  return {
+    sessionStore: makeSessionStore(),
+    store: makeStore(),
+    keyVersion: '1',
+    logger: {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()},
+    now: () => 1000,
+    subscribeRateLimiter: createRateLimiter({limit: 1000, windowMs: 60_000}),
+    unsubscribeRateLimiter: createRateLimiter({limit: 1000, windowMs: 60_000}),
+    ...overrides,
+  }
+}
+
+function buildAppWithGuard(deps: SubscriptionRouteDeps, allow = true): Hono {
+  const app = new Hono()
+  setOperatorRouteGuard(app, async () =>
+    allow
+      ? {ok: true, githubUserId: 1001, sessionId: 'sess-1'}
+      : {ok: false, response: new Response(null, {status: 404})},
+  )
+  buildSubscriptionRoutes(app, deps)
+  return app
+}
+
+describe('buildSubscriptionRoutes — subscribe', () => {
+  // #given a valid CSRF/body subscribe request
+  // #when POST /operator/push/subscriptions
+  // #then creates/replaces one record; response is safe metadata only
+  it('happy path: subscribes and returns safe metadata only', async () => {
+    const store = makeStore()
+    const deps = makeDeps({store})
+    const app = buildAppWithGuard(deps)
+
+    const res = await app.request('/operator/push/subscriptions', {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({endpoint: VALID_ENDPOINT, keys: {p256dh: 'p1', auth: 'a1'}}),
+    })
+
+    expect(res.status).toBe(200)
+    expect(store.subscribe).toHaveBeenCalledWith({
+      operatorId: OPERATOR_A_ID,
+      endpoint: VALID_ENDPOINT,
+      p256dh: 'p1',
+      auth: 'a1',
+      keyVersion: '1',
+    })
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.endpoint).toBeUndefined()
+    expect(body.p256dh).toBeUndefined()
+    expect(body.auth).toBeUndefined()
+    expect(body.endpointHash).toBe('hash-1')
+  })
+
+  // #given no authenticated session
+  // #when POST /operator/push/subscriptions
+  // #then notFoundResponse, no store write
+  it('error path: unauthenticated request is denied with no store write', async () => {
+    const store = makeStore()
+    const deps = makeDeps({store})
+    const app = buildAppWithGuard(deps, false)
+
+    const res = await app.request('/operator/push/subscriptions', {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({endpoint: VALID_ENDPOINT, keys: {p256dh: 'p1', auth: 'a1'}}),
+    })
+
+    expect(res.status).toBe(404)
+    expect(store.subscribe).not.toHaveBeenCalled()
+  })
+
+  // #given a malformed body (missing keys)
+  // #when POST /operator/push/subscriptions
+  // #then 400, no store write, endpoint never logged
+  it('error path: malformed body is rejected with 400 and no store write', async () => {
+    const store = makeStore()
+    const warn = vi.fn()
+    const deps = makeDeps({store, logger: {debug: vi.fn(), info: vi.fn(), warn, error: vi.fn()}})
+    const app = buildAppWithGuard(deps)
+
+    const res = await app.request('/operator/push/subscriptions', {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({endpoint: VALID_ENDPOINT}),
+    })
+
+    expect(res.status).toBe(400)
+    expect(store.subscribe).not.toHaveBeenCalled()
+    for (const call of warn.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain(VALID_ENDPOINT)
+    }
+  })
+
+  // #given an endpoint that fails SSRF validation (loopback)
+  // #when POST /operator/push/subscriptions
+  // #then 400, endpoint value never logged
+  it('error path: loopback endpoint is rejected without logging the endpoint value', async () => {
+    const store = makeStore()
+    const warn = vi.fn()
+    const deps = makeDeps({store, logger: {debug: vi.fn(), info: vi.fn(), warn, error: vi.fn()}})
+    const app = buildAppWithGuard(deps)
+    const loopbackEndpoint = 'https://127.0.0.1/secret-path'
+
+    const res = await app.request('/operator/push/subscriptions', {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({endpoint: loopbackEndpoint, keys: {p256dh: 'p1', auth: 'a1'}}),
+    })
+
+    expect(res.status).toBe(400)
+    expect(store.subscribe).not.toHaveBeenCalled()
+    for (const call of warn.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain('secret-path')
+    }
+  })
+
+  // #given the subscribe rate limit is exhausted
+  // #when POST /operator/push/subscriptions
+  // #then rate-limited response, no store write
+  it('rate limit: exhausted operator-keyed limit denies the request', async () => {
+    const store = makeStore()
+    const limiter = createRateLimiter({limit: 1, windowMs: 60_000})
+    const deps = makeDeps({store, subscribeRateLimiter: limiter})
+    const app = buildAppWithGuard(deps)
+
+    const requestOptions = {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({endpoint: VALID_ENDPOINT, keys: {p256dh: 'p1', auth: 'a1'}}),
+    }
+    // First request consumes the single-request budget.
+    await app.request('/operator/push/subscriptions', requestOptions)
+    const res = await app.request('/operator/push/subscriptions', requestOptions)
+
+    expect(res.status).toBe(429)
+    expect(store.subscribe).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('buildSubscriptionRoutes — unsubscribe', () => {
+  // #given an authenticated operator's own subscription
+  // #when POST /operator/push/subscriptions/unsubscribe
+  // #then marks the record inactive
+  it("happy path: unsubscribes the operator's own record", async () => {
+    const store = makeStore()
+    const deps = makeDeps({store})
+    const app = buildAppWithGuard(deps)
+
+    const res = await app.request('/operator/push/subscriptions/unsubscribe', {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({endpoint: VALID_ENDPOINT}),
+    })
+
+    expect(res.status).toBe(200)
+    expect(store.unsubscribe).toHaveBeenCalledWith({operatorId: OPERATOR_A_ID, endpoint: VALID_ENDPOINT})
+  })
+
+  // #given another operator's record (store fails-closed)
+  // #when POST /operator/push/subscriptions/unsubscribe
+  // #then a safe denial is surfaced, no distinguishing detail
+  it("error path: cannot unsubscribe another operator's record — surfaces a safe denial", async () => {
+    const store = makeStore({
+      unsubscribe: vi.fn(async () => err(createStoreError('unsubscribe: endpoint is not owned by this operator'))),
+    })
+    const deps = makeDeps({store})
+    const app = buildAppWithGuard(deps)
+
+    const res = await app.request('/operator/push/subscriptions/unsubscribe', {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({endpoint: VALID_ENDPOINT}),
+    })
+
+    expect(res.status).toBe(404)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.error).toBe('not-found')
+  })
+
+  // #given malformed body (missing endpoint)
+  // #when POST /operator/push/subscriptions/unsubscribe
+  // #then 400, no store write
+  it('error path: malformed body is rejected with 400', async () => {
+    const store = makeStore()
+    const deps = makeDeps({store})
+    const app = buildAppWithGuard(deps)
+
+    const res = await app.request('/operator/push/subscriptions/unsubscribe', {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({}),
+    })
+
+    expect(res.status).toBe(400)
+    expect(store.unsubscribe).not.toHaveBeenCalled()
+  })
+})
+
+describe('buildSubscriptionRoutes — list', () => {
+  // #given an authenticated operator with active subscriptions
+  // #when GET /operator/push/subscriptions
+  // #then returns safe metadata array only
+  it('happy path: returns safe metadata array', async () => {
+    const store = makeStore()
+    const deps = makeDeps({store})
+    const app = buildAppWithGuard(deps)
+
+    const res = await app.request('/operator/push/subscriptions')
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {subscriptions: Record<string, unknown>[]}
+    expect(body.subscriptions).toHaveLength(1)
+    expect(body.subscriptions[0]?.endpointHash).toBe('hash-1')
+    expect(body.subscriptions[0]?.endpoint).toBeUndefined()
+  })
+
+  // #given no authenticated session
+  // #when GET /operator/push/subscriptions
+  // #then notFoundResponse
+  it('error path: unauthenticated request is denied', async () => {
+    const store = makeStore()
+    const deps = makeDeps({store})
+    const app = buildAppWithGuard(deps, false)
+
+    const res = await app.request('/operator/push/subscriptions')
+
+    expect(res.status).toBe(404)
+    expect(store.listMetadataForOperator).not.toHaveBeenCalled()
+  })
+})

--- a/packages/gateway/src/web/operator-push/subscription-route.test.ts
+++ b/packages/gateway/src/web/operator-push/subscription-route.test.ts
@@ -277,6 +277,44 @@ describe('buildSubscriptionRoutes — subscribe', () => {
     expect(res.status).toBe(200)
     expect(store.subscribe).toHaveBeenCalledOnce()
   })
+
+  // #given the operator is one below the cap, and two concurrent requests
+  // subscribe two DISTINCT new endpoints at the same time
+  // #when both POST /operator/push/subscriptions fire concurrently
+  // #then both succeed — this is the expected, documented soft-bound
+  // behavior (the cap read is not atomic with the write), not a bug; the
+  // per-operator rate limit is what actually bounds the overrun
+  it('subscription cap is soft: two concurrent subscribes for distinct new endpoints at cap-1 can both succeed', async () => {
+    const activeJustUnderCap = Array.from({length: 19}, (_v, i) =>
+      makeMetadata({endpointHash: `hash-${i}`, active: true}),
+    )
+    const store = makeStore({listMetadataForOperator: vi.fn(async () => ok(activeJustUnderCap))})
+    const deps = makeDeps({store})
+    const app = buildAppWithGuard(deps)
+
+    const [resA, resB] = await Promise.all([
+      app.request('/operator/push/subscriptions', {
+        method: 'POST',
+        headers: {'content-type': 'application/json'},
+        body: JSON.stringify({
+          endpoint: 'https://fcm.googleapis.com/fcm/send/concurrent-a',
+          keys: {p256dh: 'p1', auth: 'a1'},
+        }),
+      }),
+      app.request('/operator/push/subscriptions', {
+        method: 'POST',
+        headers: {'content-type': 'application/json'},
+        body: JSON.stringify({
+          endpoint: 'https://fcm.googleapis.com/fcm/send/concurrent-b',
+          keys: {p256dh: 'p2', auth: 'a2'},
+        }),
+      }),
+    ])
+
+    expect(resA.status).toBe(200)
+    expect(resB.status).toBe(200)
+    expect(store.subscribe).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe('buildSubscriptionRoutes — unsubscribe', () => {
@@ -386,5 +424,26 @@ describe('buildSubscriptionRoutes — list', () => {
 
     expect(res.status).toBe(404)
     expect(store.listMetadataForOperator).not.toHaveBeenCalled()
+  })
+
+  // #given a record the store marked inactive with the internal-only
+  // 'transferred' reason (ownership moved to a different operator)
+  // #when GET /operator/push/subscriptions
+  // #then the response carries the coarse public 'revoked' reason — never
+  // omitted, and never the literal 'transferred' string
+  it('maps a transferred record to the coarse public "revoked" reason, not an omitted reason', async () => {
+    const store = makeStore({
+      listMetadataForOperator: vi.fn(async () => ok([makeMetadata({active: false, inactiveReason: 'transferred'})])),
+    })
+    const deps = makeDeps({store})
+    const app = buildAppWithGuard(deps)
+
+    const res = await app.request('/operator/push/subscriptions')
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {subscriptions: Record<string, unknown>[]}
+    expect(body.subscriptions[0]?.active).toBe(false)
+    expect(body.subscriptions[0]?.inactiveReason).toBe('revoked')
+    expect(JSON.stringify(body)).not.toContain('transferred')
   })
 })

--- a/packages/gateway/src/web/operator-push/subscription-route.test.ts
+++ b/packages/gateway/src/web/operator-push/subscription-route.test.ts
@@ -187,6 +187,96 @@ describe('buildSubscriptionRoutes — subscribe', () => {
     expect(res.status).toBe(429)
     expect(store.subscribe).toHaveBeenCalledTimes(1)
   })
+
+  // #given the store rejects the write (e.g. underlying object-store error)
+  // #when POST /operator/push/subscriptions
+  // #then a safe denial is surfaced, no distinguishing detail
+  it('error path: a store write failure surfaces a safe denial without leaking the endpoint', async () => {
+    const store = makeStore({
+      subscribe: vi.fn(async () => err(createStoreError('subscribe: exceeded max CAS retry attempts'))),
+    })
+    const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+    const deps = makeDeps({store, logger})
+    const app = buildAppWithGuard(deps)
+
+    const res = await app.request('/operator/push/subscriptions', {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({endpoint: VALID_ENDPOINT, keys: {p256dh: 'p1', auth: 'a1'}}),
+    })
+
+    expect(res.status).toBe(404)
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body.error).toBe('not-found')
+    for (const level of ['debug', 'info', 'warn', 'error'] as const) {
+      for (const call of logger[level].mock.calls) {
+        expect(JSON.stringify(call)).not.toContain(VALID_ENDPOINT)
+      }
+    }
+  })
+
+  // #given the operator already has the cap's worth of active subscriptions,
+  // none of which is the incoming endpoint
+  // #when POST /operator/push/subscriptions
+  // #then 400, store.subscribe is never called
+  it('subscription cap: a new endpoint at the cap is rejected without a store write', async () => {
+    const activeAtCap = Array.from({length: 20}, (_v, i) => makeMetadata({endpointHash: `hash-${i}`, active: true}))
+    const store = makeStore({listMetadataForOperator: vi.fn(async () => ok(activeAtCap))})
+    const deps = makeDeps({store})
+    const app = buildAppWithGuard(deps)
+
+    const res = await app.request('/operator/push/subscriptions', {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({endpoint: VALID_ENDPOINT, keys: {p256dh: 'p1', auth: 'a1'}}),
+    })
+
+    expect(res.status).toBe(400)
+    expect(store.subscribe).not.toHaveBeenCalled()
+  })
+
+  // #given the operator is at the cap but the incoming endpoint is already
+  // one of their active records (a replace, not a new record)
+  // #when POST /operator/push/subscriptions
+  // #then the cap does not block it — store.subscribe is called
+  it('subscription cap: a re-subscribe of an existing endpoint at the cap is allowed', async () => {
+    const {createHash} = await import('node:crypto')
+    const endpointHash = createHash('sha256').update(VALID_ENDPOINT, 'utf8').digest('hex')
+    const activeAtCap = [
+      makeMetadata({endpointHash, active: true}),
+      ...Array.from({length: 19}, (_v, i) => makeMetadata({endpointHash: `hash-${i}`, active: true})),
+    ]
+    const store = makeStore({listMetadataForOperator: vi.fn(async () => ok(activeAtCap))})
+    const deps = makeDeps({store})
+    const app = buildAppWithGuard(deps)
+
+    const res = await app.request('/operator/push/subscriptions', {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({endpoint: VALID_ENDPOINT, keys: {p256dh: 'p1', auth: 'a1'}}),
+    })
+
+    expect(res.status).toBe(200)
+    expect(store.subscribe).toHaveBeenCalledOnce()
+  })
+
+  // #given the operator is well under the cap
+  // #when POST /operator/push/subscriptions
+  // #then the write proceeds normally
+  it('subscription cap: under the cap, subscribe proceeds normally', async () => {
+    const store = makeStore({listMetadataForOperator: vi.fn(async () => ok([makeMetadata()]))})
+    const deps = makeDeps({store})
+    const app = buildAppWithGuard(deps)
+
+    const res = await app.request('/operator/push/subscriptions', {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({endpoint: VALID_ENDPOINT, keys: {p256dh: 'p1', auth: 'a1'}}),
+    })
+
+    expect(res.status).toBe(200)
+    expect(store.subscribe).toHaveBeenCalledOnce()
+  })
 })
 
 describe('buildSubscriptionRoutes — unsubscribe', () => {
@@ -244,6 +334,24 @@ describe('buildSubscriptionRoutes — unsubscribe', () => {
     })
 
     expect(res.status).toBe(400)
+    expect(store.unsubscribe).not.toHaveBeenCalled()
+  })
+
+  // #given no authenticated session
+  // #when POST /operator/push/subscriptions/unsubscribe
+  // #then notFoundResponse, no store write
+  it('error path: unauthenticated request is denied with no store write', async () => {
+    const store = makeStore()
+    const deps = makeDeps({store})
+    const app = buildAppWithGuard(deps, false)
+
+    const res = await app.request('/operator/push/subscriptions/unsubscribe', {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({endpoint: VALID_ENDPOINT}),
+    })
+
+    expect(res.status).toBe(404)
     expect(store.unsubscribe).not.toHaveBeenCalled()
   })
 })

--- a/packages/gateway/src/web/operator-push/subscription-route.ts
+++ b/packages/gateway/src/web/operator-push/subscription-route.ts
@@ -40,9 +40,10 @@ import type {
 import type {OperatorLogger} from '../server.js'
 import type {OperatorPushSubscriptionStore, SubscriptionMetadata} from './subscription-store.js'
 import {createRateLimiter} from '../../http/rate-limit.js'
-import {parseOperatorPushSubscribeRequest} from '../../operator-contract/index.js'
+import {parseOperatorPushSubscribeRequest, parseOperatorPushUnsubscribeRequest} from '../../operator-contract/index.js'
 import {getOperatorAuthContext, registerOperatorRoute} from '../operator-route.js'
 import {notFoundResponse, rateLimitedResponse} from '../safe-response.js'
+import {hashEndpoint} from './subscription-store.js'
 import {validateEndpointUrl} from './validate-endpoint.js'
 
 // ---------------------------------------------------------------------------
@@ -56,6 +57,14 @@ const SUBSCRIBE_RATE_WINDOW_MS = 60_000
 /** Per-operator unsubscribe rate limit: 10 requests per minute. */
 const UNSUBSCRIBE_RATE_LIMIT_PER_MIN = 10
 const UNSUBSCRIBE_RATE_WINDOW_MS = 60_000
+
+/**
+ * Fail-closed cap on active subscription records per operator, bounding
+ * store and dispatch-fanout growth from a single operator's browsers. A
+ * re-subscribe of an endpoint the operator already owns is a replace, not a
+ * new record, so it is exempt from this cap.
+ */
+const MAX_ACTIVE_SUBSCRIPTIONS_PER_OPERATOR = 20
 
 // ---------------------------------------------------------------------------
 // Types
@@ -85,22 +94,6 @@ export interface SubscriptionRouteDeps {
   readonly subscribeRateLimiter?: RateLimiter
   /** Optional injectable per-minute rate limiter for unsubscribe (operator-keyed). */
   readonly unsubscribeRateLimiter?: RateLimiter
-}
-
-// ---------------------------------------------------------------------------
-// Body parsing helpers
-// ---------------------------------------------------------------------------
-
-/** Parse and validate the unsubscribe request body: {endpoint: string}. */
-function parseUnsubscribeBody(body: unknown): {readonly endpoint: string} | null {
-  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
-    return null
-  }
-  const candidate = body as Record<string, unknown>
-  if (typeof candidate.endpoint !== 'string' || candidate.endpoint.length === 0) {
-    return null
-  }
-  return {endpoint: candidate.endpoint}
 }
 
 /** Map full SubscriptionMetadata (store shape) to the contract-safe response shape. */
@@ -203,6 +196,23 @@ export function buildSubscriptionRoutes(app: Hono, deps: SubscriptionRouteDeps):
 
     // ── Gate 7: Call the store ───────────────────────────────────────────────
     try {
+      // Fail-closed active-subscription cap: block a NEW endpoint once the
+      // operator is already at the cap, but never block a re-subscribe of an
+      // endpoint they already own — that write replaces the existing record
+      // rather than growing the active set.
+      const existingMetadata = await deps.store.listMetadataForOperator({operatorId})
+      if (existingMetadata.success === false) {
+        deps.logger.warn({githubUserId, gate: 'store-error'}, 'push-subscribe: store write failed')
+        return notFoundResponse(c)
+      }
+      const activeRecords = existingMetadata.data.filter(m => m.active === true)
+      const endpointHash = hashEndpoint(parsed.data.endpoint)
+      const isExistingEndpoint = activeRecords.some(m => m.endpointHash === endpointHash)
+      if (isExistingEndpoint === false && activeRecords.length >= MAX_ACTIVE_SUBSCRIPTIONS_PER_OPERATOR) {
+        deps.logger.warn({githubUserId, gate: 'subscription-cap'}, 'push-subscribe: subscription cap')
+        return c.json({error: 'bad request'}, 400)
+      }
+
       const result = await deps.store.subscribe({
         operatorId,
         endpoint: parsed.data.endpoint,
@@ -253,8 +263,8 @@ export function buildSubscriptionRoutes(app: Hono, deps: SubscriptionRouteDeps):
       return c.json({error: 'bad request'}, 400)
     }
 
-    const parsed = parseUnsubscribeBody(body)
-    if (parsed === null) {
+    const parsed = parseOperatorPushUnsubscribeRequest(body)
+    if (parsed.success === false) {
       deps.logger.warn({githubUserId, gate: 'bad-body'}, 'push-unsubscribe: denied — invalid request shape')
       return c.json({error: 'bad request'}, 400)
     }
@@ -264,7 +274,7 @@ export function buildSubscriptionRoutes(app: Hono, deps: SubscriptionRouteDeps):
     // a different operator; that denial and an unknown endpoint (idempotent
     // no-op success) both surface identically here to avoid leaking ownership.
     try {
-      const result = await deps.store.unsubscribe({operatorId, endpoint: parsed.endpoint})
+      const result = await deps.store.unsubscribe({operatorId, endpoint: parsed.data.endpoint})
       if (result.success === false) {
         deps.logger.warn({githubUserId, gate: 'store-error'}, 'push-unsubscribe: denied')
         return notFoundResponse(c)

--- a/packages/gateway/src/web/operator-push/subscription-route.ts
+++ b/packages/gateway/src/web/operator-push/subscription-route.ts
@@ -1,0 +1,315 @@
+/**
+ * Authenticated operator push subscription routes:
+ *   - POST /operator/push/subscriptions            — subscribe
+ *   - POST /operator/push/subscriptions/unsubscribe — unsubscribe
+ *   - GET  /operator/push/subscriptions             — list metadata
+ *
+ * Wires the browser's W3C `PushSubscription.toJSON()` payload to the durable
+ * subscription store (web/operator-push/subscription-store.ts). Every
+ * response returns only safe metadata — the endpoint URL and P-256/auth keys
+ * are write-only and never echoed back or logged.
+ *
+ * Gate ordering (subscribe/unsubscribe — mirrors launch-route.ts):
+ *   1. Guard (browser/session/allowlist/CSRF) — installed by buildOperatorApp
+ *   2. Read authenticated context set by the guard — undefined → notFoundResponse
+ *   3. Resolve operator identity (githubUserId) from authCtx
+ *   4. Operator-keyed rate limit (write routes only)
+ *   5. Parse + validate request body
+ *   6. Endpoint URL validation (SSRF-conservative — subscribe only)
+ *   7. Call the store
+ *   8. Map result → safe JSON
+ *
+ * List (GET) skips gates 4–6 (no body, no mutation, no endpoint to validate).
+ *
+ * Security invariants:
+ *   - Every denial (gates 2–4) returns the identical no-oracle notFoundResponse,
+ *     mirroring launch-route. Malformed body / bad endpoint → 400 (mirrors
+ *     launch-route's body-validation convention).
+ *   - A gate throw degrades to the same denial, never a distinguishable 500.
+ *   - The endpoint value is NEVER included in a response, log line, or thrown
+ *     error — only coarse gate names and rejection classes.
+ *   - CSRF/Origin middleware covers the two POST routes (write routes).
+ */
+
+import type {Hono} from 'hono'
+import type {RateLimiter} from '../../http/rate-limit.js'
+import type {
+  OperatorPushSubscriptionListResponse,
+  OperatorPushSubscriptionMetadata,
+} from '../../operator-contract/index.js'
+import type {OperatorLogger} from '../server.js'
+import type {OperatorPushSubscriptionStore, SubscriptionMetadata} from './subscription-store.js'
+import {createRateLimiter} from '../../http/rate-limit.js'
+import {parseOperatorPushSubscribeRequest} from '../../operator-contract/index.js'
+import {getOperatorAuthContext, registerOperatorRoute} from '../operator-route.js'
+import {notFoundResponse, rateLimitedResponse} from '../safe-response.js'
+import {validateEndpointUrl} from './validate-endpoint.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Per-operator subscribe rate limit: 10 requests per minute. */
+const SUBSCRIBE_RATE_LIMIT_PER_MIN = 10
+const SUBSCRIBE_RATE_WINDOW_MS = 60_000
+
+/** Per-operator unsubscribe rate limit: 10 requests per minute. */
+const UNSUBSCRIBE_RATE_LIMIT_PER_MIN = 10
+const UNSUBSCRIBE_RATE_WINDOW_MS = 60_000
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Minimal session store interface required by the push subscription routes. */
+export interface SubscriptionRouteSessionStore {
+  readonly get: (
+    sessionId: string,
+    nowMs: number,
+  ) => {readonly githubUserId: number; readonly login: string} | undefined
+}
+
+/** Dependencies for the push subscription routes. */
+export interface SubscriptionRouteDeps {
+  /** Session store for identity resolution. */
+  readonly sessionStore: SubscriptionRouteSessionStore
+  /** Durable subscription-record store. */
+  readonly store: Pick<OperatorPushSubscriptionStore, 'subscribe' | 'unsubscribe' | 'listMetadataForOperator'>
+  /** Current VAPID key version — stamped onto every subscribe call. */
+  readonly keyVersion: string
+  /** Structured logger. */
+  readonly logger: OperatorLogger
+  /** Injectable clock. */
+  readonly now: () => number
+  /** Optional injectable per-minute rate limiter for subscribe (operator-keyed). */
+  readonly subscribeRateLimiter?: RateLimiter
+  /** Optional injectable per-minute rate limiter for unsubscribe (operator-keyed). */
+  readonly unsubscribeRateLimiter?: RateLimiter
+}
+
+// ---------------------------------------------------------------------------
+// Body parsing helpers
+// ---------------------------------------------------------------------------
+
+/** Parse and validate the unsubscribe request body: {endpoint: string}. */
+function parseUnsubscribeBody(body: unknown): {readonly endpoint: string} | null {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    return null
+  }
+  const candidate = body as Record<string, unknown>
+  if (typeof candidate.endpoint !== 'string' || candidate.endpoint.length === 0) {
+    return null
+  }
+  return {endpoint: candidate.endpoint}
+}
+
+/** Map full SubscriptionMetadata (store shape) to the contract-safe response shape. */
+function toResponseMetadata(metadata: SubscriptionMetadata): OperatorPushSubscriptionMetadata {
+  const base: OperatorPushSubscriptionMetadata = {
+    endpointHash: metadata.endpointHash,
+    createdAt: metadata.createdAt,
+    updatedAt: metadata.updatedAt,
+    keyVersion: metadata.keyVersion,
+    active: metadata.active,
+  }
+  if (metadata.inactiveReason === undefined) {
+    return base
+  }
+  // The store's inactive-reason taxonomy is a superset ('transferred') of the
+  // contract's public taxonomy — 'transferred' is an internal-only reason and
+  // is intentionally omitted from the response rather than mapped.
+  if (
+    metadata.inactiveReason === 'unsubscribed' ||
+    metadata.inactiveReason === 'dead' ||
+    metadata.inactiveReason === 'key_revoked' ||
+    metadata.inactiveReason === 'session-revoked'
+  ) {
+    const mapped = metadata.inactiveReason === 'key_revoked' ? 'revoked' : metadata.inactiveReason
+    return {...base, inactiveReason: mapped}
+  }
+  return base
+}
+
+// ---------------------------------------------------------------------------
+// Route builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Register the three push subscription routes on the given Hono app.
+ *
+ * Must be called after setOperatorRouteGuard is installed in buildOperatorApp.
+ * The guard runs first (browser/session/allowlist/CSRF); each handler runs
+ * only if the guard allows the request.
+ */
+export function buildSubscriptionRoutes(app: Hono, deps: SubscriptionRouteDeps): void {
+  const subscribeLimiter =
+    deps.subscribeRateLimiter ??
+    createRateLimiter({limit: SUBSCRIBE_RATE_LIMIT_PER_MIN, windowMs: SUBSCRIBE_RATE_WINDOW_MS, clock: deps.now})
+  const unsubscribeLimiter =
+    deps.unsubscribeRateLimiter ??
+    createRateLimiter({limit: UNSUBSCRIBE_RATE_LIMIT_PER_MIN, windowMs: UNSUBSCRIBE_RATE_WINDOW_MS, clock: deps.now})
+
+  // ── POST /operator/push/subscriptions ─────────────────────────────────────
+  registerOperatorRoute(app, 'POST', '/operator/push/subscriptions', async c => {
+    const nowMs = deps.now()
+
+    // ── Gate 2: Read authenticated context set by the guard ────────────────
+    const authCtx = getOperatorAuthContext(c)
+    if (authCtx === undefined) {
+      deps.logger.warn({gate: 'no-auth-ctx'}, 'push-subscribe: denied')
+      return notFoundResponse(c)
+    }
+    const {githubUserId, sessionId} = authCtx
+    const operatorId = String(githubUserId)
+
+    // ── Gate 4: Operator rate limit ─────────────────────────────────────────
+    if (subscribeLimiter.allow(operatorId) === false) {
+      deps.logger.warn({githubUserId, gate: 'rate-limited'}, 'push-subscribe: rate limited')
+      return rateLimitedResponse(c)
+    }
+
+    // Resolve session identity — required for attribution, mirrors launch-route gate 3.
+    const sessionEntry = deps.sessionStore.get(sessionId, nowMs)
+    if (sessionEntry === undefined) {
+      deps.logger.warn({githubUserId, gate: 'no-session'}, 'push-subscribe: denied — session missing')
+      return notFoundResponse(c)
+    }
+
+    // ── Gate 5: Parse + validate request body ───────────────────────────────
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      deps.logger.warn({githubUserId, gate: 'bad-body'}, 'push-subscribe: denied — invalid JSON body')
+      return c.json({error: 'bad request'}, 400)
+    }
+
+    const parsed = parseOperatorPushSubscribeRequest(body)
+    if (parsed.success === false) {
+      deps.logger.warn({githubUserId, gate: 'bad-body'}, 'push-subscribe: denied — invalid request shape')
+      return c.json({error: 'bad request'}, 400)
+    }
+
+    // ── Gate 6: SSRF-conservative endpoint validation ───────────────────────
+    // Never log the endpoint value itself — only the coarse rejection class.
+    const endpointCheck = validateEndpointUrl(parsed.data.endpoint)
+    if (endpointCheck.ok === false) {
+      deps.logger.warn(
+        {githubUserId, gate: 'endpoint-rejected', reason: endpointCheck.reason},
+        'push-subscribe: denied — endpoint failed SSRF validation',
+      )
+      return c.json({error: 'bad request'}, 400)
+    }
+
+    // ── Gate 7: Call the store ───────────────────────────────────────────────
+    try {
+      const result = await deps.store.subscribe({
+        operatorId,
+        endpoint: parsed.data.endpoint,
+        p256dh: parsed.data.keys.p256dh,
+        auth: parsed.data.keys.auth,
+        keyVersion: deps.keyVersion,
+      })
+      if (result.success === false) {
+        deps.logger.warn({githubUserId, gate: 'store-error'}, 'push-subscribe: store write failed')
+        return notFoundResponse(c)
+      }
+
+      // ── Gate 8: Map result → safe JSON (metadata only, never endpoint/keys) ─
+      deps.logger.info({githubUserId}, 'push-subscribe: accepted')
+      return c.json(toResponseMetadata(result.data), 200)
+    } catch (error: unknown) {
+      deps.logger.warn(
+        {githubUserId, err: error instanceof Error ? error.message : String(error)},
+        'push-subscribe: store call threw — denying',
+      )
+      return notFoundResponse(c)
+    }
+  })
+
+  // ── POST /operator/push/subscriptions/unsubscribe ─────────────────────────
+  registerOperatorRoute(app, 'POST', '/operator/push/subscriptions/unsubscribe', async c => {
+    // ── Gate 2: Read authenticated context set by the guard ────────────────
+    const authCtx = getOperatorAuthContext(c)
+    if (authCtx === undefined) {
+      deps.logger.warn({gate: 'no-auth-ctx'}, 'push-unsubscribe: denied')
+      return notFoundResponse(c)
+    }
+    const {githubUserId} = authCtx
+    const operatorId = String(githubUserId)
+
+    // ── Gate 4: Operator rate limit ─────────────────────────────────────────
+    if (unsubscribeLimiter.allow(operatorId) === false) {
+      deps.logger.warn({githubUserId, gate: 'rate-limited'}, 'push-unsubscribe: rate limited')
+      return rateLimitedResponse(c)
+    }
+
+    // ── Gate 5: Parse + validate request body ───────────────────────────────
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      deps.logger.warn({githubUserId, gate: 'bad-body'}, 'push-unsubscribe: denied — invalid JSON body')
+      return c.json({error: 'bad request'}, 400)
+    }
+
+    const parsed = parseUnsubscribeBody(body)
+    if (parsed === null) {
+      deps.logger.warn({githubUserId, gate: 'bad-body'}, 'push-unsubscribe: denied — invalid request shape')
+      return c.json({error: 'bad request'}, 400)
+    }
+
+    // ── Gate 7: Call the store ───────────────────────────────────────────────
+    // Fail-closed, no-oracle: the store rejects when the endpoint is owned by
+    // a different operator; that denial and an unknown endpoint (idempotent
+    // no-op success) both surface identically here to avoid leaking ownership.
+    try {
+      const result = await deps.store.unsubscribe({operatorId, endpoint: parsed.endpoint})
+      if (result.success === false) {
+        deps.logger.warn({githubUserId, gate: 'store-error'}, 'push-unsubscribe: denied')
+        return notFoundResponse(c)
+      }
+
+      // ── Gate 8: Safe response — no endpoint/keys ─────────────────────────
+      deps.logger.info({githubUserId}, 'push-unsubscribe: accepted')
+      return c.json({ok: true}, 200)
+    } catch (error: unknown) {
+      deps.logger.warn(
+        {githubUserId, err: error instanceof Error ? error.message : String(error)},
+        'push-unsubscribe: store call threw — denying',
+      )
+      return notFoundResponse(c)
+    }
+  })
+
+  // ── GET /operator/push/subscriptions ───────────────────────────────────────
+  registerOperatorRoute(app, 'GET', '/operator/push/subscriptions', async c => {
+    // ── Gate 2: Read authenticated context set by the guard ────────────────
+    const authCtx = getOperatorAuthContext(c)
+    if (authCtx === undefined) {
+      deps.logger.warn({gate: 'no-auth-ctx'}, 'push-subscriptions-list: denied')
+      return notFoundResponse(c)
+    }
+    const {githubUserId} = authCtx
+    const operatorId = String(githubUserId)
+
+    try {
+      const result = await deps.store.listMetadataForOperator({operatorId})
+      if (result.success === false) {
+        deps.logger.warn({githubUserId, gate: 'store-error'}, 'push-subscriptions-list: denied')
+        return notFoundResponse(c)
+      }
+
+      const response: OperatorPushSubscriptionListResponse = {
+        subscriptions: result.data.map(toResponseMetadata),
+      }
+      return c.json(response, 200)
+    } catch (error: unknown) {
+      deps.logger.warn(
+        {githubUserId, err: error instanceof Error ? error.message : String(error)},
+        'push-subscriptions-list: store call threw — denying',
+      )
+      return notFoundResponse(c)
+    }
+  })
+}

--- a/packages/gateway/src/web/operator-push/subscription-route.ts
+++ b/packages/gateway/src/web/operator-push/subscription-route.ts
@@ -59,10 +59,14 @@ const UNSUBSCRIBE_RATE_LIMIT_PER_MIN = 10
 const UNSUBSCRIBE_RATE_WINDOW_MS = 60_000
 
 /**
- * Fail-closed cap on active subscription records per operator, bounding
- * store and dispatch-fanout growth from a single operator's browsers. A
- * re-subscribe of an endpoint the operator already owns is a replace, not a
- * new record, so it is exempt from this cap.
+ * Best-effort soft bound on active subscription records per operator,
+ * limiting store and dispatch-fanout growth from a single operator's
+ * browsers. The count is read before the write and is not atomic with it,
+ * so concurrent subscribes for distinct new endpoints can transiently
+ * exceed this bound by (concurrency - 1); the per-operator subscribe rate
+ * limit bounds how far that overrun can go. This limits unbounded growth,
+ * not an exact ceiling. A re-subscribe of an endpoint the operator already
+ * owns is a replace, not a new record, so it is exempt from this bound.
  */
 const MAX_ACTIVE_SUBSCRIPTIONS_PER_OPERATOR = 20
 
@@ -109,15 +113,21 @@ function toResponseMetadata(metadata: SubscriptionMetadata): OperatorPushSubscri
     return base
   }
   // The store's inactive-reason taxonomy is a superset ('transferred') of the
-  // contract's public taxonomy — 'transferred' is an internal-only reason and
-  // is intentionally omitted from the response rather than mapped.
+  // contract's public taxonomy. 'transferred' would leak that the endpoint
+  // moved to another operator, so it is mapped to the same coarse 'revoked'
+  // reason used for key_revoked rather than omitted — an omitted reason
+  // renders ambiguously (active:false with no explanation) on the client.
   if (
     metadata.inactiveReason === 'unsubscribed' ||
     metadata.inactiveReason === 'dead' ||
     metadata.inactiveReason === 'key_revoked' ||
-    metadata.inactiveReason === 'session-revoked'
+    metadata.inactiveReason === 'session-revoked' ||
+    metadata.inactiveReason === 'transferred'
   ) {
-    const mapped = metadata.inactiveReason === 'key_revoked' ? 'revoked' : metadata.inactiveReason
+    const mapped =
+      metadata.inactiveReason === 'key_revoked' || metadata.inactiveReason === 'transferred'
+        ? 'revoked'
+        : metadata.inactiveReason
     return {...base, inactiveReason: mapped}
   }
   return base
@@ -196,10 +206,12 @@ export function buildSubscriptionRoutes(app: Hono, deps: SubscriptionRouteDeps):
 
     // ── Gate 7: Call the store ───────────────────────────────────────────────
     try {
-      // Fail-closed active-subscription cap: block a NEW endpoint once the
-      // operator is already at the cap, but never block a re-subscribe of an
-      // endpoint they already own — that write replaces the existing record
-      // rather than growing the active set.
+      // Soft active-subscription bound: block a NEW endpoint once the
+      // operator is already at the bound, but never block a re-subscribe of
+      // an endpoint they already own — that write replaces the existing
+      // record rather than growing the active set. See
+      // MAX_ACTIVE_SUBSCRIPTIONS_PER_OPERATOR's docstring for why this is
+      // soft rather than atomic.
       const existingMetadata = await deps.store.listMetadataForOperator({operatorId})
       if (existingMetadata.success === false) {
         deps.logger.warn({githubUserId, gate: 'store-error'}, 'push-subscribe: store write failed')

--- a/packages/gateway/src/web/operator-push/subscription-store.test.ts
+++ b/packages/gateway/src/web/operator-push/subscription-store.test.ts
@@ -1164,6 +1164,71 @@ describe('createOperatorPushSubscriptionStore — deleteForOperator gaps', () =>
     expect(listed.data).toHaveLength(1)
     expect(listed.data[0]?.active).toBe(true)
   })
+
+  it('rolls back the tombstone when a transfer to a different operator races the physical delete (still active, different owner)', async () => {
+    // #given an active subscription owned by operator-a, plus a one-shot
+    // conditionalDelete failure that, when it fires, simulates a concurrent
+    // transfer: operator-b subscribes with the same endpoint between the
+    // delete's read and its physical delete attempt, so the on-disk record
+    // ends up active but owned by a DIFFERENT operator.
+    const backing = new Map<string, {data: string; etag: string}>()
+    const baseAdapter = createCasFakeAdapter(backing)
+    const endpoint = 'https://push.example.com/ep-transfer-race'
+    const seedStore = createOperatorPushSubscriptionStore({adapter: baseAdapter, logger: testLogger})
+    await seedStore.subscribe({operatorId: 'operator-a', endpoint, p256dh: 'p1', auth: 'a1', keyVersion: '1'})
+    const subscriptionKey = Array.from(backing.keys()).find(k => k.includes('subscriptions/by-endpoint'))
+    if (subscriptionKey === undefined) throw new Error('unreachable')
+
+    const raceAdapter = withOneShotConditionalDeleteFailure(
+      baseAdapter,
+      key => key === subscriptionKey,
+      () => {
+        // Simulate the concurrent transfer: operator-b now owns the record,
+        // still active, at a new etag.
+        const current = backing.get(subscriptionKey)
+        if (current === undefined) throw new Error('unreachable')
+        const parsed: {[k: string]: unknown} = JSON.parse(current.data) as {[k: string]: unknown}
+        backing.set(subscriptionKey, {
+          data: JSON.stringify({
+            ...parsed,
+            operatorId: 'operator-b',
+            p256dh: 'transferred-p256dh',
+            auth: 'transferred-auth',
+            ownershipGeneration: 2,
+          }),
+          etag: 'etag-transferred-during-race',
+        })
+      },
+    )
+    const warn = vi.fn()
+    const store = createOperatorPushSubscriptionStore({adapter: raceAdapter, logger: {debug: () => {}, warn}})
+
+    // #when operator-a's deleteForOperator loses the physical-delete CAS race to that transfer
+    const result = await store.deleteForOperator({operatorId: 'operator-a'})
+
+    // #then the delete is not counted as deleted (secrets were already moved
+    // to the new owner's record before the physical delete attempt), and —
+    // because the re-read shows the record active regardless of who now
+    // owns it — the tombstone is rolled back so it does not shadow the new
+    // owner's live record; a warning is logged for the lost race
+    expect(result.success).toBe(true)
+    if (result.success === false) throw new Error('unreachable')
+    expect(result.data.deleted).toBe(0)
+    expect(result.data.skipped).toBe(1)
+    expect(warn).toHaveBeenCalled()
+
+    // The now-active record (owned by operator-b) remains visible via the
+    // read surfaces — not shadowed by a leftover tombstone.
+    const bActive = await store.getActiveRecordsForOperator({operatorId: 'operator-b'})
+    if (bActive.success === false) throw new Error('unreachable')
+    expect(bActive.data).toHaveLength(1)
+    expect(bActive.data[0]?.p256dh).toBe('transferred-p256dh')
+
+    const bListed = await store.listMetadataForOperator({operatorId: 'operator-b'})
+    if (bListed.success === false) throw new Error('unreachable')
+    expect(bListed.data).toHaveLength(1)
+    expect(bListed.data[0]?.active).toBe(true)
+  })
 })
 
 describe('createOperatorPushSubscriptionStore — prune reclaims a record left behind by a skipped delete', () => {

--- a/packages/gateway/src/web/operator-push/subscription-store.ts
+++ b/packages/gateway/src/web/operator-push/subscription-store.ts
@@ -289,7 +289,13 @@ const DEFAULT_TOMBSTONE_RETENTION_MS = 90 * 24 * 60 * 60 * 1000
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-function hashEndpoint(endpoint: string): string {
+/**
+ * sha256 hex digest of a push endpoint URL — the record's key discriminant.
+ * Exported so callers (e.g. the subscription route's per-operator active-
+ * subscription cap) can check membership against `listMetadataForOperator`
+ * results without a redundant store round-trip.
+ */
+export function hashEndpoint(endpoint: string): string {
   return createHash('sha256').update(endpoint, 'utf8').digest('hex')
 }
 
@@ -1152,13 +1158,19 @@ export function createOperatorPushSubscriptionStore(
     } finally {
       // Best-effort cleanup — read current etag then delete; ignore failures
       // (a leftover self-test key does not affect the active dispatch set).
-      const cleanupRead = await adapter.getObject(testKey)
-      if (cleanupRead.success === true) {
-        try {
-          await adapter.conditionalDelete(testKey, {ifMatch: cleanupRead.data.etag})
-        } catch (error) {
-          logger.debug({error, testKey}, 'operator push subscription store: self-test cleanup delete threw')
+      // A throw from either the read or the delete must not turn a successful
+      // self-test result into a rejected promise.
+      try {
+        const cleanupRead = await adapter.getObject(testKey)
+        if (cleanupRead.success === true) {
+          try {
+            await adapter.conditionalDelete(testKey, {ifMatch: cleanupRead.data.etag})
+          } catch (error) {
+            logger.debug({error, testKey}, 'operator push subscription store: self-test cleanup delete threw')
+          }
         }
+      } catch (error) {
+        logger.debug({error, testKey}, 'operator push subscription store: self-test cleanup read threw')
       }
     }
   }

--- a/packages/gateway/src/web/operator-push/validate-endpoint.test.ts
+++ b/packages/gateway/src/web/operator-push/validate-endpoint.test.ts
@@ -1,0 +1,112 @@
+import {describe, expect, it} from 'vitest'
+import {validateEndpointUrl} from './validate-endpoint.js'
+
+describe('validateEndpointUrl', () => {
+  // #given a well-formed https push-service endpoint
+  // #when validated
+  // #then it is accepted
+  it('accepts a valid https endpoint', () => {
+    const result = validateEndpointUrl('https://fcm.googleapis.com/fcm/send/abc123')
+    expect(result.ok).toBe(true)
+    expect(result.reason).toBeUndefined()
+  })
+
+  // #given an http (non-https) endpoint
+  // #when validated
+  // #then it is rejected as not-https
+  it('rejects http scheme', () => {
+    const result = validateEndpointUrl('http://push.example.com/x')
+    expect(result).toEqual({ok: false, reason: 'not-https'})
+  })
+
+  // #given a non-http(s) scheme
+  // #when validated
+  // #then it is rejected as not-https
+  it('rejects mailto scheme', () => {
+    const result = validateEndpointUrl('mailto:someone@example.com')
+    expect(result).toEqual({ok: false, reason: 'not-https'})
+  })
+
+  // #given an unparseable string
+  // #when validated
+  // #then it is rejected as unparseable
+  it('rejects an unparseable URL', () => {
+    const result = validateEndpointUrl('not a url')
+    expect(result).toEqual({ok: false, reason: 'unparseable'})
+  })
+
+  // #given loopback hostnames
+  // #when validated
+  // #then each is rejected as loopback
+  it('rejects the localhost hostname', () => {
+    expect(validateEndpointUrl('https://localhost/x')).toEqual({ok: false, reason: 'loopback'})
+  })
+
+  it('rejects the IPv4 loopback range 127.0.0.0/8', () => {
+    expect(validateEndpointUrl('https://127.0.0.1/x')).toEqual({ok: false, reason: 'loopback'})
+    expect(validateEndpointUrl('https://127.255.255.255/x')).toEqual({ok: false, reason: 'loopback'})
+  })
+
+  it('rejects the IPv6 loopback ::1', () => {
+    expect(validateEndpointUrl('https://[::1]/x')).toEqual({ok: false, reason: 'loopback'})
+  })
+
+  // #given private IPv4 network ranges
+  // #when validated
+  // #then each is rejected as private-network
+  it('rejects 10.0.0.0/8', () => {
+    expect(validateEndpointUrl('https://10.1.2.3/x')).toEqual({ok: false, reason: 'private-network'})
+  })
+
+  it('rejects 172.16.0.0/12', () => {
+    expect(validateEndpointUrl('https://172.16.0.1/x')).toEqual({ok: false, reason: 'private-network'})
+    expect(validateEndpointUrl('https://172.31.255.255/x')).toEqual({ok: false, reason: 'private-network'})
+    expect(validateEndpointUrl('https://172.32.0.1/x').ok).toBe(true)
+    expect(validateEndpointUrl('https://172.15.255.255/x').ok).toBe(true)
+  })
+
+  it('rejects 192.168.0.0/16', () => {
+    expect(validateEndpointUrl('https://192.168.1.1/x')).toEqual({ok: false, reason: 'private-network'})
+  })
+
+  it('rejects IPv6 unique-local fc00::/7', () => {
+    expect(validateEndpointUrl('https://[fc00::1]/x')).toEqual({ok: false, reason: 'private-network'})
+    expect(validateEndpointUrl('https://[fd12::1]/x')).toEqual({ok: false, reason: 'private-network'})
+  })
+
+  // #given link-local ranges
+  // #when validated
+  // #then each is rejected as link-local
+  it('rejects the IPv4 link-local range 169.254.0.0/16', () => {
+    expect(validateEndpointUrl('https://169.254.1.1/x')).toEqual({ok: false, reason: 'link-local'})
+  })
+
+  it('rejects IPv6 link-local fe80::/10', () => {
+    expect(validateEndpointUrl('https://[fe80::1]/x')).toEqual({ok: false, reason: 'link-local'})
+  })
+
+  // #given bare hostnames or local service names with no public dot
+  // #when validated
+  // #then each is rejected as no-dot-hostname
+  it('rejects a bare hostname with no dot', () => {
+    expect(validateEndpointUrl('https://workspace/x')).toEqual({ok: false, reason: 'no-dot-hostname'})
+  })
+
+  it('rejects a .local hostname', () => {
+    expect(validateEndpointUrl('https://myhost.local/x')).toEqual({ok: false, reason: 'no-dot-hostname'})
+  })
+
+  it('rejects a .internal hostname', () => {
+    expect(validateEndpointUrl('https://service.internal/x')).toEqual({ok: false, reason: 'no-dot-hostname'})
+  })
+
+  // #given the rejection result
+  // #when inspected
+  // #then it never contains the raw endpoint string
+  it('never echoes the input endpoint in the rejection reason', () => {
+    const secretEndpoint = 'https://127.0.0.1/super-secret-path-should-not-leak'
+    const result = validateEndpointUrl(secretEndpoint)
+    expect(result.ok).toBe(false)
+    expect(JSON.stringify(result)).not.toContain('super-secret-path-should-not-leak')
+  })
+})

--- a/packages/gateway/src/web/operator-push/validate-endpoint.test.ts
+++ b/packages/gateway/src/web/operator-push/validate-endpoint.test.ts
@@ -109,4 +109,74 @@ describe('validateEndpointUrl', () => {
     expect(result.ok).toBe(false)
     expect(JSON.stringify(result)).not.toContain('super-secret-path-should-not-leak')
   })
+
+  // #given IPv4-mapped IPv6 literals in both dotted and WHATWG-normalized hex form
+  // #when validated
+  // #then the embedded IPv4 address is decoded and classified the same as the plain IPv4 literal
+  describe('IPv4-mapped IPv6 literals', () => {
+    it('rejects a mapped loopback address', () => {
+      expect(validateEndpointUrl('https://[::ffff:127.0.0.1]/p')).toEqual({ok: false, reason: 'loopback'})
+    })
+
+    it('rejects mapped private-network addresses', () => {
+      expect(validateEndpointUrl('https://[::ffff:10.0.0.1]/p')).toEqual({ok: false, reason: 'private-network'})
+      expect(validateEndpointUrl('https://[::ffff:192.168.1.1]/p')).toEqual({ok: false, reason: 'private-network'})
+      expect(validateEndpointUrl('https://[::ffff:172.16.0.1]/p')).toEqual({ok: false, reason: 'private-network'})
+    })
+
+    it('rejects mapped cloud-metadata / link-local addresses in both dotted and hex form', () => {
+      expect(validateEndpointUrl('https://[::ffff:169.254.169.254]/p')).toEqual({ok: false, reason: 'link-local'})
+      expect(validateEndpointUrl('https://[::ffff:a9fe:a9fe]/p')).toEqual({ok: false, reason: 'link-local'})
+    })
+
+    it('rejects a mapped unspecified address', () => {
+      expect(validateEndpointUrl('https://[::ffff:0:0]/p')).toEqual({ok: false, reason: 'loopback'})
+    })
+  })
+
+  // #given the IPv4 and IPv6 unspecified addresses
+  // #when validated
+  // #then each is rejected
+  it('rejects the IPv4 unspecified address 0.0.0.0', () => {
+    expect(validateEndpointUrl('https://0.0.0.0/p')).toEqual({ok: false, reason: 'loopback'})
+  })
+
+  it('rejects the IPv6 unspecified address ::', () => {
+    expect(validateEndpointUrl('https://[::]/p')).toEqual({ok: false, reason: 'loopback'})
+  })
+
+  // #given internal hostnames written with a trailing dot (a valid FQDN root marker)
+  // #when validated
+  // #then the trailing dot is normalized away and the hostname is still rejected
+  it('rejects a trailing-dot .internal hostname', () => {
+    expect(validateEndpointUrl('https://metadata.google.internal./p')).toEqual({ok: false, reason: 'no-dot-hostname'})
+    expect(validateEndpointUrl('https://service.internal./p')).toEqual({ok: false, reason: 'no-dot-hostname'})
+  })
+
+  // #given legitimate push-service origins
+  // #when validated
+  // #then each is accepted, guarding against false positives from the hardened checks
+  it('accepts real push-service hosts', () => {
+    expect(validateEndpointUrl('https://fcm.googleapis.com/fcm/send/abc').ok).toBe(true)
+    expect(validateEndpointUrl('https://updates.push.services.mozilla.com/wpush/v2/xyz').ok).toBe(true)
+    expect(validateEndpointUrl('https://web.push.apple.com/abc').ok).toBe(true)
+  })
+
+  // #given each hardened rejection case
+  // #when the rejection reason is serialized
+  // #then it never contains the raw endpoint value
+  it('never echoes the endpoint for the hardened rejection cases', () => {
+    const secretPath = '/super-secret-path-should-not-leak'
+    const endpoints = [
+      `https://[::ffff:127.0.0.1]${secretPath}`,
+      `https://0.0.0.0${secretPath}`,
+      `https://[::]${secretPath}`,
+      `https://metadata.google.internal.${secretPath}`,
+    ]
+    for (const endpoint of endpoints) {
+      const result = validateEndpointUrl(endpoint)
+      expect(result.ok).toBe(false)
+      expect(JSON.stringify(result)).not.toContain(secretPath)
+    }
+  })
 })

--- a/packages/gateway/src/web/operator-push/validate-endpoint.test.ts
+++ b/packages/gateway/src/web/operator-push/validate-endpoint.test.ts
@@ -162,6 +162,57 @@ describe('validateEndpointUrl', () => {
     expect(validateEndpointUrl('https://web.push.apple.com/abc').ok).toBe(true)
   })
 
+  // #given IPv6 literals in forms that embed or reduce to an internal address
+  // through a path the specific classifiers don't decode (IPv4-compatible,
+  // NAT64, 6to4), plus an arbitrary global-unicast literal with no internal
+  // meaning at all
+  // #when validated
+  // #then every one is rejected — the fail-closed posture treats any IPv6
+  // literal as an SSRF risk regardless of whether it decodes to something
+  // internal, since real push endpoints are never IPv6 literals
+  describe('fail-closed IPv6 literal posture', () => {
+    it('rejects an IPv4-compatible IPv6 literal embedding 127.0.0.1', () => {
+      const result = validateEndpointUrl('https://[::7f00:1]/p')
+      expect(result.ok).toBe(false)
+    })
+
+    it('rejects a NAT64-embedded literal encoding 127.0.0.1', () => {
+      const result = validateEndpointUrl('https://[64:ff9b::7f00:1]/p')
+      expect(result.ok).toBe(false)
+    })
+
+    it('rejects a 6to4-embedded literal encoding 127.0.0.1', () => {
+      const result = validateEndpointUrl('https://[2002:7f00:1::]/p')
+      expect(result.ok).toBe(false)
+    })
+
+    it('rejects an arbitrary global-unicast IPv6 literal with no internal meaning', () => {
+      const result = validateEndpointUrl('https://[2606:4700:4700::1111]/p')
+      expect(result.ok).toBe(false)
+      expect(result.reason).toBe('ipv6-literal')
+    })
+
+    it('never echoes the endpoint or IPv6 literal in the rejection', () => {
+      const endpoints = [
+        'https://[::7f00:1]/secret-path',
+        'https://[64:ff9b::7f00:1]/secret-path',
+        'https://[2002:7f00:1::]/secret-path',
+        'https://[2606:4700:4700::1111]/secret-path',
+      ]
+      for (const endpoint of endpoints) {
+        const result = validateEndpointUrl(endpoint)
+        expect(result.ok).toBe(false)
+        expect(JSON.stringify(result)).not.toContain('secret-path')
+      }
+    })
+
+    it('still accepts real push-service hostnames alongside the fail-closed IPv6 posture', () => {
+      expect(validateEndpointUrl('https://fcm.googleapis.com/fcm/send/abc').ok).toBe(true)
+      expect(validateEndpointUrl('https://updates.push.services.mozilla.com/wpush/v2/xyz').ok).toBe(true)
+      expect(validateEndpointUrl('https://web.push.apple.com/abc').ok).toBe(true)
+    })
+  })
+
   // #given each hardened rejection case
   // #when the rejection reason is serialized
   // #then it never contains the raw endpoint value

--- a/packages/gateway/src/web/operator-push/validate-endpoint.ts
+++ b/packages/gateway/src/web/operator-push/validate-endpoint.ts
@@ -16,13 +16,18 @@
  * dispatch path must additionally validate the resolved IP at connect time
  * to close that gap; this module only stops literal-address bypasses.
  *
+ * IPv6 posture: IPv6 literals are rejected wholesale — push service
+ * endpoints are DNS hostnames, so any IPv6 literal is treated as an SSRF
+ * risk and denied; specific internal forms are still classified for
+ * logging granularity.
+ *
  * Security invariant: the endpoint value itself must NEVER be echoed in a
  * thrown reason or a log line — only the coarse rejection class name.
  */
 
 /** Coarse, closed set of reasons an endpoint URL was rejected. No free-form text. */
 export type EndpointRejectionReason =
-  'not-https' | 'loopback' | 'private-network' | 'link-local' | 'no-dot-hostname' | 'unparseable'
+  'not-https' | 'loopback' | 'private-network' | 'link-local' | 'no-dot-hostname' | 'unparseable' | 'ipv6-literal'
 
 export interface EndpointValidationResult {
   readonly ok: boolean
@@ -78,7 +83,11 @@ const IPV6_MAPPED_HEX_TAIL_PATTERN = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/
 
 /**
  * Classify an IPv6 literal hostname (already bracket-stripped by URL.hostname).
- * Covers ::1 (loopback), fe80::/10 (link-local), and fc00::/7 (unique local).
+ * Fail-closed: known internal forms (::1 loopback, fe80::/10 link-local,
+ * fc00::/7 unique local, ::ffff:-mapped IPv4) get a specific reason for log
+ * granularity, but any IPv6 literal that isn't one of those still falls
+ * through to the 'ipv6-literal' catch-all reject at the end — legitimate
+ * push endpoints are always DNS hostnames, never IPv6 literals.
  */
 function classifyIpv6(hostname: string): EndpointRejectionReason | null {
   const lower = hostname.toLowerCase()
@@ -99,24 +108,35 @@ function classifyIpv6(hostname: string): EndpointRejectionReason | null {
     const suffix = lower.slice(mappedPrefix.length)
     if (suffix.includes('.')) {
       if (IPV4_PATTERN.test(suffix) === false) return 'private-network'
-      return classifyIpv4(suffix)
-    }
-    const hexMatch = IPV6_MAPPED_HEX_TAIL_PATTERN.exec(suffix)
-    if (hexMatch !== null) {
-      const group0 = Number.parseInt(hexMatch[1] ?? '', 16)
-      const group1 = Number.parseInt(hexMatch[2] ?? '', 16)
-      if (Number.isNaN(group0) === false && Number.isNaN(group1) === false) {
-        const octets = [(group0 >> 8) & 0xff, group0 & 0xff, (group1 >> 8) & 0xff, group1 & 0xff]
-        return classifyIpv4Octets(octets)
+      const mappedReason = classifyIpv4(suffix)
+      if (mappedReason !== null) return mappedReason
+      // A mapped PUBLIC IPv4 (classifyIpv4 returned null) is still an IPv6
+      // literal — fall through to the catch-all reject below rather than
+      // accept it.
+    } else {
+      const hexMatch = IPV6_MAPPED_HEX_TAIL_PATTERN.exec(suffix)
+      if (hexMatch !== null) {
+        const group0 = Number.parseInt(hexMatch[1] ?? '', 16)
+        const group1 = Number.parseInt(hexMatch[2] ?? '', 16)
+        if (Number.isNaN(group0) === false && Number.isNaN(group1) === false) {
+          const octets = [(group0 >> 8) & 0xff, group0 & 0xff, (group1 >> 8) & 0xff, group1 & 0xff]
+          const mappedReason = classifyIpv4Octets(octets)
+          if (mappedReason !== null) return mappedReason
+          // Same fall-through as above: a mapped public IPv4 is still
+          // rejected as an IPv6 literal by the catch-all below.
+        }
       }
     }
     // ::ffff: prefix present but the suffix is not a recognizable IPv4
-    // literal — fail closed rather than let an unclassified mapped
-    // address through.
+    // literal, or resolved to a public IPv4 — fail closed rather than let
+    // an unclassified or mapped-public address through.
     return 'private-network'
   }
 
-  return null
+  // Fail-closed catch-all: every IPv6 literal that reaches here is not one
+  // of the specifically-classified internal forms above, but is still
+  // rejected — push endpoints are never IPv6 literals.
+  return 'ipv6-literal'
 }
 
 /**

--- a/packages/gateway/src/web/operator-push/validate-endpoint.ts
+++ b/packages/gateway/src/web/operator-push/validate-endpoint.ts
@@ -1,0 +1,125 @@
+/**
+ * SSRF-conservative validation for browser-supplied push subscription endpoint
+ * URLs, applied before any endpoint value reaches the subscription store.
+ *
+ * A push endpoint is normally a push-service origin (e.g. Google FCM,
+ * Mozilla autopush) chosen by the browser, not the operator. Accepting it
+ * without validation would let a malicious or compromised browser register
+ * an endpoint pointing at an internal service — the dispatch path (a later
+ * unit) would then issue an authenticated-looking HTTPS POST to that URL.
+ * This module rejects the classes of URL that would make that dangerous.
+ *
+ * Security invariant: the endpoint value itself must NEVER be echoed in a
+ * thrown reason or a log line — only the coarse rejection class name.
+ */
+
+/** Coarse, closed set of reasons an endpoint URL was rejected. No free-form text. */
+export type EndpointRejectionReason =
+  'not-https' | 'loopback' | 'private-network' | 'link-local' | 'no-dot-hostname' | 'unparseable'
+
+export interface EndpointValidationResult {
+  readonly ok: boolean
+  readonly reason?: EndpointRejectionReason
+}
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost'])
+
+/** Matches IPv4-literal hostnames (e.g. "127.0.0.1"). */
+const IPV4_PATTERN = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
+
+function isIpv4Loopback(octets: readonly number[]): boolean {
+  return octets[0] === 127
+}
+
+function isIpv4PrivateNetwork(octets: readonly number[]): boolean {
+  const a = octets[0]
+  const b = octets[1]
+  if (a === 10) return true
+  if (a === 172 && b !== undefined && b >= 16 && b <= 31) return true
+  if (a === 192 && b === 168) return true
+  return false
+}
+
+function isIpv4LinkLocal(octets: readonly number[]): boolean {
+  const a = octets[0]
+  const b = octets[1]
+  return a === 169 && b === 254
+}
+
+function classifyIpv4(hostname: string): EndpointRejectionReason | null {
+  const match = IPV4_PATTERN.exec(hostname)
+  if (match === null) return null
+  const octets = [match[1] ?? '', match[2] ?? '', match[3] ?? '', match[4] ?? ''].map(part => Number.parseInt(part, 10))
+  if (octets.some(o => Number.isNaN(o) || o > 255)) return null
+  if (isIpv4Loopback(octets)) return 'loopback'
+  if (isIpv4LinkLocal(octets)) return 'link-local'
+  if (isIpv4PrivateNetwork(octets)) return 'private-network'
+  return null
+}
+
+/**
+ * Classify an IPv6 literal hostname (already bracket-stripped by URL.hostname).
+ * Covers ::1 (loopback), fe80::/10 (link-local), and fc00::/7 (unique local).
+ */
+function classifyIpv6(hostname: string): EndpointRejectionReason | null {
+  const lower = hostname.toLowerCase()
+  if (lower === '::1') return 'loopback'
+  if (lower.startsWith('fe8') || lower.startsWith('fe9') || lower.startsWith('fea') || lower.startsWith('feb')) {
+    return 'link-local'
+  }
+  // fc00::/7 covers prefixes fc00:: through fdff:: — first hex nibble 'f' with
+  // second nibble 'c' or 'd'.
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return 'private-network'
+  return null
+}
+
+/**
+ * Validate a push subscription endpoint URL against an SSRF-conservative
+ * allowlist posture: HTTPS-only, no loopback, no private/link-local network,
+ * no bare/local hostnames.
+ *
+ * Never includes the endpoint value in the returned reason — callers must
+ * not log the endpoint alongside the rejection.
+ */
+export function validateEndpointUrl(endpoint: string): EndpointValidationResult {
+  let url: URL
+  try {
+    url = new URL(endpoint)
+  } catch {
+    return {ok: false, reason: 'unparseable'}
+  }
+
+  if (url.protocol !== 'https:') {
+    return {ok: false, reason: 'not-https'}
+  }
+
+  const rawHostname = url.hostname.toLowerCase()
+
+  if (LOOPBACK_HOSTNAMES.has(rawHostname)) {
+    return {ok: false, reason: 'loopback'}
+  }
+
+  // WHATWG URL.hostname keeps the brackets for an IPv6 literal (e.g. "[::1]").
+  const isIpv6Literal = rawHostname.startsWith('[') && rawHostname.endsWith(']')
+  const hostname = isIpv6Literal ? rawHostname.slice(1, -1) : rawHostname
+
+  if (isIpv6Literal) {
+    const reason = classifyIpv6(hostname)
+    if (reason !== null) return {ok: false, reason}
+  } else {
+    const ipv4Reason = classifyIpv4(hostname)
+    if (ipv4Reason !== null) return {ok: false, reason: ipv4Reason}
+  }
+
+  if (hostname.endsWith('.local') || hostname.endsWith('.internal')) {
+    return {ok: false, reason: 'no-dot-hostname'}
+  }
+
+  // Bare hostname / local service name — no dot at all (e.g. "workspace").
+  // IPv6 literals never contain a dot check here since they already passed above.
+  if (isIpv6Literal === false && hostname.includes('.') === false) {
+    return {ok: false, reason: 'no-dot-hostname'}
+  }
+
+  return {ok: true}
+}

--- a/packages/gateway/src/web/operator-push/validate-endpoint.ts
+++ b/packages/gateway/src/web/operator-push/validate-endpoint.ts
@@ -87,9 +87,10 @@ const IPV6_MAPPED_HEX_TAIL_PATTERN = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/
  * fc00::/7 unique local, ::ffff:-mapped IPv4) get a specific reason for log
  * granularity, but any IPv6 literal that isn't one of those still falls
  * through to the 'ipv6-literal' catch-all reject at the end — legitimate
- * push endpoints are always DNS hostnames, never IPv6 literals.
+ * push endpoints are always DNS hostnames, never IPv6 literals. Every IPv6
+ * literal is therefore rejected; the function is total (never returns null).
  */
-function classifyIpv6(hostname: string): EndpointRejectionReason | null {
+function classifyIpv6(hostname: string): EndpointRejectionReason {
   const lower = hostname.toLowerCase()
   if (lower === '::1') return 'loopback'
   if (lower === '::' || lower === '0:0:0:0:0:0:0:0') return 'loopback'
@@ -170,12 +171,11 @@ export function validateEndpointUrl(endpoint: string): EndpointValidationResult 
   const hostname = isIpv6Literal ? rawHostname.slice(1, -1) : rawHostname
 
   if (isIpv6Literal) {
-    const reason = classifyIpv6(hostname)
-    if (reason !== null) return {ok: false, reason}
-  } else {
-    const ipv4Reason = classifyIpv4(hostname)
-    if (ipv4Reason !== null) return {ok: false, reason: ipv4Reason}
+    // Every IPv6 literal is rejected — classifyIpv6 is total.
+    return {ok: false, reason: classifyIpv6(hostname)}
   }
+  const ipv4Reason = classifyIpv4(hostname)
+  if (ipv4Reason !== null) return {ok: false, reason: ipv4Reason}
 
   // A trailing dot is a valid FQDN root marker ("foo.internal.") that Node
   // fetch still resolves, but it defeats a naive suffix/no-dot check. Strip
@@ -188,8 +188,8 @@ export function validateEndpointUrl(endpoint: string): EndpointValidationResult 
   }
 
   // Bare hostname / local service name — no dot at all (e.g. "workspace").
-  // IPv6 literals never contain a dot check here since they already passed above.
-  if (isIpv6Literal === false && normalizedHostname.includes('.') === false) {
+  // IPv6 literals already returned above, so only DNS-style hosts reach here.
+  if (normalizedHostname.includes('.') === false) {
     return {ok: false, reason: 'no-dot-hostname'}
   }
 

--- a/packages/gateway/src/web/operator-push/validate-endpoint.ts
+++ b/packages/gateway/src/web/operator-push/validate-endpoint.ts
@@ -5,9 +5,16 @@
  * A push endpoint is normally a push-service origin (e.g. Google FCM,
  * Mozilla autopush) chosen by the browser, not the operator. Accepting it
  * without validation would let a malicious or compromised browser register
- * an endpoint pointing at an internal service — the dispatch path (a later
- * unit) would then issue an authenticated-looking HTTPS POST to that URL.
- * This module rejects the classes of URL that would make that dangerous.
+ * an endpoint pointing at an internal service — the dispatch path would
+ * then issue an authenticated-looking HTTPS POST to that URL. This module
+ * rejects the classes of URL that would make that dangerous.
+ *
+ * Architectural boundary: this is a parse-time literal-address guard. It
+ * classifies the hostname as written in the URL and cannot defend against
+ * DNS rebinding, where a hostname resolves to a public IP at validation
+ * time and to a private or metadata IP at fetch/dispatch time. The push
+ * dispatch path must additionally validate the resolved IP at connect time
+ * to close that gap; this module only stops literal-address bypasses.
  *
  * Security invariant: the endpoint value itself must NEVER be echoed in a
  * thrown reason or a log line — only the coarse rejection class name.
@@ -46,16 +53,28 @@ function isIpv4LinkLocal(octets: readonly number[]): boolean {
   return a === 169 && b === 254
 }
 
-function classifyIpv4(hostname: string): EndpointRejectionReason | null {
-  const match = IPV4_PATTERN.exec(hostname)
-  if (match === null) return null
-  const octets = [match[1] ?? '', match[2] ?? '', match[3] ?? '', match[4] ?? ''].map(part => Number.parseInt(part, 10))
-  if (octets.some(o => Number.isNaN(o) || o > 255)) return null
+function isIpv4Unspecified(octets: readonly number[]): boolean {
+  return octets.every(o => o === 0)
+}
+
+function classifyIpv4Octets(octets: readonly number[]): EndpointRejectionReason | null {
+  if (isIpv4Unspecified(octets)) return 'loopback'
   if (isIpv4Loopback(octets)) return 'loopback'
   if (isIpv4LinkLocal(octets)) return 'link-local'
   if (isIpv4PrivateNetwork(octets)) return 'private-network'
   return null
 }
+
+function classifyIpv4(hostname: string): EndpointRejectionReason | null {
+  const match = IPV4_PATTERN.exec(hostname)
+  if (match === null) return null
+  const octets = [match[1] ?? '', match[2] ?? '', match[3] ?? '', match[4] ?? ''].map(part => Number.parseInt(part, 10))
+  if (octets.some(o => Number.isNaN(o) || o > 255)) return null
+  return classifyIpv4Octets(octets)
+}
+
+/** Matches a two-hex-group IPv6 tail, e.g. the "7f00:1" in "::ffff:7f00:1". */
+const IPV6_MAPPED_HEX_TAIL_PATTERN = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/
 
 /**
  * Classify an IPv6 literal hostname (already bracket-stripped by URL.hostname).
@@ -64,12 +83,39 @@ function classifyIpv4(hostname: string): EndpointRejectionReason | null {
 function classifyIpv6(hostname: string): EndpointRejectionReason | null {
   const lower = hostname.toLowerCase()
   if (lower === '::1') return 'loopback'
+  if (lower === '::' || lower === '0:0:0:0:0:0:0:0') return 'loopback'
   if (lower.startsWith('fe8') || lower.startsWith('fe9') || lower.startsWith('fea') || lower.startsWith('feb')) {
     return 'link-local'
   }
   // fc00::/7 covers prefixes fc00:: through fdff:: — first hex nibble 'f' with
   // second nibble 'c' or 'd'.
   if (lower.startsWith('fc') || lower.startsWith('fd')) return 'private-network'
+
+  // IPv4-mapped IPv6 (::ffff:a.b.c.d). WHATWG URL normalizes the dotted form
+  // to a hex-compressed tail (e.g. "::ffff:127.0.0.1" -> "::ffff:7f00:1"), so
+  // both the dotted and hex forms must be decoded and classified as IPv4.
+  const mappedPrefix = '::ffff:'
+  if (lower.startsWith(mappedPrefix)) {
+    const suffix = lower.slice(mappedPrefix.length)
+    if (suffix.includes('.')) {
+      if (IPV4_PATTERN.test(suffix) === false) return 'private-network'
+      return classifyIpv4(suffix)
+    }
+    const hexMatch = IPV6_MAPPED_HEX_TAIL_PATTERN.exec(suffix)
+    if (hexMatch !== null) {
+      const group0 = Number.parseInt(hexMatch[1] ?? '', 16)
+      const group1 = Number.parseInt(hexMatch[2] ?? '', 16)
+      if (Number.isNaN(group0) === false && Number.isNaN(group1) === false) {
+        const octets = [(group0 >> 8) & 0xff, group0 & 0xff, (group1 >> 8) & 0xff, group1 & 0xff]
+        return classifyIpv4Octets(octets)
+      }
+    }
+    // ::ffff: prefix present but the suffix is not a recognizable IPv4
+    // literal — fail closed rather than let an unclassified mapped
+    // address through.
+    return 'private-network'
+  }
+
   return null
 }
 
@@ -111,13 +157,19 @@ export function validateEndpointUrl(endpoint: string): EndpointValidationResult 
     if (ipv4Reason !== null) return {ok: false, reason: ipv4Reason}
   }
 
-  if (hostname.endsWith('.local') || hostname.endsWith('.internal')) {
+  // A trailing dot is a valid FQDN root marker ("foo.internal.") that Node
+  // fetch still resolves, but it defeats a naive suffix/no-dot check. Strip
+  // it before those checks — never before IP literal parsing above, since
+  // IP literals don't carry a trailing dot.
+  const normalizedHostname = hostname.endsWith('.') ? hostname.slice(0, -1) : hostname
+
+  if (normalizedHostname.endsWith('.local') || normalizedHostname.endsWith('.internal')) {
     return {ok: false, reason: 'no-dot-hostname'}
   }
 
   // Bare hostname / local service name — no dot at all (e.g. "workspace").
   // IPv6 literals never contain a dot check here since they already passed above.
-  if (isIpv6Literal === false && hostname.includes('.') === false) {
+  if (isIpv6Literal === false && normalizedHostname.includes('.') === false) {
     return {ok: false, reason: 'no-dot-hostname'}
   }
 

--- a/packages/gateway/src/web/operator-push/vapid-public-key-route.test.ts
+++ b/packages/gateway/src/web/operator-push/vapid-public-key-route.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the authenticated VAPID public key route: GET /operator/push/vapid-key
+ *
+ * All tests go through the REAL HTTP route (with the operator route guard
+ * installed) — not a handler-only call.
+ */
+
+import type {VapidPublicKeyRouteDeps} from './vapid-public-key-route.js'
+import {Hono} from 'hono'
+import {describe, expect, it, vi} from 'vitest'
+import {setOperatorRouteGuard} from '../operator-route.js'
+import {buildVapidPublicKeyRoute} from './vapid-public-key-route.js'
+
+function makeDeps(overrides?: Partial<VapidPublicKeyRouteDeps>): VapidPublicKeyRouteDeps {
+  return {
+    vapidPublicKeyInfo: {
+      publicKey: 'BOb1EqJOpvFSxr2XOPIr82Ktdxl6AibGOAiPmrkjbsv0mpr9In09mLbskqVAgLPIDjb0UIb7mZpU0SJKWWsVazc',
+      keyVersion: '1',
+    },
+    logger: {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()},
+    ...overrides,
+  }
+}
+
+function buildAppWithGuard(deps: VapidPublicKeyRouteDeps, allow: boolean): Hono {
+  const app = new Hono()
+  setOperatorRouteGuard(app, async () =>
+    allow
+      ? {ok: true, githubUserId: 1001, sessionId: 'sess-1'}
+      : {ok: false, response: new Response(null, {status: 404})},
+  )
+  buildVapidPublicKeyRoute(app, deps)
+  return app
+}
+
+describe('buildVapidPublicKeyRoute', () => {
+  // #given an authenticated operator session
+  // #when GET /operator/push/vapid-key
+  // #then returns {publicKey, keyVersion}; private key never present
+  it('happy path: returns publicKey and keyVersion for an authenticated operator', async () => {
+    const deps = makeDeps()
+    const app = buildAppWithGuard(deps, true)
+
+    const res = await app.request('/operator/push/vapid-key')
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {publicKey: string; keyVersion: string}
+    expect(body).toEqual({publicKey: deps.vapidPublicKeyInfo.publicKey, keyVersion: '1'})
+    expect(JSON.stringify(body)).not.toContain('privateKey')
+  })
+
+  // #given no authenticated session (guard rejects)
+  // #when GET /operator/push/vapid-key
+  // #then denied with the guard's response — handler never runs
+  it('error path: guard denial short-circuits before the handler', async () => {
+    const deps = makeDeps()
+    const app = buildAppWithGuard(deps, false)
+
+    const res = await app.request('/operator/push/vapid-key')
+
+    expect(res.status).toBe(404)
+  })
+})

--- a/packages/gateway/src/web/operator-push/vapid-public-key-route.ts
+++ b/packages/gateway/src/web/operator-push/vapid-public-key-route.ts
@@ -1,0 +1,68 @@
+/**
+ * Authenticated operator push route: GET /operator/push/vapid-key
+ *
+ * Returns the current VAPID public key and key version so an authenticated
+ * operator's browser can call `PushManager.subscribe({applicationServerKey})`.
+ * Never exposes the private key — the route only ever reads
+ * `vapidPublicKeyInfo` (see web/operator-push/vapid.ts), which structurally
+ * excludes the private key field.
+ *
+ * Gate ordering:
+ *   1. Guard (browser/session/allowlist) — installed by buildOperatorApp
+ *      (GET → requireCsrf=false; this is a read route)
+ *   2. Read authenticated context set by the guard
+ *   3. Return {publicKey, keyVersion}
+ *
+ * Security invariants:
+ *   - The private VAPID key never flows into this module.
+ *   - Every denial mirrors the launch route's no-oracle notFoundResponse.
+ */
+
+import type {Hono} from 'hono'
+import type {OperatorPushVapidKeyResponse} from '../../operator-contract/index.js'
+import type {OperatorLogger} from '../server.js'
+import type {VapidPublicKeyInfo} from './vapid.js'
+import {getOperatorAuthContext, registerOperatorRoute} from '../operator-route.js'
+import {notFoundResponse} from '../safe-response.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Dependencies for the VAPID public key route. */
+export interface VapidPublicKeyRouteDeps {
+  /** Client-safe VAPID material (public key + key version only). */
+  readonly vapidPublicKeyInfo: VapidPublicKeyInfo
+  /** Structured logger. */
+  readonly logger: OperatorLogger
+}
+
+// ---------------------------------------------------------------------------
+// Route builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Register GET /operator/push/vapid-key on the given Hono app.
+ *
+ * Must be called after setOperatorRouteGuard is installed in buildOperatorApp.
+ * The guard runs first (browser/session/allowlist); this handler runs only
+ * if the guard allows the request.
+ */
+export function buildVapidPublicKeyRoute(app: Hono, deps: VapidPublicKeyRouteDeps): void {
+  registerOperatorRoute(app, 'GET', '/operator/push/vapid-key', c => {
+    // ── Gate: Read authenticated context set by the guard ────────────────────
+    // In production the guard always sets this; undefined is unreachable.
+    // Return not-found as a safe fallback (no oracle — same shape as all denials).
+    const authCtx = getOperatorAuthContext(c)
+    if (authCtx === undefined) {
+      deps.logger.warn({gate: 'no-auth-ctx'}, 'push-vapid-key: denied')
+      return notFoundResponse(c)
+    }
+
+    const response: OperatorPushVapidKeyResponse = {
+      publicKey: deps.vapidPublicKeyInfo.publicKey,
+      keyVersion: deps.vapidPublicKeyInfo.keyVersion,
+    }
+    return c.json(response, 200)
+  })
+}

--- a/packages/gateway/src/web/operator-route-smoke.test.ts
+++ b/packages/gateway/src/web/operator-route-smoke.test.ts
@@ -160,6 +160,97 @@ describe('buildOperatorServerInputs — parity with production wiring', () => {
     expect(routeSet).toContain('POST:/operator/runs/:runId/approvals/:requestId/decision')
   })
 
+  it('threads operatorPush deps through to mount the push routes', () => {
+    // #given — operatorPush deps present (mirrors a passed self-test)
+    const logger = makeStubLogger()
+    const denylistCache = makeStubDenylistCache()
+    const bindingsStore = makeStubBindingsStore()
+    const runObservationManager = makeStubRunObservationManager()
+    const runIndex = makeStubRunIndex()
+    const approvalRegistry = makeStubApprovalRegistry()
+    const operatorWebConfig = makeStubOperatorWebConfig()
+
+    // #when — build inputs via the shared helper with operatorPush present
+    const {deps, config} = buildOperatorServerInputs({
+      logger,
+      isShuttingDown: () => false,
+      denylistCache,
+      bindingsStore,
+      runObservationManager,
+      runIndex,
+      approvalRegistry,
+      launchWorkDeps: makeStubLaunchWorkDeps(),
+      operatorPush: {
+        store: {
+          subscribe: async () => ({
+            success: true as const,
+            data: {
+              endpointHash: 'h',
+              operatorId: 'op',
+              active: true,
+              keyVersion: '1',
+              ownershipGeneration: 1,
+              createdAt: 0,
+              updatedAt: 0,
+            },
+          }),
+          unsubscribe: async () => ({success: true as const, data: undefined}),
+          listMetadataForOperator: async () => ({success: true as const, data: []}),
+        },
+        vapidPublicKeyInfo: {
+          publicKey: 'BOb1EqJOpvFSxr2XOPIr82Ktdxl6AibGOAiPmrkjbsv0mpr9In09mLbskqVAgLPIDjb0UIb7mZpU0SJKWWsVazc',
+          keyVersion: '1',
+        },
+      },
+      operatorWebConfig,
+    })
+
+    // #then — the deps are threaded through unchanged
+    expect(deps.operatorPushStore).toBeDefined()
+    expect(deps.operatorPushVapidKeyInfo).toEqual({
+      publicKey: 'BOb1EqJOpvFSxr2XOPIr82Ktdxl6AibGOAiPmrkjbsv0mpr9In09mLbskqVAgLPIDjb0UIb7mZpU0SJKWWsVazc',
+      keyVersion: '1',
+    })
+
+    // #and — the push routes are mounted
+    const app = buildOperatorApp(deps, config)
+    const routePaths = app.routes.map((r: {method: string; path: string}) => `${r.method}:${r.path}`)
+    expect(routePaths).toContain('GET:/operator/push/vapid-key')
+    expect(routePaths).toContain('POST:/operator/push/subscriptions')
+    expect(routePaths).toContain('POST:/operator/push/subscriptions/unsubscribe')
+    expect(routePaths).toContain('GET:/operator/push/subscriptions')
+  })
+
+  it('omitting operatorPush causes the push routes to be absent', () => {
+    // #given — operatorPush omitted (simulates disabled/self-test-failed)
+    const logger = makeStubLogger()
+    const denylistCache = makeStubDenylistCache()
+    const bindingsStore = makeStubBindingsStore()
+    const runObservationManager = makeStubRunObservationManager()
+    const runIndex = makeStubRunIndex()
+    const approvalRegistry = makeStubApprovalRegistry()
+    const operatorWebConfig = makeStubOperatorWebConfig()
+
+    // #when
+    const {deps, config} = buildOperatorServerInputs({
+      logger,
+      isShuttingDown: () => false,
+      denylistCache,
+      bindingsStore,
+      runObservationManager,
+      runIndex,
+      approvalRegistry,
+      launchWorkDeps: makeStubLaunchWorkDeps(),
+      operatorWebConfig,
+    })
+
+    // #then — the push routes are NOT mounted
+    const app = buildOperatorApp(deps, config)
+    const routePaths = app.routes.map((r: {method: string; path: string}) => `${r.method}:${r.path}`)
+    expect(routePaths).not.toContain('GET:/operator/push/vapid-key')
+    expect(routePaths).not.toContain('POST:/operator/push/subscriptions')
+  })
+
   it('omitting listBindings from bindingsStore causes GET /operator/repos to be absent', () => {
     // #given — bindingsStore WITHOUT listBindings (a route gated on a missing dep is unmounted)
     const logger = makeStubLogger()
@@ -302,6 +393,21 @@ describe('runOperatorRouteSmoke — regression guard (non-vacuous)', () => {
     })
 
     // #then — non-zero exit (GET /operator/runs absent)
+    expect(exitCode).not.toBe(0)
+  })
+
+  it('returns non-zero when push routes are absent (operatorPushOverride: undefined)', async () => {
+    // #given — operatorPush flows through buildOperatorServerInputs; passing
+    // operatorPushOverride: undefined causes the helper to pass undefined to
+    // deps.operatorPushStore/deps.operatorPushVapidKeyInfo, and server.ts gates
+    // the /operator/push/* routes on both being present. Simulates a self-test
+    // failure or push disabled.
+    // #when
+    const exitCode = await runOperatorRouteSmoke({
+      operatorPushOverride: undefined,
+    })
+
+    // #then — non-zero exit (push routes absent)
     expect(exitCode).not.toBe(0)
   })
 })

--- a/packages/gateway/src/web/operator-route-smoke.ts
+++ b/packages/gateway/src/web/operator-route-smoke.ts
@@ -25,6 +25,7 @@
 
 import {Buffer} from 'node:buffer'
 
+import {ok} from '@fro-bot/runtime'
 import {buildOperatorServerInputs} from '../program.js'
 import {loadAllowlistFromText} from './auth/allowlist.js'
 import {buildOperatorApp} from './server.js'
@@ -51,6 +52,10 @@ export const EXPECTED_OPERATOR_ROUTES: readonly {readonly method: string; readon
   {method: 'POST', path: '/operator/runs/:runId/approvals/:requestId/decision'},
   {method: 'GET', path: '/operator/runs/:runId/approvals'},
   {method: 'POST', path: '/operator/runs/:runId/cancel'},
+  {method: 'GET', path: '/operator/push/vapid-key'},
+  {method: 'POST', path: '/operator/push/subscriptions'},
+  {method: 'POST', path: '/operator/push/subscriptions/unsubscribe'},
+  {method: 'GET', path: '/operator/push/subscriptions'},
 ]
 
 // ---------------------------------------------------------------------------
@@ -120,6 +125,29 @@ function makeStubLaunchWorkDeps() {
   return {} as NonNullable<Parameters<typeof buildOperatorApp>[0]['launchWorkDeps']>
 }
 
+function makeStubOperatorPush(): NonNullable<Parameters<typeof buildOperatorServerInputs>[0]['operatorPush']> {
+  return {
+    store: {
+      subscribe: async () =>
+        ok({
+          endpointHash: 'stub-hash',
+          operatorId: 'stub-operator',
+          active: true,
+          keyVersion: '1',
+          ownershipGeneration: 1,
+          createdAt: 0,
+          updatedAt: 0,
+        }),
+      unsubscribe: async () => ok(undefined),
+      listMetadataForOperator: async () => ok([]),
+    },
+    vapidPublicKeyInfo: {
+      publicKey: 'BOb1EqJOpvFSxr2XOPIr82Ktdxl6AibGOAiPmrkjbsv0mpr9In09mLbskqVAgLPIDjb0UIb7mZpU0SJKWWsVazc',
+      keyVersion: '1',
+    },
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Options — allow test overrides for regression-guard tests
 // ---------------------------------------------------------------------------
@@ -165,6 +193,12 @@ export interface OperatorRouteSmokeOptions {
    * undefined here flows through the helper and causes the cancel route to be absent.
    */
   readonly cancelRunDepsOverride?: Parameters<typeof buildOperatorServerInputs>[0]['cancelRunDeps'] | undefined
+  /**
+   * Override the operatorPush deps passed to buildOperatorServerInputs.
+   * Pass undefined to simulate push disabled or a self-test failure (push
+   * routes absent). When omitted, the default stub is used (push routes present).
+   */
+  readonly operatorPushOverride?: Parameters<typeof buildOperatorServerInputs>[0]['operatorPush'] | undefined
   /**
    * Whether to suppress log output. Defaults to false (logs to stdout).
    */
@@ -257,6 +291,14 @@ export async function runOperatorRouteSmoke(options?: OperatorRouteSmokeOptions)
   const hasCancelRunDepsOverride = options !== undefined && 'cancelRunDepsOverride' in options
   const cancelRunDeps = hasCancelRunDepsOverride ? options.cancelRunDepsOverride : makeStubCancelRunDeps()
 
+  // Resolve operatorPush — use the override if provided, else the default stub.
+  // When the override is explicitly undefined, the push routes will not register
+  // because buildOperatorServerInputs passes it through to
+  // deps.operatorPushStore/deps.operatorPushVapidKeyInfo, and server.ts gates
+  // the push routes on both being present.
+  const hasOperatorPushOverride = options !== undefined && 'operatorPushOverride' in options
+  const operatorPush = hasOperatorPushOverride ? options.operatorPushOverride : makeStubOperatorPush()
+
   // Build the operator server inputs via the shared production helper.
   // This is the seam that makes the diagnostic catch wiring gaps: if a dep is
   // dropped from buildOperatorServerInputs, both production and this diagnostic
@@ -284,6 +326,11 @@ export async function runOperatorRouteSmoke(options?: OperatorRouteSmokeOptions)
     // sees the same value as production. When undefined (regression test), the
     // helper passes undefined to deps.launchWorkDeps and POST /operator/runs is absent.
     launchWorkDeps,
+    // operatorPush flows through the helper so the route gate in server.ts sees
+    // the same value as production. When undefined (regression test), the helper
+    // passes undefined to deps.operatorPushStore/deps.operatorPushVapidKeyInfo
+    // and the /operator/push/* routes are absent.
+    operatorPush,
     operatorWebConfig,
   })
 

--- a/packages/gateway/src/web/server.test.ts
+++ b/packages/gateway/src/web/server.test.ts
@@ -1744,6 +1744,34 @@ function makeStubLaunchWorkDeps(): NonNullable<OperatorServerDeps['launchWorkDep
   return {} as unknown as NonNullable<OperatorServerDeps['launchWorkDeps']>
 }
 
+/** Shared stub for the operator push subscription store — no-op for registration tests. */
+function makeStubOperatorPushStore(): NonNullable<OperatorServerDeps['operatorPushStore']> {
+  return {
+    subscribe: async () => ({
+      success: true as const,
+      data: {
+        endpointHash: 'stub-hash',
+        operatorId: 'stub-operator',
+        active: true,
+        keyVersion: '1',
+        ownershipGeneration: 1,
+        createdAt: 0,
+        updatedAt: 0,
+      },
+    }),
+    unsubscribe: async () => ({success: true as const, data: undefined}),
+    listMetadataForOperator: async () => ({success: true as const, data: []}),
+  }
+}
+
+/** Shared stub for client-safe VAPID key info — registration tests only. */
+function makeStubOperatorPushVapidKeyInfo(): NonNullable<OperatorServerDeps['operatorPushVapidKeyInfo']> {
+  return {
+    publicKey: 'BOb1EqJOpvFSxr2XOPIr82Ktdxl6AibGOAiPmrkjbsv0mpr9In09mLbskqVAgLPIDjb0UIb7mZpU0SJKWWsVazc',
+    keyVersion: '1',
+  }
+}
+
 /** Build a full-deps OperatorServerDeps with all privileged routes enabled. */
 function makeFullPrivilegedDeps(sessionStore: ReturnType<typeof createInMemorySessionStore>): OperatorServerDeps {
   const {logger, auditLogger, allowlist, csrfSecret} = makeStubBrowserGuardDeps(sessionStore)
@@ -1764,6 +1792,8 @@ function makeFullPrivilegedDeps(sessionStore: ReturnType<typeof createInMemorySe
     launchWorkDeps: makeStubLaunchWorkDeps(),
     approvalRegistry: makeStubApprovalRegistry(),
     cancelRunDeps: makeStubCancelRunDeps(),
+    operatorPushStore: makeStubOperatorPushStore(),
+    operatorPushVapidKeyInfo: makeStubOperatorPushVapidKeyInfo(),
     rateLimiter: {allow: () => true},
   })
 }

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -34,6 +34,9 @@ import type {OperatorAllowlist} from './auth/allowlist.js'
 import type {GitHubOAuthConfig, GitHubOAuthDeps} from './auth/github.js'
 import type {RepoAuthzCache} from './auth/repo-authz.js'
 import type {SessionDeps, SessionStore} from './auth/session.js'
+import type {SubscriptionRouteSessionStore} from './operator-push/subscription-route.js'
+import type {OperatorPushSubscriptionStore} from './operator-push/subscription-store.js'
+import type {VapidPublicKeyInfo} from './operator-push/vapid.js'
 import type {IdempotencyGuard} from './operator/idempotency.js'
 import type {RunObservationManager} from './sse/manager.js'
 import {serve} from '@hono/node-server'
@@ -48,6 +51,8 @@ import {buildGitHubOAuthRoutes} from './auth/github.js'
 import {createRepoAuthzCache} from './auth/repo-authz.js'
 import {buildSessionInfoRoute} from './auth/session-info-route.js'
 import {buildLogoutRoutes} from './auth/session.js'
+import {buildSubscriptionRoutes} from './operator-push/subscription-route.js'
+import {buildVapidPublicKeyRoute} from './operator-push/vapid-public-key-route.js'
 import {assertAllPrivilegedRoutesWrapped, registerPublicRoute, setOperatorRouteGuard} from './operator-route.js'
 import {buildCancelRoute} from './operator/cancel-route.js'
 import {buildDecisionRoute} from './operator/decision-route.js'
@@ -227,6 +232,21 @@ export interface OperatorServerDeps {
    * When absent, the route is not registered (opt-in).
    */
   readonly cancelRunDeps?: CancelRunDeps
+  /**
+   * Durable operator push subscription store.
+   * When present (alongside operatorPushVapidKeyInfo, sessionStore, and the
+   * browser guard), the /operator/push/* routes are registered. When absent,
+   * those routes are not registered (opt-in, fail-closed).
+   */
+  readonly operatorPushStore?: Pick<
+    OperatorPushSubscriptionStore,
+    'subscribe' | 'unsubscribe' | 'listMetadataForOperator'
+  >
+  /**
+   * Client-safe VAPID material (public key + key version only).
+   * Required when operatorPushStore is present; ignored otherwise.
+   */
+  readonly operatorPushVapidKeyInfo?: VapidPublicKeyInfo
 }
 
 export interface OperatorServerConfig {
@@ -945,6 +965,42 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
         cache: deps.repoAuthzCache ?? createRepoAuthzCache(),
       },
       registry: deps.approvalRegistry,
+      logger: deps.logger,
+      now: clock,
+    })
+  }
+
+  // ── Operator push routes ───────────────────────────────────────────────────
+  //
+  // Registered only when the full browser guard is present AND operatorPushStore
+  // and operatorPushVapidKeyInfo are provided AND sessionStore is present.
+  // Routes:
+  //   GET  /operator/push/vapid-key              — privileged (session + allowlist; safe GET)
+  //   POST /operator/push/subscriptions           — privileged (session + allowlist + CSRF)
+  //   POST /operator/push/subscriptions/unsubscribe — privileged (session + allowlist + CSRF)
+  //   GET  /operator/push/subscriptions            — privileged (session + allowlist; safe GET)
+  //
+  // Fail-closed by construction: the caller (program.ts) only threads
+  // operatorPushStore/operatorPushVapidKeyInfo through when the object store
+  // has passed its CAS self-test at startup. A self-test failure (or push
+  // disabled entirely) means these deps are absent here and the routes never
+  // mount — matching the fail-closed posture of every other opt-in route above.
+  if (
+    browserGuardDeps !== undefined &&
+    deps.sessionStore !== undefined &&
+    deps.operatorPushStore !== undefined &&
+    deps.operatorPushVapidKeyInfo !== undefined
+  ) {
+    const clock = deps.sessionDeps?.clock ?? (() => Date.now())
+    const sessionStoreForPush: SubscriptionRouteSessionStore = deps.sessionStore
+    buildVapidPublicKeyRoute(app, {
+      vapidPublicKeyInfo: deps.operatorPushVapidKeyInfo,
+      logger: deps.logger,
+    })
+    buildSubscriptionRoutes(app, {
+      sessionStore: sessionStoreForPush,
+      store: deps.operatorPushStore,
+      keyVersion: deps.operatorPushVapidKeyInfo.keyVersion,
       logger: deps.logger,
       now: clock,
     })


### PR DESCRIPTION
Adds the authenticated operator Web Push routes to the gateway — the server-side counterpart to the dashboard's push subscription UI. Third unit of the operator push feature; still disabled-by-default with no `web-push` dependency and no dispatch path yet.

## What this adds

Four routes under `/operator/push/`, all privileged (session + allowlist + CSRF via `registerOperatorRoute`):

- `GET /operator/push/vapid-key` — returns the public VAPID key + key version (never the private key)
- `POST /operator/push/subscriptions` — stores a browser push subscription's safe metadata
- `POST /operator/push/subscriptions/unsubscribe` — deactivates by endpoint
- `GET /operator/push/subscriptions` — lists the operator's own subscription metadata

The routes mount **only** when push config is present **and** the store's CAS self-test passes at startup. A failed or throwing self-test disables push and logs a warning — the rest of the gateway (Discord, operator web, announce) still starts. Fail-closed.

## Security posture

- **SSRF endpoint validation** — browser-supplied endpoint URLs are validated before any value reaches the store: HTTPS-only, and loopback / private / link-local / unspecified addresses are rejected across their encodings, including IPv4-mapped IPv6 (`[::ffff:127.0.0.1]`, `[::ffff:169.254.169.254]`), `0.0.0.0`, IPv6 `::`, and trailing-dot FQDNs. This is a parse-time literal-address guard; it cannot stop DNS rebinding, so the dispatch path must additionally validate the resolved IP at connect time (documented in the module).
- **No secret leakage** — the endpoint value is never logged or echoed; rejections carry only a coarse reason class. Every denial returns an identical not-found response (no oracle).
- **Identity from session** — subscribe/unsubscribe operate on the authenticated operator, never a body-supplied id.
- **Per-operator subscription cap** — bounds record growth; re-subscribing an existing endpoint is exempt.

The operator contract version is deliberately unchanged — these additive REST routes are invisible to the SSE ready-frame drift gate.

## Note for the dashboard side

The `GET /operator/push/subscriptions` response is `{subscriptions: [...]}` with numeric (ms-epoch) timestamps. The dashboard's forward-looking client currently expects a single metadata object with string timestamps — it will adapt its parser to this shape as the browser UI lands.

## Verification

Gateway type-check, lint, and full suite green (3078 tests). SSRF validator and the self-test gate carry dedicated tests, including the fail-closed / throw-degrades-gracefully paths and the SSRF bypass classes above.
