### PR TITLE
docs(solutions): capture retry and recovery learnings

### DIFF
--- a/docs/solutions/best-practices/extract-shared-helpers-toward-the-value-dependency-2026-08-08.md
+++ b/docs/solutions/best-practices/extract-shared-helpers-toward-the-value-dependency-2026-08-08.md
@@ -1,0 +1,74 @@
+---
+title: Extract a shared helper toward the value dependency, not toward the type that names it
+date: 2026-08-08
+category: best-practices
+module: agent-execution
+problem_type: best_practice
+component: development_workflow
+severity: medium
+applies_when:
+  - Deduplicating a helper that exists in two modules which already import each other
+  - One direction of the existing dependency is a type-only import
+  - Choosing which module should own an extracted function
+tags:
+  - import-cycle
+  - type-only-imports
+  - dependency-direction
+  - refactoring
+---
+
+## Context
+
+Two modules each held an identical copy of a small mapping function. They agreed, but duplicated rules drift, and this one decided whether a failed attempt could be retried — not somewhere drift is acceptable.
+
+The obvious home is the module that owns the type the helper operates on. That is the wrong answer here, and the reason is invisible unless you check how the two modules already import each other.
+
+## Guidance
+
+Before extracting, classify each existing edge between the two modules as **type-only** or **value**:
+
+```ts
+// retry.ts
+import type {AttemptOutcome, AttemptResult} from "./prompt-sender.js"
+
+// prompt-sender.ts
+import {runPromptAttempt, type ExecutionDeadline} from "./retry.js"
+```
+
+These are not symmetric. The first is erased at compile time and creates no runtime edge. The second is a real import. So the only runtime dependency runs `prompt-sender → retry`, even though each file names the other.
+
+Moving the helper to `prompt-sender.ts` — the module that declares `AttemptOutcome`, and the intuitive owner — would force `retry.ts` to import it as a _value_. That converts the erased edge into a real one and closes the runtime cycle.
+
+Extracting toward `retry.ts` instead follows the existing runtime edge and adds nothing:
+
+```ts
+// retry.ts — single source of truth
+export function shouldRetryFromOutcome(outcome: AttemptOutcome): boolean {
+  return outcome === 'turn_failed_retryable'
+}
+
+// prompt-sender.ts — already depends on retry at runtime
+import {runPromptAttempt, shouldRetryFromOutcome, …} from './retry.js'
+```
+
+Leave a comment recording _why_ the helper lives away from its type, or the next reader will move it back.
+
+## Why This Matters
+
+A type-only import looks like a dependency in the source and is not one in the build. Reasoning about ownership from the import list alone gives the wrong answer, and the resulting cycle may not surface immediately — it can appear later as a module-initialization order bug in a bundled artifact, far from the refactor that caused it.
+
+This is not a hypothetical trap. An automated reviewer flagged the duplication correctly and proposed exactly the cycle-forming direction, on the reasonable grounds that the type's owner should own the helper. The suggestion was right about the problem and wrong about the destination.
+
+## When to Apply
+
+- Any deduplication between two modules that already reference each other.
+- Any time the intuitive owner is chosen because it declares the relevant type rather than because it is depended on.
+- Any language with erasable imports — TypeScript's `import type`, Java's compile-time-only annotations, and similar — where the source graph and the runtime graph differ.
+
+Verify rather than assume: a cycle check after the extraction is cheap, and it is the only way to know the erased edge stayed erased.
+
+## Examples
+
+**Wrong direction.** Helper moves to the type's owner; the other module must now import it as a value; a previously type-only edge becomes real; cycle.
+
+**Right direction.** Helper moves to the module that is already a runtime dependency; the type-only edge stays erased; no new edge exists. Confirmed after the change with a project-wide cycle check reporting zero import cycles.

--- a/docs/solutions/logic-errors/file-existence-is-not-deliverable-existence-2026-08-08.md
+++ b/docs/solutions/logic-errors/file-existence-is-not-deliverable-existence-2026-08-08.md
@@ -1,0 +1,116 @@
+---
+title: File existence is not deliverable existence, and an unknown status must fail closed
+date: 2026-08-08
+category: logic-errors
+module: agent-execution
+problem_type: logic_error
+component: service_object
+symptoms:
+  - "A recovery path is suppressed, and then delivery fails, so nothing is produced at all"
+  - "A partially written artifact counts as a completed one"
+  - 'A permission or I/O error on a safety gate is treated as "not there"'
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - fail-closed
+  - safety-gate
+  - filesystem
+  - response-file
+  - three-state
+---
+
+## Problem
+
+A recovery gate needed to know whether the agent had already produced a response, so that recovery would not duplicate a delivery. It asked the filesystem:
+
+```ts
+async function responseFileExists(responseFilePath: string | null | undefined): Promise<boolean> {
+  if (responseFilePath == null) return false
+  try {
+    await fs.access(responseFilePath)
+    return true
+  } catch {
+    return false
+  }
+}
+```
+
+Two distinct defects, in opposite directions.
+
+**Existence is weaker than the property being gated.** An agent that created the file and then failed before writing a body leaves an empty file. `fs.access` reports it present, so recovery is suppressed. Delivery then reads the same file and rejects it, because the parser refuses empty content:
+
+```ts
+if (raw.trim().length === 0) {
+  return err(createResponseFileError("empty", "Response file is empty"))
+}
+```
+
+Recovery declined because a deliverable existed; delivery declined because it did not. Nothing was posted — strictly worse than the gate this replaced.
+
+**`catch { return false }` fails open on a safety gate.** `EACCES`, `EIO`, and `EBUSY` are reported as "no deliverable", which is the permissive answer. The gate exists to prevent duplicate work, so an unreadable file should make it _more_ cautious, not less.
+
+## What Didn't Work
+
+**Treating the cheap check as a conservative one.** `fs.access` feels like the safe, minimal question. It is only safe when existence and the gated property coincide, and here they diverge exactly in the failure case the gate is for.
+
+**Collapsing errors to a boolean.** A two-state return has nowhere to put "I could not find out", so that case has to be assigned to one of the two answers. Whichever is chosen is wrong half the time; the type forces the bug.
+
+## Solution
+
+Return three states, and make the affirmative answer require actually parsing the artifact:
+
+```ts
+export type ResponseFileStatus = 'present' | 'absent' | 'unknown'
+
+export async function inspectResponseFile(
+  responseFilePath: string | null | undefined,
+  surface: ResponseSurface,
+  logger: Logger,
+): Promise<ResponseFileStatus> {
+  if (responseFilePath == null) return 'absent'
+
+  let raw: string
+  try {
+    raw = await fs.readFile(responseFilePath, 'utf8')
+  } catch (error) {
+    if (isMissingFileError(error)) return 'absent'
+    logger.warning('Response-file status is unknown; declining recovery', {responseFilePath, error: …})
+    return 'unknown'
+  }
+
+  const parsed = parseResponseFile(raw, {surface})
+  if (parsed.success === true) return 'present'
+
+  logger.warning('Response file is not a valid deliverable; allowing recovery', {responseFilePath, reason: parsed.error.reason})
+  return 'absent'
+}
+```
+
+Callers proceed only on `absent`:
+
+```ts
+if (responseFileStatus !== "absent") break
+```
+
+`present` requires the same parse that delivery will later perform, so the gate and the consumer agree on what counts. `unknown` declines, because an unreadable file is not evidence of absence.
+
+Reusing `parseResponseFile` rather than hand-rolling a validity check is load-bearing: a second implementation would drift, and the gate would resume disagreeing with delivery.
+
+## Why This Works
+
+The gate now measures the property it is gating on rather than a proxy that usually correlates with it. The three-state return gives the uncertain case its own home, so it can be routed by policy — decline — instead of being silently folded into an answer.
+
+## Prevention
+
+- **Ask whether the cheap predicate and the gated property can ever diverge.** If they can, the divergence will happen exactly in the failure case the gate exists for, because that is when partial states occur.
+- **Gate on the same check the consumer performs.** If delivery parses the artifact, the gate must parse it too, or the two will disagree.
+- **A boolean cannot express "unknown".** When a check can fail for reasons other than the answer being no, use three states and decide the uncertain case deliberately.
+- **On a safety gate, unknown takes the cautious branch.** Fail-soft is right for observability; fail-closed is right for anything preventing duplicate or destructive work.
+- **Test the partial-artifact case.** An empty or truncated file is the state that distinguishes existence from validity, and a test that only covers present-and-valid versus absent will pass against the broken gate.
+
+## Related Issues
+
+- [A gate that cannot fail manufactures confidence](../workflow-issues/non-failing-gates-are-worse-than-no-gates-2026-08-07.md) — the same theme from the other end: there, a gate no input could fail; here, a gate whose predicate was too weak.
+- [Absence of an outcome is not a failed outcome](../workflow-issues/absence-of-outcome-is-not-a-failed-outcome-2026-08-07.md) — the same three-state discipline applied to run scoring.
+- [A failed run reported success with no delivery surface](failed-run-reported-success-with-no-delivery-surface-2026-08-07.md) — an adjacent way the delivery path can produce nothing while looking fine.

--- a/docs/solutions/logic-errors/inferred-counters-are-not-control-flow-authority-2026-08-08.md
+++ b/docs/solutions/logic-errors/inferred-counters-are-not-control-flow-authority-2026-08-08.md
@@ -1,0 +1,86 @@
+---
+title: Counters inferred from stream text cannot authorize a replay decision
+date: 2026-08-08
+category: logic-errors
+module: agent-execution
+problem_type: logic_error
+component: service_object
+symptoms:
+  - "A recovery gate reads zero side effects from an attempt that died mid-flight"
+  - "A counter intended as reporting metadata is used to make a safety decision"
+  - "A planned design variant has no observable input that can populate it"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags:
+  - inference
+  - observability
+  - recovery
+  - replay-safety
+  - control-flow
+---
+
+## Problem
+
+The execution result carries `prsCreated`, `commitsCreated`, and `commentsPosted`. They look like a record of what the agent did, and a recovery gate used one of them to decide whether re-running was safe:
+
+```ts
+if (result.llmError?.type === 'context_overflow' && result.commentsPosted === 0 && sessionId != null) {
+```
+
+Those counters are populated by detecting artifacts in SSE events and tool-output text. They evidence that a write was _attempted and observed_, never that it _landed_. Two consequences:
+
+- A write that reached GitHub before the stream died leaves the counters at zero, because detection never ran.
+- Text that resembles a result — a model quoting a URL, a tool echoing a command — can increment them without any write occurring.
+
+The failure direction is the dangerous one. The counters read empty exactly when an attempt dies mid-flight, which is precisely when the gate is consulted. A gate keyed on "zero effects observed" therefore reads _permissive_ in the case where effects are most likely to be unconfirmed.
+
+## Symptoms
+
+- Recovery proceeds after an attempt that may have already posted or pushed.
+- Reasoning about the gate looks sound in the happy path and inverts under partial failure.
+- A design that depends on classifying "completed with side effects" cannot be implemented honestly, because no input can populate it.
+
+## What Didn't Work
+
+**Reading the counters as a ledger.** They are named for the effects, not for the evidence, so they invite being trusted as a record. The name describes intent; the derivation describes reliability.
+
+**Looking for a better detector.** The signals that genuinely prove an effect — the return values of the commit, comment, and review calls — exist only in the delivery path, downstream of where the recovery decision is made. There is no reliable pre-replay detector to find. That is a fact about the architecture, not a gap in the search.
+
+## Solution
+
+Gate on facts that are structural rather than inferred:
+
+```ts
+// Provisioned credentials can hide completed external writes; only a non-provisioned run without a valid response may be replayed.
+if (
+  result.llmError?.type === 'context_overflow' &&
+  credentialProvisioned === false &&
+  responseFileStatus === 'absent' &&
+  sessionId != null
+) {
+```
+
+Both inputs are observable rather than inferred. The credential is withheld entirely for the events that carry one, so on those events the agent _cannot_ write to GitHub — that is enforced by construction, not detected after the fact. The response file is removed before the run, so its state is attributable to this attempt.
+
+The planned outcome variant that would have described "completed, with side effects" was dropped rather than implemented, because the only inputs available to populate it were the inference-derived counters. A variant asserting a fact the system cannot observe is worse than not having the variant: it launders an unknown into a claim.
+
+The counters remain, and remain useful, for reporting and run summaries. They just do not authorize decisions.
+
+## Why This Works
+
+Replay safety needs evidence of what happened. Where such evidence does not exist, the honest options are to narrow the decision to facts that are structurally guaranteed, or to decline. Both are available here; inventing confidence was not.
+
+## Prevention
+
+- **Ask how a value is derived before letting it gate anything.** Detected-from-text and returned-by-the-API are different reliability classes wearing the same field name.
+- **Check which way the signal fails.** A signal that reads empty on partial failure is unusable for a gate consulted on partial failure, regardless of accuracy in the happy path.
+- **Prefer structural facts to observed ones.** "This event class never receives a credential" is stronger than "we did not detect a write", because it is enforced rather than measured.
+- **Write the fallback into the plan before the investigation runs.** This unit was specified as "name the signal before building the lattice", with an explicit instruction that a narrower design was the correct outcome if no sufficient signal existed. That pre-authorization is what made dropping a planned variant a normal step rather than a scope failure — without it, the pressure is to implement the variant on whatever data is nearest.
+- **A variant no input can populate is not a conservative placeholder.** It reads as a supported case to every future caller.
+
+## Related Issues
+
+- [Absence of an outcome is not a failed outcome](../workflow-issues/absence-of-outcome-is-not-a-failed-outcome-2026-08-07.md) — the same separation of observed fact from missing evidence, applied to scoring.
+- [A gate that cannot fail manufactures confidence](../workflow-issues/non-failing-gates-are-worse-than-no-gates-2026-08-07.md) — a gate whose input could not distinguish the states it claimed to.
+- [File existence is not deliverable existence](file-existence-is-not-deliverable-existence-2026-08-08.md) — the replacement gate's other input, and its own weak-predicate history.

--- a/docs/solutions/logic-errors/submission-failure-does-not-prove-the-work-never-started-2026-08-08.md
+++ b/docs/solutions/logic-errors/submission-failure-does-not-prove-the-work-never-started-2026-08-08.md
@@ -1,0 +1,103 @@
+---
+title: A submission failure does not prove the work never started when observation began first
+date: 2026-08-08
+category: logic-errors
+module: agent-execution
+problem_type: logic_error
+component: service_object
+symptoms:
+  - "A retried request repeats work the server had already accepted and begun"
+  - "Artifacts detected during a failed attempt are missing from the result"
+  - "The failure classification contradicts activity visible in the event stream"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - retry
+  - classification
+  - sse
+  - idempotency
+  - transport-error
+---
+
+## Problem
+
+The agent retry path classified an attempt from the return value of the submit call alone. A submission failure meant "the prompt was never accepted", which in turn licensed resending the original prompt — the one operation that can duplicate work.
+
+That inference is only valid if a submission failure proves the server never received the request. It does not. A transport error on the _response_ path is indistinguishable, from the client, from a transport error on the _request_ path. In the first case the turn is already running.
+
+The code had the evidence to tell the difference and threw it away:
+
+```ts
+// Ensure the lazy SDK SSE stream begins connecting before prompt submission. Without this,
+// event.subscribe().stream is only consumed after promptAsync returns, so early current-turn
+// events can be missed while the agent is already working.
+await Promise.resolve()
+```
+
+The event stream is subscribed _before_ submission, deliberately, precisely because the agent can start working before the submit call returns. Then:
+
+```ts
+if (promptStartResult != null) {
+  await collectEventResults()
+  return promptStartResult // observed activity discarded
+}
+```
+
+`collectEventResults()` drains the stream, and the result is dropped on the floor. The comment three lines up describes the exact race the next branch ignores.
+
+## Symptoms
+
+- A second attempt sends the original request into a session already executing the first.
+- Artifacts (comment URLs, commit SHAs) detected during the failed turn are absent from the final result, because the discarded stream result was the only place they lived.
+- Nothing looks wrong in logs: the submit error is real and retryable, and the retry is the documented behavior.
+
+## What Didn't Work
+
+**Reasoning from the classification's name.** `submit_failed` reads like "nothing happened", and that reading is what makes it feel safe to replay. The name describes which call reported the error, not which side effects occurred.
+
+**Trusting the error's retryability.** `retryable: true` is a statement about the transport, not about idempotency. It says the request may succeed if repeated; it says nothing about whether the previous one already took effect.
+
+## Solution
+
+Consult the observation that was already running before deciding what the failure means:
+
+```ts
+if (promptStartResult != null) {
+  await collectEventResults()
+  if (activityTracker.firstMeaningfulEventReceived === true) {
+    const effectiveLlmError = eventStreamResult.llmError ?? promptStartResult.llmError
+    const outcome: AttemptOutcome =
+      effectiveLlmError?.retryable === true ? "turn_failed_retryable" : "turn_failed_terminal"
+    return {
+      ...promptStartResult,
+      llmError: effectiveLlmError,
+      outcome,
+      shouldRetry: shouldRetryFromOutcome(outcome),
+      eventStreamResult,
+    }
+  }
+  return promptStartResult
+}
+```
+
+If current-turn activity was observed, the turn was accepted regardless of what the submit call reported. It is reclassified as a failed turn, so recovery sends a continuation instead of replaying, and `eventStreamResult` is returned so artifacts observed during that turn survive.
+
+`activityTracker.currentTurnArmed` is set immediately before submission, so `firstMeaningfulEventReceived` cannot be satisfied by activity from a previous turn.
+
+## Why This Works
+
+The window between "server accepted the request" and "client learned the outcome" is unobservable from the return value alone — that is what a transport failure means. But it is not unobservable from the _stream_, which is why the stream is subscribed first. The fix stops treating one channel's silence as authoritative when a second channel is already reporting.
+
+## Prevention
+
+- **When observation starts before an operation, the operation's failure is not the whole story.** Before treating a failed call as "never happened", ask what else was watching during that call, and consult it.
+- **Separate "which call reported the error" from "what side effects occurred."** They are different facts and only the second one licenses a replay.
+- **Retryable means safe to repeat only when the operation is idempotent.** For non-idempotent work, transport retryability and replay safety are independent questions.
+- **Test the accepted-then-failed interleaving explicitly.** A test that only covers a clean submit failure will pass against the broken classification. Drive stream activity first, _then_ fail the submit, and assert the follow-up is a continuation rather than the original request.
+
+## Related Issues
+
+- [Terminal outcomes must survive deadline cleanup](terminal-outcomes-must-survive-deadline-cleanup-2026-07-24.md) — the mirror case: that one protects an outcome already decided, this one is about deciding correctly in the first place.
+- [Absence of an outcome is not a failed outcome](../workflow-issues/absence-of-outcome-is-not-a-failed-outcome-2026-08-07.md) — the same distinction between missing evidence and observed fact, applied to scoring.
+- Found by two independent reviewers during PR #1343; the mechanism was visible in the code's own comment.


### PR DESCRIPTION
Four docs from the attempt-outcome work in #1343. Two came out of defects the review caught, one records why a planned design was narrowed, and one is a refactoring trap an automated reviewer walked into.

## New docs

**[A submission failure does not prove the work never started](docs/solutions/logic-errors/submission-failure-does-not-prove-the-work-never-started-2026-08-08.md)** — the event stream is subscribed *before* the prompt is submitted, deliberately, because the agent can start working before the submit call returns. The submit-failure path then discarded everything the stream had observed, so a transport error on the *response* read as "never accepted" and licensed resending the original prompt into a session already running it. The code's own comment described the exact race the next branch ignored.

**[File existence is not deliverable existence](docs/solutions/logic-errors/file-existence-is-not-deliverable-existence-2026-08-08.md)** — a gate used `fs.access` to decide whether a response artifact existed. An empty file counted as present, suppressing recovery, and then failed delivery because the parser rejects empty content — so nothing was produced at all. The same helper folded `EACCES`/`EIO` into "absent", failing open on a gate whose purpose is preventing duplicate work. A boolean has nowhere to put "I could not find out".

**[Counters inferred from stream text cannot authorize a replay](docs/solutions/logic-errors/inferred-counters-are-not-control-flow-authority-2026-08-08.md)** — `prsCreated`/`commitsCreated`/`commentsPosted` are populated by detecting artifacts in SSE events and tool output, so they evidence *attempted* rather than *landed*, and read empty exactly when an attempt dies mid-flight. This also records why a planned outcome variant was dropped instead of implemented on that data, and the planning technique that made dropping it a normal step.

**[Extract shared helpers toward the value dependency](docs/solutions/best-practices/extract-shared-helpers-toward-the-value-dependency-2026-08-08.md)** — when two modules import each other and one edge is `import type`, the source graph and the runtime graph differ. Moving a helper to the module that *names* its type can convert an erased edge into a real one and close a cycle. Worth documenting because an automated reviewer flagged the duplication correctly and proposed exactly that direction.

## Notes on scope

The overlap finder recommended folding the first two into existing docs. I read both targets and disagreed: the terminal-outcomes doc governs *post-terminal* protection ("once an outcome is accepted, cleanup must not rewrite it") while this is about deciding the outcome correctly in the first place; and the delivery-surface doc is about an exit code encoding a false claim, not about a gate predicate being weaker than the property it gates. Keyword overlap, different root causes — created with cross-links instead.

A fifth candidate was dropped as too thin to earn a doc.

## Validation

- `bun run check:md-links` — 313 links across 291 files
- Every code snippet verified against the merged source rather than reconstructed
- All four `category` fields match their parent directory; enum values checked against the existing corpus
- Prettier scoped to the four new files