### PR TITLE
fix(evals): make session retrieval real in isolated eval runs

### DIFF
--- a/evals/runner.test.ts
+++ b/evals/runner.test.ts
@@ -626,6 +626,7 @@ describe('runScenario orchestration', () => {
         // #then both modes retain the real continuation identity and seed the same logical session
         expect(report.state).toBe('passed')
         expect(observedConfig?.continueSessionId).toBe('seeded-session-42')
+        expect(report.sessionPresearch?.executedSessionId).toBe('seeded-session-42')
         expectProcessRestored(setup)
       })
     },

--- a/evals/runner.test.ts
+++ b/evals/runner.test.ts
@@ -1,3 +1,4 @@
+import type {SessionClient} from '../packages/runtime/src/session/backend.js'
 import type {AgentResult, ExecutionConfig, PromptOptions} from '../src/features/agent/types.js'
 import type {Logger} from '../src/shared/logger.js'
 import type {Scenario} from './types.js'
@@ -9,6 +10,7 @@ import * as path from 'node:path'
 import process from 'node:process'
 import {describe, expect, it, vi} from 'vitest'
 import {RESPONSE_FILE_DIR_SEGMENT} from '../packages/runtime/src/agent/response-file.js'
+import {searchSessions} from '../packages/runtime/src/session/search.js'
 import {buildAgentPrompt} from '../src/features/agent/index.js'
 import {createIssueCommentCreatedEvent} from '../src/features/triggers/__fixtures__/payloads.js'
 import {createLogger} from '../src/shared/logger.js'
@@ -22,6 +24,7 @@ import {
   resolveHarnessBinary,
   resolveModel,
   runScenario,
+  seedPriorWorkSession,
   treatmentSessionPrepStrategy,
 } from './runner.js'
 import {cleanPrScenario} from './scenarios/clean-pr.js'
@@ -518,6 +521,73 @@ describe('runScenario orchestration', () => {
     })
   }, 30_000)
 
+  it('seeds prior work through the SDK path consumed by session_search', async () => {
+    // #given a fake SDK client that persists created sessions and prompted messages in memory
+    const workspacePath = '/fixture/continuation-relevant'
+    const createdSession = {
+      id: 'seeded-session-42',
+      version: '1.18.18',
+      projectID: 'fixture-project',
+      directory: workspacePath,
+      title: 'fro-bot: issue-1',
+      time: {created: 1, updated: 1},
+    }
+    const persistedMessages: {readonly info: unknown; readonly parts: readonly {readonly text: string}[]}[] = []
+    const createSpy = vi.fn().mockResolvedValue({data: createdSession})
+    const promptSpy = vi.fn(
+      async (request: {readonly query?: {readonly directory?: string}; readonly body?: unknown}) => {
+        const body = request.body as {
+          readonly parts?: readonly [{readonly type: 'text'; readonly text: string}]
+        }
+        const text = body.parts?.[0]?.text ?? ''
+        persistedMessages.push({
+          info: {
+            id: `message-${persistedMessages.length + 1}`,
+            sessionID: createdSession.id,
+            role: 'user',
+            time: {created: persistedMessages.length + 1},
+            agent: 'build',
+            model: {providerID: 'opencode', modelID: 'eval-model'},
+          },
+          parts: [{text}],
+        })
+        return {data: {id: `message-${persistedMessages.length}`}}
+      },
+    )
+    const listSpy = vi.fn().mockResolvedValue({data: [createdSession]})
+    const messagesSpy = vi.fn().mockImplementation(async () => ({data: persistedMessages}))
+    const client = {
+      session: {
+        create: createSpy,
+        prompt: promptSpy,
+        list: listSpy,
+        messages: messagesSpy,
+      },
+    } as unknown as SessionClient
+
+    // #when prior work is seeded and searched through the runtime SDK primitives
+    const seededSessionId = await seedPriorWorkSession(
+      client,
+      workspacePath,
+      continuationRelevantScenario,
+      {key: 'issue-1', entityType: 'issue', entityId: '1'},
+      logger,
+    )
+    const results = await searchSessions('ORBIT-217', client, workspacePath, {limit: 5}, logger)
+
+    // #then creation, message persistence, directory scoping, and retrieval all use the public SDK path
+    expect(seededSessionId).toBe('seeded-session-42')
+    expect(createSpy).toHaveBeenCalledWith({
+      query: {directory: workspacePath},
+      body: {title: 'fro-bot: issue-1'},
+    })
+    expect(promptSpy).toHaveBeenCalledWith(expect.objectContaining({query: {directory: workspacePath}}))
+    expect(persistedMessages[0]?.parts[0]?.text).toContain('ORBIT-217')
+    expect(results).toHaveLength(1)
+    expect(results[0]?.sessionId).toBe('seeded-session-42')
+    expect(results[0]?.matches[0]?.excerpt).toContain('ORBIT-217')
+  })
+
   it.each([
     ['production', productionSessionPrepStrategy],
     ['treatment', treatmentSessionPrepStrategy],
@@ -527,38 +597,15 @@ describe('runScenario orchestration', () => {
       // #given a continuation scenario and an injected execution seam
       await withTestEnvironment(async setup => {
         let observedConfig: ExecutionConfig | undefined
-        let observedStorageRoot: string | undefined
-        let observedSessionTitle: string | undefined
-        let observedMessage: string | undefined
-        let observedPart: string | undefined
         const execution = async (_promptOptions: PromptOptions, _logger: Logger, config?: ExecutionConfig) => {
           observedConfig = config
           const configHome = process.env.XDG_CONFIG_HOME
-          const dataHome = process.env.XDG_DATA_HOME
-          if (configHome == null || dataHome == null) {
-            throw new Error('Injected execution could not locate isolated OpenCode directories')
+          if (configHome == null) {
+            throw new Error('Injected execution could not locate isolated OpenCode config')
           }
-          observedStorageRoot = path.join(dataHome, 'opencode', 'storage')
           const toolFile = path.join(configHome, 'opencode', 'tool', 'session.js')
           const toolContents = fs.readFileSync(toolFile, 'utf8')
           expect(toolContents).toContain('No matches found.')
-          const sessionPath = path.join(dataHome, 'opencode', 'storage', 'session')
-          expect(fs.existsSync(sessionPath)).toBe(true)
-          const projectDirectory = fs.readdirSync(sessionPath)[0]
-          if (projectDirectory == null) {
-            throw new Error('Seeded session project directory is missing')
-          }
-          const seededSessionPath = path.join(sessionPath, projectDirectory, 'continuation-session-42.json')
-          observedSessionTitle = (JSON.parse(fs.readFileSync(seededSessionPath, 'utf8')) as {readonly title?: string})
-            .title
-          observedMessage = fs.readFileSync(
-            path.join(dataHome, 'opencode', 'storage', 'message', 'continuation-session-42', 'message-orbit-217.json'),
-            'utf8',
-          )
-          observedPart = fs.readFileSync(
-            path.join(dataHome, 'opencode', 'storage', 'part', 'message-orbit-217', 'part-orbit-217.json'),
-            'utf8',
-          )
           const responseFilePath = _promptOptions.responseFilePath
           if (responseFilePath == null) {
             throw new Error('Injected execution did not receive a response file path')
@@ -568,22 +615,17 @@ describe('runScenario orchestration', () => {
         }
 
         // #when the selected mode runs through the isolated eval environment
-        const report = await runScenario(continuationRelevantScenario, logger, execution, strategy)
+        const report = await runScenario(
+          continuationRelevantScenario,
+          logger,
+          execution,
+          strategy,
+          async () => 'seeded-session-42',
+        )
 
         // #then both modes retain the real continuation identity and seed the same logical session
         expect(report.state).toBe('passed')
-        expect(observedConfig?.continueSessionId).toBe('continuation-session-42')
-        if (
-          observedStorageRoot == null ||
-          observedSessionTitle == null ||
-          observedMessage == null ||
-          observedPart == null
-        ) {
-          throw new Error('Injected execution did not observe isolated session storage')
-        }
-        expect(observedSessionTitle).toBe('fro-bot: issue-1')
-        expect(observedMessage).toContain('message-orbit-217')
-        expect(observedPart).toContain('ORBIT-217')
+        expect(observedConfig?.continueSessionId).toBe('seeded-session-42')
         expectProcessRestored(setup)
       })
     },

--- a/evals/runner.test.ts
+++ b/evals/runner.test.ts
@@ -284,6 +284,25 @@ describe('runScenario orchestration', () => {
     },
   )
 
+  it('uses distinct deterministic provenance for production and treatment prompt strategies', () => {
+    // #given one continuation scenario projected through the two supported strategies
+    // #when deterministic prompt provenance is computed for each strategy
+    const production = buildDeterministicScenarioProvenance(
+      continuationRelevantScenario,
+      logger,
+      productionSessionPrepStrategy,
+    )
+    const treatment = buildDeterministicScenarioProvenance(
+      continuationRelevantScenario,
+      logger,
+      treatmentSessionPrepStrategy,
+    )
+
+    // #then the prompt hash records the strategy actually used while the fixture commit remains stable
+    expect(treatment.promptHash).not.toBe(production.promptHash)
+    expect(treatment.scenarioCommitSha).toBe(production.scenarioCommitSha)
+  })
+
   it('restores cwd and env and removes the fixture when injected execution throws', async () => {
     // #given an injected execution that observes the fixture and then throws
     await withTestEnvironment(async setup => {
@@ -498,6 +517,78 @@ describe('runScenario orchestration', () => {
       expectProcessRestored(setup)
     })
   }, 30_000)
+
+  it.each([
+    ['production', productionSessionPrepStrategy],
+    ['treatment', treatmentSessionPrepStrategy],
+  ] as const)(
+    'provisions session tools, seeds prior work, and carries continuation for %s',
+    async (_mode, strategy) => {
+      // #given a continuation scenario and an injected execution seam
+      await withTestEnvironment(async setup => {
+        let observedConfig: ExecutionConfig | undefined
+        let observedStorageRoot: string | undefined
+        let observedSessionTitle: string | undefined
+        let observedMessage: string | undefined
+        let observedPart: string | undefined
+        const execution = async (_promptOptions: PromptOptions, _logger: Logger, config?: ExecutionConfig) => {
+          observedConfig = config
+          const configHome = process.env.XDG_CONFIG_HOME
+          const dataHome = process.env.XDG_DATA_HOME
+          if (configHome == null || dataHome == null) {
+            throw new Error('Injected execution could not locate isolated OpenCode directories')
+          }
+          observedStorageRoot = path.join(dataHome, 'opencode', 'storage')
+          const toolFile = path.join(configHome, 'opencode', 'tool', 'session.js')
+          const toolContents = fs.readFileSync(toolFile, 'utf8')
+          expect(toolContents).toContain('No matches found.')
+          const sessionPath = path.join(dataHome, 'opencode', 'storage', 'session')
+          expect(fs.existsSync(sessionPath)).toBe(true)
+          const projectDirectory = fs.readdirSync(sessionPath)[0]
+          if (projectDirectory == null) {
+            throw new Error('Seeded session project directory is missing')
+          }
+          const seededSessionPath = path.join(sessionPath, projectDirectory, 'continuation-session-42.json')
+          observedSessionTitle = (JSON.parse(fs.readFileSync(seededSessionPath, 'utf8')) as {readonly title?: string})
+            .title
+          observedMessage = fs.readFileSync(
+            path.join(dataHome, 'opencode', 'storage', 'message', 'continuation-session-42', 'message-orbit-217.json'),
+            'utf8',
+          )
+          observedPart = fs.readFileSync(
+            path.join(dataHome, 'opencode', 'storage', 'part', 'message-orbit-217', 'part-orbit-217.json'),
+            'utf8',
+          )
+          const responseFilePath = _promptOptions.responseFilePath
+          if (responseFilePath == null) {
+            throw new Error('Injected execution did not receive a response file path')
+          }
+          fs.writeFileSync(responseFilePath, '---\nschemaVersion: 1\n---\nseq ORBIT-217\n', 'utf8')
+          return createAgentResult()
+        }
+
+        // #when the selected mode runs through the isolated eval environment
+        const report = await runScenario(continuationRelevantScenario, logger, execution, strategy)
+
+        // #then both modes retain the real continuation identity and seed the same logical session
+        expect(report.state).toBe('passed')
+        expect(observedConfig?.continueSessionId).toBe('continuation-session-42')
+        if (
+          observedStorageRoot == null ||
+          observedSessionTitle == null ||
+          observedMessage == null ||
+          observedPart == null
+        ) {
+          throw new Error('Injected execution did not observe isolated session storage')
+        }
+        expect(observedSessionTitle).toBe('fro-bot: issue-1')
+        expect(observedMessage).toContain('message-orbit-217')
+        expect(observedPart).toContain('ORBIT-217')
+        expectProcessRestored(setup)
+      })
+    },
+    30_000,
+  )
 
   it('fails a valid response when a sibling markdown artifact is delivered', async () => {
     // #given successful injected execution that writes the valid response and a duplicate artifact

--- a/evals/runner.ts
+++ b/evals/runner.ts
@@ -876,6 +876,7 @@ export type EvalSessionSeeder = (
 ) => Promise<string | null>
 
 const seedPriorWorkInOpenCode: EvalSessionSeeder = async (repoPath, scenario, logicalKey, logger) => {
+  // Seed and execution servers must share this isolated data home: discovery is directory-scoped, but message retrieval by ID is not.
   const opencode = await withScrubbedEnv(
     async (): Promise<Awaited<ReturnType<typeof createOpencode>>> => createOpencode({port: 0}),
     logger,
@@ -1036,6 +1037,10 @@ export async function runScenario(
       evaluation.gates,
     )
     const deterministicProvenance = buildDeterministicScenarioProvenance(scenario, logger, sessionPrepStrategy)
+    const sessionPresearch =
+      resolvedSessionSeeder == null || continuationSessionId == null
+        ? preparedScenario.sessionPrep.accounting
+        : {...preparedScenario.sessionPrep.accounting, executedSessionId: continuationSessionId}
     const redactedAgentError = redactSensitiveText(agentResult.error ?? '', environment.authSecretValues)
     const redactedExecutionFailureReason = redactSensitiveText(
       completeArtifacts.executionFailureReason ?? '',
@@ -1079,7 +1084,7 @@ export async function runScenario(
         error: agentResult.error == null ? null : redactedAgentError,
         tokenUsage: agentResult.tokenUsage,
       },
-      sessionPresearch: preparedScenario.sessionPrep.accounting,
+      sessionPresearch,
     }
   } catch (error) {
     primaryError = error

--- a/evals/runner.ts
+++ b/evals/runner.ts
@@ -1,6 +1,7 @@
 import type {DiffFileSummary} from '../packages/runtime/src/agent/index.js'
 import type {ParsedResponse, ResponseSurface} from '../packages/runtime/src/agent/response-file.js'
 import type {SessionContext, TriggerContext} from '../packages/runtime/src/agent/types.js'
+import type {SessionClient} from '../packages/runtime/src/session/backend.js'
 import type {LogicalSessionKey} from '../packages/runtime/src/session/logical-key.js'
 import type {OmoProviders} from '../packages/runtime/src/shared/types.js'
 import type {AgentResult, ExecutionConfig, PromptOptions} from '../src/features/agent/types.js'
@@ -23,14 +24,15 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import process from 'node:process'
 import {pathToFileURL} from 'node:url'
+import {createOpencode} from '@opencode-ai/sdk'
 import {redactSecrets} from '../packages/harness/src/format-error.js'
 import {
   buildResponseFilePath,
   parseResponseFile,
   RESPONSE_FILE_DIR_SEGMENT,
 } from '../packages/runtime/src/agent/response-file.js'
+import {withScrubbedEnv} from '../packages/runtime/src/agent/with-scrubbed-env.js'
 import {buildLogicalKey, buildSessionTitle} from '../packages/runtime/src/session/logical-key.js'
-import {getOpenCodeStoragePath} from '../packages/runtime/src/shared/env.js'
 import {buildAgentPrompt, executeOpenCode} from '../src/features/agent/index.js'
 import {resolveResponseSurface} from '../src/features/agent/response-file.js'
 import {buildTriggerContext} from '../src/features/triggers/context-builders.js'
@@ -819,76 +821,69 @@ export function createFixtureFiles(scenario: Scenario, canary: string): Readonly
   return files
 }
 
-function writeEvalJson(filePath: string, value: unknown): void {
-  fs.mkdirSync(path.dirname(filePath), {recursive: true})
-  fs.writeFileSync(filePath, JSON.stringify(value, null, 2), 'utf8')
-}
-
-function seedPriorWorkSession(
+export async function seedPriorWorkSession(
+  client: SessionClient,
   repoPath: string,
   scenario: Scenario,
-  headSha: string,
   logicalKey: LogicalSessionKey | null,
-): void {
-  if (scenario.priorWork == null || logicalKey == null) return
+  logger: Logger,
+): Promise<string | null> {
+  if (scenario.priorWork == null) return null
+  if (logicalKey == null) throw new Error(`Scenario ${scenario.id} requires a logical key for prior-work seeding`)
 
-  const storagePath = getOpenCodeStoragePath()
   const sessionID = scenario.priorWork.currentThreadSessionId
   const priorMatches = scenario.priorWork.sessionContext.priorWorkContext
     .filter(result => result.sessionId === sessionID)
     .flatMap(result => result.matches)
-  if (priorMatches.length === 0) return
-  const timestamp = Date.now()
-  const project = {
-    id: headSha,
-    worktree: repoPath,
-    vcs: 'git',
-    time: {created: timestamp, updated: timestamp},
+  if (priorMatches.length === 0) throw new Error(`Scenario ${scenario.id} has no prior-work matches to seed`)
+
+  const sessionResponse = await client.session.create({
+    query: {directory: repoPath},
+    body: {title: buildSessionTitle(logicalKey)},
+  })
+  if (sessionResponse.error != null || sessionResponse.data == null) {
+    throw new Error(`Failed to seed prior-work session: ${String(sessionResponse.error ?? 'No session returned')}`)
   }
-  const session = {
-    id: sessionID,
-    version: '1.18.18',
-    projectID: headSha,
+  const seededSessionID = sessionResponse.data.id
+
+  for (const match of priorMatches) {
+    const promptResponse = await client.session.prompt({
+      path: {id: seededSessionID},
+      query: {directory: repoPath},
+      body: {
+        noReply: true,
+        parts: [{type: 'text', text: match.excerpt}],
+      },
+    })
+    if (promptResponse.error != null) {
+      throw new Error(`Failed to seed prior-work message: ${String(promptResponse.error)}`)
+    }
+  }
+  logger.info('Seeded eval prior-work session through OpenCode SDK', {
+    sessionID: seededSessionID,
     directory: repoPath,
     title: buildSessionTitle(logicalKey),
-    time: {created: timestamp, updated: timestamp},
-  }
-  fs.mkdirSync(storagePath, {recursive: true})
-  fs.writeFileSync(path.join(storagePath, '.version'), '1', 'utf8')
-  writeEvalJson(path.join(storagePath, 'project', `${headSha}.json`), project)
-  writeEvalJson(path.join(storagePath, 'session', headSha, `${sessionID}.json`), session)
-  for (const [index, match] of priorMatches.entries()) {
-    const message = {
-      id: match.messageId,
-      sessionID,
-      role: match.role,
-      time: {created: timestamp + index, ...(match.role === 'assistant' ? {completed: timestamp + index} : {})},
-      ...(match.role === 'assistant'
-        ? {
-            parentID: `message-parent-${index}`,
-            modelID: 'eval-model',
-            providerID: 'opencode',
-            mode: 'build',
-            agent: match.agent ?? 'build',
-            path: {cwd: repoPath, root: repoPath},
-            cost: 0,
-            tokens: {input: 0, output: 0, reasoning: 0, cache: {read: 0, write: 0}},
-            finish: 'end_turn',
-          }
-        : {
-            agent: match.agent ?? 'build',
-            model: {providerID: 'opencode', modelID: 'eval-model'},
-          }),
-    }
-    const part = {
-      id: match.partId,
-      sessionID,
-      messageID: match.messageId,
-      type: 'text',
-      text: match.excerpt,
-    }
-    writeEvalJson(path.join(storagePath, 'message', sessionID, `${match.messageId}.json`), message)
-    writeEvalJson(path.join(storagePath, 'part', match.messageId, `${match.partId}.json`), part)
+    matchCount: priorMatches.length,
+  })
+  return seededSessionID
+}
+
+export type EvalSessionSeeder = (
+  repoPath: string,
+  scenario: Scenario,
+  logicalKey: LogicalSessionKey | null,
+  logger: Logger,
+) => Promise<string | null>
+
+const seedPriorWorkInOpenCode: EvalSessionSeeder = async (repoPath, scenario, logicalKey, logger) => {
+  const opencode = await withScrubbedEnv(
+    async (): Promise<Awaited<ReturnType<typeof createOpencode>>> => createOpencode({port: 0}),
+    logger,
+  )
+  try {
+    return await seedPriorWorkSession(opencode.client, repoPath, scenario, logicalKey, logger)
+  } finally {
+    opencode.server.close()
   }
 }
 
@@ -961,6 +956,7 @@ export async function runScenario(
   logger: Logger,
   execution: EvalExecution = executeOpenCode,
   sessionPrepStrategy: EvalSessionPrepStrategy = productionSessionPrepStrategy,
+  sessionSeeder?: EvalSessionSeeder,
 ): Promise<EvalRunReport> {
   const startedAt = Date.now()
   const originalCwd = process.cwd()
@@ -978,7 +974,17 @@ export async function runScenario(
     const environment = await createIsolatedEvalEnv(fixtureRepo.path, scenario, fixtureRepo.headSha, model, logger)
     isolatedEnv = environment
     const preparedScenario = prepareScenarioPrompt(scenario, fixtureRepo.headSha, sessionPrepStrategy)
-    seedPriorWorkSession(fixtureRepo.path, scenario, fixtureRepo.headSha, preparedScenario.sessionPrep.logicalKey)
+    const resolvedSessionSeeder = sessionSeeder ?? (execution === executeOpenCode ? seedPriorWorkInOpenCode : null)
+    let continuationSessionId: string | null = null
+    if (preparedScenario.sessionPrep.currentThreadSessionId != null) {
+      continuationSessionId =
+        resolvedSessionSeeder == null
+          ? preparedScenario.sessionPrep.currentThreadSessionId
+          : await resolvedSessionSeeder(fixtureRepo.path, scenario, preparedScenario.sessionPrep.logicalKey, logger)
+      if (continuationSessionId == null) {
+        throw new Error(`Scenario ${scenario.id} declared continuation but seeding returned no session ID`)
+      }
+    }
     const promptOptions = buildPromptOptionsFromPrepared(scenario, environment.responseFilePath, preparedScenario)
     const responseSurface = resolveResponseSurface(promptOptions.context, promptOptions.triggerContext)
     const timeoutMs = resolveEvalTimeoutMs()
@@ -987,9 +993,7 @@ export async function runScenario(
       model: modelConfig,
       timeoutMs,
       omoProviders: NO_OMO_PROVIDERS,
-      ...(preparedScenario.sessionPrep.currentThreadSessionId == null
-        ? {}
-        : {continueSessionId: preparedScenario.sessionPrep.currentThreadSessionId}),
+      ...(continuationSessionId == null ? {} : {continueSessionId: continuationSessionId}),
     }
     let agentResult: AgentResult
     const openCodeVersion = readOpenCodeVersion(environment.opencodeBin)

--- a/evals/runner.ts
+++ b/evals/runner.ts
@@ -22,17 +22,20 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import process from 'node:process'
+import {pathToFileURL} from 'node:url'
 import {redactSecrets} from '../packages/harness/src/format-error.js'
 import {
   buildResponseFilePath,
   parseResponseFile,
   RESPONSE_FILE_DIR_SEGMENT,
 } from '../packages/runtime/src/agent/response-file.js'
-import {buildLogicalKey} from '../packages/runtime/src/session/logical-key.js'
+import {buildLogicalKey, buildSessionTitle} from '../packages/runtime/src/session/logical-key.js'
+import {getOpenCodeStoragePath} from '../packages/runtime/src/shared/env.js'
 import {buildAgentPrompt, executeOpenCode} from '../src/features/agent/index.js'
 import {resolveResponseSurface} from '../src/features/agent/response-file.js'
 import {buildTriggerContext} from '../src/features/triggers/context-builders.js'
 import {normalizeEvent} from '../src/services/github/context.js'
+import {writeSessionToolsFile} from '../src/services/setup/session-tools-config.js'
 import {
   captureDiagnostics,
   clearScenarioDiagnostics,
@@ -232,7 +235,13 @@ function cleanupIsolatedEvalEnv(env: IsolatedEvalEnv): void {
   }
 }
 
-function createIsolatedEvalEnv(repoPath: string, scenario: Scenario, headSha: string, model: string): IsolatedEvalEnv {
+async function createIsolatedEvalEnv(
+  repoPath: string,
+  scenario: Scenario,
+  headSha: string,
+  model: string,
+  logger: Logger,
+): Promise<IsolatedEvalEnv> {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), `fro-bot-eval-${scenario.id}-`))
   const runnerTemp = fs.mkdtempSync(path.join(os.tmpdir(), `fro-bot-eval-temp-${scenario.id}-`))
   const runId = String(Date.now())
@@ -284,6 +293,8 @@ function createIsolatedEvalEnv(repoPath: string, scenario: Scenario, headSha: st
     fs.writeFileSync(opencodeBin, `#!/bin/sh\nexec "${resolveHarnessBinary()}" "$@"\n`, {mode: 0o755})
     const pluginVersions = resolveConfiguredPluginVersions(model)
     const authPlugin = pluginVersions[0]
+    const sessionToolsAsset = path.resolve(import.meta.dirname, '..', 'dist', 'session-tools.js')
+    await writeSessionToolsFile(configDir, logger, () => pathToFileURL(sessionToolsAsset))
     fs.writeFileSync(
       path.join(configDir, 'opencode.json'),
       JSON.stringify(
@@ -684,20 +695,27 @@ export function hashEvalPrompt(promptOptions: PromptOptions, logger: Logger): st
 export function buildDeterministicScenarioProvenance(
   scenario: Scenario,
   logger: Logger,
+  sessionPrepStrategy: EvalSessionPrepStrategy = productionSessionPrepStrategy,
 ): {readonly promptHash: string; readonly scenarioCommitSha: string} {
-  const cached = deterministicProvenanceCache.get(scenario.id)
+  const cacheKey = `${scenario.id}:${sessionPrepStrategy === productionSessionPrepStrategy ? 'production' : 'treatment'}`
+  const cached = deterministicProvenanceCache.get(cacheKey)
   if (cached != null) {
     return cached
   }
 
   const fixtureRepo = createFixtureRepo(createFixtureFiles(scenario, EVAL_PROVENANCE_CANARY))
   try {
-    const promptOptions = buildPromptOptions(scenario, fixtureRepo.headSha, EVAL_RESPONSE_PATH_SENTINEL)
+    const promptOptions = buildPromptOptions(
+      scenario,
+      fixtureRepo.headSha,
+      EVAL_RESPONSE_PATH_SENTINEL,
+      sessionPrepStrategy,
+    )
     const provenance = {
       promptHash: hashEvalPrompt(promptOptions, logger),
       scenarioCommitSha: fixtureRepo.headSha,
     }
-    deterministicProvenanceCache.set(scenario.id, provenance)
+    deterministicProvenanceCache.set(cacheKey, provenance)
     return provenance
   } finally {
     cleanupFixtureRepo(fixtureRepo)
@@ -801,6 +819,79 @@ export function createFixtureFiles(scenario: Scenario, canary: string): Readonly
   return files
 }
 
+function writeEvalJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), {recursive: true})
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2), 'utf8')
+}
+
+function seedPriorWorkSession(
+  repoPath: string,
+  scenario: Scenario,
+  headSha: string,
+  logicalKey: LogicalSessionKey | null,
+): void {
+  if (scenario.priorWork == null || logicalKey == null) return
+
+  const storagePath = getOpenCodeStoragePath()
+  const sessionID = scenario.priorWork.currentThreadSessionId
+  const priorMatches = scenario.priorWork.sessionContext.priorWorkContext
+    .filter(result => result.sessionId === sessionID)
+    .flatMap(result => result.matches)
+  if (priorMatches.length === 0) return
+  const timestamp = Date.now()
+  const project = {
+    id: headSha,
+    worktree: repoPath,
+    vcs: 'git',
+    time: {created: timestamp, updated: timestamp},
+  }
+  const session = {
+    id: sessionID,
+    version: '1.18.18',
+    projectID: headSha,
+    directory: repoPath,
+    title: buildSessionTitle(logicalKey),
+    time: {created: timestamp, updated: timestamp},
+  }
+  fs.mkdirSync(storagePath, {recursive: true})
+  fs.writeFileSync(path.join(storagePath, '.version'), '1', 'utf8')
+  writeEvalJson(path.join(storagePath, 'project', `${headSha}.json`), project)
+  writeEvalJson(path.join(storagePath, 'session', headSha, `${sessionID}.json`), session)
+  for (const [index, match] of priorMatches.entries()) {
+    const message = {
+      id: match.messageId,
+      sessionID,
+      role: match.role,
+      time: {created: timestamp + index, ...(match.role === 'assistant' ? {completed: timestamp + index} : {})},
+      ...(match.role === 'assistant'
+        ? {
+            parentID: `message-parent-${index}`,
+            modelID: 'eval-model',
+            providerID: 'opencode',
+            mode: 'build',
+            agent: match.agent ?? 'build',
+            path: {cwd: repoPath, root: repoPath},
+            cost: 0,
+            tokens: {input: 0, output: 0, reasoning: 0, cache: {read: 0, write: 0}},
+            finish: 'end_turn',
+          }
+        : {
+            agent: match.agent ?? 'build',
+            model: {providerID: 'opencode', modelID: 'eval-model'},
+          }),
+    }
+    const part = {
+      id: match.partId,
+      sessionID,
+      messageID: match.messageId,
+      type: 'text',
+      text: match.excerpt,
+    }
+    writeEvalJson(path.join(storagePath, 'message', sessionID, `${match.messageId}.json`), message)
+    writeEvalJson(path.join(storagePath, 'part', match.messageId, `${match.partId}.json`), part)
+  }
+}
+
 interface CollectedResponseArtifacts {
   readonly artifacts: ResponseArtifacts
   readonly rawResponse: string | null
@@ -884,9 +975,10 @@ export async function runScenario(
   let cleanupError: string | null = null
 
   try {
-    const environment = createIsolatedEvalEnv(fixtureRepo.path, scenario, fixtureRepo.headSha, model)
+    const environment = await createIsolatedEvalEnv(fixtureRepo.path, scenario, fixtureRepo.headSha, model, logger)
     isolatedEnv = environment
     const preparedScenario = prepareScenarioPrompt(scenario, fixtureRepo.headSha, sessionPrepStrategy)
+    seedPriorWorkSession(fixtureRepo.path, scenario, fixtureRepo.headSha, preparedScenario.sessionPrep.logicalKey)
     const promptOptions = buildPromptOptionsFromPrepared(scenario, environment.responseFilePath, preparedScenario)
     const responseSurface = resolveResponseSurface(promptOptions.context, promptOptions.triggerContext)
     const timeoutMs = resolveEvalTimeoutMs()
@@ -895,6 +987,9 @@ export async function runScenario(
       model: modelConfig,
       timeoutMs,
       omoProviders: NO_OMO_PROVIDERS,
+      ...(preparedScenario.sessionPrep.currentThreadSessionId == null
+        ? {}
+        : {continueSessionId: preparedScenario.sessionPrep.currentThreadSessionId}),
     }
     let agentResult: AgentResult
     const openCodeVersion = readOpenCodeVersion(environment.opencodeBin)
@@ -936,7 +1031,7 @@ export async function runScenario(
       completeArtifacts.parsedResponse?.verdict ?? null,
       evaluation.gates,
     )
-    const deterministicProvenance = buildDeterministicScenarioProvenance(scenario, logger)
+    const deterministicProvenance = buildDeterministicScenarioProvenance(scenario, logger, sessionPrepStrategy)
     const redactedAgentError = redactSensitiveText(agentResult.error ?? '', environment.authSecretValues)
     const redactedExecutionFailureReason = redactSensitiveText(
       completeArtifacts.executionFailureReason ?? '',

--- a/evals/types.ts
+++ b/evals/types.ts
@@ -40,6 +40,7 @@ export interface SessionPresearchAccounting {
   readonly strategy: SessionPresearchStrategy
   readonly logicalKey: string | null
   readonly continuationSessionId: string | null
+  readonly executedSessionId?: string
   readonly recentSessionCount: number
   readonly priorWorkResultCount: number
   readonly injectedContextBytes: number


### PR DESCRIPTION
## What

The eval corpus advertised a capability it never had. Scenarios that depend on recalling a prior decision only ever received that decision as text pasted into the prompt — no prior session existed anywhere the agent could actually reach. The native `session_*` tools were never provisioned into the isolated eval config, prior work was never persisted to a real session, and `continueSessionId` never reached `ExecutionConfig`, so every scenario silently started fresh.

## Why it matters

This makes any experiment that varies prompt-injected session context meaningless. Disabling eager presearch doesn't measure whether on-demand retrieval can substitute for it — it deletes the only copy of the data. The result is a guaranteed failure that reads like a finding.

## Changes

- Provision the native `session_*` tools into the isolated eval config through the same `writeSessionToolsFile` used in setup, so both modes expose the real tool surface.
- Seed a scenario's prior work as a genuine OpenCode session through the SDK (`session.create` plus `session.prompt` with `noReply: true`), scoped to the fixture repo directory that `session_search` resolves against. Seeding is deterministic and invokes no inference.
- Pass the seeded session ID through as `continueSessionId` so continuation semantics actually apply.
- Make deterministic prompt provenance strategy-aware, so `promptHash` distinguishes the two modes.

Seeding runs against a short-lived server on the isolated data home and closes it in a `finally`; the execution server that follows reads the same store.

## Verification

A live probe confirms end-to-end retrieval: the seeded session is returned by the same `session.list()` / `session.messages()` path `session_search` uses, carrying the required signal.

Tests now assert retrieval through an injected SDK client rather than filesystem paths. The previous filesystem-only assertions are exactly why this went unnoticed — they proved files were written, not that anything could read them.

`check-types`, `lint` (0 errors), `test:evals` (159 passed, 1 skipped), `dist/` clean.
