### PR TITLE
docs(solutions): capture blind checks and machine-checked dependency triage

### DIFF
--- a/docs/solutions/best-practices/machine-checked-advisory-ranges-and-version-floors-2026-08-10.md
+++ b/docs/solutions/best-practices/machine-checked-advisory-ranges-and-version-floors-2026-08-10.md
@@ -1,0 +1,110 @@
+---
+title: Read advisory ranges from machine data and bound every version floor
+date: 2026-08-10
+category: best-practices
+module: dependency-management
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - Deciding whether a resolved version is still exposed to a published advisory
+  - Reading affected-version information from advisory summary prose
+  - Raising a minimum version in an overrides or resolutions block
+  - Confirming that a dependency fix actually changed what the resolver picked
+tags:
+  - osv
+  - advisory-ranges
+  - semver
+  - version-floors
+  - supply-chain
+  - dependency-triage
+---
+
+# Read advisory ranges from machine data and bound every version floor
+
+## Context
+
+Clearing 24 advisories across nine transitive packages produced two mistakes worth keeping, both in the same short stretch of work, and both made twice — once by me and once by a delegated research lane working independently.
+
+The first was reading affected-version information out of advisory prose. Summary text like _affects 8.5.22_ reads as an exact statement about one version. On that basis I excluded three of the 24 advisories as already patched, and reported a smaller number with confidence. The machine-readable data said otherwise:
+
+```bash
+curl -s https://api.osv.dev/v1/vulns/GHSA-fxqj-rqcc-2cmp | jq '.affected[0].ranges[0].events'
+# [{"introduced":"0"},{"fixed":"8.5.23"}]
+```
+
+`introduced: 0` means every version below the fix. The resolved `8.5.21` was inside the range, not below it. All 24 advisories applied.
+
+Two of the three exclusions were `brace-expansion` advisories whose ranges begin at `4.0.0` and end at `5.0.8` and `5.0.9`. The resolved `5.0.6` looked comfortably below a range starting at `5.0.7` in prose, and was in fact inside a range starting at `4.0.0`. Multi-major packages are where prose diverges most from the data, because a single advisory carries a separate range per major line and prose tends to describe only the newest.
+
+The second mistake came while fixing the advisories. Raising a floor to `"nanoid": ">=3.3.17"` resolved to `6.0.1` — nearly three major versions above the `3.3.x` line in use. A bare floor says _at least this_, and the resolver obliges by taking the newest thing that satisfies it. That would have shipped a breaking upgrade inside a change whose stated purpose was a security patch, which is close to the least scrutinized place a major bump can hide.
+
+The behaviour reproduces in isolation, so it costs nothing to confirm before trusting a floor:
+
+```bash
+echo '{"name":"t","dependencies":{"nanoid":">=3.3.17"}}' > package.json && bun install
+node -e "console.log(require('./node_modules/nanoid/package.json').version)"
+# 6.0.1
+```
+
+## Guidance
+
+**Query the range events rather than reading the summary.** OSV exposes them per advisory, and they are unambiguous in a way prose is not:
+
+```bash
+curl -s https://api.osv.dev/v1/vulns/<GHSA-ID> | jq '.affected[] | {pkg: .package.name, events: .ranges[].events}'
+```
+
+Read every `affected[]` entry. One advisory commonly carries several, one per major line, each with its own `introduced`/`fixed` pair. A resolved version is exposed if it sits at or above an `introduced` and below the matching `fixed`.
+
+Better still, let the scanner make the determination. It reads the same data and does not get tired:
+
+```bash
+docker run --rm -v "$PWD:/src" -w /src ghcr.io/google/osv-scanner:v2.5.0 --lockfile=/src/bun.lock
+```
+
+**Bound a floor to the major line you intend to stay on.** A floor exists to keep a package above a known-bad version, not to opt into whatever ships next:
+
+```json
+"nanoid": ">=3.3.17 <4.0.0"
+```
+
+Leave the floor open only when crossing majors is genuinely acceptable for that dependency. In the same change, eight of nine packages kept bare floors deliberately and picked up newer patched releases. `nanoid` was the one case where the next major was three releases away and the constraint had to say so.
+
+**Verify what the resolver actually chose.** A floor expresses intent; the lockfile records outcome. They diverge quietly, in both directions — a floor can fail to move anything, or move something much further than intended. Read the resolved versions out of the lockfile after installing, and re-run the scanner to confirm the count actually reached zero rather than assuming the edit was sufficient.
+
+## Why This Matters
+
+Both errors produce a confident, specific, wrong number, which is worse than an uncertain one because it ends the investigation. The prose reading understated exposure by three advisories and would have left them unfixed with a written rationale explaining why they were fine. The bare floor would have passed review as a security fix while carrying a three-major upgrade.
+
+That two independent readers made the identical prose error is the useful part. It is not a lapse in care — advisory summaries are written for humans skimming for relevance, not for deciding whether a specific resolved version is exposed. Treating them as the latter will keep producing the same mistake.
+
+## When to Apply
+
+Whenever a resolved version is being compared against a published advisory, whenever a minimum is raised in `overrides`, `resolutions`, or an equivalent policy block, and whenever a dependency change is about to be described as complete.
+
+## Examples
+
+The bounded floor, alongside the unbounded ones that were correct to leave open:
+
+```json
+// package.json
+"overrides": {
+  "nanoid": ">=3.3.17 <4.0.0",
+  "tar": ">=7.5.21",
+  "undici": ">=8.9.0"
+}
+```
+
+The scan output is the acceptance criterion for this kind of change, and it is cheap enough to run before and after:
+
+```
+Total 9 packages affected by 24 known vulnerabilities (1 Critical, 13 High, 10 Medium)
+```
+
+versus, after raising the floors, no findings at all.
+
+## Related
+
+- [A check reports clean for the part of the world it cannot observe](../workflow-issues/checks-report-clean-for-what-they-cannot-observe-2026-08-10.md) — how these 24 advisories went unnoticed: the dependency graph parsed only direct dependencies, so Dependabot reported zero while the transitive tree went unscanned.
+- [Verify the signal before implementing the plan](../workflow-issues/evidence-first-scope-correction-under-incomplete-signals-2026-08-08.md) — the same instinct applied to premises rather than version ranges.

--- a/docs/solutions/workflow-issues/checks-report-clean-for-what-they-cannot-observe-2026-08-10.md
+++ b/docs/solutions/workflow-issues/checks-report-clean-for-what-they-cannot-observe-2026-08-10.md
@@ -1,0 +1,114 @@
+---
+title: A check reports clean for the part of the world it cannot observe
+date: 2026-08-10
+category: workflow-issues
+module: development-workflow
+problem_type: workflow_issue
+component: development_workflow
+severity: high
+applies_when:
+  - A scanner, report, or gate summarizes a population it does not fully enumerate
+  - A green result is trusted without knowing what the check was able to look at
+  - Two implementations of the same concern exist and only one is fixed
+  - A validation compares an artifact against values derived from that same artifact
+  - An absent API response is read as evidence that a feature is off
+tags:
+  - observable-scope
+  - false-confidence
+  - dependency-scanning
+  - partial-coverage
+  - verification
+---
+
+# A check reports clean for the part of the world it cannot observe
+
+## Context
+
+Several unrelated defects surfaced in a single session, and they shared one shape: a check working correctly, reporting honestly, and covering less than anyone believed.
+
+None of these were broken gates. Each one ran, passed, and reported a result that was true about its own inputs and false about the thing people were relying on it for.
+
+**Dependency scanning covered about six percent of the tree.** GitHub's dependency graph parses only the direct dependencies of `bun.lock`. At commit `48d09adda`, `gh api repos/OWNER/REPO/dependency-graph/sbom` returned 65 packages while osv-scanner reading the same lockfile reported 1169. Dependabot's open-alert count was zero and had been printed as a daily green tick. That zero was accurate for the 65 packages it could see. Every one of the nine vulnerable packages was transitive and absent from the graph — the only one that appeared, `js-yaml`, was there because it happens to be a direct devDependency.
+
+The tell was available the whole time: `state=fixed` returned 78. The pipeline was alive and had resolved dozens of alerts. It simply had no view of the rest of the tree.
+
+**A report counted only findings that had a file.** The daily maintenance report's instruction said `security alerts if accessible` and nothing more. Left to define that, the agent settled on alerts with a file location. Four repository-level Scorecard findings carry `location.path: "no file associated with this alert"`, so they fell out of the count — and their absence was then narrated as _these alerts have cleared_. Five open reported against nine actually open.
+
+**A redaction fix landed on one of two identical loggers.** `makeLogger` in `packages/gateway/src/program.ts` spread caller context straight into `JSON.stringify`. It was fixed. `CONSOLE_GATEWAY_LOGGER` in `packages/gateway/src/discord/client.ts` had the same defect and was initially dismissed as an incidental console call, though it is reachable in production through the ping command. Review caught it. Half a fix would have left one logger redacting beside a twin that did not, which is worse than neither — it makes the whole package look handled.
+
+**A baseline validated itself against a copy of itself.** `evals/baselines/u1.test.ts` compared the committed baseline JSON against hardcoded constants that had been copied out of that same JSON. It stayed green while all six prompt hashes drifted.
+
+One more instance came from reading an API response rather than a codebase. `gh api repos/OWNER/REPO/vulnerability-alerts` returns 404 when the calling token lacks admin, not 403. That 404 was read — by me, and independently by a delegated research lane — as _the feature is disabled_, and a wrong root cause was reported with confidence. Alerts had been enabled the entire time.
+
+## Guidance
+
+Before trusting a clean result, establish what the check was able to look at. That is a separate question from whether it passed, and it is almost never reported alongside the pass.
+
+**Compare the check's population against an independent count of the same population.** For dependency scanning the two numbers are one command apart:
+
+```bash
+gh api repos/OWNER/REPO/dependency-graph/sbom --jq '.sbom.packages | length'
+docker run --rm -v "$PWD:/src" -w /src ghcr.io/google/osv-scanner:v2.5.0 --lockfile=/src/bun.lock
+```
+
+Sixty-five against 1169 is not a subtle discrepancy. Nobody had put the two numbers next to each other.
+
+**Key status off the field that carries it, not off an incidental property.** An alert's `state` says whether it is open. Whether it has a file path says where it was found. The maintenance report's prompt now states this outright, because leaving it to inference is what produced the wrong count:
+
+```text
+The `state` field is the only authority on whether an alert is open. Report an
+alert as resolved only when its own state says so — never because it is missing
+from a narrower view.
+```
+
+**When fixing a class of defect, enumerate every implementation of that class before scoping the fix.** Search for the shape, not the symptom. Two `GatewayLogger` implementations existed; only one was found by looking at where the reported problem was.
+
+**Make a validation derive its expected value from a source independent of the artifact under test.** If the expectation and the artifact share an origin, the test asserts that a value equals itself.
+
+**Distinguish "no" from "you cannot see."** Before concluding a feature is off, prove the caller could observe it if it were on:
+
+```bash
+gh api repos/OWNER/REPO --jq '.permissions'
+```
+
+GitHub hides several endpoints behind 404 rather than 403 for tokens without admin, so absence has at least two causes and the response does not tell you which.
+
+## Why This Matters
+
+A broken check announces itself. A blind one accumulates trust while the uncovered region grows.
+
+The dependency case had been reporting zero long enough for the number to become background reassurance, and the daily report reinforced it. Twenty-four advisories — one critical, thirteen high — sat in the ninety-four percent nobody was looking at. The fix took a scanner that reads the lockfile directly and a set of version-floor bumps; finding the problem took noticing that two tools disagreed and asking why rather than trusting the friendlier answer.
+
+The twin-logger case is the same failure in miniature and shows why partial fixes are dangerous beyond the code they leave unfixed: the package now _looked_ audited.
+
+## When to Apply
+
+Any time a green result covers a population rather than a single assertion — dependency and vulnerability scanning, alert and compliance summaries, coverage reports, lint or policy sweeps, and any validation whose expected values are generated rather than stated.
+
+Also when a fix targets a defect class that could plausibly exist in more than one place, and when an API's absence is about to become a root cause.
+
+## Examples
+
+Both gateway loggers now route context through the shared redactor, and `withLogContext` needs no change of its own because it delegates rather than writing to the console:
+
+```ts
+// packages/gateway/src/discord/client.ts
+warn: (ctx: Record<string, unknown>, msg: string) =>
+  console.warn(JSON.stringify({level: 'warn', ...redactSensitiveFields(ctx), msg})),
+```
+
+The eval baseline guard now recomputes provenance from the live scenario registry rather than comparing the committed artifact against constants copied out of it. The hardcoded expectation table was deleted outright — deriving it from the same source would have reproduced the original defect in a less obvious form.
+
+Measured at `48d09adda`, an independent lockfile scan showed the population Dependabot could not see:
+
+```text
+Scanned /src/bun.lock file and found 1169 packages
+Total 9 packages affected by 24 known vulnerabilities (1 Critical, 13 High, 10 Medium)
+```
+
+## Related
+
+- [A gate that cannot fail manufactures confidence](non-failing-gates-are-worse-than-no-gates-2026-08-07.md) — the adjacent failure mode. That doc covers gates where _no reachable input can turn them red_; this one covers gates that can fail but observe a narrower population than they appear to. A gate can be perfectly capable of failing and still be blind.
+- [Verify the signal before implementing the plan](evidence-first-scope-correction-under-incomplete-signals-2026-08-08.md) — verifying a premise before building on it.
+- [Trustworthy agent eval corpus design](../best-practices/deterministic-agent-outcome-eval-corpus-2026-08-09.md) — where the self-referential baseline was fixed.
+- [Machine-readable advisory data over prose](../best-practices/machine-checked-advisory-ranges-and-version-floors-2026-08-10.md) — the dependency triage that followed from this coverage gap.


### PR DESCRIPTION
## Summary

Two learning docs from the security triage work that landed today (#1357, #1359, #1361, #1364, #1365).

## What they cover

**`workflow-issues/checks-report-clean-for-what-they-cannot-observe`** — several defects this session shared one shape: a check that runs, passes, and reports honestly about a population narrower than the one people rely on it for.

- Dependency scanning covered 65 of 1169 packages and reported zero open alerts. The tell was available the whole time: `state=fixed` returned 78, so the pipeline was alive and simply had no view of the rest of the tree.
- The maintenance report counted only findings carrying a file path, then described the four repo-level findings that fell out as *cleared*.
- A redaction fix landed on one of two identical gateway loggers.
- A baseline compared an artifact against constants copied out of that same artifact.
- A 404 from a permission-gated endpoint was read as *the feature is disabled*.

None of these were broken gates, which is why they went unnoticed. A broken check announces itself; a blind one accumulates trust while the uncovered region grows.

**`best-practices/machine-checked-advisory-ranges-and-version-floors`** — the triage that followed. Advisory prose is not the machine-readable range data (`introduced: 0` means every version below the fix, not the one version the summary names), and a bare version floor resolves across majors unless bounded.

## Why these are separate from the existing gate doc

`non-failing-gates-are-worse-than-no-gates` covers gates where no reachable input can turn them red. These are gates that fail correctly and observe a narrower population than they appear to. A gate can be perfectly capable of failing and still be blind — different defect, different fix. The first doc links to it and states the distinction explicitly.

## Verification

Every quoted snippet, file path, measured number, and OSV range was checked against source or fetched live, and a source-accuracy review re-verified them independently. Counts are pinned to commit `48d09adda` because raising the version floors changed them mid-round.

One claim — that a bare `>=3.3.17` floor resolves to `6.0.1` — could not be verified from history, since the interim state was caught before it was ever committed. Rather than soften the wording, it was reproduced in an isolated project; the reproduction is in the doc so a reader can confirm it rather than take it on trust.
