### PR TITLE
docs: describe the full Fro Bot platform

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -230,7 +230,9 @@ Agent prompts are assembled from named XML-tagged sections with an explicit auth
 
 ### Two-Layer Session Management
 
-Session persistence spans two distinct layers that are easy to conflate. The **agent-side** layer is a set of in-session tools the model calls _during_ a run — `session_search` and `session_read`, injected into the prompt (`packages/runtime/src/agent/prompt.ts`) so the agent can recall relevant prior work before re-investigating. The **action-side** layer is a set of TypeScript utilities the harness runs _around_ execution — `listSessions`, `searchSessions`, `pruneSessions`, and `writeSessionSummary` (`packages/runtime/src/session/`) — invoked by the finalize and cleanup phases to persist, summarize, and prune session state across CI runs. The agent never calls the action-side utilities directly, and the harness never invokes the agent-side tools; they meet only through the persisted session store.
+Session persistence spans two distinct layers that are easy to conflate. During execution, the **agent-side** layer is a set of always-on native OpenCode file tools that let the model query prior sessions directly. Around execution, the **action-side** layer is a set of runtime utilities that summarize, prune, and write session state. Both layers share the same SDK-backed persisted session store, but neither calls the other directly.
+
+> See also: [Session Persistence](docs/wiki/Session%20Persistence.md) — canonical reference for the native tool inventory, config-dir registration, fallback behavior, and detailed session lifecycle.
 
 ### OIDC Trusted Publishing
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,17 @@
 
 ## Overview
 
-Fro Bot Agent is a GitHub Action that runs an [OpenCode](https://opencode.ai/) agent in response to repository events — issues, pull requests, comments, reviews, and scheduled runs — and **remembers previous interactions across workflow runs**.
+Fro Bot Agent is a Bun monorepo that runs an [OpenCode](https://opencode.ai/) agent across several surfaces: a **GitHub Action** that responds to repository events (issues, pull requests, comments, reviews, and scheduled runs), a **Discord-first Gateway** daemon with an authenticated operator web/API surface for launching and observing runs outside of CI, a **sandboxed workspace executor** that clones and runs the agent in an isolated container, a **patched OpenCode harness** build/publish pipeline, and shared **runtime/session primitives** used across all of the above. The GitHub Action **preserves OpenCode session state across runs**, while the Gateway starts a fresh OpenCode session per run but persists coordination and run state through its S3-backed control plane.
 
-Traditional CI-based AI agents are stateless: each run starts from scratch, repeating investigations and burning tokens. Fro Bot persists its session state across runs (GitHub Actions cache, with optional S3 backup), so it builds context over time, references prior work instead of redoing it, and resumes interrupted tasks.
+Traditional CI-based AI agents are stateless: each run starts from scratch, repeating investigations and burning tokens. The GitHub Action persists its session state across runs (GitHub Actions cache, with optional S3 backup), so it builds context over time, references prior work instead of redoing it, and resumes interrupted tasks.
 
 ### Key Features
 
 - **Persistent memory** — session state survives workflow runs via cache, with optional S3 write-through backup that outlives cache eviction.
 - **Multiple triggers** — responds to comments, issues, pull requests, review threads, and scheduled or manually dispatched runs.
+- **Discord Gateway** — a daemon that runs OpenCode work from authorized `@fro-bot` mentions and exposes slash commands for setup and operator controls (e.g. adding a project, clearing the queue).
+- **Operator web surface** — an authenticated HTTP/SSE control surface for launching, observing, and approving gateway agent runs from a browser.
+- **Sandboxed workspace executor** — a workspace-agent container that clones repositories and runs the agent behind an egress-allowlisted proxy, deployable via the `deploy/` Compose stack.
 - **Auto-setup** — installs OpenCode on first run; no manual toolchain setup.
 - **Security-first** — author-association gating, credential hygiene, and fork-PR protection are enforced, not optional.
 - **Observability** — every run writes a summary with metrics and error context.
@@ -224,7 +227,7 @@ For Cloudflare R2, Backblaze B2, or MinIO, set `s3-endpoint` and `s3-sse-encrypt
 
 ## Repository Structure
 
-The repository is a Bun monorepo: the Action's logic lives in the layered root `src/`, alongside the gateway, harness, and runtime packages. See **[STRUCTURE.md](STRUCTURE.md)** for the directory layout, key file locations, and where to add new code.
+The repository is a Bun monorepo: the Action's logic lives in the layered root `src/`, alongside the `apps/workspace-agent` sandboxed executor and the gateway, harness, and runtime packages under `packages/`; the `deploy/` directory holds the Docker Compose stack that runs the gateway and workspace executor behind a mitmproxy egress proxy enforcing an allowlist of permitted outbound hosts. See **[STRUCTURE.md](STRUCTURE.md)** for the directory layout, key file locations, and where to add new code, and **[deploy/README.md](deploy/README.md)** / **[apps/workspace-agent/README.md](apps/workspace-agent/README.md)** for running the gateway and workspace stack.
 
 ## Development
 

--- a/docs/wiki/Session Persistence.md
+++ b/docs/wiki/Session Persistence.md
@@ -99,6 +99,12 @@ The key operations:
 
 All SDK operations return empty arrays or `null` on failure — they never throw. This null-safe pattern prevents a single bad session from crashing the entire run.
 
+These runtime-side operations are distinct from the native agent tools described below: the operations above are invoked by harness/runtime code outside of model tool calls, never by the model directly. The native tools are what the model itself calls mid-run.
+
+### Native Agent Session Tools
+
+`packages/runtime/src/agent/session-tools.ts` implements the always-on `session_list` / `session_read` / `session_search` / `session_info` tool contract as a plain config-dir file tool (`tool/session.js`), independent of any plugin. Setup copies the compiled asset into the CI OpenCode config dir via `writeSessionToolsFile` (`src/services/setup/session-tools-config.ts`); OpenCode's tool registry loads it as a file tool before plugin tools, so an oh-my-openagent plugin tool of the same id overrides it at registry time (later-wins). The tools resolve an OpenCode client from `FRO_BOT_OPENCODE_URL` at call time (never at import time) and delegate to the same `packages/runtime/src/session/` primitives (`listSessions`, `getSession`, `getSessionMessages`, `getSessionTodos`, `getSessionInfo`, `searchSessions`) described above — they are a thin, string-formatted, model-facing wrapper over the SDK operations, not a separate storage path. Every failure path returns a `'session store unavailable: ...'` string rather than throwing, so a session-tool failure never fails the run; if the asset is missing at setup time, setup warns and continues, and the tools are simply absent from that run.
+
 ## Mapper Architecture
 
 SDK types don't perfectly match the project's local types. The mapper layer in `packages/runtime/src/session/` (`storage-mappers.ts`, `storage-message-mappers.ts`) translates between them:
@@ -112,12 +118,12 @@ The local types in `types.ts` are authoritative — they define the canonical sh
 
 ## Session Search
 
-The search module (`packages/runtime/src/session/search.ts`) provides two capabilities consumed by the prompt builder:
+The search module (`packages/runtime/src/session/search.ts`) provides two capabilities consumed by both the prompt builder and the native `session_list` / `session_search` agent tools:
 
 - **`listSessions`** — Returns recent non-child sessions sorted by `updatedAt`. Child sessions (those with a `parentID`, representing agent-spawned branches) are filtered out of the main listing.
 - **`searchSessions`** — Full-text search across session message content. Returns excerpts with context so the agent can decide which prior sessions are relevant without reading every message.
 
-During the session-prep phase of each run (see [[Execution Lifecycle]]), the system searches for sessions related to the current issue or PR. Matching excerpts are injected into the prompt as "Relevant Prior Work," giving the agent a lightweight summary of past interactions.
+During the session-prep phase of each run (see [[Execution Lifecycle]]), the system searches for sessions related to the current issue or PR. Matching excerpts are injected into the prompt as "Relevant Prior Work," giving the agent a lightweight summary of past interactions. Mid-run, the agent can additionally reach for the same search directly via the native `session_search` tool instead of waiting on the pre-injected excerpts.
 
 ## Logical Session Keys
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -6,7 +6,7 @@ summary: "Navigable entry point for the Fro Bot Agent project wiki"
 
 # Fro Bot Agent Wiki
 
-An Obsidian-powered project wiki maintained by Fro Bot. This vault provides human-readable documentation covering the architecture, subsystems, and conventions of the [fro-bot/agent](https://github.com/fro-bot/agent) GitHub Action.
+An Obsidian-powered project wiki maintained by Fro Bot. This vault provides human-readable documentation covering the architecture, subsystems, and conventions of the [fro-bot/agent](https://github.com/fro-bot/agent) Bun monorepo — the GitHub Action, the Discord-first Gateway and operator web surface, the sandboxed workspace executor, the patched OpenCode harness, and the shared runtime/session primitives underneath them.
 
 > **Getting started:** Open this folder (`docs/wiki/`) as a vault in [Obsidian](https://obsidian.md/) for the best experience — graph view, backlinks, and search work out of the box. For the Dataview plugin (optional), install it from Obsidian's community plugins after opening the vault.
 


### PR DESCRIPTION
## Summary

- present the GitHub Action, Discord Gateway, operator surface, workspace executor, harness, and runtime as one platform
- replace obsolete prompt-injected session-tool documentation with the native OpenCode file-tool architecture
- align the wiki landing page and session-persistence guide with the current monorepo

## Verification

- `bun run fix`
- `bun run lint`
- `bun run check:md-links`
- `git diff --check`
