### PR TITLE
docs(solutions): sharpen two false-confidence learnings

### DIFF
--- a/docs/solutions/workflow-issues/checks-report-clean-for-what-they-cannot-observe-2026-08-10.md
+++ b/docs/solutions/workflow-issues/checks-report-clean-for-what-they-cannot-observe-2026-08-10.md
@@ -42,7 +42,7 @@ One more instance came from reading an API response rather than a codebase. `gh 
 
 ## Guidance
 
-Before trusting a clean result, establish what the check was able to look at. That is a separate question from whether it passed, and it is almost never reported alongside the pass.
+Before trusting a clean result, establish what the check was able to look at and which interface the production consumer actually reads through. A check can pass on artifacts written by one interface while the real consumer reads through a different path, in which case the artifacts prove only that a write happened. That is a separate question from whether it passed, and it is almost never reported alongside the pass.
 
 **Compare the check's population against an independent count of the same population.** For dependency scanning the two numbers are one command apart:
 

--- a/docs/solutions/workflow-issues/non-failing-gates-are-worse-than-no-gates-2026-08-07.md
+++ b/docs/solutions/workflow-issues/non-failing-gates-are-worse-than-no-gates-2026-08-07.md
@@ -107,6 +107,6 @@ A gate is only evidence if some reachable input makes it red. Until you have exe
 - **Write the failing case first.** If you cannot construct an input that fails the gate, the gate is not measuring what you think.
 - **Trace the canary's path to the system under test.** For anything planted in the environment, confirm no scrubbing, filtering, or sandboxing sits between the plant and the observer. Security controls are the most likely thing to silently neutralise a canary.
 - **Do not let one function assemble both observations and expectations.** Split the types so placeholder values cannot occupy fields that must be measured.
-- **Be suspicious of a gate that is green on its first run.** A gate written against a real hazard usually fails once before it passes.
+- **Be suspicious of a gate that is green on its first run.** A gate written against a real hazard usually fails once before it passes. A green result can also mean the harness never exposed the capability under test, leaving the gate nothing to evaluate.
 
 Related: [an env-var scrub can silently no-op when the key name does not match](../logic-errors/actions-core-input-env-hyphen-mapping-2026-07-01.md) is the same class of self-consistent-but-wrong wiring, and [credential isolation via an OIDC broker](isolate-ci-credential-via-oidc-broker-2026-07-01.md) documents the scrubbing behaviour that made this canary unobservable.


### PR DESCRIPTION
## What

Two one-sentence additions to existing learnings, prompted by a recent eval defect.

`checks-report-clean-for-what-they-cannot-observe` gains the distinction between the interface a check writes through and the interface the production consumer reads through. A check can pass on written artifacts while the real consumer resolves data by a different path, in which case those artifacts prove only that a write happened.

`non-failing-gates-are-worse-than-no-gates` gains a sibling case to "impossible to fail": a gate can be green because the harness never exposed the capability under test, leaving it nothing to evaluate.

## Why

An eval compared a treatment that disabled eager session-context injection against production, and the treatment failed every sample. That looked decisive but was a tautology — the harness never provisioned the native `session_*` tools or persisted prior work as a retrievable session, so disabling injection removed the only copy of the data. Filesystem assertions confirmed files were written and passed through two invalid runs without ever establishing that anything could read them.

Both edits generalize that into guidance the existing docs were adjacent to but did not state.

## Reviewed without changes

`deterministic-agent-outcome-eval-corpus` already states that deterministic provenance does not guarantee a trustworthy outcome, so the new finding complements it rather than narrowing it. No edit.

A document-set review of the four related learnings found high overlap between several pairs but distinct retrieval value for each, and no contradictions. They stay separate; consolidation is worth revisiting only if another doc lands in this space without a distinct search intent.
