### PR TITLE
docs: capture credential-selector and marker-anchoring learnings

### DIFF
--- a/docs/solutions/best-practices/key-credential-switch-on-operation-input-not-audit-token-2026-07-17.md
+++ b/docs/solutions/best-practices/key-credential-switch-on-operation-input-not-audit-token-2026-07-17.md
@@ -1,0 +1,140 @@
+---
+title: Key a CI credential switch on the operation input, not an audit token
+date: 2026-07-17
+category: best-practices
+module: release-notes-narration
+problem_type: best_practice
+component: development_workflow
+severity: high
+applies_when:
+  - an automation splits into jobs/steps that use different credentials (read-only vs write)
+  - the dispatch surface accepts both an operation input and an audit/tracing token that can be set independently
+  - untrusted content (PR titles, commit subjects, issue bodies) flows into a step the credential gates
+  - a workflow may be dispatched by an older caller checked out from a released tag during a rollout window
+related_components:
+  - tooling
+tags:
+  - credential-selector
+  - operation-input
+  - audit-vs-trace
+  - prompt-injection-via-forgeable-key
+  - deploy-window-compat
+  - release-pipeline
+  - github-actions
+---
+
+# Key a CI credential switch on the operation input, not an audit token
+
+## Context
+
+The two-phase release-notes narration flow runs a **read-only generation agent**
+(workflow `GITHUB_TOKEN`, `contents: read` + `pull-requests: read`) that gathers
+untrusted PR evidence and writes a candidate, then a **separate trusted apply job**
+(`FRO_BOT_PAT`, a single `gh release edit`). The whole security posture rests on one
+conditional: which credential the generation agent's checkout and action step receive.
+
+The first implementation keyed that switch on `correlation-id` — a UUID used purely
+for run selection and audit correlation. That is the wrong axis. `correlation-id`
+is a tracing token; it says nothing about whether the run is performing the
+privileged operation. Two independent reviewers (security and adversarial)
+converged on the same hole.
+
+## Guidance
+
+Key the read-only-vs-write credential switch on the **operation input** (the input
+that names the privileged action being performed), never on an audit/tracing token
+that can be set independently.
+
+```yaml
+# .github/workflows/fro-bot.yaml
+# Keyed on release-tag (the operation), not correlation-id (an audit token):
+#   (a) a manual dispatch that sets release-tag without correlation-id must NOT
+#       hand the generation agent the PAT;
+#   (b) deploy-window compatibility — an old dispatcher (checked out from a
+#       released tag) that sets correlation-id but not release-tag keeps the old
+#       PAT + old mutation-prompt behavior working unchanged, instead of
+#       403-hard-failing the release job.
+token: ${{ github.event.inputs.release-tag != '' && github.token || secrets.FRO_BOT_PAT }}
+```
+
+The mutating apply job requires **both** inputs, so a half-specified manual dispatch
+degrades to a harmless read-only generate run with no apply:
+
+```yaml
+# Both inputs required: the artifact name needs correlation-id, and a
+# half-specified manual dispatch should produce a read-only generate run with no
+# apply — fail-soft.
+if: ${{ github.event.inputs.release-tag != '' && github.event.inputs.correlation-id != '' }}
+```
+
+Null-coercion note: for non-`workflow_dispatch` events (`mention`/`comment`/
+`schedule`/`workflow_call`), `github.event.inputs.release-tag` is null and
+`null != ''` evaluates false, so every non-release path keeps the write-capable PAT
+unchanged. A future refactor to strict comparison here would silently downgrade
+those write paths to the read-only token — the coercion behavior is load-bearing.
+
+## Why This Matters
+
+**Security.** Keying on `correlation-id` let a manual dispatch set `release-tag`
+(triggering the apply intent) while leaving `correlation-id` empty — handing the
+generation agent the write-capable PAT while it processes prompt-injectable,
+contributor-authored PR bodies. Keying on the operation input decouples the
+write credential from a non-security field that an attacker or a misdispatch can
+set on its own. The credential now tracks the operation, not a diagnostic label.
+
+**Deploy-window compatibility, for free.** `@semantic-release/exec` runs its
+`successCmd` from the checkout of the **released tag**, not from `main`. During a
+rollout, an *old* dispatcher (from a tag published before this change) dispatches
+the *new* workflow and sets `correlation-id` but not `release-tag`. Because the
+switch keys on `release-tag` (absent → PAT), that old dispatcher keeps its old
+PAT + mutation-prompt behavior working unchanged, instead of receiving the
+read-only token, hitting a `403` on `gh release edit`, and hard-failing an
+already-published release. One design decision closed the security hole and
+removed the rollout hazard simultaneously.
+
+## When to Apply
+
+- Any workflow where a credential or permission boundary is gated by a dispatch input.
+- Especially when multiple inputs exist and at least one is diagnostic/audit-only —
+  the credential selector must be the operation, never the label.
+- Any semantic-release (or other tag-checkout) dispatch, where old callers can hit a
+  new workflow during the deploy window and must degrade safely.
+
+## Examples
+
+### Bad: credential keyed on the audit token
+
+```yaml
+# release-tag (the operation) and correlation-id (audit) are independent inputs.
+# A manual dispatch can set release-tag without correlation-id → PAT on an
+# agent processing untrusted PR content.
+token: ${{ github.event.inputs.correlation-id != '' && github.token || secrets.FRO_BOT_PAT }}
+```
+
+### Good: credential keyed on the operation input
+
+```yaml
+token: ${{ github.event.inputs.release-tag != '' && github.token || secrets.FRO_BOT_PAT }}
+# mutating apply job additionally requires BOTH inputs:
+if: ${{ github.event.inputs.release-tag != '' && github.event.inputs.correlation-id != '' }}
+```
+
+## Related
+
+- [`release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md`](./release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md)
+  — the progenitor doc for this pipeline. Its correlation-id guidance is for run
+  selection/audit only; this doc adds the constraint that the credential selector
+  must be the operation input.
+- [`response-file-is-untrusted-input-2026-07-11.md`](./response-file-is-untrusted-input-2026-07-11.md)
+  — closest neighbor: "delivery mode and credential provisioning are two
+  independent axes, resolved separately." Same trust-boundary discipline, applied
+  to response delivery rather than the operation-vs-audit input split.
+- [`same-job-phase-split-not-a-security-boundary-2026-07-04.md`](./same-job-phase-split-not-a-security-boundary-2026-07-04.md)
+  — same problem space (isolate a write credential from a prompt-injectable step),
+  different mechanism (cross-job vs input-selector).
+- [`inline-scoped-app-token-mint-2026-07-12.md`](./inline-scoped-app-token-mint-2026-07-12.md)
+  — a neighboring rung on the credential-minimization ladder.
+- [`../workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md`](../workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md)
+  — same trust-boundary discipline applied to credential issuance; the prohibition
+  generalizes to credential-selector inputs.
+- PR #1239 — the two-phase narration redesign that introduced this switch.

--- a/docs/solutions/best-practices/release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md
+++ b/docs/solutions/best-practices/release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md
@@ -6,6 +6,7 @@ module: release-notes
 problem_type: best_practice
 component: development_workflow
 severity: high
+last_updated: 2026-07-17
 applies_when:
   - release automation dispatches a narration or rewrite workflow
   - model identifiers are routed through a provider proxy
@@ -78,15 +79,25 @@ effect**. Six rules:
 3. **Bound the narration path with a real timeout.** A stalled provider must fail
    fast and be classified as a soft warning — never an unbounded hang.
 
-4. **Make the release-body update idempotent.** A stable marker
-   (`<!-- fro-bot-narration-v1 -->`) lets a re-run skip instead of double-narrating;
-   keep the raw changelog under `<details>`.
+4. **Make the release-body update idempotent — and anchor the marker structurally.**
+   A stable marker (`<!-- fro-bot-narration-v1 -->`) on its own line, immediately
+   under the `## What's new` heading, lets a re-run skip instead of double-narrating;
+   keep the raw changelog under `<details>`. Match it by structural position, **not**
+   by substring: the body embeds a `<details>` changelog whose PR titles are
+   user-influenced, so a bare `body.includes(marker)` check lets a forged marker in a
+   PR title suppress narration permanently. See
+   [`../logic-errors/sentinel-marker-must-be-position-anchored-when-body-contains-untrusted-content-2026-07-17.md`](../logic-errors/sentinel-marker-must-be-position-anchored-when-body-contains-untrusted-content-2026-07-17.md).
 
 5. **Enforce side effects structurally, not by prompt wording.** Do not rely on
    prompt text to suppress unwanted GitHub posts. Dispatch with
    `response-mode: none` so the workflow edits the release body directly and posts
    nothing. (Narration also runs `enable-omo: false` — it needs no orchestration —
-   and `output-mode: working-dir`, all gated on the correlation id.)
+   and `output-mode: working-dir`, all gated on the correlation id.) Note the scope
+   boundary: `correlation-id` is for **run selection / audit only**. The credential
+   scope selector (read-only `GITHUB_TOKEN` vs write-capable `FRO_BOT_PAT`) must be
+   keyed on the **operation input** (`release-tag` present vs absent), never on the
+   tracing token — see
+   [`key-credential-switch-on-operation-input-not-audit-token-2026-07-17.md`](./key-credential-switch-on-operation-input-not-audit-token-2026-07-17.md).
 
 6. **Classify outcomes by precedence — security first, narration soft.**
    - **Auth failure is the only hard fail (exit 1), checked first.**
@@ -201,6 +212,11 @@ Short human-readable summary of the release.
 
 ## Related
 
+- [`key-credential-switch-on-operation-input-not-audit-token-2026-07-17.md`](./key-credential-switch-on-operation-input-not-audit-token-2026-07-17.md)
+  — the two-phase redesign (PR #1239): the credential selector for the read-only
+  generate phase keys on the operation input, not the correlation id.
+- [`../logic-errors/sentinel-marker-must-be-position-anchored-when-body-contains-untrusted-content-2026-07-17.md`](../logic-errors/sentinel-marker-must-be-position-anchored-when-body-contains-untrusted-content-2026-07-17.md)
+  — the position-anchoring requirement behind Rule #4's marker scheme.
 - [`workspace-executor-opencode-provisioning-best-practices-2026-06-01.md`](./workspace-executor-opencode-provisioning-best-practices-2026-06-01.md)
   — the cliproxy / model-routing / deploy-time provisioning surface. Same
   "route models through config, distinguish absent vs malformed" axis, but for

--- a/docs/solutions/logic-errors/sentinel-marker-must-be-position-anchored-when-body-contains-untrusted-content-2026-07-17.md
+++ b/docs/solutions/logic-errors/sentinel-marker-must-be-position-anchored-when-body-contains-untrusted-content-2026-07-17.md
@@ -1,0 +1,125 @@
+---
+title: Idempotency sentinel markers must be position-anchored when the body contains untrusted content
+date: 2026-07-17
+category: logic-errors
+module: release-notes-narration
+problem_type: logic_error
+component: tooling
+symptoms:
+  - apply step skips narration despite it having never run for this release (idempotency false positive)
+  - idempotency check returns true when the marker substring appears anywhere in the release body, not only where the apply step writes it
+  - a PR titled or commit-subjected with the literal marker string suppresses narration permanently for that release
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+related_components:
+  - development_workflow
+tags:
+  - sentinel-marker
+  - position-anchor
+  - structural-prefix
+  - untrusted-body-content
+  - changelog-forgery
+  - idempotency-by-marker
+---
+
+# Idempotency sentinel markers must be position-anchored when the body contains untrusted content
+
+## Problem
+
+The release-notes apply job decides "already narrated, skip" by looking for a
+sentinel marker (`<!-- fro-bot-narration-v1 -->`) in the release body. A bare
+substring check treats the marker as present no matter where it appears — but the
+release body embeds a `<details>` changelog whose PR titles and commit subjects are
+user-influenced. A forged marker anywhere in that untrusted text trips the skip.
+
+## Symptoms
+
+- Narration is skipped for a release that was never narrated (idempotency false positive).
+- The trigger is a PR title / commit subject containing the literal string
+  `<!-- fro-bot-narration-v1 -->`, which semantic-release folds into the changelog.
+- The suppression is permanent: the marker stays in the preserved changelog, so
+  every re-run keeps skipping.
+
+## What Didn't Work
+
+```ts
+// Substring-anywhere: any occurrence of the marker — including inside the
+// embedded <details> changelog, where PR titles are user-influenced — counts
+// as "already narrated."
+if (body.includes(NARRATION_MARKER)) {
+  return alreadyApplied()
+}
+```
+
+## Solution
+
+Anchor the check to the marker's **assembled position** — the marker only means
+"narrated" when it sits immediately under the `## What's new` heading, which is the
+one place the apply step writes it. `hasAppliedNarration` checks that structural
+prefix at a line boundary, and the same function single-sources both the
+idempotency skip and the post-edit verification.
+
+```ts
+// scripts/release/release-notes.ts
+export const NARRATION_MARKER = '<!-- fro-bot-narration-v1 -->'
+
+// The assembled shape always emits the heading line immediately followed by the
+// marker line. Checking that exact structural prefix — rather than a bare
+// substring search — prevents a forged marker embedded mid-changelog (e.g. inside
+// a PR title that lands in the changelog) from being mistaken for applied narration.
+const APPLIED_NARRATION_PREFIX = `## What's new\n${NARRATION_MARKER}`
+
+export function hasAppliedNarration(body: string): boolean {
+  if (body.startsWith(APPLIED_NARRATION_PREFIX)) {
+    return true
+  }
+  return body.includes(`\n${APPLIED_NARRATION_PREFIX}`)
+}
+```
+
+```ts
+// scripts/release/assemble-release-notes.ts — runApply Step 1
+// structural check (hasAppliedNarration), not a bare marker substring search
+const currentBody = extractBody(ghView())
+if (hasAppliedNarration(currentBody)) {
+  return {exitCode: 0, message: `already-applied: release ${tag} body already contains the narration marker`}
+}
+```
+
+## Why This Works
+
+The marker is only semantically meaningful in the position the assembler writes it:
+a heading line followed immediately by the marker line. User-influenced content in
+the `<details>` changelog can contain the marker string, but it can never reach that
+heading-adjacent position — the assembler controls the region above the changelog.
+Anchoring the check to structure rather than presence makes the forgery inert.
+
+## Prevention
+
+- A sentinel/idempotency marker embedded in a body that **also** contains untrusted
+  or user-influenced content must be **position-anchored** (matched at the exact
+  structural position the writer emits it), never substring-matched anywhere in the body.
+- Single-source the anchored check so the idempotency skip and the post-write
+  verification cannot drift apart.
+- Pin the forgery shape in a test:
+
+```ts
+// A marker forged inside a changelog-style bullet must NOT read as applied.
+const forged = `## What's new\n\nsummary\n\n<details>\n* feat: add ${NARRATION_MARKER} support\n</details>`
+expect(hasAppliedNarration(forged)).toBe(false)
+```
+
+## Related Issues
+
+- [`../best-practices/release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md`](../best-practices/release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md)
+  — the progenitor doc. Its idempotency rule now states the position-anchor
+  requirement (a bare substring check is unsafe).
+- [`retry-clobbers-previous-invocation-comment-2026-07-11.md`](./retry-clobbers-previous-invocation-comment-2026-07-11.md)
+  — the identity-anchored twin. That bug keys idempotency on the invocation's own
+  identity (run id + attempt); this one keys on structural position. Together they
+  cover the marker-idempotency design space.
+- [`../best-practices/response-file-is-untrusted-input-2026-07-11.md`](../best-practices/response-file-is-untrusted-input-2026-07-11.md)
+  — same "the body contains untrusted content" trust-boundary discipline, applied
+  to a committed response file rather than an in-body changelog.
+- PR #1239 — the two-phase narration redesign where this was caught and fixed.


### PR DESCRIPTION
Two learnings from the two-phase release-notes narration redesign (#1239), plus a targeted refresh of the progenitor narration doc.

## New docs

- **`best-practices/key-credential-switch-on-operation-input-not-audit-token-2026-07-17.md`** — when a workflow's read-only-vs-write credential switch is gated by dispatch inputs, key it on the operation input (`release-tag`), never an audit/tracing token (`correlation-id`). Keying on the audit token let a half-specified dispatch hand the write-capable PAT to an agent processing untrusted PR content; keying on the operation also made the semantic-release deploy window compatible for free (old dispatchers checked out from released tags keep their old behavior instead of 403-hard-failing). Cross-linked into the existing credential-isolation cluster (OIDC broker, same-job-phase-split, inline App-token mint, response-file-is-untrusted-input).

- **`logic-errors/sentinel-marker-must-be-position-anchored-when-body-contains-untrusted-content-2026-07-17.md`** — a substring-anywhere idempotency check on the narration marker could be forged by a PR title containing the literal marker string (it lands in the embedded changelog → narration permanently suppressed for that release). The fix anchors the check to the assembled structural position (`## What's new` + marker at a line boundary), single-sourced for both the idempotency skip and post-edit verification. Cross-linked to the identity-anchored twin (`retry-clobbers-previous-invocation-comment`).

## Refresh

- **`best-practices/release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md`** — Rule 4 now states the position-anchor requirement (a reader could previously implement it as a naive substring check and ship the forgery bug); Rule 5 gains the correlation-id scope boundary (run selection/audit only, never the credential selector); Related links added; `last_updated: 2026-07-17`.

Links validated (231 across 255 files). All snippets verbatim from current main.