### PR TITLE
fix(gateway): redact sensitive fields from logger context

### DIFF
--- a/packages/gateway/src/discord/client.test.ts
+++ b/packages/gateway/src/discord/client.test.ts
@@ -3,9 +3,9 @@ import type {EventEmitter} from 'node:events'
 import type {Client} from 'discord.js'
 
 import {GatewayIntentBits} from 'discord.js'
-import {beforeAll, describe, expect, it, vi} from 'vitest'
+import {afterEach, beforeAll, describe, expect, it, vi} from 'vitest'
 
-import {createDiscordClient, DEFAULT_INTENTS, withLogContext} from './client.js'
+import {CONSOLE_GATEWAY_LOGGER, createDiscordClient, DEFAULT_INTENTS, withLogContext} from './client.js'
 import {validateTokenIsFake} from './test-token-guard.js'
 
 // discord.js Client constructor makes no network calls — safe to instantiate in tests.
@@ -116,6 +116,78 @@ describe('createDiscordClient', () => {
       GatewayIntentBits.GuildMembers,
     ]
     expectClientIntents(client, expected)
+  })
+})
+
+describe('CONSOLE_GATEWAY_LOGGER', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('redacts sensitive fields from warn output while preserving exempt and ordinary fields', () => {
+    // #given caller context containing a token, an exempt cache key, and an ordinary request id
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    // #when the console gateway logger emits a warning
+    CONSOLE_GATEWAY_LOGGER.warn(
+      {token: 'warn-token', cacheKey: 'cache-key-123', requestId: 'request-123'},
+      'warn message',
+    )
+
+    // #then the token is redacted, while cacheKey, requestId, level, and msg are preserved
+    expect(warnSpy).toHaveBeenCalledWith(
+      '{"level":"warn","token":"[REDACTED]","cacheKey":"cache-key-123","requestId":"request-123","msg":"warn message"}',
+    )
+  })
+
+  it('redacts sensitive fields from nested error context', () => {
+    // #given an error context containing a token and nested auth/clientSecret fields
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    // #when the console gateway logger emits an error
+    CONSOLE_GATEWAY_LOGGER.error(
+      {token: 'error-token', nested: {auth: {clientSecret: 'nested-secret'}}},
+      'error message',
+    )
+
+    // #then both the direct and nested sensitive values are redacted
+    expect(errorSpy).toHaveBeenCalledWith(
+      '{"level":"error","token":"[REDACTED]","nested":{"auth":{"clientSecret":"[REDACTED]"}},"msg":"error message"}',
+    )
+  })
+
+  it('keeps debug and info silent', () => {
+    // #given spies on every console output method
+    const spies = [
+      vi.spyOn(console, 'log').mockImplementation(() => undefined),
+      vi.spyOn(console, 'info').mockImplementation(() => undefined),
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined),
+      vi.spyOn(console, 'error').mockImplementation(() => undefined),
+      vi.spyOn(console, 'debug').mockImplementation(() => undefined),
+    ]
+
+    // #when debug and info receive caller context
+    CONSOLE_GATEWAY_LOGGER.debug({token: 'debug-token'}, 'debug message')
+    CONSOLE_GATEWAY_LOGGER.info({token: 'info-token'}, 'info message')
+
+    // #then no console output is emitted
+    for (const spy of spies) {
+      expect(spy).not.toHaveBeenCalled()
+    }
+  })
+
+  it('redacts context through withLogContext before reaching the console sink', () => {
+    // #given a scoped logger backed by the console gateway logger
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const scopedLogger = withLogContext(CONSOLE_GATEWAY_LOGGER, {command: 'ping'})
+
+    // #when the wrapped logger emits a warning with a sensitive token
+    scopedLogger.warn({token: 'wrapped-token', cacheKey: 'cache-key-456'}, 'wrapped warning')
+
+    // #then the scoped context is forwarded and the sink redacts the token
+    expect(warnSpy).toHaveBeenCalledWith(
+      '{"level":"warn","command":"ping","token":"[REDACTED]","cacheKey":"cache-key-456","msg":"wrapped warning"}',
+    )
   })
 })
 

--- a/packages/gateway/src/discord/client.ts
+++ b/packages/gateway/src/discord/client.ts
@@ -1,3 +1,4 @@
+import {redactSensitiveFields} from '@fro-bot/runtime'
 import {Client, GatewayIntentBits} from 'discord.js'
 
 export interface GatewayLogger {
@@ -85,8 +86,10 @@ export const NOOP_GATEWAY_LOGGER: GatewayLogger = Object.freeze({
 export const CONSOLE_GATEWAY_LOGGER: GatewayLogger = Object.freeze({
   debug: () => undefined,
   info: () => undefined,
-  warn: (ctx: Record<string, unknown>, msg: string) => console.warn(JSON.stringify({level: 'warn', ...ctx, msg})),
-  error: (ctx: Record<string, unknown>, msg: string) => console.error(JSON.stringify({level: 'error', ...ctx, msg})),
+  warn: (ctx: Record<string, unknown>, msg: string) =>
+    console.warn(JSON.stringify({level: 'warn', ...redactSensitiveFields(ctx), msg})),
+  error: (ctx: Record<string, unknown>, msg: string) =>
+    console.error(JSON.stringify({level: 'error', ...redactSensitiveFields(ctx), msg})),
 })
 
 /**

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -6,7 +6,7 @@ import type {CoordinationLogger} from './runtime-effect.js'
 
 import {GatewayIntentBits} from 'discord.js'
 import {Effect} from 'effect'
-import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 // Spy on createDiscordClient so we can assert the intents wiring without
 // touching the network or requiring a real Discord token.
@@ -115,7 +115,7 @@ vi.mock('./web/operator-push/subscription-store.js', async importOriginal => {
   }
 })
 
-const {makeDiscordClientFromConfig, makeGatewayProgram} = await import('./program.js')
+const {makeDiscordClientFromConfig, makeGatewayProgram, makeLogger} = await import('./program.js')
 const {createDiscordClient} = await import('./discord/client.js')
 const createDiscordClientSpy = vi.mocked(createDiscordClient)
 
@@ -187,6 +187,68 @@ describe('makeDiscordClientFromConfig', () => {
       intents: [GatewayIntentBits.MessageContent, GatewayIntentBits.GuildMembers],
       logger: stubLogger,
     })
+  })
+})
+
+describe('makeLogger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('redacts sensitive context across every log level while preserving the structured output shape', () => {
+    // #given a logger receiving sensitive, nested, exempt, and ordinary context
+    const logger = makeLogger('debug')
+    const context = {
+      token: 'sensitive-token',
+      nested: {auth: {clientSecret: 'sensitive-client-secret'}},
+      cacheKey: 'cache-key-123',
+      requestId: 'request-123',
+    }
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    // #when each enabled log method receives that context
+    logger.debug(context, 'debug message')
+    logger.info(context, 'info message')
+    logger.warn(context, 'warn message')
+    logger.error(context, 'error message')
+
+    // #then each level redacts sensitive fields, preserves cacheKey and requestId,
+    // and keeps level/context/message ordering and values intact
+    expect(logSpy).toHaveBeenNthCalledWith(
+      1,
+      '{"level":"debug","token":"[REDACTED]","nested":{"auth":{"clientSecret":"[REDACTED]"}},"cacheKey":"cache-key-123","requestId":"request-123","msg":"debug message"}',
+    )
+    expect(logSpy).toHaveBeenNthCalledWith(
+      2,
+      '{"level":"info","token":"[REDACTED]","nested":{"auth":{"clientSecret":"[REDACTED]"}},"cacheKey":"cache-key-123","requestId":"request-123","msg":"info message"}',
+    )
+    expect(warnSpy).toHaveBeenCalledWith(
+      '{"level":"warn","token":"[REDACTED]","nested":{"auth":{"clientSecret":"[REDACTED]"}},"cacheKey":"cache-key-123","requestId":"request-123","msg":"warn message"}',
+    )
+    expect(errorSpy).toHaveBeenCalledWith(
+      '{"level":"error","token":"[REDACTED]","nested":{"auth":{"clientSecret":"[REDACTED]"}},"cacheKey":"cache-key-123","requestId":"request-123","msg":"error message"}',
+    )
+  })
+
+  it('suppresses calls below the configured level without changing enabled output', () => {
+    // #given a warn-level logger
+    const logger = makeLogger('warn')
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    // #when debug and info are below threshold, while warn and error are enabled
+    logger.debug({token: 'debug-token'}, 'debug message')
+    logger.info({token: 'info-token'}, 'info message')
+    logger.warn({token: 'warn-token'}, 'warn message')
+    logger.error({token: 'error-token'}, 'error message')
+
+    // #then below-threshold calls are suppressed and enabled calls retain their level/msg
+    expect(logSpy).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith('{"level":"warn","token":"[REDACTED]","msg":"warn message"}')
+    expect(errorSpy).toHaveBeenCalledWith('{"level":"error","token":"[REDACTED]","msg":"error message"}')
   })
 })
 

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_PENDING_STALE_THRESHOLD_MS,
   DEFAULT_STALE_THRESHOLD_MS,
   err,
+  redactSensitiveFields,
 } from '@fro-bot/runtime'
 import {getConnInfo} from '@hono/node-server/conninfo'
 import {Effect} from 'effect'
@@ -89,17 +90,17 @@ export function makeLogger(level: 'debug' | 'info' | 'warn' | 'error'): GatewayL
   return {
     debug: (ctx, msg) => {
       // eslint-disable-next-line no-console
-      if (minLevel <= levels.debug) console.log(JSON.stringify({level: 'debug', ...ctx, msg}))
+      if (minLevel <= levels.debug) console.log(JSON.stringify({level: 'debug', ...redactSensitiveFields(ctx), msg}))
     },
     info: (ctx, msg) => {
       // eslint-disable-next-line no-console
-      if (minLevel <= levels.info) console.log(JSON.stringify({level: 'info', ...ctx, msg}))
+      if (minLevel <= levels.info) console.log(JSON.stringify({level: 'info', ...redactSensitiveFields(ctx), msg}))
     },
     warn: (ctx, msg) => {
-      if (minLevel <= levels.warn) console.warn(JSON.stringify({level: 'warn', ...ctx, msg}))
+      if (minLevel <= levels.warn) console.warn(JSON.stringify({level: 'warn', ...redactSensitiveFields(ctx), msg}))
     },
     error: (ctx, msg) => {
-      if (minLevel <= levels.error) console.error(JSON.stringify({level: 'error', ...ctx, msg}))
+      if (minLevel <= levels.error) console.error(JSON.stringify({level: 'error', ...redactSensitiveFields(ctx), msg}))
     },
   }
 }


### PR DESCRIPTION
## Summary

The gateway had two `GatewayLogger` implementations, and both wrote caller-supplied context straight into the serialized line:

```ts
console.log(JSON.stringify({level: 'debug', ...ctx, msg}))
```

Any field named `token`, `clientSecret`, or similar would have been written verbatim. The Action side already guards this — the runtime logger masks fields whose names look sensitive before formatting — so this closes the gap on the gateway side using the same function.

No current caller passes a secret, so this is a latent path rather than an active leak. It surfaced while proving CodeQL alert #63 a false positive.

## The change

`redactSensitiveFields` from `@fro-bot/runtime` is applied to context in both sinks:

- `makeLogger` (`program.ts`) — all four levels, inside each level guard so a suppressed call still costs nothing.
- `CONSOLE_GATEWAY_LOGGER` (`discord/client.ts`) — `warn` and `error`; `debug` and `info` are no-ops with nothing to redact. Reachable in production through the ping command.

Fixing only the first would have left the pair inconsistent, which is worse than either uniform state because it invites the assumption that gateway logging is safe everywhere.

`withLogContext` needs no change of its own. It merges scoped context into caller meta and delegates to a base logger without writing to the console, so redaction at the sink already covers every wrapped call. A test drives that path to prove it.

The `GatewayLogger` interface is untouched. Its signature is `(context, message)` — reversed from the runtime `Logger` — so swapping in the runtime logger was never an option, and redacting context in place is the smaller change.

## What is deliberately not covered

`packages/gateway/src/main.ts:7` logs `String(error)`. Redaction walks object fields, so it cannot mask anything inside an already-stringified value; applying it there would imply a protection that does not exist. Fourteen other incidental `console.*` calls elsewhere in the package are also untouched — none is a `GatewayLogger` implementation taking caller-supplied context.

## Verification

Five tests fail when the redaction is stripped — two in `program.test.ts`, three in `client.test.ts` — so they pin real behavior rather than restating the implementation. They assert exact serialized output, which also covers field ordering (`level`, context, `msg`), and cover nested masking, the `cacheKey` exemption, ordinary fields passing through, level-threshold suppression, and the wrapped `withLogContext` path.

Gateway suite 3180/3180, type checks clean, lint clean with no new warnings.
