### PR TITLE
fix(release): compose narrative in short paragraphs, not walls of text

### DIFF
--- a/scripts/release/release-notes.ts
+++ b/scripts/release/release-notes.ts
@@ -108,7 +108,7 @@ A meaningful change has audience impact: user- or operator-visible behavior, sec
 
 ## Compose
 
-For each logical change, write one paragraph of 3-6 sentences: observable problem or capability → what changed → mechanism → rationale or an important preserved behavior. End the paragraph with the PR link(s), e.g. [#123](https://github.com/${repo}/pull/123).
+For each logical change, write 1-3 SHORT paragraphs of 2-4 sentences each, separated by blank lines. Lead with the observable problem or capability and what changed; put mechanism, rationale, or important preserved behavior in the follow-on sentences or a second paragraph. Never compress a whole change into one dense wall of text — prefer two or three short paragraphs over one long one. End the LAST paragraph of the change with the PR link(s), e.g. [#123](https://github.com/${repo}/pull/123).
 
 If there are multiple logical changes, you may open with an optional 1-2 sentence release summary. Use \`###\` headings (e.g. Features, Bug fixes) ONLY when at least two logical changes share a category — do not use a heading for a single change.
 


### PR DESCRIPTION
The first live narration (v0.93.0) produced two dense wall-of-text paragraphs — one per feature — far past the compose contract's 3-6 sentence bound. The instruction "write one paragraph of 3-6 sentences" was the root cause: it forces every mechanism/rationale detail into a single paragraph.

## Change

One instruction block in `buildNarrationPrompt`: each logical change is now 1-3 short paragraphs of 2-4 sentences, blank-line separated, never one dense block, PR link at the end of the change's last paragraph. All other compose rules (sparse headings, no bullets, no commit-list restatement, evidence requirement) unchanged.

## Verified live

Tested by resetting v0.93.0 to its raw changelog and re-dispatching with the revised prompt (the dispatcher builds the prompt locally, so no merge was needed to test):

- Sonnet (`claude-sonnet-4-6`): 4 short paragraphs across the two features, category heading, mechanism and rationale intact — matches the reference formatting.
- Haiku (`claude-haiku-4-5-20251001`): acceptable but flatter — collapsed back to one paragraph per change and skipped the category heading.

v0.93.0 now carries the Sonnet output. Prompt-contract tests unchanged and green (no assertion pinned the old wording); 377 scripts tests pass.