### PR TITLE
fix: accept the implied metadata:read echo on minted App tokens

### DIFF
--- a/scripts/harness/mint-app-token.test.ts
+++ b/scripts/harness/mint-app-token.test.ts
@@ -41,7 +41,7 @@ function decodeJwtSegment(segment: string | undefined): Record<string, unknown> 
 const VALID_TOKEN_BODY = {
   token: 'ghs_faketoken123',
   expires_at: '2026-07-11T13:00:00Z',
-  permissions: {contents: 'write'},
+  permissions: {contents: 'write', metadata: 'read'},
   repositories: [{name: 'agent'}],
 }
 
@@ -105,7 +105,7 @@ describe('validateTokenResponse', () => {
 
   it('rejects broader-than-requested permissions', () => {
     // #given
-    const body = {...VALID_TOKEN_BODY, permissions: {contents: 'write', issues: 'write'}}
+    const body = {...VALID_TOKEN_BODY, permissions: {contents: 'write', metadata: 'read', issues: 'write'}}
 
     // #when
     const result = validateTokenResponse(body)
@@ -116,7 +116,29 @@ describe('validateTokenResponse', () => {
 
   it('rejects narrower-than-requested permissions', () => {
     // #given
-    const body = {...VALID_TOKEN_BODY, permissions: {contents: 'read'}}
+    const body = {...VALID_TOKEN_BODY, permissions: {contents: 'read', metadata: 'read'}}
+
+    // #when
+    const result = validateTokenResponse(body)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects an echo missing the implied metadata:read grant', () => {
+    // #given
+    const body = {...VALID_TOKEN_BODY, permissions: {contents: 'write'}}
+
+    // #when
+    const result = validateTokenResponse(body)
+
+    // #then
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects an echo with metadata other than read', () => {
+    // #given
+    const body = {...VALID_TOKEN_BODY, permissions: {contents: 'write', metadata: 'write'}}
 
     // #when
     const result = validateTokenResponse(body)
@@ -424,7 +446,7 @@ describe('main — error paths (fail closed)', () => {
       .fn()
       .mockResolvedValueOnce(jsonResponse(200, {id: 999}))
       .mockResolvedValueOnce(
-        jsonResponse(201, {...VALID_TOKEN_BODY, permissions: {contents: 'write', issues: 'write'}}),
+        jsonResponse(201, {...VALID_TOKEN_BODY, permissions: {contents: 'write', metadata: 'read', issues: 'write'}}),
       )
     vi.stubGlobal('fetch', fetchMock)
 
@@ -441,7 +463,9 @@ describe('main — error paths (fail closed)', () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(jsonResponse(200, {id: 999}))
-      .mockResolvedValueOnce(jsonResponse(201, {...VALID_TOKEN_BODY, permissions: {contents: 'read'}}))
+      .mockResolvedValueOnce(
+        jsonResponse(201, {...VALID_TOKEN_BODY, permissions: {contents: 'read', metadata: 'read'}}),
+      )
     vi.stubGlobal('fetch', fetchMock)
 
     // #when

--- a/scripts/harness/mint-app-token.ts
+++ b/scripts/harness/mint-app-token.ts
@@ -13,7 +13,11 @@
 //      timeout — no retry loop.
 //   3. Validate the minted token response ALL-OR-NOTHING: token, expires_at,
 //      exact permissions echo, and exact single-repo echo must all hold or
-//      the entire mint is rejected.
+//      the entire mint is rejected. GitHub adds the implied `metadata: read`
+//      grant to every installation access token — it is not requestable or
+//      declinable — so the echo is pinned to exactly the requested grant
+//      plus that implied read; any other extra, missing, or different grant
+//      still rejects.
 //   4. Emit the minted token as a masked GitHub Actions step output — never
 //      write it to disk, never place it (or the private key) in
 //      process.env, GITHUB_ENV, or logs.
@@ -44,6 +48,12 @@ const MINT_TIMEOUT_MS = 30_000
 const JWT_BACKDATE_SECONDS = 60
 const JWT_LIFETIME_SECONDS = 540
 const REQUESTED_PERMISSIONS: Readonly<Record<string, string>> = {contents: 'write'}
+// GitHub always adds the implied `metadata: read` grant to every installation
+// access token — it is not requestable or declinable in the request body, but
+// it is always present in the response echo. The validator pins the echo to
+// exactly the requested grant plus that implied read; any other extra,
+// missing, or different grant still rejects.
+const EXPECTED_PERMISSIONS_ECHO: Readonly<Record<string, string>> = {contents: 'write', metadata: 'read'}
 
 function base64url(input: Buffer | string): string {
   const buffer = typeof input === 'string' ? Buffer.from(input, 'utf8') : input
@@ -93,11 +103,11 @@ export function validateTokenResponse(parsed: unknown): ValidateTokenResponseRes
     return {ok: false, reason: 'token response permissions is not an object'}
   }
   const permissionEntries = Object.entries(permissions as Record<string, unknown>)
-  const requestedEntries = Object.entries(REQUESTED_PERMISSIONS)
-  if (permissionEntries.length !== requestedEntries.length) {
+  const expectedEntries = Object.entries(EXPECTED_PERMISSIONS_ECHO)
+  if (permissionEntries.length !== expectedEntries.length) {
     return {ok: false, reason: 'token response permissions do not match the requested scope exactly'}
   }
-  for (const [key, value] of requestedEntries) {
+  for (const [key, value] of expectedEntries) {
     if ((permissions as Record<string, unknown>)[key] !== value) {
       return {ok: false, reason: 'token response permissions do not match the requested scope exactly'}
     }


### PR DESCRIPTION
The U4 dry-run proof for #1179 failed closed at the mint step (run 29179903069, `token-mint-failed`) — exactly as designed, but for a contract detail the validator got wrong: GitHub adds an implied, non-requestable `metadata: read` grant to every App installation token, so the permissions echo is always `{contents: write, metadata: read}` even when the request asks for `{contents: write}` alone. Deep-equaling the echo against the request body rejected every real mint.

## Fix

- The request body is unchanged (`{contents: write}`, single repo).
- Validation now pins the echo against an explicit `EXPECTED_PERMISSIONS_ECHO` — the requested grant plus the implied read — with the same all-or-nothing semantics: any extra, missing, or different grant (including `metadata: write`, or a missing `metadata` echo signaling an API contract change) still fails closed. The repository echo validation is unchanged.

## Verification

- 36 mint tests (322 total in scripts/): existing broader/narrower/wrong-repo rejections updated to carry the implied echo; two new pins — echo missing `metadata` entirely → rejected, `metadata: write` → rejected.
- The fail-closed path is live-proven: the dry-run stopped at the mint with no merge, no push, no fallback credential.
- Re-proof after merge: re-dispatch harness-release `dry_run: true` and verify mint → merge → push on the App token.