### PR TITLE
chore: drop expired OpenCode SDK age-gate exclusion

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -12,8 +12,3 @@ linker = "hoisted"
 # Supply-chain age gate: refuse dependency versions published within this window.
 # Mirrors the prior pnpm minimumReleaseAge policy. Seconds (3 days).
 minimumReleaseAge = 259200
-
-# Temporary fast-track: @opencode-ai/sdk 1.17.18 pairs with the released
-# harness base (1.17.18+harness.4ec05a47) and clears the 3-day window at
-# 2026-07-12T18:50Z. Remove this exclusion after that.
-minimumReleaseAgeExcludes = ["@opencode-ai/sdk"]


### PR DESCRIPTION
## Summary

Remove the temporary `@opencode-ai/sdk` release-age exclusion now that version 1.17.18 has cleared the three-day supply-chain gate.

## Verification

- `bun install` completed with no dependency changes
- `bun.lock` remained byte-identical
- `bun run lint` passed
- `git diff --check` passed
