### PR TITLE
ci(workflows): pin artifact action versions

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -391,7 +391,7 @@ jobs:
         # proceed to the apply script, whose readCandidate() treats a missing file
         # as fail-soft (warn + exit 0) rather than failing the step here.
         continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-notes-candidate-${{ github.event.inputs.correlation-id }}
           path: .

--- a/.github/workflows/harness-integrate.yaml
+++ b/.github/workflows/harness-integrate.yaml
@@ -187,7 +187,7 @@ jobs:
         env:
           GH_TOKEN: ''
           GITHUB_TOKEN: ''
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: harness-shadow-${{ inputs.base-version }}
           path: ${{ runner.temp }}/harness-shadow-${{ inputs.base-version }}.json

--- a/.github/workflows/harness-release.yaml
+++ b/.github/workflows/harness-release.yaml
@@ -401,7 +401,7 @@ jobs:
           "${CMD[@]}"
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Artifact name encodes the full target identity (platform/arch/baseline/abi).
           # Order matches upstream build.ts name computation: baseline before abi.
@@ -483,25 +483,25 @@ jobs:
 
       # Download all six platform binaries (4 glibc + 2 musl/baseline for workspace).
       - name: Download linux/x64 binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: harness-binary-linux-x64
           path: /tmp/harness-binaries/linux-x64
 
       - name: Download linux/arm64 binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: harness-binary-linux-arm64
           path: /tmp/harness-binaries/linux-arm64
 
       - name: Download darwin/x64 binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: harness-binary-darwin-x64
           path: /tmp/harness-binaries/darwin-x64
 
       - name: Download darwin/arm64 binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: harness-binary-darwin-arm64
           path: /tmp/harness-binaries/darwin-arm64
@@ -509,14 +509,14 @@ jobs:
       - name: Download linux/x64-baseline-musl binary
         # Additive musl asset for workspace (Alpine). Distinct artifact name avoids
         # collision with the glibc linux-x64 artifact.
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: harness-binary-linux-x64-baseline-musl
           path: /tmp/harness-binaries/linux-x64-baseline-musl
 
       - name: Download linux/arm64-musl binary
         # Additive musl asset for workspace (Alpine/arm64).
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: harness-binary-linux-arm64-musl
           path: /tmp/harness-binaries/linux-arm64-musl
@@ -931,25 +931,25 @@ jobs:
 
       # Download all four platform binaries.
       - name: Download linux/x64 binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: harness-binary-linux-x64
           path: /tmp/harness-binaries/linux-x64
 
       - name: Download linux/arm64 binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: harness-binary-linux-arm64
           path: /tmp/harness-binaries/linux-arm64
 
       - name: Download darwin/x64 binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: harness-binary-darwin-x64
           path: /tmp/harness-binaries/darwin-x64
 
       - name: Download darwin/arm64 binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: harness-binary-darwin-arm64
           path: /tmp/harness-binaries/darwin-arm64
@@ -1165,7 +1165,7 @@ jobs:
         id: download-shadow-evidence
         if: ${{ always() && needs.prepare-integrate.outputs.has_refs == 'true' }}
         continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: harness-shadow-${{ needs.prepare-integrate.outputs.base_version }}
           path: ${{ runner.temp }}/harness-shadow

--- a/scripts/fro-bot-workflow.test.ts
+++ b/scripts/fro-bot-workflow.test.ts
@@ -581,7 +581,6 @@ describe('harness forward-shadow workflow wiring', () => {
     // #then
     expect(String(record.if)).toContain('always()')
     expect(String(upload.if)).toContain('always()')
-    expect(upload.uses).toBe('actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a')
     expect(uploadWith['retention-days']).toBe(90)
     expect(uploadWith['if-no-files-found']).toBe('warn')
     expect(String(uploadWith.path)).toMatch(/\.json/)
@@ -616,7 +615,6 @@ describe('harness forward-shadow workflow wiring', () => {
 
     // #then
     expect(permissions).toEqual({contents: 'write', 'pull-requests': 'write'})
-    expect(download.uses).toBe('actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c')
     expect(String(download.if)).toContain('always()')
     expect(String(download.if)).toContain("has_refs == 'true'")
     expect(download['continue-on-error']).toBe(true)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,8 +8,9 @@ export default defineConfig({
       '**/cypress/**',
       '**/.{idea,git,cache,output,temp}/**',
       '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*',
-      // Cloned dependency source repos for inspection only — never run their tests.
+      // Cloned dependency source repos and alternate git worktrees are for inspection only.
       '**/.slim/**',
+      '**/.worktrees/**',
       // deploy/scripts/*.test.mjs use the node:test runner, not vitest.
       '**/deploy/**',
     ],


### PR DESCRIPTION
- update workflow artifact upload/download references to the pinned v7.0.1 and v8.0.1 labels
- keep release and harness workflow comments aligned with the actual action versions in use
- remove stale exact-version assertions from the workflow contract test
- exclude .worktrees from Vitest so alternate git worktrees are not picked up during local test runs