### PR TITLE
chore: strip plan-unit taxonomy from source comments and test labels

### DIFF
--- a/apps/workspace-agent/src/opencode-server.test.ts
+++ b/apps/workspace-agent/src/opencode-server.test.ts
@@ -387,7 +387,7 @@ describe('defaultPollReady — per-probe timeout', () => {
 
 // ── Supervised respawn tests ──────────────────────────────────────────────────
 //
-// These tests exercise the supervised respawn loop added in Unit 5.
+// These tests exercise the supervised respawn loop.
 // Real timers, zero/tiny delays, injected spawnFn/pollReadyFn per convention.
 
 /**
@@ -444,7 +444,7 @@ function makeControllableChild() {
   return {child, killCalls, triggerExit}
 }
 
-describe('runSupervisedOpencode — happy path (Unit 5)', () => {
+describe('runSupervisedOpencode — happy path', () => {
   it('resolves with status ready when first spawn becomes ready (then exits cleanly)', async () => {
     // #given — first child becomes ready immediately, then exits cleanly (simulates
     // a normal lifecycle: ready → child exits → supervisor goes to degraded since
@@ -494,7 +494,7 @@ describe('runSupervisedOpencode — happy path (Unit 5)', () => {
   })
 })
 
-describe('runSupervisedOpencode — transient failure recovery (Unit 5)', () => {
+describe('runSupervisedOpencode — transient failure recovery', () => {
   it('recovers when first spawn fails but second becomes ready', async () => {
     // #given — first child exits immediately (failure), second becomes ready then exits
     const failChild = makeFakeChild({exitImmediately: true, exitCode: 1})
@@ -597,7 +597,7 @@ describe('runSupervisedOpencode — transient failure recovery (Unit 5)', () => 
   })
 })
 
-describe('runSupervisedOpencode — exhaustion (Unit 5)', () => {
+describe('runSupervisedOpencode — exhaustion', () => {
   it('lands in degraded (not starting, not down) when all attempts fail', async () => {
     // #given — all children exit immediately
     const children = [
@@ -658,7 +658,7 @@ describe('runSupervisedOpencode — exhaustion (Unit 5)', () => {
   })
 })
 
-describe('runSupervisedOpencode — post-ready exit latch fix (Unit 5)', () => {
+describe('runSupervisedOpencode — post-ready exit latch fix', () => {
   it('flips status away from ready when child exits after becoming ready', async () => {
     // #given — child becomes ready, then exits unexpectedly
     const {child, triggerExit} = makeControllableChild()
@@ -712,7 +712,7 @@ describe('runSupervisedOpencode — post-ready exit latch fix (Unit 5)', () => {
   })
 })
 
-describe('runSupervisedOpencode — fail-closed transition (Unit 5)', () => {
+describe('runSupervisedOpencode — fail-closed transition', () => {
   it('sets status to starting (not-ready) before killing the child on respawn', async () => {
     // #given — first child times out (kill is called); we capture status at kill time.
     // Second child becomes ready then exits so the supervisor can resolve.
@@ -788,7 +788,7 @@ describe('runSupervisedOpencode — fail-closed transition (Unit 5)', () => {
   })
 })
 
-// ── Unit 6: Process-group reaping tests ──────────────────────────────────────
+// ── Process-group reaping tests ──────────────────────────────────────
 //
 // These tests verify that:
 // 1. When child.pid is a number, kill uses process.kill(-pid, 'SIGTERM') (group kill).
@@ -852,7 +852,7 @@ function makeSpawnFnWithOpts(
   }
 }
 
-describe('process-group reaping (Unit 6) — group kill when pid is present', () => {
+describe('process-group reaping — group kill when pid is present', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
@@ -1328,7 +1328,7 @@ describe('killChildGroup — does not throw on ESRCH (Fix 3)', () => {
   })
 })
 
-// ── Unit 3: Per-probe readiness deadline cap ──────────────────────────────────
+// ── Per-probe readiness deadline cap ──────────────────────────────────
 //
 // The readiness polling loop must cap each probe to the remaining overall
 // deadline so the loop can't overshoot WORKSPACE_OPENCODE_READY_TIMEOUT_MS by
@@ -1342,7 +1342,7 @@ describe('killChildGroup — does not throw on ESRCH (Fix 3)', () => {
 // the probe timeout is set to a large value (e.g. 3000ms). The spy asserts the
 // capped value (≤ remaining) was passed, not the raw 3000ms.
 
-describe('startOpencodeServer — per-probe deadline cap (Unit 3)', () => {
+describe('startOpencodeServer — per-probe deadline cap', () => {
   it('caps per-probe timeout to remaining deadline when overall timeout is very short', async () => {
     // #given — overall timeout 50ms, default probe timeout 3000ms
     // The spy records every probeTimeoutMs value passed to it
@@ -1438,7 +1438,7 @@ describe('startOpencodeServer — per-probe deadline cap (Unit 3)', () => {
   })
 })
 
-describe('runSupervisedOpencode — per-probe deadline cap (Unit 3)', () => {
+describe('runSupervisedOpencode — per-probe deadline cap', () => {
   it('caps per-probe timeout to remaining deadline in the supervisor readiness loop', async () => {
     // #given — overall timeout 50ms, default probe timeout 3000ms
     // The supervisor readiness loop must also cap per-probe timeout
@@ -1712,7 +1712,7 @@ describe('runSupervisedOpencode — abort signal wires through (Fix 4)', () => {
   })
 })
 
-describe('process-group reaping (Unit 6) — supervised respawn group kill', () => {
+describe('process-group reaping — supervised respawn group kill', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })

--- a/apps/workspace-agent/src/server.test.ts
+++ b/apps/workspace-agent/src/server.test.ts
@@ -496,7 +496,7 @@ describe('GET /readyz', () => {
   })
 })
 
-describe('GET /readyz — proxy-listening gate (Unit 2)', () => {
+describe('GET /readyz — proxy-listening gate', () => {
   it('returns 200 when opencode is ready AND proxy is listening', async () => {
     // #given — both conditions satisfied: the happy path
     const opencodeStatus = {status: 'ready' as const}

--- a/packages/gateway/src/approvals/coordinator.test.ts
+++ b/packages/gateway/src/approvals/coordinator.test.ts
@@ -92,7 +92,7 @@ describe('parsePermissionRequest', () => {
 })
 
 // ---------------------------------------------------------------------------
-// parsePermissionRequest — command/filepath fields (Unit 1)
+// parsePermissionRequest — command/filepath fields
 // ---------------------------------------------------------------------------
 
 describe('parsePermissionRequest — command/filepath fields', () => {

--- a/packages/gateway/src/approvals/registry.test.ts
+++ b/packages/gateway/src/approvals/registry.test.ts
@@ -954,7 +954,7 @@ describe('P2 — confirmReply sessionID mismatch guard', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Unit 2: hasPendingForScope
+// hasPendingForScope
 // ---------------------------------------------------------------------------
 
 describe('hasPendingForScope', () => {

--- a/packages/gateway/src/bindings/store.test.ts
+++ b/packages/gateway/src/bindings/store.test.ts
@@ -544,7 +544,7 @@ describe('createBindingsStore', () => {
     }
   })
 
-  // ─── Unit 1: deny-key fields (databaseId / nodeId) ──────────────────────────
+  // ─── deny-key fields (databaseId / nodeId) ──────────────────────────
 
   // Happy path — binding with deny keys round-trips through the store
   it('createBinding + getBindingByRepo round-trips a binding that carries databaseId and nodeId', async () => {

--- a/packages/gateway/src/discord/commands/add-project.test.ts
+++ b/packages/gateway/src/discord/commands/add-project.test.ts
@@ -1552,7 +1552,7 @@ describe('executeAddProject', () => {
   })
 
   // -------------------------------------------------------------------------
-  // Identity capture at ingest (Unit 2)
+  // Identity capture at ingest
   // -------------------------------------------------------------------------
 
   describe('WRITING_BINDING: repo identity captured at ingest', () => {

--- a/packages/gateway/src/execute/abort-registry.ts
+++ b/packages/gateway/src/execute/abort-registry.ts
@@ -24,7 +24,7 @@
 /**
  * Attribution metadata for an operator-initiated cancel.
  *
- * Written by `cancelRun` (Unit 2) alongside `abort()` so the run's own
+ * Written by `cancelRun` alongside `abort()` so the run's own
  * settlement path in `run.ts` (the single writer of the CANCELLED transition)
  * can read it back and thread `details.cancelledBy` onto the transition —
  * without the orchestrator reaching into run.ts's private execution state.

--- a/packages/gateway/src/execute/cancel.ts
+++ b/packages/gateway/src/execute/cancel.ts
@@ -9,8 +9,8 @@
  *    release).
  *  - **Executing** (abort-registry hit): pending approvals for the run's scope
  *    are rejected through the single fail-closed settlement gate
- *  (`registry.handleDecision`), then the abort handle fires. The run's error
- *  path in `run.ts` owns the CANCELLED transition and resource release.
+ *    (`registry.handleDecision`), then the abort handle fires. The run's error
+ *    path in `run.ts` owns the CANCELLED transition and resource release.
  *  - **Pre-ACK rendezvous** (double miss — the registration window between
  *    dequeue and abort-registry registration): a direct conditional-write
  *    `transitionRun(currentPhase → CANCELLED)` IS the rendezvous. Either the

--- a/packages/gateway/src/execute/cancel.ts
+++ b/packages/gateway/src/execute/cancel.ts
@@ -9,8 +9,8 @@
  *    release).
  *  - **Executing** (abort-registry hit): pending approvals for the run's scope
  *    are rejected through the single fail-closed settlement gate
- *    (`registry.handleDecision`), then the abort handle fires. Unit 1's error
- *    path in `run.ts` owns the CANCELLED transition and resource release.
+ *  (`registry.handleDecision`), then the abort handle fires. The run's error
+ *  path in `run.ts` owns the CANCELLED transition and resource release.
  *  - **Pre-ACK rendezvous** (double miss — the registration window between
  *    dequeue and abort-registry registration): a direct conditional-write
  *    `transitionRun(currentPhase → CANCELLED)` IS the rendezvous. Either the
@@ -46,7 +46,7 @@ import {toCoordLogger} from './run.js'
  * Minimal, readonly actor-attribution shape accepted by `cancelRun`.
  *
  * Structurally compatible with `OperatorIdentity`/`WebOperatorActor` — the
- * Unit 3 web route passes those fields directly. Kept as its own type here so
+ * operator web cancel route passes those fields directly. Kept as its own type here so
  * `cancel.ts` (execute-layer, transport-neutral) does not import the web
  * operator-contract module.
  */
@@ -358,7 +358,7 @@ export async function cancelRun(params: CancelRunParams, deps: CancelRunDeps): P
       sessionCorrelationId: actor.sessionCorrelationId,
     }
 
-    // Settle pending approvals FIRST — Unit 1's error path (triggered by the
+    // Settle pending approvals FIRST — the run's error path (triggered by the
     // abort below) owns the run-state transition/cleanup; approvals must be
     // rejected before the abort so the run's own catch handler doesn't race
     // a still-open approval against the cancel.

--- a/packages/gateway/src/execute/run.test.ts
+++ b/packages/gateway/src/execute/run.test.ts
@@ -5660,10 +5660,10 @@ describe('threadFactory timeout path', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Unit 1: Approval transport selection and web surface support
+// Approval transport selection and web surface support
 // ---------------------------------------------------------------------------
 
-describe('Unit 1 — approval transport selection', () => {
+describe('approval transport selection', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -5860,9 +5860,9 @@ describe('Unit 1 — approval transport selection', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Unit 0: Characterization — Phase A seam invariants
+// Characterization — seam invariants (static guards)
 //
-// These static guards pin the public API contract that Phase B depends on:
+// These static guards pin the public API contract that the seam depends on:
 //   1. `executeWorkOnHeldSlot` is NOT exported — callers must use `launchWork`.
 //   2. `launchWork` IS exported — it is the single public front door.
 //   3. `runMention` IS exported — it is the Discord adapter entry point.
@@ -5871,7 +5871,7 @@ describe('Unit 1 — approval transport selection', () => {
 // front door has been removed. Both require deliberate security review.
 // ---------------------------------------------------------------------------
 
-describe('Unit 0 — Phase A seam invariants (static guards)', () => {
+describe('seam invariants (static guards)', () => {
   it('executeWorkOnHeldSlot is NOT exported from run.ts — callers must use launchWork', async () => {
     // #given — import the run module
     const runModule = await import('./run.js')
@@ -6874,7 +6874,7 @@ describe('early-abort gates terminalize to FAILED', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Operator cancel — abort-registry integration (Unit 1)
+// Operator cancel — abort-registry integration
 // ---------------------------------------------------------------------------
 
 const CANCEL_RUN_ID = 'cancel-run-id-1'
@@ -7915,7 +7915,7 @@ describe('operator cancel — abort-registry integration', () => {
 })
 
 // ---------------------------------------------------------------------------
-// failureKind persistence on the FAILED transition (Unit 3)
+// failureKind persistence on the FAILED transition
 // ---------------------------------------------------------------------------
 
 describe('failureKind persistence on FAILED transitions', () => {
@@ -8165,7 +8165,7 @@ describe('failureKind persistence on FAILED transitions', () => {
 })
 
 // ---------------------------------------------------------------------------
-// failAdmittedRun failureKind threading (Unit 4) — pre-ACK gates
+// failAdmittedRun failureKind threading — pre-ACK gates
 // ---------------------------------------------------------------------------
 
 describe('failAdmittedRun failureKind threading (pre-ACK gates)', () => {
@@ -8188,7 +8188,7 @@ describe('failAdmittedRun failureKind threading (pre-ACK gates)', () => {
     const failedOptions = failedCall?.[7] as {detailsPatch: {failureKind: unknown}} | undefined
     expect(failedOptions?.detailsPatch.failureKind).toBe('unreachable')
 
-    // #and — this projects to 'workspace-unreachable' via the operator mapping (Unit 1)
+    // #and — this projects to 'workspace-unreachable' via the operator mapping
     const {toOperatorFailureKind} = await import('../operator-contract/run-status.js')
     expect(toOperatorFailureKind(failedOptions?.detailsPatch.failureKind)).toBe('workspace-unreachable')
   })
@@ -8263,7 +8263,7 @@ describe('failAdmittedRun failureKind threading (pre-ACK gates)', () => {
     // #when
     await runMention(message, makeBinding(), deps)
 
-    // #then — FAILED transition still occurs with no failureKind (this failure is post-ACK, Unit 3's path)
+    // #then — FAILED transition still occurs with no failureKind (this failure is post-ACK)
     const failedCall = mockRuntime.transitionRun.mock.calls.find((c: unknown[]) => c[4] === 'FAILED')
     const failedOptions = failedCall?.[7] as {detailsPatch?: {failureKind?: unknown}}
     expect(failedOptions?.detailsPatch?.failureKind).toBeUndefined()

--- a/packages/gateway/src/execute/run.ts
+++ b/packages/gateway/src/execute/run.ts
@@ -637,7 +637,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       // ── Operator-cancel registration ──────────────────────────────────────────
       // Registered only after EXECUTING commits — the pre-ACK/pre-EXECUTING window is
       // covered by the run-state conditional-write rendezvous (see the ACK/EXECUTING
-      // etag-mismatch handling above and Unit 2's orchestrator), not by this registry.
+      // etag-mismatch handling above and the cancellation orchestrator), not by this registry.
       // Always deleted in the outer finally below, regardless of settlement outcome.
       // The returned signal is composed into effectiveSignal at the timeout seam below.
       const cancelSignal = abortRegistry.register(runId)
@@ -889,12 +889,12 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
       if (wasCancelled === true) {
         // ── Operator-cancel settlement path ──────────────────────────────────────────
         // Distinct from the generic FAILED path below: settles CANCELLED, suppresses the
-        // user-facing failure reply (Unit 2's thread notice is the communication), and
+        // user-facing failure reply (the cancellation thread notice is the communication), and
         // still flushes partial output.
 
         // Replaces the working/awaiting reaction with the failed cue — no distinct
         // "cancelled" reaction exists yet; reusing 'failed' here is a UX nit, not a
-        // correctness issue (the thread notice, added in Unit 2, carries the real signal).
+        // correctness issue (the thread notice carries the real signal).
         statusSink.setReaction('failed')
 
         // heartbeat.stop() FIRST — its runEtag/lockEtag are the authoritative
@@ -925,7 +925,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
 
         // Transition to CANCELLED (best-effort) with the fresh heartbeat-stop etag.
         // Attribution: the abort-registry entry may carry `cancelledBy` metadata,
-        // written by `cancelRun` (Unit 2) alongside its `abort()` call. This is the
+        // written by `cancelRun` alongside its `abort()` call. This is the
         // single writer of the CANCELLED transition, so reading it back here (rather
         // than a follow-up write from the orchestrator) keeps attribution atomic with
         // the phase write and avoids a second etag round-trip.
@@ -1006,7 +1006,7 @@ async function executeWorkOnHeldSlot(task: RunTask): Promise<void> {
         // was already updated above so the outer finally's releaseLock uses the fresh value.
 
         // Suppress the user-facing failure reply for operator-initiated cancels — no
-        // "task failed" message to the thread. Unit 2 posts the cancellation notice.
+        // "task failed" message to the thread. The cancellation notice is posted separately.
         // Log instead so the suppression is observable in gateway logs.
         logger.info({repo, runId}, 'run: cancelled — suppressing user-facing failure reply')
       } else {

--- a/packages/gateway/src/web/auth/csrf.test.ts
+++ b/packages/gateway/src/web/auth/csrf.test.ts
@@ -361,7 +361,7 @@ describe('CSRF token constants', () => {
 })
 
 // ---------------------------------------------------------------------------
-// applyBrowserGuard — absent Origin on mutating requests (Unit 3e gap #5)
+// applyBrowserGuard — absent Origin on mutating requests
 // ---------------------------------------------------------------------------
 
 function makeBrowserGuardDeps(sessionStore: ReturnType<typeof createInMemorySessionStore>) {
@@ -379,7 +379,7 @@ function makeBrowserGuardDeps(sessionStore: ReturnType<typeof createInMemorySess
   }
 }
 
-describe('applyBrowserGuard — absent Origin on mutating requests (Unit 3e gap #5)', () => {
+describe('applyBrowserGuard — absent Origin on mutating requests', () => {
   it('rejects POST with no Origin and no Fetch Metadata headers', async () => {
     // #given — valid session, no Origin, no Sec-Fetch-* headers
     const sessionStore = createInMemorySessionStore()
@@ -512,10 +512,10 @@ describe('applyBrowserGuard — absent Origin on mutating requests (Unit 3e gap 
 })
 
 // ---------------------------------------------------------------------------
-// applyBrowserGuard — typed audit events (Unit 3e gap #4)
+// applyBrowserGuard — typed audit events
 // ---------------------------------------------------------------------------
 
-describe('applyBrowserGuard — typed audit events (Unit 3e gap #4)', () => {
+describe('applyBrowserGuard — typed audit events', () => {
   it('emits browser.guard.rejected with reason non_cookie_credential for Authorization header', async () => {
     // #given — valid session but Authorization header present
     const sessionStore = createInMemorySessionStore()

--- a/packages/gateway/src/web/auth/github.test.ts
+++ b/packages/gateway/src/web/auth/github.test.ts
@@ -2202,7 +2202,7 @@ describe('GET /operator/auth/github/callback — onSessionRevoke wiring', () => 
 })
 
 // ---------------------------------------------------------------------------
-// OAuth callback — OAuth token retention in session (Unit 3h)
+// OAuth callback — OAuth token retention in session
 // ---------------------------------------------------------------------------
 
 describe('GET /operator/auth/github/callback — OAuth token retention', () => {

--- a/packages/gateway/src/web/auth/session.test.ts
+++ b/packages/gateway/src/web/auth/session.test.ts
@@ -1048,7 +1048,7 @@ describe('parseSessionCookie — empty value', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Session store — OAuth token retention (Unit 3h)
+// Session store — OAuth token retention
 // ---------------------------------------------------------------------------
 
 describe('createInMemorySessionStore — getOperatorToken (token retention)', () => {

--- a/packages/gateway/src/web/operator/web-approval.ts
+++ b/packages/gateway/src/web/operator/web-approval.ts
@@ -125,7 +125,7 @@ export function createWebApprovalOnPending(
 
       // Build the bounded frame data. Apply boundApprovalDetail to command and
       // filepath here — the caller (this transport) is responsible for bounding
-      // per the U2 contract.
+      // per the cancellation settlement contract.
       const boundedCommand = boundApprovalDetail(req.command)
       const boundedFilepath = boundApprovalDetail(req.filepath)
 

--- a/packages/gateway/src/web/operator/web-approval.ts
+++ b/packages/gateway/src/web/operator/web-approval.ts
@@ -124,8 +124,8 @@ export function createWebApprovalOnPending(
       )
 
       // Build the bounded frame data. Apply boundApprovalDetail to command and
-      // filepath here — the caller (this transport) is responsible for bounding
-      // per the cancellation settlement contract.
+      // filepath here — this transport is responsible for bounding the raw
+      // approval detail before it is sent in the SSE frame.
       const boundedCommand = boundApprovalDetail(req.command)
       const boundedFilepath = boundApprovalDetail(req.filepath)
 

--- a/packages/gateway/src/web/server.test.ts
+++ b/packages/gateway/src/web/server.test.ts
@@ -1197,7 +1197,7 @@ describe('GET /operator/session/csrf — happy path', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Auto-guard: registerOperatorRoute applies browser guard automatically (Unit 3e gap #2)
+// Auto-guard: registerOperatorRoute applies browser guard automatically
 // ---------------------------------------------------------------------------
 
 describe('registerOperatorRoute — auto-guard applies browser guard to privileged routes', () => {
@@ -1264,10 +1264,10 @@ describe('registerOperatorRoute — auto-guard applies browser guard to privileg
 })
 
 // ---------------------------------------------------------------------------
-// Logout protection: POST /operator/auth/logout requires session + CSRF (Unit 3e gap #3)
+// Logout protection: POST /operator/auth/logout requires session + CSRF
 // ---------------------------------------------------------------------------
 
-describe('POST /operator/auth/logout — browser guard protection (Unit 3e gap #3)', () => {
+describe('POST /operator/auth/logout — browser guard protection', () => {
   it('rejects logout without session cookie with 401 when browser guard is enabled', async () => {
     // #given — app with browser guard deps
     const sessionStore = createInMemorySessionStore()

--- a/packages/harness/src/cli.test.ts
+++ b/packages/harness/src/cli.test.ts
@@ -178,7 +178,7 @@ describe('probeBinary', () => {
 
 // #endregion
 
-// #region doctor version-form (U3)
+// #region doctor version-form
 
 // Mirror the cmdDoctor logic for computing expectedVersion from provenance.
 // Extracted to outer scope to satisfy unicorn/consistent-function-scoping.

--- a/packages/harness/src/integrate-command.test.ts
+++ b/packages/harness/src/integrate-command.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for integrate-command.ts — config assembly, flag parsing, exit-code mapping,
- * artifact packaging (Unit 2).
+ * artifact packaging.
  *
  * No real merge runs here. runIntegration and makeRealAdapters are stubbed.
  * packageArtifact is injected as a stub for command-level tests; it is tested

--- a/packages/harness/src/integrate.test.ts
+++ b/packages/harness/src/integrate.test.ts
@@ -521,7 +521,7 @@ describe('runIntegration', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // U4: Per-ref provenance SHA
+  // Per-ref provenance SHA
   // ---------------------------------------------------------------------------
 
   it('per-ref SHA: 3 refs → 3 distinct resolvedSha values in manifest', async () => {
@@ -659,10 +659,10 @@ describe('runIntegration', () => {
 })
 
 // ---------------------------------------------------------------------------
-// U5: Clean-snapshot guarantee tests
+// Clean-snapshot guarantee tests
 // ---------------------------------------------------------------------------
 
-describe('U5: clean-snapshot guarantees', () => {
+describe('clean-snapshot guarantees', () => {
   it('git archive produces no .git entry in the artifact', async () => {
     // #given — packageArtifact uses git archive which by design excludes .git
     // We verify the invariant by asserting the git archive command excludes .git

--- a/packages/runtime/src/coordination/run-state.test.ts
+++ b/packages/runtime/src/coordination/run-state.test.ts
@@ -65,7 +65,7 @@ function createCoordinationConfig(storeAdapter: Required<ObjectStoreAdapter>): C
 }
 
 // ---------------------------------------------------------------------------
-// Unit 1: Surface widening — web surface validation
+// Surface widening — web surface validation
 // ---------------------------------------------------------------------------
 
 describe('parseRunState — surface validation', () => {
@@ -111,7 +111,7 @@ describe('parseRunState — surface validation', () => {
     expect(result.success).toBe(true)
   })
 
-  it("accepts surface: 'web' (Unit 1 widening)", () => {
+  it("accepts surface: 'web' (web surface widening)", () => {
     // #given a run-state with web surface
     const state = {
       run_id: 'run-1',

--- a/src/harness/config/inputs.test.ts
+++ b/src/harness/config/inputs.test.ts
@@ -886,7 +886,7 @@ describe('parseActionInputs', () => {
     })
   })
 
-  // --- Unit 1: enable-omo and agent contract tests ---
+  // --- enable-omo and agent contract tests ---
 
   describe('enable-omo mode flag', () => {
     it('defaults to false when enable-omo is not provided', () => {

--- a/src/harness/phases/acquire-lock.ts
+++ b/src/harness/phases/acquire-lock.ts
@@ -36,7 +36,7 @@ export interface AcquireLockPhaseOptions {
  * Acquires the per-repo coordination lock so the Action and the Discord gateway
  * cannot execute concurrently against the same repository.
  *
- * Decisions captured in `docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md` (Unit 3):
+ * Design decisions (see `docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md`):
  * - No `validateProviderSemantics` self-test on Action invocations — the gateway runs validation
  *   at startup as the long-lived process; the Action assumes provider semantics are valid.
  * - No heartbeat in v1 — the 15-min TTL covers the median ~2-min Action run; rare long runs


### PR DESCRIPTION
Strips internal plan-unit taxonomy from shipped source comments and test labels. Comment- and label-text only — no logic, renaming, or behavior changes.

Comments and `describe`/`it` labels across the gateway, runtime, harness, and action trees carried references like "Unit 2's orchestrator", "Phase A seam invariants", "Unit 3e gap #5", and "per the U2 contract" — planning-document structure that means nothing to someone reading the code. Each is rewritten to describe the actual technical thing it refers to ("the cancellation orchestrator", "seam invariants (static guards)", "absent Origin on mutating requests", "the cancellation settlement contract"), preserving the full technical intent.

Scope: 20 files, ~55 references. Genuine references are kept — e.g. `acquire-lock.ts` keeps its plan-doc path reference and only drops the bare "(Unit 3)" label.

Verified: type-check clean across all packages, full test suite green (runtime, action, harness, gateway), lint clean, and the committed `dist/` is byte-identical (comments are stripped in the minified bundle, so a source comment change produces no dist diff).
