### PR TITLE
docs: close out the harness flexibility plan and record its learnings

### DIFF
--- a/docs/plans/2026-08-07-001-refactor-bitter-lesson-harness-flexibility-plan.md
+++ b/docs/plans/2026-08-07-001-refactor-bitter-lesson-harness-flexibility-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "refactor: Make the harness improve when the models do"
 type: refactor
-status: active
+status: done
 date: 2026-08-07
 ---
 
@@ -422,7 +422,7 @@ The conversion target the estimate missed is **`ApiError.data.isRetryable`** —
 - Retry and terminal decisions are unchanged for every currently-covered error shape, except an `APIError` with `isRetryable: true` that previously became a terminal configuration error.
 - `provider_auth_error` and `quota_exceeded` remain terminal under every input, including one carrying `isRetryable: true`.
 
-- [ ] **U5. Retarget prompt assertions and remove the redundant session ritual**
+- [x] **U5. Retarget prompt assertions and remove the redundant session ritual**
 
 **Goal:** Stop prescribing a working method the harness already performed.
 
@@ -464,7 +464,7 @@ The conversion target the estimate missed is **`ApiError.data.isRetryable`** —
 - `packages/harness/src/prompt-template.test.ts` is untouched and still pins the workflow strip and its ordering.
 - No safety or output-contract assertion was relaxed.
 
-- [ ] **U6. Context page selection**
+- [x] **U6. Context page selection**
 
 **Goal:** Surface the newest evidence rather than the oldest.
 

--- a/docs/solutions/best-practices/deterministic-agent-outcome-eval-corpus-2026-08-09.md
+++ b/docs/solutions/best-practices/deterministic-agent-outcome-eval-corpus-2026-08-09.md
@@ -100,6 +100,15 @@ Delete duplicated constants that a live value can reproduce. Keep a constant onl
 
 A prompt change therefore has an honest cost — a fresh run, a re-recorded baseline, and updated byte pins. Document those steps together, because a contributor who follows a partial checklist hits an unexplained failure in a test they did not touch.
 
+The order matters, because the baseline is legitimately stale in the middle of it:
+
+1. Commit the code change. The recorded run commit is read from `HEAD`, so the tree must be clean and the change must already be in history.
+2. Run the corpus once at that commit.
+3. Promote the baseline from the completed report.
+4. Commit the baseline, and update the recorded run commit that is pinned by hand.
+
+Between steps 1 and 4 the integrity check fails on purpose, and any hook that runs it fails with it. Expect that window, keep it short, and do not resolve it by editing the baseline directly — a hand-edited baseline is no longer evidence of a run that happened.
+
 ### Capture diagnostics as bounded evidence, not proof of isolation
 
 Failed and inconclusive runs need enough evidence to distinguish a provider failure, wrong working directory, permission stall, and model regression. `captureDiagnostics()` therefore accepts only immediate expected log files, skips directories and symlinks, redacts known and credential-shaped secrets before bounding content, caps the total retained bytes, and writes files with restrictive permissions.

--- a/docs/solutions/test-failures/gateway-operator-route-health-timeout-flake-2026-07-30.md
+++ b/docs/solutions/test-failures/gateway-operator-route-health-timeout-flake-2026-07-30.md
@@ -32,6 +32,10 @@ tags:
 - The failure is the whole-file 5s ceiling being exceeded under parallel load; it is not tied to one specific `it()`.
 - Re-running the full suite, or running just the file, passes: `bunx vitest run packages/gateway/src/web/operator-route.test.ts` → 35/35 in ~1.4s.
 
+## Not Every 5s Timeout Is This Flake
+
+A timeout is only this flake when the test is normally fast and fails under parallel load. A test that legitimately costs more than the default budget every time it runs — for example one that builds several temporary git repositories — fails deterministically in isolation too, and needs an explicit timeout rather than a re-run. Check isolation first: passing alone points here, failing alone points at the test's own cost.
+
 ## What Didn't Work
 
 Treating a single occurrence as a code failure. The test exercises static route-classification guards (public/health vs privileged) with no timing-sensitive production logic — there is nothing in the assertions that legitimately takes 5s. The timeout is scheduler contention when many gateway suites run concurrently, not a bug in the code under test or the test itself.

--- a/docs/solutions/workflow-issues/delegated-contract-refactors-need-an-enumerated-inventory-2026-08-09.md
+++ b/docs/solutions/workflow-issues/delegated-contract-refactors-need-an-enumerated-inventory-2026-08-09.md
@@ -1,0 +1,88 @@
+---
+title: Delegated refactors that touch a contract need an enumerated inventory and a signature diff
+date: 2026-08-09
+category: workflow-issues
+module: development-workflow
+problem_type: workflow_issue
+component: development_workflow
+severity: high
+applies_when:
+  - Delegating a refactor that touches prompt text, delivery rules, or another enforced contract
+  - Accepting delegated work whose summary reports success
+  - Reviewing a change that could quietly widen or delete a fail-closed path
+tags:
+  - delegation
+  - contract-safety
+  - refactoring
+  - code-review
+  - public-api
+---
+
+# Delegated refactors that touch a contract need an enumerated inventory and a signature diff
+
+## Context
+
+A prompt change was delegated with a clear objective: replace a prescribed session-tool sequence with an affordance, and leave delivery contracts alone. The returned work reported success, showed a passing test run, and listed the contract items it claimed to have preserved.
+
+Reading the actual diff showed something else. Beyond the requested edit it had:
+
+- deleted the `### GitHub Operations` section, removing the statement that `gh` is pre-authenticated on the paths that post through the model
+- collapsed `buildPullRequestDirective` to a single variant, dropping the `file-convention` verdict-frontmatter instruction and the silent-run directive
+- reduced `buildOutputContractSection` to a pointer, discarding the per-delivery verdict mapping that backs the fail-closed `missing-verdict` path in `src/features/agent/response-post.ts`
+- added an unrequested emission gate on the output contract
+- removed a parameter from `getTriggerDirective` and `buildTaskSection`, which are exported from both `packages/runtime/src/agent/index.ts` and `src/features/agent/index.ts`
+
+Every test still passed, because the deleted text had no assertion pinning it.
+
+## Guidance
+
+### Enumerate the contract before delegating, not after
+
+State the protected items as an explicit list in the brief, and treat the work as incomplete until each one is confirmed individually. For this change the list was: the response-file path, the verdict token set, the exactly-one-response rule, the `gh`-unavailable statement in file-convention mode, the non-posting prohibition when delivery is `none`, delivery-mode authority over user-supplied instructions, and the bot marker.
+
+Enumerating beats describing. "Do not weaken delivery contracts" is a judgement call that a good-faith implementer can satisfy while deleting the specific sentence that carries the contract. A list is checkable.
+
+### Diff exported signatures against the base branch
+
+A refactor brief that never mentions the public surface will not stop a parameter from disappearing. Before accepting, compare the exported signatures directly:
+
+```bash
+git diff origin/main -- packages/runtime/src/agent/prompt.ts
+```
+
+Then confirm each changed symbol against its barrel exports. A parameter removed from a function exported by two packages is an API change regardless of how local the edit looked.
+
+### Read the diff, not the report
+
+A summary describing what was done is evidence of intent, not of content. In this case the report named the right contract items while the diff had removed the text implementing several of them. The same session later reported two file edits that had not been made.
+
+Verify claims against source. When the claim is "nothing else changed", the diff is the only thing that can establish it.
+
+### Prefer under-consolidation on contract-bearing text
+
+The brief also asked to consolidate duplicated delivery rules. Consolidation is where deletions hide: merging two statements into one is indistinguishable from dropping one until you check what survived. Instruct that consolidation happens only for verbatim duplicates, and that if it cannot be done without removing a contract statement, it should not happen at all.
+
+## Why This Matters
+
+The deleted verdict mapping was not decoration. It is the instruction that makes a review run produce a verdict the harness can act on; without it the run reaches the fail-closed `missing-verdict` path and delivers nothing. A green test suite would have shipped that, because prose has no assertion unless someone writes one.
+
+The general shape: delegated work is judged by its report and its test results, and neither covers text that nothing pins. Contract-bearing prose needs an explicit inventory precisely because the test suite cannot infer which sentences are load-bearing.
+
+## When to Apply
+
+- Any delegated change to prompt text, delivery rules, permission wording, or another contract enforced by convention rather than by type.
+- Any refactor touching a function exported from a package barrel.
+- Any brief that includes "consolidate", "simplify", or "clean up" alongside a correctness constraint.
+- Whenever a returned summary asserts that unrelated behavior is unchanged.
+
+## Examples
+
+The recovery was to keep the requested edit and revert everything else, item by item, then pin the seven contract statements with exact assertions so the next change cannot delete them silently. The affordance rewrite itself was correct and shipped unchanged.
+
+An honest limitation: exact-string assertions catch deletion and rewording, not a semantically equivalent reintroduction under different wording. Behavioral coverage — for this repository, the eval corpus — remains the check for whether the prompt still produces the required outcome.
+
+## Related
+
+- [Non-failing gates are worse than no gates](non-failing-gates-are-worse-than-no-gates-2026-08-07.md)
+- [Build agent eval corpora around observable outcomes](../best-practices/deterministic-agent-outcome-eval-corpus-2026-08-09.md)
+- [Inferred counters are not control-flow authority](../logic-errors/inferred-counters-are-not-control-flow-authority-2026-08-08.md)


### PR DESCRIPTION
## Summary

Every unit in the harness flexibility plan is now merged, so the remaining checkboxes and the status field are brought in line with reality. The mutation eval scenario stays cut; its rationale was already recorded when the stop condition triggered.

## Learnings

**Delegated refactors that touch a contract** — a new entry covering what the prompt work exposed: a brief needs an enumerated inventory of the protected statements and a signature diff against the base branch. A delegated pass deleted the `gh` availability section, the per-delivery pull request directives, and the verdict mapping behind the fail-closed missing-verdict path, then reported success. Every test still passed, because none of that prose had an assertion pinning it.

**Baseline ordering** — folded into the existing eval corpus entry rather than shipped separately. A prompt change makes the committed baseline legitimately stale, so the order is: commit the code, run the corpus at that commit, promote the baseline, commit it. The integrity check fails on purpose in the middle of that window, and the wrong fix is to hand-edit the baseline.

**Timeout triage** — added to the existing flake entry rather than given its own. A load-dependent timeout passes in isolation; a test that is simply slower than the default budget fails in isolation too and needs an explicit timeout. They look identical in a failing run and are resolved differently.

## Validation

- Prettier and markdown link checks pass across 329 links.
- Every source claim was checked against merged code: the exported prompt builders keep their delivery parameter, the per-delivery directives and verdict mapping are intact, the fail-closed missing-verdict path exists, and the seven pinned contract assertions pass.
- Documentation only; no source, test, or `dist/` changes.
