### PR TITLE
feat: mint a scoped App token inline for the integrate merge push

### DIFF
--- a/.github/workflows/harness-integrate.yaml
+++ b/.github/workflows/harness-integrate.yaml
@@ -27,8 +27,11 @@ on:
         type: string
         required: false
     secrets:
-      FRO_BOT_PAT:
-        description: PAT used for checkout and as the action's github-token. Required.
+      APPLICATION_ID:
+        description: GitHub App id used to mint the scoped installation token for the merge push. Required.
+        required: true
+      APPLICATION_PRIVATE_KEY:
+        description: GitHub App private key (PEM). Mapped only to the mint step's env; never job-level. Required.
         required: true
       OPENCODE_CONFIG:
         description: JSON merged into the OpenCode config (OPENCODE_CONFIG_CONTENT). Optional.
@@ -79,7 +82,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          token: ${{ secrets.FRO_BOT_PAT }}
+          # Default GITHUB_TOKEN: checkout needs only contents: read. The
+          # scoped App token is minted as late as possible (below) so its
+          # ~1h TTL is not spent on checkout/setup.
+          token: ${{ github.token }}
 
       - name: Setup Node.js and Bun
         uses: ./.github/actions/setup
@@ -88,12 +94,25 @@ jobs:
         id: mint
         run: node --experimental-strip-types scripts/harness/mint-broker-credential.ts
 
+      # Trusted inline no-post mint. MUST stay a plain run: step invoking the
+      # checked-in script — never a marketplace action with a post: hook (the
+      # runner re-supplies INPUT_* — including the private key — during the
+      # post phase, and a prompt-injected earlier step can tamper the on-disk
+      # post script; see docs/plans/2026-07-11-002-feat-inline-app-token-mint-integrate-plan.md).
+      # The App secrets are mapped to THIS step's env only — never job-level.
+      - name: Mint scoped App token
+        id: mint-app-token
+        run: node --experimental-strip-types scripts/harness/mint-app-token.ts
+        env:
+          APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
+          APPLICATION_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+
       # SYNC: keep the shared merge inputs in step with fro-bot.yaml's Run Fro Bot step
       - name: Run Fro Bot
         uses: ./
         with:
           auth-json: ${{ steps.mint.outputs.auth-json }}
-          github-token: ${{ secrets.FRO_BOT_PAT }}
+          github-token: ${{ steps.mint-app-token.outputs.github-token }}
           model: ${{ inputs.model || vars.HARNESS_MODEL }}
           prompt: ${{ inputs.prompt }}
           response-mode: none

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -205,7 +205,8 @@ jobs:
       contents: read
     uses: ./.github/workflows/harness-integrate.yaml
     secrets:
-      FRO_BOT_PAT: ${{ secrets.FRO_BOT_PAT }}
+      APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
+      APPLICATION_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       OPENCODE_CONFIG: ${{ secrets.OPENCODE_CONFIG }}
       OMO_PROVIDERS: ${{ secrets.OMO_PROVIDERS }}
     with:

--- a/docs/plans/2026-07-11-002-feat-inline-app-token-mint-integrate-plan.md
+++ b/docs/plans/2026-07-11-002-feat-inline-app-token-mint-integrate-plan.md
@@ -1,0 +1,223 @@
+---
+title: 'feat: replace FRO_BOT_PAT with an inline-minted scoped App token on the integrate path'
+type: feat
+status: active
+date: 2026-07-11
+origin: https://github.com/fro-bot/agent/issues/1126
+---
+
+# feat: replace FRO_BOT_PAT with an inline-minted scoped App token on the integrate path
+
+## Overview
+
+`harness-integrate.yaml` hands its prompt-injectable LLM merge agent the durable, broad classic PAT `FRO_BOT_PAT`. This plan replaces it with a short-lived (~1h), single-repo, `contents: write`-only GitHub App installation token, minted by a trusted inline no-post step inside the same job. After this lands, `FRO_BOT_PAT` is gone from the integrate path entirely; the worst a fully compromised merge agent can do with its credential is push to `fro-bot/agent` for under an hour.
+
+Design source: issue #1126 (supersedes the broker-side mint explored in `marcusrbrown/infra#771` and the older brainstorm `docs/brainstorms/2026-07-04-harness-integrate-app-token-broker-requirements.md` — the broker-consumption half of that doc is superseded; its security-contract requirements for mint scripts survive and are honored here).
+
+## Problem Frame
+
+The integrate job runs an autonomous OpenCode agent over upstream PR content (prompt-injectable by construction). That agent needs a GitHub credential for exactly one thing: `git push` of the integration result to `refs/harness-integrate/<version>`. Today it holds `FRO_BOT_PAT` — durable, account-broad, and usable anywhere. Interim hygiene (#1119) masks and scrubs copies but cannot isolate a credential the agent genuinely needs. Credential minimization is the root-cause fix: mint per-run, scope to one repo and one permission, expire in ~1h.
+
+## Requirements Trace
+
+- R1. The merge agent never holds a durable credential — only a ~1h App installation token scoped `{contents: write}` on `fro-bot/agent` alone.
+- R2. `FRO_BOT_PAT` is removed from the integrate path entirely (workflow_call secrets decl, checkout, github-token input, caller pass-through).
+- R3. The App **private key** never leaves the trusted mint step: mapped only to that step's `env` (never job-level env, never `with:` of a post-hooked action), never written to disk, `$GITHUB_OUTPUT`, or `$GITHUB_ENV`, and never included in error text. The minted **token** is intentionally handed off via a masked `$GITHUB_OUTPUT` step output — it is the same token the merge agent receives anyway, so its on-disk step-output residence adds no authority the agent doesn't already hold.
+- R4. No `actions/create-github-app-token` or any post-hooked action performs the mint (post-phase `INPUT_*` re-injection + same-job on-disk tamper vector — see issue #1126 evidence).
+- R5. Fail closed: any mint failure fails the job before the merge step runs; no durable-credential fallback.
+- R6. One-job security invariant preserved (broker OIDC allowlist pins `job_workflow_ref`; no new job).
+- R7. End-to-end proof on a real dispatch: mint succeeds, LLM merge runs, push to `refs/harness-integrate/<version>` completes on the App token.
+
+## Scope Boundaries
+
+- No egress-containment changes (that half is `marcusrbrown/infra#751`).
+- No changes to the broker OIDC model-credential mint (`scripts/harness/mint-broker-credential.ts` stays as-is; the new mint is a sibling).
+- No changes to `packages/harness/prompt.txt` — the push block consumes `GH_TOKEN` via `x-access-token` askpass (prompt.txt:74-95), and an installation token is a verified drop-in.
+- Optional token revoke step (`DELETE /installation/token`) deferred — hygiene, not a boundary; TTL is the boundary.
+
+### Deferred to Separate Tasks
+
+- Dedicated minimal App migration if the current App's installed scope is broad (operator decision after U0 verification).
+- workflow_dispatch/schedule model-credential minimization for the main fro-bot.yaml flows (#1167 residual, infra-dependent).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/harness/mint-broker-credential.ts:5-18,112-166` — the mint-script security contract to mirror exactly: mask secret material immediately (before any log/throw), single bounded request (no retry), all-or-nothing response validation, masked step output only, fail closed via `process.exitCode = 1`.
+- `scripts/harness/mint-broker-credential.test.ts` — test patterns: URL resolution, invalid-payload rejection, all-or-nothing, happy-path masking/output ordering.
+- `.github/workflows/harness-integrate.yaml:29-32,77-82,92-96` — the three FRO_BOT_PAT entry points; step order harden-runner → checkout → setup → broker mint → Run Fro Bot; permissions `{id-token: write, contents: read}` (:53-55); harden-runner allowlist already includes `api.github.com:443` (:64-75) so the mint's REST calls clear egress.
+- `.github/workflows/harness-release.yaml:206-210` — explicit secrets pass-through (`secrets: inherit` deliberately dropped in the #1060 hardening); new secrets must be threaded explicitly.
+- `src/services/setup/setup.ts:307-314` + `packages/runtime/src/agent/response-delivery.ts` — on the integrate path the caller's event (`workflow_dispatch`/`push`, per fro-bot.yaml:38-43 the callee sees the caller's event) classifies credential=provision, so the action exports the supplied `github-token` as `GH_TOKEN` for the agent's push. Unchanged by this plan; the token *value* changes from PAT to App token.
+
+### Institutional Learnings
+
+- `docs/solutions/workflow-issues/create-github-app-token-caller-mint-invalid-2026-07-04.md` — mint cannot live in the caller (a `uses:` job has no steps; `secrets:` can't read `steps.*`). Validates the inline-in-called-job placement.
+- `docs/solutions/best-practices/same-job-phase-split-not-a-security-boundary-2026-07-04.md` — step ordering is not a boundary against an *earlier* hostile step or *post* hooks. Here the key-bearing step runs before the injectable step and has no post hook, which is exactly why the no-post constraint (R4) is load-bearing.
+- `docs/solutions/best-practices/reusable-workflow-permissions-replace-not-merge-2026-07-01.md` — caller job must keep `{id-token: write, contents: read}`; no permission changes needed (App mint uses the App JWT, not GITHUB_TOKEN).
+- `docs/solutions/workflow-issues/harden-runner-allowed-endpoints-literal-scalar-drops-endpoints-2026-07-07.md` — allowlist scalar stays folded (`>-`); no allowlist change needed (api.github.com present).
+- `docs/solutions/workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md` — fail-closed mint hygiene contract; also documents why scrubs alone can't isolate a needed credential (minimization is the fix).
+
+## Key Technical Decisions
+
+- **Inline no-post mint via checked-in script, not `actions/create-github-app-token`**: the marketplace action declares a `post:` hook; the runner re-supplies `INPUT_PRIVATE-KEY` at post time, and a prompt-injected step can tamper the on-disk post script → key exfiltration. A plain `run:` step invoking a checked-in script has no post phase. (origin: #1126)
+- **Hand-rolled RS256 App JWT via `node:crypto`, zero new dependencies**: the mint needs one JWT signature (`crypto.createSign('RSA-SHA256')`) and two REST calls (`GET /repos/fro-bot/agent/installation` for the installation id, `POST /app/installations/{id}/access_tokens`). Adding `@octokit/auth-app` or a JWT lib for this is dependency sprawl on a security-critical path; the broker mint script set the no-deps precedent.
+- **Key mapped step-env-only**: `APPLICATION_ID`/`APPLICATION_PRIVATE_KEY` appear in the mint step's `env:` block only (R3). This prevents exposure through normal step env inheritance — it is not claimed as a standalone isolation guarantee (same-job on-disk surfaces are the real boundary concern); the load-bearing protections are no-post (R4), no disk writes, constant-class error text, and fail-closed.
+- **Scoped mint request**: token request body carries `permissions: {contents: 'write'}` and `repositories: ['agent']`; response validation asserts BOTH echoes match exactly — `permissions` equal to `{contents: 'write'}` AND the repository scope equal to the single `agent` repo (all-or-nothing — any broader/narrower/absent echo on either axis fails the mint). The exact echo field shape (`repositories` array of repo objects vs `repository_selection`) is pinned against the live REST response during U1 test writing.
+- **Checkout moves to the default `GITHUB_TOKEN`**: checkout needs only `contents: read` (already granted); spending the ~1h App-token TTL on checkout/setup is waste and widens exposure. Mint as late as possible — immediately before Run Fro Bot.
+- **Mint-step placement after the broker mint**: keeps the two mints adjacent and the token's exposure window minimal; both are trusted steps preceding the injectable one.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Does harden-runner egress permit the mint? Yes — `api.github.com:443` already allowlisted (harness-integrate.yaml:64-75).
+- Does the prompt's push path accept an installation token? Yes — `x-access-token:<token>` over HTTPS (prompt.txt:74-95); installation tokens authenticate exactly this way.
+- Are the App secrets available? Yes — `APPLICATION_ID` (2026-01-02) and `APPLICATION_PRIVATE_KEY` (2026-01-02) exist as repo Actions secrets.
+- How do secrets reach the reusable workflow? Explicitly — `harness-release.yaml` passes named secrets (no `inherit`); both new secrets must be declared in `workflow_call` and passed by the caller.
+
+### Deferred to Implementation
+
+- Exact installation-id lookup response shape assertions: pin against the live REST response during U1 test writing.
+
+## Implementation Units
+
+- [ ] **Unit 0: Verify App installed scope (precondition)**
+
+**Goal:** Confirm the App behind `APPLICATION_ID` is installed on `fro-bot/agent` with permissions covering `contents: write`, and record its full installed scope so the blast radius of key theft is known.
+
+**Requirements:** R1 (scoping feasibility)
+
+**Dependencies:** None. Operator-assisted: requires reading the App installation via an App JWT or the GitHub UI (Settings → GitHub Apps).
+
+**Files:** none (verification only; findings recorded in the PR description)
+
+**Approach:**
+- Mint an App JWT locally or inspect via UI; `GET /app` + `GET /app/installations` to enumerate installed repos + permissions.
+- If installed scope is broad (many repos or permissions beyond contents/metadata), surface to the operator: proceed (token is scoped regardless; key custody unchanged) and file the dedicated-App migration as the deferred task.
+
+**Test scenarios:** Test expectation: none — verification-only unit.
+
+**Verification:** Installed scope documented; `contents: write` on `fro-bot/agent` confirmed available to mint.
+
+- [ ] **Unit 1: `scripts/harness/mint-app-token.ts` + tests**
+
+**Goal:** A no-deps, no-post mint script mirroring the broker-mint security contract, emitting a single masked `github-token` step output.
+
+**Requirements:** R1, R3, R4, R5
+
+**Dependencies:** Unit 0
+
+**Files:**
+- Create: `scripts/harness/mint-app-token.ts`
+- Test: `scripts/harness/mint-app-token.test.ts`
+
+**Approach:**
+- Read `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY` from `process.env`; `core.setSecret` the key material immediately; fail closed if either is missing/empty.
+- Build RS256 App JWT with `node:crypto` (`iat` backdated 60s, `exp` +9min, `iss` = app id).
+- Call `GET /repos/fro-bot/agent/installation` (App JWT auth) → installation id; then `POST /app/installations/{id}/access_tokens` with `{repositories: ['agent'], permissions: {contents: 'write'}}`.
+- All-or-nothing validation: response must carry a non-empty `token` (mask it via `setSecret` before ANY other statement), an `expires_at` timestamp, echoed `permissions` exactly `{contents: 'write'}`, AND a repository echo naming exactly the `agent` repo — any mismatch or extra grant on either axis fails the mint.
+- Error hygiene: `setSecret` the private key before any parsing; every failure path throws/logs constant-class messages only (e.g. `app-jwt-build-failed`, `installation-lookup-failed`, `token-mint-failed`) — never interpolate caught error text, PEM content, or response bodies into emitted errors (the key/token could ride along in a parser message).
+- Single bounded attempt per request (shared `AbortSignal.timeout`, body read inside the guard — the #1081 lesson); no retry; `process.exitCode = 1` on any failure.
+- Emit only `core.setOutput('github-token', token)`. Never write the key or token to disk, `GITHUB_ENV`, or logs.
+
+**Patterns to follow:** `scripts/harness/mint-broker-credential.ts` (contract + structure), its test file (mock fetch, ordering assertions).
+
+**Test scenarios:**
+- Happy path: valid env + mocked 200s → output emitted, `setSecret(token)` called BEFORE `setOutput` (ordering assertion).
+- Error path: missing/empty `APPLICATION_ID` or key → exitCode 1, no fetch.
+- Error path: installation lookup 404/non-200 → exitCode 1, no token request.
+- Error path: token response missing `token`/`expires_at` → exitCode 1, no output.
+- Edge case: echoed permissions broader than requested (e.g. `{contents: 'write', issues: 'write'}`) → rejected, exitCode 1.
+- Edge case: echoed permissions narrower (`{contents: 'read'}`) → rejected.
+- Edge case: repository echo missing the `agent` repo, or naming additional repos → rejected, exitCode 1.
+- Error path: key-parse failure (malformed PEM) → exitCode 1 with a constant-class message; assert the error/log output contains no PEM fragment.
+- Integration: JWT shape — decode the generated JWT header/payload (no signature verify) and assert `alg: RS256`, `iss`, `iat < exp`.
+- Error path: fetch timeout/abort → exitCode 1 (no hang, body read guarded).
+
+**Verification:** `bun run test:scripts` green; script passes lint + the Node 24 strip-only TS constraints (no non-erasable syntax).
+
+- [ ] **Unit 2: Wire the mint into `harness-integrate.yaml`**
+
+**Goal:** Integrate job mints and consumes the scoped token; `FRO_BOT_PAT` fully removed from the workflow.
+
+**Requirements:** R1, R2, R3, R5, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `.github/workflows/harness-integrate.yaml`
+
+**Approach:**
+- `workflow_call.secrets`: drop `FRO_BOT_PAT`; add `APPLICATION_ID` + `APPLICATION_PRIVATE_KEY` (required, with descriptions).
+- Checkout step: `token: ${{ github.token }}` (default, `contents: read`), keep `persist-credentials: false`.
+- New step "Mint scoped App token" (id: `mint-app-token`) between the broker mint and Run Fro Bot: `run:` invoking the script via the same Node invocation pattern as the broker mint step; `env:` block carries ONLY the two App secrets — job-level env untouched.
+- Run Fro Bot step: `github-token: ${{ steps.mint-app-token.outputs.github-token }}`.
+- One-job invariant: no new jobs; permissions block unchanged.
+
+**Test scenarios:** Test expectation: none — workflow YAML has no unit-test harness; behavior is proven by U4's live dispatch. `js-yaml`-parse sanity via existing lint/CI.
+
+**Verification:** YAML parses; grep confirms zero `FRO_BOT_PAT` references remain in the file; step order harden-runner → checkout → setup → broker mint → app mint → Run Fro Bot.
+
+- [ ] **Unit 3: Caller pass-through in `harness-release.yaml`**
+
+**Goal:** The integrate call passes the App secrets and stops passing the PAT.
+
+**Requirements:** R2
+
+**Dependencies:** Unit 2 (lands in the same PR — the secrets contracts must move together)
+
+**Files:**
+- Modify: `.github/workflows/harness-release.yaml`
+
+**Approach:**
+- In the `integrate` job's `secrets:` block (:206-210): remove `FRO_BOT_PAT`, add `APPLICATION_ID: ${{ secrets.APPLICATION_ID }}` and `APPLICATION_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}`.
+- Caller job permissions unchanged (`{id-token: write, contents: read}` — the replace-not-merge trap already handled).
+
+**Test scenarios:** Test expectation: none — same rationale as Unit 2.
+
+**Verification:** Zero `FRO_BOT_PAT` references remain on the integrate path across both workflows (release workflow may still use it elsewhere — only the integrate call changes).
+
+- [ ] **Unit 4: End-to-end proof on a real dispatch**
+
+**Goal:** Prove the full pipeline on the App token (R7) — fail-closed if anything is mis-wired.
+
+**Requirements:** R5, R7
+
+**Dependencies:** Units 2-3 merged to main (the release workflow dispatches from main).
+
+**Files:** none
+
+**Approach:**
+- Dispatch `harness-release.yaml` with the current base version. The workflow has a `dry_run` input, and publish is idempotent per package/version (existing versions are skipped) — prefer `dry_run: true` when only mint/merge verification is wanted; a full run is safe for already-published versions but still executes the whole build/release orchestration.
+- Watch the integrate job: app-token mint step succeeds (masked output), merge agent runs, push to `refs/harness-integrate/<version>` succeeds authenticated as the App.
+- Confirm from logs the push authenticated via the App token (pusher identity = the App's bot user), and that no step env carries the PAT.
+
+**Test scenarios:** Test expectation: none — live verification unit.
+
+**Verification:** Green integrate job on a real dispatch; push ref exists; workflow run shows the App-token mint step; `FRO_BOT_PAT` absent from the job's secret surface.
+
+## System-Wide Impact
+
+- **Interaction graph:** integrate path only. The fro-bot.yaml comment/review + dispatch/schedule flows are untouched (their github-token remains as-is). The broker model-credential mint is untouched.
+- **Error propagation:** mint failure → step exit 1 → job fails before the merge step (fail-closed, no fallback). Same posture as the broker mint.
+- **State lifecycle risks:** the App token expires ~1h after mint; the integrate merge has completed well within that in all observed runs (~15 min worst case). If a pathological merge exceeds TTL, the push fails with 401 — fail-closed, re-dispatch.
+- **API surface parity:** none — the `github-token` input contract of the action is unchanged; only the supplied value's provenance changes.
+- **Unchanged invariants:** one-job integrate workflow; broker OIDC `job_workflow_ref` allowlist; harden-runner egress allowlist; response-mode none (no posting from the merge agent).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| App's installed scope is broader than needed (key theft blast radius) | U0 documents it; dedicated-App migration filed as deferred task if broad. Key custody is unchanged by this plan (same secret, same repo) — the plan strictly shrinks what the *agent* holds. |
+| Post-hook tamper vector reintroduced later by swapping in a marketplace action | R4 is explicit in the workflow comment on the mint step; the learnings doc records the evidence. |
+| Token TTL expiry mid-merge | Mint placed immediately before the merge step; observed merge duration ≤ ~15 min vs ~60 min TTL. Fail-closed on expiry. |
+| Echoed-permissions drift (GitHub grants more than requested) | All-or-nothing validation rejects any echo ≠ `{contents: 'write'}`. |
+| Missing secrets at the callee (explicit pass-through forgotten) | Units 2+3 land in one PR; `workflow_call` marks both secrets `required: true` so a missing pass-through fails at dispatch, not mid-run. |
+
+## Sources & References
+
+- **Origin:** issue #1126 (design + evidence); #1124 closed as superseded; `marcusrbrown/infra#771` closed (broker-side mint ruled out).
+- Prior brainstorm (partially superseded): `docs/brainstorms/2026-07-04-harness-integrate-app-token-broker-requirements.md`
+- Related PRs: #1119 (interim hygiene), #1080/#1081/#1082 (broker mint arc), #1170 (comment/review credential removal)
+- Related code: `scripts/harness/mint-broker-credential.ts`, `.github/workflows/harness-integrate.yaml`, `.github/workflows/harness-release.yaml`

--- a/scripts/harness/mint-app-token.test.ts
+++ b/scripts/harness/mint-app-token.test.ts
@@ -1,0 +1,500 @@
+import {Buffer} from 'node:buffer'
+import {generateKeyPairSync} from 'node:crypto'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  setSecret: vi.fn<(value: string) => void>(),
+  setOutput: vi.fn<(name: string, value: unknown) => void>(),
+}))
+
+vi.mock('@actions/core', () => ({
+  setSecret: mocks.setSecret,
+  setOutput: mocks.setOutput,
+}))
+
+const {buildAppJwt, main, validateTokenResponse} = await import('./mint-app-token.js')
+
+const {privateKey, publicKey} = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: {type: 'spki', format: 'pem'},
+  privateKeyEncoding: {type: 'pkcs8', format: 'pem'},
+})
+
+const MALFORMED_PEM = '-----BEGIN PRIVATE KEY-----\nnot-a-real-key\n-----END PRIVATE KEY-----\n'
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response
+}
+
+function decodeJwtSegment(segment: string | undefined): Record<string, unknown> {
+  if (segment === undefined) {
+    throw new Error('missing JWT segment')
+  }
+  const padded = segment.replaceAll('-', '+').replaceAll('_', '/')
+  return JSON.parse(Buffer.from(padded, 'base64').toString('utf8')) as Record<string, unknown>
+}
+
+const VALID_TOKEN_BODY = {
+  token: 'ghs_faketoken123',
+  expires_at: '2026-07-11T13:00:00Z',
+  permissions: {contents: 'write'},
+  repositories: [{name: 'agent'}],
+}
+
+describe('buildAppJwt', () => {
+  it('produces a JWT with RS256 header, correct iss, and backdated iat', () => {
+    // #given
+    const nowSeconds = 1_752_000_000
+
+    // #when
+    const jwt = buildAppJwt('app-123', privateKey, nowSeconds)
+
+    // #then
+    const [headerSegment, payloadSegment] = jwt.split('.')
+    const header = decodeJwtSegment(headerSegment)
+    const payload = decodeJwtSegment(payloadSegment)
+    expect(header.alg).toBe('RS256')
+    expect(header.typ).toBe('JWT')
+    expect(payload.iss).toBe('app-123')
+    expect(payload.iat).toBe(nowSeconds - 60)
+    expect(payload.exp).toBe(nowSeconds + 540)
+    expect((payload.iat as number) < (payload.exp as number)).toBe(true)
+  })
+
+  it('throws when the private key is malformed', () => {
+    // #given / #when / #then
+    expect(() => buildAppJwt('app-123', MALFORMED_PEM, 1_752_000_000)).toThrow()
+  })
+})
+
+describe('validateTokenResponse', () => {
+  it('accepts a well-formed response', () => {
+    // #given / #when
+    const result = validateTokenResponse(VALID_TOKEN_BODY)
+
+    // #then
+    expect(result.ok).toBe(true)
+    expect((result as {ok: true; token: string}).token).toBe('ghs_faketoken123')
+  })
+
+  it('rejects a response missing token', () => {
+    // #given
+    const body = {...VALID_TOKEN_BODY, token: undefined}
+
+    // #when
+    const result = validateTokenResponse(body)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects a response missing expires_at', () => {
+    // #given
+    const body = {...VALID_TOKEN_BODY, expires_at: undefined}
+
+    // #when
+    const result = validateTokenResponse(body)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects broader-than-requested permissions', () => {
+    // #given
+    const body = {...VALID_TOKEN_BODY, permissions: {contents: 'write', issues: 'write'}}
+
+    // #when
+    const result = validateTokenResponse(body)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects narrower-than-requested permissions', () => {
+    // #given
+    const body = {...VALID_TOKEN_BODY, permissions: {contents: 'read'}}
+
+    // #when
+    const result = validateTokenResponse(body)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it.each([
+    ['empty repositories array', []],
+    ['two repositories', [{name: 'agent'}, {name: 'other'}]],
+    ['wrong repository name', [{name: 'other'}]],
+  ])('rejects repository echo: %s', (_label, repositories) => {
+    // #given
+    const body = {...VALID_TOKEN_BODY, repositories}
+
+    // #when
+    const result = validateTokenResponse(body)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+})
+
+describe('main — happy path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.exitCode = undefined
+    process.env.APPLICATION_ID = 'app-123'
+    process.env.APPLICATION_PRIVATE_KEY = privateKey
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    process.exitCode = undefined
+    delete process.env.APPLICATION_ID
+    delete process.env.APPLICATION_PRIVATE_KEY
+  })
+
+  it('emits the masked token as a step output', async () => {
+    // #given
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, {id: 999}))
+      .mockResolvedValueOnce(jsonResponse(201, VALID_TOKEN_BODY))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBeUndefined()
+    expect(mocks.setOutput).toHaveBeenCalledWith('github-token', 'ghs_faketoken123')
+    expect(mocks.setSecret).toHaveBeenCalledWith('ghs_faketoken123')
+  })
+
+  it('masks the token via setSecret before setOutput', async () => {
+    // #given
+    const callOrder: string[] = []
+    mocks.setSecret.mockImplementation((value: string) => {
+      if (value === 'ghs_faketoken123') callOrder.push('setSecret(token)')
+    })
+    mocks.setOutput.mockImplementation(() => {
+      callOrder.push('setOutput')
+    })
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, {id: 999}))
+      .mockResolvedValueOnce(jsonResponse(201, VALID_TOKEN_BODY))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(callOrder).toEqual(['setSecret(token)', 'setOutput'])
+  })
+
+  it('masks the private key via setSecret before any fetch', async () => {
+    // #given
+    const callOrder: string[] = []
+    mocks.setSecret.mockImplementation((value: string) => {
+      if (value === privateKey) callOrder.push('setSecret(key)')
+    })
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      callOrder.push('fetch')
+      return jsonResponse(200, {id: 999})
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(callOrder[0]).toBe('setSecret(key)')
+    expect(callOrder).toContain('fetch')
+  })
+
+  it('sends the Authorization bearer JWT with expected shape on the installation lookup', async () => {
+    // #given
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, {id: 999}))
+      .mockResolvedValueOnce(jsonResponse(201, VALID_TOKEN_BODY))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://api.github.com/repos/fro-bot/agent/installation')
+    const headers = init.headers as Record<string, string>
+    expect(headers.Authorization).toBeDefined()
+    const jwt = (headers.Authorization ?? '').replace('Bearer ', '')
+    const [headerSegment, payloadSegment] = jwt.split('.')
+    const header = decodeJwtSegment(headerSegment)
+    const payload = decodeJwtSegment(payloadSegment)
+    expect(header.alg).toBe('RS256')
+    expect(payload.iss).toBe('app-123')
+    expect(payload.iat as number).toBeLessThan(payload.exp as number)
+    expect(Math.floor(Date.now() / 1000) - (payload.iat as number)).toBeGreaterThanOrEqual(59)
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('sends the correct POST body on the token mint request', async () => {
+    // #given
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, {id: 999}))
+      .mockResolvedValueOnce(jsonResponse(201, VALID_TOKEN_BODY))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    const [url, init] = fetchMock.mock.calls[1] as [string, RequestInit]
+    expect(url).toBe('https://api.github.com/app/installations/999/access_tokens')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({repositories: ['agent'], permissions: {contents: 'write'}})
+  })
+
+  it('verifies the JWT signature using the public key', async () => {
+    // #given
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, {id: 999}))
+      .mockResolvedValueOnce(jsonResponse(201, VALID_TOKEN_BODY))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const headers = init.headers as Record<string, string>
+    const jwt = (headers.Authorization ?? '').replace('Bearer ', '')
+    const [headerSegment, payloadSegment, signatureSegment] = jwt.split('.')
+    if (signatureSegment === undefined) {
+      throw new Error('missing JWT signature segment')
+    }
+    const signingInput = `${headerSegment}.${payloadSegment}`
+    const signature = Buffer.from(signatureSegment.replaceAll('-', '+').replaceAll('_', '/'), 'base64')
+    const {createVerify} = await import('node:crypto')
+    const verified = createVerify('RSA-SHA256').update(signingInput).verify(publicKey, signature)
+    expect(verified).toBe(true)
+  })
+})
+
+describe('main — error paths (fail closed)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.exitCode = undefined
+    process.env.APPLICATION_ID = 'app-123'
+    process.env.APPLICATION_PRIVATE_KEY = privateKey
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    process.exitCode = undefined
+    delete process.env.APPLICATION_ID
+    delete process.env.APPLICATION_PRIVATE_KEY
+  })
+
+  it('exits non-zero and never fetches when APPLICATION_ID is missing', async () => {
+    // #given
+    delete process.env.APPLICATION_ID
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('exits non-zero and never fetches when APPLICATION_PRIVATE_KEY is empty', async () => {
+    // #given
+    process.env.APPLICATION_PRIVATE_KEY = ''
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('exits non-zero when the installation lookup returns non-200', async () => {
+    // #given
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(404, {message: 'Not Found'}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('exits non-zero when the token response is missing token', async () => {
+    // #given
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, {id: 999}))
+      .mockResolvedValueOnce(jsonResponse(201, {...VALID_TOKEN_BODY, token: undefined}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('exits non-zero when the token response is missing expires_at', async () => {
+    // #given
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, {id: 999}))
+      .mockResolvedValueOnce(jsonResponse(201, {...VALID_TOKEN_BODY, expires_at: undefined}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('rejects broader-than-requested echoed permissions', async () => {
+    // #given
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, {id: 999}))
+      .mockResolvedValueOnce(
+        jsonResponse(201, {...VALID_TOKEN_BODY, permissions: {contents: 'write', issues: 'write'}}),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('rejects narrower-than-requested echoed permissions', async () => {
+    // #given
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, {id: 999}))
+      .mockResolvedValueOnce(jsonResponse(201, {...VALID_TOKEN_BODY, permissions: {contents: 'read'}}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['empty repositories array', []],
+    ['two repositories', [{name: 'agent'}, {name: 'other'}]],
+    ['wrong repository name', [{name: 'other'}]],
+  ])('rejects repository echo: %s', async (_label, repositories) => {
+    // #given
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, {id: 999}))
+      .mockResolvedValueOnce(jsonResponse(201, {...VALID_TOKEN_BODY, repositories}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('fails closed on a malformed PEM without leaking key material in the error', async () => {
+    // #given
+    process.env.APPLICATION_PRIVATE_KEY = MALFORMED_PEM
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+    const loggedText = stderrSpy.mock.calls.map(call => String(call[0])).join('\n')
+    expect(loggedText).not.toContain('BEGIN PRIVATE KEY')
+    expect(loggedText).not.toContain('not-a-real-key')
+    stderrSpy.mockRestore()
+  })
+
+  it('fails closed without retrying when the installation fetch throws', async () => {
+    // #given
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('fetch failed: ECONNRESET'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('fails closed without retrying on a timeout-shaped abort', async () => {
+    // #given
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      throw new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the token POST returns non-201', async () => {
+    // #given
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, {id: 999}))
+      .mockResolvedValueOnce(jsonResponse(403, {message: 'Forbidden'}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+})

--- a/scripts/harness/mint-app-token.test.ts
+++ b/scripts/harness/mint-app-token.test.ts
@@ -201,9 +201,11 @@ describe('main — happy path', () => {
     mocks.setSecret.mockImplementation((value: string) => {
       if (value === privateKey) callOrder.push('setSecret(key)')
     })
+    let callCount = 0
     const fetchMock = vi.fn().mockImplementation(async () => {
       callOrder.push('fetch')
-      return jsonResponse(200, {id: 999})
+      callCount += 1
+      return callCount === 1 ? jsonResponse(200, {id: 999}) : jsonResponse(201, VALID_TOKEN_BODY)
     })
     vi.stubGlobal('fetch', fetchMock)
 
@@ -211,6 +213,8 @@ describe('main — happy path', () => {
     await main()
 
     // #then
+    expect(process.exitCode).toBeUndefined()
+    expect(mocks.setOutput).toHaveBeenCalledWith('github-token', 'ghs_faketoken123')
     expect(callOrder[0]).toBe('setSecret(key)')
     expect(callOrder).toContain('fetch')
   })
@@ -232,7 +236,7 @@ describe('main — happy path', () => {
     const headers = init.headers as Record<string, string>
     expect(headers.Authorization).toBeDefined()
     const jwt = (headers.Authorization ?? '').replace('Bearer ', '')
-    const [headerSegment, payloadSegment] = jwt.split('.')
+    const [headerSegment, payloadSegment, signatureSegment] = jwt.split('.')
     const header = decodeJwtSegment(headerSegment)
     const payload = decodeJwtSegment(payloadSegment)
     expect(header.alg).toBe('RS256')
@@ -240,6 +244,10 @@ describe('main — happy path', () => {
     expect(payload.iat as number).toBeLessThan(payload.exp as number)
     expect(Math.floor(Date.now() / 1000) - (payload.iat as number)).toBeGreaterThanOrEqual(59)
     expect(init.signal).toBeInstanceOf(AbortSignal)
+    for (const segment of [headerSegment, payloadSegment, signatureSegment]) {
+      expect(segment).toBeDefined()
+      expect(segment).not.toMatch(/[+/=]/)
+    }
   })
 
   it('sends the correct POST body on the token mint request', async () => {
@@ -488,6 +496,22 @@ describe('main — error paths (fail closed)', () => {
       .fn()
       .mockResolvedValueOnce(jsonResponse(200, {id: 999}))
       .mockResolvedValueOnce(jsonResponse(403, {message: 'Forbidden'}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(process.exitCode).toBe(1)
+    expect(mocks.setOutput).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the token POST returns 200 with an otherwise-valid body', async () => {
+    // #given
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, {id: 999}))
+      .mockResolvedValueOnce(jsonResponse(200, VALID_TOKEN_BODY))
     vi.stubGlobal('fetch', fetchMock)
 
     // #when

--- a/scripts/harness/mint-app-token.test.ts
+++ b/scripts/harness/mint-app-token.test.ts
@@ -354,6 +354,38 @@ describe('main — error paths (fail closed)', () => {
     expect(mocks.setOutput).not.toHaveBeenCalled()
   })
 
+  it.each([
+    ['empty body', {}],
+    ['non-numeric id', {id: '999'}],
+  ])(
+    'exits non-zero and never mints a token when the installation lookup id is not numeric: %s',
+    async (_label, body) => {
+      // #given
+      const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(200, body))
+      vi.stubGlobal('fetch', fetchMock)
+
+      // #when
+      await main()
+
+      // #then
+      expect(process.exitCode).toBe(1)
+      expect(mocks.setOutput).not.toHaveBeenCalled()
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    },
+  )
+
+  it('never issues the token POST fetch when the installation lookup fails', async () => {
+    // #given
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(404, {message: 'Not Found'}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // #when
+    await main()
+
+    // #then
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('exits non-zero when the token response is missing token', async () => {
     // #given
     const fetchMock = vi

--- a/scripts/harness/mint-app-token.ts
+++ b/scripts/harness/mint-app-token.ts
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+
+// Mints a short-lived, single-repo, contents:write-only GitHub App
+// installation token for the harness-integrate merge agent.
+//
+// Security contract (docs/plans/2026-07-11-002-feat-inline-app-token-mint-integrate-plan.md),
+// mirroring scripts/harness/mint-broker-credential.ts:
+//   1. Read the App private key from process.env and IMMEDIATELY mask it via
+//      core.setSecret, before any parsing, HTTP call, error log, or stack
+//      trace can surface it.
+//   2. Build the App JWT locally (node:crypto, no dependencies) and use it
+//      for a SINGLE bounded GET + SINGLE bounded POST under one shared
+//      timeout — no retry loop.
+//   3. Validate the minted token response ALL-OR-NOTHING: token, expires_at,
+//      exact permissions echo, and exact single-repo echo must all hold or
+//      the entire mint is rejected.
+//   4. Emit the minted token as a masked GitHub Actions step output — never
+//      write it to disk, never place it (or the private key) in
+//      process.env, GITHUB_ENV, or logs.
+//   5. Fail closed: any error exits non-zero and emits nothing usable. Error
+//      messages are constant-class only — never interpolate caught error
+//      text, PEM content, or response bodies (they could carry the key or
+//      token along for the ride).
+//
+// Run via: node --experimental-strip-types scripts/harness/mint-app-token.ts
+//
+// This file uses no sibling .ts imports. main() is exported (not called at
+// module top level) and only invoked by the guard at the bottom of this
+// file, which fires solely when the script is executed directly — mirrors
+// mint-broker-credential.ts and packages/harness/scripts/build-platform.ts.
+// This keeps the module import-safe for the test file (imported under
+// Vitest, .js extension), while `node --experimental-strip-types` execution
+// still runs main().
+
+import {Buffer} from 'node:buffer'
+import {createSign} from 'node:crypto'
+import process from 'node:process'
+import {fileURLToPath} from 'node:url'
+import * as core from '@actions/core'
+
+const OWNER = 'fro-bot'
+const REPO = 'agent'
+const MINT_TIMEOUT_MS = 30_000
+const JWT_BACKDATE_SECONDS = 60
+const JWT_LIFETIME_SECONDS = 540
+const REQUESTED_PERMISSIONS: Readonly<Record<string, string>> = {contents: 'write'}
+
+function base64url(input: Buffer | string): string {
+  const buffer = typeof input === 'string' ? Buffer.from(input, 'utf8') : input
+  return buffer.toString('base64').replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '')
+}
+
+/**
+ * Build and sign an RS256 App JWT. Pure — no I/O. Throws a generic Error on
+ * any signing failure; the caller wraps it in a constant-class message
+ * (never interpolating the caught error, which could echo PEM content).
+ */
+export function buildAppJwt(appId: string, privateKey: string, nowSeconds: number): string {
+  const header = {alg: 'RS256', typ: 'JWT'}
+  const payload = {
+    iat: nowSeconds - JWT_BACKDATE_SECONDS,
+    exp: nowSeconds + JWT_LIFETIME_SECONDS,
+    iss: appId,
+  }
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`
+  const signature = createSign('RSA-SHA256').update(signingInput).sign(privateKey)
+  return `${signingInput}.${base64url(signature)}`
+}
+
+export type ValidateTokenResponseResult =
+  {readonly ok: true; readonly token: string} | {readonly ok: false; readonly reason: string}
+
+/**
+ * Validate the installation access-token response ALL-OR-NOTHING. Pure — no
+ * I/O, never throws; every branch returns a discriminated result. Mirrors
+ * validateBrokerResponse in mint-broker-credential.ts.
+ */
+export function validateTokenResponse(parsed: unknown): ValidateTokenResponseResult {
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {ok: false, reason: 'token response is not an object'}
+  }
+  const body = parsed as Record<string, unknown>
+
+  if (typeof body.token !== 'string' || body.token.length === 0) {
+    return {ok: false, reason: 'token response has an empty or missing token'}
+  }
+  if (typeof body.expires_at !== 'string' || body.expires_at.length === 0) {
+    return {ok: false, reason: 'token response has an empty or missing expires_at'}
+  }
+
+  const permissions = body.permissions
+  if (typeof permissions !== 'object' || permissions === null || Array.isArray(permissions)) {
+    return {ok: false, reason: 'token response permissions is not an object'}
+  }
+  const permissionEntries = Object.entries(permissions as Record<string, unknown>)
+  const requestedEntries = Object.entries(REQUESTED_PERMISSIONS)
+  if (permissionEntries.length !== requestedEntries.length) {
+    return {ok: false, reason: 'token response permissions do not match the requested scope exactly'}
+  }
+  for (const [key, value] of requestedEntries) {
+    if ((permissions as Record<string, unknown>)[key] !== value) {
+      return {ok: false, reason: 'token response permissions do not match the requested scope exactly'}
+    }
+  }
+
+  const repositories = body.repositories
+  if (!Array.isArray(repositories) || repositories.length !== 1) {
+    return {ok: false, reason: 'token response repositories does not name exactly one repository'}
+  }
+  const repository: unknown = repositories[0]
+  if (typeof repository !== 'object' || repository === null || (repository as Record<string, unknown>).name !== REPO) {
+    return {ok: false, reason: 'token response repository echo does not match the requested repository'}
+  }
+
+  return {ok: true, token: body.token}
+}
+
+/**
+ * Orchestrates the mint: read + mask key → build App JWT → single bounded
+ * installation lookup → single bounded token mint (no retry) →
+ * all-or-nothing validation → masked step output.
+ *
+ * Fails closed: every error branch throws inside the try block, caught by
+ * the single catch below. The try/finally guarantees a non-zero exit and
+ * that no output is emitted on any failure branch.
+ */
+export async function main(): Promise<void> {
+  let succeeded = false
+  try {
+    const appId = process.env.APPLICATION_ID?.trim() ?? ''
+    const privateKey = process.env.APPLICATION_PRIVATE_KEY ?? ''
+    // Mask the key IMMEDIATELY — before any parsing, HTTP call, log, or
+    // thrown error can surface it.
+    if (privateKey.length > 0) {
+      core.setSecret(privateKey)
+    }
+    if (appId.length === 0 || privateKey.trim().length === 0) {
+      throw new Error('missing-app-credentials')
+    }
+
+    let jwt: string
+    try {
+      jwt = buildAppJwt(appId, privateKey, Math.floor(Date.now() / 1000))
+    } catch {
+      throw new Error('app-jwt-build-failed')
+    }
+
+    // One AbortSignal bounds BOTH requests. A signal passed to fetch also
+    // aborts an in-progress response body read, so every response.json()
+    // below is covered by the same timeout — a slow/hung body cannot
+    // exceed the bound.
+    const signal = AbortSignal.timeout(MINT_TIMEOUT_MS)
+
+    let installationResponse: Response
+    try {
+      installationResponse = await fetch(`https://api.github.com/repos/${OWNER}/${REPO}/installation`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        signal,
+      })
+    } catch {
+      throw new Error('installation-lookup-failed')
+    }
+    if (!installationResponse.ok) {
+      throw new Error(`installation-lookup-failed: HTTP ${installationResponse.status}`)
+    }
+    let installationBody: unknown
+    try {
+      installationBody = await installationResponse.json()
+    } catch {
+      throw new Error('installation-lookup-failed')
+    }
+    const installationId =
+      typeof installationBody === 'object' && installationBody !== null
+        ? (installationBody as Record<string, unknown>).id
+        : undefined
+    if (typeof installationId !== 'number') {
+      throw new TypeError('installation-lookup-failed')
+    }
+
+    let tokenResponse: Response
+    try {
+      tokenResponse = await fetch(`https://api.github.com/app/installations/${installationId}/access_tokens`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({repositories: [REPO], permissions: REQUESTED_PERMISSIONS}),
+        // Single attempt — no retry loop.
+        signal,
+      })
+    } catch {
+      throw new Error('token-mint-failed')
+    }
+    if (tokenResponse.status !== 201) {
+      throw new Error('token-mint-failed')
+    }
+    let tokenBody: unknown
+    try {
+      tokenBody = await tokenResponse.json()
+    } catch {
+      throw new Error('token-mint-failed')
+    }
+
+    const result = validateTokenResponse(tokenBody)
+    if (!result.ok) {
+      throw new Error('token-mint-failed')
+    }
+
+    // Mask BEFORE any other statement touches the token.
+    core.setSecret(result.token)
+    core.setOutput('github-token', result.token)
+    succeeded = true
+  } catch (error: unknown) {
+    // Constant-class messages only — never interpolate the caught error,
+    // response bodies, or key material. `error.message` here is always one
+    // of the constant strings thrown above (or an HTTP-status suffix with
+    // no body content), never a raw caught exception.
+    const message = error instanceof Error ? error.message : 'mint-app-token-failed'
+    process.stderr.write(`[mint-app-token] ${message}\n`)
+  } finally {
+    if (!succeeded) {
+      process.exitCode = 1
+    }
+  }
+}
+
+// Only run when executed directly (node --experimental-strip-types ...), not
+// when imported by the test file under Vitest.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main()
+}


### PR DESCRIPTION
Closes #1126. Replaces the durable, account-broad `FRO_BOT_PAT` on the harness-integrate path with a short-lived (~1h) GitHub App installation token scoped `{contents: write}` to `fro-bot/agent` alone, minted by a trusted inline no-post step in the same job. After this, the worst a fully compromised merge agent can do with its GitHub credential is push to this one repo for under an hour.

## How

- **`scripts/harness/mint-app-token.ts`** — checked-in mint script mirroring the broker-mint security contract: the App private key is masked via `setSecret` before any parsing, the RS256 App JWT is built with `node:crypto` (zero new dependencies), one bounded GET (installation id) + one bounded POST (token) under a single shared timeout with no retries, and every failure path emits constant-class error text only — no caught-error interpolation, no PEM content, no response bodies. Fail-closed via `process.exitCode = 1`.
- **All-or-nothing echo validation on both axes** — the response must carry a non-empty masked token, `expires_at`, permissions exactly `{contents: 'write'}`, and a repository echo naming exactly `agent`. Broader, narrower, or absent on either axis rejects the mint. Strict 201 (a 200 with a valid body is rejected).
- **`harness-integrate.yaml`** — the App secrets are mapped to the mint step's `env:` only, never job-level. The step is a plain `run:` invoking the checked-in script — deliberately never a marketplace action with a `post:` hook, because the runner re-supplies `INPUT_*` (including the private key) during the post phase and a prompt-injected earlier step can tamper the on-disk post script. Checkout moves to the default `GITHUB_TOKEN` (`contents: read` suffices), so the token's TTL is spent only on the merge. One-job invariant preserved.
- **`harness-release.yaml`** — passes `APPLICATION_ID`/`APPLICATION_PRIVATE_KEY` explicitly (no `secrets: inherit` on this path); both are `required: true` in `workflow_call`, so a forgotten pass-through fails at dispatch, not mid-run.
- **`FRO_BOT_PAT` is gone from the integrate path entirely** — zero references remain in either workflow.

## Verification

- 31 mint-script tests (317 total in `scripts/`): setSecret-before-fetch and setSecret-before-setOutput ordering, missing-credential guards, non-200 lookup, strict-201, permissions/repository echo rejections (broader, narrower, wrong repo, multiple repos), malformed-PEM with a no-key-fragment-leak assertion, JWT shape (RS256, backdated iat, unpadded base64url segments) verified against a generated throwaway keypair.
- Direct-entry guard verified live: `node --experimental-strip-types scripts/harness/mint-app-token.ts` → constant-class error, exit 1.
- Both workflows parse; `api.github.com:443` already in the harden-runner allowlist, so the mint clears egress.
- End-to-end proof after merge: a `dry_run: true` harness-release dispatch exercises mint → LLM merge → push on the App token.

Plan: `docs/plans/2026-07-11-002-feat-inline-app-token-mint-integrate-plan.md` (included).