### PR TITLE
ci(renovate): align security PR age gate with bunfig install gate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -224,4 +224,15 @@
     commands: ['bun install', 'bun run fix', 'bun run build'],
     executionMode: 'branch',
   },
+  vulnerabilityAlerts: {
+    // Security updates bypass minimumReleaseAge by default and open immediately.
+    // But bunfig.toml sets a hard 3-day install gate (minimumReleaseAge = 259200),
+    // so `bun install --frozen-lockfile` refuses to resolve any version younger
+    // than 3 days — a same-day [SECURITY] PR is guaranteed CI-red until the gate
+    // clears. Re-impose the matching 3-day age on the security path so these PRs
+    // open only once the fix is installable (green), not 3 days early as red noise.
+    // For a genuinely exploitable fix that must land sooner, use a deliberate
+    // per-incident bunfig minimumReleaseAgeExcludes bypass instead.
+    minimumReleaseAge: '3 days',
+  },
 }


### PR DESCRIPTION
## Summary

Aligns Renovate's security-PR age gate with the repository's bun install gate, so `[SECURITY]` update PRs open only once they can actually pass CI.

## The incoherence

Renovate's security path **bypasses `minimumReleaseAge` by default** — it opens a `[SECURITY]` PR the moment a fix is detected, and this setting is *not* inherited from the top-level/packageRules config. But `bunfig.toml` sets a hard 3-day install gate (`minimumReleaseAge = 259200`), so `bun install --frozen-lockfile` refuses to resolve any version younger than 3 days. The result: a same-day security PR is **guaranteed CI-red** (Setup + `renovate/artifacts` fail on the frozen install) until the plain 3-day gate clears — it can never pass in that window.

Observed on the open hono `[SECURITY]` PR (4.12.34, CVE-2026-69207 / GHSA-8j4g-w8fx-2239, MODERATE), which failed `Setup` with `No version matching "hono" found for specifier "4.12.34" (blocked by minimum-release-age: 259200 seconds)`.

## Fix

Add a `vulnerabilityAlerts.minimumReleaseAge: '3 days'` override, re-imposing an age delay on the security path that matches the bun install gate. Security PRs now open when the fix is **installable** (green), instead of sitting red for ~3 days. For a genuinely exploitable fix that must land sooner, the documented path is a deliberate per-incident `minimumReleaseAgeExcludes` bypass in `bunfig.toml` — not opening a red PR early.

Validated with the official `renovate-config-validator` (config validates successfully). Placed in this repo rather than the shared `fro-bot/.github` preset because the driver is this repo's bunfig install gate, which other preset consumers may not share.

Forward-looking: this does not retroactively unblock the already-open hono security PR (that clears its bun gate on its own schedule); it prevents the red-PR-noise pattern for future same-day security updates.
