### PR TITLE
docs: compound three learnings from the timeout, listener, and SDK-bump work

### DIFF
--- a/docs/solutions/best-practices/extract-timer-primitive-keep-policy-per-surface-2026-07-13.md
+++ b/docs/solutions/best-practices/extract-timer-primitive-keep-policy-per-surface-2026-07-13.md
@@ -1,0 +1,87 @@
+---
+title: Extract the timer primitive, keep the timeout policy per surface
+date: 2026-07-13
+category: best-practices
+module: runtime
+problem_type: best_practice
+component: service_object
+severity: medium
+applies_when:
+  - "Two execution surfaces need the same timing mechanics with different reset/pause policy"
+  - "Converging duplicated timeout logic without forcing one surface's policy onto another"
+  - "A refactor must be provably behavior-preserving"
+tags: [inactivity-timer, abort-signal, shared-primitive, policy-boundary, behavior-preserving-refactor]
+---
+
+# Extract the timer primitive, keep the timeout policy per surface
+
+## Context
+
+The GitHub Action and the gateway tracked run timeouts divergently. The gateway had a resettable 5-minute inactivity window (reset on text deltas and tool completions, paused during approval waits). The action had only a hard ceiling plus a 90s startup-stall watchdog. Converging them risked either duplicating the timer mechanics across both surfaces or smuggling one surface's policy into the other.
+
+## Guidance
+
+Extract only the mechanism into a dependency-free primitive, and leave every policy decision — which events reset the timer, when to pause it, whether the window exists at all — in the caller.
+
+`createInactivityTimer` (`packages/runtime/src/agent/inactivity-timer.ts`) owns the mechanics only:
+
+```ts
+export interface InactivityTimer {
+  /** Aborts when the configured window elapses without a `reset()` call. Stable for the instance's life. */
+  readonly signal: AbortSignal
+  /** Clears any pending timeout and re-arms a fresh window. No-op when inert. */
+  readonly reset: () => void
+  /** Clears the pending timeout without aborting — the timer goes dormant until `reset()` or `resume()`. */
+  readonly pause: () => void
+  /** Re-arms a fresh window after a `pause()`. Equivalent to `reset()`. No-op when inert. */
+  readonly resume: () => void
+  /** Clears any pending timeout and marks the instance inert. Never aborts. Safe to call multiple times. */
+  readonly dispose: () => void
+}
+```
+
+`timeoutMs <= 0` produces an inert instance whose signal never aborts — callers that treat "no timeout configured" as "feature disabled" get that for free.
+
+The gateway (`packages/gateway/src/execute/run-core.ts`) composes the primitive with its own event-driven policy:
+
+```ts
+// When inactivityTimeoutMs is set (>0), the shared `createInactivityTimer` primitive
+// arms a timeout that fires after the configured window of silence. It is reset on
+// every text delta, tool completion, and permission.replied event. It is paused on
+// permission.asked and resumed+reset on permission.replied.
+const inactivityTimer = createInactivityTimer({timeoutMs: inactivityTimeoutMs ?? 0})
+```
+
+The gateway's pre-existing timeout tests passed unchanged after the refactor onto the shared primitive — the unchanged-tests property is the behavior-preservation proof, not an assertion of it.
+
+The action deliberately did not adopt an inactivity window. CI runs execute single long tool calls (full builds, complete test suites) that legitimately emit nothing for many minutes; a rolling inactivity window sized for interactive mention-driven runs would false-abort them. Non-adoption here is documented policy, not an omission.
+
+## Why This Matters
+
+A "shared abstraction" that carries policy across surfaces couples workloads with different characteristics — an interactive Discord mention loop and a batch CI run don't share an idle-time definition, even though they share timer mechanics. The primitive/policy split keeps the reusable part small and lets each surface make workload-appropriate choices without either surface reaching into the other's decisions.
+
+## When to Apply
+
+- Two or more call sites need identical timing/abort mechanics but different triggering rules.
+- A convergence refactor is proposed and the risk is one surface's semantics leaking into another.
+- Verifying a refactor didn't change behavior — an existing test suite passing unchanged is stronger evidence than new tests written after the fact.
+
+## Examples
+
+Primitive (mechanism, no policy):
+```ts
+const inactivityTimer = createInactivityTimer({timeoutMs: 0}) // inert — never aborts
+```
+
+Caller (policy, no mechanism):
+```ts
+const inactivityArmed = inactivityTimeoutMs !== undefined && inactivityTimeoutMs > 0
+function resetInactivity(): void {
+  if (!inactivityArmed) return
+  inactivityTimer.reset()
+}
+```
+
+## Related
+
+- [AbortSignal.any() reason-classification race](../logic-errors/abortsignal-any-reason-classification-race-2026-07-03.md) — a related hazard when composing this primitive's `signal` with other abort sources via `AbortSignal.any`.

--- a/docs/solutions/test-failures/daemon-signal-handlers-accumulate-listeners-in-tests-2026-07-13.md
+++ b/docs/solutions/test-failures/daemon-signal-handlers-accumulate-listeners-in-tests-2026-07-13.md
@@ -1,0 +1,72 @@
+---
+title: Daemon signal handlers accumulate across repeated test constructions
+date: 2026-07-13
+category: test-failures
+module: gateway
+problem_type: test_failure
+component: testing_framework
+severity: low
+symptoms:
+  - "MaxListenersExceededWarning for SIGTERM/SIGINT during the gateway test suite"
+  - "Warning count grows with the number of tests that construct the program"
+root_cause: test_isolation
+resolution_type: test_fix
+tags: [max-listeners, process-signals, test-isolation, shutdown, daemon-lifecycle]
+---
+
+# Daemon signal handlers accumulate across repeated test constructions
+
+## Problem
+
+`packages/gateway/src/shutdown.ts` installs process-level `SIGTERM`/`SIGINT` handlers that are deliberately never removed in production — correct for a daemon, which installs them once per process lifetime. `packages/gateway/src/program.test.ts` constructs the gateway program roughly 36 times in a single Vitest worker process, and `makeGatewayProgram` calls `installShutdownHandlers` internally without exposing the returned cleanup function to callers. Each construction adds another pair of listeners that never gets removed, eventually exceeding Node's default listener threshold.
+
+## Symptoms
+
+- `MaxListenersExceededWarning` for `SIGTERM`/`SIGINT` printed during the gateway test suite.
+- The warning count scales with the number of tests that call `makeGatewayProgram`, not with anything related to actual shutdown behavior.
+
+## What Didn't Work
+
+- Raising `process.setMaxListeners()` would silence the warning without addressing the leak — it masks the signal rather than fixing isolation, and hides a genuine growth-with-test-count pattern.
+- Removing the handlers in production teardown was considered and rejected: an audit confirmed exactly one construction per process in production, so there is no real leak there — the accumulation is an artifact of repeated test construction, not a defect in `shutdown.ts`.
+
+## Solution
+
+Fixed in the test file only: snapshot the process's `SIGTERM`/`SIGINT` listeners before each test, and strip only the listeners added during that test, restoring the exact pre-test set — the same cleanup `installShutdownHandlers`'s own return value would perform if it were reachable from the test.
+
+```ts
+// makeGatewayProgram calls installShutdownHandlers internally and does not expose
+// its returned cleanup fn to callers — that's intentional for production (the
+// process owns its own shutdown lifecycle). Tests that invoke makeGatewayProgram
+// repeatedly would otherwise accumulate SIGTERM/SIGINT listeners across cases
+// (Issue #1134). Since the cleanup closure isn't reachable here, snapshot the
+// listener set before each test and strip anything added during it, restoring
+// the exact pre-test listener set the same way installShutdownHandlers's own
+// cleanup would (process.off per added listener).
+beforeEach(() => {
+  const sigtermBefore = process.listeners('SIGTERM')
+  const sigintBefore = process.listeners('SIGINT')
+  return () => {
+    for (const listener of process.listeners('SIGTERM')) {
+      if (!sigtermBefore.includes(listener)) process.off('SIGTERM', listener)
+    }
+    for (const listener of process.listeners('SIGINT')) {
+      if (!sigintBefore.includes(listener)) process.off('SIGINT', listener)
+    }
+  }
+})
+```
+
+## Why This Works
+
+The side effect being accumulated is process-lifetime by design — a daemon installs its signal handlers once and keeps them for the life of the process, which is correct. The defect is test isolation: repeated construction in one process simulates a scenario that never happens in production. The `beforeEach`/teardown pair mirrors the real cleanup contract (`process.off` per handler `installShutdownHandlers` added) without touching production behavior in `shutdown.ts`.
+
+## Prevention
+
+- Treat `MaxListenersExceededWarning` in a test suite as a test-isolation smell first, not a signal to raise the listener cap.
+- Snapshot and strip process-level listeners in any test that repeatedly constructs something with process-lifetime side effects (signal handlers, `process.on('exit', ...)`, global singletons).
+- Never reach for `setMaxListeners()` as the first response — it suppresses the diagnostic without checking whether the accumulation reflects a real production leak.
+
+## Related Issues
+
+- Issue #1134

--- a/docs/solutions/workflow-issues/bun-local-cache-masks-minimum-release-age-2026-07-13.md
+++ b/docs/solutions/workflow-issues/bun-local-cache-masks-minimum-release-age-2026-07-13.md
@@ -1,0 +1,84 @@
+---
+title: Bun's local cache can mask the minimumReleaseAge gate
+date: 2026-07-13
+category: workflow-issues
+module: tooling
+problem_type: workflow_issue
+component: tooling
+severity: medium
+applies_when:
+  - "A dependency bump is validated with a local bun install while CI runs with a cold cache"
+  - "A package version is near the bunfig minimumReleaseAge boundary"
+  - "Deciding whether a minimumReleaseAgeExcludes fast-track entry is removable"
+tags: [bun, minimum-release-age, supply-chain, cache, verify-before-act]
+---
+
+# Bun's local cache can mask the minimumReleaseAge gate
+
+## Context
+
+A bump of `@opencode-ai/sdk` to `1.17.18` passed a local `bun install --frozen-lockfile` and was pushed as verified. CI then failed with "blocked by minimum-release-age". The version was 2.5 days old against the 3-day gate (published `2026-07-09T18:50Z`, checked from CI around `2026-07-12T06:50Z`).
+
+## Guidance
+
+Bun does not re-apply `minimumReleaseAge` to versions already present in the local package cache — a warm cache silently satisfies an install that a cold cache would reject. Local success is not evidence the gate passes.
+
+The authoritative pre-push check is publish-timestamp arithmetic, not a local install:
+
+```bash
+npm view @opencode-ai/sdk@1.17.18 time --json
+```
+
+Compare the published timestamp against the gate window in `bunfig.toml`:
+
+```toml
+[install]
+# Supply-chain age gate: refuse dependency versions published within this window.
+minimumReleaseAge = 259200
+
+# Temporary fast-track: @opencode-ai/sdk 1.17.18 pairs with the released
+# harness base (1.17.18+harness.4ec05a47) and clears the 3-day window at
+# 2026-07-12T18:50Z. Remove this exclusion after that.
+minimumReleaseAgeExcludes = ["@opencode-ai/sdk"]
+```
+
+If the gate hasn't cleared and the bump can't wait, add a temporary `minimumReleaseAgeExcludes` entry with the clearing timestamp noted in a comment, and track its removal once the window passes.
+
+To locally reproduce what CI sees, clear the bun cache before the frozen install:
+
+```bash
+rm -rf ~/.bun/install/cache
+bun install --frozen-lockfile
+```
+
+## Why This Matters
+
+The gate exists to delay adoption of fresh publishes so a supply-chain compromise has a window to surface before the package lands. A warm-cache local pass is a false verification signal that defeats the check exactly when it matters — a fresh publish is the case the gate is meant to catch.
+
+## When to Apply
+
+- Validating any dependency bump before push, especially near a `minimumReleaseAge` boundary.
+- Deciding whether a `minimumReleaseAgeExcludes` entry is safe to remove.
+- Diagnosing a CI-only "blocked by minimum-release-age" failure that didn't reproduce locally.
+
+## Examples
+
+Before (misleading local pass):
+```
+$ bun install --frozen-lockfile   # warm cache, package already downloaded → succeeds
+$ git push                        # CI: cold cache → "blocked by minimum-release-age"
+```
+
+After (timestamp arithmetic before push):
+```
+$ npm view @opencode-ai/sdk@1.17.18 time --json
+{ "1.17.18": "2026-07-09T18:50:00.000Z" }
+$ node -e 'const pub=new Date("2026-07-09T18:50:00.000Z").getTime();
+const ageMs=Date.now()-pub; console.log({ageDays:(ageMs/86400000).toFixed(2), cleared: ageMs>=259200000});'
+{ ageDays: '2.50', cleared: false }
+```
+
+## Related
+
+- [A time-gated "ready" signal can fire before the real boundary](./time-gated-smart-note-surfaced-ready-early-2026-07-04.md) — same verify-the-timestamp-not-the-date discipline, applied to smart-note readiness rather than install caching.
+- [Migrating a pnpm workspace to Bun](./migrate-pnpm-to-bun-monorepo-2026-06-24.md) — where the `minimumReleaseAge` gate configuration lives.

--- a/docs/solutions/workflow-issues/time-gated-smart-note-surfaced-ready-early-2026-07-04.md
+++ b/docs/solutions/workflow-issues/time-gated-smart-note-surfaced-ready-early-2026-07-04.md
@@ -6,6 +6,7 @@ module: development-workflow
 problem_type: workflow_issue
 component: assistant
 severity: medium
+last_updated: 2026-07-13
 applies_when:
   - A smart note, reminder, or CI gate is conditioned on an age window, embargo, or release-timing rule
   - A background checker marks something "ready" on or near the boundary date
@@ -90,3 +91,4 @@ Rule: verify-then-act on any time-gated condition; a "ready" flag is a prompt to
 ## Related
 
 - [Migrating a pnpm workspace to Bun](migrate-pnpm-to-bun-monorepo-2026-06-24.md) — where `minimumReleaseAge` moved into `bunfig.toml` (§3c); this is the operational hazard of acting on that gate too early.
+- [Bun's local cache can mask the minimumReleaseAge gate](./bun-local-cache-masks-minimum-release-age-2026-07-13.md) — the same verify-the-timestamp discipline applied to install-cache freshness rather than smart-note readiness.


### PR DESCRIPTION
Three new solution docs + one scoped cross-link update, from recently shipped and verified work.

- **workflow-issues/bun-local-cache-masks-minimum-release-age** — bun does not re-apply the `minimumReleaseAge` gate to locally-cached versions, so a warm-cache `bun install` success is a false verification signal; CI's cold cache enforces the gate. Authoritative check is publish-timestamp arithmetic (`npm view <pkg>@<ver> time --json`); the temporary `minimumReleaseAgeExcludes` fast-track with tracked removal is the escape hatch. (From the #1186 SDK bump.)
- **best-practices/extract-timer-primitive-keep-policy-per-surface** — converge duplicated timing mechanics into a dependency-free primitive (`createInactivityTimer`), keep every policy decision (reset triggers, pause windows, adoption itself) in the calling surface. The gateway's pre-existing timeout tests passing unchanged is the behavior-preservation proof; the action's non-adoption is documented, deliberate policy (long silent CI tool calls would false-abort). (From #1189/#1069.)
- **test-failures/daemon-signal-handlers-accumulate-listeners-in-tests** — process-lifetime SIGTERM/SIGINT handlers are correct for a daemon; MaxListenersExceededWarning in a suite that repeatedly constructs the program is a test-isolation defect. Snapshot/strip listeners in the harness; never mask with setMaxListeners. (From #1187/#1134.)
- Scoped update: the time-gated smart-note doc gains a Related link to the bun-cache variant of the same verify-time-boundaries discipline (+ last_updated).

Links resolve (219/244). Frontmatter validated against the schema; categories match directories; new test-failures/ category directory introduced.