### PR TITLE
ci(workflow): wire durable S3 session storage

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -275,6 +275,12 @@ jobs:
         uses: ./
         env:
           OPENCODE_PROMPT_ARTIFACT: 'true'
+          # The S3 adapter resolves credentials through the ambient AWS SDK chain --
+          # parseActionInputs never populates storeConfig.credentials -- so these must
+          # be job env, not action inputs. filterAgentEnv denies AWS_* from the agent
+          # child, so the harness keeps them while the model's bash never sees them.
+          AWS_ACCESS_KEY_ID: ${{ secrets.FRO_BOT_S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.FRO_BOT_S3_SECRET_ACCESS_KEY }}
           PROMPT: >-
             ${{
               (inputs.prompt != '' && inputs.prompt)
@@ -288,6 +294,18 @@ jobs:
         with:
           auth-json: ${{ secrets.AUTH_JSON }}
           trusted-head-sha: ${{ steps.prehead.outputs.ref }}
+          # Durable session state. The Actions cache alone is not sufficient: GitHub
+          # issues read-only cache tokens for issue_comment and issues runs, so the
+          # mention flows cannot persist state through the cache at all.
+          s3-backup: 'true'
+          s3-bucket: ${{ vars.FRO_BOT_S3_BUCKET }}
+          aws-region: ${{ vars.FRO_BOT_S3_REGION }}
+          s3-prefix: ${{ vars.FRO_BOT_S3_PREFIX }}
+          s3-expected-bucket-owner: ${{ vars.FRO_BOT_S3_EXPECTED_BUCKET_OWNER }}
+          # Required. Left unset, getEffectiveEncryption defaults to aws:kms on real
+          # AWS, which would demand KMS grants the session-state policy does not have.
+          # The bucket is SSE-S3.
+          s3-sse-encryption: 'AES256'
           # Same read-only-by-construction switch as the checkout token above, keyed on
           # release-tag (the operation) rather than correlation-id (an audit token) —
           # see the checkout step comment for the full rationale.


### PR DESCRIPTION
Restores session continuity on the mention flows. Completes the work started in #1370 and #1373; documented in #1374.

## Why the cache alone cannot do this

GitHub issues a **read-only Actions cache token** for triggers a user without write access can initiate. `issue_comment` and `issues` are affected. Every mention run was therefore unable to persist session state, and started cold.

`#1370` made that failure visible (the denied write had been reported as `Cache saved`) and `#1373` fixed restore ordering so a stale cache cannot mask fresher storage. Neither restores continuity on its own — there was no durable store to fall back to. This adds it.

The `pull_request` path is unaffected and deliberately left alone: verified against a post-fix run that its cache write succeeds (`Cache saved`, zero denials), so it has a writable token and does not need this.

## Two non-obvious details

**Credentials are job env, not action inputs.** The S3 adapter resolves through the ambient AWS SDK chain — `parseActionInputs` never populates `storeConfig.credentials`, and `createClient` only sets explicit credentials when that field is non-null. `filterAgentEnv` denies `AWS_*` from the agent child, so the harness holds them while the model's bash never sees them.

**`s3-sse-encryption` is set explicitly rather than left to default.** Unset, `getEffectiveEncryption` returns `aws:kms` on real AWS. The bucket is SSE-S3/AES256 and the IAM policy grants no KMS actions, so every upload would have failed. This is the one input where the default is wrong for this setup.

## Storage configuration

Bucket `fro-bot-agent-storage-286556883534-us-east-1` — SSE-S3, versioning enabled, public access blocked. Verified by round trip before wiring.

The IAM user needs **four** actions, not three. An earlier revision of this description claimed the policy held "exactly `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`" with no `ListBucket`, justified by keys coming from a known filename set rather than discovery. That reasoning holds only for the **save** path. The **restore** path calls `syncSessionsFromStore` → `adapter.list(prefix)` → `ListObjectsV2Command`, which requires `s3:ListBucket` — and restore is the entire point of this change. `README.md:229` already documented the requirement; the original claim contradicted it.

`ListBucket` is bucket-level, so it needs its own statement:

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "SessionObjects",
      "Effect": "Allow",
      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
      "Resource": "arn:aws:s3:::fro-bot-agent-storage-286556883534-us-east-1/fro-bot-state/*"
    },
    {
      "Sid": "SessionList",
      "Effect": "Allow",
      "Action": "s3:ListBucket",
      "Resource": "arn:aws:s3:::fro-bot-agent-storage-286556883534-us-east-1",
      "Condition": {"StringLike": {"s3:prefix": "fro-bot-state/*"}}
    }
  ]
}
```

Every key is built through `buildObjectStoreKey`, which prefixes unconditionally, so all reads and writes land inside the granted scope. `FRO_BOT_S3_PREFIX` is `fro-bot-state`, matching the policy.

Had this shipped with the three-action policy, the failure would have been invisible: `restore.ts:108-112` treats `AccessDenied` from `list` as a cache miss and logs a warning. CI stays green, restore silently never returns anything, and behaviour degrades to exactly the cold start this PR set out to fix.

## Verification

Lint and link checks pass; no source or `dist/` changes. Full effect is only observable on a real mention run, since `s3-backup` is a runtime input — the next `@fro-bot` mention should sync state and a following one should resume rather than mint a fresh session.