### PR TITLE
ci: run the full scan in the merge queue, not the PR diff

### DIFF
--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -15,8 +15,12 @@ on:
 permissions: {}
 
 jobs:
+  # Pull requests only. The upstream PR workflow reports what a change introduces
+  # by checking out GITHUB_BASE_REF and diffing against it. Neither that ref nor
+  # the pull_request payload exists in a merge queue, so merge_group runs the full
+  # scan below instead.
   scan-pr:
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    if: ${{ github.event_name == 'pull_request' }}
     name: OSV-Scanner PR scan
     permissions:
       actions: read
@@ -34,7 +38,7 @@ jobs:
       fail-on-vuln: false
 
   scan-scheduled:
-    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'merge_group' }}
     name: OSV-Scanner full scan
     permissions:
       actions: read


### PR DESCRIPTION
## Summary

The merge queue was running the pull-request scan, which has nothing to compare against in that context. Route `merge_group` to the full scan instead.

Follows up a non-blocking review note on #1364.

## What was wrong

`osv-scanner-reusable-pr.yml` reports what a change *introduces*, and it does that by checking out the base ref and diffing against it:

```yaml
git checkout $GITHUB_BASE_REF          # line 85
```

It also links results using the pull request number:

```yaml
.../security/code-scanning?query=pr%3A${{ github.event.pull_request.number }}   # line 176
```

A merge queue supplies neither. `GITHUB_BASE_REF` is empty and there is no `pull_request` payload, so the diff resolved against nothing and the printed link carried no number. The scan still ran and coverage was never weakened — the comparison the workflow exists to perform simply had no meaning in the queue.

`osv-scanner-reusable.yml` has zero references to either, because a full scan needs no pull request context.

## The change

`pull_request` keeps the diff-mode scan. `merge_group` joins `push` and `schedule` on the full scan. Each of the four triggers now routes to exactly one job.

Job IDs are unchanged, so check names stay stable.

## Verification

Both upstream reusable workflows were read at the pinned SHA `8deb546f` to confirm the line references above rather than inferring them from behaviour.

Two things worth stating because they made this safe:

- The merge queue is real here — `ci.yaml` also subscribes to `merge_group`, so this was not dead configuration.
- No OSV check is a required status context, so changing which job reports in the queue cannot wedge it. That was read from `.github/settings.yml`, the code-managed source of truth, because the protection API returns 404 for a token without admin rather than saying so.

The workflow parses, Prettier passes, and the routing table was asserted programmatically.
