### PR TITLE
feat(gateway): operator push privacy, retention policy, and lifecycle audit events

### DIFF
--- a/docs/privacy/operator-push-retention.md
+++ b/docs/privacy/operator-push-retention.md
@@ -1,0 +1,50 @@
+# Operator Push Notification: Privacy and Retention Policy
+
+This document describes the data the gateway's operator push notification surface stores, what it puts in a notification payload, how long it keeps records, and how an operator's data can be exported or deleted.
+
+Push notifications are an optional, opt-in convenience for operators using the browser-based control surface. They exist to nudge an operator that a run needs attention (a pending approval or a failed run) when they are not already watching the dashboard. They are never the system of record — the dashboard's live status stream and Discord remain the authoritative, detailed channels.
+
+## What is stored
+
+When an operator opts in, the browser creates a [W3C Push API](https://www.w3.org/TR/push-api/) subscription and the gateway persists one record per subscription:
+
+- **Endpoint URL** — the push service URL the browser gave us. Write-only: it is used to send notifications and is never returned by any listing, export, or audit surface.
+- **Browser public keys** (`p256dh`, `auth`) — the encryption keys the browser subscription requires. Also write-only, for the same reason.
+- **Operator GitHub user ID** — the numeric identity that owns the subscription.
+- **Key version** — which VAPID key the subscription was created or refreshed under (see rotation, below).
+- **Timestamps** — created, last updated, and (if inactive) deactivated.
+- **Active state** and, when inactive, a coarse reason.
+
+**Nothing else is stored.** A subscription record never contains message content, prompt text, repository names, run identifiers, or run output. There is no field for any of that, and no code path writes one in.
+
+## What a notification contains
+
+Every push notification uses fixed, neutral copy: a short message indicating something needs attention, a link that opens the operator dashboard, and — for failures — a label drawn from a small, pre-defined, allowlisted set of failure categories (for example, a timeout or a workspace error). The payload never includes the run's repository, prompt, or any of its output. An operator who wants details opens the dashboard, authenticates, and sees them there under the normal authorization rules — the push payload itself carries none of it.
+
+## Retention
+
+An active subscription record persists until one of the following happens:
+
+- The operator explicitly unsubscribes (opt-out) from the dashboard.
+- The operator's session is revoked — logging out (or a session expiring) deactivates every push subscription tied to that operator's GitHub identity, across all of their browsers and devices.
+- The push relay reports the subscription is dead (the browser/service has discarded it).
+- The VAPID key the subscription was signed under is revoked outside a normal rotation window.
+- The operator requests deletion (see Deletion, below).
+
+Once a record becomes inactive it is retained for 30 days — enough time for operational troubleshooting and audit correlation — and then purged automatically. Deletion additionally writes a durable tombstone at a separate key from the subscription record itself, so that restoring an older backup of just the subscription object cannot resurrect a record a privacy delete already removed. (A full-bucket restore that rewinds the entire object store, tombstones included, to a point before the delete is a disaster-recovery scenario outside the scope of this application-level protection.)
+
+## Export
+
+A privacy export of an operator's push data returns only safe metadata: the record's identifier (a hash, not the endpoint itself), timestamps, key version, active state, and — if inactive — a coarse reason. The export never includes the endpoint URL or the browser's encryption keys; those fields are write-only and structurally excluded from every non-mutating surface.
+
+## Deletion
+
+A privacy delete for an operator marks every one of their active subscription records inactive immediately, removes them from the active dispatch set (so no further notification can be sent to them even before the tombstone write completes), and writes a durable tombstone before the request returns. A privacy delete is not a permanent ban on that endpoint: a legitimate, authenticated re-subscribe from the same browser later is honored normally.
+
+## Audit
+
+The subscription lifecycle is recorded on the same coarse audit trail as the rest of the operator surface (see the [Operator Web Control Surface](../wiki/Operator%20Web%20Control%20Surface.md) wiki page): an operator subscribing, unsubscribing, having a subscription deactivated, and per-broadcast dispatch summaries. Every one of these audit records carries only the operator's GitHub user ID, coarse enum reasons, and counts — never an endpoint, a key, or notification payload content.
+
+## Enablement
+
+Push is disabled by default. Turning it on in a given deployment requires provisioning VAPID key material as server-only configuration and accepting the retention policy described here — there is no way to enable the surface without both.

--- a/docs/wiki/Operator Web Control Surface.md
+++ b/docs/wiki/Operator Web Control Surface.md
@@ -26,6 +26,12 @@ sources:
   - packages/gateway/src/web/sse/projection.ts
   - packages/gateway/src/web/sse/run-stream-route.ts
   - packages/gateway/src/web/audit.ts
+  - packages/gateway/src/web/operator-push/subscription-route.ts
+  - packages/gateway/src/web/operator-push/subscription-store.ts
+  - packages/gateway/src/web/operator-push/dispatcher.ts
+  - packages/gateway/src/web/operator-push/trigger-policy.ts
+  - packages/gateway/src/web/operator-push/vapid.ts
+  - docs/privacy/operator-push-retention.md
   - packages/gateway/src/operator-contract/identity.ts
   - packages/gateway/src/operator-contract/approval.ts
   - packages/gateway/src/operator-contract/approval-frame.ts
@@ -155,7 +161,26 @@ When a run fails, both projections may carry a `failureKind` — a coarse, sanit
 
 ## Audit
 
-Security-critical events on this surface — sign-ins, authorization decisions, launches, and stream lifecycle — flow through a typed audit seam (`web/audit.ts`) that records the numeric GitHub user ID and other safe fields while excluding tokens, prompts, and internal identifiers.
+Security-critical events on this surface — sign-ins, authorization decisions, launches, and stream lifecycle — flow through a typed audit seam (`web/audit.ts`) that records the numeric GitHub user ID and other safe fields while excluding tokens, prompts, and internal identifiers. The push subscription lifecycle (subscribe, unsubscribe, deactivation, dispatch, and startup disablement — see [Operator Push Notifications](#operator-push-notifications) below) is folded into the same seam, holding to the same rule: only operator identity, coarse enums, and counts, never endpoints or key material.
+
+## Operator Push Notifications
+
+Alongside the SSE stream, operators can opt into browser push notifications for two events: a run entering `waiting for approval` and a run failing. Push is **opt-in and disabled by default** — a deployment must both provision VAPID key material and start the object-store CAS self-test successfully before the surface is registered at all (`program.ts`; see the [privacy and retention policy](../privacy/operator-push-retention.md) for what is stored and how it is deleted).
+
+The surface exposes four authenticated operator routes (`web/operator-push/`):
+
+- `GET /operator/push/vapid-key` — the current VAPID public key and key version, used by the browser to create a `PushSubscription`.
+- `POST /operator/push/subscriptions` — register (or refresh) a subscription for the authenticated operator.
+- `POST /operator/push/subscriptions/unsubscribe` — remove a subscription.
+- `GET /operator/push/subscriptions` — list the operator's own subscription metadata (never the endpoint or keys — see `toSubscriptionMetadata` in `subscription-store.ts`).
+
+**Broadcast model.** The operator dashboard is a shared surface, not a per-operator one — approvals are run-scoped, not operator-scoped, and there is no dashboard-operator identity available at the run-failed or approval-pending seams. Every opted-in operator with an active subscription is nudged, regardless of who launched the run. The notification payload is fixed and repo-neutral ("something needs attention, open the dashboard" plus an allowlisted failure label) so a broadcast never leaks run, repo, or prompt content — Discord and the SSE stream remain the authoritative, detailed channels; push is a fail-soft nudge on top.
+
+### VAPID key rotation and leak response
+
+The VAPID private key is server-only, per-environment configuration — never logged, serialized, or returned by any route. Rotation supports a current key plus an optional previous key during a rollout window: each subscription record stores the key version it was created or refreshed under, and the dispatcher's trigger policy still delivers to previous-key records for the duration of the window (`web/operator-push/trigger-policy.ts`). Once the window closes, previous-key subscribers stop being notified until they re-subscribe under the new public key (their next browser-side subscribe call picks up the current key automatically).
+
+If the private key leaks, the response is: provision a fresh VAPID keypair, roll the current key into the previous-key slot for a bounded rollout window, then retire the old key entirely once the window ends. There is no way to invalidate an individual leaked key server-side beyond this rotation — the protection comes from bounding how long the compromised key remains honored, not from revoking specific subscriptions.
 
 ## Relationship to Other Surfaces
 

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -1357,6 +1357,7 @@ describe('button interaction handler (approval flow)', () => {
     const fakeClient = makeFakeClient()
     const startOperatorServerSpy = vi.fn().mockReturnValue(makeFakeServerHandle())
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
     const deps = {
       makeClient: () => fakeClient as unknown as import('discord.js').Client,
@@ -1388,7 +1389,14 @@ describe('button interaction handler (approval flow)', () => {
     // #then — a warn is logged, no throw escapes the hook
     const warnedSkipped = consoleWarnSpy.mock.calls.some(([line]) => String(line).includes('CAS exhausted'))
     expect(warnedSkipped).toBe(true)
+
+    // #then — no audit event fires since nothing was actually updated
+    const emittedDeactivated = consoleLogSpy.mock.calls.some(([line]) =>
+      String(line).includes('push.subscription.deactivated'),
+    )
+    expect(emittedDeactivated).toBe(false)
     consoleWarnSpy.mockRestore()
+    consoleLogSpy.mockRestore()
   })
 
   it('session-revoke hook: a real deactivation emits a push.subscription.deactivated audit event', async () => {
@@ -1451,6 +1459,7 @@ describe('button interaction handler (approval flow)', () => {
     const fakeClient = makeFakeClient()
     const startOperatorServerSpy = vi.fn().mockReturnValue(makeFakeServerHandle())
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
     const deps = {
       makeClient: () => fakeClient as unknown as import('discord.js').Client,
@@ -1484,7 +1493,14 @@ describe('button interaction handler (approval flow)', () => {
       String(line).includes('session-revoke deactivation failed'),
     )
     expect(warnedFailed).toBe(true)
+
+    // #then — no audit event fires since the deactivation was not successful
+    const emittedDeactivated = consoleLogSpy.mock.calls.some(([line]) =>
+      String(line).includes('push.subscription.deactivated'),
+    )
+    expect(emittedDeactivated).toBe(false)
     consoleWarnSpy.mockRestore()
+    consoleLogSpy.mockRestore()
   })
 
   it('operator push disabled (config absent): no dispatcher on launchWorkDeps, push stays inert', async () => {

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -1139,6 +1139,44 @@ describe('button interaction handler (approval flow)', () => {
     consoleWarnSpy.mockRestore()
   })
 
+  it('operator push self-test failure emits a push.disabled audit event with reason self_test_failed', async () => {
+    // #given — self-test resolves a failed Result (not a throw)
+    selfTestCasMock.mockResolvedValueOnce({
+      success: false,
+      error: Object.assign(new Error('cas contended-write self-test failed'), {
+        code: 'OPERATOR_PUSH_SELF_TEST_CAS_FAILURE' as const,
+      }),
+    })
+    const fakeConfig = makeFakeConfig({
+      announce: undefined,
+      operatorWeb: makeOperatorWebConfig(),
+      operatorPush: makeOperatorPushConfig(),
+    })
+    const fakeClient = makeFakeClient()
+    const startOperatorServerSpy = vi.fn().mockReturnValue(makeFakeServerHandle())
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: startOperatorServerSpy,
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    // #when
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then — a warn-level push.disabled audit record with reason self_test_failed
+    const emittedDisabled = consoleWarnSpy.mock.calls.some(([line]) => {
+      const serialized = String(line)
+      return serialized.includes('push.disabled') && serialized.includes('self_test_failed')
+    })
+    expect(emittedDisabled).toBe(true)
+    consoleWarnSpy.mockRestore()
+  })
+
   it('operator push self-test failure (Result err): push omitted, warn logged, gateway still starts', async () => {
     // #given — self-test resolves a failed Result (not a throw)
     selfTestCasMock.mockResolvedValueOnce({
@@ -1239,6 +1277,37 @@ describe('button interaction handler (approval flow)', () => {
     expect(serverDeps.operatorPushStore).toBeUndefined()
   })
 
+  it('operator push absent from config: emits a push.disabled audit event with reason config_absent', async () => {
+    // #given — no operatorPush block in config
+    const fakeConfig = makeFakeConfig({
+      announce: undefined,
+      operatorWeb: makeOperatorWebConfig(),
+    })
+    const fakeClient = makeFakeClient()
+    const startOperatorServerSpy = vi.fn().mockReturnValue(makeFakeServerHandle())
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: startOperatorServerSpy,
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    // #when
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then — an info-level push.disabled audit record with reason config_absent
+    const emittedDisabled = consoleLogSpy.mock.calls.some(([line]) => {
+      const serialized = String(line)
+      return serialized.includes('push.disabled') && serialized.includes('config_absent')
+    })
+    expect(emittedDisabled).toBe(true)
+    consoleLogSpy.mockRestore()
+  })
+
   it('operator push enabled: dispatcher is threaded into launchWorkDeps and the session-revoke hook is registered', async () => {
     // #given — operatorWeb and operatorPush are both configured, self-test succeeds
     selfTestCasMock.mockResolvedValueOnce({success: true, data: undefined})
@@ -1320,6 +1389,55 @@ describe('button interaction handler (approval flow)', () => {
     const warnedSkipped = consoleWarnSpy.mock.calls.some(([line]) => String(line).includes('CAS exhausted'))
     expect(warnedSkipped).toBe(true)
     consoleWarnSpy.mockRestore()
+  })
+
+  it('session-revoke hook: a real deactivation emits a push.subscription.deactivated audit event', async () => {
+    // #given — operatorWeb and operatorPush are both configured, self-test succeeds
+    selfTestCasMock.mockResolvedValueOnce({success: true, data: undefined})
+    const fakeConfig = makeFakeConfig({
+      announce: undefined,
+      operatorWeb: makeOperatorWebConfig(),
+      operatorPush: makeOperatorPushConfig(),
+    })
+    const fakeClient = makeFakeClient()
+    const startOperatorServerSpy = vi.fn().mockReturnValue(makeFakeServerHandle())
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: startOperatorServerSpy,
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    const [serverDeps] = startOperatorServerSpy.mock.calls[0] as [
+      import('./web/server.js').OperatorServerDeps,
+      import('./web/server.js').OperatorServerConfig,
+    ]
+    const {createOperatorPushSubscriptionStore} = await import('./web/operator-push/subscription-store.js')
+    const storeMock = vi.mocked(createOperatorPushSubscriptionStore).mock.results[0]?.value as {
+      deactivateForOperator: (args: {readonly operatorId: string}) => Promise<unknown>
+    }
+    const deactivateForOperatorMock = vi.mocked(storeMock.deactivateForOperator)
+    deactivateForOperatorMock.mockResolvedValueOnce({success: true, data: {updated: 1, skipped: 0}})
+
+    // #when — the revoke hook fires with a real deactivation (updated > 0)
+    expect(() => serverDeps.githubOAuth?.onSessionRevoke?.(12345)).not.toThrow()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // #then — a push.subscription.deactivated audit record with reason
+    // session_revoked was logged
+    const emittedDeactivated = consoleLogSpy.mock.calls.some(([line]) => {
+      const serialized = String(line)
+      return serialized.includes('push.subscription.deactivated') && serialized.includes('session_revoked')
+    })
+    expect(emittedDeactivated).toBe(true)
+    consoleLogSpy.mockRestore()
   })
 
   it('session-revoke hook: a failed deactivation Result logs a warn, does not throw', async () => {

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -44,6 +44,7 @@ import {createDenylistCache} from './redaction/denylist.js'
 import {createAppClientMetadataReader} from './redaction/reader-app-client.js'
 import {forceReleaseStaleLockEffect} from './runtime-effect.js'
 import {DEFAULT_DRAIN_MS, installShutdownHandlers, isShuttingDown} from './shutdown.js'
+import {emitAudit} from './web/audit.js'
 import {buildGitHubOAuthDeps} from './web/auth/github.js'
 import {createInMemorySessionStore} from './web/auth/session.js'
 import {createDedupeCache} from './web/operator-push/dedupe-cache.js'
@@ -728,7 +729,9 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
             readonly vapidPublicKeyInfo: VapidPublicKeyInfo
           }
         | undefined
-      if (config.operatorPush !== undefined) {
+      if (config.operatorPush === undefined) {
+        emitAudit({kind: 'push.disabled', correlationId: 'startup', reason: 'config_absent'}, logger)
+      } else {
         const pushStore = createOperatorPushSubscriptionStore({
           adapter: s3Adapter,
           logger,
@@ -767,9 +770,11 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
                 : {previousKeyVersion: config.operatorPush.previous.keyVersion}),
             },
             logger,
+            auditLogger: logger,
           })
         } else {
           logger.warn({err: selfTest.error.message}, 'operator push disabled — object store failed CAS self-test')
+          emitAudit({kind: 'push.disabled', correlationId: 'startup', reason: 'self_test_failed'}, logger)
         }
       }
 
@@ -825,6 +830,19 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
                       )
                     } else if (result.success === false) {
                       logger.warn({err: result.error.message}, 'operator push: session-revoke deactivation failed')
+                    }
+                    // Emit one coarse audit event per revoke when a real
+                    // deactivation happened — not one per record.
+                    if (result.success === true && result.data.updated > 0) {
+                      emitAudit(
+                        {
+                          kind: 'push.subscription.deactivated',
+                          correlationId: `push-session-revoke:${githubUserId}`,
+                          githubUserId,
+                          reason: 'session_revoked',
+                        },
+                        logger,
+                      )
                     }
                   })
                   .catch(() => {

--- a/packages/gateway/src/web/audit.test.ts
+++ b/packages/gateway/src/web/audit.test.ts
@@ -1236,6 +1236,188 @@ describe('emitAudit — authz.denied with insufficient_permission', () => {
 })
 
 // ---------------------------------------------------------------------------
+// push.subscribed / push.unsubscribed
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — push.subscribed', () => {
+  it('emits a structured info record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'push.subscribed', correlationId: 'corr-push-1', githubUserId: 42}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.info).toHaveBeenCalledOnce()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.info)).toBe('audit: push.subscribed')
+    expect(firstCallCtx(logger.info)).toMatchObject({
+      kind: 'push.subscribed',
+      correlationId: 'corr-push-1',
+      githubUserId: 42,
+    })
+  })
+
+  it('redacts sensitive values planted in correlationId', () => {
+    // #given
+    for (const planted of [PLANTED_COOKIE, PLANTED_TOKEN, PLANTED_BEARER, PLANTED_SECRET, PLANTED_PROMPT]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {kind: 'push.subscribed', correlationId: planted, githubUserId: 42}
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+    }
+  })
+})
+
+describe('emitAudit — push.unsubscribed', () => {
+  it('emits a structured info record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'push.unsubscribed', correlationId: 'corr-push-2', githubUserId: 42}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.info).toHaveBeenCalledOnce()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.info)).toBe('audit: push.unsubscribed')
+    expect(firstCallCtx(logger.info)).toMatchObject({
+      kind: 'push.unsubscribed',
+      correlationId: 'corr-push-2',
+      githubUserId: 42,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// push.subscription.deactivated
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — push.subscription.deactivated', () => {
+  it('emits a structured info record with expected fields', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {
+      kind: 'push.subscription.deactivated',
+      correlationId: 'corr-push-3',
+      githubUserId: 42,
+      reason: 'session_revoked',
+    }
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.info).toHaveBeenCalledOnce()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(firstCallCtx(logger.info)).toMatchObject({
+      kind: 'push.subscription.deactivated',
+      githubUserId: 42,
+      reason: 'session_revoked',
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// push.dispatch
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — push.dispatch', () => {
+  it('emits a structured info record carrying only trigger and coarse counts', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {
+      kind: 'push.dispatch',
+      correlationId: 'approval-123',
+      trigger: 'approval',
+      delivered: 2,
+      dead: 1,
+      failed: 0,
+    }
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.info).toHaveBeenCalledOnce()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(firstCallMsg(logger.info)).toBe('audit: push.dispatch')
+    expect(firstCallCtx(logger.info)).toMatchObject({
+      kind: 'push.dispatch',
+      correlationId: 'approval-123',
+      trigger: 'approval',
+      delivered: 2,
+      dead: 1,
+      failed: 0,
+    })
+    // Structural: the recorded context must never carry an endpoint, key, or payload field.
+    const ctx = firstCallCtx(logger.info)
+    expect(Object.keys(ctx).sort()).toEqual(['correlationId', 'dead', 'delivered', 'failed', 'kind', 'trigger'].sort())
+  })
+
+  it('redacts sensitive values planted in correlationId', () => {
+    // #given
+    for (const planted of [PLANTED_COOKIE, PLANTED_TOKEN, PLANTED_BEARER, PLANTED_SECRET, PLANTED_PROMPT]) {
+      const logger = makeLogger()
+      const event: AuditEvent = {
+        kind: 'push.dispatch',
+        correlationId: planted,
+        trigger: 'run_failed',
+        delivered: 0,
+        dead: 0,
+        failed: 1,
+      }
+
+      // #when
+      emitAudit(event, logger)
+
+      // #then
+      assertNoSensitiveValues(logger)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// push.disabled
+// ---------------------------------------------------------------------------
+
+describe('emitAudit — push.disabled', () => {
+  it('logs config_absent at info level', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'push.disabled', correlationId: 'startup', reason: 'config_absent'}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.info).toHaveBeenCalledOnce()
+    expect(logger.warn).not.toHaveBeenCalled()
+    expect(firstCallCtx(logger.info)).toMatchObject({kind: 'push.disabled', reason: 'config_absent'})
+  })
+
+  it('logs self_test_failed at warn level', () => {
+    // #given
+    const logger = makeLogger()
+    const event: AuditEvent = {kind: 'push.disabled', correlationId: 'startup', reason: 'self_test_failed'}
+
+    // #when
+    emitAudit(event, logger)
+
+    // #then
+    expect(logger.warn).toHaveBeenCalledOnce()
+    expect(logger.info).not.toHaveBeenCalled()
+    expect(firstCallCtx(logger.warn)).toMatchObject({kind: 'push.disabled', reason: 'self_test_failed'})
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Sink resilience — throwing logger must not propagate
 // ---------------------------------------------------------------------------
 

--- a/packages/gateway/src/web/audit.ts
+++ b/packages/gateway/src/web/audit.ts
@@ -195,6 +195,62 @@ export interface BrowserGuardRejectedEvent {
   readonly githubUserId?: number
 }
 
+/**
+ * Coarse reason a push subscription record became inactive, as surfaced on
+ * the audit trail. Aligns with (but is a superset-safe mirror of) the
+ * store's `SubscriptionInactiveReason` taxonomy — snake_case to match the
+ * other reason enums in this module.
+ */
+export type PushDeactivationReason =
+  'dead_relay' | 'session_revoked' | 'transferred' | 'key_revoked' | 'privacy_delete' | 'unknown'
+
+/** Safe reasons the operator push surface is disabled at startup. */
+export type PushDisabledReason = 'config_absent' | 'self_test_failed'
+
+/** An operator registered a push subscription. Endpoint/keys are NEVER included. */
+export interface PushSubscribedEvent {
+  readonly kind: 'push.subscribed'
+  readonly correlationId: string
+  readonly githubUserId: number
+}
+
+/** An operator removed a push subscription. Endpoint is NEVER included. */
+export interface PushUnsubscribedEvent {
+  readonly kind: 'push.unsubscribed'
+  readonly correlationId: string
+  readonly githubUserId: number
+}
+
+/** A push subscription record was deactivated (session revoke, privacy delete, etc). */
+export interface PushSubscriptionDeactivatedEvent {
+  readonly kind: 'push.subscription.deactivated'
+  readonly correlationId: string
+  readonly githubUserId: number
+  readonly reason: PushDeactivationReason
+}
+
+/**
+ * Coarse per-broadcast dispatch summary — counts only, never per-operator
+ * rows, never endpoints. Records "a broadcast for trigger X reached N
+ * subscriptions, D died, F failed."
+ */
+export interface PushDispatchEvent {
+  readonly kind: 'push.dispatch'
+  /** The triggering run/approval id — same redaction class as requestId/runId. */
+  readonly correlationId: string
+  readonly trigger: 'approval' | 'run_failed'
+  readonly delivered: number
+  readonly dead: number
+  readonly failed: number
+}
+
+/** The operator push surface was disabled at startup. */
+export interface PushDisabledEvent {
+  readonly kind: 'push.disabled'
+  readonly correlationId: string
+  readonly reason: PushDisabledReason
+}
+
 /** All security-critical audit events. */
 export type AuditEvent =
   | AuthStartEvent
@@ -212,6 +268,11 @@ export type AuditEvent =
   | BrowserGuardRejectedEvent
   | RunCancelRequestedEvent
   | RunCancelRejectedEvent
+  | PushSubscribedEvent
+  | PushUnsubscribedEvent
+  | PushSubscriptionDeactivatedEvent
+  | PushDispatchEvent
+  | PushDisabledEvent
 
 // ---------------------------------------------------------------------------
 // Redaction
@@ -266,10 +327,11 @@ function redactIfSensitive(value: string): string {
  * Exhaustive log-level map: every AuditEvent kind must be present.
  * Adding a new variant without updating this map is a compile-time error.
  *
- * Note: 'approval.rejected' is intentionally absent — its level is reason-dependent.
- * See approvalRejectedLevel() below.
+ * Note: 'approval.rejected' and 'push.disabled' are intentionally absent —
+ * their levels are reason-dependent. See approvalRejectedLevel() and
+ * pushDisabledLevel() below.
  */
-const LOG_LEVEL: Record<Exclude<AuditEvent['kind'], 'approval.rejected'>, 'info' | 'warn'> = {
+const LOG_LEVEL: Record<Exclude<AuditEvent['kind'], 'approval.rejected' | 'push.disabled'>, 'info' | 'warn'> = {
   'auth.start': 'info',
   'auth.callback.success': 'info',
   'auth.callback.failure': 'warn',
@@ -284,6 +346,10 @@ const LOG_LEVEL: Record<Exclude<AuditEvent['kind'], 'approval.rejected'>, 'info'
   'browser.guard.rejected': 'warn',
   'run.cancel.requested': 'info',
   'run.cancel.rejected': 'warn',
+  'push.subscribed': 'info',
+  'push.unsubscribed': 'info',
+  'push.subscription.deactivated': 'info',
+  'push.dispatch': 'info',
 }
 
 /**
@@ -305,6 +371,24 @@ function approvalRejectedLevel(reason: ApprovalRejectedReason): 'info' | 'warn' 
     case 'scope_mismatch':
     case 'unknown':
     case 'deadline_expired':
+      return 'warn'
+  }
+}
+
+/**
+ * Per-reason log level for 'push.disabled' events.
+ *
+ * - 'config_absent': INFO — the normal, expected state for any deployment
+ *   that has not opted into operator push.
+ * - 'self_test_failed': WARN — the object store failed the startup CAS
+ *   self-test and push was forced closed; a genuine operational anomaly
+ *   that warrants attention.
+ */
+function pushDisabledLevel(reason: PushDisabledReason): 'info' | 'warn' {
+  switch (reason) {
+    case 'config_absent':
+      return 'info'
+    case 'self_test_failed':
       return 'warn'
   }
 }
@@ -348,6 +432,11 @@ export function emitAudit(event: AuditEvent, logger: AuditLogger): void {
     case 'bearer.rejected':
     case 'browser.guard.rejected':
     case 'run.cancel.rejected':
+    case 'push.subscribed':
+    case 'push.unsubscribed':
+    case 'push.subscription.deactivated':
+    case 'push.dispatch':
+    case 'push.disabled':
       // No additional caller-controlled string fields on these variants.
       break
     default:
@@ -356,7 +445,12 @@ export function emitAudit(event: AuditEvent, logger: AuditLogger): void {
   }
 
   try {
-    const level = event.kind === 'approval.rejected' ? approvalRejectedLevel(event.reason) : LOG_LEVEL[event.kind]
+    const level =
+      event.kind === 'approval.rejected'
+        ? approvalRejectedLevel(event.reason)
+        : event.kind === 'push.disabled'
+          ? pushDisabledLevel(event.reason)
+          : LOG_LEVEL[event.kind]
     if (level === 'warn') {
       logger.warn(ctx, msg)
     } else {

--- a/packages/gateway/src/web/operator-push/dispatcher.test.ts
+++ b/packages/gateway/src/web/operator-push/dispatcher.test.ts
@@ -327,11 +327,18 @@ describe('createPushDispatcher — broadcast', () => {
   // #when inspected
   // #then no log call contains an endpoint, key, or payload body
   it('never logs sensitive detail', async () => {
-    const records = [makeRecord({endpoint: 'https://push.example.com/super-secret-path'})]
+    const records = [
+      makeRecord({
+        endpoint: 'https://push.example.com/SUPER-SECRET-ENDPOINT-PATH',
+        p256dh: 'P256DH-SECRET-KEY-MATERIAL',
+        auth: 'AUTH-SECRET-KEY-MATERIAL',
+      }),
+    ]
     const listAllActiveRecords = vi.fn(async () => ({success: true as const, data: records}))
     const markDead = vi.fn(async () => ({success: true as const, data: undefined}))
     const sender = createFakeSender([{outcome: 'retryable', statusCode: 500}])
     const logger = createLogger()
+    const auditLogger = createAuditLogger()
 
     const dispatcher = createPushDispatcher({
       store: {listAllActiveRecords, markDead},
@@ -340,16 +347,21 @@ describe('createPushDispatcher — broadcast', () => {
       triggerPolicy: {shouldNotify},
       vapidConfig: VAPID_CONFIG,
       logger,
-      auditLogger: createAuditLogger(),
+      auditLogger,
     })
 
     await dispatcher.dispatchRunFailed('run-1')
-    const allCalls = [...logger.debug.mock.calls, ...logger.warn.mock.calls]
+    const allCalls = [
+      ...logger.debug.mock.calls,
+      ...logger.warn.mock.calls,
+      ...auditLogger.info.mock.calls,
+      ...auditLogger.warn.mock.calls,
+    ]
     for (const call of allCalls) {
       const serialized = JSON.stringify(call)
-      expect(serialized).not.toContain('super-secret-path')
-      expect(serialized).not.toContain('p256dh')
-      expect(serialized).not.toContain('auth-value')
+      expect(serialized).not.toContain('SUPER-SECRET-ENDPOINT-PATH')
+      expect(serialized).not.toContain('P256DH-SECRET-KEY-MATERIAL')
+      expect(serialized).not.toContain('AUTH-SECRET-KEY-MATERIAL')
     }
   })
 })

--- a/packages/gateway/src/web/operator-push/dispatcher.test.ts
+++ b/packages/gateway/src/web/operator-push/dispatcher.test.ts
@@ -464,6 +464,42 @@ describe('createPushDispatcher — push.dispatch audit event', () => {
     expect(auditLogger.warn).not.toHaveBeenCalled()
   })
 
+  // #given a non-empty active list where every record is filtered by stale key
+  // #when a broadcast reaches the send loop but sends nothing over the wire
+  // #then one push.dispatch event still fires with all-zero counts (a broadcast
+  //       ran; distinct from the empty-list / dedupe-suppressed paths that emit nothing)
+  it('emits a zero-count dispatch event when every record is skipped by stale key', async () => {
+    const records = [makeRecord({keyVersion: 'old-version'}), makeRecord({keyVersion: 'old-version'})]
+    const listAllActiveRecords = vi.fn(async () => ({success: true as const, data: records}))
+    const markDead = vi.fn(async () => ({success: true as const, data: undefined}))
+    const sender = createFakeSender([])
+    const auditLogger = createAuditLogger()
+
+    const dispatcher = createPushDispatcher({
+      store: {listAllActiveRecords, markDead},
+      sender,
+      dedupeCache: createDedupeCache(),
+      triggerPolicy: {shouldNotify},
+      vapidConfig: VAPID_CONFIG,
+      logger: createLogger(),
+      auditLogger,
+    })
+
+    await dispatcher.dispatchApprovalPending('approval-1')
+
+    expect(sender.sendNotification).not.toHaveBeenCalled()
+    expect(auditLogger.info).toHaveBeenCalledOnce()
+    const [ctx] = auditLogger.info.mock.calls[0] as [Record<string, unknown>, string]
+    expect(ctx).toMatchObject({
+      kind: 'push.dispatch',
+      correlationId: 'approval-1',
+      trigger: 'approval',
+      delivered: 0,
+      dead: 0,
+      failed: 0,
+    })
+  })
+
   // #given the emitted push.dispatch audit event
   // #when serialized
   // #then it never contains an endpoint, key, or payload value

--- a/packages/gateway/src/web/operator-push/dispatcher.test.ts
+++ b/packages/gateway/src/web/operator-push/dispatcher.test.ts
@@ -33,6 +33,10 @@ function createLogger() {
   return {debug: vi.fn(), warn: vi.fn()}
 }
 
+function createAuditLogger() {
+  return {info: vi.fn(), warn: vi.fn()}
+}
+
 function createFakeSender(outcomes: readonly PushRelayResult[]) {
   const queue = [...outcomes]
   const sendNotification = vi.fn(async () => {
@@ -65,6 +69,7 @@ describe('createPushDispatcher — broadcast', () => {
       triggerPolicy: {shouldNotify},
       vapidConfig: VAPID_CONFIG,
       logger: createLogger(),
+      auditLogger: createAuditLogger(),
     })
 
     await dispatcher.dispatchApprovalPending('approval-1')
@@ -87,6 +92,7 @@ describe('createPushDispatcher — broadcast', () => {
       triggerPolicy: {shouldNotify},
       vapidConfig: VAPID_CONFIG,
       logger: createLogger(),
+      auditLogger: createAuditLogger(),
     })
 
     await dispatcher.dispatchApprovalPending('approval-1')
@@ -114,6 +120,7 @@ describe('createPushDispatcher — broadcast', () => {
       triggerPolicy: {shouldNotify},
       vapidConfig: VAPID_CONFIG,
       logger: createLogger(),
+      auditLogger: createAuditLogger(),
     })
 
     await dispatcher.dispatchRunFailed('run-1')
@@ -143,6 +150,7 @@ describe('createPushDispatcher — broadcast', () => {
         triggerPolicy: {shouldNotify},
         vapidConfig: VAPID_CONFIG,
         logger: createLogger(),
+        auditLogger: createAuditLogger(),
       })
 
       await dispatcher.dispatchRunFailed('run-1')
@@ -176,6 +184,7 @@ describe('createPushDispatcher — broadcast', () => {
       triggerPolicy: {shouldNotify},
       vapidConfig: VAPID_CONFIG,
       logger: createLogger(),
+      auditLogger: createAuditLogger(),
     })
 
     await dispatcher.dispatchApprovalPending('approval-1')
@@ -201,6 +210,7 @@ describe('createPushDispatcher — broadcast', () => {
       triggerPolicy: {shouldNotify},
       vapidConfig: VAPID_CONFIG,
       logger,
+      auditLogger: createAuditLogger(),
     })
 
     await dispatcher.dispatchApprovalPending('approval-1')
@@ -230,6 +240,7 @@ describe('createPushDispatcher — broadcast', () => {
       triggerPolicy: {shouldNotify},
       vapidConfig: VAPID_CONFIG,
       logger,
+      auditLogger: createAuditLogger(),
     })
 
     await dispatcher.dispatchApprovalPending('approval-1')
@@ -256,6 +267,7 @@ describe('createPushDispatcher — broadcast', () => {
       triggerPolicy: {shouldNotify},
       vapidConfig: VAPID_CONFIG,
       logger: createLogger(),
+      auditLogger: createAuditLogger(),
     })
 
     await dispatcher.dispatchApprovalPending('approval-1')
@@ -279,6 +291,7 @@ describe('createPushDispatcher — broadcast', () => {
       triggerPolicy: {shouldNotify},
       vapidConfig: VAPID_CONFIG,
       logger,
+      auditLogger: createAuditLogger(),
     })
 
     await expect(dispatcher.dispatchRunFailed('run-1')).resolves.toBeUndefined()
@@ -303,6 +316,7 @@ describe('createPushDispatcher — broadcast', () => {
       triggerPolicy: {shouldNotify},
       vapidConfig: VAPID_CONFIG,
       logger,
+      auditLogger: createAuditLogger(),
     })
 
     await expect(dispatcher.dispatchApprovalPending('approval-1')).resolves.toBeUndefined()
@@ -326,6 +340,7 @@ describe('createPushDispatcher — broadcast', () => {
       triggerPolicy: {shouldNotify},
       vapidConfig: VAPID_CONFIG,
       logger,
+      auditLogger: createAuditLogger(),
     })
 
     await dispatcher.dispatchRunFailed('run-1')
@@ -336,5 +351,131 @@ describe('createPushDispatcher — broadcast', () => {
       expect(serialized).not.toContain('p256dh')
       expect(serialized).not.toContain('auth-value')
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// push.dispatch audit event
+// ---------------------------------------------------------------------------
+
+describe('createPushDispatcher — push.dispatch audit event', () => {
+  // #given two delivered records and one dead record
+  // #when dispatchApprovalPending completes the broadcast
+  // #then exactly one push.dispatch audit event fires with the aggregated counts
+  it('emits one push.dispatch event per broadcast with correct counts', async () => {
+    const records = [
+      makeRecord({endpointHash: 'h1', endpoint: 'https://push.example.com/1'}),
+      makeRecord({endpointHash: 'h2', endpoint: 'https://push.example.com/2'}),
+      makeRecord({endpointHash: 'h3', endpoint: 'https://push.example.com/3'}),
+    ]
+    const listAllActiveRecords = vi.fn(async () => ({success: true as const, data: records}))
+    const markDead = vi.fn(async () => ({success: true as const, data: undefined}))
+    const sender = createFakeSender([
+      {outcome: 'accepted', statusCode: 201},
+      {outcome: 'accepted', statusCode: 201},
+      {outcome: 'dead-subscription', statusCode: 410},
+    ])
+    const auditLogger = createAuditLogger()
+
+    const dispatcher = createPushDispatcher({
+      store: {listAllActiveRecords, markDead},
+      sender,
+      dedupeCache: createDedupeCache(),
+      triggerPolicy: {shouldNotify},
+      vapidConfig: VAPID_CONFIG,
+      logger: createLogger(),
+      auditLogger,
+    })
+
+    await dispatcher.dispatchApprovalPending('approval-1')
+
+    expect(auditLogger.info).toHaveBeenCalledOnce()
+    const [ctx] = auditLogger.info.mock.calls[0] as [Record<string, unknown>, string]
+    expect(ctx).toMatchObject({
+      kind: 'push.dispatch',
+      correlationId: 'approval-1',
+      trigger: 'approval',
+      delivered: 2,
+      dead: 1,
+      failed: 0,
+    })
+  })
+
+  // #given a dedupe-suppressed second call for the same event
+  // #when dispatchApprovalPending is called twice within the dedupe window
+  // #then the audit event fires only once (for the first, actually-dispatched call)
+  it('does not emit a dispatch audit event on a dedupe-suppressed call', async () => {
+    const records = [makeRecord()]
+    const listAllActiveRecords = vi.fn(async () => ({success: true as const, data: records}))
+    const markDead = vi.fn(async () => ({success: true as const, data: undefined}))
+    const sender = createFakeSender([{outcome: 'accepted', statusCode: 201}])
+    const auditLogger = createAuditLogger()
+
+    const dispatcher = createPushDispatcher({
+      store: {listAllActiveRecords, markDead},
+      sender,
+      dedupeCache: createDedupeCache({windowMs: 60_000}),
+      triggerPolicy: {shouldNotify},
+      vapidConfig: VAPID_CONFIG,
+      logger: createLogger(),
+      auditLogger,
+    })
+
+    await dispatcher.dispatchApprovalPending('approval-1')
+    await dispatcher.dispatchApprovalPending('approval-1')
+
+    expect(auditLogger.info).toHaveBeenCalledOnce()
+  })
+
+  // #given no active subscriptions
+  // #when dispatchApprovalPending is called
+  // #then no dispatch audit event fires — nothing was dispatched
+  it('does not emit a dispatch audit event when the active-subscription list is empty', async () => {
+    const listAllActiveRecords = vi.fn(async () => ({success: true as const, data: []}))
+    const markDead = vi.fn(async () => ({success: true as const, data: undefined}))
+    const sender = createFakeSender([])
+    const auditLogger = createAuditLogger()
+
+    const dispatcher = createPushDispatcher({
+      store: {listAllActiveRecords, markDead},
+      sender,
+      dedupeCache: createDedupeCache(),
+      triggerPolicy: {shouldNotify},
+      vapidConfig: VAPID_CONFIG,
+      logger: createLogger(),
+      auditLogger,
+    })
+
+    await dispatcher.dispatchApprovalPending('approval-1')
+
+    expect(auditLogger.info).not.toHaveBeenCalled()
+    expect(auditLogger.warn).not.toHaveBeenCalled()
+  })
+
+  // #given the emitted push.dispatch audit event
+  // #when serialized
+  // #then it never contains an endpoint, key, or payload value
+  it('emitted dispatch audit event never carries endpoint or key material', async () => {
+    const records = [makeRecord({endpoint: 'https://push.example.com/super-secret-path', p256dh: 'p256dh-secret'})]
+    const listAllActiveRecords = vi.fn(async () => ({success: true as const, data: records}))
+    const markDead = vi.fn(async () => ({success: true as const, data: undefined}))
+    const sender = createFakeSender([{outcome: 'accepted', statusCode: 201}])
+    const auditLogger = createAuditLogger()
+
+    const dispatcher = createPushDispatcher({
+      store: {listAllActiveRecords, markDead},
+      sender,
+      dedupeCache: createDedupeCache(),
+      triggerPolicy: {shouldNotify},
+      vapidConfig: VAPID_CONFIG,
+      logger: createLogger(),
+      auditLogger,
+    })
+
+    await dispatcher.dispatchApprovalPending('approval-1')
+
+    const serialized = JSON.stringify(auditLogger.info.mock.calls)
+    expect(serialized).not.toContain('super-secret-path')
+    expect(serialized).not.toContain('p256dh-secret')
   })
 })

--- a/packages/gateway/src/web/operator-push/dispatcher.ts
+++ b/packages/gateway/src/web/operator-push/dispatcher.ts
@@ -133,6 +133,13 @@ export function createPushDispatcher(deps: CreatePushDispatcherDeps): PushDispat
             break
           case 'skipped':
             break
+          default: {
+            // Exhaustiveness guard: if a new dispatchToRecord outcome
+            // variant is added without a case here, TypeScript will fail
+            // to compile.
+            const exhaustiveCheck: never = outcome
+            throw new Error(`broadcast: unhandled dispatchToRecord outcome variant: ${String(exhaustiveCheck)}`)
+          }
         }
       } catch (error: unknown) {
         // One failing record must never abort dispatch to the rest.

--- a/packages/gateway/src/web/operator-push/dispatcher.ts
+++ b/packages/gateway/src/web/operator-push/dispatcher.ts
@@ -151,6 +151,13 @@ export function createPushDispatcher(deps: CreatePushDispatcherDeps): PushDispat
       }
     }
 
+    // Emitted once per broadcast that reached the send loop. A record set
+    // entirely filtered by stale-key (e.g. during a VAPID rotation window)
+    // still records a {delivered:0, dead:0, failed:0} event — that a broadcast
+    // ran with no wire sends is itself worth an audit trail, and it is
+    // unambiguous: the empty-list and dedupe-suppressed paths return before
+    // this point, so a zero-count event can only mean "all subscribers were
+    // skipped".
     emitAudit({kind: 'push.dispatch', correlationId: dedupeId, trigger: kind, delivered, dead, failed}, auditLogger)
   }
 

--- a/packages/gateway/src/web/operator-push/dispatcher.ts
+++ b/packages/gateway/src/web/operator-push/dispatcher.ts
@@ -37,10 +37,12 @@
  */
 
 import type {OperatorFailureKind} from '../../operator-contract/run-status.js'
+import type {AuditLogger} from '../audit.js'
 import type {DedupeCache} from './dedupe-cache.js'
 import type {PushSender} from './push-sender.js'
 import type {OperatorPushSubscriptionStore, SubscriptionRecord} from './subscription-store.js'
 import type {TriggerDecision} from './trigger-policy.js'
+import {emitAudit} from '../audit.js'
 import {buildApprovalPayload, buildFailedRunPayload} from './payload-builder.js'
 
 export interface DispatcherLogger {
@@ -71,6 +73,8 @@ export interface CreatePushDispatcherDeps {
   readonly triggerPolicy: PushDispatcherTriggerPolicy
   readonly vapidConfig: PushDispatcherVapidConfig
   readonly logger: DispatcherLogger
+  /** Audit logger — one coarse push.dispatch summary event is emitted per broadcast. */
+  readonly auditLogger: AuditLogger
 }
 
 export interface PushDispatcher {
@@ -79,7 +83,7 @@ export interface PushDispatcher {
 }
 
 export function createPushDispatcher(deps: CreatePushDispatcherDeps): PushDispatcher {
-  const {store, sender, dedupeCache, triggerPolicy, vapidConfig, logger} = deps
+  const {store, sender, dedupeCache, triggerPolicy, vapidConfig, logger, auditLogger} = deps
 
   async function broadcast(kind: 'approval' | 'run_failed', dedupeId: string, payload: string): Promise<void> {
     const dedupeKey = `${dedupeId}:${kind}`
@@ -96,39 +100,65 @@ export function createPushDispatcher(deps: CreatePushDispatcherDeps): PushDispat
     if (activeRecords.data.length === 0) {
       // Nothing was sent, so a later retry (once subscriptions exist)
       // should still fire — do not consume the dedupe slot here either.
+      // No dispatch audit event either: nothing was dispatched.
       return
     }
 
     if (dedupeCache.shouldSend(dedupeKey) === false) {
       logger.debug({kind}, 'operator push dispatch: suppressed by dedupe window')
+      // No dispatch audit event: suppressed, nothing was dispatched.
       return
     }
 
+    // Coarse per-broadcast tally for the push.dispatch audit event. Dead
+    // subscriptions are counted here and covered by this single summary —
+    // markDead is NOT separately audited per record, which would be
+    // per-endpoint noise (see markDead's dead-subscription branch below).
+    let delivered = 0
+    let dead = 0
+    let failed = 0
+
     for (const record of activeRecords.data) {
       try {
-        await dispatchToRecord(kind, record, payload)
+        const outcome = await dispatchToRecord(kind, record, payload)
+        switch (outcome) {
+          case 'delivered':
+            delivered += 1
+            break
+          case 'dead':
+            dead += 1
+            break
+          case 'failed':
+            failed += 1
+            break
+          case 'skipped':
+            break
+        }
       } catch (error: unknown) {
         // One failing record must never abort dispatch to the rest.
+        failed += 1
         logger.warn(
           {kind, err: error instanceof Error ? error.message : String(error)},
           'operator push dispatch: one subscription failed — continuing with the rest',
         )
       }
     }
+
+    emitAudit({kind: 'push.dispatch', correlationId: dedupeId, trigger: kind, delivered, dead, failed}, auditLogger)
   }
 
   async function dispatchToRecord(
     kind: 'approval' | 'run_failed',
     record: SubscriptionRecord,
     payload: string,
-  ): Promise<void> {
+  ): Promise<'delivered' | 'dead' | 'failed' | 'skipped'> {
     const decision = triggerPolicy.shouldNotify(record, {
       current: vapidConfig.keyVersion,
       previous: vapidConfig.previousKeyVersion,
     })
     if (decision === 'skip-stale-key') {
       logger.debug({kind}, 'operator push dispatch: skipped stale key version')
-      return
+      return 'skipped'
     }
 
     const result = await sender.sendNotification(
@@ -139,20 +169,25 @@ export function createPushDispatcher(deps: CreatePushDispatcherDeps): PushDispat
 
     switch (result.outcome) {
       case 'accepted': {
-        return
+        return 'delivered'
       }
       case 'dead-subscription': {
         const marked = await store.markDead({operatorId: record.operatorId, endpoint: record.endpoint})
         if (marked.success === false) {
           logger.warn({kind}, 'operator push dispatch: failed to mark dead subscription')
         }
-        return
+        // Counted in the broadcast's coarse 'dead' tally — not separately
+        // audited per record; a per-record deactivation event would leak
+        // per-endpoint dispatch cadence. See push.subscription.deactivated
+        // usage at the session-revoke site for the one case that IS audited
+        // individually.
+        return 'dead'
       }
       case 'retryable':
       case 'payload-too-large':
       case 'error': {
         logger.warn({kind, outcome: result.outcome}, 'operator push dispatch: relay send did not succeed')
-        return
+        return 'failed'
       }
       default: {
         // Exhaustiveness guard: if a new PushRelayResult outcome variant is

--- a/packages/gateway/src/web/operator-push/subscription-route.test.ts
+++ b/packages/gateway/src/web/operator-push/subscription-route.test.ts
@@ -54,6 +54,7 @@ function makeDeps(overrides?: Partial<SubscriptionRouteDeps>): SubscriptionRoute
     sessionStore: makeSessionStore(),
     store: makeStore(),
     keyVersion: '1',
+    auditLogger: {info: vi.fn(), warn: vi.fn()},
     logger: {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()},
     now: () => 1000,
     subscribeRateLimiter: createRateLimiter({limit: 1000, windowMs: 60_000}),
@@ -79,7 +80,8 @@ describe('buildSubscriptionRoutes — subscribe', () => {
   // #then creates/replaces one record; response is safe metadata only
   it('happy path: subscribes and returns safe metadata only', async () => {
     const store = makeStore()
-    const deps = makeDeps({store})
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = makeDeps({store, auditLogger})
     const app = buildAppWithGuard(deps)
 
     const res = await app.request('/operator/push/subscriptions', {
@@ -101,6 +103,12 @@ describe('buildSubscriptionRoutes — subscribe', () => {
     expect(body.p256dh).toBeUndefined()
     expect(body.auth).toBeUndefined()
     expect(body.endpointHash).toBe('hash-1')
+
+    // #then a push.subscribed audit event fires with no endpoint/key material
+    expect(auditLogger.info).toHaveBeenCalledOnce()
+    const [ctx] = auditLogger.info.mock.calls[0] as [Record<string, unknown>, string]
+    expect(ctx).toMatchObject({kind: 'push.subscribed', githubUserId: 1001})
+    expect(JSON.stringify(ctx)).not.toContain(VALID_ENDPOINT)
   })
 
   // #given no authenticated session
@@ -323,7 +331,8 @@ describe('buildSubscriptionRoutes — unsubscribe', () => {
   // #then marks the record inactive
   it("happy path: unsubscribes the operator's own record", async () => {
     const store = makeStore()
-    const deps = makeDeps({store})
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = makeDeps({store, auditLogger})
     const app = buildAppWithGuard(deps)
 
     const res = await app.request('/operator/push/subscriptions/unsubscribe', {
@@ -334,6 +343,12 @@ describe('buildSubscriptionRoutes — unsubscribe', () => {
 
     expect(res.status).toBe(200)
     expect(store.unsubscribe).toHaveBeenCalledWith({operatorId: OPERATOR_A_ID, endpoint: VALID_ENDPOINT})
+
+    // #then a push.unsubscribed audit event fires with no endpoint material
+    expect(auditLogger.info).toHaveBeenCalledOnce()
+    const [ctx] = auditLogger.info.mock.calls[0] as [Record<string, unknown>, string]
+    expect(ctx).toMatchObject({kind: 'push.unsubscribed', githubUserId: 1001})
+    expect(JSON.stringify(ctx)).not.toContain(VALID_ENDPOINT)
   })
 
   // #given another operator's record (store fails-closed)

--- a/packages/gateway/src/web/operator-push/subscription-route.test.ts
+++ b/packages/gateway/src/web/operator-push/subscription-route.test.ts
@@ -116,7 +116,8 @@ describe('buildSubscriptionRoutes — subscribe', () => {
   // #then notFoundResponse, no store write
   it('error path: unauthenticated request is denied with no store write', async () => {
     const store = makeStore()
-    const deps = makeDeps({store})
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = makeDeps({store, auditLogger})
     const app = buildAppWithGuard(deps, false)
 
     const res = await app.request('/operator/push/subscriptions', {
@@ -127,6 +128,10 @@ describe('buildSubscriptionRoutes — subscribe', () => {
 
     expect(res.status).toBe(404)
     expect(store.subscribe).not.toHaveBeenCalled()
+    expect(auditLogger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({kind: 'push.subscribed'}),
+      expect.anything(),
+    )
   })
 
   // #given a malformed body (missing keys)
@@ -135,7 +140,8 @@ describe('buildSubscriptionRoutes — subscribe', () => {
   it('error path: malformed body is rejected with 400 and no store write', async () => {
     const store = makeStore()
     const warn = vi.fn()
-    const deps = makeDeps({store, logger: {debug: vi.fn(), info: vi.fn(), warn, error: vi.fn()}})
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = makeDeps({store, logger: {debug: vi.fn(), info: vi.fn(), warn, error: vi.fn()}, auditLogger})
     const app = buildAppWithGuard(deps)
 
     const res = await app.request('/operator/push/subscriptions', {
@@ -149,6 +155,10 @@ describe('buildSubscriptionRoutes — subscribe', () => {
     for (const call of warn.mock.calls) {
       expect(JSON.stringify(call)).not.toContain(VALID_ENDPOINT)
     }
+    expect(auditLogger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({kind: 'push.subscribed'}),
+      expect.anything(),
+    )
   })
 
   // #given an endpoint that fails SSRF validation (loopback)
@@ -157,7 +167,8 @@ describe('buildSubscriptionRoutes — subscribe', () => {
   it('error path: loopback endpoint is rejected without logging the endpoint value', async () => {
     const store = makeStore()
     const warn = vi.fn()
-    const deps = makeDeps({store, logger: {debug: vi.fn(), info: vi.fn(), warn, error: vi.fn()}})
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = makeDeps({store, logger: {debug: vi.fn(), info: vi.fn(), warn, error: vi.fn()}, auditLogger})
     const app = buildAppWithGuard(deps)
     const loopbackEndpoint = 'https://127.0.0.1/secret-path'
 
@@ -172,6 +183,10 @@ describe('buildSubscriptionRoutes — subscribe', () => {
     for (const call of warn.mock.calls) {
       expect(JSON.stringify(call)).not.toContain('secret-path')
     }
+    expect(auditLogger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({kind: 'push.subscribed'}),
+      expect.anything(),
+    )
   })
 
   // #given the subscribe rate limit is exhausted
@@ -180,7 +195,8 @@ describe('buildSubscriptionRoutes — subscribe', () => {
   it('rate limit: exhausted operator-keyed limit denies the request', async () => {
     const store = makeStore()
     const limiter = createRateLimiter({limit: 1, windowMs: 60_000})
-    const deps = makeDeps({store, subscribeRateLimiter: limiter})
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = makeDeps({store, subscribeRateLimiter: limiter, auditLogger})
     const app = buildAppWithGuard(deps)
 
     const requestOptions = {
@@ -190,10 +206,15 @@ describe('buildSubscriptionRoutes — subscribe', () => {
     }
     // First request consumes the single-request budget.
     await app.request('/operator/push/subscriptions', requestOptions)
+    auditLogger.info.mockClear()
     const res = await app.request('/operator/push/subscriptions', requestOptions)
 
     expect(res.status).toBe(429)
     expect(store.subscribe).toHaveBeenCalledTimes(1)
+    expect(auditLogger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({kind: 'push.subscribed'}),
+      expect.anything(),
+    )
   })
 
   // #given the store rejects the write (e.g. underlying object-store error)
@@ -204,7 +225,8 @@ describe('buildSubscriptionRoutes — subscribe', () => {
       subscribe: vi.fn(async () => err(createStoreError('subscribe: exceeded max CAS retry attempts'))),
     })
     const logger = {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
-    const deps = makeDeps({store, logger})
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = makeDeps({store, logger, auditLogger})
     const app = buildAppWithGuard(deps)
 
     const res = await app.request('/operator/push/subscriptions', {
@@ -221,6 +243,10 @@ describe('buildSubscriptionRoutes — subscribe', () => {
         expect(JSON.stringify(call)).not.toContain(VALID_ENDPOINT)
       }
     }
+    expect(auditLogger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({kind: 'push.subscribed'}),
+      expect.anything(),
+    )
   })
 
   // #given the operator already has the cap's worth of active subscriptions,
@@ -230,7 +256,8 @@ describe('buildSubscriptionRoutes — subscribe', () => {
   it('subscription cap: a new endpoint at the cap is rejected without a store write', async () => {
     const activeAtCap = Array.from({length: 20}, (_v, i) => makeMetadata({endpointHash: `hash-${i}`, active: true}))
     const store = makeStore({listMetadataForOperator: vi.fn(async () => ok(activeAtCap))})
-    const deps = makeDeps({store})
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = makeDeps({store, auditLogger})
     const app = buildAppWithGuard(deps)
 
     const res = await app.request('/operator/push/subscriptions', {
@@ -241,6 +268,10 @@ describe('buildSubscriptionRoutes — subscribe', () => {
 
     expect(res.status).toBe(400)
     expect(store.subscribe).not.toHaveBeenCalled()
+    expect(auditLogger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({kind: 'push.subscribed'}),
+      expect.anything(),
+    )
   })
 
   // #given the operator is at the cap but the incoming endpoint is already
@@ -358,7 +389,8 @@ describe('buildSubscriptionRoutes — unsubscribe', () => {
     const store = makeStore({
       unsubscribe: vi.fn(async () => err(createStoreError('unsubscribe: endpoint is not owned by this operator'))),
     })
-    const deps = makeDeps({store})
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = makeDeps({store, auditLogger})
     const app = buildAppWithGuard(deps)
 
     const res = await app.request('/operator/push/subscriptions/unsubscribe', {
@@ -370,6 +402,10 @@ describe('buildSubscriptionRoutes — unsubscribe', () => {
     expect(res.status).toBe(404)
     const body = (await res.json()) as Record<string, unknown>
     expect(body.error).toBe('not-found')
+    expect(auditLogger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({kind: 'push.unsubscribed'}),
+      expect.anything(),
+    )
   })
 
   // #given malformed body (missing endpoint)
@@ -377,7 +413,8 @@ describe('buildSubscriptionRoutes — unsubscribe', () => {
   // #then 400, no store write
   it('error path: malformed body is rejected with 400', async () => {
     const store = makeStore()
-    const deps = makeDeps({store})
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = makeDeps({store, auditLogger})
     const app = buildAppWithGuard(deps)
 
     const res = await app.request('/operator/push/subscriptions/unsubscribe', {
@@ -388,6 +425,10 @@ describe('buildSubscriptionRoutes — unsubscribe', () => {
 
     expect(res.status).toBe(400)
     expect(store.unsubscribe).not.toHaveBeenCalled()
+    expect(auditLogger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({kind: 'push.unsubscribed'}),
+      expect.anything(),
+    )
   })
 
   // #given no authenticated session
@@ -395,7 +436,8 @@ describe('buildSubscriptionRoutes — unsubscribe', () => {
   // #then notFoundResponse, no store write
   it('error path: unauthenticated request is denied with no store write', async () => {
     const store = makeStore()
-    const deps = makeDeps({store})
+    const auditLogger = {info: vi.fn(), warn: vi.fn()}
+    const deps = makeDeps({store, auditLogger})
     const app = buildAppWithGuard(deps, false)
 
     const res = await app.request('/operator/push/subscriptions/unsubscribe', {
@@ -406,6 +448,10 @@ describe('buildSubscriptionRoutes — unsubscribe', () => {
 
     expect(res.status).toBe(404)
     expect(store.unsubscribe).not.toHaveBeenCalled()
+    expect(auditLogger.info).not.toHaveBeenCalledWith(
+      expect.objectContaining({kind: 'push.unsubscribed'}),
+      expect.anything(),
+    )
   })
 })
 

--- a/packages/gateway/src/web/operator-push/subscription-route.ts
+++ b/packages/gateway/src/web/operator-push/subscription-route.ts
@@ -37,10 +37,12 @@ import type {
   OperatorPushSubscriptionListResponse,
   OperatorPushSubscriptionMetadata,
 } from '../../operator-contract/index.js'
+import type {AuditLogger} from '../audit.js'
 import type {OperatorLogger} from '../server.js'
 import type {OperatorPushSubscriptionStore, SubscriptionMetadata} from './subscription-store.js'
 import {createRateLimiter} from '../../http/rate-limit.js'
 import {parseOperatorPushSubscribeRequest, parseOperatorPushUnsubscribeRequest} from '../../operator-contract/index.js'
+import {emitAudit} from '../audit.js'
 import {getOperatorAuthContext, registerOperatorRoute} from '../operator-route.js'
 import {notFoundResponse, rateLimitedResponse} from '../safe-response.js'
 import {hashEndpoint} from './subscription-store.js'
@@ -90,6 +92,8 @@ export interface SubscriptionRouteDeps {
   readonly store: Pick<OperatorPushSubscriptionStore, 'subscribe' | 'unsubscribe' | 'listMetadataForOperator'>
   /** Current VAPID key version — stamped onto every subscribe call. */
   readonly keyVersion: string
+  /** Audit logger for security events. */
+  readonly auditLogger: AuditLogger
   /** Structured logger. */
   readonly logger: OperatorLogger
   /** Injectable clock. */
@@ -239,6 +243,10 @@ export function buildSubscriptionRoutes(app: Hono, deps: SubscriptionRouteDeps):
 
       // ── Gate 8: Map result → safe JSON (metadata only, never endpoint/keys) ─
       deps.logger.info({githubUserId}, 'push-subscribe: accepted')
+      emitAudit(
+        {kind: 'push.subscribed', correlationId: `push-subscribe:${githubUserId}`, githubUserId},
+        deps.auditLogger,
+      )
       return c.json(toResponseMetadata(result.data), 200)
     } catch (error: unknown) {
       deps.logger.warn(
@@ -294,6 +302,10 @@ export function buildSubscriptionRoutes(app: Hono, deps: SubscriptionRouteDeps):
 
       // ── Gate 8: Safe response — no endpoint/keys ─────────────────────────
       deps.logger.info({githubUserId}, 'push-unsubscribe: accepted')
+      emitAudit(
+        {kind: 'push.unsubscribed', correlationId: `push-unsubscribe:${githubUserId}`, githubUserId},
+        deps.auditLogger,
+      )
       return c.json({ok: true}, 200)
     } catch (error: unknown) {
       deps.logger.warn(

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -989,7 +989,8 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
     browserGuardDeps !== undefined &&
     deps.sessionStore !== undefined &&
     deps.operatorPushStore !== undefined &&
-    deps.operatorPushVapidKeyInfo !== undefined
+    deps.operatorPushVapidKeyInfo !== undefined &&
+    deps.auditLogger !== undefined
   ) {
     const clock = deps.sessionDeps?.clock ?? (() => Date.now())
     const sessionStoreForPush: SubscriptionRouteSessionStore = deps.sessionStore
@@ -1001,6 +1002,7 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
       sessionStore: sessionStoreForPush,
       store: deps.operatorPushStore,
       keyVersion: deps.operatorPushVapidKeyInfo.keyVersion,
+      auditLogger: deps.auditLogger,
       logger: deps.logger,
       now: clock,
     })

--- a/packages/gateway/src/web/server.ts
+++ b/packages/gateway/src/web/server.ts
@@ -985,6 +985,11 @@ export function buildOperatorApp(deps: OperatorServerDeps, config: OperatorServe
   // has passed its CAS self-test at startup. A self-test failure (or push
   // disabled entirely) means these deps are absent here and the routes never
   // mount — matching the fail-closed posture of every other opt-in route above.
+  //
+  // auditLogger is also required to mount: the push routes never run without
+  // an audit logger present, so every push route action (subscribe,
+  // unsubscribe, dispatch, deactivate) is guaranteed to be audited — there is
+  // no silently-unaudited push route.
   if (
     browserGuardDeps !== undefined &&
     deps.sessionStore !== undefined &&


### PR DESCRIPTION
Adds the privacy and operational surface for operator push notifications: coarse audit events for the push lifecycle, a privacy/retention policy, VAPID rotation and leak-response notes, and route documentation. This is the last piece of the Gateway push feature — audit and docs only, no dispatch/route/store behavior change. Push stays disabled-by-default.

## Audit events

Five coarse events join the typed audit seam, each carrying only non-sensitive fields — never an endpoint, browser key, payload, prompt, repo, or raw failure kind:

- `push.subscribed` / `push.unsubscribed` — operator GitHub id, on the accepted path only.
- `push.subscription.deactivated` — operator id + a coarse reason (e.g. `session_revoked`).
- `push.dispatch` — a per-broadcast **summary**: the trigger plus delivered/dead/failed **counts**. One event per broadcast, never per-recipient, so the audit log can't be used to correlate a notification to an endpoint. It's emitted only when a broadcast actually ran (not on an empty subscription list or a dedupe-suppressed call).
- `push.disabled` — emitted once at startup: `config_absent` (info) when push isn't configured, `self_test_failed` (warn) when the CAS self-test forced the surface closed.

The events plug into the existing exhaustive log-level map and redaction switch, so a future push event can't skip redaction without a compile error. Dead subscriptions found during dispatch are folded into the `push.dispatch` `dead` count rather than emitted per-endpoint.

## Documentation

- `docs/privacy/operator-push-retention.md` — what's stored (write-only endpoint/keys, operator id, key version, timestamps, active state; no message content ever), what a notification contains, retention (30-day inactive window, durable tombstone against backup-restore resurrection), export (safe metadata only), deletion, and the coarse audit trail.
- VAPID key rotation and leak-response notes, plus a push section on the Operator Web Control Surface wiki page (the four authenticated routes, opt-in, fail-soft, broadcast model).

## Verification

Gateway type-check, lint, and full suite green (3173 tests). The privacy invariant is pinned structurally — a test asserts the emitted `push.dispatch` context contains exactly the coarse field set, and the dispatch sensitive-detail test now plants distinctive endpoint/key values and asserts none reach the audit output. Denied subscribe/unsubscribe gates assert no audit event fires; the outcome-tally switch has an exhaustiveness guard. `dist/` is unchanged.
