### PR TITLE
docs(harness): record why each carried upstream patch exists

### DIFF
--- a/.slim/clonedeps.json
+++ b/.slim/clonedeps.json
@@ -1,24 +1,24 @@
 {
   "version": "1.0.0",
-  "updatedAt": "2026-07-13T00:00:00.000Z",
+  "updatedAt": "2026-08-08T00:00:00.000Z",
   "dependencies": [
     {
       "name": "opencode (server)",
-      "resolvedVersion": "1.17.20",
+      "resolvedVersion": "1.18.14",
       "repoUrl": "https://github.com/anomalyco/opencode.git",
-      "ref": "v1.17.20",
+      "ref": "v1.18.14",
       "path": ".slim/clonedeps/repos/anomalyco__opencode",
       "packagePath": "packages/opencode",
-      "reason": "OpenCode server source — owns session/prompt machinery and publishes message.part.updated bus events."
+      "reason": "OpenCode server source — owns session/prompt machinery and publishes message.part.updated bus events. Pinned to the harness base_version so source checks reflect what we ship."
     },
     {
       "name": "@opencode-ai/sdk",
-      "resolvedVersion": "1.17.20",
+      "resolvedVersion": "1.18.14",
       "repoUrl": "https://github.com/anomalyco/opencode.git",
-      "ref": "v1.17.20",
+      "ref": "v1.18.14",
       "path": ".slim/clonedeps/repos/anomalyco__opencode",
       "packagePath": "packages/sdk/js",
-      "reason": "OpenCode SDK source for inspecting SSE subscription contract."
+      "reason": "OpenCode SDK source for inspecting SSE subscription contract and error/status payload shapes."
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,17 +13,17 @@ GitHub Action harness for [OpenCode](https://opencode.ai/) + [oMo](https://githu
 
 Highest-traffic entry points — see [STRUCTURE.md](STRUCTURE.md) for the full directory layout and where-to-add-code map, and [ARCHITECTURE.md](ARCHITECTURE.md) for the complete code map.
 
-| Task | Location |
-| --- | --- |
-| Action orchestration | `src/harness/run.ts` (`run`) |
-| Agent SDK execution | `src/features/agent/execution.ts` (`executeOpenCode`) |
-| Event routing | `src/features/triggers/router.ts` (`routeEvent`) |
-| Event parsing / types | `src/services/github/context.ts`, `src/services/github/types.ts` (`NormalizedEvent`) |
-| Prompt building | `packages/runtime/src/agent/prompt.ts` (`buildAgentPrompt`) |
-| Setup / CI config | `src/services/setup/` (`runSetup`, `buildCIConfig`) |
-| Comment / review posting | `src/features/comments/writer.ts`, `src/features/reviews/reviewer.ts` |
-| Gateway mention loop | `packages/gateway/src/execute/run.ts` (`runMention`) |
-| Version pins | `packages/runtime/src/shared/constants.ts` |
+| Task                     | Location                                                                             |
+| ------------------------ | ------------------------------------------------------------------------------------ |
+| Action orchestration     | `src/harness/run.ts` (`run`)                                                         |
+| Agent SDK execution      | `src/features/agent/execution.ts` (`executeOpenCode`)                                |
+| Event routing            | `src/features/triggers/router.ts` (`routeEvent`)                                     |
+| Event parsing / types    | `src/services/github/context.ts`, `src/services/github/types.ts` (`NormalizedEvent`) |
+| Prompt building          | `packages/runtime/src/agent/prompt.ts` (`buildAgentPrompt`)                          |
+| Setup / CI config        | `src/services/setup/` (`runSetup`, `buildCIConfig`)                                  |
+| Comment / review posting | `src/features/comments/writer.ts`, `src/features/reviews/reviewer.ts`                |
+| Gateway mention loop     | `packages/gateway/src/execute/run.ts` (`runMention`)                                 |
+| Version pins             | `packages/runtime/src/shared/constants.ts`                                           |
 
 ## CONVENTIONS
 
@@ -97,8 +97,9 @@ For architecture (the four-layer rule, committed `dist/`, NormalizedEvent, dual 
 
 ## Cloned Dependency Source
 
-Read-only dependency source repositories are available under
-`.slim/clonedeps/repos/` for inspection. Do not edit these clones.
+Read-only dependency source repositories are available under `.slim/clonedeps/repos/` for inspection. Do not edit these clones.
 
-- `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/` — `anomalyco/opencode` at `v1.17.20`; OpenCode server source. Read `src/session/{prompt,message,message-v2,processor}.ts` to understand how `message.part.updated` bus events transition through the tool-part lifecycle (pending → running → completed) the Fro Bot harness consumes.
-- `.slim/clonedeps/repos/anomalyco__opencode/packages/sdk/js/` — `@opencode-ai/sdk` at `v1.17.20`; thin HTTP + SSE client over the server. Useful for confirming event shapes pass through unchanged and for verifying our `processEventStream` consumer matches the SSE subscription contract.
+Both are pinned to the `base_version` in `packages/harness/harness.config.json`, so what you read is what the harness ships. Re-pin them when that base moves — a source check against a stale clone can be confidently wrong.
+
+- `.slim/clonedeps/repos/anomalyco__opencode/packages/opencode/` — `anomalyco/opencode` at `v1.18.14`; OpenCode server source. Read `src/session/{prompt,message,message-v2,processor}.ts` to understand how `message.part.updated` bus events transition through the tool-part lifecycle (pending → running → completed) the Fro Bot harness consumes, and `src/session/{status,run-state}.ts` for how session status is written and cleared.
+- `.slim/clonedeps/repos/anomalyco__opencode/packages/sdk/js/` — `@opencode-ai/sdk` at `v1.18.14`; thin HTTP + SSE client over the server. Useful for confirming event shapes pass through unchanged, verifying our `processEventStream` consumer matches the SSE subscription contract, and checking error/status payload shapes in `src/v2/gen/types.gen.ts`.

--- a/docs/plans/2026-08-07-001-refactor-bitter-lesson-harness-flexibility-plan.md
+++ b/docs/plans/2026-08-07-001-refactor-bitter-lesson-harness-flexibility-plan.md
@@ -476,7 +476,7 @@ The conversion target the estimate missed is **`ApiError.data.isRetryable`** —
 - All existing caps are unchanged in value.
 - Truncation is still disclosed in the prompt.
 
-- [ ] **U7. Liveness signals and the carry ledger**
+- [x] **U7. Liveness signals and the carry ledger**
 
 **Goal:** Give the twelve upstream carries an exit path. The silence-as-failure proxy stays; see the investigation below for why replacing it is not currently possible.
 

--- a/docs/plans/2026-08-07-001-refactor-bitter-lesson-harness-flexibility-plan.md
+++ b/docs/plans/2026-08-07-001-refactor-bitter-lesson-harness-flexibility-plan.md
@@ -478,7 +478,7 @@ The conversion target the estimate missed is **`ApiError.data.isRetryable`** —
 
 - [ ] **U7. Liveness signals and the carry ledger**
 
-**Goal:** Replace the silence-as-failure proxy, and give the twelve upstream carries an exit path.
+**Goal:** Give the twelve upstream carries an exit path. The silence-as-failure proxy stays; see the investigation below for why replacing it is not currently possible.
 
 **Requirements:** R6
 
@@ -499,13 +499,22 @@ The conversion target the estimate missed is **`ApiError.data.isRetryable`** —
 
 The approach also dismissed `busy` as internal pool state. That conflates two different things. `run-state.ts` keeps an internal `busy` flag used to reject concurrent prompts, which is indeed not consumable. But `SessionStatus` is a published union of `{type:'idle'} | {type:'retry', …} | {type:'busy'}`, and the server writes `{type:'busy'}` through `SessionStatus.set` from three call sites. `set` persists every non-idle status in the instance map (idle deletes the entry and returns early), and `list` backs the `/session/status` endpoint.
 
-That makes `busy` observable in the response the poll loop **already requests every iteration**. `session-poll.ts` switches on `sessionStatus.type` today, handling `idle` and `retry` and letting `busy` fall through to a debug log. The liveness signal was already arriving and being discarded.
+That makes `busy` observable in the response the poll loop already requests every iteration. But observable is not the same as useful, and a further check refuted the idea of building on it — including an earlier revision of this section, which proposed exactly that.
 
-**Approach:**
+`busy` is **latched state, not a heartbeat.** The server sets it at the top of each prompt-loop iteration and clears it only on idle. The payload is `{type: 'busy'}` with no timestamp and no progress field, so an observer cannot distinguish a session that set it one second ago from one that set it twenty minutes ago. Re-setting it to the same value carries no information.
 
-- Prefer real protocol signals over the 90-second no-initial-activity timeout, bounded always by the absolute deadline. Leave the poll interval, race guard, grace cycles, and backoff alone.
-- Use the `busy` session status as the liveness signal. The existing timeout infers a crashed server from silence; a `busy` status is direct evidence the server is alive and the session is advancing, so it must suppress that inference. No new request, event subscription, or plumbing is required — only handling a status the poll already receives.
-- The absolute deadline remains the sole hard bound. Suppressing the silence heuristic must never remove it.
+That matters because of which failure the 90-second timeout actually catches. A crashed server does not answer `session.status()` at all; that path fails and is handled separately. The timeout exists for the case where the process is _responsive_ but the session is wedged mid-prompt — and that is precisely the case where the status stays `busy` forever. Suppressing the timeout on `busy` would delete the only detector for the failure it was written for, trading a 90-second failure for one that burns the entire execution deadline.
+
+This was already settled. `opencode.test.ts` carries a test named "does not treat matching busy session status as activity", added deliberately by an earlier fix. The prior decision considered `busy` and rejected it for these reasons; it was correct.
+
+**Outcome: the liveness half of this unit cannot be implemented as specified.** Of the three signals named, one does not exist, one is declared in the SDK types but never emitted by the server, and the third carries no progress information. The only real progress signal, `message.part.delta`, is already consumed and is what sets the activity flag today. There is no unused signal to promote.
+
+The honest result is therefore the same discipline applied in U3 and U4: where no sufficient signal exists, narrow the unit rather than build on false confidence. The 90-second heuristic stays until a signal that distinguishes _slow_ from _wedged_ becomes available — a per-session progress timestamp, or a tool-progress event the server actually emits.
+
+**Approach (carry ledger only):**
+
+- Leave `session-poll.ts` unchanged. The poll interval, race guard, grace cycles, backoff, and the initial-activity timeout all stay as they are.
+- The absolute deadline remains the sole hard bound, as before.
 - Scope the ledger to the twelve upstream carries only. A generalised "expiry register" covering every accommodation is process overhead ahead of demonstrated need; the carries have that need already — the same carry has been wrongly proposed for removal in two consecutive base-bump audits, each time costing a source-level re-litigation.
 - For each carry, record the capability it provides, which surface it serves, upstream status, the evidence it is still needed, and its removal condition. The exact version pin stays; the liability is fork-delta with no exit path.
 - **Record absent evidence as absent.** A survey of the twelve found that six (`#33134`, `#33159`, `#31922`, `#34975`, `#34977`, `#36361`) have no in-repo test, consumer, or assertion establishing they are still needed — only a line in a prior bump note. No carry has an in-repo record of the upstream version that would contain it. A schema that demands those fields invites inventing them, which is worse than the gap: a fabricated justification survives the next audit unchallenged. Entries state what the repo actually supports and mark the rest unestablished.
@@ -519,17 +528,13 @@ That makes `busy` observable in the response the poll loop **already requests ev
 
 **Test scenarios:**
 
-- Happy path: a session reporting `busy` past the silence threshold is not aborted while the deadline remains.
-- Edge case: a session reporting no status at all past the silence threshold still aborts as it does today.
-- Edge case: a run emitting no signals at all is still bounded by the absolute deadline.
-- Integration: the absolute deadline still terminates a hung run, including one reporting `busy` throughout.
-
-The earlier `Retry-After` scenario is dropped: honoring it would change the backoff this unit's approach explicitly leaves alone, and the `retry` status is already handled separately.
+The polling scenarios are dropped along with the liveness change. The existing coverage stands unmodified, including the test asserting that a `busy` status is not treated as activity — that test now guards a decision this unit re-confirmed rather than one it replaced.
 
 **Verification:**
 
-- No path can wait indefinitely; the absolute deadline remains the hard bound, and a permanently-`busy` session still terminates on it.
+- `session-poll.ts` is unchanged, and its existing tests pass untouched.
 - Every carry in `packages/harness/harness.config.json` has a ledger entry, with either a removal condition or an explicit note that its justification is unestablished in-repo.
+- The ledger is discoverable from where a base-bump operator already reads.
 
 ## System-Wide Impact
 

--- a/docs/plans/2026-08-07-001-refactor-bitter-lesson-harness-flexibility-plan.md
+++ b/docs/plans/2026-08-07-001-refactor-bitter-lesson-harness-flexibility-plan.md
@@ -493,10 +493,23 @@ The conversion target the estimate missed is **`ApiError.data.isRetryable`** —
 
 **Approach:**
 
+**Signal investigation outcome (2026-08-08): the named signal does not exist, and the dismissed one does.**
+
+`server.heartbeat` is not an event. The SDK's server-level events are `server.connected` and `server.instance.disposed`; neither is periodic, so there is no server-level liveness signal to consume. The distinction the approach drew between server-level heartbeat and session-level progress is therefore moot — only session-level evidence exists.
+
+The approach also dismissed `busy` as internal pool state. That conflates two different things. `run-state.ts` keeps an internal `busy` flag used to reject concurrent prompts, which is indeed not consumable. But `SessionStatus` is a published union of `{type:'idle'} | {type:'retry', …} | {type:'busy'}`, and the server writes `{type:'busy'}` through `SessionStatus.set` from three call sites. `set` persists every non-idle status in the instance map (idle deletes the entry and returns early), and `list` backs the `/session/status` endpoint.
+
+That makes `busy` observable in the response the poll loop **already requests every iteration**. `session-poll.ts` switches on `sessionStatus.type` today, handling `idle` and `retry` and letting `busy` fall through to a debug log. The liveness signal was already arriving and being discarded.
+
+**Approach:**
+
 - Prefer real protocol signals over the 90-second no-initial-activity timeout, bounded always by the absolute deadline. Leave the poll interval, race guard, grace cycles, and backoff alone.
-- The available signals are `session.idle`, `session.next.tool.progress`, and the server-level `server.heartbeat`; the harness already consumes `session.idle` and `message.part.delta`. Note that `busy` is **internal pool state, not an SSE event** — do not build on it. Distinguish server-level heartbeats (the process is alive) from session-level progress (this run is advancing); only the latter is evidence the agent is working.
+- Use the `busy` session status as the liveness signal. The existing timeout infers a crashed server from silence; a `busy` status is direct evidence the server is alive and the session is advancing, so it must suppress that inference. No new request, event subscription, or plumbing is required — only handling a status the poll already receives.
+- The absolute deadline remains the sole hard bound. Suppressing the silence heuristic must never remove it.
 - Scope the ledger to the twelve upstream carries only. A generalised "expiry register" covering every accommodation is process overhead ahead of demonstrated need; the carries have that need already — the same carry has been wrongly proposed for removal in two consecutive base-bump audits, each time costing a source-level re-litigation.
-- For each carry, record the capability it provides, upstream status, the test proving it is still needed, the first upstream version that would contain it, and its removal condition. The exact version pin stays; the liability is fork-delta with no exit path.
+- For each carry, record the capability it provides, which surface it serves, upstream status, the evidence it is still needed, and its removal condition. The exact version pin stays; the liability is fork-delta with no exit path.
+- **Record absent evidence as absent.** A survey of the twelve found that six (`#33134`, `#33159`, `#31922`, `#34975`, `#34977`, `#36361`) have no in-repo test, consumer, or assertion establishing they are still needed — only a line in a prior bump note. No carry has an in-repo record of the upstream version that would contain it. A schema that demands those fields invites inventing them, which is worse than the gap: a fabricated justification survives the next audit unchallenged. Entries state what the repo actually supports and mark the rest unestablished.
+- The ledger's first job is to stop re-derivation. `#33444` is the worked example: it has been proposed for removal in two consecutive audits and kept both times, because the reason — a downstream consumer reads the aggregate session summary that stock still does not populate — lived only in session history rather than in the repo.
 - Ordinary deadlines, safety gates, and race guards get no entry. Prose-fallback and prompt-coaching removal conditions live with the code that owns them (U4, U5), not in a central register.
 - The ledger is **documentation, not enforcement**, and is explicitly non-authoritative for auth, delivery, and retry policy. An entry never justifies weakening a guard; removal still requires the normal review path.
 
@@ -506,15 +519,17 @@ The conversion target the estimate missed is **`ApiError.data.isRetryable`** —
 
 **Test scenarios:**
 
-- Happy path: a run emitting protocol progress signals is not aborted while the deadline remains.
+- Happy path: a session reporting `busy` past the silence threshold is not aborted while the deadline remains.
+- Edge case: a session reporting no status at all past the silence threshold still aborts as it does today.
 - Edge case: a run emitting no signals at all is still bounded by the absolute deadline.
-- Error path: a provider supplying `Retry-After` has it honored within the deadline rather than overridden by a fixed backoff.
-- Integration: the absolute deadline still terminates a hung run.
+- Integration: the absolute deadline still terminates a hung run, including one reporting `busy` throughout.
+
+The earlier `Retry-After` scenario is dropped: honoring it would change the backoff this unit's approach explicitly leaves alone, and the `retry` status is already handled separately.
 
 **Verification:**
 
-- No path can wait indefinitely; the absolute deadline remains the hard bound.
-- Every carry in `packages/harness/harness.config.json` has a ledger entry with a removal condition.
+- No path can wait indefinitely; the absolute deadline remains the hard bound, and a permanently-`busy` session still terminates on it.
+- Every carry in `packages/harness/harness.config.json` has a ledger entry, with either a removal condition or an explicit note that its justification is unestablished in-repo.
 
 ## System-Wide Impact
 

--- a/docs/plans/2026-08-07-001-refactor-bitter-lesson-harness-flexibility-plan.md
+++ b/docs/plans/2026-08-07-001-refactor-bitter-lesson-harness-flexibility-plan.md
@@ -497,6 +497,10 @@ The conversion target the estimate missed is **`ApiError.data.isRetryable`** —
 
 `server.heartbeat` is not an event. The SDK's server-level events are `server.connected` and `server.instance.disposed`; neither is periodic, so there is no server-level liveness signal to consume. The distinction the approach drew between server-level heartbeat and session-level progress is therefore moot — only session-level evidence exists.
 
+> [!NOTE]
+>
+> These signal claims were verified against upstream `v1.18.14` — the harness `base_version`, so the source checked is the source shipped. The relevant mechanism is unchanged from `v1.17.20`: same absent heartbeat, same bare `{type: 'busy'}`, and `status.set` at identical positions in the prompt loop and run-state. Re-check against the base in force whenever this is revisited; a signal being absent is the kind of claim that ages silently.
+
 The approach also dismissed `busy` as internal pool state. That conflates two different things. `run-state.ts` keeps an internal `busy` flag used to reject concurrent prompts, which is indeed not consumable. But `SessionStatus` is a published union of `{type:'idle'} | {type:'retry', …} | {type:'busy'}`, and the server writes `{type:'busy'}` through `SessionStatus.set` from three call sites. `set` persists every non-idle status in the instance map (idle deletes the entry and returns early), and `list` backs the `/session/status` endpoint.
 
 That makes `busy` observable in the response the poll loop already requests every iteration. But observable is not the same as useful, and a further check refuted the idea of building on it — including an earlier revision of this section, which proposed exactly that.

--- a/docs/reference/carry-ledger.md
+++ b/docs/reference/carry-ledger.md
@@ -1,0 +1,127 @@
+# Harness carry ledger
+
+The harness build merges a set of upstream OpenCode pull requests into a pinned base version. Those patches are listed in [`packages/harness/harness.config.json`](../../packages/harness/harness.config.json), which is the authoritative set — this document explains the entries, it does not define them.
+
+The pinned version is not the liability. Carrying a patch whose justification exists only in someone's memory is. Without a written reason, every base bump re-derives it from source, and a carry that is still load-bearing can look droppable to a reader who was not there. That has already happened: `#33444` has been proposed for removal in two consecutive audits and kept both times, each round costing a source-level re-litigation of the same question.
+
+## How to read an entry
+
+Each carry records what it does, which surface it serves, its upstream status, the evidence it is still needed, and what would make it safe to drop.
+
+**Two surfaces ship from this repo.** The **headless CI** path is the GitHub Action running agents in workflows. The **headed/local** path is the harness binary users install and run interactively. A carry can be load-bearing for one and irrelevant to the other, and conflating them has produced wrong drop verdicts before — "we don't use it in CI" is not grounds for removing it from a binary other people run locally.
+
+**An unmerged upstream PR is not a reason to drop a carry.** Carries exist precisely because a fix has not landed upstream. Absence from stock plus value to a served surface is the KEEP case.
+
+**Where the evidence is thin, this document says so.** Several carries have no in-repo test, consumer, or assertion establishing they are still needed — only a line in a prior bump note. Recording that honestly is the point: a fabricated justification would survive the next audit unchallenged, which is worse than a gap someone can see and close.
+
+No carry has an in-repo record of the upstream version that would contain it, so no entry claims one.
+
+## Carries
+
+### #33444 — aggregate session summary diffs
+
+- **Capability:** Populates `session.summary.diffs` at the session level. Stock builds compute per-message summaries but never fold them into the session-level row.
+- **Surface:** Both, and load-bearing for headed/local consumers.
+- **Upstream status:** Open. Verified absent from stock through 1.18.14.
+- **Evidence it is still needed:** A downstream consumer (Space Bus) reads the aggregate summary as its preferred tier. Without this carry it falls back to fetching every message and aggregating per-turn diffs client-side.
+- **Removal condition:** Stock exposes the aggregate fold — not merely a `summary.diffs` field in the schema, which stock already has while leaving it unpopulated. Verify the value is written, not just typed.
+
+> [!IMPORTANT]
+>
+> This carry has twice been proposed for removal by audits that checked the schema and found `summary.diffs` present. The field exists in stock; nothing writes it at the session level. Check the write path, not the type.
+
+### #33713 — idle instance memory eviction
+
+- **Capability:** Adds opt-in idle/LRU eviction for per-directory OpenCode instances, bounding memory growth in a long-lived server.
+- **Surface:** Headed/local only.
+- **Upstream status:** Open. Absent from stock.
+- **Evidence it is still needed:** The headed/local harness is a long-lived server where a user may serve several directories in one session. CI runs are short-lived and single-directory, so this buys nothing there — which is exactly why it was once proposed for removal.
+- **Removal condition:** Stock includes equivalent idle-instance eviction and headed/local memory stays bounded without the patch.
+
+### #36045 — batch streamed part deltas
+
+- **Capability:** Batches streamed message-part deltas so the TUI does not re-render per delta under heavy output.
+- **Surface:** Headed/local only.
+- **Upstream status:** Open. Absent from stock.
+- **Evidence it is still needed:** Protects interactive responsiveness during high-rate streaming. "UI-only" is the reason to keep it, not to drop it — the headed surface is where a user watches output arrive.
+- **Removal condition:** Stock batches streamed deltas in the TUI render path.
+
+### #19961 — session transform ordering
+
+- **Capability:** Orders `system.transform` before `messages.transform` in the session pipeline.
+- **Surface:** Headless CI and the shared session/compaction path.
+- **Upstream status:** Open.
+- **Evidence it is still needed:** Recorded across two prior bump cycles as still required. The integration diff is expected to touch the session prompt/transform files; their absence from a merge indicates the carry did not land.
+- **Removal condition:** Stock applies the same transform ordering in the session pipeline.
+
+### #31859 — shared plugin client runtime
+
+- **Capability:** Reuses a shared client runtime for plugin bootstrap rather than constructing per-plugin clients.
+- **Surface:** Headless CI and the plugin injection path.
+- **Upstream status:** Open.
+- **Evidence it is still needed:** Prior cycles require the integration diff to include the plugin index/client path; a merge that does not touch it has not applied the carry.
+- **Removal condition:** Stock shares the plugin client runtime, and plugin injection works without the patch.
+
+### #31638 — bounded history after compaction
+
+- **Capability:** Avoids rehydrating full session history after compaction, keeping message pagination bounded.
+- **Surface:** Headless CI and the session message storage path.
+- **Upstream status:** Open.
+- **Evidence it is still needed:** Prior cycles name the session message-v2 path as the required diff-scope target for this carry.
+- **Removal condition:** Stock avoids the post-compaction hydration regression in the same path.
+
+### #33134 — orphan part projection tolerance
+
+- **Capability:** Guards against projecting a child row whose parent was already deleted.
+- **Surface:** Headless CI, session event projection.
+- **Upstream status:** Open.
+- **Evidence it is still needed:** **Unestablished in-repo.** Listed as still-needed in a prior bump note, with no test, consumer, or assertion here that would regress without it.
+- **Removal condition:** Stock contains an equivalent orphan-child projection guard. Establishing whether this carry is still load-bearing requires an upstream source check, not a repo search.
+
+### #33159 — SQLite lock timeout retry
+
+- **Capability:** Adds retry and busy-timeout handling for concurrent SQLite writers on durable commits.
+- **Surface:** Headless CI, durable session commit path.
+- **Upstream status:** Open.
+- **Evidence it is still needed:** **Unestablished in-repo.** Carried forward from a prior bump note. Related to session durability, but nothing here fails without it.
+- **Removal condition:** Stock includes equivalent retry/busy-timeout behavior for concurrent writers.
+
+### #31922 — SSE backlog bounding
+
+- **Capability:** Bounds the server-sent-event backlog so a slow consumer cannot grow it without limit.
+- **Surface:** Headless CI, streaming event path.
+- **Upstream status:** Open.
+- **Evidence it is still needed:** **Unestablished in-repo.** Carry-list mention only.
+- **Removal condition:** Stock bounds the SSE backlog in the same stream path.
+
+### #34975 — AbortSignal listener leak
+
+- **Capability:** Fixes an `AbortSignal` listener leak in runtime cleanup.
+- **Surface:** Headless CI, runtime cleanup.
+- **Upstream status:** Open.
+- **Evidence it is still needed:** **Unestablished in-repo.** Carry-list mention only.
+- **Removal condition:** Stock avoids the same listener leak.
+
+### #34977 — queue resolver leak
+
+- **Capability:** Fixes a resolver leak in the runtime queueing path.
+- **Surface:** Headless CI, runtime queueing.
+- **Upstream status:** Open.
+- **Evidence it is still needed:** **Unestablished in-repo.** Carry-list mention only.
+- **Removal condition:** Stock includes the equivalent fix.
+
+### #36361 — surfaced background task failures
+
+- **Capability:** Stops background summary/prune failures from being swallowed silently.
+- **Surface:** Not clearly separated; likely the headless runtime session cleanup path.
+- **Upstream status:** Open.
+- **Evidence it is still needed:** **Unestablished in-repo, and the weakest of the set.** No test, consumer, or surface attribution.
+- **Removal condition:** Stock surfaces or handles those background failures. This is the first carry to re-examine on the next bump.
+
+## Scope and authority
+
+This ledger is documentation. It is **not** enforcement, and it is explicitly non-authoritative for authentication, delivery, and retry policy. An entry never justifies weakening a guard, and removing a carry still goes through the normal review path.
+
+It covers upstream carries only. Ordinary deadlines, safety gates, and race guards get no entry — they are not fork-delta and have no upstream exit path to track. Removal conditions for things like prose fallbacks live in comments beside the code that owns them, where they travel with the thing they describe.
+
+Nothing asserts the carry count or set programmatically; the manifest is the single source of truth, and this document tracks it by hand. If the two disagree, the manifest is right and this file is stale.

--- a/packages/harness/AGENTS.md
+++ b/packages/harness/AGENTS.md
@@ -6,6 +6,8 @@
 
 The harness embeds [cortexkit/orw](https://github.com/cortexkit/orw)'s integration method: on each deliberately-pinned upstream OpenCode release, it bases an integration branch on the release tag, fetches a configured set of integration refs (stalled/closed upstream PRs, branch URLs), and runs an LLM merge (`opencode run`) to carry those refs onto the release tag — resolving the base drift that `git am`/cherry-pick cannot handle. The produced per-platform binary is the `harness` binary (the patched OpenCode), shipped in the package dist.
 
+Why each carried ref exists, which surface it serves, and what would make it safe to drop are recorded in the [carry ledger](../../docs/reference/carry-ledger.md). Read it before proposing a removal during a base bump — an unmerged upstream PR is not grounds for dropping a carry, and at least one entry has been wrongly proposed for removal twice by audits that checked the type and not the write path.
+
 ## CLI Contract
 
 ```


### PR DESCRIPTION
Docs-only. `src/`, `packages/runtime/`, and `dist/` are byte-identical to main.

## The ledger

The harness merges twelve upstream OpenCode pull requests onto a pinned base. The pin isn't the liability — carrying a patch whose justification lives only in memory is. Every base bump then re-derives it from source, and a carry that is still load-bearing looks droppable to a reader who wasn't there.

`#33444` is the worked example. Stock exposes a `session.summary.diffs` field in its schema but never populates it at the session level, so an audit that checks the type finds it present and concludes the patch is redundant. A downstream consumer reads that aggregate and would fall back to per-turn reconstruction without it. It has been proposed for removal in two consecutive audits and kept both times, each round costing a source-level re-litigation of the same question.

Each entry records the capability, which of the two shipped surfaces it serves (headless CI vs headed/local — conflating these has produced wrong drop verdicts before), upstream status, the evidence it is still needed, and the removal condition.

**Six entries state plainly that no in-repo evidence establishes they are still needed**, and none claims an upstream landing version, because none is recorded here. That is deliberate: a justification I can't support would survive the next audit unchallenged, which is worse than a gap someone can see and close. The ledger is documentation, not enforcement, and is non-authoritative for auth, delivery, and retry policy.

Discoverable from `packages/harness/AGENTS.md`, where a base-bump operator already reads.

## The liveness half is withdrawn

The unit also proposed replacing the 90-second no-activity timeout with real protocol signals. Investigating the three it named:

- **`server.heartbeat` does not exist.** The SDK's server-level events are `server.connected` and `server.instance.disposed`, neither periodic.
- **`session.next.tool.progress`** is declared in the SDK types but never emitted by the server.
- **`busy`** is latched state, not a heartbeat.

That last one is the interesting case, because it looked promising — the unit had dismissed `busy` as internal pool state, which conflates the internal flag rejecting concurrent prompts with the published `SessionStatus` union. `{type:'busy'}` really is written by the server and really does arrive in the poll response the harness already makes every iteration.

But it carries no timestamp and no progress field. The server sets it at the top of each prompt-loop iteration and clears it only on idle, so an observer cannot distinguish a session that set it one second ago from one that set it twenty minutes ago.

That matters because of which failure the timeout actually catches. A crashed server doesn't answer `session.status()` at all — that path fails and is handled separately. The timeout exists for a *responsive process with a wedged session*, which is exactly the case where the status stays `busy` forever. Suppressing on `busy` would delete the only detector for the failure it was written for, trading a 90-second failure for one that burns the entire execution deadline.

This was already settled. `opencode.test.ts` carries a test named "does not treat matching busy session status as activity", added deliberately by an earlier fix. That decision was correct, and the test now guards a conclusion this unit re-confirmed rather than one it replaced.

The only real progress signal, `message.part.delta`, is already consumed and is what sets the activity flag today. There is no unused signal to promote, so the heuristic stays until one exists that distinguishes *slow* from *wedged* — a per-session progress timestamp, or a tool-progress event the server actually emits. Same discipline as the two preceding units: where no sufficient signal exists, narrow rather than build on false confidence.

## Verification

- `session-poll.ts` unchanged; its existing tests pass untouched (189 in the poll suite)
- No source, bundle, or config changes — `git diff origin/main...HEAD` touches three markdown files
- All twelve carries in `harness.config.json` have an entry
- 315 markdown links resolve