### PR TITLE
fix(harness): strip workflow files from the integration commit

### DIFF
--- a/packages/harness/prompt.txt
+++ b/packages/harness/prompt.txt
@@ -45,6 +45,7 @@ git checkout -b {{branch}} refs/tags/{{tag}}
 
 ```bash
 git reset --soft {{tag}}
+git rm -r --cached --quiet --ignore-unmatch .github/workflows
 git commit -m "harness: integrate OpenCode {{version}} carrying {{branches}}"
 ```
 
@@ -52,6 +53,16 @@ git commit -m "harness: integrate OpenCode {{version}} carrying {{branches}}"
    only discards the intermediate merge commits, so this does not change any
    file content — it only flattens history. After this, {{branch}} has exactly
    one commit above {{tag}}, and `git diff {{tag}}..HEAD` shows all carries.
+
+   The `git rm --cached` line drops `.github/workflows/` from the integration
+   commit. It is required: the push in step 6 authenticates as a GitHub App,
+   and GitHub rejects any App push that creates or updates a workflow file
+   unless the token carries the `workflows` permission — which this job's token
+   deliberately does not. `--cached` removes the files from the commit only,
+   leaving them on disk so the step 4 build is unaffected; `--ignore-unmatch`
+   makes the command a no-op if upstream ever ships no workflows directory.
+   The integration ref is a throwaway build input — the release build consumes
+   the source tree to compile the CLI and never reads these files.
 
 4. Build the host CLI. Run from the repo root ({{repo}}) — build.ts does its own chdir into packages/opencode:
 

--- a/packages/harness/src/prompt-template.test.ts
+++ b/packages/harness/src/prompt-template.test.ts
@@ -62,6 +62,35 @@ describe('prompt.txt bash snippet syntax', () => {
     expect(allBlocks).toContain('refs/harness-integrate')
   })
 
+  it('strips .github/workflows from the integration commit before pushing', () => {
+    // #given
+    // The integration push authenticates as a GitHub App, and GitHub rejects any
+    // App push that creates or updates a workflow file without the `workflows`
+    // permission. Releases previously survived this only because the agent
+    // improvised a fix after the push was rejected; a run that declined to
+    // improvise failed the whole pipeline. Keep the removal explicit and pinned.
+    const allBlocks = bashBlocks.join('\n')
+
+    // #then
+    expect(allBlocks).toContain('.github/workflows')
+    expect(allBlocks).toMatch(/git rm -r --cached [^\n]*--ignore-unmatch [^\n]*\.github\/workflows/)
+  })
+
+  it('removes workflows from the index only, before the integration commit', () => {
+    // #given
+    const allBlocks = bashBlocks.join('\n')
+    const stripIndex = allBlocks.indexOf('.github/workflows')
+    const commitIndex = allBlocks.indexOf('git commit -m "harness: integrate OpenCode')
+
+    // #then
+    // `--cached` keeps the files on disk so the build step is unaffected.
+    expect(allBlocks).toContain('--cached')
+    // The strip must precede the single integration commit, or the commit still
+    // carries the workflow files and the push is rejected.
+    expect(stripIndex).toBeGreaterThan(-1)
+    expect(commitIndex).toBeGreaterThan(stripIndex)
+  })
+
   it.each(bashBlocks.map((block, i) => ({block, index: i})))(
     'bash block $index passes bash -n syntax check (stderr must be empty)',
     ({block}) => {


### PR DESCRIPTION
## Summary

The 1.18.14 harness release failed at the integrate step: the LLM merge succeeded (all 12 carries merged, 3 with conflict resolution), but the push to the throwaway integration ref was rejected:

```
! [remote rejected] integrate/v1.18.14 -> refs/harness-integrate/1.18.14
(refusing to allow a GitHub App to create or update workflow
 .github/workflows/beta.yml without workflows permission)
```

The ref was never created, so all six build jobs failed with `couldn't find remote ref` and the pipeline stopped before publishing anything.

## Root cause

The integrate job pushes the merged upstream tree — which includes upstream's own `.github/workflows/*.yml` — and authenticates as a GitHub App. GitHub rejects any App push that creates or updates a workflow file unless the token carries the `workflows` permission, which the minted token deliberately does not (it requests exactly `contents: write`).

This constraint is not new. Every prior release hit it too, and only got past it because the agent improvised: run `29772360474` (1.18.4) shows a first push rejected, then `git rm -r --cached .github/workflows`, `git commit --amend`, and a second push that succeeded. Its own summary says it "amended to drop `.github/workflows/*` … their presence caused GitHub to reject the push." Nothing in `prompt.txt` asked for that. The 1.18.14 run correctly declined to improvise ("Per the operating constraints I could not improvise alternate auth or strip the workflow files") and the pipeline broke.

Confirming the mechanism: the trees behind `refs/harness-integrate/1.18.4` and `refs/harness-integrate/1.18.5` both contain **zero** files under `.github/workflows/` (neither tree is truncated; the rest of `.github/` — CODEOWNERS, ISSUE_TEMPLATE, actions — is intact), while upstream v1.18.5 ships 26 workflow files.

## Fix

Make the removal an explicit, documented step in the integration procedure, folded into the existing squash so no amend is needed:

```bash
git reset --soft {{tag}}
git rm -r --cached --quiet --ignore-unmatch .github/workflows
git commit -m "harness: integrate OpenCode {{version}} carrying {{branches}}"
```

`--cached` drops the files from the commit only, leaving them on disk so the build step is unaffected. `--ignore-unmatch` makes it a no-op if upstream ever ships no workflows directory.

Stripping is preferred over granting the App `workflows: write`: the integration ref is a throwaway build input, the release build compiles the source tree and never reads those files, all existing integration refs already look exactly like this, and keeping the minted token at `contents: write` avoids permanently widening its scope on every integrate run.

## Tests

Two pins in `prompt-template.test.ts` — one asserting the strip is present with `--ignore-unmatch`, one asserting it uses `--cached` and precedes the integration commit (ordering matters; after the commit it would be useless). Verified non-tautological: deleting the strip line from `prompt.txt` fails exactly these two tests and no others.

Harness suite 231 passed (up from 229), type checks and lint clean. No `dist/` rebuild — `prompt.txt` is harness package data, not bundled into the action.
