### PR TITLE
docs(harness): correct the integrate job's credential model

### DIFF
--- a/packages/harness/AGENTS.md
+++ b/packages/harness/AGENTS.md
@@ -61,11 +61,13 @@ Resolves the base version (dispatch input or tag) and renders the merge prompt f
 
 ### `integrate` job (merge via Fro Bot)
 
-Skipped when `has_refs == 'false'` (empty carry set). When it runs, `uses: ./.github/workflows/fro-bot.yaml` with `secrets: inherit`, passing `model: ${{ vars.HARNESS_MODEL }}` and the rendered prompt. The Fro Bot agent:
+Skipped when `has_refs == 'false'` (empty carry set). When it runs, `uses: ./.github/workflows/harness-integrate.yaml` — a dedicated workflow, **not** `fro-bot.yaml`, and **never** `secrets: inherit`. The caller job declares `permissions: {id-token: write, contents: read}` and passes exactly four secrets explicitly (`APPLICATION_ID`, `APPLICATION_PRIVATE_KEY`, `OPENCODE_CONFIG`, `OMO_PROVIDERS`) plus `model: ${{ vars.HARNESS_MODEL }}` and the rendered prompt. Withholding the durable model credential is the point: it must never reach this workflow. The Fro Bot agent:
 
 1. Clones `anomalyco/opencode` into a disposable work dir, creates the integration branch at the base version tag, and merges the configured refs.
 2. Builds and verifies the host CLI as a correctness gate.
-3. Pushes the integrated branch to `refs/harness-integrate/<version>` in this repo using the workflow's inherited push credentials (`GH_TOKEN`, never echoed). It posts nothing to GitHub — the summary is plain text in the job log only.
+3. Pushes the integrated branch to `refs/harness-integrate/<version>` in this repo using an **inline-minted, short-lived GitHub App installation token** scoped to `contents: write` on this repo (`scripts/harness/mint-app-token.ts`; the App private key is step-env-only and never touches disk or `GITHUB_ENV`). It posts nothing to GitHub — the summary is plain text in the job log only.
+
+The model credential is likewise minted per run: `scripts/harness/mint-broker-credential.ts` exchanges the job's GitHub OIDC token for a short-lived credential and feeds it in as `auth-json`. Neither credential is a durable secret, and the job's `contents: write` scope is why the integration commit must omit workflow files (see below).
 
 The merge runs with `output-mode: working-dir` so branch/PR delivery semantics do not apply; the prompt itself owns the push to the throwaway ref.
 


### PR DESCRIPTION
## Summary

`packages/harness/AGENTS.md` described the integrate job's credential model as the one we deliberately replaced. I hit this while adding an unrelated line to the same section during the 1.18.14 release write-up, and verified every claim against the workflows.

| Documented | Actual |
| --- | --- |
| `uses: ./.github/workflows/fro-bot.yaml` | `uses: ./.github/workflows/harness-integrate.yaml` — a dedicated workflow |
| `secrets: inherit` | An explicit four-secret map; `harness-integrate.yaml` carries a literal `NO AUTH_JSON. NO secrets: inherit.` comment |
| Pushes with "inherited push credentials (`GH_TOKEN`)" | Pushes with an inline-minted, short-lived GitHub App installation token scoped to `contents: write` |

This is the inverse of the current design in the way that matters: the whole point of the dedicated workflow is that the durable model credential never reaches it, and the push authority is a per-run minted token rather than an inherited long-lived one. A reader trusting the old text would conclude the opposite about both, which is the wrong mental model to carry into any change in this area.

Also documents the broker mint (`scripts/harness/mint-broker-credential.ts`, OIDC-exchanged per run) and notes that the token's `contents: write` scope is precisely why the integration commit must omit workflow files — connecting this section to the constraint described a few lines below it.

## Verification

Every claim checked against `.github/workflows/harness-release.yaml` (the caller job's `uses`, `permissions`, and `secrets` map), `.github/workflows/harness-integrate.yaml` (both mint steps and what each feeds into the action inputs), and the mint scripts. Prettier clean; 297 relative links resolve.

## Note on the base

Stacked on #1335, which touches the adjacent lines of this same section — basing it there avoids a needless conflict. GitHub retargets this to `main` automatically once #1335 merges; the diff here is one file either way.
