### PR TITLE
docs(solutions): capture two learnings from wiring durable session storage

### DIFF
--- a/docs/solutions/security-issues/s3-restore-needs-listbucket-and-prefix-scope-2026-08-12.md
+++ b/docs/solutions/security-issues/s3-restore-needs-listbucket-and-prefix-scope-2026-08-12.md
@@ -1,0 +1,115 @@
+---
+title: An IAM policy derived from the save path silently disabled restore
+date: 2026-08-12
+category: security-issues
+module: runtime
+problem_type: security_issue
+component: service_object
+symptoms:
+  - "Object store restore failed - treating as miss"
+  - "Failed to list object store session files"
+  - "Runs stay green while every session cold-starts"
+  - "A shared-bucket policy grants delete reach over a co-tenant repository's data"
+root_cause: missing_permission
+resolution_type: config_change
+severity: high
+related_components:
+  - documentation
+tags:
+  - s3
+  - iam
+  - least-privilege
+  - listbucket
+  - session-storage
+  - fail-soft
+---
+
+# An IAM policy derived from the save path silently disabled restore
+
+## Problem
+
+The IAM policy for durable S3 session storage was derived from how the save path behaves — object keys come from a fixed filename set, so nothing needs to list. That reasoning produced `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, and omitted `s3:ListBucket`. The restore path lists before it downloads, so restore would have returned nothing, permanently and quietly.
+
+## Symptoms
+
+Nothing raises. The observable signature is a run that succeeds while behaving as though no state exists:
+
+- One warning, `Failed to list object store session files` (`packages/runtime/src/object-store/content-sync.ts`)
+- Every session starts cold, with no failed step and no non-zero exit
+
+## What Didn't Work
+
+**Reasoning from the write path.** `syncSessionsToStore` iterates a fixed constant and uploads each name it finds — no discovery, so no listing. True, and only half the subsystem. `syncSessionsFromStore` opens with `adapter.list(prefix)`, which issues `ListObjectsV2Command` and requires `s3:ListBucket`.
+
+**Checking against the repo's own documentation.** `README.md:229` already stated the principal needs `s3:GetObject`, `s3:PutObject`, and `s3:ListBucket`. The policy contradicted published setup instructions and nobody noticed, because a contradiction between a policy and a README produces no signal at all.
+
+**Verifying with a text pattern.** Enumerating the adapter's commands with a regex of the shape `new [A-Za-z]+Command\(` returned three results and appeared to confirm the original claim. `ListObjectsV2Command` contains a digit, so the character class could not match it. The verification step reproduced the bug it was meant to catch.
+
+## Solution
+
+Grant `s3:ListBucket` alongside the object actions, and scope each to the narrowest path that satisfies it. `ListBucket` is a bucket-level action, so it cannot share a statement with the object-level ones:
+
+```json
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+      "Resource": "arn:aws:s3:::BUCKET/PREFIX/*/OWNER/REPO/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::BUCKET",
+      "Condition": {"StringLike": {"s3:prefix": "PREFIX/*/OWNER/REPO/*"}}
+    }
+  ]
+}
+```
+
+Keys are built as:
+
+```ts
+const baseKey = `${validatedPrefix.data}/${sanitizedIdentity.data}/${repoPath}/${contentType}`
+```
+
+Identity is `github` for session content and `coordination` for the lock. The wildcard in that segment is a deliberate tradeoff, not a minimal grant, and it is worth being precise about why: **`*` matches `/` in both resource ARNs and `s3:prefix` conditions**, so `PREFIX/*/OWNER/REPO/*` also admits deeper paths such as `PREFIX/a/b/OWNER/REPO/...`. The key builder sanitizes its identity segment and cannot produce those, but an IAM policy bounds the principal, not one code path.
+
+Enumerating `github` and `coordination` explicitly is the stricter posture, at the cost of a new identity constant failing closed until someone updates the policy — a failure this doc argues is easy to miss. Pick deliberately; do not assume the wildcard is minimal because it looks scoped.
+
+This policy covers the Action's identity only. The gateway additionally writes tagged run-state and heartbeat objects (`tagging: RUN_STATE_TAG`), which require `s3:PutObjectTagging`; the Action runs neither, per the design note in `src/harness/phases/acquire-lock.ts`.
+
+## Why This Works
+
+Both paths are now covered, and the failure mode that hid the gap is understood rather than removed.
+
+The degradation is quieter than it first appears. `adapter.list` returns a `Result` rather than throwing, so a denied list takes the handled branch in `syncSessionsFromStore` — one warning, then `{downloaded: 0, failed: 1, mainDbRestored: false}`. It never reaches the `catch` in `restore.ts` that logs `Object store restore failed - treating as miss`; that path is for thrown errors. The store simply reports itself empty, `restoreCache` falls through to the Actions cache, and the run is green.
+
+That fail-soft design is correct — a storage outage must not break a run. It also means an under-granted policy is indistinguishable from an empty store. **The more gracefully a subsystem degrades, the less its permissions can be validated by watching it run.**
+
+## Prevention
+
+**Enumerate call sites structurally, across every arity.** A text search matches the shape you imagined; a structural query matches the code:
+
+```bash
+ast-grep --pattern 'buildObjectStoreKey($C, $I, $R, $T, $$$)' --lang ts
+ast-grep --pattern 'buildObjectStoreKey($C, $I, $R, $T)'      --lang ts
+```
+
+Both forms, and every package. Scoping the first sweep to two directories undercounted by four call sites; the real figure is 13 matches, 10 outside tests, against the two that were front of mind.
+
+**Enumerate the read path separately from the write path.** They are different code with different operations. Listing, tagging, and metadata reads are routinely present on one side and absent from the other.
+
+**Treat disagreement with existing documentation as a finding.** Here the README was right and the fresh analysis was wrong.
+
+**Verify a tightened policy with a negative case.** Positive checks prove sufficiency; only a negative check proves boundedness. Under the runtime identity, this repository's subtrees should allow put/list/get/delete while co-tenant prefixes deny list and head.
+
+Read raw responses when probing. A projection such as `--query KeyCount` against `list-objects-v2` returns empty because that field is absent from the response shape — indistinguishable from a denial, and it sent this investigation sideways for a step.
+
+**Re-scope when the bucket is shared.** Listing the prefix during verification surfaced another repository's data under the same root, including a 331 MB session database. Key construction namespaces by owner and repository so there was no collision risk, but the prefix-level policy granted `DeleteObject` over a co-tenant's state. Getting the operations right and the resource path wrong still leaves a policy far broader than the workload.
+
+## Related Issues
+
+- [A check reports clean for the part of the world it cannot observe](../workflow-issues/checks-report-clean-for-what-they-cannot-observe-2026-08-10.md) — the sibling epistemic failure: a check that runs, passes, and covers less than assumed.
+- [A read-only Actions cache token broke session continuity](../integration-issues/read-only-actions-cache-token-broke-session-continuity-2026-08-11.md) — the incident this storage work resolved, also hidden by a layer that degraded politely.
+- [Reusable-workflow permissions replace, not merge](../best-practices/reusable-workflow-permissions-replace-not-merge-2026-07-01.md) — another permission model whose real behavior differs from the intuitive reading.

--- a/docs/solutions/workflow-issues/comment-only-review-blocked-approval-2026-06-01.md
+++ b/docs/solutions/workflow-issues/comment-only-review-blocked-approval-2026-06-01.md
@@ -1,7 +1,7 @@
 ---
 title: Couple the review verdict to the GitHub review event so PR reviews satisfy branch protection
 date: 2026-06-01
-last_updated: 2026-07-11
+last_updated: 2026-08-12
 category: workflow-issues
 module: response-delivery
 problem_type: workflow_issue
@@ -103,7 +103,14 @@ That triggered the deferred backstop — a harness reconciliation phase (PR #808
 
 Lesson: when a verdict maps to a side-effecting platform event the agent emits itself, the prompt is the first control point but not the last. A post-action reconciliation that reads the **posted artifact** (not the agent's private log) is the durable guarantee — and it must verify *which* state it is approving, or it becomes a wrongful-approval vector itself.
 
+## Scope note (2026-08-12)
+
+Everything below — the prompt contract and the reconciliation backstop — applies only to runs triggered by a `pull_request` event. Those are the runs that reach the review surface at all.
+
+A mention (`issue_comment`) resolves to a comment surface and can never emit a review, so neither lever reaches it: the reconciliation phase no-ops on `isPullRequestReviewTrigger === false`. That is a deliberate security boundary, not a gap to close. See [A mention-triggered run cannot clear a blocking review, by design](./mention-triggered-run-cannot-clear-changes-requested-review-2026-08-12.md).
+
 ## Related
 
+- [A mention-triggered run cannot clear a blocking review, by design](./mention-triggered-run-cannot-clear-changes-requested-review-2026-08-12.md) — the structural counterpart: this doc covers an agent choosing the wrong delivery when the right one was available; that one covers the right delivery being unreachable from the triggering event.
 - [Delivery-mode contract for manual triggers](./delivery-mode-contract-for-manual-triggers-2026-04-17.md) — the same principle applied to a different prompt contract: make the intended action explicit rather than leaving the agent to infer it from heuristics.
 - [Discord slash-command orchestration patterns](../best-practices/discord-slash-command-orchestration-patterns-2026-05-27.md) — agent-driven actions that must couple a decision to a platform side effect.

--- a/docs/solutions/workflow-issues/mention-triggered-run-cannot-clear-changes-requested-review-2026-08-12.md
+++ b/docs/solutions/workflow-issues/mention-triggered-run-cannot-clear-changes-requested-review-2026-08-12.md
@@ -1,0 +1,98 @@
+---
+title: A mention-triggered run cannot clear a blocking review, by design
+date: 2026-08-12
+category: workflow-issues
+module: development-workflow
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+applies_when:
+  - A PR carries CHANGES_REQUESTED and the blocking condition was satisfied outside the diff
+  - The bot replies to a mention saying no blockers remain, and the PR stays blocked
+  - Reasoning about which GitHub event can produce which response surface
+  - Designing an agent whose verdict must become a platform event with side effects
+tags:
+  - pr-review
+  - mention-trigger
+  - changes-requested
+  - event-routing
+  - response-delivery
+  - security-boundary
+---
+
+# A mention-triggered run cannot clear a blocking review, by design
+
+## Context
+
+A PR carried a `CHANGES_REQUESTED` review. Its condition was satisfied **out of band** — the concern was about deployed IAM configuration, resolved by probing the live account. There was no code change to push, so no commit would ever land to re-trigger review naturally.
+
+Mentioning the bot on the PR produced a thorough, correct reply that ended: *"no blockers remain — this is good to merge."* The PR stayed blocked.
+
+The verdict was right. Delivering it as a review was structurally impossible, and no amount of prompting would have changed that.
+
+## Guidance
+
+**The response surface is keyed off the triggering event, not the target.** The whole of `resolveResponseSurface` in `src/features/agent/response-file.ts`:
+
+```ts
+if (triggerContext?.eventType === 'pull_request') return 'pr-review'
+if (agentContext.issueType === 'pr') return 'pr-comment'
+return 'issue-comment'
+```
+
+A mention is an `issue_comment` event. It resolves to `pr-comment` — a comment on a PR, never a review. Only a review event supersedes `CHANGES_REQUESTED`; a comment, however well-reasoned, never does.
+
+**The reconciliation backstop does not rescue this.** It no-ops on the same distinction, in `src/harness/phases/review-reconciliation.ts`:
+
+```ts
+if (isFileConventionDelivery === true) {
+  return {reconciled: false, reason: 'finalize-owns-response'}
+}
+
+if (isPullRequestReviewTrigger === false) {
+  return {reconciled: false, reason: 'not-pr-review-trigger'}
+}
+```
+
+where `isPullRequestReviewTrigger` is derived in `src/harness/run.ts` as `triggerContext.eventType === 'pull_request'`.
+
+**What resolves it:** re-run the CI job that carries the review. That replays the `pull_request` event, reaches the `pr-review` surface, and produces a real review superseding the stale one.
+
+**What does not:** re-requesting review. The workflow subscribes to a fixed type list in `.github/workflows/ci.yaml`:
+
+```yaml
+pull_request:
+  branches: [main]
+  types: [opened, synchronize, ready_for_review, reopened]
+```
+
+`review_requested` is absent, so the request registers on the PR and fires nothing.
+
+Avoid an empty commit to force `synchronize`; it pollutes history to solve a routing problem. If the blocker was resolved outside the diff, dismiss the stale review manually and record the reason on the PR — a human action is the right shape for a condition the diff cannot show.
+
+## Why This Matters
+
+This is a security property, not a defect. A comment-triggered run is initiated by anyone who can comment. If such a run could clear a blocking review, unblocking a PR would be one comment away.
+
+The same rule is stated explicitly in `src/features/reviews/review-guards.ts`, where the fork/self refusal applies only to `APPROVE`: request-changes and comment can only ever block a PR, so they are safe from any source, while approve can unblock and needs the stricter surface. The asymmetry is consistent and deliberate.
+
+The operational trap: **prose agreement from a surface that cannot act looks resolved in the transcript and changes nothing on the PR.** The reply said the blocker was gone. The blocker was not gone. Both were true.
+
+## When to Apply
+
+- Diagnosing a PR that stays blocked after the bot says it should not be
+- Designing any agent whose verdict must become a platform event with side effects — check whether the triggering event can reach the surface that emits it, before assuming a prompt fix is possible
+- Deciding whether a workflow needs an additional `pull_request` trigger type, versus whether the omission is load-bearing
+
+## Examples
+
+| Trigger | Surface | Can supersede a blocking review |
+|---|---|---|
+| `pull_request` | `pr-review` | yes |
+| `issue_comment` on a PR | `pr-comment` | no |
+| `issue_comment` on an issue | `issue-comment` | n/a |
+
+## Related
+
+- [Couple the review verdict to the GitHub review event so PR reviews satisfy branch protection](./comment-only-review-blocked-approval-2026-06-01.md) — the adjacent failure and its prompt-level fix. That one is about an agent *choosing* the wrong delivery when the right one was available; this one is about the right delivery being unreachable from the triggering event. The reconciliation backstop described there explicitly no-ops here.
+- [Sender-substituted association breaks mention authority](../logic-errors/sender-substituted-association-breaks-mention-authority-2026-07-17.md) — another case where the trust level of a mention-triggered run is load-bearing.


### PR DESCRIPTION
Two learnings from the session-storage work in #1370, #1373, and #1381. Docs only — no source or `dist/` changes.

## An IAM policy derived from the save path silently disabled restore

`docs/solutions/security-issues/` (new category)

The policy was reasoned out from how the save path behaves: object keys come from a fixed filename set, so nothing needs to list. That produced Get/Put/Delete and omitted `s3:ListBucket`. The restore path lists before it downloads.

The failure would not have raised. `adapter.list` returns a `Result` rather than throwing, so a denied list takes the handled branch, logs one warning, and reports the store empty. The run stays green and every session starts cold — indefinitely. `README.md:229` had documented the required permission all along; a policy contradicting a README produces no signal.

Verifying the claim reproduced it twice. A text pattern of shape `new [A-Za-z]+Command\(` cannot match `ListObjectsV2Command` because of the digit. A structural sweep then found 13 call sites — but only after a first attempt scoped to two directories undercounted by four. Both mistakes are the mistake the doc is about, which is why the prevention section is specific about arity and package scope.

The doc also covers scoping on a shared bucket. Verification surfaced a co-tenant repository's data under the same prefix, including a 331 MB session database that the original policy granted delete reach over.

## A mention-triggered run cannot clear a blocking review, by design

`docs/solutions/workflow-issues/`

A PR carried `CHANGES_REQUESTED` whose condition was satisfied out of band, with no code change to push. Mentioning the bot produced a correct analysis ending "no blockers remain — this is good to merge." The PR stayed blocked.

`resolveResponseSurface` keys the surface off the triggering event: only `pull_request` reaches `pr-review`. A mention is `issue_comment`, so it can only comment, and the reconciliation backstop no-ops on the same distinction. This is a security boundary — a comment-triggered run is initiated by anyone who can comment, so allowing it to clear a blocking review would make unblocking a PR one comment away. The same asymmetry gates approve-but-not-request-changes in `review-guards.ts`.

Resolution is re-running the CI job carrying the review. Re-requesting review fires nothing, because the workflow subscribes only to `opened, synchronize, ready_for_review, reopened`.

`comment-only-review-blocked-approval-2026-06-01.md` gains a scope note bounding its prompt-and-backstop guidance to `pull_request` runs, with links both ways.

## Review

Three Phase 3 reviewers ran; each found something real:

- **Source-accuracy** corrected the call-site count (13/10, not 11/8) and caught that the doc implied two warnings appear when a denied list only produces one — it never reaches the `restore.ts` catch, which handles thrown errors.
- **Security** flagged that `*` matches `/` in IAM resource ARNs and `s3:prefix` conditions, so the identity wildcard is a deliberate tradeoff rather than the minimal grant the draft implied. Its `s3:PutObjectTagging` finding was verified as gateway-only and correctly excluded.
- **Simplicity** contributed snippet trims. One was declined: the proposed JSON cut dropped `Effect` and the `Version`/`Statement` wrapper, which would fail if copied into AWS.