### PR TITLE
chore: remove expired @opencode-ai/sdk age-gate exclusion

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -12,8 +12,3 @@ linker = "hoisted"
 # Supply-chain age gate: refuse dependency versions published within this window.
 # Mirrors the prior pnpm minimumReleaseAge policy. Seconds (3 days).
 minimumReleaseAge = 259200
-
-# Temporary fast-track for the deliberate @opencode-ai/sdk 1.17.20 bump; publish
-# time 2026-07-13T21:08:29.496Z, clears the 3-day window 2026-07-16T21:08:30Z.
-# Remove this exclusion after that date.
-minimumReleaseAgeExcludes = ["@opencode-ai/sdk"]


### PR DESCRIPTION
The temporary `minimumReleaseAgeExcludes` fast-track for the deliberate @opencode-ai/sdk 1.17.20 bump has served its purpose: the version published 2026-07-13T21:08:29Z and cleared the 3-day supply-chain window on 2026-07-16T21:08:30Z.

Verified with a cold-cache `bun install --frozen-lockfile` (fresh `BUN_INSTALL_CACHE_DIR`) — the authoritative check, since a warm local cache masks the age gate. No lockfile changes.