### PR TITLE
docs(solutions): capture the ID-wrap incident and its adjacent failures

### DIFF
--- a/docs/solutions/best-practices/stale-dependency-clone-invalidated-upstream-diagnosis-2026-08-14.md
+++ b/docs/solutions/best-practices/stale-dependency-clone-invalidated-upstream-diagnosis-2026-08-14.md
@@ -1,0 +1,73 @@
+---
+title: A stale dependency clone can invalidate an upstream diagnosis
+date: 2026-08-14
+category: best-practices
+module: dependency-management
+problem_type: best_practice
+component: documentation
+severity: medium
+applies_when:
+  - About to conclude that a bug is unreported or unfixed upstream
+  - Searching pinned clones under `.slim/clonedeps/repos/` for upstream behavior
+  - Attributing a root cause that implies writing a patch rather than bumping a pin
+related_components:
+  - harness-release
+  - documentation
+tags:
+  - clonedeps
+  - upstream-drift
+  - pinned-dependency
+  - diagnosis
+  - evidence-of-absence
+---
+
+## Context
+
+This repo keeps read-only dependency clones under `.slim/clonedeps/repos/`, pinned to `base_version` in `packages/harness/harness.config.json`. During the [OpenCode ID-space wrap investigation](../logic-errors/opencode-id-space-wrap-silently-froze-sessions-2026-08-14.md), the clone sat at `v1.18.14`. Searching it — and searching upstream by symptom text — turned up no report and no fix, which was reported as "this is unreported, we are first to the diagnosis."
+
+That was wrong. Upstream had diagnosed and fixed it a week earlier, before the bug ever triggered in the wild.
+
+## Guidance
+
+Treat a pinned clone as authoritative for exactly one thing: what the currently pinned base ships. It says nothing about what upstream has since fixed.
+
+`AGENTS.md` already carries the rule:
+
+> Both are pinned to the `base_version` in `packages/harness/harness.config.json`, so what you read is what the harness ships. Re-pin them when that base moves — a source check against a stale clone can be confidently wrong.
+
+Before concluding that upstream has not addressed something, check upstream's commit log on its actual default branch. For `anomalyco/opencode` that is `dev`, not `main` — a `main`-oriented check sees nothing even when the fix has landed.
+
+## Why This Matters
+
+Three independent factors lined up to make the search return clean when the fix already existed:
+
+1. **The clone predated the fix.** It was pinned two days before the fixing commits landed.
+2. **No issue was ever filed.** The fix arrived as bot-authored commits (`opencode-agent[bot]`), so searching by symptom text — the natural way to look for a bug report — returns nothing regardless of how well-phrased the query is.
+3. **The default branch is not `main`.** Fixes land on `dev`.
+
+The cost of getting this wrong is not just an inaccurate claim. It changes the proposed remedy: "nobody has fixed this" leads toward writing and filing a patch, while "already fixed in a later tag" leads to a one-line version bump. Work was drafted against the first conclusion before the second turned out to be true.
+
+Absence of search results is not evidence of absence. It is evidence that the query did not match — which is a much weaker statement.
+
+## When to Apply
+
+Any time a conclusion depends on upstream *not* having something: no fix, no report, no prior art. The asymmetry matters — confirming that upstream has a fix is cheap and reliable, while confirming it does not requires ruling out every way a search can miss.
+
+## Examples
+
+Weak, and how it fails:
+
+```sh
+# Symptom-text search across issues. Returns nothing when the fix
+# landed as a bot-authored commit with no issue behind it.
+gh search issues --repo anomalyco/opencode "session not responding"
+```
+
+Direct, against the branch that actually receives fixes:
+
+```sh
+git -C <clone> log --oneline origin/dev -- packages/opencode/src/session/
+git merge-base --is-ancestor <commit> <tag> && echo "contained in tag"
+```
+
+The second form answers the question that actually matters — is the fix in the tag we ship — and cannot be defeated by missing issue text or a wrong default branch.

--- a/docs/solutions/integration-issues/cross-provider-server-tool-ids-break-anthropic-replay-2026-08-14.md
+++ b/docs/solutions/integration-issues/cross-provider-server-tool-ids-break-anthropic-replay-2026-08-14.md
@@ -1,0 +1,77 @@
+---
+title: Cross-provider server-tool IDs break Anthropic session replay
+date: 2026-08-14
+category: integration-issues
+module: agent-execution
+problem_type: integration_issue
+component: assistant
+symptoms:
+  - "Anthropic rejects the request with `server_tool_use.id: String should match pattern '^srvtoolu_[a-zA-Z0-9_]+$'`"
+  - "Rewriting the IDs to the required prefix produces a different failure about a missing result block"
+  - "A session that worked under one provider fails on replay after switching models"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+related_components:
+  - runtime
+  - agent-execution
+tags:
+  - anthropic
+  - openai
+  - provider-interop
+  - tool-call-id
+  - session-replay
+  - server-tools
+---
+
+## Problem
+
+A session whose history contains `web_search` parts written by an OpenAI model cannot be replayed to Anthropic. Anthropic rejects the request during validation, because those parts are translated into its server-tool wire format regardless of which provider produced them.
+
+## Symptoms
+
+```
+messages.7283.content.0.server_tool_use.id:
+  String should match pattern '^srvtoolu_[a-zA-Z0-9_]+$'
+```
+
+The failing parts were written by `openai/gpt-5.6-sol` with `ws_*` call IDs, in a session whose active model is `anthropic/claude-opus-5`.
+
+## What Didn't Work
+
+Rewriting the eight offending call IDs to `srvtoolu_*` satisfied the pattern and immediately failed differently: Anthropic expects a `server_tool_use` block to be paired with a matching `web_search_tool_result` block. Making the ID look native committed to a contract the stored history could not satisfy.
+
+## Solution
+
+Demote the parts to ordinary tool calls instead of trying to satisfy the server-tool contract. Two changes are required together:
+
+- rewrite `callID` to an ordinary `toolu_*` value
+- delete `metadata.providerExecuted`
+
+Either alone is insufficient. The metadata flag is what routes the part down the server-tool path; the ID pattern is only the first thing that path validates.
+
+The 1,961 OpenAI-style `call_*` IDs elsewhere in the same session needed no change. Anthropic accepts them as ordinary `tool_use.id` values. The problem is specific to provider-executed server tools, not to cross-provider IDs in general.
+
+## Why This Works
+
+The translation layer dispatches on **tool name**, not on originating provider:
+
+```ts
+const serverToolResultType = (name: string): AnthropicServerToolResultType | undefined => {
+  if (name === "web_search") return "web_search_tool_result"
+  if (name === "code_execution") return "code_execution_tool_result"
+  if (name === "web_fetch") return "web_fetch_tool_result"
+  return undefined
+}
+```
+
+Any part named `web_search` is mapped onto Anthropic's `server_tool_use` / `web_search_tool_result` pair. Nothing in that decision consults which model actually produced the part, so a part authored by OpenAI's provider-executed search is replayed as though Anthropic had executed it — including the strict ID pattern and the paired-result requirement.
+
+Removing `providerExecuted` takes the part off that path entirely. It then replays as a normal tool call with a normal tool result, which has no prefix constraint and no pairing requirement.
+
+## Prevention
+
+- Never infer provider compatibility from an ID prefix alone. The prefix is a symptom; the routing decision is made by tool name plus the `providerExecuted` metadata, and both have to be considered together.
+- Server-tool metadata is provider-specific state, not portable history. Any code that migrates or rewrites stored parts across providers must clear it rather than translate it.
+- Mixed-provider sessions are a real configuration, not a corner case — a session's model can change between turns while its history persists. Replay tests should construct a history where `tool_use` and `server_tool_use` parts coexist and assert the conversion is schema-valid.
+- When a provider rejects a payload, read the next constraint before assuming the first fix is sufficient. Satisfying the ID pattern here moved the failure rather than removing it.

--- a/docs/solutions/logic-errors/harness-git-calls-depended-on-ambient-developer-identity-2026-08-14.md
+++ b/docs/solutions/logic-errors/harness-git-calls-depended-on-ambient-developer-identity-2026-08-14.md
@@ -1,0 +1,91 @@
+---
+title: Harness git calls depended on ambient developer identity and failed on runners
+date: 2026-08-14
+category: logic-errors
+module: harness-release
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "`git merge --no-ff` fails with `Committer identity unknown / *** Please tell me who you are.`"
+  - "Seven conflict-resolver tests fail in CI and every one of them passes locally"
+  - "The failure appears in disposable checkouts created under `RUNNER_TEMP`"
+root_cause: config_error
+resolution_type: code_fix
+severity: high
+related_components:
+  - ci-workflows
+  - development-workflow
+tags:
+  - git-identity
+  - ambient-config
+  - ci-only-failure
+  - conflict-resolver
+  - environment-dependence
+---
+
+## Problem
+
+The harness conflict resolver ran `git merge` in disposable checkouts without supplying a committer identity. It worked on developer machines, which have a global git identity, and failed on GitHub Actions runners, which do not.
+
+## Symptoms
+
+```
+Command failed: git -c credential.helper= -c core.askPass= merge --no-ff --no-edit refs/harness/conflict-source
+Committer identity unknown
+
+*** Please tell me who you are.
+```
+
+Seven conflict-resolver tests failed in CI. All seven shared this single root cause, and all seven passed locally.
+
+## What Didn't Work
+
+The obvious reading is "the test environment is missing configuration," which points at fixing CI — setting a global identity in the workflow, or configuring it in test setup.
+
+That would have been wrong. The `git merge` is executed by the resolver itself, not by test scaffolding. The resolver creates fresh checkouts under `RUNNER_TEMP` and merges in them, so a real release run on a real runner would have failed in exactly the same way. Fixing the test environment would have hidden a production defect behind green CI.
+
+## Solution
+
+Pass the identity explicitly on every commit-producing invocation, alongside the existing hardening flags:
+
+```ts
+// Runners have no global git identity, so every commit-producing invocation
+// carries its own. Matches DEFAULT_AUTHOR in src/features/delegated/types.ts;
+// the harness package is standalone and cannot import it.
+export const HARNESS_GIT_IDENTITY = [
+  '-c',
+  'user.name=Fro Bot',
+  '-c',
+  'user.email=fro-bot[bot]@users.noreply.github.com',
+] as const
+```
+
+The value has to match the repository's existing convention in `src/features/delegated/types.ts`:
+
+```ts
+export const DEFAULT_AUTHOR = {
+  name: 'Fro Bot',
+  email: 'fro-bot[bot]@users.noreply.github.com',
+} as const
+```
+
+An initial attempt used `github-actions[bot]@users.noreply.github.com`, which would have silently misattributed harness integration commits to a different bot. The constant is exported from `conflict-resolver.ts` and imported by `integrate.ts` rather than duplicated, so the two callsites cannot drift.
+
+Do **not** solve this with `GIT_AUTHOR_*` / `GIT_COMMITTER_*` environment variables. Inheriting identity from the environment is the same defect in a different costume — the point is that the command carries everything it needs.
+
+## Why This Works
+
+`git commit` requires an identity and resolves it from configuration: repository, global, or system. A disposable checkout has no repository-level config, and an ephemeral runner has no global config, so resolution fails. Passing `-c user.name` / `-c user.email` supplies it at the invocation itself, which is the only scope guaranteed to exist.
+
+The deeper property is that the command becomes independent of the machine it runs on. The original code was not "missing config" — it was reading state it did not own and could not guarantee.
+
+## Prevention
+
+- A test that passes locally and fails in CI is evidence about the *code*, not just the environment. Before adjusting CI, establish which side actually owns the missing state — here, production code was reading developer machine configuration.
+- Subprocess invocations that must work in a clean environment should carry their required configuration inline. This code already did that for `credential.helper` and `core.askPass`; identity was the gap in an otherwise deliberate pattern.
+- Keep identity constants in one place and import them. Two literals in two files is one careless edit away from commits attributed to two different authors.
+- When a bot identity is involved, check the repo's existing convention before writing one. Misattribution is silent, survives review, and is annoying to correct after the fact.
+
+## Related
+
+- [gh auth login refuses to persist when GH_TOKEN is set](../workflow-issues/gh-auth-login-refuses-to-persist-when-gh-token-set-2026-07-10.md) — same class: tooling behavior that changes based on ambient environment state.

--- a/docs/solutions/logic-errors/opencode-id-space-wrap-silently-froze-sessions-2026-08-14.md
+++ b/docs/solutions/logic-errors/opencode-id-space-wrap-silently-froze-sessions-2026-08-14.md
@@ -1,0 +1,107 @@
+---
+title: OpenCode ID-space wrap silently froze every session with prior history
+date: 2026-08-14
+category: logic-errors
+module: harness-release
+problem_type: logic_error
+component: assistant
+symptoms:
+  - "The agent accepts a prompt and never answers, with no error surfaced anywhere"
+  - "Logs show `loop step=0` immediately followed by `exiting loop`, with no `stream` line"
+  - "Every session created before a fixed instant is affected at once; brand-new sessions work"
+root_cause: logic_error
+resolution_type: dependency_update
+severity: critical
+related_components:
+  - agent-execution
+  - dependency-management
+tags:
+  - opencode
+  - session-continuity
+  - silent-failure
+  - id-generation
+  - harness-base-version
+---
+
+## Problem
+
+OpenCode message IDs encode a timestamp in a field too narrow to hold it. The field wrapped on 2026-08-14T11:19:55Z, and every session holding pre-wrap history stopped calling the model — silently, with no error.
+
+## Symptoms
+
+The agent accepts prompts and returns nothing. No exception, no failed request, no provider error. It reads as "the agent just stops answering."
+
+A frozen turn logs:
+
+```
+loop step=0
+exiting loop
+```
+
+A healthy turn logs:
+
+```
+loop step=0
+process messageID=msg_001ab5d9a001EaEi1geh51PjAK
+stream providerID=anthropic modelID=claude-opus-5
+```
+
+The absence of the `stream` line is the diagnostic. The model was never invoked.
+
+Locally this affected 12,103 of 12,144 sessions — effectively everything except sessions created after the wrap instant.
+
+## Solution
+
+Bump the harness base to a release that contains the upstream fix. In `packages/harness/harness.config.json`:
+
+```json
+"base_version": "1.18.18"
+```
+
+Do **not** add the upstream fixes to `integrationRefs`. That list carries upstream work that is *not* in the base; these commits are contained in the 1.18.18 tag, so listing them would ask the integration step to re-merge commits already present. Verify containment rather than assuming it:
+
+```sh
+git merge-base --is-ancestor <commit> <tag>
+```
+
+No data migration is required. This was verified empirically against an untouched frozen session — 30 pre-wrap messages, `max_user` lexically below `max_assistant`, the exact freeze condition — which replied normally on `1.18.18+harness.417b2b35`.
+
+## Why This Works
+
+`Identifier.create()` builds a monotonic value from the clock and a counter, then serializes only its low six bytes:
+
+```ts
+let now = BigInt(currentTimestamp) * BigInt(0x1000) + BigInt(counter)
+now = direction === "descending" ? ~now : now
+
+const timeBytes = Buffer.alloc(6)
+for (let i = 0; i < 6; i++) {
+  timeBytes[i] = Number((now >> BigInt(40 - 8 * i)) & BigInt(0xff))
+}
+return prefix + "_" + timeBytes.toString("hex") + randomBase62(LENGTH - 12)
+```
+
+A millisecond timestamp shifted left by 12 bits needs 53 bits. Six bytes hold 48. The high bits are discarded, so the encoded value wraps every 2^36 ms — about 795 days. After a wrap, freshly minted IDs begin near `msg_0004…` while existing history sits at `msg_ffe…`.
+
+The 1.18.14 run loop decided whether a user turn was still outstanding by comparing IDs lexically — roughly `lastUser.id < lastAssistant.id`. That comparison assumes ID order tracks chronological order. Post-wrap it inverts permanently: a new user message sorts *below* an old assistant message, the loop concludes there is nothing to answer, and it exits before dispatching to the provider.
+
+Upstream removed the assumption rather than patching the comparison. The loop now checks conversational structure:
+
+```ts
+lastAssistant.parentID === lastUser.id
+```
+
+and ordering elsewhere goes through an `isAfter` helper in `session/message-v2.ts` that compares `time.created` first and uses the ID only as a tiebreaker. Neither depends on IDs sorting correctly, so a future wrap cannot reintroduce the freeze. Both changes are in the 1.18.18 tag.
+
+## Prevention
+
+The generative defect is unfixed upstream: `id.ts` still truncates to six bytes, so the field wraps again around 2028-10-17. Ordering no longer depends on it, which downgrades the consequence from "everything freezes" to "IDs are not globally sortable across a wrap" — but code that sorts, compares, or ranges over these IDs is still wrong.
+
+- Never order messages or sessions by ID. Use `time.created` / `time.updated`. This repo's `packages/runtime/src/session/` already does this everywhere — worth keeping that way.
+- When a whole class of sessions breaks at once with no error, check for a shared boundary condition before investigating any individual session.
+- A silent early return in a loop that should have called a provider is worth an explicit log line. The freeze was diagnosable only because `exiting loop` was logged at all.
+- Keep `.slim/clonedeps/` re-pinned when `base_version` moves. See [a stale dependency clone can invalidate an upstream diagnosis](../best-practices/stale-dependency-clone-invalidated-upstream-diagnosis-2026-08-14.md) — that mistake was made during this investigation.
+
+## Related
+
+- [Read-only Actions cache token broke session continuity](../integration-issues/read-only-actions-cache-token-broke-session-continuity-2026-08-11.md) — a different, independent way session continuity fails silently. Both share a failure signature worth internalizing: continuity breaks without an error, and the absence of expected output is the only signal.

--- a/docs/solutions/security-issues/toctou-at-the-untrusted-model-output-extraction-boundary-2026-08-14.md
+++ b/docs/solutions/security-issues/toctou-at-the-untrusted-model-output-extraction-boundary-2026-08-14.md
@@ -1,0 +1,91 @@
+---
+title: TOCTOU at the untrusted model-output extraction boundary
+date: 2026-08-14
+category: security-issues
+module: harness-release
+problem_type: security_issue
+component: tooling
+symptoms:
+  - "CodeQL reports a high-severity file system race: the file may have changed since it was checked"
+  - "Path components are validated with `lstat` and then read again by path string"
+  - "Symlink rejection provably covers the check but not the subsequent read"
+root_cause: missing_validation
+resolution_type: code_fix
+severity: high
+related_components:
+  - ci-workflows
+tags:
+  - toctou
+  - symlink
+  - o-nofollow
+  - untrusted-input
+  - codeql
+  - file-handle
+---
+
+## Problem
+
+The harness conflict resolver validated a file path with `lstat` and then read it by path. Between the check and the read, the path can be swapped — so the bytes read were not provably the bytes that were validated. This sits at the boundary where untrusted model output becomes artifact input.
+
+## Symptoms
+
+CodeQL, high severity:
+
+> Potential file system race condition — The file may have changed since it was checked.
+
+The reported code walked each path component with `fs.lstat`, rejected symlinks, and then called `fs.readFile(current)`.
+
+## Why It Mattered Here
+
+The unit's contract is that only validated regular-file bytes from the allowed conflict set become artifact input. Everything downstream — path allowlisting, conflict-marker rejection, encoding checks, size caps — assumes the bytes it inspects are the bytes that were validated. A check-then-read-by-path gap undercuts that assumption at the one place where the input is adversarial by construction.
+
+## What Didn't Work
+
+Adding more validation before the read does not help. Any amount of path-based checking followed by a path-based open has the same window; the gap is structural, not a matter of checking harder.
+
+## Solution
+
+Validate and read through the same file handle. A shared helper opens the final component with `O_NOFOLLOW`, re-checks it through the open handle, and returns the handle; both read and write paths go through it.
+
+```ts
+async function openRegularFile(root: string, relative: string, flags: number): Promise<FileHandle> {
+  // ... component-by-component parent traversal, rejecting symlinks ...
+  const handle = await fs.open(current, flags, 0o666)
+  const finalStat = await handle.stat()
+  if (finalStat.isFile() === false) throw new Error(/* ... */)
+  return handle
+}
+
+async function readRegularFile(root: string, relative: string): Promise<Uint8Array> {
+  const handle = await openRegularFile(root, relative, O_RDONLY | O_NOFOLLOW)
+  try {
+    return await handle.readFile()
+  } finally {
+    await handle.close()
+  }
+}
+
+async function writeRegularFile(root: string, relative: string, bytes: Uint8Array): Promise<void> {
+  const handle = await openRegularFile(root, relative, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW)
+  try {
+    await handle.writeFile(bytes)
+  } finally {
+    await handle.close()
+  }
+}
+```
+
+The write side originally had the same asymmetry — it re-validated in one loop and wrote by path in a second — and now goes through the same helper.
+
+## Why This Works
+
+`O_NOFOLLOW` makes a final-component symlink fail at open rather than being followed. `handle.stat()` inspects the already-open file description rather than re-resolving the name, so the inode confirmed is the inode held. Reading and writing through that same handle means no second name resolution ever happens, and a swap after open affects the name but not the open file.
+
+Parent-component traversal still resolves by path, because Node exposes no `openat`. That residual race is documented in a comment at the callsite rather than papered over — the honest claim is that the final component is closed and the parent walk is not.
+
+## Prevention
+
+- At a trust boundary, validate and use the same handle. `lstat` then `readFile(path)` is the pattern to look for; the fix is `open` + `fstat` + read from the handle.
+- `O_NOFOLLOW` belongs on both read and write flags. Hardening one direction and leaving the other by-path is easy to miss, since the write side often looks like "we already validated this."
+- Pin the behavior with a test that swaps the target after open. The regression test here replaces the validated target with a symlink and asserts the redirect file is not written and the target remains a symlink — proving the write landed on the original inode rather than merely that no error was thrown.
+- State residual limitations in code. `openat` is unavailable in Node, so the parent walk keeps a window; a comment saying so is more useful than an implied guarantee that does not hold.


### PR DESCRIPTION
The OpenCode ID space wrapped on 2026-08-14 and every session holding prior history stopped calling the model. No error surfaced anywhere — the loop accepted each prompt and exited before dispatching, so it read as the agent simply going quiet. Locally that was 12,103 of 12,144 sessions.

Five learnings came out of it. They are separate problems rather than one story, so they are five documents.

**The wrap itself.** `Identifier.create()` builds a 53-bit value from the clock and a counter and serializes only its low six bytes, so the encoded timestamp wraps every ~795 days. The 1.18.14 run loop decided whether a user turn was outstanding by comparing IDs lexically, which inverts permanently after a wrap. Upstream removed the assumption rather than patching the comparison — a structural `lastAssistant.parentID === lastUser.id` check plus time-first ordering — and both changes are in the 1.18.18 tag. So the fix is a base bump, not a carry, and no data migration is required. That last part is verified against an untouched frozen session rather than argued.

**The wrong turn during the investigation.** It was reported that the bug was unreported upstream and we were first to the diagnosis. That was wrong; upstream had fixed it a week earlier. The pinned clone predated the fix, no issue was ever filed so symptom-text search could not match, and upstream's default branch is `dev` rather than `main`. `AGENTS.md` already carries the rule that a stale clone can be confidently wrong, which makes this a documented rule violated in practice — worth writing down for that reason specifically.

**Two more that surfaced only after the freeze lifted.** Replay failed on Anthropic because provider-executed `web_search` parts written by an OpenAI model are translated by tool name regardless of origin; satisfying the ID pattern just moves the failure, and the working fix is to demote them to ordinary tool calls and drop `providerExecuted`. Separately, the harness conflict resolver depended on ambient developer git config — it passed locally and died on runners with `Committer identity unknown` — and carried a check-then-read race at the boundary where model output becomes artifact input.

Both of those were caught by CI on work that passed locally, and both were real production defects rather than test-environment problems. The git identity one is worth noting: the obvious reading is that CI is missing configuration, and fixing it there would have hidden a defect that would have failed on a real release run.

Each document records the diagnostic signature, not just the fix. In every one of these the symptom pointed somewhere other than the cause — a frozen session looks like a hung model, an ID pattern error looks like an ID problem, a CI-only failure looks like a CI problem.

Docs only; no source paths touched.