### PR TITLE
docs: capture code-span-aware validator lesson from v0.93.0 narration

### DIFF
--- a/docs/solutions/best-practices/release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md
+++ b/docs/solutions/best-practices/release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md
@@ -87,6 +87,10 @@ effect**. Six rules:
    user-influenced, so a bare `body.includes(marker)` check lets a forged marker in a
    PR title suppress narration permanently. See
    [`../logic-errors/sentinel-marker-must-be-position-anchored-when-body-contains-untrusted-content-2026-07-17.md`](../logic-errors/sentinel-marker-must-be-position-anchored-when-body-contains-untrusted-content-2026-07-17.md).
+   The candidate validator's structural scans (marker/details forgery) are
+   additionally **code-span aware**: they run on `stripCodeSpans(candidate)` so
+   legitimate prose describing the defenses in inline code is not rejected — see
+   [`../logic-errors/release-notes-candidate-validation-must-be-code-span-aware-2026-07-17.md`](../logic-errors/release-notes-candidate-validation-must-be-code-span-aware-2026-07-17.md).
 
 5. **Enforce side effects structurally, not by prompt wording.** Do not rely on
    prompt text to suppress unwanted GitHub posts. Dispatch with
@@ -217,6 +221,9 @@ Short human-readable summary of the release.
   generate phase keys on the operation input, not the correlation id.
 - [`../logic-errors/sentinel-marker-must-be-position-anchored-when-body-contains-untrusted-content-2026-07-17.md`](../logic-errors/sentinel-marker-must-be-position-anchored-when-body-contains-untrusted-content-2026-07-17.md)
   — the position-anchoring requirement behind Rule #4's marker scheme.
+- [`../logic-errors/release-notes-candidate-validation-must-be-code-span-aware-2026-07-17.md`](../logic-errors/release-notes-candidate-validation-must-be-code-span-aware-2026-07-17.md)
+  — the code-span exemption in Rule #4's candidate validation (raw-text scans
+  rejected the first live narration for describing the validator itself).
 - [`workspace-executor-opencode-provisioning-best-practices-2026-06-01.md`](./workspace-executor-opencode-provisioning-best-practices-2026-06-01.md)
   — the cliproxy / model-routing / deploy-time provisioning surface. Same
   "route models through config, distinguish absent vs malformed" axis, but for

--- a/docs/solutions/logic-errors/release-notes-candidate-validation-must-be-code-span-aware-2026-07-17.md
+++ b/docs/solutions/logic-errors/release-notes-candidate-validation-must-be-code-span-aware-2026-07-17.md
@@ -1,0 +1,146 @@
+---
+title: Structural validators over markdown bodies must be code-span aware
+date: 2026-07-17
+category: logic-errors
+module: release-notes-narration
+problem_type: logic_error
+component: tooling
+symptoms:
+  - apply job rejects a legitimate narration candidate with `contains-details` (or `contains-marker`)
+  - the rejected candidate never contains a real details block — only prose describing one in inline code
+  - the false positive is self-referential — narrative text describing the validator's own defenses trips the validator
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+related_components:
+  - development_workflow
+tags:
+  - markdown-validation
+  - code-spans
+  - inline-code
+  - fenced-code
+  - self-referential-prose
+  - fail-closed
+---
+
+# Structural validators over markdown bodies must be code-span aware
+
+## Problem
+
+The release-notes apply job validates the model-written narrative candidate before
+assembling the release body, rejecting structural forgery: a smuggled narration
+marker (`contains-marker`) or a details tag (`contains-details`, matched with the
+structural regex `/<\/?\s*details\b/i`).
+
+Both checks scanned the **raw candidate text**. But markdown has two render layers:
+a code-quoted tag (`` `<details>` `` or a fenced block) renders as literal text on
+GitHub and can never open a block or forge the marker's structural position. Prose
+that *describes* the defense is indistinguishable from an attack when the scan
+ignores code spans.
+
+The first live narration run (v0.93.0) hit exactly this: the model legitimately
+summarized the new validation pipeline — "validates it (size, control characters,
+no marker or `<details>` forgery, …)" — and the apply job rejected its own
+feature's release notes. Self-referential prose is not an edge case here: release
+notes about security hardening will routinely name the structures the validator
+scans for.
+
+## Symptoms
+
+- `candidate rejected (contains-details); release vX.Y.Z left untouched` in the
+  apply-job log, while the downloaded candidate contains no raw details tag —
+  only a code-quoted mention.
+- Fail-soft masking: the release ships with the plain changelog and the run stays
+  green (warning only), so the false positive is easy to miss without reading the
+  apply log.
+
+## What Didn't Work
+
+```ts
+// Scanning the raw candidate: prose describing the defense in inline code
+// (`<details>`) matches the same regex as a real forgery attempt.
+if (DETAILS_TAG_PATTERN.test(candidate)) {
+  return {ok: false, reason: 'contains-details'}
+}
+```
+
+## Solution
+
+Strip **well-formed** code spans before the structural scans — and only before
+those scans. `stripCodeSpans` blanks the contents of fenced code blocks and inline
+code spans (preserving newlines/offsets); the `contains-marker` and
+`contains-details` checks run on the stripped text. All other checks (size,
+control characters, commit-list dump, PR-link presence) still scan the raw text.
+
+```ts
+// scripts/release/assemble-release-notes.ts
+const candidateWithoutCodeSpans = stripCodeSpans(candidate)
+
+if (candidateWithoutCodeSpans.includes(NARRATION_MARKER)) {
+  return {ok: false, reason: 'contains-marker'}
+}
+
+// Code-quoted tags are rendered as text by GitHub and cannot open a details block.
+if (DETAILS_TAG_PATTERN.test(candidateWithoutCodeSpans)) {
+  return {ok: false, reason: 'contains-details'}
+}
+```
+
+The stripper's correctness burden is asymmetric: **failing to strip is safe
+(over-rejection, fail-soft), stripping too much is a security hole (fail-open)**.
+Two fail-open hazards were caught during review and are pinned by tests:
+
+1. **Invalid backtick fences.** CommonMark forbids backticks in a backtick fence's
+   info string — a line like ```` ```js` ```` is *not* a fence, and GitHub renders
+   the following lines as live markup. Blanking that region would hide a real
+   `<details>` from the scan. The stripper rejects such fences (tilde fences are
+   exempt; tildes may appear in `~~~` info strings).
+2. **Cross-newline inline spans.** A stray backtick opening a "span" that closes
+   on a later line would blank line-starting HTML in between — and a line-starting
+   HTML tag interrupts the paragraph as a block per CommonMark, i.e. it renders
+   live. Inline spans are confined to a single line.
+
+Anything unbalanced or malformed stays in the scanned text.
+
+## Why This Works
+
+The threat model is *rendered structure*, not byte content: a details tag or
+marker only matters if GitHub renders it structurally. Code spans are the one
+markdown construct guaranteed to render as literal text, so exempting well-formed
+spans removes exactly the false-positive class without widening the attack
+surface. Keeping every ambiguous case (unbalanced backticks, invalid fences,
+multi-line spans) in the scanned text preserves the fail-closed default: when the
+stripper is unsure whether text renders literally, the validator still sees it.
+
+## Prevention
+
+- When a validator scans a **markdown body** for structural threats (HTML tags,
+  sentinel markers, injection shapes), decide explicitly which render layer the
+  threat lives in. If the threat requires rendering, exempt well-formed code
+  spans; if it is byte-level (control characters, hidden Unicode), scan raw.
+- Make the stripper conservative in the fail-closed direction: only blank spans
+  that are unambiguously well-formed under the renderer's actual rules
+  (CommonMark), and leave everything else visible to the scan.
+- Expect self-referential prose: any feature whose release notes, docs, or review
+  comments describe the validator will contain the scanned-for strings in code
+  spans. Pin that exact shape as an accepted-input test — the v0.93.0 incident
+  candidate is the fixture.
+- Pin the fail-open hazards as rejected-input tests (invalid info-string fence
+  followed by a raw tag; unbalanced backtick before a raw tag), so a future
+  stripper refactor cannot silently widen what gets blanked.
+
+## Related Issues
+
+- [`./sentinel-marker-must-be-position-anchored-when-body-contains-untrusted-content-2026-07-17.md`](./sentinel-marker-must-be-position-anchored-when-body-contains-untrusted-content-2026-07-17.md)
+  — the adjacent validation bug in the same pipeline: that one anchors *where* the
+  marker means something; this one scopes *which render layer* the scan applies to.
+- [`../best-practices/release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md`](../best-practices/release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md)
+  — the progenitor narration doc (routing, fail-soft posture, marker scheme).
+- [`../best-practices/response-file-is-untrusted-input-2026-07-11.md`](../best-practices/response-file-is-untrusted-input-2026-07-11.md)
+  — same trust-boundary discipline: untrusted authored text must not control
+  structural enforcement, applied to a committed response file.
+- [`./injected-deny-blocks-own-delivery-path-2026-07-13.md`](./injected-deny-blocks-own-delivery-path-2026-07-13.md)
+  — sibling incident class: a security feature colliding with its own legitimate
+  delivery path.
+- PRs #1241 (the fix + both fail-open pins) and #1243 (compose-contract fix from
+  the same v0.93.0 shakeout); incident run 29556739851.

--- a/docs/solutions/logic-errors/sentinel-marker-must-be-position-anchored-when-body-contains-untrusted-content-2026-07-17.md
+++ b/docs/solutions/logic-errors/sentinel-marker-must-be-position-anchored-when-body-contains-untrusted-content-2026-07-17.md
@@ -112,6 +112,11 @@ expect(hasAppliedNarration(forged)).toBe(false)
 
 ## Related Issues
 
+- [`release-notes-candidate-validation-must-be-code-span-aware-2026-07-17.md`](./release-notes-candidate-validation-must-be-code-span-aware-2026-07-17.md)
+  — the companion validation hardening in the same apply job. Position anchoring
+  alone did not close the class: the candidate validator's structural scans also
+  had to become code-span aware (raw-text scans rejected legitimate prose that
+  described the defenses in inline code).
 - [`../best-practices/release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md`](../best-practices/release-notes-narration-routing-and-fail-soft-guards-2026-06-07.md)
   — the progenitor doc. Its idempotency rule now states the position-anchor
   requirement (a bare substring check is unsafe).


### PR DESCRIPTION
Compound doc from the v0.93.0 narration shakeout: the apply job's candidate validator rejected the first live narration (`contains-details`) because the narrative legitimately described the validator's own defenses — ``no marker or `<details>` forgery`` in inline code. Fixed in #1241; this captures the durable lesson.

## New doc

`docs/solutions/logic-errors/release-notes-candidate-validation-must-be-code-span-aware-2026-07-17.md`

- The render-layer distinction: structural threats (details tags, sentinel markers) only exist outside code spans — GitHub renders code-quoted tags as literal text. Byte-level threats (control characters) still scan raw.
- The asymmetric correctness burden: under-stripping is safe (fail-soft over-rejection), over-stripping is fail-open — with both hazards from #1241's review pinned (invalid backtick fences per CommonMark's info-string rule; cross-newline inline spans blanking line-starting HTML).
- Self-referential prose as the expected trigger: release notes about security hardening routinely name the scanned-for structures.

## Refreshes

- Sentinel-marker sibling doc: related-link noting position anchoring alone didn't close the class.
- Progenitor narration doc Rule 4: candidate validation is code-span aware, with link.

Links 242/257 green, lint clean.