### PR TITLE
feat(harness): bump base to OpenCode 1.17.18 with 17 carries

### DIFF
--- a/docs/brainstorms/2026-07-11-opencode-1.17.18-bump-requirements.md
+++ b/docs/brainstorms/2026-07-11-opencode-1.17.18-bump-requirements.md
@@ -1,0 +1,88 @@
+# OpenCode 1.17.18 bump — harness base + native SDK
+
+**Date:** 2026-07-11
+**Status:** confirmed
+**Scope:** Standard
+
+## Problem
+
+The harness build sits on OpenCode base `1.17.14` and the native `@opencode-ai/sdk` pin lags at `1.17.13`. Upstream is at `1.17.18`. Two model/agent defects affect current use: `openai/gpt-5.6-luna` fails with `model_not_found` in the current harness build (upstream #36140, fixed by open PR #36143), and the harness TUI selects the wrong agent or overwrites the configured variant (addressed by open PR #7156). The bump also picks up upstream provider-routing and stability fixes and refreshes the carry set.
+
+## Release-gap findings (1.17.14 → 1.17.18)
+
+Verified against upstream release notes, tag diffs, and the SDK package manifest:
+
+- **No contract changes** on any consumed surface: `/event` SSE shapes, `@opencode-ai/sdk` exports (no SDK source files in the gap diff), permission reply API, `GET /session/{id}` summary/diffs, server lifecycle. Drop-in safe for both the action and the gateway.
+- **Gap delivers:** provider/model routing fixes (Copilot zero-billing catalog crash #36123, Meta/Grok variant logic #36079/#36017, xAI cache routing #35970), config-directory resilience (#35632), home-relative permission-path expansion (#35737 — mild watch item for approval path matching). Remainder is desktop UX.
+- **Gap does NOT remediate** the pains our carries address: SSE backlog, session file growth, 409-reentry, idle-instance memory eviction. All 10 existing carries remain open upstream and are still needed.
+
+## Requirements
+
+### R1 — Harness base bump to 1.17.18
+
+`packages/harness/harness.config.json`: `base_version` `1.17.14` → `1.17.18`. The `getProvenance` base-version assertion in `packages/harness/src/cli.test.ts` (`expect(p.baseVersion).toBe('1.17.14')`) updated in lockstep. This is the same shape as the 1.17.14 bump (PR #1136).
+
+### R2 — Carry set: 17 refs
+
+All 10 existing carries verified still open upstream (none contained in v1.17.18) and kept, in existing order:
+
+| Ref | Note |
+| --- | --- |
+| #19961 | system.transform ordering — **high** rebase-conflict risk (session prompt/compaction churn in the gap); LLM merge attempts, fail-closed |
+| #31859 | bootstrap client reentry guard |
+| #31638 | avoid full history hydration after compaction |
+| #33134 | orphan part projection tolerance — med risk |
+| #33159 | SQLite lock-timeout retry — med risk |
+| #33444 | session summary from per-turn diffs |
+| #31922 | SSE backlog bounding |
+| #34975 | AbortSignal listener leak |
+| #34977 | queue resolver leak |
+| #33713 | idle-instance memory eviction — med risk |
+
+New carries appended (all open, base `dev`, MERGEABLE, green CI):
+
+| Ref | Fixes | Size |
+| --- | --- | --- |
+| #36143 | gpt-5.6 Sol/Terra/Luna via Responses Lite — closes the `gpt-5.6-luna` `model_not_found` (#36140, still open with fresh confirmations) | +336/−2 |
+| #7156 | TUI/desktop agent default-variant handling — the wrong-agent/variant-overwrite symptom; **attempt** despite drift risk (11 files, old thread); superseding #33960 was closed unmerged, so the symptom is unfixed upstream | +244/−42 |
+| #36045 | TUI batches streaming part deltas — render-loop saturation on fast streams | +48/−10 |
+| #36281 | subagent `agent.model`/`agent.variant` ignored in handleSubtask | +15/−11 |
+| #36002 | session busy-status stuck after stream close | +47/−2 |
+| #36361 | swallowed background summary/prune failures | +20/−2 |
+| #36179 | OTEL root span per prompt | +13/−5 |
+
+**Excluded:** #35913 (removes the SSE directory filter for worktree sessions) — semantics-checked: safe for our consumers (every actionable branch in `src/features/agent/streaming.ts` and `packages/gateway/src/execute/run-core.ts` gates on sessionID before acting), but it fixes a worktree bug we don't hit, drops a bandwidth optimization we benefit from (directory-scoped `/event` on shared servers), and has zero human review upstream. Excluded on value, not risk. Watchlist, not carried: #36364 (skill-discovery traversal hardening), #35931 (TUI listener limits).
+
+### R3 — Native SDK pin bump + fallback version, gated
+
+`@opencode-ai/sdk` `1.17.13` → `1.17.18` in the only two source pin sites: root `package.json` and `packages/runtime/package.json` (lockfile follows). Version-only from the consumer's perspective (no shape change verified). Same PR also bumps `FALLBACK_VERSION` `1.17.13` → `1.17.18` in `src/services/setup/opencode.ts` — the plain-stock fallback used when latest-fetch fails; it is not covered by the auto-PR. **Sequencing:** `1.17.18` published 2026-07-09T18:50Z; the bunfig `minimumReleaseAge` (3 days) clears ~2026-07-12T18:50Z. The pin bump waits for the gate — no `minimumReleaseAgeExcludes` churn.
+
+### R4 — Release + verification
+
+Dispatch `harness-release.yaml` with `base_version: 1.17.18` after the config PR merges. Full-pipeline verification as in the 1.17.14 round: integrate (broker mint + 17-carry LLM merge) → 4-platform build matrix → npm publish + GitHub Release → `sync-default-version` auto-PR bumping the two harness-version sites (`DEFAULT_OPENCODE_VERSION` in `packages/runtime/src/shared/constants.ts` and the `deploy/workspace.Dockerfile` `OPENCODE_VERSION` ARG), as auto-PR #1141 did for 1.17.14. If the integrate job fails on a carry (most likely #7156 or #19961), drop the failing ref from the config and re-dispatch — fail-closed, no partial publish.
+
+## Key decisions
+
+1. **#7156 attempted despite drift risk** — the TUI symptom is real, current, and unfixed upstream; drop-and-redispatch is the cheap fallback.
+2. **#35913 excluded on value** — verified safe (both consumers sessionID-gate every actionable branch), but it fixes a worktree bug we don't have and removes a directory-filter bandwidth benefit we use; zero upstream review engagement.
+3. **SDK waits for the age gate** — harness release has no age-gate dependency and proceeds immediately; the native bump follows ~24h later with zero bunfig churn.
+4. **All 10 existing carries kept** — reconciliation confirmed none merged upstream; conflict risk concentrated in #19961 (accepted, same posture as the 1.17.14 round).
+
+## Success criteria
+
+- Harness release `1.17.18+harness.<sha>` published to npm `latest` with all carries integrated (or a documented subset after fail-closed drops).
+- `openai/gpt-5.6-luna` resolves in the new harness build.
+- TUI agent/variant selection respects configuration (if #7156 survives integration).
+- Native SDK pin at `1.17.18` with green CI (`bun install` clean past the age gate).
+- Action + gateway test suites green with no consumer-surface regressions.
+
+## Out of scope
+
+- #35913 semantics check (separate follow-up if pursued).
+- Any gateway/action code changes — the gap has no contract changes; this is a pins-and-carries bump.
+
+## References
+
+- Prior bump: PR #1136 (1.17.13 → 1.17.14, 10 carries), release run pattern in `.github/workflows/harness-release.yaml`
+- Carry policy: `packages/harness/harness.config.json`
+- Version pins: `packages/runtime/src/shared/constants.ts` (`DEFAULT_OPENCODE_VERSION`), root + runtime `package.json` (SDK)

--- a/packages/harness/harness.config.json
+++ b/packages/harness/harness.config.json
@@ -1,7 +1,7 @@
 {
   "release_repo": "anomalyco/opencode",
   "source_repo": "https://github.com/anomalyco/opencode.git",
-  "base_version": "1.17.14",
+  "base_version": "1.17.18",
   "integrationRefs": [
     "https://github.com/anomalyco/opencode/pull/19961",
     "https://github.com/anomalyco/opencode/pull/31859",
@@ -12,7 +12,14 @@
     "https://github.com/anomalyco/opencode/pull/31922",
     "https://github.com/anomalyco/opencode/pull/34975",
     "https://github.com/anomalyco/opencode/pull/34977",
-    "https://github.com/anomalyco/opencode/pull/33713"
+    "https://github.com/anomalyco/opencode/pull/33713",
+    "https://github.com/anomalyco/opencode/pull/36143",
+    "https://github.com/anomalyco/opencode/pull/7156",
+    "https://github.com/anomalyco/opencode/pull/36045",
+    "https://github.com/anomalyco/opencode/pull/36281",
+    "https://github.com/anomalyco/opencode/pull/36002",
+    "https://github.com/anomalyco/opencode/pull/36361",
+    "https://github.com/anomalyco/opencode/pull/36179"
   ],
   "agent": "build",
   "model": "anthropic/claude-sonnet-4-6",

--- a/packages/harness/src/cli.test.ts
+++ b/packages/harness/src/cli.test.ts
@@ -13,7 +13,7 @@ describe('getProvenance', () => {
     const p = getProvenance()
 
     // #then
-    expect(p.baseVersion).toBe('1.17.14')
+    expect(p.baseVersion).toBe('1.17.18')
     expect(Array.isArray(p.integrationRefs)).toBe(true)
     expect(p.integrationCommit).toBeNull()
     expect(p.buildSha).toBe('dev')


### PR DESCRIPTION
Bumps the harness base from 1.17.14 to 1.17.18 and refreshes the carry set to 17 refs. Same shape as #1136.

## Release gap (verified)

- Contract-neutral for the action and gateway: no changes to /event SSE shapes, @opencode-ai/sdk exports, the permission reply API, session/diff endpoints, or server lifecycle across 1.17.15–1.17.18.
- The gap delivers provider/model routing fixes (Copilot zero-billing catalog crash, Meta/Grok variant logic, xAI cache routing) and config-directory resilience; it does not remediate the pains the existing carries address.

## Carry set

All 10 existing carries verified still open upstream (none contained in v1.17.18) and kept in order. Seven new carries appended, all open on `dev`, MERGEABLE, green CI:

- **#36143** — gpt-5.6 Sol/Terra/Luna via Responses Lite; fixes `model_not_found` for `openai/gpt-5.6-luna` (upstream #36140, still open)
- **#7156** — TUI/desktop agent default-variant handling; the wrong-agent/variant-overwrite symptom. Attempted despite drift risk (11 files, older thread; the narrower #33960 was closed unmerged, so the symptom is unfixed upstream). If integration fails, drop the ref and re-dispatch — the integrate job fails closed.
- **#36045** — batch streaming part deltas to keep the TUI responsive on fast streams
- **#36281** — subagent `agent.model`/`agent.variant` config ignored in handleSubtask
- **#36002** — session busy-status stuck after stream close
- **#36361** — swallowed background summary/prune failures
- **#36179** — OTEL root span per prompt

Excluded on value: **#35913** (SSE directory-filter removal) — verified safe for our sessionID-gated consumers, but it fixes a worktree bug we don't hit, drops a directory-scoping bandwidth benefit we use, and has no upstream review engagement.

## Follow-ups (not this PR)

- Dispatch `harness-release.yaml` with `base_version: 1.17.18` after merge; `sync-default-version` auto-PR bumps `DEFAULT_OPENCODE_VERSION` + the workspace Dockerfile ARG on success.
- Native `@opencode-ai/sdk` pin bump (1.17.13 → 1.17.18) + `FALLBACK_VERSION` lands separately once the 3-day supply-chain age gate clears (~2026-07-12T18:50Z).

## Verification

- `harness.config.json` parses; 17 refs, base 1.17.18.
- Harness suite green (`getProvenance` base-version assertion updated in lockstep).