### PR TITLE
ci: fail pull requests that introduce new vulnerabilities

### DIFF
--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -33,9 +33,10 @@ jobs:
         -r
         ./
       upload-sarif: true
-      # Report-only on purpose: existing findings must not block every PR.
-      # Change this to true only as a deliberate fail-on-new policy decision.
-      fail-on-vuln: false
+      # Fails only on vulnerabilities this pull request introduces. The upstream
+      # workflow scans the base ref and the head ref, then reports the difference,
+      # so a previously known finding cannot fail an unrelated change.
+      fail-on-vuln: true
 
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'merge_group' }}
@@ -51,6 +52,8 @@ jobs:
         -r
         ./
       upload-sarif: true
-      # Report-only on purpose: known findings are uploaded to code scanning.
-      # Change this to true only as a deliberate fail-on-new policy decision.
+      # Report-only, deliberately. This scans the whole tree with no baseline to
+      # compare against, so failing here would break pushes to main and merge
+      # queue entries whenever a new advisory is published against a dependency
+      # nobody touched. Findings go to code scanning instead.
       fail-on-vuln: false

--- a/scripts/osv-scanner-workflow.test.ts
+++ b/scripts/osv-scanner-workflow.test.ts
@@ -1,0 +1,143 @@
+import {readFileSync} from 'node:fs'
+import {describe, expect, it} from 'vitest'
+import {parse} from 'yaml'
+
+/**
+ * Guards the OSV-Scanner workflow's routing and enforcement invariants.
+ *
+ * Two properties are easy to break by editing one line and are expensive to
+ * notice afterwards, because a wrong value still produces a green run:
+ *
+ * 1. `merge_group` must use the full scan. The upstream PR workflow reports what
+ *    a change introduces by checking out `$GITHUB_BASE_REF` and diffing against
+ *    it, and links results with `github.event.pull_request.number`. A merge queue
+ *    supplies neither, so pointing `merge_group` at it compares against nothing.
+ *
+ * 2. Only the pull request path may fail on vulnerabilities. That path has a
+ *    baseline to diff against, so a failure means the change itself introduced
+ *    something. The full scan has no baseline; failing it would break unrelated
+ *    pushes and queue entries whenever a new advisory is published against a
+ *    dependency nobody touched.
+ */
+
+interface WorkflowJob {
+  readonly if: string
+  readonly uses: string
+  readonly with: Record<string, unknown>
+}
+
+interface Workflow {
+  readonly on: Record<string, unknown>
+  readonly jobs: Record<string, WorkflowJob>
+}
+
+const WORKFLOW_PATH = '.github/workflows/osv-scanner.yaml'
+
+const PR_DIFF_WORKFLOW = 'osv-scanner-reusable-pr.yml'
+const FULL_SCAN_WORKFLOW = 'osv-scanner-reusable.yml'
+
+function loadWorkflow(): Workflow {
+  // `on` is parsed as the boolean `true` by YAML 1.1 semantics in some parsers;
+  // read both spellings so this guard does not depend on that detail.
+  const parsed = parse(readFileSync(WORKFLOW_PATH, 'utf8')) as Record<string, unknown>
+  const triggers = (parsed.on ?? parsed[String(true)]) as Record<string, unknown>
+  return {on: triggers, jobs: parsed.jobs as Record<string, WorkflowJob>}
+}
+
+/** Returns the job ids whose `if` expression names the given event. */
+function jobsForEvent(workflow: Workflow, event: string): readonly string[] {
+  return Object.entries(workflow.jobs)
+    .filter(([, job]) => job.if.includes(`'${event}'`))
+    .map(([id]) => id)
+}
+
+/** Returns the reusable workflow filename a job delegates to. */
+function reusableWorkflowOf(job: WorkflowJob): string {
+  const path = job.uses.split('@')[0] ?? job.uses
+  return path.slice(path.lastIndexOf('/') + 1)
+}
+
+/** Resolves the single job handling an event, failing loudly if that is not true. */
+function soleJobForEvent(workflow: Workflow, event: string): WorkflowJob {
+  const ids = jobsForEvent(workflow, event)
+  if (ids.length !== 1) {
+    throw new Error(`event '${event}' must route to exactly one job, found ${ids.length}`)
+  }
+  const [id] = ids
+  const job = id === undefined ? undefined : workflow.jobs[id]
+  if (job === undefined) {
+    throw new Error(`event '${event}' routes to a job that does not exist`)
+  }
+  return job
+}
+
+describe('osv-scanner workflow — event routing', () => {
+  it('routes every subscribed event to exactly one job', () => {
+    // #given the workflow and the events it subscribes to
+    const workflow = loadWorkflow()
+    const events = Object.keys(workflow.on)
+
+    // #when each event is matched against the job conditions
+    const routing = events.map(event => [event, jobsForEvent(workflow, event)] as const)
+
+    // #then no event is unhandled and none is claimed by two jobs
+    for (const [event, jobs] of routing) {
+      expect(jobs, `event '${event}' must route to exactly one job`).toHaveLength(1)
+    }
+  })
+
+  it('sends merge_group to the full scan, which needs no pull request context', () => {
+    // #given the workflow
+    const workflow = loadWorkflow()
+
+    // #when the merge queue event is routed
+    const job = soleJobForEvent(workflow, 'merge_group')
+
+    // #then it reaches the full scan rather than the base-vs-head diff
+    expect(reusableWorkflowOf(job)).toBe(FULL_SCAN_WORKFLOW)
+  })
+
+  it('sends pull_request to the diff scan', () => {
+    // #given the workflow
+    const workflow = loadWorkflow()
+
+    // #when the pull request event is routed
+    const job = soleJobForEvent(workflow, 'pull_request')
+
+    // #then it reaches the workflow that compares base against head
+    expect(reusableWorkflowOf(job)).toBe(PR_DIFF_WORKFLOW)
+  })
+})
+
+describe('osv-scanner workflow — failure policy', () => {
+  it('fails only on the path that has a baseline to compare against', () => {
+    // #given every job in the workflow
+    const workflow = loadWorkflow()
+
+    // #when each job's failure policy is read alongside the workflow it delegates to
+    const policies = Object.values(workflow.jobs).map(job => ({
+      reusable: reusableWorkflowOf(job),
+      failOnVuln: job.with['fail-on-vuln'],
+    }))
+
+    // #then the diff scan enforces and the baseline-free full scan reports only
+    for (const {reusable, failOnVuln} of policies) {
+      const expected = reusable === PR_DIFF_WORKFLOW
+      expect(failOnVuln, `${reusable} must have fail-on-vuln: ${String(expected)}`).toBe(expected)
+    }
+  })
+
+  it('uploads findings to code scanning from every job', () => {
+    // #given every job in the workflow
+    const workflow = loadWorkflow()
+
+    // #when the upload setting is read
+    const uploads = Object.values(workflow.jobs).map(job => job.with['upload-sarif'])
+
+    // #then findings stay visible regardless of whether the job can fail
+    expect(uploads.length).toBeGreaterThan(0)
+    for (const upload of uploads) {
+      expect(upload).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

The scanner shipped report-only because two dozen findings would have failed every pull request on the first run. Those are fixed, so the pull request path can start enforcing.

Only that path.

## Why the asymmetry

The two jobs delegate to different upstream workflows, and only one of them has a baseline:

| job | what it scans | `fail-on-vuln` |
| --- | --- | --- |
| `scan-pr` | base ref, then head ref, then reports the difference | `true` |
| `scan-scheduled` | the whole tree, no comparison | `false` |

`osv-scanner-reusable-pr.yml` runs the scanner twice and hands the reporter `--old`, `--new`, and `--fail-on-vuln` together, so a failure there means the change itself introduced something. That is worth blocking on.

`osv-scanner-reusable.yml` passes `--fail-on-vuln` against the full tree with nothing to compare against. Since #1367 routed `merge_group` there, enabling it would mean the next advisory published against any of our 1169 packages breaks every push to `main` and every merge queue entry, with no code change involved. That is a tripwire on someone else's disclosure schedule rather than a guard, so those findings continue to go to code scanning.

## The guard test

A review note on #1367 pointed out that I described the routing as programmatically asserted while shipping no such assertion. `scripts/osv-scanner-workflow.test.ts` now commits it, covering three properties that are each one edited line from breaking and produce a green run when wrong:

- every subscribed event routes to exactly one job
- `merge_group` reaches the full scan, `pull_request` reaches the diff scan
- only the workflow with a baseline may fail on vulnerabilities, and both jobs upload findings regardless

Each assertion was checked by breaking the workflow and confirming the matching test goes red — routing `merge_group` back to the diff job, enabling `fail-on-vuln` on the full scan, and disabling SARIF upload each produce exactly one targeted failure. That was re-run after the test file was refactored, since a refactor is a common way for a guard to quietly stop being able to fail.

The guard runs on every change to this file: CI invokes `test:scripts`, the Test job has no `if:` condition, and the `config` path filter covers `.github/**`.

## Verification

382 scripts tests pass, type checks and lint are clean, and the fail-on-vuln matrix was asserted after the pre-commit hook ran. The PR scan on this pull request exercises the new `fail-on-vuln: true` setting directly.
