### PR TITLE
docs: refresh living documentation against the current tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,8 +53,9 @@ Highest-traffic entry points — see [STRUCTURE.md](STRUCTURE.md) for the full d
 
 ```bash
 bun install                          # Install dependencies
-bun run test                         # Run workspace + scripts/ tests (vitest from repo root)
+bun run test                         # Run workspace package tests + evals/ (vitest from repo root)
 bun run test:scripts                 # Run only scripts/ tests
+bun run test:evals                   # Run only evals/ tests (live scenarios need FRO_BOT_EVAL=1)
 bun run lint                         # ESLint check (also checks the committed dist/ for hidden Unicode)
 bun run fix                          # ESLint auto-fix
 bun run check-types                  # TypeScript type check (tsc --noEmit)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -56,8 +56,8 @@ Symbols verified against the live source tree. Where a symbol has moved to `pack
 | `processEventStream` | Function | `src/features/agent/streaming.ts` | Process SDK event stream |
 | `bootstrapOpenCodeServer` | Function | `src/features/agent/server.ts` | Initialize SDK server lifecycle |
 | `TriggerDirective` | Interface | `packages/runtime/src/agent/prompt.ts` | Directive + appendMode for triggers |
-| `DEFAULT_SYSTEMATIC_VERSION` | Constant | `packages/runtime/src/shared/constants.ts` | Pinned Systematic version (`2.32.2`) |
-| `DEFAULT_OPENCODE_VERSION` | Constant | `packages/runtime/src/shared/constants.ts` | Pinned harness version (`1.17.13+harness.ee55e157`) |
+| `DEFAULT_SYSTEMATIC_VERSION` | Constant | `packages/runtime/src/shared/constants.ts` | Pinned Systematic version (`3.6.0`) |
+| `DEFAULT_OPENCODE_VERSION` | Constant | `packages/runtime/src/shared/constants.ts` | Pinned harness version (`1.18.14+harness.202732ae`) |
 
 ### `packages/gateway/`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,9 @@ This installs workspace dependencies and registers the git hooks (via `simple-gi
 ## Command Surface
 
 ```bash
-bun run test          # Run the workspace package test suites (Vitest)
+bun run test          # Run the workspace package test suites plus evals/ (Vitest)
 bun run test:scripts  # Run the repo-root scripts/ test suite (Vitest)
+bun run test:evals    # Run only the evals/ suite (Vitest)
 bun run lint          # ESLint check (also scans committed dist/ for hidden Unicode)
 bun run fix           # ESLint auto-fix
 bun run check-types   # TypeScript type check (tsc --noEmit)
@@ -37,6 +38,7 @@ bun run build         # Type-check + bundle to dist/ (dist/ is committed and mus
 - **Vitest** for the workspace; test files are colocated as `<name>.test.ts` next to the code they cover.
 - **BDD comments** mark the phases of each test: `// #given`, `// #when`, `// #then`.
 - **`deploy/scripts/`** is a carve-out: plain Node ESM (`.mjs`) run with the built-in `node --test` runner, not Vitest. It is exercised in CI by the `workspace-smoke` job.
+- **`evals/`** holds a gated agent-outcome corpus. Its pure gate, scenario, and baseline-integrity tests run as part of `bun run test`; the live scenarios execute a real model and only run when `FRO_BOT_EVAL=1` is set explicitly, so ordinary contributions never trigger them. Changing the agent prompt invalidates the recorded baseline — see [`evals/README.md`](evals/README.md) for the re-recording procedure.
 - Write the test alongside the change in the same PR; behavior changes need a test that pins the new behavior.
 
 ## Type Safety

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -6,7 +6,7 @@ This document maps the repository's directory layout and explains where code liv
 
 ```text
 fro-bot/agent/
-├── src/                        # GitHub Action logic — 4-layer architecture (~14.6k lines)
+├── src/                        # GitHub Action logic — 4-layer architecture (~17.4k lines, excluding tests)
 │   ├── shared/                 # Layer 0: pure types, utils, constants (only @bfra.me/es Result; no heavy deps)
 │   ├── services/               # Layer 1: external adapters (GitHub, cache, setup, object-store, artifact)
 │   │   ├── github/             # Octokit client, context parsing, NormalizedEvent
@@ -59,12 +59,21 @@ fro-bot/agent/
 ├── .github/
 │   └── workflows/              # 11 CI/CD workflow files
 │
+├── evals/                      # Gated agent-outcome eval corpus (live runs need FRO_BOT_EVAL=1)
+│   ├── scenarios/             # Frozen scenario definitions and fixture repos
+│   └── baselines/             # Committed reviewed baseline + provenance integrity test
+│
 ├── RFCs/                       # 19 RFC documents (architecture specs)
 ├── docs/
 │   ├── wiki/                   # 8 Obsidian deep-dive pages
 │   ├── plans/                  # Architecture plans and design docs
 │   ├── solutions/              # Documented solutions to past problems
-│   └── decisions/              # Architecture decision records
+│   ├── product/                # Product requirements and feature docs
+│   ├── brainstorms/            # Requirements documents from design sessions
+│   ├── decisions/              # Architecture decision records
+│   └── …                       # audits/, examples/, ideation/, privacy/, reference/
+│
+├── assets/                     # Repository images and branding
 │
 ├── action.yaml                 # GitHub Action definition (node24 runtime)
 ├── dist/                       # Committed bundled output — must stay in sync with src/
@@ -88,9 +97,12 @@ fro-bot/agent/
 - **`deploy/`** — Docker Compose stack, Dockerfiles, mitmproxy egress topology, and deploy validation scripts.
 - **`deploy/scripts/`** — Plain Node ESM (`.mjs`) helpers for deploy-time operations; uses `node --test`, not Vitest.
 - **`scripts/`** — Repo-level build tooling: action dist builder, hidden-Unicode scrubber, third-party notices, release dispatch.
+- **`evals/`** — Gated agent-outcome eval corpus that runs the real execution path against disposable fixture repos; the pure gate and baseline tests run in normal CI, while live scenarios require `FRO_BOT_EVAL=1`.
 - **`.github/workflows/`** — All CI/CD automation; 11 workflow files covering tests, releases, security scanning, and bot triggers.
 - **`RFCs/`** — 19 architecture specification documents; read before making cross-cutting changes.
 - **`docs/wiki/`** — 8 Obsidian deep-dive pages covering architecture, execution lifecycle, prompt design, and operator surface.
+- **`docs/solutions/`** — Documented solutions to past problems, organized by category with YAML frontmatter (`module`, `tags`, `problem_type`); relevant when implementing or debugging in a documented area.
+- **`assets/`** — Repository images and branding referenced by `README.md`.
 - **`dist/`** — Committed bundle output; CI fails if a fresh build produces a diff here.
 
 ## Key File Locations


### PR DESCRIPTION
## Summary

The living documentation had drifted from the repository it describes. This corrects the facts that were wrong and adds the one top-level directory the docs never covered.

## What was wrong

**Version pins** — `ARCHITECTURE.md` listed Systematic `2.32.2` and OpenCode `1.17.13+harness.ee55e157`. The pinned values are `3.6.0` and `1.18.14+harness.202732ae`.

**Layout** — `STRUCTURE.md` described `src/` as roughly 14.6k lines against a current 17.4k excluding tests, listed four of the eleven directories under `docs/`, and omitted both `evals/` and `assets/` entirely.

**Command surface** — `bun run test` now chains the eval suite alongside the workspace packages, but `CONTRIBUTING.md` and `AGENTS.md` both described it as workspace-only. A contributor reading either would not know the eval suite runs, or that `test:evals` exists.

## The eval corpus

`evals/` is now documented where a contributor would look for it: in the layout tree, in the directory purposes, and in the contributor command surface. The note that matters is which parts run by default — the gate, scenario, and baseline-integrity tests run in normal CI, while the live scenarios execute a real model and require `FRO_BOT_EVAL=1`, so ordinary contributions never trigger them.

## Verification

Every corrected number and path was re-derived from the tree rather than copied between documents. Counts that were already right — 19 RFCs, 11 workflows, 8 wiki deep dives — were left untouched.

A full staleness pass over all 88 entries in `docs/solutions/` found nothing to change: no broken references, no contradictions, and no citations of the runtime execution and retry modules that were recently removed.

Prettier and the markdown link check pass across 330 links. Documentation only; no source, test, or `dist/` changes.
