### PR TITLE
docs(solutions): #1311/#1314 learnings — review-model diagnostic, session archive v1/v2, resolver ordering, overflow recovery

### DIFF
--- a/docs/solutions/best-practices/overflow-recovery-architecture-2026-08-03.md
+++ b/docs/solutions/best-practices/overflow-recovery-architecture-2026-08-03.md
@@ -1,0 +1,88 @@
+---
+title: Recover a persistent agent session from context overflow without breaking continuity
+date: 2026-08-03
+category: best-practices
+module: agent-execution
+problem_type: architecture_pattern
+component: development_workflow
+applies_when:
+  - "Recovering a long-lived persistent agent session from ContextOverflowError"
+  - "Session continuity across runs is a core product value that recovery must preserve"
+  - "Recovery needs one bounded restart with a shared deadline across attempts"
+tags:
+  - context-overflow
+  - session-recovery
+  - session-continuity
+  - phase-layer
+  - execution-deadline
+  - bounded-restart
+---
+
+# Recover a persistent agent session from context overflow without breaking continuity
+
+## Context
+
+A persistent, long-lived agent session (continued across CI runs by a stable logical key) can accumulate enough transcript to exceed the model context window and emit `ContextOverflowError`. If that terminally fails a required check, the run wedges and re-running just re-continues the same overflowed session. The fix must make overflow **recoverable** without discarding the persistent continuity that is the product's core value.
+
+## Guidance
+
+- **A fresh session drops the bloated transcript by construction — that is the primary size reduction.** Restarting on a new session (not continuing the overflowed one) is what actually escapes the overflow. Bounded prior-work recall (excluding the archived session from search and capping the result count) is **defense-in-depth**, not the primary mechanism.
+- **Orchestrate recovery at the phase layer, not inside the single-attempt executor.** Only the phase layer (`runExecute`) holds the session-prep, client, logical key, and workspace needed to rebuild the bounded prior-work search _excluding the just-archived session_. Keep the executor (`executeOpenCode`) as "run one attempt under a deadline." Pushing recovery down into the executor forces a downward layering leak and makes the exclusion impossible.
+- **Share one absolute deadline across both attempts.** The executor mints its own deadline from `config.timeoutMs`, so a naive second call would grant a fresh full budget. Thread the _remaining_ budget (`timeoutMs − elapsed`) into the recovery attempt; if it is `<= 0`, do not restart.
+- **Bound to exactly one restart; next-run recovery is the floor.** If the fresh session also overflows, archive it too and fail cleanly — no loop. Because the overflowed session is archived, the next run starts fresh regardless.
+- **Never key the session on head SHA just to bound growth.** Fragmenting the continuity key (`pr:<number>:<sha>`) would discard the persistent memory on every push — the antithesis of a persistent-session product. Bound growth via recovery/compaction, not by fragmenting the identity key.
+- **Archive before the fresh attempt, and preserve the audit trail.** Archiving (not deleting) keeps the overflowed session inspectable while making it ineligible for continuation. Archiving before the restart guarantees a crash mid-recovery cannot re-wedge the next run on the known-overflowed session.
+
+## Why This Matters
+
+Overflow is otherwise terminal _and self-perpetuating_: the same stable key re-continues the same overflowed session every run. Recovery at the wrong layer either cannot exclude the archived session (re-ingesting the overflow) or silently doubles the execution budget. Getting the layer, the deadline threading, and the transcript-drop-vs-recall roles right is what makes recovery both correct and bounded — while the persistent continuity that justifies the whole architecture stays intact.
+
+## When to Apply
+
+- Recovering long-lived persistent agent sessions from context or resource exhaustion where continuity across runs must be preserved.
+- Any recovery-restart pattern where a second attempt shares a bounded resource (deadline, budget) with the first.
+
+## Examples
+
+Phase-layer gate (only on overflow, only when nothing was delivered):
+
+```ts
+if (result.llmError?.type === "context_overflow" && result.commentsPosted === 0 && sessionId != null) {
+  result = await recoverFromContextOverflow({
+    overflowedResult: result,
+    overflowedSessionId: sessionId,
+    // plus the phase-layer context needed to start a fresh attempt
+  })
+}
+```
+
+Inside the recovery helper — archive, bounded exclusion, shared deadline:
+
+```ts
+const archiveSucceeded = await archiveSession(cacheRestore.serverHandle.server.url, overflowedSessionId, execLogger)
+if (archiveSucceeded === false) {
+  execLogger.warning("Overflowed session archive failed; next run may re-continue it", {sessionId: overflowedSessionId})
+}
+
+// Defense-in-depth: exclude the archived session from prior-work recall.
+const recoveryPriorWorkContext = await searchSessions(
+  recoverySearchQuery,
+  cacheRestore.serverHandle.client,
+  sessionPrep.normalizedWorkspace,
+  {limit: 5, excludeSessionIds: [overflowedSessionId]},
+  execLogger,
+)
+
+// Shared absolute deadline: remaining budget, not a fresh one.
+const remainingMs = bootstrap.inputs.timeoutMs - (Date.now() - executionStartTime)
+if (remainingMs <= 0) return overflowedResult // no restart
+
+const recoveryExecutionConfig = {...executionConfig, continueSessionId: undefined, timeoutMs: remainingMs}
+```
+
+## Related
+
+- [Terminal outcomes must survive deadline cleanup](../logic-errors/terminal-outcomes-must-survive-deadline-cleanup-2026-07-24.md) — sibling on execution-deadline authority; recovery must not let a restart rewrite an already-accepted outcome or double the budget.
+- [Filter archived/compacting sessions before title match](../logic-errors/resolver-eligibility-ordering-2026-08-03.md) — the resolver fix that makes "the fresh recovered session is what the next run continues" actually hold.
+- [OpenCode SDK v1 can read but not typed-write session.time.archived](../logic-errors/archive-v1-read-v2-write-asymmetry-2026-08-03.md) — how the archive primitive used here is implemented.
+- fro-bot/agent#1311 / PR #1313.

--- a/docs/solutions/integration-issues/review-model-outage-diagnostic-2026-08-03.md
+++ b/docs/solutions/integration-issues/review-model-outage-diagnostic-2026-08-03.md
@@ -1,0 +1,97 @@
+---
+title: Diagnosing a Fro Bot review-model outage (APIError 400 in the required check)
+date: 2026-08-03
+category: integration-issues
+module: agent-execution
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - "Test GitHub Action (the Fro Bot review job) failed with Session error: name=APIError; status=400"
+  - "Failure occurred ~1s after session start, through the generic grace-period path (graceCycles=3)"
+  - "No review verdict was produced; the required check hard-failed and wedged merge"
+  - "Re-running reproduced the identical error on the same session id"
+root_cause: config_error
+resolution_type: config_change
+severity: high
+tags:
+  - review-model
+  - anthropic
+  - clear-thinking
+  - opencode-log
+  - cliproxy
+  - session-error
+  - timeout
+---
+
+# Diagnosing a Fro Bot review-model outage (APIError 400 in the required check)
+
+## Problem
+
+The required `Test GitHub Action` check (the Fro Bot PR-review job) failed ~1 second into execution with a generic `Session error: name=APIError; status=400` and produced no verdict, blocking merge on every human-authored PR. The generic action-level error hid a provider-side model-config failure, and the diagnostic instinct to "re-run the flake" was wrong.
+
+## Symptoms
+
+- The review job fails through the generic session-error grace path (`graceCycles=3`), not a distinct error kind.
+- The only action-visible detail is `name=APIError; status=400`.
+- Re-running reproduces the **identical** error — same message, same session id — minutes apart.
+- Every other CI check is green; CodeQL clean.
+- Bot/renovate PRs merge fine (they are review-exempt).
+
+## What Didn't Work
+
+- **Re-running as a transient flake.** A flake does not reproduce identically minutes later; identical reproduction (same session id, same error) means a systematic/deterministic cause, not a flake.
+- **Blaming the PR's own diff.** Every non-review check passed, and the failing model call is upstream of any repo code — the diff was not the cause.
+- **Reading only the GitHub Action failure surface.** The action collapses the provider stream error into a generic `APIError; status=400`; the real cause is not visible there.
+
+## Solution
+
+Pull the run's `opencode.log` artifact — the provider-specific error lives only there:
+
+```bash
+gh run download <run-id> -n opencode-logs-<run-id>-<N>   # artifact name is run-suffixed
+```
+
+For this outage the log revealed:
+
+```
+AI_APICallError: `clear_thinking_20251015` strategy requires `thinking` to be enabled or adaptive
+providerID=anthropic modelID=claude-opus-4-8
+```
+
+Then prove whether it is model-specific with a benign model-override dispatch (the review path is reachable via `fro-bot.yaml`'s `model` input, which overrides `vars.FRO_BOT_MODEL`):
+
+```bash
+gh workflow run fro-bot.yaml --ref main \
+  -f model='anthropic/claude-sonnet-5' \
+  -f prompt='Model connectivity check only. Reply with one line. Take no actions.'
+```
+
+Then download that run's `opencode.log` (as above) and check whether the `clear_thinking` error is present.
+
+Three-model result (identical benign prompt, through cliproxy):
+
+| Model                         | Result                           |
+| ----------------------------- | -------------------------------- |
+| `anthropic/claude-opus-4-8`   | ❌ `clear_thinking_20251015` 400 |
+| `anthropic/claude-sonnet-4-6` | ❌ `clear_thinking_20251015` 400 |
+| `anthropic/claude-sonnet-5`   | ✅ clean, 0 errors               |
+
+**Interim fix (ops):** set the `FRO_BOT_MODEL` repository variable to `anthropic/claude-sonnet-5`, then re-run the failed `Test GitHub Action` check. **Root fix** is proxy-side and lives in a separate repo (see Related Issues) — the model swap is a stopgap, not the fix.
+
+## Why This Works
+
+The `clear_thinking_20251015` context-management strategy is applied on the **cliproxy / model-catalog** request path, not by fro-bot/agent or the bundled OpenCode harness. Verified against OpenCode's own source: it never sets Anthropic `contextManagement`/`clear_thinking` (it only gates such a strategy for Z.ai/ZhipuAI over openai-compatible) and is otherwise pass-through, reading `providerOptions.anthropic.thinking` only if already present. Model options come from the models.dev catalog plus provider config. So the strategy is injected proxy-side, and older Anthropic models trip the provider's "requires `thinking` enabled or adaptive" enforcement while thinking is off. `claude-sonnet-5` is not affected.
+
+## Prevention
+
+- **On a review-job session failure, download `opencode.log` first.** The action surface only shows `APIError; status=<code>`; the provider stream error (the real cause) is in the log artifact.
+- **Identical reproduction = systematic, not flake.** Do not burn re-runs on a deterministic error; the same session id + same error across attempts is the tell.
+- **Bot/renovate PRs mask review-model outages.** They are review-exempt, so the review model can be broken for days while bot PRs merge cleanly — the first _human_ PR after a provider/model/proxy change is the real detector. Treat a review-model change as needing a human-PR (or dispatched-canary) check.
+- **A model swap is a workaround; the provider/proxy config is the fix.** When the injection point is the proxy/model catalog, file the fix against the infra repo that owns it (cross-repo split) and keep the agent-side impact issue open until the proxy fix lands.
+- **Use the `fro-bot.yaml` `model` dispatch input as a canary** to test a specific model through cliproxy without changing the repo default.
+
+## Related Issues
+
+- fro-bot/agent#1314 — agent-side impact record (reopened; tracks the outage until the proxy fix lands).
+- marcusrbrown/infra#1036 — the actual fix owner (CLIProxy applies `clear_thinking` with thinking disabled).
+- Related but distinct: [Fail fast on structured provider authentication failures](provider-auth-failure-hangs-to-timeout-2026-07-25.md) — that doc classifies provider-auth errors as terminal in-code; this doc is the diagnostic runbook for a review-model config outage.

--- a/docs/solutions/logic-errors/archive-v1-read-v2-write-asymmetry-2026-08-03.md
+++ b/docs/solutions/logic-errors/archive-v1-read-v2-write-asymmetry-2026-08-03.md
@@ -1,0 +1,98 @@
+---
+title: OpenCode SDK v1 can read but not typed-write session.time.archived (use v2 client)
+date: 2026-08-03
+category: logic-errors
+module: agent-execution
+problem_type: logic_error
+component: service_object
+symptoms:
+  - "Reading session.time.archived compiled fine on the v1 SDK client"
+  - "Writing time.archived via v1 session.update failed typecheck (body typed {title?})"
+  - "The archive flow appeared to require an `as unknown as` cast"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: medium
+tags:
+  - session-archive
+  - opencode-sdk
+  - sdk-v1
+  - sdk-v2
+  - time-archived
+  - type-safety
+---
+
+# OpenCode SDK v1 can read but not typed-write session.time.archived (use v2 client)
+
+## Problem
+
+To archive an OpenCode session (set `time.archived` so it is skipped for continuation), the v1 `@opencode-ai/sdk` client can **read** `time.archived` (the `Session` type carries it) but **cannot** typed-write it — the v1 `session.update` body is typed `{title?}` only. The archive path looked like it needed a type cast; it did not.
+
+## Symptoms
+
+- `check-types` fails on the write: `Object literal may only specify known properties, and 'time' does not exist in type '{ title?: string | undefined; }'`.
+- The read side (`resolveSessionForLogicalKey` reading `session.time.archived`) compiles and works.
+- A cast makes the error disappear but hides whether the request shape is even correct.
+
+## What Didn't Work
+
+```ts
+// Bad: an `as unknown as` double-cast to silence the type system.
+// Violates the project's no-type-suppression rule AND hides a genuinely
+// wrong request shape (the v1 body cannot express time.archived at all).
+const update = client.session.update.bind(client.session) as unknown as (options: {
+  path: {id: string}
+  body: {time: {archived: number}}
+}) => Promise<{error?: unknown}>
+```
+
+## Solution
+
+The **v2** SDK client (`@opencode-ai/sdk/v2/client`) types the field. Its `session.update` is a flat shape (`{sessionID, time:{archived}}`), distinct from v1's `{path, body}`. Build a v2 client from the server loopback URL and write through it — fully typed, no suppression:
+
+```ts
+import type {Logger} from "../shared/logger.js"
+
+// The v1 session client can READ time.archived but its typed session.update
+// body only exposes {title?} — it cannot write time.archived. The v2 client
+// is the typed write path; do not "simplify" this back to the v1 client.
+import {createOpencodeClient} from "@opencode-ai/sdk/v2/client"
+
+export async function archiveSession(baseUrl: string, sessionId: string, logger: Logger): Promise<boolean> {
+  try {
+    const client = createOpencodeClient({baseUrl})
+    const response = await client.session.update({
+      sessionID: sessionId,
+      time: {archived: Date.now()},
+    })
+    if (response.error != null) {
+      logger.warning("SDK session archive failed", {sessionId, error: String(response.error)})
+      return false
+    }
+    logger.debug("Archived session via SDK", {sessionId})
+    return true
+  } catch (error: unknown) {
+    logger.warning("SDK session archive failed", {
+      sessionId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return false
+  }
+}
+```
+
+The caller passes the server's loopback URL (`serverHandle.server.url`) as `baseUrl`.
+
+## Why This Works
+
+The v1 and v2 SDK surfaces are genuinely different APIs. The write field (`time.archived`) exists on the v2 `SessionUpdateData` body but not on v1's. Constructing a per-call v2 client from the loopback baseURL is an established repo pattern (session tools do the same). Reading `time.archived` continues to work through the v1 client because the `Session` **read** type carries it — the asymmetry is read-anywhere / write-v2-only.
+
+## Prevention
+
+- When a typed SDK write appears to "need" a cast, first check whether a **v2 / alternate client subpath** types the field. A cast that hides a wrong request shape is worse than a compile error.
+- Keep an explanatory comment at the v2 import (as above) so a future maintainer does not "simplify" the archive back to the v1 client and silently break the write.
+- Never reach for `as unknown as` to satisfy a request-body type — it is type suppression by another name and is forbidden project-wide.
+
+## Related Issues
+
+- fro-bot/agent#1311 / PR #1313 — the overflow-recovery work that needed a session-archive primitive.
+- See also: [Overflow-recovery architecture](../best-practices/overflow-recovery-architecture-2026-08-03.md) — where `archiveSession` is used.

--- a/docs/solutions/logic-errors/resolver-eligibility-ordering-2026-08-03.md
+++ b/docs/solutions/logic-errors/resolver-eligibility-ordering-2026-08-03.md
@@ -1,0 +1,79 @@
+---
+title: Filter archived/compacting sessions before title match, not after
+date: 2026-08-03
+category: logic-errors
+module: agent-execution
+problem_type: logic_error
+component: service_object
+symptoms:
+  - "resolveSessionForLogicalKey returned not-found even though a fresh eligible session existed"
+  - "A newer archived same-title session masked an older eligible one"
+  - "Session continuity could be silently lost after archiving"
+root_cause: scope_issue
+resolution_type: code_fix
+severity: high
+tags:
+  - session-continuity
+  - logical-key
+  - archived-session
+  - eligibility-ordering
+  - resolver
+---
+
+# Filter archived/compacting sessions before title match, not after
+
+## Problem
+
+`resolveSessionForLogicalKey` selected the newest same-title session first (`findSessionByTitle`, ranked by `time.updated`) and only _then_ rejected it if it was archived or compacting. Because archiving bumps `time.updated`, a freshly archived session could win the title match and shadow an eligible non-archived session with the same title — causing a false `not-found` and silently losing session continuity.
+
+## Symptoms
+
+- Two workspace sessions share a title; the archived one has the newer `time.updated`.
+- `resolveSessionForLogicalKey` returns `not-found` instead of the eligible non-archived session.
+- Continuity is lost: the next run starts cold even though a valid continuable session exists.
+
+## What Didn't Work
+
+Ranking by title first, then filtering eligibility:
+
+```ts
+// Bug: newest-by-title chosen first; archived winner then rejected as not-found,
+// never falling back to the eligible older same-title session.
+const matchedSession = findSessionByTitle(matchingWorkspaceSessions, title)
+if (matchedSession != null && (matchedSession.time.archived != null || matchedSession.time.compacting != null)) {
+  return {status: "not-found"}
+}
+```
+
+## Solution
+
+Filter archived/compacting out of the candidate set **before** ranking by title, so the newest _eligible_ same-title session wins:
+
+```ts
+const eligibleWorkspaceSessions = matchingWorkspaceSessions.filter(
+  session => session.time.archived == null && session.time.compacting == null,
+)
+const matchedSession = findSessionByTitle(eligibleWorkspaceSessions, title)
+```
+
+Apply the same eligibility filter on any sibling resolution path (e.g. the stale-directory fallback) that also ranks by title.
+
+## Why This Works
+
+Archiving a session updates its `time.updated`, so "most recently updated" is exactly the wrong selection criterion when eligibility is checked afterward — the archived session is guaranteed to look newest. Filtering eligibility first makes the ranking operate only over sessions that can actually be continued.
+
+## Prevention
+
+Regression test that fails before the fix and passes after:
+
+- Create two same-title workspace sessions.
+- Give the **archived** one the **newer** `time.updated`.
+- Assert `resolveSessionForLogicalKey` returns the **non-archived** session (`status: 'found'`), not `not-found`.
+- Keep the existing case: when the _only_ same-title session is archived, still return `not-found`.
+
+General rule: when a lookup both **ranks** and **filters for eligibility**, filter first — otherwise an ineligible top-ranked item can mask an eligible one instead of falling through to it.
+
+## Related Issues
+
+- fro-bot/agent#1311 / PR #1313 — a latent bug the overflow-recovery path would have exposed (the fresh recovered session shares the archived session's title).
+- See also: [Overflow-recovery architecture](../best-practices/overflow-recovery-architecture-2026-08-03.md).


### PR DESCRIPTION
## Summary

Captures the reusable learnings from the #1311 overflow-recovery work (PR #1313) and the review-model outage diagnosed alongside it (#1314 → marcusrbrown/infra#1036), as four `docs/solutions/` entries.

## Docs

- **integration-issues/review-model-outage-diagnostic** — how to diagnose a Fro Bot review-model outage: the required check fails with a generic `APIError; status=400`, but the real provider error (`clear_thinking_20251015 strategy requires thinking to be enabled or adaptive`) lives only in the run's `opencode.log` artifact. Includes the 3-model dispatch canary, the "identical reproduction = systematic not flake" tell, and the fact that review-exempt bot PRs mask these outages.
- **logic-errors/archive-v1-read-v2-write-asymmetry** — the OpenCode v1 SDK client can read `session.time.archived` but its typed `session.update` body only exposes `{title?}`; the v2 client (`@opencode-ai/sdk/v2/client`) is the typed write path. Avoids the `as unknown as` cast the wrong instinct reaches for.
- **logic-errors/resolver-eligibility-ordering** — filter archived/compacting sessions *before* the title match in `resolveSessionForLogicalKey`, not after; archiving bumps `time.updated`, so a newer archived session can otherwise mask an eligible fresh one and silently lose continuity.
- **best-practices/overflow-recovery-architecture** — recovering a persistent agent session from `ContextOverflowError` without breaking continuity: fresh-session transcript-drop as the primary size reduction (bounded recall is defense-in-depth), recovery orchestration at the phase layer, one absolute deadline across both attempts, bounded single restart, and why you must never key the session on head SHA to bound growth.

All four cross-link their siblings (and the existing deadline-cleanup / provider-auth docs). Reviewed for TypeScript accuracy against the shipped source (zero findings) and simplified per a code-simplicity pass.
