### PR TITLE
ci: scan the full dependency tree with osv-scanner

### DIFF
--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -1,0 +1,52 @@
+---
+name: OSV-Scanner
+
+on:
+  merge_group:
+    types: [checks_requested]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, ready_for_review, reopened]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '12 12 * * 1'
+
+permissions: {}
+
+jobs:
+  scan-pr:
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    name: OSV-Scanner PR scan
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@8deb546fdb875b9996d27d4950be7312dac076a1 # v2.5.0
+    with:
+      scan-args: |-
+        --include-git-root
+        -r
+        ./
+      upload-sarif: true
+      # Report-only on purpose: existing findings must not block every PR.
+      # Change this to true only as a deliberate fail-on-new policy decision.
+      fail-on-vuln: false
+
+  scan-scheduled:
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    name: OSV-Scanner full scan
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@8deb546fdb875b9996d27d4950be7312dac076a1 # v2.5.0
+    with:
+      scan-args: |-
+        --include-git-root
+        -r
+        ./
+      upload-sarif: true
+      # Report-only on purpose: known findings are uploaded to code scanning.
+      # Change this to true only as a deliberate fail-on-new policy decision.
+      fail-on-vuln: false


### PR DESCRIPTION
## Summary

GitHub's dependency graph parses only the direct dependencies of `bun.lock`, so most of the tree is invisible to Dependabot. This adds an osv-scanner workflow that reads the lockfile itself.

## The coverage gap

| | |
| --- | --- |
| Direct dependencies declared across all `package.json` files | 42 |
| Packages in GitHub's SBOM | 63 |
| Resolved entries in `bun.lock` | ~1036 |
| Packages osv-scanner sees | 1169 |

Every package currently carrying an advisory sits in the part GitHub cannot see — `tar`, `undici`, `fast-uri`, `ip-address`, `brace-expansion`, `nanoid`, `fast-xml-parser`, `postcss`. The single exception is `js-yaml`, which appears because it is declared directly.

That explains a reading that looks reassuring and is not: Dependabot reports zero open alerts while `state=fixed` is 78. The pipeline works — it just covers about six percent of the tree. OpenSSF Scorecard already flags 24 vulnerabilities here (alert #13) precisely because it runs osv-scanner instead of reading the graph.

A local run against this lockfile confirms it: 1169 packages scanned, 9 affected, 24 vulnerabilities — 1 critical, 13 high, 10 medium.

## Reporting only, deliberately

Findings upload to code scanning but do not fail the job. With 24 existing findings, a failing gate would block every pull request from the first run. Both jobs carry a comment marking `fail-on-vuln: false` as a policy choice, so switching it on later is a deliberate one-line decision rather than an accident.

## Triggers

Pull requests and the merge queue for fast feedback on newly introduced dependencies, pushes to `main` for post-merge visibility, and a weekly schedule so newly disclosed advisories reach code that has not changed.

## Verification

The pinned SHA `8deb546f` was resolved through the GitHub API and matches the `v2.5.0` tag. Both referenced reusable workflows exist at that ref, and `scan-args`, `upload-sarif`, and `fail-on-vuln` were each confirmed against their declared `workflow_call` inputs rather than assumed.

The workflow parses, carries a top-level `permissions: {}` with both jobs declaring their own scopes, and passes Prettier. A follow-up will address the 24 findings themselves.
