### PR TITLE
test: restore signal listeners between gateway program tests

### DIFF
--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -126,6 +126,27 @@ const stubLogger: GatewayLogger = {
   error: vi.fn(),
 }
 
+// makeGatewayProgram calls installShutdownHandlers internally and does not expose
+// its returned cleanup fn to callers — that's intentional for production (the
+// process owns its own shutdown lifecycle). Tests that invoke makeGatewayProgram
+// repeatedly would otherwise accumulate SIGTERM/SIGINT listeners across cases
+// (Issue #1134). Since the cleanup closure isn't reachable here, snapshot the
+// listener set before each test and strip anything added during it, restoring
+// the exact pre-test listener set the same way installShutdownHandlers's own
+// cleanup would (process.off per added listener).
+beforeEach(() => {
+  const sigtermBefore = process.listeners('SIGTERM')
+  const sigintBefore = process.listeners('SIGINT')
+  return () => {
+    for (const listener of process.listeners('SIGTERM')) {
+      if (!sigtermBefore.includes(listener)) process.off('SIGTERM', listener)
+    }
+    for (const listener of process.listeners('SIGINT')) {
+      if (!sigintBefore.includes(listener)) process.off('SIGINT', listener)
+    }
+  }
+})
+
 describe('makeDiscordClientFromConfig', () => {
   it('passes empty privilegedIntents to createDiscordClient (common case after posture flip)', () => {
     // #given a config with no privileged intents opted in


### PR DESCRIPTION
Closes #1134. The gateway suite emitted `MaxListenersExceededWarning` for SIGTERM/SIGINT once `program.test.ts` constructed `makeGatewayProgram` enough times — each construction installs shutdown handlers that are deliberately not exposed for cleanup (a daemon owns its shutdown lifecycle and never tears them down).

## Fix

Test-only: snapshot the process signal-listener set before each test in `program.test.ts` and strip anything added during the test in teardown — the same `process.off` per listener that `installShutdownHandlers`' own cleanup performs. No `maxListeners` bump anywhere (that would mask accumulation instead of fixing it).

## Production audit

`installShutdownHandlers` has exactly one production caller (`makeGatewayProgram`, invoked once per process at daemon start) — installing handlers once for the process lifetime is correct; there is no production leak. `shutdown.test.ts` already invoked the returned cleanup correctly; the accumulation was entirely in `program.test.ts`, which cannot reach the cleanup closure.

## Verification

- Before: `MaxListenersExceededWarning: ... 11 SIGTERM listeners` (and SIGINT) reproduced on main.
- After: full gateway suite (3174 tests) green with zero warnings in captured output; gateway `tsc` and eslint clean.