### PR TITLE
docs: capture brokered-push arc learnings (#1297)

### DIFF
--- a/docs/solutions/best-practices/credential-gated-surface-is-event-intersection-2026-07-30.md
+++ b/docs/solutions/best-practices/credential-gated-surface-is-event-intersection-2026-07-30.md
@@ -1,0 +1,73 @@
+---
+title: A credential-gated action's eligible surface is the intersection of credential-withheld events and resource-bearing events
+date: 2026-07-30
+category: best-practices
+module: runtime-response-delivery
+problem_type: best_practice
+component: authentication
+severity: medium
+applies_when:
+  - Deciding which trigger events a credential-sensitive capability may run on
+  - A capability needs both a credential posture and a specific resource (e.g. a PR head)
+  - Trigger and credential behavior are defined in separate files
+tags:
+  - github-events
+  - credential-scope
+  - eligible-surface
+  - issue-comment
+  - pull-request
+  - response-delivery
+---
+
+# A credential-gated action's eligible surface is the intersection of credential-withheld events and resource-bearing events
+
+## Context
+
+Brokered push exists to help the _credential-withheld_ mention path: on those triggers the model has no push credential, so a trusted maintainer's fix can't be delivered. The tempting framing was "it applies to PR-ish events — `pull_request` / `issue_comment` / `issues`." That framing is wrong on two independent axes, and each has to be checked against source, not assumed.
+
+## Guidance
+
+Derive the eligible surface as the **intersection of two source-verified sets**:
+
+1. **Events where the capability's precondition holds** — here, events that _withhold_ the credential. That is decided by `classifyEvent` in `packages/runtime/src/agent/response-delivery.ts`, which returns `affected` (credential withheld) only for `pull_request` / `issue_comment` / `issues`.
+2. **Events that actually carry the needed resource** — here, events that expose a _PR head branch_ to push to.
+
+Only the overlap qualifies. Working it through:
+
+- `issues` withholds the credential but has **no PR head** → out.
+- `pull_request` would withhold the credential but is **not subscribed** by the workflow at all (`.github/workflows/fro-bot.yaml`) → moot.
+- `pull_request_review_comment` is PR-bound but is **not credential-withheld** (`classifyEvent` → not `affected`), so it already pushes via its provisioned credential → not stranded, out of scope.
+- `issue_comment` where `issue.pull_request != null` is **both** credential-withheld **and** PR-bound → the one eligible surface.
+
+## Why This Matters
+
+Getting the surface wrong in either direction is a bug: too broad authorizes a privileged write where the precondition doesn't hold (e.g. treating `pull_request_review_comment` as needing brokering when it already has a credential); too narrow silently drops the case the feature exists for. Because the two facts live in _different files_ (event classification in the runtime, subscribed triggers in the workflow YAML), assuming either one from the feature's name — instead of reading both — is how the surface silently drifts from reality.
+
+## When to Apply
+
+- Any capability gated on a credential _posture_ that also needs a specific event-carried resource.
+- Any time the trigger list and the credential/permission logic are defined in separate files — verify both, intersect, don't infer from the feature name.
+- Whenever a design says "applies to PR events": pin down _which_ PR events, on _which_ axis, against source.
+
+## Examples
+
+**Wrong** — infer the surface from the feature's intent:
+
+> "It's a PR fix-delivery feature, so it applies to `pull_request` / `issue_comment` / `issues`."
+
+`issues` has no PR head; `pull_request` isn't even subscribed; this over-claims two events and says nothing about `pull_request_review_comment`.
+
+**Right** — intersect two source-verified sets:
+
+```
+credential-withheld (classifyEvent === 'affected'): pull_request, issue_comment, issues
+resource-bearing (has a PR head branch):            pull_request, issue_comment-on-PR, pull_request_review_comment
+subscribed (workflow YAML):                         issue_comment, pull_request_review_comment, discussion_comment, issues, …
+∩  →  issue_comment where issue.pull_request != null
+```
+
+## Related
+
+- [Treat a model-authored response file as untrusted input and bind posting to the trusted event context](response-file-is-untrusted-input-2026-07-11.md) — the companion rule for _where_ a credential-withheld run may post; this doc is the rule for _which events_ the credential-gated capability runs on.
+- [A fork/self PR review guard must refuse APPROVE only](../workflow-issues/fork-review-guard-gates-approve-only-2026-07-11.md) — another case of gating a privileged event precisely rather than broadly.
+- Established while shipping brokered push for trusted mention runs (#1297 / PR #1304).

--- a/docs/solutions/best-practices/net-diff-delivery-needs-an-allowlist-not-a-denylist-2026-07-30.md
+++ b/docs/solutions/best-practices/net-diff-delivery-needs-an-allowlist-not-a-denylist-2026-07-30.md
@@ -1,0 +1,71 @@
+---
+title: A mechanism that can deliver any tracked change needs a path allowlist, not a denylist
+date: 2026-07-30
+category: best-practices
+module: delegated
+problem_type: best_practice
+component: development_workflow
+severity: medium
+applies_when:
+  - A mechanism can deliver arbitrary tracked file changes from a working tree
+  - You need to bound which files a trusted run may write on a user's behalf
+  - The change source is a net diff rather than a curated, model-chosen set
+tags:
+  - allowlist
+  - denylist
+  - delivery-surface
+  - execution-surface
+  - brokered-push
+  - prompt-injection
+---
+
+# A mechanism that can deliver any tracked change needs a path allowlist, not a denylist
+
+## Context
+
+Brokered push reconstructs the _net diff_ of the whole working tree against a trusted base and writes it to a branch. That means the delivery surface is "anything tracked in the workspace," and a prompt-injected model could steer a change onto any file. The first instinct was a denylist (`.github/**`, manifests, lockfiles). The problem: when the input is the entire working tree, a denylist has to enumerate _every_ executable or config surface, and it never can.
+
+## Guidance
+
+When a mechanism can carry any file in the tree, constrain it with a small **allowlist** of intended surfaces and deny everything else by default:
+
+```ts
+const BROKERED_PUSH_ALLOWED_PATHS = [/^src\//, /^packages\/[^/]+\/src\//, /^docs\//]
+const BROKERED_PUSH_ALLOWED_ROOT_FILES = new Set(["README.md", "ARCHITECTURE.md", "STRUCTURE.md"])
+// everything else is denied
+```
+
+A denylist for the same feature would have to remember all of: `.github/**`, `scripts/**`, `.husky/**`, `deploy/**`, `Dockerfile*`, `Makefile`, `*.sh`, `.npmrc`, `.yarnrc*`, `.bunfig.toml`, `.mise.toml`, `.tool-versions`, `.devcontainer/**`, `lefthook.yml`, `renovate.json`, release configs, `package.json`, every lockfile, every `tsconfig*`… and would still miss the next one added to the repo.
+
+## Why This Matters
+
+An allowlist fails safe: a surface nobody thought about is denied until explicitly added. A denylist fails open: a surface nobody thought about is permitted until someone notices. For a capability that writes to the repo under the bot's identity, driven by input that may be adversarial, fail-open is a persistent-compromise vector (a poisoned `Makefile`/`*.sh`/CI file executes on the next run). The allowlist trades some convenience — the bot can't push a config or script fix in v1 — for closing the entire execution-surface class in one rule.
+
+## When to Apply
+
+- Any delivery/apply path whose input is "everything in the working tree" rather than a curated set.
+- Any write capability driven by model- or contributor-influenceable content.
+- Whenever you catch yourself extending a denylist to cover "one more" dangerous path — that is the signal the posture is inverted.
+
+## Examples
+
+**Wrong** — denylist over a net-diff surface:
+
+```ts
+const FORBIDDEN = [/^\.github\//, /^package\.json$/, /^bun\.lock$/]
+// Makefile, Dockerfile, scripts/**, .husky/**, .npmrc, .mise.toml, deploy/** all slip through
+```
+
+**Right** — allowlist product/docs/test surfaces, deny the rest, and keep the size/sensitive-path checks on top:
+
+```ts
+if (isAllowedBrokeredPushPath(path) === false) return reject(path, "path not in brokered-push allowlist")
+// then existing validateFiles: traversal, sensitive files, size cap
+```
+
+## Related
+
+- [An injected permission deny blocked the harness's own delivery path](../logic-errors/injected-deny-blocks-own-delivery-path-2026-07-13.md) — a related "security controls compose" lesson; there a deny broke delivery, here the posture choice bounds it.
+- [A same-job phase split is not a security boundary](same-job-phase-split-not-a-security-boundary-2026-07-04.md) — where the real trust boundary for model-influenced work lives.
+- [Reconstructing from git diff drops untracked files](../logic-errors/untracked-files-dropped-by-git-diff-reconstruction-2026-07-30.md) — the net-diff source this allowlist gates.
+- Shipped with brokered push for trusted mention runs (#1297 / PR #1304).

--- a/docs/solutions/logic-errors/toctou-file-read-race-in-net-diff-reconstruction-2026-07-30.md
+++ b/docs/solutions/logic-errors/toctou-file-read-race-in-net-diff-reconstruction-2026-07-30.md
@@ -1,0 +1,78 @@
+---
+title: An lstat-then-readFile guard is a TOCTOU file-system race; use an O_NOFOLLOW handle
+date: 2026-07-30
+category: logic-errors
+module: delegated
+problem_type: logic_error
+component: service_object
+symptoms:
+  - "CodeQL js/file-system-race (high) on a file read that follows a stat-based guard"
+  - "A symlink swapped in after the guard but before the read would be followed"
+root_cause: async_timing
+resolution_type: code_fix
+severity: high
+tags:
+  - toctou
+  - filesystem
+  - symlink
+  - o-nofollow
+  - codeql
+  - secure-read
+---
+
+# An lstat-then-readFile guard is a TOCTOU file-system race; use an O_NOFOLLOW handle
+
+## Problem
+
+Reconstructing a change set from the workspace read each file with a `lstat` guard (reject symlinks / non-regular / executable) followed by a path-based `readFile`. The two operations resolve the path independently, so anything swapped in between the check and the read is acted on — a classic time-of-check-to-time-of-use race. CodeQL flagged it as `js/file-system-race` (high).
+
+## Symptoms
+
+- CodeQL alert `js/file-system-race` (high) at the read site in `src/features/delegated/reconstruct-changes.ts`.
+- The check (`lstat`) and the use (`readFile`) each re-resolve the path; a symlink planted between them is followed, defeating the symlink rejection.
+
+## What Didn't Work
+
+The `lstat`-then-`readFile` guard looked correct because it rejected symlinks — but the rejection is evaluated against a _different_ filesystem lookup than the read. Adding more checks before the read does not close the window; every path-based check-then-use pair reopens it.
+
+## Solution
+
+Open the file once with `O_NOFOLLOW`, then `stat` and read from that same handle, closing it in `finally`:
+
+```ts
+// Before — check and use resolve the path independently (racy)
+const stats = await fs.lstat(filePath)
+if (stats.isSymbolicLink() || stats.isFile() === false) throw new Error(...)
+const content = await fs.readFile(filePath)
+
+// After — one handle; O_NOFOLLOW rejects a symlink at open time
+let handle: fs.FileHandle
+try {
+  handle = await fs.open(filePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW)
+} catch {
+  throw new Error(`${relativePath}: only regular files may be reconstructed`)
+}
+try {
+  const stats = await handle.stat()
+  if (stats.isFile() === false || isExecutable) throw new Error(...)
+  const content = await handle.readFile()
+  // …decode…
+} finally {
+  await handle.close()
+}
+```
+
+## Why This Works
+
+`O_NOFOLLOW` makes `open` fail if the final path component is a symlink, so a symlink swap is rejected at open time rather than checked and then re-followed. Once the handle is open it refers to a specific inode; `handle.stat()` and `handle.readFile()` both operate on that inode, so there is no second path resolution to race against. The `finally` close releases the descriptor on every path, including the size/exec-bit rejections.
+
+## Prevention
+
+- For any security-relevant file read, prefer a single `open` + handle-based `stat`/`read` over a path-based check followed by a path-based read.
+- Treat `lstat`/`stat` followed by a path-based `readFile`/`writeFile` as a TOCTOU smell in review, especially where the path is attacker- or model-influenceable.
+- Pin the behavior with a test that a symlink at the path fails `open` (rejected as "only regular files may be reconstructed"), and that oversized/exec files are rejected from the handle stat before `readFile` is ever called.
+
+## Related Issues
+
+- [Reconstructing from git diff silently drops untracked files](untracked-files-dropped-by-git-diff-reconstruction-2026-07-30.md) — the sibling reconstruction bug found in the same review.
+- Introduced and fixed while shipping brokered push for trusted mention runs (#1297 / PR #1304); the race was caught by CodeQL alert #69 before merge.

--- a/docs/solutions/logic-errors/untracked-files-dropped-by-git-diff-reconstruction-2026-07-30.md
+++ b/docs/solutions/logic-errors/untracked-files-dropped-by-git-diff-reconstruction-2026-07-30.md
@@ -1,0 +1,67 @@
+---
+title: Reconstructing a change set from git diff silently drops untracked files
+date: 2026-07-30
+category: logic-errors
+module: delegated
+problem_type: logic_error
+component: service_object
+symptoms:
+  - "A newly created (untracked) file in an allowed path is missing from the reconstructed change set"
+  - "The run reports nothing-to-deliver / success even though the model created a file"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+tags:
+  - git-diff
+  - untracked-files
+  - change-reconstruction
+  - ls-files
+  - net-diff
+---
+
+# Reconstructing a change set from git diff silently drops untracked files
+
+## Problem
+
+Reconstructing the model's changes as the net difference of the workspace against a trusted base commit used `git diff <sha>` alone. `git diff` reports only _tracked_ changes, so a file the model newly created (untracked) never appeared in the reconstructed set — it silently vanished, and the run reported "nothing to deliver" or succeeded while dropping real work.
+
+## Symptoms
+
+- A model-created new file under an allowed path is absent from the reconstructed `FileChange[]`.
+- The delivery path reports nothing-to-deliver / green even though the workspace clearly changed.
+- Modified tracked files come through fine; only brand-new files are missing — the tell that the diff, not the logic, is the boundary.
+
+## What Didn't Work
+
+Relying on `git diff <sha>` as the single source of "what changed." It is correct for tracked modifications and deletions but is silent on untracked files by design — there is no flag on `git diff` that makes a never-added file appear.
+
+## Solution
+
+Union the diff result with an explicit untracked-file listing, using the same neutralized git environment:
+
+```ts
+const untracked = await execAdapter.getExecOutput(
+  "git",
+  ["--no-pager", "-c", "core.quotepath=false", "ls-files", "--others", "--exclude-standard", "-z", "--"],
+  {cwd: repoRoot, env: GIT_ENV, ignoreReturnCode: true, silent: true},
+)
+// merge untracked paths (added) with the tracked add/modify/delete set from `git diff`
+```
+
+`git ls-files --others --exclude-standard` lists workspace files git is not tracking, excluding `.gitignore`d paths — exactly the newly created files `git diff` omits. Each is treated as an addition and run through the same path/type/size validation as diffed files.
+
+## Why This Works
+
+`git diff` and `git ls-files --others` cover disjoint halves of "what's different from the base": diff owns tracked modifications/deletions, `ls-files --others` owns brand-new untracked files. Only their union is the true net change set. `--exclude-standard` keeps ignored scratch/build files out, so the union stays scoped to intentional content.
+
+## Prevention
+
+- Any "reconstruct changes from a diff" path must make an explicit, documented decision about tracked-only vs tracked+untracked, and test a brand-new file end to end — not just a modified one.
+- When a feature's correctness depends on capturing _all_ workspace changes, treat `git diff` as necessary-but-insufficient and pair it with `ls-files --others --exclude-standard`.
+- Keep a regression test asserting a freshly created allowed-path file survives reconstruction and reaches delivery.
+
+## Related Issues
+
+- [An lstat-then-readFile guard is a TOCTOU race](toctou-file-read-race-in-net-diff-reconstruction-2026-07-30.md) — the sibling reconstruction hardening from the same review.
+- [Net-diff delivery needs an allowlist, not a denylist](../best-practices/net-diff-delivery-needs-an-allowlist-not-a-denylist-2026-07-30.md) — the surface this reconstruction feeds.
+- Found and fixed during brokered push for trusted mention runs (#1297 / PR #1304).


### PR DESCRIPTION
## Summary

Captures the durable learnings from the brokered-push feature (#1297, PR #1304) as four `docs/solutions/` entries.

- **TOCTOU file read** (`logic-errors/`): an `lstat`-then-`readFile` guard is a file-system race; open with `O_NOFOLLOW` and stat/read from the same handle. (Caught by CodeQL before merge.)
- **Untracked files dropped** (`logic-errors/`): `git diff <sha>` omits newly created files; union with `git ls-files --others --exclude-standard`.
- **Allowlist over denylist** (`best-practices/`): when a mechanism can push any tracked change, a denylist can't enumerate every execution surface — allow product/docs/test paths and deny the rest.
- **Credential-gated surface = event intersection** (`best-practices/`): the eligible surface is the intersection of credential-withheld events and resource-bearing events, each verified against source — here, only `issue_comment` on a PR.

Each cross-links the adjacent existing learnings.
