### PR TITLE
fix(ci): isolate PR release validation concurrency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -730,7 +730,7 @@ jobs:
 
   release:
     concurrency:
-      group: release
+      group: ${{ github.ref_name == github.event.repository.default_branch && 'release' || format('release-validation-{0}', github.event.pull_request.number || github.run_id) }}
       cancel-in-progress: false
     env:
       DRY_RUN: ${{ github.ref_name != github.event.repository.default_branch }}


### PR DESCRIPTION
## Summary
- give each PR release-validation job its own concurrency group
- let PR validation run concurrently across PRs and during production releases
- keep push/dispatch-to-default-branch writers serialized with production release workflows on `release`

## Verification
- reproduced the original cross-workflow concurrency collision
- validated pull requests resolve to `release-validation-<PR number>`
- validated default-branch push/dispatch runs remain on `release`
- validated merge-group and non-default dispatch dry-runs get unique validation groups
- `bun run lint`
- `bun run test:scripts` (322 tests)
- `bun run build`
