### PR TITLE
fix(release): exempt code-quoted tags from candidate validation

### DIFF
--- a/scripts/release/assemble-release-notes.test.ts
+++ b/scripts/release/assemble-release-notes.test.ts
@@ -161,6 +161,15 @@ describe('validateCandidate', () => {
     })
   })
 
+  it('rejects a raw details tag behind an invalid backtick fence (backtick in info string)', () => {
+    // #given — CommonMark forbids backticks in a backtick fence's info string, so ```js` is NOT
+    // a fence and GitHub renders the following <details> as live markup. The stripper must not
+    // blank the region (fail-open) — the structural check must still see the raw tag.
+    const candidate = 'Narrative text.\n```js`\n<details>\n```\nSee [#1](https://github.com/o/r/pull/1).'
+    // #then
+    expect(validateCandidate(candidate, 'anything')).toEqual({ok: false, reason: 'contains-details'})
+  })
+
   it.each([
     ['closing tag only', 'Some narrative.\n</details>\nMore text.'],
     ['open tag with attribute', 'Some narrative.\n<details open>\nMore text.'],
@@ -346,6 +355,23 @@ describe('stripCodeSpans', () => {
 
     // #when / #then
     expect(stripCodeSpans(text)).toBe(text)
+  })
+
+  it('leaves an invalid backtick fence (backtick in info string) intact', () => {
+    // #given — ```js` is not a valid fence per CommonMark (no backticks in a backtick
+    // fence's info string); blanking it would hide live markup from the structural checks
+    const text = '```js`\n<details>\n```\nafter'
+
+    // #then — the <details> line must survive stripping
+    expect(stripCodeSpans(text)).toContain('<details>')
+  })
+
+  it('still strips a tilde fence whose info string contains a backtick', () => {
+    // #given — tildes fences MAY carry backticks in the info string per CommonMark
+    const text = '~~~js`\n<details>\n~~~\nafter'
+
+    // #then
+    expect(stripCodeSpans(text)).not.toContain('<details>')
   })
 })
 

--- a/scripts/release/assemble-release-notes.test.ts
+++ b/scripts/release/assemble-release-notes.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it, vi} from 'vitest'
 import {
   assembleReleaseBody,
   MAX_CANDIDATE_LENGTH,
+  stripCodeSpans,
   validateCandidate,
   type ValidateCandidateResult,
 } from './assemble-release-notes.js'
@@ -113,6 +114,51 @@ describe('validateCandidate', () => {
     // #then
     expect(result.ok).toBe(false)
     expect((result as {reason: string}).reason).toBe('contains-details')
+  })
+
+  it('accepts a candidate describing a details tag in inline code', () => {
+    // #given
+    const candidate =
+      'The validator rejects no marker or `<details>` forgery ([#42](https://github.com/fro-bot/agent/pull/42)).'
+    const originalBody = '* fix: validator ([#42](https://github.com/fro-bot/agent/pull/42))'
+
+    // #when
+    const result = validateCandidate(candidate, originalBody)
+
+    // #then
+    expect(result.ok).toBe(true)
+  })
+
+  it('accepts details tags and the narration marker inside a fenced code block', () => {
+    // #given
+    const candidate = `Example validator input:\n\`\`\`markdown\n<details>\n${NARRATION_MARKER}\n</details>\n\`\`\``
+
+    // #when
+    const result = validateCandidate(candidate, 'anything')
+
+    // #then
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects raw closing and opening details tags outside code spans', () => {
+    // #given / #when / #then
+    for (const candidate of ['Some text.\n</details>', 'Some text.\n<details open>']) {
+      expect(validateCandidate(candidate, 'anything')).toEqual({ok: false, reason: 'contains-details'})
+    }
+  })
+
+  it('rejects the raw narration marker outside code spans', () => {
+    expect(validateCandidate(`Some text.\n${NARRATION_MARKER}`, 'anything')).toEqual({
+      ok: false,
+      reason: 'contains-marker',
+    })
+  })
+
+  it('fails closed for an unbalanced backtick before a raw details tag', () => {
+    expect(validateCandidate('Some ` explanation with <details> still exposed.', 'anything')).toEqual({
+      ok: false,
+      reason: 'contains-details',
+    })
   })
 
   it.each([
@@ -273,6 +319,33 @@ describe('validateCandidate', () => {
     // #then
     expect(result.ok).toBe(true)
     expect('reason' in result).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// stripCodeSpans
+// ---------------------------------------------------------------------------
+
+describe('stripCodeSpans', () => {
+  it('strips inline code, double-backtick code, and fenced code contents', () => {
+    // #given
+    const text = 'a `<details>` b ``<details>`` c\n~~~md\n<details>\n~~~\n d'
+
+    // #when
+    const stripped = stripCodeSpans(text)
+
+    // #then
+    expect(stripped).not.toContain('<details>')
+    expect(stripped).toContain('a ')
+    expect(stripped).toContain(' d')
+  })
+
+  it('leaves unbalanced spans unchanged', () => {
+    // #given
+    const text = 'a `unbalanced <details>\n```\n<details>'
+
+    // #when / #then
+    expect(stripCodeSpans(text)).toBe(text)
   })
 })
 

--- a/scripts/release/assemble-release-notes.ts
+++ b/scripts/release/assemble-release-notes.ts
@@ -73,13 +73,25 @@ export function stripCodeSpans(text: string): string {
     if (!isLineStart(position)) return null
 
     let cursor = position
-    while (text[cursor] === ' ' && cursor < text.length && cursor - position < 4) cursor += 1
+    while (cursor < text.length && text[cursor] === ' ' && cursor - position < 4) cursor += 1
     const character = text[cursor]
     if (character !== '`' && character !== '~') return null
 
     let length = 0
     while (text[cursor + length] === character) length += 1
-    return length >= 3 ? {character, length} : null
+    if (length < 3) return null
+
+    // CommonMark: a backtick fence's info string may not contain a backtick. A line like
+    // ```js` is NOT a fence — GitHub renders the following lines as live markup — so treating
+    // it as one here would blank a region the structural checks must still see (fail-open).
+    // Tilde fences are exempt: tildes are permitted in ~~~ info strings.
+    if (character === '`') {
+      const lineEnd = text.indexOf('\n', cursor + length)
+      const infoString = text.slice(cursor + length, lineEnd === -1 ? text.length : lineEnd)
+      if (infoString.includes('`')) return null
+    }
+
+    return {character, length}
   }
 
   const closingFenceAt = (
@@ -89,7 +101,7 @@ export function stripCodeSpans(text: string): string {
     if (!isLineStart(position)) return false
 
     let cursor = position
-    while (text[cursor] === ' ' && cursor < text.length && cursor - position < 4) cursor += 1
+    while (cursor < text.length && text[cursor] === ' ' && cursor - position < 4) cursor += 1
     let length = 0
     while (text[cursor + length] === fence.character) length += 1
     if (length < fence.length) return false
@@ -119,15 +131,21 @@ export function stripCodeSpans(text: string): string {
     if (character === '`') {
       let length = 1
       while (text[index + length] === '`') length += 1
+      // Inline spans are confined to a single line: a line-starting HTML tag (e.g. <details>)
+      // interrupts the enclosing paragraph as a block per CommonMark, so a span crossing a
+      // newline could blank live markup the structural checks must still see. Scanning less
+      // aggressively here is the fail-closed direction.
+      const lineEnd = text.indexOf('\n', index + length)
+      const searchLimit = lineEnd === -1 ? text.length : lineEnd
       let closing = text.indexOf('`'.repeat(length), index + length)
-      while (closing !== -1) {
+      while (closing !== -1 && closing < searchLimit) {
         let runLength = 0
         while (text[closing + runLength] === '`') runLength += 1
         const startsRun = closing === 0 || text[closing - 1] !== '`'
         if (runLength === length && startsRun) break
         closing = text.indexOf('`'.repeat(length), closing + 1)
       }
-      if (closing !== -1) {
+      if (closing !== -1 && closing < searchLimit) {
         const end = closing + length
         output.push(blanked(text.slice(index, end)))
         index = end

--- a/scripts/release/assemble-release-notes.ts
+++ b/scripts/release/assemble-release-notes.ts
@@ -59,6 +59,89 @@ const PR_LINK_PATTERN = /\]\([^)]*\/(?:issues|pull)\/\d[^)]*\)/
 // '<details>', which a candidate could trivially dodge with '<details open>' or '</details>'.
 const DETAILS_TAG_PATTERN = /<\/?\s*details\b/i
 
+/**
+ * Removes well-formed fenced and inline Markdown code spans while leaving unbalanced markup intact.
+ * This is deliberately small and conservative: callers use the result only for structural checks,
+ * so anything that cannot be paired unambiguously remains visible to those checks.
+ */
+export function stripCodeSpans(text: string): string {
+  const output: string[] = []
+  let index = 0
+
+  const isLineStart = (position: number): boolean => position === 0 || text[position - 1] === '\n'
+  const fenceAt = (position: number): {readonly character: '`' | '~'; readonly length: number} | null => {
+    if (!isLineStart(position)) return null
+
+    let cursor = position
+    while (text[cursor] === ' ' && cursor < text.length && cursor - position < 4) cursor += 1
+    const character = text[cursor]
+    if (character !== '`' && character !== '~') return null
+
+    let length = 0
+    while (text[cursor + length] === character) length += 1
+    return length >= 3 ? {character, length} : null
+  }
+
+  const closingFenceAt = (
+    position: number,
+    fence: {readonly character: '`' | '~'; readonly length: number},
+  ): boolean => {
+    if (!isLineStart(position)) return false
+
+    let cursor = position
+    while (text[cursor] === ' ' && cursor < text.length && cursor - position < 4) cursor += 1
+    let length = 0
+    while (text[cursor + length] === fence.character) length += 1
+    if (length < fence.length) return false
+
+    cursor += length
+    while (text[cursor] === ' ' || text[cursor] === '\t') cursor += 1
+    return text[cursor] === '\n' || cursor === text.length
+  }
+
+  const blanked = (value: string): string => value.replaceAll(/[^\n]/g, ' ')
+
+  while (index < text.length) {
+    const fence = fenceAt(index)
+    if (fence !== null) {
+      let closing = index + 1
+      while (closing < text.length && !closingFenceAt(closing, fence)) closing += 1
+      if (closing < text.length) {
+        let end = text.indexOf('\n', closing)
+        end = end === -1 ? text.length : end + 1
+        output.push(blanked(text.slice(index, end)))
+        index = end
+        continue
+      }
+    }
+
+    const character = text[index]
+    if (character === '`') {
+      let length = 1
+      while (text[index + length] === '`') length += 1
+      let closing = text.indexOf('`'.repeat(length), index + length)
+      while (closing !== -1) {
+        let runLength = 0
+        while (text[closing + runLength] === '`') runLength += 1
+        const startsRun = closing === 0 || text[closing - 1] !== '`'
+        if (runLength === length && startsRun) break
+        closing = text.indexOf('`'.repeat(length), closing + 1)
+      }
+      if (closing !== -1) {
+        const end = closing + length
+        output.push(blanked(text.slice(index, end)))
+        index = end
+        continue
+      }
+    }
+
+    output.push(character ?? '')
+    index += 1
+  }
+
+  return output.join('')
+}
+
 // Rejects candidates containing ANSI escape sequences, C0 control characters other than
 // \n \r \t, DEL, or hidden/bidi Unicode formatting characters. These have no legitimate
 // place in release-notes prose and can be used to spoof terminal/rendering output or hide
@@ -82,11 +165,15 @@ export function validateCandidate(candidate: string, originalBody: string): Vali
     return {ok: false, reason: 'oversized'}
   }
 
-  if (candidate.includes(NARRATION_MARKER)) {
+  const candidateWithoutCodeSpans = stripCodeSpans(candidate)
+
+  if (candidateWithoutCodeSpans.includes(NARRATION_MARKER)) {
     return {ok: false, reason: 'contains-marker'}
   }
 
-  if (DETAILS_TAG_PATTERN.test(candidate)) {
+  // Code-quoted tags are rendered as text by GitHub and cannot open a details block. The live v0.93.0
+  // candidate was rejected for legitimately describing this validator with `<details>` in code.
+  if (DETAILS_TAG_PATTERN.test(candidateWithoutCodeSpans)) {
     return {ok: false, reason: 'contains-details'}
   }
 


### PR DESCRIPTION
The first live two-phase narration run (v0.93.0, run 29556739851) produced a high-quality candidate that the apply job rejected with `contains-details`. The narrative legitimately described the validator itself — the phrase ``no marker or `<details>` forgery`` in inline code — and the structural regex matched the code-quoted tag.

GitHub renders code-quoted tags as literal text; they can never open a details block or forge the idempotency marker's structural position. The threat the `contains-marker`/`contains-details` checks defend against only exists outside code spans.

## Change

- `stripCodeSpans()`: removes the contents of well-formed fenced code blocks (``` and ~~~, with indent/info-string handling) and inline code spans (matching backtick-run lengths exactly) by blanking to spaces, preserving newlines and offsets. Anything unbalanced or malformed is left intact.
- `validateCandidate()` applies the `contains-marker` and `contains-details` checks to the stripped text. All other checks (empty, oversized, control-characters, commit-list-dump, missing-pr-link) still scan the raw candidate.
- Fail-closed posture: an unbalanced backtick or unterminated fence leaves the raw text in place, so a real `<details>` tag hiding behind broken markup is still rejected — pinned by test.

## Tests

8 new (41 in file, 374 scripts total): the live v0.93.0 incident shape (inline-code `<details>` mention → accepted), fenced block containing both the marker and a details tag → accepted, raw `<details>`/`</details>`/`<details open>` outside code → rejected, raw marker outside code → rejected, unbalanced-backtick-then-raw-tag → rejected, plus `stripCodeSpans` unit coverage.

After merge, re-dispatching narration against v0.93.0 (body carries no marker) will regenerate the candidate and exercise the full apply path live.