### PR TITLE
fix(harness): let the forward-shadow integration reach its conflict resolver

### DIFF
--- a/packages/harness/src/forward-shadow-command.test.ts
+++ b/packages/harness/src/forward-shadow-command.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import {describe, expect, it} from 'vitest'
 import {runForwardShadowCommand} from './forward-shadow-command.js'
-import {buildForwardShadowRecord} from './forward-shadow.js'
+import {buildForwardShadowRecord, compareForwardShadow} from './forward-shadow.js'
 
 const OID_A = 'a'.repeat(40)
 const OID_B = 'b'.repeat(40)
@@ -275,6 +275,72 @@ describe('forward shadow command', () => {
     // #then
     expect(code).toBe(0)
     expect(receivedRecord?.verdict).toBe('inconclusive')
+    await fs.rm(directory, {recursive: true, force: true})
+  })
+
+  it('preserves a failed integration stage and bounds its error in the record', async () => {
+    // #given
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'forward-shadow-command-test-'))
+    const resultPath = path.join(directory, 'result.json')
+    const recordPath = path.join(directory, 'record.json')
+    const failureError = `merge ref source failed: ${'x'.repeat(600)}`
+    await fs.writeFile(
+      resultPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        ok: false,
+        startedAt: '2026-08-14T00:00:00.000Z',
+        endedAt: '2026-08-14T00:00:01.000Z',
+        elapsedMs: 1000,
+        conflictMetrics: {
+          hadConflict: false,
+          conflictPathCount: 0,
+          conflictSizeBytes: 0,
+          resolverAttempts: 0,
+          contextRequestCount: 0,
+        },
+        failure: {stage: 'merge', error: failureError},
+      }),
+      'utf8',
+    )
+
+    // #when
+    let receivedRecord: ForwardShadowRecord | undefined
+    const code = await runForwardShadowCommand(
+      [
+        '--result-out',
+        resultPath,
+        '--record-out',
+        recordPath,
+        '--base-version',
+        '1.15.13',
+        '--shadow-work-dir',
+        directory,
+        '--release-repo',
+        'anomalyco/opencode',
+        '--authoritative-repository',
+        'fro-bot/agent',
+        '--authoritative-ref',
+        'refs/harness-integrate/1.15.13',
+        '--run-identity',
+        'run-1',
+      ],
+      {
+        readFile: async file => fs.readFile(file, 'utf8'),
+        compare: async input => compareForwardShadow(input),
+        writeRecord: async (_file, record) => {
+          receivedRecord = record
+        },
+        now: () => new Date('2026-08-14T00:00:02.000Z'),
+      },
+    )
+
+    // #then
+    expect(code).toBe(0)
+    expect(receivedRecord?.verdict).toBe('inconclusive')
+    expect(receivedRecord?.failureStage).toBe('merge')
+    expect(receivedRecord?.failureError).toBe(failureError.slice(0, 512))
+    expect(receivedRecord?.failureError?.length).toBeLessThanOrEqual(512)
     await fs.rm(directory, {recursive: true, force: true})
   })
 })

--- a/packages/harness/src/forward-shadow-command.test.ts
+++ b/packages/harness/src/forward-shadow-command.test.ts
@@ -343,4 +343,61 @@ describe('forward shadow command', () => {
     expect(receivedRecord?.failureError?.length).toBeLessThanOrEqual(512)
     await fs.rm(directory, {recursive: true, force: true})
   })
+
+  it('falls back to the generic failure when the outcome stage is outside the integration union', async () => {
+    // #given
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'forward-shadow-command-test-'))
+    const resultPath = path.join(directory, 'result.json')
+    const bogusStage = 'not-a-real-integration-stage'
+    await fs.writeFile(
+      resultPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        ok: false,
+        startedAt: '2026-08-14T00:00:00.000Z',
+        endedAt: '2026-08-14T00:00:01.000Z',
+        elapsedMs: 1000,
+        failure: {stage: bogusStage, error: 'bogus failure details'},
+      }),
+      'utf8',
+    )
+
+    // #when
+    let receivedRecord: ForwardShadowRecord | undefined
+    const code = await runForwardShadowCommand(
+      [
+        '--result-out',
+        resultPath,
+        '--record-out',
+        path.join(directory, 'record.json'),
+        '--base-version',
+        '1.15.13',
+        '--shadow-work-dir',
+        directory,
+        '--release-repo',
+        'anomalyco/opencode',
+        '--authoritative-repository',
+        'fro-bot/agent',
+        '--authoritative-ref',
+        'refs/harness-integrate/1.15.13',
+        '--run-identity',
+        'run-1',
+      ],
+      {
+        readFile: async file => fs.readFile(file, 'utf8'),
+        compare: async input => compareForwardShadow(input),
+        writeRecord: async (_file, record) => {
+          receivedRecord = record
+        },
+        now: () => new Date('2026-08-14T00:00:02.000Z'),
+      },
+    )
+
+    // #then
+    expect(code).toBe(0)
+    expect(receivedRecord?.failureStage).toBe('integration')
+    expect(receivedRecord?.failureStage).not.toBe(bogusStage)
+    expect(receivedRecord?.failureError).toBe('shadow integration outcome reported failure')
+    await fs.rm(directory, {recursive: true, force: true})
+  })
 })

--- a/packages/harness/src/forward-shadow-command.ts
+++ b/packages/harness/src/forward-shadow-command.ts
@@ -50,23 +50,24 @@ const DEFAULT_DEPENDENCIES: ForwardShadowCommandDependencies = {
 
 const OID_PATTERN = /^[0-9a-f]{40}$/i
 const MAX_RUN_IDENTITY_LENGTH = 512
-const INTEGRATION_STAGES = [
-  'sources',
-  'clone',
-  'fetch-tags',
-  'branch',
-  'fetch',
-  'merge',
-  'squash',
-  'workflow-strip',
-  'commit',
-  'build',
-  'version',
-  'tree',
-  'provenance',
-  'cleanup',
-  'push',
-] as const satisfies readonly IntegrationStage[]
+// The Record keys are exhaustive: adding an IntegrationStage requires updating this map.
+const INTEGRATION_STAGES: Readonly<Record<IntegrationStage, true>> = {
+  sources: true,
+  clone: true,
+  'fetch-tags': true,
+  branch: true,
+  fetch: true,
+  merge: true,
+  squash: true,
+  'workflow-strip': true,
+  commit: true,
+  build: true,
+  version: true,
+  tree: true,
+  provenance: true,
+  cleanup: true,
+  push: true,
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && Array.isArray(value) === false
@@ -84,12 +85,14 @@ function isNonNegativeInteger(value: unknown): value is number {
   return typeof value === 'number' && Number.isInteger(value) && value >= 0
 }
 
+function isIntegrationStage(value: unknown): value is IntegrationStage {
+  return typeof value === 'string' && Object.hasOwn(INTEGRATION_STAGES, value)
+}
+
 function parseFailure(value: unknown): {readonly stage: IntegrationStage; readonly error: string} | undefined {
-  if (isRecord(value) === false || isString(value.stage) === false || isString(value.error) === false) return undefined
-  for (const stage of INTEGRATION_STAGES) {
-    if (stage === value.stage) return {stage, error: value.error}
-  }
-  return undefined
+  if (isRecord(value) === false || isIntegrationStage(value.stage) === false || isString(value.error) === false)
+    return undefined
+  return {stage: value.stage, error: value.error}
 }
 
 function emptyMetrics(): ForwardShadowConflictMetrics {

--- a/packages/harness/src/forward-shadow-command.ts
+++ b/packages/harness/src/forward-shadow-command.ts
@@ -8,7 +8,7 @@
  */
 
 import type {ForwardShadowComparisonInput, ForwardShadowConflictMetrics, ForwardShadowRecord} from './forward-shadow.js'
-import type {IntegrationResult, ProvenanceManifest} from './integrate.js'
+import type {IntegrationResult, IntegrationStage, ProvenanceManifest} from './integrate.js'
 import fs from 'node:fs/promises'
 import process from 'node:process'
 import {buildForwardShadowRecord, compareForwardShadow, writeForwardShadowRecord} from './forward-shadow.js'
@@ -50,6 +50,23 @@ const DEFAULT_DEPENDENCIES: ForwardShadowCommandDependencies = {
 
 const OID_PATTERN = /^[0-9a-f]{40}$/i
 const MAX_RUN_IDENTITY_LENGTH = 512
+const INTEGRATION_STAGES = [
+  'sources',
+  'clone',
+  'fetch-tags',
+  'branch',
+  'fetch',
+  'merge',
+  'squash',
+  'workflow-strip',
+  'commit',
+  'build',
+  'version',
+  'tree',
+  'provenance',
+  'cleanup',
+  'push',
+] as const satisfies readonly IntegrationStage[]
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && Array.isArray(value) === false
@@ -65,6 +82,14 @@ function isDateString(value: unknown): value is string {
 
 function isNonNegativeInteger(value: unknown): value is number {
   return typeof value === 'number' && Number.isInteger(value) && value >= 0
+}
+
+function parseFailure(value: unknown): {readonly stage: IntegrationStage; readonly error: string} | undefined {
+  if (isRecord(value) === false || isString(value.stage) === false || isString(value.error) === false) return undefined
+  for (const stage of INTEGRATION_STAGES) {
+    if (stage === value.stage) return {stage, error: value.error}
+  }
+  return undefined
 }
 
 function emptyMetrics(): ForwardShadowConflictMetrics {
@@ -156,8 +181,12 @@ async function readOutcome(
   if (conflictMetrics === undefined)
     return invalidOutcome(dependencies.now(), 'shadow outcome conflict metrics are invalid')
   if (parsed.ok === false) {
+    const failure = parseFailure(parsed.failure)
     return {
-      result: {ok: false, kind: 'failure', error: 'shadow integration outcome reported failure'},
+      result:
+        failure === undefined
+          ? {ok: false, kind: 'failure', error: 'shadow integration outcome reported failure'}
+          : {ok: false, kind: 'failure', stage: failure.stage, error: failure.error},
       conflictMetrics,
       startedAt,
       endedAt,

--- a/packages/harness/src/integrate.test.ts
+++ b/packages/harness/src/integrate.test.ts
@@ -1147,6 +1147,51 @@ describe('U5 code-owned integration driver', () => {
     }
   })
 
+  it('real adapters surface a conflict when the merge base lies beyond a shallow clone boundary', async () => {
+    // #given
+    const repositoryDir = await makeTmpDir()
+    const workDir = path.join(await makeTmpDir(), 'worktree')
+    const adapters = makeRealAdapters()
+    try {
+      runGit(repositoryDir, ['init', '--quiet'])
+      runGit(repositoryDir, ['config', 'user.name', 'harness-test'])
+      runGit(repositoryDir, ['config', 'user.email', 'harness-test@example.invalid'])
+      await fs.writeFile(path.join(repositoryDir, 'conflict.txt'), 'root\n', 'utf8')
+      runGit(repositoryDir, ['add', 'conflict.txt'])
+      runGit(repositoryDir, ['commit', '--quiet', '-m', 'root'])
+      const mergeBase = runGit(repositoryDir, ['rev-parse', 'HEAD'])
+
+      await fs.writeFile(path.join(repositoryDir, 'conflict.txt'), 'integration\n', 'utf8')
+      runGit(repositoryDir, ['add', 'conflict.txt'])
+      runGit(repositoryDir, ['commit', '--quiet', '-m', 'release'])
+      runGit(repositoryDir, ['tag', 'v1.15.13'])
+
+      runGit(repositoryDir, ['checkout', '--quiet', '-b', 'source', mergeBase])
+      await fs.writeFile(path.join(repositoryDir, 'conflict.txt'), 'source\n', 'utf8')
+      runGit(repositoryDir, ['commit', '--quiet', '-am', 'source'])
+
+      const repositoryUrl = `file://${repositoryDir}`
+      const sourceRef = 'refs/remotes/watch/local/source'
+      await adapters.cloneRepo(repositoryUrl, workDir, 'v1.15.13')
+
+      // #when
+      await adapters.fetchRef(workDir, repositoryUrl, 'refs/heads/source', sourceRef)
+      const actualMergeBase = runGit(workDir, ['merge-base', 'HEAD', sourceRef])
+      const outcome = await adapters.mergeRef(workDir, sourceRef)
+
+      // #then
+      expect(runGit(workDir, ['rev-parse', '--is-shallow-repository'])).toBe('false')
+      expect(actualMergeBase).toBe(mergeBase)
+      expect(outcome.kind).toBe('conflict')
+      if (outcome.kind !== 'conflict') throw new Error('expected real adapter to return a typed conflict')
+      expect(outcome.conflictPaths).toEqual(['conflict.txt'])
+    } finally {
+      await adapters.dispose?.()
+      await fs.rm(repositoryDir, {recursive: true, force: true})
+      await fs.rm(path.dirname(workDir), {recursive: true, force: true})
+    }
+  })
+
   it('rejects clean-filter transformed staged bytes despite ambient GIT_CONFIG injection', async () => {
     // #given
     const dir = await makeTmpDir()

--- a/packages/harness/src/integrate.ts
+++ b/packages/harness/src/integrate.ts
@@ -657,8 +657,7 @@ export function makeRealAdapters(options: RealAdapterOptions = {}): IntegrationA
     cloneRepo: async (repoUrl, workDir, tag) => {
       await fs.rm(workDir, {recursive: true, force: true})
       await fs.mkdir(path.dirname(workDir), {recursive: true})
-      const cloneArgs =
-        tag === undefined ? ['clone', repoUrl, workDir] : ['clone', '--depth', '1', '--branch', tag, repoUrl, workDir]
+      const cloneArgs = tag === undefined ? ['clone', repoUrl, workDir] : ['clone', '--branch', tag, repoUrl, workDir]
       await git.exec(cloneArgs, undefined, publicGitEnv())
     },
 


### PR DESCRIPTION
## What

The forward-shadow integration has never produced a usable evidence record. Two independent defects, found by running a release dry run and reading the artifact it emitted.

## The shallow clone

`makeRealAdapters` cloned the base tag with `--depth 1`. Merging a fetched PR ref into a depth-one clone fails with `refusing to merge unrelated histories`, and that failure creates no unmerged index entries — so `mergeRef` sees an empty conflict-path list, rethrows the original error, and the pipeline exits at the surrounding catch. That is one branch short of the conflict-resolution path.

The resolver is fully implemented and correctly wired. Execution simply never reached it, which is why emitted records carried `resolverAttempts: 0` despite a real merge conflict in the carried refs.

The tagged clone no longer limits depth. The untagged path is unchanged. A full clone costs bandwidth and latency; no filtering machinery is added, since the simple fix is sufficient until measurement says otherwise.

This is a regression — the adapter performed a full clone before the code-owned integration landed.

## The discarded failure stage

`readOutcome` replaced a parsed failure with a generic `shadow integration outcome reported failure` and dropped `stage` and `error`. With no stage on the reconstructed result, `failureStage()` fell back to `integration`, so a merge failure was recorded as an integration failure and the real git error was lost. Diagnosing the observed run required reading raw job logs.

The parsed stage is now validated against the `IntegrationStage` union and preserved with its bounded error, so a merge failure records `failureStage: "merge"`. Errors stay capped at 512 characters. When a failure cannot be parsed, the previous generic message is still used.

## Tests

Existing coverage could not catch the clone defect: tests either mock `mergeRef`, or exercise the real adapter starting from an already-initialised full local repository.

The new regression test builds local repositories where the merge base sits behind the release tag, so a depth-limited clone cannot reach it. It asserts the clone is not shallow, that the merge base resolves, and that `mergeRef` returns a typed conflict — proving execution reaches the path the resolver is on. No network access.

## Scope

This unblocks the resolver. It does not by itself make the forward-shadow evidence gate satisfiable: the authoritative integration also makes compatibility edits outside the conflicted set, and the resolver's write scope is deliberately limited to conflicted paths. That gap is real and separate from these two defects.
