### PR TITLE
build(harness): retire superseded OpenCode carries

### DIFF
--- a/packages/harness/harness.config.json
+++ b/packages/harness/harness.config.json
@@ -14,8 +14,6 @@
     "https://github.com/anomalyco/opencode/pull/34977",
     "https://github.com/anomalyco/opencode/pull/33713",
     "https://github.com/anomalyco/opencode/pull/36045",
-    "https://github.com/anomalyco/opencode/pull/36281",
-    "https://github.com/anomalyco/opencode/pull/36002",
     "https://github.com/anomalyco/opencode/pull/36361"
   ],
   "agent": "build",


### PR DESCRIPTION
## Summary
- remove OpenCode carry #36281 because stock v1.17.20 now preserves configured subagent model/variant behavior
- remove OpenCode carry #36002 because stock v1.17.20 now settles session busy state after stream completion
- retain the remaining 12 behaviorally justified carries

## Verification
- stock v1.17.20 model/variant regression probes pass
- stock v1.17.20 busy-to-idle lifecycle probe passes
- `bun run --filter @fro.bot/harness test`
- `bun run --filter @fro.bot/harness build`
- `bun run check-types`
- `bun run lint`
- `bun run build`
