### PR TITLE
docs(plans): close OpenCode 1.18.4 harness release

### DIFF
--- a/docs/plans/2026-07-20-001-feat-opencode-1.18.4-harness-release-plan.md
+++ b/docs/plans/2026-07-20-001-feat-opencode-1.18.4-harness-release-plan.md
@@ -240,6 +240,7 @@ Completed on 2026-07-20.
 
 - Preparation PR [#1254](https://github.com/fro-bot/agent/pull/1254) merged the `1.18.4` base, Sonnet 5 local-integration model, preserved carry manifest, and validation ceiling.
 - Release run [29772360474](https://github.com/fro-bot/agent/actions/runs/29772360474) integrated all 12 carries at commit `1ff4b3232a0ca1637c450192e6ff6dfebb4f17ef`, built all six targets, and published `1.18.4-harness.1ff4b323` to npm and GitHub Releases.
+- npm uses the prerelease form `1.18.4-harness.1ff4b323`, while runtime pins and the GitHub release tag use build metadata as `1.18.4+harness.1ff4b323`; both identify the same integration build.
 - The published package provenance contains all 12 ordered carry refs, npm `latest` resolves to the new harness, and `SHA256SUMS` covers all six platform assets.
 - Default-sync PR [#1256](https://github.com/fro-bot/agent/pull/1256) advanced both `DEFAULT_OPENCODE_VERSION` and the workspace Dockerfile pin to `1.18.4+harness.1ff4b323`.
 - A headed/local installation successfully started OpenCode `1.18.4` from the published harness.

--- a/docs/plans/2026-07-20-001-feat-opencode-1.18.4-harness-release-plan.md
+++ b/docs/plans/2026-07-20-001-feat-opencode-1.18.4-harness-release-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Rebase @fro.bot/harness to OpenCode 1.18.4'
 type: feat
-status: active
+status: completed
 date: 2026-07-20
 ---
 
@@ -148,7 +148,7 @@ flowchart TB
   - Negative: the preparation diff contains no SDK, fallback, default harness, Dockerfile, probe, lockfile, or generated bundle changes.
 - **Verification:** Harness tests, repository type checks, lint, tests, and build pass; committed `dist/` remains unchanged.
 
-- [ ] **Unit 2: Integrate and build the 12-carry harness**
+- [x] **Unit 2: Integrate and build the 12-carry harness**
 
 - **Goal:** Resolve all carries against stock `1.18.4` and produce verified binaries for every supported target.
 - **Requirements:** R2-R4, R7-R8
@@ -168,7 +168,7 @@ flowchart TB
   - Integration: musl artifacts pass the linkage assertion and do not reference a glibc loader.
 - **Verification:** Integration, all six matrix jobs, provenance checks, native binary checks, and musl linkage checks succeed at one integration commit.
 
-- [ ] **Unit 3: Publish and reconcile defaults**
+- [x] **Unit 3: Publish and reconcile defaults**
 
 - **Goal:** Publish one complete harness release and advance the action/workspace defaults through the existing coupled sync PR.
 - **Requirements:** R8-R10
@@ -231,6 +231,18 @@ The harness release cycle is complete when the harness is published and the coup
 - Release notes should distinguish inherited upstream behavior from Fro Bot carries: OpenAI's header-timeout increase, the Azure endpoint correction, Kimi/Moonshot adaptive thinking, Meta `xhigh` reasoning, and the native `subagent_depth` default all arrive through the `1.18.4` base.
 - Operational review must distinguish the headless CI Action from the headed/local harness; carries may serve either surface.
 - After the age gate clears, open the independent SDK/FALLBACK/probe update rather than extending this release PR.
+
+---
+
+## Resolution
+
+Completed on 2026-07-20.
+
+- Preparation PR [#1254](https://github.com/fro-bot/agent/pull/1254) merged the `1.18.4` base, Sonnet 5 local-integration model, preserved carry manifest, and validation ceiling.
+- Release run [29772360474](https://github.com/fro-bot/agent/actions/runs/29772360474) integrated all 12 carries at commit `1ff4b3232a0ca1637c450192e6ff6dfebb4f17ef`, built all six targets, and published `1.18.4-harness.1ff4b323` to npm and GitHub Releases.
+- The published package provenance contains all 12 ordered carry refs, npm `latest` resolves to the new harness, and `SHA256SUMS` covers all six platform assets.
+- Default-sync PR [#1256](https://github.com/fro-bot/agent/pull/1256) advanced both `DEFAULT_OPENCODE_VERSION` and the workspace Dockerfile pin to `1.18.4+harness.1ff4b323`.
+- A headed/local installation successfully started OpenCode `1.18.4` from the published harness.
 
 ---
 


### PR DESCRIPTION
## Summary

- Mark the OpenCode 1.18.4 harness release plan complete.
- Record the immutable integration commit, published harness version, six-target artifact verification, and coupled default-sync merge.
- Preserve the separately tracked SDK/FALLBACK age-gated follow-up as non-blocking work.

## Verification

- `bun scripts/check-md-links.ts` — 247 links across 259 files
- Published npm `latest`: `1.18.4-harness.1ff4b323`
- GitHub Release: six platform assets plus six matching `SHA256SUMS` entries
- `DEFAULT_OPENCODE_VERSION` and workspace image pin match `1.18.4+harness.1ff4b323` on `main`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this PR only records the already-verified release outcome and does not change runtime behavior.
