### PR TITLE
build(harness): retire low-value OpenCode carries

### DIFF
--- a/packages/harness/harness.config.json
+++ b/packages/harness/harness.config.json
@@ -13,12 +13,10 @@
     "https://github.com/anomalyco/opencode/pull/34975",
     "https://github.com/anomalyco/opencode/pull/34977",
     "https://github.com/anomalyco/opencode/pull/33713",
-    "https://github.com/anomalyco/opencode/pull/7156",
     "https://github.com/anomalyco/opencode/pull/36045",
     "https://github.com/anomalyco/opencode/pull/36281",
     "https://github.com/anomalyco/opencode/pull/36002",
-    "https://github.com/anomalyco/opencode/pull/36361",
-    "https://github.com/anomalyco/opencode/pull/36179"
+    "https://github.com/anomalyco/opencode/pull/36361"
   ],
   "agent": "build",
   "model": "anthropic/claude-sonnet-4-6",


### PR DESCRIPTION
## Summary

- remove the default-variant carry while retaining subtask model/variant handling
- remove the prompt-root OTEL span carry because shipped surfaces do not configure an OTLP exporter
- retain 14 higher-value carries, including TUI stream batching and background-failure diagnostics

## Verification

- `bun run --filter @fro.bot/harness test`
- `bun run --filter @fro.bot/harness build`
- `bun run check-types`
- `bun run lint`
- `bun run build`
- `git diff --check`
