### PR TITLE
ci(harness): deny workflow-level permissions by default on integrate

### DIFF
--- a/.github/workflows/harness-integrate.yaml
+++ b/.github/workflows/harness-integrate.yaml
@@ -15,6 +15,13 @@
 # ---------------------------------------------------------------------------
 name: harness-integrate
 
+# Deny every scope by default. The single `integrate` job below declares the two
+# scopes it needs, and a job-level block replaces this one rather than merging
+# with it, so the existing mint and checkout are unaffected. A future job added
+# without its own block gets nothing and fails loudly at checkout, which is the
+# intended outcome for a file where adding a job is security-critical.
+permissions: {}
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Summary

`harness-integrate.yaml` was the only workflow in the repository without a top-level `permissions:` block, so its default came from repository settings rather than from the file itself. This adds a deny-all default.

Resolves OpenSSF Scorecard alert #67 (`TokenPermissionsID`, high — "no topLevel permission defined").

## Why this is inert today

The workflow has exactly one job, and that job already declares the two scopes it needs:

```yaml
permissions:
  id-token: write
  contents: read
```

A job-level block **replaces** the workflow-level block rather than merging with it, so the effective permissions of `integrate` are byte-identical before and after this change. The credential mint and the checkout are untouched.

## Why it still matters

The value is for the job that does not exist yet.

The broker allowlist pins `job_workflow_ref` to this file, which authorizes *any* job in it to mint a credential — the file's own header calls that out and asks that adding a job be treated as security-critical. Until now, a new job added without its own `permissions:` block would have inherited whatever the repository default happened to be. With a deny-all default it inherits nothing and fails loudly at checkout, which is the outcome you want when the alternative is silently acquiring mint-adjacent authority.

## Why `{}` rather than `contents: read`

Sibling workflows use `contents: read`, and that would also clear the alert. `{}` is chosen deliberately here because this is the one file where an unreviewed job is a security event rather than an inconvenience — failing closed is more useful than granting a small default.

## Verification

The workflow parses, the top-level block is `{}`, the job count is still 1 as the invariant requires, the `integrate` job's scopes are unchanged, and all six steps plus both `workflow_call` input and secret lists are intact. Comment and permissions only — no job, trigger, step, or secret changes.
