### PR TITLE
refactor: extract the gateway inactivity timer into a shared runtime primitive

### DIFF
--- a/packages/gateway/src/execute/run-core.ts
+++ b/packages/gateway/src/execute/run-core.ts
@@ -25,6 +25,7 @@ import type {OpenCodeServerHandle} from '@fro-bot/runtime'
 import type {PermissionCoordinator} from '../approvals/coordinator.js'
 import type {GatewayLogger} from '../discord/client.js'
 
+import {createInactivityTimer} from '@fro-bot/runtime'
 import {parsePermissionReply, parsePermissionRequest} from '../approvals/coordinator.js'
 import {formatToolPart} from './format-part.js'
 
@@ -271,37 +272,34 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
     )
   }
 
-  // ── 0b. Inactivity controller setup ───────────────────────────────────────
-  // When inactivityTimeoutMs is set, arm an AbortController that fires after the
-  // configured window of silence. The controller is reset on every text delta,
-  // tool completion, and permission.replied event. It is cleared (paused) on
-  // permission.asked and re-armed on permission.replied.
+  // ── 0b. Inactivity timer setup ─────────────────────────────────────────────
+  // When inactivityTimeoutMs is set (>0), the shared `createInactivityTimer` primitive
+  // arms a timeout that fires after the configured window of silence. It is reset on
+  // every text delta, tool completion, and permission.replied event. It is paused on
+  // permission.asked and resumed+reset on permission.replied.
+  // `timer.signal` never aborts when inactivityTimeoutMs is undefined or <= 0 (inert
+  // instance), mirroring the previous `inactivityController === null` arming guard.
   // The combined signal merges the wall-clock timeout signal with the inactivity signal
   // so either can abort the event loop.
-  let inactivityController: AbortController | null = null
-  let inactivityTimer: ReturnType<typeof setTimeout> | null = null
+  const inactivityTimer = createInactivityTimer({timeoutMs: inactivityTimeoutMs ?? 0})
+  const inactivityArmed = inactivityTimeoutMs !== undefined && inactivityTimeoutMs > 0
+  // The primitive auto-arms on creation; run-core's contract is to NOT start counting
+  // idle time until the prompt is actually sent (resetInactivity() below, after
+  // promptAsync succeeds) — pause immediately to cancel that initial auto-arm and
+  // preserve the exact prior timing (no timer running during session.create/subscribe).
+  inactivityTimer.pause()
 
   function clearInactivity(): void {
-    if (inactivityTimer !== null) {
-      clearTimeout(inactivityTimer)
-      inactivityTimer = null
-    }
+    inactivityTimer.pause()
   }
 
   function resetInactivity(): void {
-    if (inactivityController === null || inactivityTimeoutMs === undefined) return
-    clearInactivity()
-    inactivityTimer = setTimeout(() => {
-      inactivityController?.abort()
-    }, inactivityTimeoutMs)
-  }
-
-  if (inactivityTimeoutMs !== undefined && inactivityTimeoutMs > 0) {
-    inactivityController = new AbortController()
+    if (!inactivityArmed) return
+    inactivityTimer.reset()
   }
 
   // combinedSignal: aborts when either the wall-clock signal or the inactivity signal fires.
-  const combinedSignal = inactivityController === null ? signal : AbortSignal.any([signal, inactivityController.signal])
+  const combinedSignal = inactivityArmed ? AbortSignal.any([signal, inactivityTimer.signal]) : signal
 
   // ── 0c. Pre-flight abort check ─────────────────────────────────────────────
   // Check before any external call so an already-expired signal (e.g. AbortSignal.timeout
@@ -642,10 +640,10 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
       }
     }
   } finally {
-    // Ensure the inactivity timer is always cleared on loop exit (normal, break, or throw).
+    // Ensure the inactivity timer is always disposed on loop exit (normal, break, or throw).
     // The explicit clearInactivity() calls on the session.idle and session.error paths are
-    // kept as defensive double-clears — clearTimeout on an already-cleared handle is a no-op.
-    clearInactivity()
+    // kept as defensive double-clears — pause()/dispose() on an already-cleared timer is a no-op.
+    inactivityTimer.dispose()
   }
 
   // Stream exhausted (loop exited normally or via break). Distinguish timeout from premature close.
@@ -653,7 +651,7 @@ export async function runOpenCodeCore(params: RunCoreParams): Promise<void> {
   if (combinedSignal.aborted) {
     // Inactivity is the tighter bound (always < hard ceiling), so on the rare both-aborted
     // tick we attribute to inactivity-timeout deliberately.
-    if (inactivityController !== null && inactivityController.signal.aborted) {
+    if (inactivityArmed && inactivityTimer.signal.aborted) {
       logger.warn(
         {sessionId, totalEvents, activityEvents, lastEventType},
         'run-core: stream ended due to inactivity timeout',

--- a/packages/runtime/src/agent/inactivity-timer.test.ts
+++ b/packages/runtime/src/agent/inactivity-timer.test.ts
@@ -1,0 +1,157 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createInactivityTimer} from './inactivity-timer.js'
+
+describe('createInactivityTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('arms on create when timeoutMs > 0 and fires abort after the window elapses', () => {
+    // #given — a timer with a 1000ms window
+    const timer = createInactivityTimer({timeoutMs: 1000})
+
+    // #when — no reset; advance past the window
+    expect(timer.signal.aborted).toBe(false)
+    vi.advanceTimersByTime(1000)
+
+    // #then — signal aborts
+    expect(timer.signal.aborted).toBe(true)
+  })
+
+  it('reset defers firing: advancing to just-before-deadline then resetting prevents the original-deadline fire', () => {
+    // #given
+    const timer = createInactivityTimer({timeoutMs: 1000})
+
+    // #when — advance to just before the deadline, then reset
+    vi.advanceTimersByTime(900)
+    timer.reset()
+    // Advance past the ORIGINAL deadline (100ms more = 1000ms total) — should not fire
+    // because reset() re-armed a fresh 1000ms window at t=900.
+    vi.advanceTimersByTime(100)
+
+    // #then — no abort yet
+    expect(timer.signal.aborted).toBe(false)
+
+    // #when — advance the full new window
+    vi.advanceTimersByTime(900)
+
+    // #then — fires
+    expect(timer.signal.aborted).toBe(true)
+  })
+
+  it('pause prevents firing indefinitely', () => {
+    // #given
+    const timer = createInactivityTimer({timeoutMs: 1000})
+
+    // #when
+    vi.advanceTimersByTime(500)
+    timer.pause()
+    vi.advanceTimersByTime(10_000)
+
+    // #then — never fires while paused
+    expect(timer.signal.aborted).toBe(false)
+  })
+
+  it('resume re-arms a fresh window after pause', () => {
+    // #given — paused timer
+    const timer = createInactivityTimer({timeoutMs: 1000})
+    vi.advanceTimersByTime(500)
+    timer.pause()
+    vi.advanceTimersByTime(10_000)
+    expect(timer.signal.aborted).toBe(false)
+
+    // #when — resume and advance less than the window
+    timer.resume()
+    vi.advanceTimersByTime(999)
+    expect(timer.signal.aborted).toBe(false)
+
+    // #then — fires once the full window elapses post-resume
+    vi.advanceTimersByTime(1)
+    expect(timer.signal.aborted).toBe(true)
+  })
+
+  it('dispose prevents firing', () => {
+    // #given
+    const timer = createInactivityTimer({timeoutMs: 1000})
+
+    // #when
+    vi.advanceTimersByTime(500)
+    timer.dispose()
+    vi.advanceTimersByTime(10_000)
+
+    // #then
+    expect(timer.signal.aborted).toBe(false)
+  })
+
+  it('is inert when timeoutMs is 0 — signal never aborts, methods are no-ops', () => {
+    // #given
+    const timer = createInactivityTimer({timeoutMs: 0})
+
+    // #when
+    timer.reset()
+    timer.pause()
+    timer.resume()
+    vi.advanceTimersByTime(1_000_000)
+
+    // #then
+    expect(timer.signal.aborted).toBe(false)
+  })
+
+  it('is inert when timeoutMs is negative', () => {
+    // #given
+    const timer = createInactivityTimer({timeoutMs: -1})
+
+    // #when
+    vi.advanceTimersByTime(1_000_000)
+
+    // #then
+    expect(timer.signal.aborted).toBe(false)
+  })
+
+  it('signal.reason is distinguishable — abort() with no reason argument yields a default AbortError-like reason', () => {
+    // #given
+    const timer = createInactivityTimer({timeoutMs: 1000})
+
+    // #when
+    vi.advanceTimersByTime(1000)
+
+    // #then — the signal identity itself is the distinguishing mechanism (callers compare
+    // `timer.signal === abortedSignal` or `timer.signal.aborted`); reason is present but not
+    // asserted structurally here since callers probe identity, not reason shape.
+    expect(timer.signal.aborted).toBe(true)
+    expect(timer.signal.reason).toBeDefined()
+  })
+
+  it('double-dispose is safe', () => {
+    // #given
+    const timer = createInactivityTimer({timeoutMs: 1000})
+
+    // #when / #then — no throw
+    expect(() => {
+      timer.dispose()
+      timer.dispose()
+    }).not.toThrow()
+    vi.advanceTimersByTime(10_000)
+    expect(timer.signal.aborted).toBe(false)
+  })
+
+  it('reset after dispose is a safe no-op — does not resurrect the timer', () => {
+    // #given
+    const timer = createInactivityTimer({timeoutMs: 1000})
+    timer.dispose()
+
+    // #when
+    expect(() => {
+      timer.reset()
+    }).not.toThrow()
+    vi.advanceTimersByTime(10_000)
+
+    // #then
+    expect(timer.signal.aborted).toBe(false)
+  })
+})

--- a/packages/runtime/src/agent/inactivity-timer.test.ts
+++ b/packages/runtime/src/agent/inactivity-timer.test.ts
@@ -113,7 +113,7 @@ describe('createInactivityTimer', () => {
     expect(timer.signal.aborted).toBe(false)
   })
 
-  it('signal.reason is distinguishable — abort() with no reason argument yields a default AbortError-like reason', () => {
+  it('fired signal carries a defined reason — callers distinguish sources by signal identity, not reason shape', () => {
     // #given
     const timer = createInactivityTimer({timeoutMs: 1000})
 
@@ -125,6 +125,38 @@ describe('createInactivityTimer', () => {
     // asserted structurally here since callers probe identity, not reason shape.
     expect(timer.signal.aborted).toBe(true)
     expect(timer.signal.reason).toBeDefined()
+  })
+
+  it('reset after fire is a no-op — an aborted timer is never re-armed', () => {
+    // #given
+    const timer = createInactivityTimer({timeoutMs: 1000})
+    vi.advanceTimersByTime(1000)
+    expect(timer.signal.aborted).toBe(true)
+
+    // #when — attempt to resurrect
+    timer.reset()
+    vi.advanceTimersByTime(10_000)
+
+    // #then — still the same aborted signal, no new timer scheduled
+    expect(timer.signal.aborted).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('signal identity is stable across pause/resume cycles', () => {
+    // #given
+    const timer = createInactivityTimer({timeoutMs: 1000})
+    const before = timer.signal
+
+    // #when
+    timer.pause()
+    timer.resume()
+    timer.pause()
+    timer.resume()
+
+    // #then — same signal object; composed AbortSignal.any() references stay valid
+    expect(timer.signal).toBe(before)
+    vi.advanceTimersByTime(1000)
+    expect(before.aborted).toBe(true)
   })
 
   it('double-dispose is safe', () => {

--- a/packages/runtime/src/agent/inactivity-timer.ts
+++ b/packages/runtime/src/agent/inactivity-timer.ts
@@ -1,0 +1,82 @@
+/**
+ * Resettable inactivity abort-timer.
+ *
+ * A dependency-free closure-based primitive: arms a timeout that aborts its own
+ * `signal` if not reset/paused before the window elapses. Callers compose
+ * `signal` with any other abort sources (e.g. `AbortSignal.any([outer, timer.signal])`)
+ * and can distinguish "this timer fired" from other abort sources by checking
+ * `timer.signal.aborted` directly — the signal identity is stable for the life
+ * of the instance.
+ *
+ * Policy (counters, logging, pause/resume triggers) stays with the caller;
+ * this module owns only the timer mechanics.
+ */
+
+export interface InactivityTimer {
+  /** Aborts when the configured window elapses without a `reset()` call. Stable for the instance's life. */
+  readonly signal: AbortSignal
+  /** Clears any pending timeout and re-arms a fresh window. No-op when inert. */
+  readonly reset: () => void
+  /** Clears the pending timeout without aborting — the timer goes dormant until `reset()` or `resume()`. */
+  readonly pause: () => void
+  /** Re-arms a fresh window after a `pause()`. Equivalent to `reset()`. No-op when inert. */
+  readonly resume: () => void
+  /** Clears any pending timeout and marks the instance inert. Never aborts. Safe to call multiple times. */
+  readonly dispose: () => void
+}
+
+/**
+ * Create an inactivity timer.
+ *
+ * `timeoutMs <= 0` produces an inert instance: `signal` never aborts and all
+ * methods are no-ops. This mirrors the `inactivityTimeoutMs > 0` arming guard
+ * used by callers that treat "no timeout configured" as "feature disabled".
+ */
+export function createInactivityTimer(options: {readonly timeoutMs: number}): InactivityTimer {
+  const {timeoutMs} = options
+
+  if (timeoutMs <= 0) {
+    // Inert instance: a controller whose signal never aborts, and no-op methods.
+    const inertController = new AbortController()
+    return {
+      signal: inertController.signal,
+      reset: () => {},
+      pause: () => {},
+      resume: () => {},
+      dispose: () => {},
+    }
+  }
+
+  const controller = new AbortController()
+  let handle: ReturnType<typeof setTimeout> | null = null
+  let disposed = false
+
+  function clear(): void {
+    if (handle !== null) {
+      clearTimeout(handle)
+      handle = null
+    }
+  }
+
+  function arm(): void {
+    if (disposed || controller.signal.aborted) return
+    clear()
+    handle = setTimeout(() => {
+      handle = null
+      controller.abort()
+    }, timeoutMs)
+  }
+
+  arm()
+
+  return {
+    signal: controller.signal,
+    reset: arm,
+    pause: clear,
+    resume: arm,
+    dispose: () => {
+      clear()
+      disposed = true
+    },
+  }
+}

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -14,6 +14,8 @@ export type {ErrorInfo, ErrorType} from './error-format/types.js'
 export {ERROR_TYPES} from './error-format/types.js'
 export {executeOpenCode} from './execution.js'
 export {filterAgentEnv} from './filter-env.js'
+export {createInactivityTimer} from './inactivity-timer.js'
+export type {InactivityTimer} from './inactivity-timer.js'
 export {resolveOutputMode} from './output-mode.js'
 export {
   buildCurrentThreadContextSection,


### PR DESCRIPTION
Closes #1069. The gateway's resettable inactivity abort-timer — the piece #1068 built inline in `run-core.ts` — moves to `packages/runtime/src/agent/inactivity-timer.ts` as a dependency-free primitive, so the timeout mechanics have one home instead of drifting per surface.

## Shape

- **Primitive owns mechanics:** arm/reset/pause/resume/dispose, inert instance when the window is `<= 0` (feature-disabled), stable `signal` identity so callers can probe which abort source fired. No logger, no counters — pure timer.
- **run-core keeps policy:** the #1116 activity counters, approval-window pause (`permission.asked` → pause, `permission.replied` → reset), reset triggers (text deltas + tool completions), and the inactivity-vs-ceiling error classification are unchanged.
- **Behavior-preserving by construction:** the pre-existing `run-core.test.ts` fake-timer tests pass **unchanged** (zero diff on that file) — they pin identical reset/pause/ceiling semantics. One wiring nuance: the primitive auto-arms on creation, but run-core's contract starts the countdown only after the prompt is sent, so construction is immediately followed by `pause()` and the first real arm stays at the original post-`promptAsync` site.

## Scope boundary

The action deliberately does **not** adopt an inactivity window here. Action runs routinely execute single long tool calls (builds, full test suites) that emit nothing mid-flight — a gateway-sized window would false-abort legitimate CI runs. The action keeps its 90s startup-stall watchdog + 30-min ceiling; adoption stays available later with a workload-appropriate window if silent-hang symptoms ever warrant it.

## Verification

- 10 new fake-timer tests on the primitive (arm/fire, reset-defers, pause/resume, dispose, inert, reason distinguishability, double-dispose).
- Full suite green: runtime 529, action 5260, harness 229, gateway **3174 with `run-core.test.ts` untouched**.
- Types + lint clean across all packages; committed `dist/` unaffected (verified by rebuild — the action doesn't import the new export, and tree-shaking keeps the bundle byte-identical).