### PR TITLE
ci(workflows): remove legacy oMo provider wiring

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -205,7 +205,7 @@ jobs:
               || ''
             }}
         with:
-          auth-json: ${{ secrets.AUTH_JSON }}
+          auth-json: ${{ secrets.OPENCODE_AUTH_JSON }}
           github-token: ${{ secrets.FRO_BOT_PAT }}
           model: ${{ vars.FRO_BOT_MODEL }}
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -208,7 +208,6 @@ jobs:
           auth-json: ${{ secrets.AUTH_JSON }}
           github-token: ${{ secrets.FRO_BOT_PAT }}
           model: ${{ vars.FRO_BOT_MODEL }}
-          omo-providers: ${{ secrets.OMO_PROVIDERS }}
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}
           prompt: ${{ env.PROMPT }}
 

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -300,7 +300,7 @@ jobs:
               || ''
             }}
         with:
-          auth-json: ${{ secrets.AUTH_JSON }}
+          auth-json: ${{ secrets.OPENCODE_AUTH_JSON }}
           trusted-head-sha: ${{ steps.prehead.outputs.ref }}
           # Durable session state. The Actions cache alone is not sufficient: GitHub
           # issues read-only cache tokens for issue_comment and issues runs, so the

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -318,11 +318,6 @@ jobs:
           # release-tag narration uses github.token; all other paths retain the PAT.
           github-token: ${{ steps.mint-app-token.outputs.github-token || (github.event.inputs.release-tag != '' && github.token) || secrets.FRO_BOT_PAT }}
           model: ${{ inputs.model || vars.FRO_BOT_MODEL }}
-          # Release-notes narration (correlation-id-tagged) uses an explicit model
-          # override; oMo is skipped so its provider routing does not interfere with
-          # the narration model.
-          enable-omo: ${{ github.event.inputs.correlation-id != '' && 'false' || 'true' }}
-          omo-providers: ${{ github.event.inputs.correlation-id != '' && '' || secrets.OMO_PROVIDERS }}
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}
           # Wiki paths opt into branch-pr explicitly so delivery contract is
           # self-documenting and decoupled from prompt-wording drift. Correlation

--- a/.github/workflows/harness-integrate.yaml
+++ b/.github/workflows/harness-integrate.yaml
@@ -46,7 +46,7 @@ on:
       OMO_PROVIDERS:
         description: Comma-separated oMo providers passed through to the merge (enable-omo is true on this path). Optional.
         required: false
-      # NO AUTH_JSON. NO secrets: inherit. The durable model credential must
+      # NO OPENCODE_AUTH_JSON. NO secrets: inherit. The durable model credential must
       # never reach this workflow — see docs/plans/2026-07-01-001-feat-harness-merge-credential-broker-plan.md.
 
 jobs:

--- a/.github/workflows/harness-integrate.yaml
+++ b/.github/workflows/harness-integrate.yaml
@@ -129,10 +129,5 @@ jobs:
           # Integration delivery is always local; keep this caller explicit so
           # prompt wording cannot change the output contract.
           output-mode: working-dir
-          # Preserve the current integrate behavior: the merge runs with oMo
-          # enabled (the correlation-id-gated disable in fro-bot.yaml applies
-          # only to release-notes narration, not this path).
-          enable-omo: true
-          omo-providers: ${{ secrets.OMO_PROVIDERS }}
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}
           timeout: '0'

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -191,8 +191,8 @@ jobs:
   # ---------------------------------------------------------------------------
   # Integrate job — calls harness-integrate.yaml as a reusable workflow.
   # harness-integrate.yaml mints a short-lived credential from the OIDC
-  # credential broker (no secrets: inherit, no AUTH_JSON) and runs the LLM
-  # merge on it via the Fro Bot action.
+  # credential broker (no secrets: inherit, no OPENCODE_AUTH_JSON) and runs the
+  # LLM merge on it via the Fro Bot action.
   # vars.HARNESS_MODEL must be set to anthropic/claude-sonnet-5 in repo vars.
   # Skipped when the carry set is empty (has_refs == 'false').
   # ---------------------------------------------------------------------------

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -208,7 +208,6 @@ jobs:
       APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
       APPLICATION_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       OPENCODE_CONFIG: ${{ secrets.OPENCODE_CONFIG }}
-      OMO_PROVIDERS: ${{ secrets.OMO_PROVIDERS }}
     with:
       model: ${{ vars.HARNESS_MODEL }}
       prompt: ${{ needs.prepare-integrate.outputs.rendered_prompt }}

--- a/packages/harness/AGENTS.md
+++ b/packages/harness/AGENTS.md
@@ -96,11 +96,11 @@ The `--source-tree` flag is explicit and fail-closed: if the directory is missin
 - The release is maintainer-gated `workflow_dispatch`.
 - `build` and `publish` are commit-pinned to a single resolved `integration_commit` (resolved once in `build`, consumed by `publish`).
 
-### `AUTH_JSON` secret
+### `OPENCODE_AUTH_JSON` secret
 
-Required for any release that runs an LLM merge (i.e. any release with integration refs configured). The integrate job reuses the repository's existing `AUTH_JSON` secret (the same model credential the action uses), so no separate secret is needed:
+Required for any release that runs an LLM merge (i.e. any release with integration refs configured). The integrate job reuses the repository's existing `OPENCODE_AUTH_JSON` secret (the same model credential the action uses), so no separate secret is needed:
 
-- **Name:** `AUTH_JSON`
+- **Name:** `OPENCODE_AUTH_JSON`
 - **Value:** JSON mapping provider to auth config:
   ```json
   {"anthropic": {"type": "api", "key": "sk-ant-..."}}
@@ -119,7 +119,7 @@ gh workflow run harness-release.yaml \
   --field dry_run=true
 ```
 
-**Real patched release** (the merge runs through Fro Bot, which uses the inherited `AUTH_JSON` model credential):
+**Real patched release** (the merge runs through Fro Bot, which uses the inherited `OPENCODE_AUTH_JSON` model credential):
 
 ```bash
 gh workflow run harness-release.yaml \

--- a/packages/harness/BOOTSTRAP.md
+++ b/packages/harness/BOOTSTRAP.md
@@ -105,15 +105,15 @@ A green dry run means the build infrastructure is solid and the real `1.15.13` p
 
 The dry run above uses a stock OpenCode commit with no LLM-merge patch. A real patched release (the actual point of this package) requires the `AUTH_JSON` secret to be configured in the repository, because the `integrate` job runs an LLM merge via `opencode run` and needs model credentials.
 
-### Required secret: `AUTH_JSON`
+### Required secret: `OPENCODE_AUTH_JSON`
 
-The `integrate` job reuses the repository's existing `AUTH_JSON` secret — the same model credential the action uses — so no separate secret needs to be created. Its value is a JSON object mapping provider name to auth config, e.g.:
+The `integrate` job reuses the repository's existing `OPENCODE_AUTH_JSON` secret — the same model credential the action uses — so no separate secret needs to be created. Its value is a JSON object mapping provider name to auth config, e.g.:
 
 ```json
 {"anthropic":{"type":"api","key":"sk-ant-..."}}
 ```
 
-The integrate job maps `AUTH_JSON` to an internal env var, writes it to a 0600 temp file, and passes it to OpenCode as a file-based credential. The secret value is never echoed to logs.
+The integrate job maps `OPENCODE_AUTH_JSON` to an internal env var, writes it to a 0600 temp file, and passes it to OpenCode as a file-based credential. The secret value is never echoed to logs.
 
 ### How a patched release works
 
@@ -148,4 +148,4 @@ gh run watch --repo fro-bot/agent
 
 ## After bootstrap
 
-Every subsequent release is triggered by dispatching `harness-release.yaml` with the appropriate `base_version` (and `dry_run=true` to skip publish). The `integrate` job derives the integration commit from the LLM merge; the `build` matrix consumes the resulting artifact. The `publish` job obtains an OIDC token from GitHub and publishes to npm with automatic provenance — no npm token, no secrets to rotate beyond `AUTH_JSON`.
+Every subsequent release is triggered by dispatching `harness-release.yaml` with the appropriate `base_version` (and `dry_run=true` to skip publish). The `integrate` job derives the integration commit from the LLM merge; the `build` matrix consumes the resulting artifact. The `publish` job obtains an OIDC token from GitHub and publishes to npm with automatic provenance — no npm token, no secrets to rotate beyond `OPENCODE_AUTH_JSON`.


### PR DESCRIPTION
- remove the obsolete `omo-providers` secret from the CI workflow invocation
- drop explicit oMo gating from the fro-bot workflow release-narration path
- remove legacy oMo provider wiring from the harness integrate flow and release env
- keep the workflow callers aligned with the action's default opt-in oMo behavior