### PR TITLE
fix(workflow): count every open security alert in the maintenance report

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -97,7 +97,19 @@ env:
 
     Sections (in order):
     - Summary metrics (issues opened since last run, currently open PRs, stale
-      issues/PRs count, main branch check status, security alerts if accessible)
+      issues/PRs count, main branch check status, security alerts)
+
+    For the security alert counts, query both sources explicitly and report each
+    total separately:
+      gh api "repos/{owner}/{repo}/dependabot/alerts?state=open&per_page=100" --paginate
+      gh api "repos/{owner}/{repo}/code-scanning/alerts?state=open&per_page=100" --paginate
+    The `state` field is the only authority on whether an alert is open. Report an
+    alert as resolved only when its own state says so — never because it is missing
+    from a narrower view. Repo-level findings (Scorecard rules such as branch
+    protection or known vulnerabilities) legitimately have no file location and
+    still count toward the total, so never filter on the presence of a file path.
+    If a source is genuinely inaccessible, write "data unavailable" for that source
+    rather than reporting a partial count as complete.
     - Stale issues (no activity >30 days; recommend next step)
     - Stale PRs (no activity >7 days; stale >14 days)
     - Unassigned bugs (label bug, no assignee)


### PR DESCRIPTION
## Summary

The Daily Maintenance Report has been undercounting open security alerts and then describing the missing ones as resolved.

Today's run reported "5 open (down from 9 last run)" and stated that four alerts "have cleared." The API disagrees — all nine are `state: open`, `fixed_at: null`, and the oldest has been open since January.

## Why it happened

The report instruction said only:

```
security alerts if accessible
```

That leaves the definition entirely to the agent, and it settled on alerts carrying a file location. Four of the nine are repository-level Scorecard findings — branch protection, known vulnerabilities, fuzzing, best-practices badge — which have no associated file by nature. They dropped out of the view, and their absence was then narrated as improvement.

The two highest-value findings in the set are among the four that disappeared.

## The change

The instruction now names both API queries, makes each alert's own `state` the sole authority on whether it is open, and says directly that a finding without a file location still counts. When a source genuinely cannot be read, the report must say `data unavailable` rather than present a partial count as complete.

This is the same failure mode already documented in `docs/solutions/workflow-issues/non-failing-gates-are-worse-than-no-gates-2026-08-07.md`: a check that cannot observe a category will report that category as clean. Here it was worse than silence, because the gap was reported as progress.

## Verification

The workflow parses, both queries are present in the rendered prompt, the file-path filter is explicitly forbidden, and both `cron` schedules are unchanged. Prompt text only — no job, trigger, permission, or step changes.

The corrected count takes effect on the next scheduled run.
