### PR TITLE
ci: run lint, build, and review on evals/ changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,7 @@ jobs:
             src-changed: &src-changed
               - apps/**
               - assets/**
+              - evals/**
               - packages/**
               - src/**
               - action.yaml


### PR DESCRIPTION
## What

`evals/**` was missing from every `paths-filter` in `ci.yaml`, so a PR touching only the eval corpus resolved `should-lint` and `should-build` to `false`.

## Why it matters

That skips Lint, Build, the `dist/` drift comparison, and the `test-action` job that carries the PR review prompt. `Test` has no gate, so it still runs — which makes such a PR look green while several thousand lines of TypeScript merge with a single job as their only coverage.

The effect is also arbitrary. An eval PR that happens to touch a `.md` file or `package.json` matches other filters and gets the full treatment; one touching only `evals/*.ts` does not. Coverage depended on incidental file types rather than on risk.

## Change

Adds `evals/**` to the `src-changed` anchor, which both `should-lint` and `should-build` reference.

This also triggers the gateway and workspace image smoke tests on eval-only changes, which cannot affect those images. That is accepted rather than worked around: `should-build` is a coarse source-changed proxy, and narrowing it is a separate concern from closing the coverage hole.
