### PR TITLE
docs(solutions): normalize module frontmatter taxonomy

### DIFF
--- a/docs/solutions/best-practices/architectural-issues-type-safety-and-resource-cleanup.md
+++ b/docs/solutions/best-practices/architectural-issues-type-safety-and-resource-cleanup.md
@@ -2,7 +2,7 @@
 title: "OpenCode SDK Session Backend: Architectural Issues in Type Safety and Resource Cleanup"
 date: 2026-02-16
 category: best-practices
-module: packages/runtime/src/session
+module: runtime
 problem_type: best_practice
 component: assistant
 severity: high

--- a/docs/solutions/best-practices/broadcast-notifications-when-operator-identity-is-absent-2026-07-10.md
+++ b/docs/solutions/best-practices/broadcast-notifications-when-operator-identity-is-absent-2026-07-10.md
@@ -2,7 +2,7 @@
 title: 'Broadcast repo-neutral notifications to all subscribers when no per-request identity exists at the event seam'
 date: 2026-07-10
 category: best-practices
-module: packages/gateway
+module: gateway
 problem_type: architecture_pattern
 component: assistant
 severity: low

--- a/docs/solutions/best-practices/credential-gated-surface-is-event-intersection-2026-07-30.md
+++ b/docs/solutions/best-practices/credential-gated-surface-is-event-intersection-2026-07-30.md
@@ -2,7 +2,7 @@
 title: A credential-gated action's eligible surface is the intersection of credential-withheld events and resource-bearing events
 date: 2026-07-30
 category: best-practices
-module: runtime-response-delivery
+module: runtime
 problem_type: best_practice
 component: authentication
 severity: medium

--- a/docs/solutions/best-practices/cross-libc-build-and-release-safety-2026-06-14.md
+++ b/docs/solutions/best-practices/cross-libc-build-and-release-safety-2026-06-14.md
@@ -1,5 +1,5 @@
 ---
-module: "harness/release pipeline"
+module: harness/release-pipeline
 date: 2026-06-14
 category: best-practices
 problem_type: best_practice

--- a/docs/solutions/best-practices/gateway-control-surface-spine-2026-06-15.md
+++ b/docs/solutions/best-practices/gateway-control-surface-spine-2026-06-15.md
@@ -1,5 +1,5 @@
 ---
-module: gateway control-surface spine
+module: gateway
 date: 2026-06-15
 category: best-practices
 problem_type: architecture_pattern

--- a/docs/solutions/best-practices/options-object-for-shared-signature-extension-2026-07-03.md
+++ b/docs/solutions/best-practices/options-object-for-shared-signature-extension-2026-07-03.md
@@ -2,7 +2,7 @@
 title: Extend a shared function via an options object, not a positional optional, to survive cross-branch merges
 date: 2026-07-03
 category: best-practices
-module: runtime/coordination
+module: runtime
 problem_type: best_practice
 component: assistant
 severity: medium

--- a/docs/solutions/best-practices/same-job-phase-split-not-a-security-boundary-2026-07-04.md
+++ b/docs/solutions/best-practices/same-job-phase-split-not-a-security-boundary-2026-07-04.md
@@ -3,7 +3,7 @@ title: Sequential steps in one GitHub Actions job are not a security boundary
 date: 2026-07-04
 last_updated: 2026-07-12
 category: best-practices
-module: ci security
+module: ci-security
 problem_type: best_practice
 component: development_workflow
 severity: high

--- a/docs/solutions/best-practices/signed-webhook-ingress-hardening-2026-05-29.md
+++ b/docs/solutions/best-practices/signed-webhook-ingress-hardening-2026-05-29.md
@@ -2,7 +2,7 @@
 title: Signed webhook ingress hardening
 date: 2026-05-29
 category: best-practices
-module: packages/gateway/src/http
+module: gateway
 problem_type: best_practice
 component: authentication
 severity: high

--- a/docs/solutions/build-errors/gateway-docker-runtime-resolution-crash-loop-2026-05-31.md
+++ b/docs/solutions/build-errors/gateway-docker-runtime-resolution-crash-loop-2026-05-31.md
@@ -2,7 +2,7 @@
 title: Gateway Docker image crash-loop — workspace runtime externalized but not shipped
 date: 2026-05-31
 category: build-errors
-module: packages/gateway
+module: gateway
 problem_type: build_error
 component: tooling
 severity: high

--- a/docs/solutions/logic-errors/abortsignal-any-reason-classification-race-2026-07-03.md
+++ b/docs/solutions/logic-errors/abortsignal-any-reason-classification-race-2026-07-03.md
@@ -2,7 +2,7 @@
 title: Classifying an abort by AbortSignal.any's composite reason is racy — use a side-channel
 date: 2026-07-03
 category: logic-errors
-module: gateway/execute
+module: gateway
 problem_type: logic_error
 component: assistant
 symptoms:

--- a/docs/solutions/logic-errors/node-24-happy-eyeballs-breaks-custom-dns-lookup-ssrf-guard-2026-07-10.md
+++ b/docs/solutions/logic-errors/node-24-happy-eyeballs-breaks-custom-dns-lookup-ssrf-guard-2026-07-10.md
@@ -2,7 +2,7 @@
 title: 'Node 24 Happy Eyeballs (autoSelectFamily) breaks a custom-DNS-lookup SSRF guard'
 date: 2026-07-10
 category: logic-errors
-module: packages/gateway
+module: gateway
 problem_type: logic_error
 component: service_object
 severity: high

--- a/docs/solutions/logic-errors/terminal-outcomes-must-survive-deadline-cleanup-2026-07-24.md
+++ b/docs/solutions/logic-errors/terminal-outcomes-must-survive-deadline-cleanup-2026-07-24.md
@@ -2,7 +2,7 @@
 title: Terminal outcomes must survive deadline cleanup
 date: 2026-07-24
 category: logic-errors
-module: action/agent-execution
+module: agent-execution
 problem_type: logic_error
 component: assistant
 symptoms:

--- a/docs/solutions/logic-errors/thread-id-persistence-gap-in-run-state-2026-07-03.md
+++ b/docs/solutions/logic-errors/thread-id-persistence-gap-in-run-state-2026-07-03.md
@@ -2,7 +2,7 @@
 title: A coordination field written empty at creation and never updated silently breaks every reader
 date: 2026-07-03
 category: logic-errors
-module: gateway/coordination
+module: gateway
 problem_type: logic_error
 component: assistant
 symptoms:

--- a/docs/solutions/workflow-issues/create-github-app-token-caller-mint-invalid-2026-07-04.md
+++ b/docs/solutions/workflow-issues/create-github-app-token-caller-mint-invalid-2026-07-04.md
@@ -3,7 +3,7 @@ title: You cannot caller-mint a GitHub App token and pass it into a reusable wor
 date: 2026-07-04
 last_updated: 2026-07-12
 category: workflow-issues
-module: harness/release pipeline
+module: harness/release-pipeline
 problem_type: workflow_issue
 component: development_workflow
 severity: high

--- a/docs/solutions/workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md
+++ b/docs/solutions/workflow-issues/isolate-ci-credential-via-oidc-broker-2026-07-01.md
@@ -3,7 +3,7 @@ title: Isolate a CI credential from an autonomous agent via an OIDC broker
 date: 2026-07-01
 last_updated: 2026-07-12
 category: workflow-issues
-module: harness/release pipeline
+module: harness/release-pipeline
 problem_type: workflow_issue
 component: tooling
 severity: high

--- a/docs/solutions/workflow-issues/migrate-pnpm-to-bun-monorepo-2026-06-24.md
+++ b/docs/solutions/workflow-issues/migrate-pnpm-to-bun-monorepo-2026-06-24.md
@@ -2,7 +2,7 @@
 title: 'Migrating a pnpm workspace to Bun: diagnostics, spike-then-cutover, and the semantics that bite'
 date: 2026-06-24
 category: workflow-issues
-module: workspace tooling
+module: workspace-tooling
 problem_type: workflow_issue
 component: tooling
 severity: high

--- a/docs/solutions/workflow-issues/preview-dependency-release-recovery-requires-single-use-reruns-2026-07-30.md
+++ b/docs/solutions/workflow-issues/preview-dependency-release-recovery-requires-single-use-reruns-2026-07-30.md
@@ -2,7 +2,7 @@
 title: Preview-dependency release recovery requires provenance checks and single-use reruns
 date: "2026-07-30"
 category: workflow-issues
-module: "harness/release pipeline"
+module: harness/release-pipeline
 problem_type: workflow_issue
 component: development_workflow
 severity: medium

--- a/docs/solutions/workflow-issues/semantic-release-tag-namespace-collision-2026-06-14.md
+++ b/docs/solutions/workflow-issues/semantic-release-tag-namespace-collision-2026-06-14.md
@@ -1,6 +1,6 @@
 ---
 title: "Auxiliary v-Prefixed Tags Poison semantic-release Version Computation"
-module: "release-pipeline"
+module: harness/release-pipeline
 date: 2026-06-14
 category: workflow-issues
 problem_type: workflow_issue


### PR DESCRIPTION
## Summary

Normalizes the `module:` frontmatter taxonomy across `docs/solutions/`. The values had drifted into ~40 distinct forms mixing conceptual names, source-path fragments, and space-separated typos, which fragments search/aggregation (a review of the compound docs surfaced one such inconsistency; this is the corpus-wide cleanup).

Scope: Tier 1 (fix clearly-wrong values) + Tier 2 (collapse variant clusters to their dominant root). Deliberately does **not** attempt Tier 3 (purging every source-path value into a concept name or inventing hierarchies like `pr-review/*`) — that's a larger taxonomy-design decision left for a separate pass.

## Changes (18 files, `module:`-line only)

- `action/agent-execution` → `agent-execution` (6 docs already used the clean form)
- `packages/gateway`, `gateway/execute`, `gateway/coordination`, `packages/gateway/src/http`, `gateway control-surface spine` → `gateway` (now 17 docs aggregate cleanly)
- `runtime-response-delivery`, `runtime/coordination`, `packages/runtime/src/session` → `runtime`
- `harness/release pipeline`, `release-pipeline` → `harness/release-pipeline`
- `ci security` → `ci-security`, `workspace tooling` → `workspace-tooling` (space-separated → hyphenated)

Every changed line is a `module:` frontmatter value — no prose, no code, no other frontmatter touched (18 insertions / 18 deletions).
