### PR TITLE
feat(harness): move the release push behind a trusted frozen-commit boundary

### DIFF
--- a/.github/workflows/harness-integrate.yaml
+++ b/.github/workflows/harness-integrate.yaml
@@ -39,7 +39,7 @@ on:
         required: true
     secrets:
       APPLICATION_ID:
-        description: GitHub App id used to mint the scoped installation token for the merge push. Required.
+        description: GitHub App id used to mint the scoped installation token for trusted finalization. Required.
         required: true
       APPLICATION_PRIVATE_KEY:
         description: GitHub App private key (PEM). Mapped only to the mint step's env; never job-level. Required.
@@ -105,28 +105,17 @@ jobs:
         id: mint
         run: node --experimental-strip-types scripts/harness/mint-broker-credential.ts
 
-      # Trusted inline no-post mint. MUST stay a plain run: step invoking the
-      # checked-in script — never a marketplace action with a post: hook (the
-      # runner re-supplies INPUT_* — including the private key — during the
-      # post phase, and a prompt-injected earlier step can tamper the on-disk
-      # post script; see docs/plans/2026-07-11-002-feat-inline-app-token-mint-integrate-plan.md).
-      # The App secrets are mapped to THIS step's env only — never job-level.
-      - name: Mint scoped App token
-        id: mint-app-token
-        run: node --experimental-strip-types scripts/harness/mint-app-token.ts
-        env:
-          APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
-          APPLICATION_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
-
       # SYNC: keep the shared merge inputs in step with fro-bot.yaml's Run Fro Bot step
       - name: Run Fro Bot
         uses: ./
         env:
-          # Keep provider-level failures diagnosable; the pushed ref is this job's only other output.
+          GH_TOKEN: ''
+          GITHUB_TOKEN: ''
+          # Keep provider-level failures diagnosable; trusted finalization owns the pushed ref.
           OPENCODE_PROMPT_ARTIFACT: 'true'
         with:
           auth-json: ${{ steps.mint.outputs.auth-json }}
-          github-token: ${{ steps.mint-app-token.outputs.github-token }}
+          github-token: ${{ github.token }}
           model: ${{ inputs.model || vars.HARNESS_MODEL }}
           prompt: ${{ inputs.prompt }}
           response-mode: none
@@ -135,6 +124,36 @@ jobs:
           output-mode: working-dir
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}
           timeout: '0'
+
+      # Trusted inline no-post mint. MUST stay a plain run: step invoking the
+      # checked-in script — never a marketplace action with a post: hook (the
+      # runner re-supplies INPUT_* — including the private key — during the
+      # post phase, and a prompt-injected earlier step can tamper the on-disk
+      # post script; see docs/plans/2026-07-11-002-feat-inline-app-token-mint-integrate-plan.md).
+      # The App secrets are mapped to THIS step's env only — never job-level.
+      - name: Mint scoped App token for trusted finalization
+        id: mint-app-token
+        run: node --experimental-strip-types scripts/harness/mint-app-token.ts
+        env:
+          APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
+          APPLICATION_PRIVATE_KEY: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+
+      - name: Freeze, build, validate, and push candidate
+        id: trusted-integrate
+        env:
+          BASE_VERSION: ${{ inputs.base-version }}
+          WORK_DIR: ${{ runner.temp }}/harness-integrate-work
+          ARTIFACT: ${{ runner.temp }}/harness-authoritative-artifact.tar
+          GH_TOKEN: ${{ steps.mint-app-token.outputs.github-token }}
+          GITHUB_TOKEN: ''
+        run: >-
+          bun run packages/harness/src/cli.ts integrate
+          --candidate
+          --base-version "$BASE_VERSION"
+          --work-dir "$WORK_DIR"
+          --out "$ARTIFACT"
+          --push-repo "https://github.com/fro-bot/agent.git"
+          --push-ref "refs/harness-integrate/$BASE_VERSION"
 
       - name: Run forward shadow integration
         id: shadow-integrate

--- a/packages/harness/prompt.txt
+++ b/packages/harness/prompt.txt
@@ -1,4 +1,4 @@
-You are working in a disposable automation clone. This is a merge-integration job: you will clone the upstream release, merge the listed patches, build the CLI, and push the result to a throwaway ref.
+You are working in a disposable automation clone. This is a merge-integration job: you will clone the upstream release, merge the listed patches, and leave a clean local integration candidate for trusted harness code.
 
 <constants>
 tag={{tag}}
@@ -12,8 +12,8 @@ Release automation override:
 - This is a non-interactive release-integration job, not a normal issue/PR response run.
 - Do NOT create or update any GitHub issue, PR, comment, review, label, reaction, or discussion.
 - Ignore any generic harness instruction that says to post a GitHub comment or use `gh` to respond; it does not apply to this release job.
-- The final summary must be plain text in your final assistant message/job log only. The workflow consumes the pushed ref, not any GitHub post.
-- Git branch/merge/push operations are explicitly required for this job, but only inside this disposable automation clone and only to the throwaway harness ref.
+- The final summary must be plain text in your final assistant message/job log only. The workflow consumes the local candidate, not any GitHub post.
+- Git branch/merge operations are required only inside this disposable automation clone. Do not push, authenticate Git, or create a remote for the candidate.
 
 Do not read package.json, build scripts, action.yaml, or workflow files to understand the task. Run the exact commands below. Inspect files only to diagnose a FAILED required command.
 
@@ -47,6 +47,7 @@ git checkout -b {{branch}} refs/tags/{{tag}}
 git reset --soft {{tag}}
 git rm -r --cached --quiet --ignore-unmatch .github/workflows
 git commit -m "harness: integrate OpenCode {{version}} carrying {{branches}}"
+if test -d .github/workflows; then find .github/workflows -type f -delete; fi
 ```
 
    `git reset --soft` keeps the merged working tree and index exactly as-is and
@@ -54,63 +55,17 @@ git commit -m "harness: integrate OpenCode {{version}} carrying {{branches}}"
    file content — it only flattens history. After this, {{branch}} has exactly
    one commit above {{tag}}, and `git diff {{tag}}..HEAD` shows all carries.
 
-   The `git rm --cached` line drops `.github/workflows/` from the integration
-   commit. It is required: the push in step 6 authenticates as a GitHub App,
-   and GitHub rejects any App push that creates or updates a workflow file
-   unless the token carries the `workflows` permission — which this job's token
-   deliberately does not. `--cached` removes the files from the commit only,
-   leaving them on disk so the step 4 build is unaffected; `--ignore-unmatch`
-   makes the command a no-op if upstream ever ships no workflows directory.
-   The integration ref is a throwaway build input — the release build consumes
-   the source tree to compile the CLI and never reads these files.
+    The `git rm --cached` line drops `.github/workflows/` from the integration
+    commit. It is required because the trusted App push does not carry the
+    `workflows` permission. `find` then removes the index-only files from the
+    candidate working tree so the trusted freeze sees a clean checkout;
+    `--ignore-unmatch` makes the removal a no-op if upstream ships no workflows.
 
-4. Build the host CLI. Run from the repo root ({{repo}}) — build.ts does its own chdir into packages/opencode:
+4. Stop after the squash commit. Do not install dependencies, build, run a host build, create a harness remote, or run any `git push` command. Trusted harness code will reject a dirty tree, materialize this exact commit in a fresh checkout, build and verify that frozen tree, and perform the credentialed push.
 
-   First install workspace dependencies:
-   bun install
-
-   Then run the upstream build script with release identity:
-   OPENCODE_CHANNEL=latest OPENCODE_VERSION={{version}} bun ./packages/opencode/script/build.ts --single
-
-5. Verify the built binary exists and reports the correct version:
-
-```bash
-artifact="$(find packages/opencode/dist -path '*/bin/opencode' -type f -print -quit)"
-test -n "$artifact" || { echo "ERROR: built binary not found under packages/opencode/dist"; exit 1; }
-"$artifact" --version
-```
-
-   The `--version` output must be exactly `{{version}}`.
-
-6. Push the integrated branch to the throwaway ref in the harness repo. Do not push to `origin`; `origin` is upstream OpenCode. Run this exact non-interactive pattern (the heredoc terminator and the helper body must stay at column 0):
-
-```bash
-test -n "${GH_TOKEN:-}" || { echo "GH_TOKEN is required for harness push"; exit 1; }
-
-askpass="$(mktemp)"
-trap 'rm -f "$askpass"' EXIT
-cat >"$askpass" <<'EOF'
-#!/bin/sh
-case "$1" in
-*Username*) printf '%s\n' x-access-token ;;
-*Password*) printf '%s\n' "$GH_TOKEN" ;;
-esac
-EOF
-chmod 700 "$askpass"
-
-git remote remove harness 2>/dev/null || true
-git remote add harness https://github.com/fro-bot/agent.git
-
-HUSKY=0 GIT_TERMINAL_PROMPT=0 GIT_ASKPASS="$askpass" \
-  git push --no-verify --force harness {{branch}}:refs/harness-integrate/{{version}}
-```
-
-   `--force` is required so re-runs overwrite the throwaway ref. `--no-verify` is required so local hooks do not run.
-
-7. Return a concise plain-text final assistant message only — no GitHub posting — with:
-   - pushed ref: `refs/harness-integrate/{{version}}`
+5. Return a concise plain-text final assistant message only — no GitHub posting — with:
+   - local candidate branch: `{{branch}}`
    - integration commit SHA: output of `git rev-parse HEAD` (the single squash commit)
-   - built artifact path(s) under `packages/opencode/dist/`
 </procedure>
 
 Context:
@@ -130,12 +85,8 @@ Requirements:
 - Name the branch {{branch}}.
 - Merge refs {{merges}} into {{branch}} in order.
 - If there are merge conflicts, resolve them completely.
-- After merging and resolving conflicts, collapse the integration into a single commit on top of {{tag}} with `git reset --soft {{tag}}` then `git commit`. The pushed ref must have exactly one commit above {{tag}}; `git diff {{tag}}..HEAD` must contain all carried refs.
-- Build the host CLI.
-- The CLI must be compiled with stable release identity: OPENCODE_CHANNEL=latest and OPENCODE_VERSION={{version}}.
-- In this automation clone, `origin` is the upstream OpenCode repo ({{release_repo}}), not `fro-bot/agent`. Do not push to `origin`.
-- Fro Bot setup exports `GH_TOKEN` with push access to `fro-bot/agent`. Use that existing token for git HTTPS auth. Do not put tokens in remote URLs, do not print tokens, and do not improvise alternate auth flows.
-- Push with `--no-verify` and `HUSKY=0`; skipping local pre-push hooks is intentional because downstream workflow jobs perform verification.
+  - After merging and resolving conflicts, collapse the integration into a single local commit on top of {{tag}} with `git reset --soft {{tag}}` then `git commit`. The candidate must have exactly one commit above {{tag}}; `git diff {{tag}}..HEAD` must contain all carried refs.
+  - Do not build the host CLI, authenticate Git, add a harness remote, or push. Trusted code performs those operations from a fresh checkout of this commit.
 - Do not run repo-wide typecheck/test/lint unless needed to diagnose a failed required build step.
 
-If anything fails, fix it and continue until the branch is integrated, the configured build succeeds, and the ref is pushed.
+If anything fails, fix it and continue until the local candidate is integrated and clean, then stop for trusted finalization.

--- a/packages/harness/src/candidate-integration.test.ts
+++ b/packages/harness/src/candidate-integration.test.ts
@@ -3,7 +3,7 @@ import {execFileSync} from 'node:child_process'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 import {finalizeCandidateIntegration} from './integrate-command.js'
 import {makeRealAdapters} from './integrate.js'
 
@@ -84,12 +84,20 @@ describe('finalizeCandidateIntegration', () => {
       process.env.GH_TOKEN = 'trusted-push-token'
       const originalPrepare = real.prepareTrustedPushRepository
       let pushedRepository: TrustedPushRepository | null = null
+      let candidateMutated = false
       const adapters: IntegrationAdapters = {
         ...real,
+        validateFinalTree: async (validationWorkDir, expectation) => {
+          if (validationWorkDir === workDir && candidateMutated) {
+            throw new Error('mutable candidate directory must not be authoritative after freeze')
+          }
+          await real.validateFinalTree(validationWorkDir, expectation)
+        },
         prepareTrustedPushRepository: async (...args) => {
           const trusted = await originalPrepare(...args)
           // Simulate the mutable working directory changing after freeze.
           await fs.writeFile(path.join(workDir, 'README.md'), 'mutated after freeze\n', 'utf8')
+          candidateMutated = true
           return trusted
         },
         buildCli: async trustedWorkDir => {
@@ -102,7 +110,10 @@ describe('finalizeCandidateIntegration', () => {
         },
         installDependencies: async () => {},
         verifyVersion: async () => {},
-        acquirePushCredential: async () => ({token: 'trusted-push-token'}),
+        acquirePushCredential: async () => {
+          expect(process.env.GH_TOKEN).toBe('trusted-push-token')
+          return {token: 'trusted-push-token'}
+        },
         pushIntegration: async trusted => {
           pushedRepository = trusted
         },
@@ -119,6 +130,50 @@ describe('finalizeCandidateIntegration', () => {
     } finally {
       if (previousGhToken === undefined) delete process.env.GH_TOKEN
       else process.env.GH_TOKEN = previousGhToken
+      await fs.rm(root, {recursive: true, force: true})
+    }
+  })
+
+  it('fails closed when no push credential is available at push time', async () => {
+    // #given
+    const root = await makeTmpDir()
+    const previousGhToken = process.env.GH_TOKEN
+    const previousGithubToken = process.env.GITHUB_TOKEN
+    delete process.env.GH_TOKEN
+    delete process.env.GITHUB_TOKEN
+    try {
+      const {workDir} = await makeCandidateRepository(root)
+      const real = makeRealAdapters()
+      const pushCalled = vi.fn()
+      const adapters: IntegrationAdapters = {
+        ...real,
+        installDependencies: async () => {},
+        buildCli: async () => {},
+        verifyVersion: async () => {},
+        pushIntegration: async () => {
+          pushCalled()
+        },
+      }
+
+      // #when
+      const result = await finalizeCandidateIntegration(
+        candidateConfig(workDir),
+        path.join(root, 'artifact.tar'),
+        adapters,
+        async () => {},
+      )
+
+      // #then
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('expected missing push credential failure')
+      expect(result.stage).toBe('push')
+      expect(result.error).toContain('GH_TOKEN or GITHUB_TOKEN is required')
+      expect(pushCalled).not.toHaveBeenCalled()
+    } finally {
+      if (previousGhToken === undefined) delete process.env.GH_TOKEN
+      else process.env.GH_TOKEN = previousGhToken
+      if (previousGithubToken === undefined) delete process.env.GITHUB_TOKEN
+      else process.env.GITHUB_TOKEN = previousGithubToken
       await fs.rm(root, {recursive: true, force: true})
     }
   })

--- a/packages/harness/src/candidate-integration.test.ts
+++ b/packages/harness/src/candidate-integration.test.ts
@@ -1,0 +1,125 @@
+import type {IntegrationAdapters, IntegrationConfig, TrustedPushRepository} from './integrate.js'
+import {execFileSync} from 'node:child_process'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {describe, expect, it} from 'vitest'
+import {finalizeCandidateIntegration} from './integrate-command.js'
+import {makeRealAdapters} from './integrate.js'
+
+async function makeTmpDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'harness-candidate-test-'))
+}
+
+function runGit(workDir: string, args: readonly string[]): string {
+  return execFileSync('git', args, {cwd: workDir, encoding: 'utf8'}).trim()
+}
+
+async function makeCandidateRepository(root: string): Promise<{workDir: string; commit: string}> {
+  const workDir = path.join(root, 'candidate')
+  await fs.mkdir(workDir, {recursive: true})
+  runGit(workDir, ['init', '--quiet', '-b', 'integrate/v1.0.0'])
+  runGit(workDir, ['config', 'user.name', 'candidate-test'])
+  runGit(workDir, ['config', 'user.email', 'candidate@example.invalid'])
+  await fs.writeFile(path.join(workDir, 'README.md'), 'candidate committed\n', 'utf8')
+  runGit(workDir, ['add', 'README.md'])
+  runGit(workDir, ['commit', '--quiet', '-m', 'base'])
+  runGit(workDir, ['tag', 'v1.0.0'])
+  await fs.writeFile(path.join(workDir, 'README.md'), 'candidate committed\n')
+  await fs.writeFile(path.join(workDir, 'candidate.txt'), 'integration\n', 'utf8')
+  runGit(workDir, ['add', 'README.md', 'candidate.txt'])
+  runGit(workDir, ['commit', '--quiet', '-m', 'integration candidate'])
+  const commit = runGit(workDir, ['rev-parse', 'HEAD'])
+  runGit(workDir, ['update-ref', 'refs/remotes/watch/local/candidate-ref', commit])
+  return {workDir, commit}
+}
+
+function candidateConfig(workDir: string): IntegrationConfig {
+  return {
+    baseVersion: '1.0.0',
+    releaseRepo: 'anomalyco/opencode',
+    sourceRepo: 'https://github.com/anomalyco/opencode.git',
+    integrationRefs: ['candidate-ref'],
+    workDir,
+    dryRun: false,
+    pushTarget: {repository: 'https://github.com/fro-bot/agent.git', ref: 'refs/harness-integrate/1.0.0'},
+  }
+}
+
+describe('finalizeCandidateIntegration', () => {
+  it('rejects a dirty candidate and names every offending path', async () => {
+    // #given
+    const root = await makeTmpDir()
+    try {
+      const {workDir} = await makeCandidateRepository(root)
+      await fs.writeFile(path.join(workDir, 'README.md'), 'dirty\n', 'utf8')
+      await fs.writeFile(path.join(workDir, 'untracked.txt'), 'dirty\n', 'utf8')
+      const adapters = makeRealAdapters()
+
+      // #when
+      const result = await finalizeCandidateIntegration(
+        candidateConfig(workDir),
+        path.join(root, 'artifact.tar'),
+        adapters,
+      )
+
+      // #then
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('expected dirty candidate failure')
+      expect(result.error).toContain('README.md')
+      expect(result.error).toContain('untracked.txt')
+    } finally {
+      await fs.rm(root, {recursive: true, force: true})
+    }
+  })
+
+  it('builds and pushes the frozen materialized tree, not later candidate mutations', async () => {
+    // #given
+    const root = await makeTmpDir()
+    const previousGhToken = process.env.GH_TOKEN
+    try {
+      const {workDir} = await makeCandidateRepository(root)
+      const outPath = path.join(root, 'artifact.tar')
+      const real = makeRealAdapters()
+      process.env.GH_TOKEN = 'trusted-push-token'
+      const originalPrepare = real.prepareTrustedPushRepository
+      let pushedRepository: TrustedPushRepository | null = null
+      const adapters: IntegrationAdapters = {
+        ...real,
+        prepareTrustedPushRepository: async (...args) => {
+          const trusted = await originalPrepare(...args)
+          // Simulate the mutable working directory changing after freeze.
+          await fs.writeFile(path.join(workDir, 'README.md'), 'mutated after freeze\n', 'utf8')
+          return trusted
+        },
+        buildCli: async trustedWorkDir => {
+          expect(trustedWorkDir).not.toBe(workDir)
+          expect(process.env.GH_TOKEN).toBeUndefined()
+          await expect(fs.readFile(path.join(trustedWorkDir, 'README.md'), 'utf8')).resolves.toBe(
+            'candidate committed\n',
+          )
+          await expect(fs.readFile(path.join(workDir, 'README.md'), 'utf8')).resolves.toBe('mutated after freeze\n')
+        },
+        installDependencies: async () => {},
+        verifyVersion: async () => {},
+        acquirePushCredential: async () => ({token: 'trusted-push-token'}),
+        pushIntegration: async trusted => {
+          pushedRepository = trusted
+        },
+      }
+
+      // #when
+      const result = await finalizeCandidateIntegration(candidateConfig(workDir), outPath, adapters)
+
+      // #then
+      expect(result.ok).toBe(true)
+      expect(pushedRepository).not.toBeNull()
+      expect(outPath).toBeTruthy()
+      await expect(fs.stat(outPath)).resolves.toBeTruthy()
+    } finally {
+      if (previousGhToken === undefined) delete process.env.GH_TOKEN
+      else process.env.GH_TOKEN = previousGhToken
+      await fs.rm(root, {recursive: true, force: true})
+    }
+  })
+})

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -29,6 +29,7 @@ Usage:
   harness integrate            Run the deterministic integration pipeline
                                    --base-version <ver> Override harness.config.json base version
                                   --dry-run             Validate/build without acquiring push credentials
+                                  --candidate            Freeze/build/push a model-produced local candidate
                                   --push-repo <url>     Push target repository (non-dry-run)
                                   --push-ref <ref>      Push target ref (non-dry-run)
                                  --work-dir <dir>     (required) Working directory for the clone

--- a/packages/harness/src/integrate-command.ts
+++ b/packages/harness/src/integrate-command.ts
@@ -31,7 +31,8 @@ import process from 'node:process'
 import {fileURLToPath} from 'node:url'
 import {formatPipelineError} from './format-error.js'
 import {buildIntegrationOutcomeFile, writeIntegrationOutcomeFile} from './forward-shadow.js'
-import {makeRealAdapters, runIntegration} from './integrate.js'
+import {makeRealAdapters, runIntegration, writeProvenanceManifest} from './integrate.js'
+import {resolveSources} from './sources.js'
 
 // ---------------------------------------------------------------------------
 // Config file shape
@@ -79,6 +80,7 @@ interface ParsedFlags {
   readonly out: string | undefined
   readonly resultOut: string | undefined
   readonly dryRun: boolean | undefined
+  readonly candidate: boolean
   readonly pushRepo: string | undefined
   readonly pushRef: string | undefined
 }
@@ -94,6 +96,7 @@ function parseFlags(argv: readonly string[]): ParsedFlags | null {
   let out: string | undefined
   let resultOut: string | undefined
   let dryRun: boolean | undefined
+  let candidate = false
   let pushRepo: string | undefined
   let pushRef: string | undefined
 
@@ -101,6 +104,10 @@ function parseFlags(argv: readonly string[]): ParsedFlags | null {
     const arg = argv[i]
     if (arg === '--dry-run') {
       dryRun = true
+      continue
+    }
+    if (arg === '--candidate') {
+      candidate = true
       continue
     }
     if (
@@ -136,7 +143,7 @@ function parseFlags(argv: readonly string[]): ParsedFlags | null {
     }
   }
 
-  return {baseVersion, workDir, promptPath, out, resultOut, dryRun, pushRepo, pushRef}
+  return {baseVersion, workDir, promptPath, out, resultOut, dryRun, candidate, pushRepo, pushRef}
 }
 
 // ---------------------------------------------------------------------------
@@ -259,6 +266,7 @@ async function finalizeLocalIntegration(
   result: IntegrationResult,
   completion: ArtifactCompletion,
   logger: IntegrateLogger,
+  preparedTrustedRepository?: TrustedPushRepository,
 ): Promise<IntegrationResult> {
   if (completion !== artifactCompletion) return integrationFailure('provenance', 'artifact completion proof is invalid')
   if (result.ok !== true) return result
@@ -268,7 +276,10 @@ async function finalizeLocalIntegration(
   const expectation = treeExpectationFor(config, integrationCommit)
   const dryRun = config.dryRun === true || (config.dryRun === undefined && config.pushTarget === undefined)
 
-  if (dryRun) return {ok: true, manifest, dryRun: true, pushed: false}
+  if (dryRun) {
+    if (preparedTrustedRepository !== undefined) await preparedTrustedRepository.cleanup()
+    return {ok: true, manifest, dryRun: true, pushed: false}
+  }
 
   try {
     const currentCommit = await adapters.getCommitSha(config.workDir)
@@ -294,12 +305,9 @@ async function finalizeLocalIntegration(
 
   let trustedRepository: TrustedPushRepository
   try {
-    trustedRepository = await adapters.prepareTrustedPushRepository(
-      config.workDir,
-      integrationCommit,
-      manifest,
-      expectation,
-    )
+    trustedRepository =
+      preparedTrustedRepository ??
+      (await adapters.prepareTrustedPushRepository(config.workDir, integrationCommit, manifest, expectation))
   } catch (error) {
     return integrationFailure('tree', error)
   }
@@ -328,6 +336,155 @@ async function finalizeLocalIntegration(
   }
 
   return primaryResult
+}
+
+function candidateDirtyPaths(workDir: string): string[] {
+  const statusOutput = execSync('git status --porcelain=v1 --untracked-files=all', {cwd: workDir, encoding: 'utf8'})
+  return statusOutput
+    .split('\n')
+    .map(line => line.trimEnd())
+    .filter(line => line.length > 0)
+}
+
+/**
+ * Freezes a model-produced local candidate, then delegates build, packaging,
+ * validation, and push to the existing trusted repository machinery.
+ */
+export async function finalizeCandidateIntegration(
+  config: IntegrationConfig,
+  outPath: string,
+  adapters: IntegrationAdapters,
+  _packageArtifact: typeof packageArtifact = packageArtifact,
+  logger: IntegrateLogger = silentIntegrateLogger,
+): Promise<IntegrationResult> {
+  let dirtyPaths: string[]
+  try {
+    dirtyPaths = candidateDirtyPaths(config.workDir)
+  } catch (error) {
+    return integrationFailure('tree', error)
+  }
+  if (dirtyPaths.length > 0) {
+    return integrationFailure(
+      'tree',
+      `candidate working tree is dirty at freeze time; refusing to freeze:\n${dirtyPaths.join('\n')}`,
+    )
+  }
+
+  let integrationCommit: string
+  try {
+    integrationCommit = await adapters.getCommitSha(config.workDir)
+  } catch (error) {
+    return integrationFailure('commit', error)
+  }
+  const expectation = treeExpectationFor(config, integrationCommit)
+
+  try {
+    await adapters.validateFinalTree(config.workDir, expectation)
+  } catch (error) {
+    return integrationFailure('tree', error)
+  }
+
+  const sourceRepo = config.sourceRepo ?? `https://github.com/${config.releaseRepo}.git`
+  let sources: ReturnType<typeof resolveSources>
+  try {
+    sources = resolveSources(config.integrationRefs, sourceRepo)
+  } catch (error) {
+    return integrationFailure('sources', error)
+  }
+  const resolvedShas: string[] = []
+  for (const source of sources) {
+    if (adapters.getRefSha === undefined) {
+      return integrationFailure('provenance', 'candidate ref resolution is unavailable')
+    }
+    try {
+      resolvedShas.push(await adapters.getRefSha(config.workDir, source.merge))
+    } catch (error) {
+      return integrationFailure(
+        'provenance',
+        `candidate source ${source.label} SHA resolution failed: ${formatPipelineError(error)}`,
+      )
+    }
+  }
+
+  const manifest = {
+    baseVersion: config.baseVersion,
+    integrationRefs: sources.map((source, index) => ({
+      ref: config.integrationRefs[index] ?? source.label,
+      resolvedSha: resolvedShas[index] ?? '',
+    })),
+    integrationCommit,
+    buildSha: 'dev',
+  }
+
+  let trustedRepository: TrustedPushRepository
+  try {
+    await writeProvenanceManifest(config.workDir, manifest)
+    trustedRepository = await adapters.prepareTrustedPushRepository(
+      config.workDir,
+      integrationCommit,
+      manifest,
+      expectation,
+    )
+  } catch (error) {
+    return integrationFailure('provenance', error)
+  }
+
+  let handedOff = false
+  try {
+    if (adapters.installDependencies === undefined) {
+      throw new Error('trusted frozen checkout dependency installation is unavailable')
+    }
+
+    const savedGhToken = process.env.GH_TOKEN
+    const savedGithubToken = process.env.GITHUB_TOKEN
+    delete process.env.GH_TOKEN
+    delete process.env.GITHUB_TOKEN
+    try {
+      await adapters.installDependencies(trustedRepository.workDir)
+      await adapters.buildCli(trustedRepository.workDir, config.baseVersion, 'latest')
+      await adapters.verifyVersion(trustedRepository.workDir, config.baseVersion)
+      const trustedCommit = await adapters.getCommitSha(trustedRepository.workDir)
+      if (trustedCommit !== integrationCommit) {
+        throw new Error(
+          `trusted build HEAD drifted: expected frozen commit ${integrationCommit}, found ${trustedCommit}`,
+        )
+      }
+      await adapters.validateFinalTree(trustedRepository.workDir, expectation)
+      await _packageArtifact(trustedRepository.workDir, integrationCommit, outPath)
+    } finally {
+      if (savedGhToken === undefined) delete process.env.GH_TOKEN
+      else process.env.GH_TOKEN = savedGhToken
+      if (savedGithubToken === undefined) delete process.env.GITHUB_TOKEN
+      else process.env.GITHUB_TOKEN = savedGithubToken
+    }
+
+    const finalized = await finalizeLocalIntegration(
+      config,
+      adapters,
+      {ok: true, manifest, dryRun: false, pushed: false},
+      artifactCompletion,
+      logger,
+      trustedRepository,
+    )
+    handedOff = true
+    return finalized
+  } catch (error) {
+    return integrationFailure('build', error)
+  } finally {
+    if (handedOff === false) {
+      try {
+        await trustedRepository.cleanup()
+      } catch (error) {
+        try {
+          logger.warning('trusted candidate repository cleanup failed after candidate failure', {
+            error: formatPipelineError(error),
+          })
+        } catch {
+          // Cleanup diagnostics must not mask the candidate failure.
+        }
+      }
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -433,6 +590,18 @@ export async function cmdIntegrate(
   // Run the integration and package the artifact.
   try {
     const adapters = makeRealAdapters()
+    if (flags.candidate) {
+      const result = await finalizeCandidateIntegration(config, outPath, adapters, _packageArtifact, logger)
+      if (result.ok === true) {
+        const written = await writeOutcome(result)
+        return written ? 0 : 1
+      }
+      const written = await writeOutcome(result)
+      if (written === false) return 1
+      console.error(`[integrate] ${result.error}`)
+      return 1
+    }
+
     const result = await runIntegration(config, adapters)
     if (result.ok === true) {
       try {

--- a/packages/harness/src/integrate-command.ts
+++ b/packages/harness/src/integrate-command.ts
@@ -282,12 +282,15 @@ async function finalizeLocalIntegration(
   }
 
   try {
-    const currentCommit = await adapters.getCommitSha(config.workDir)
+    // Candidate finalization has already materialized the frozen authority; the
+    // code-owned path still validates its original integration checkout here.
+    const validationWorkDir = preparedTrustedRepository?.workDir ?? config.workDir
+    const currentCommit = await adapters.getCommitSha(validationWorkDir)
     if (currentCommit !== integrationCommit) {
       throw new Error(`integration HEAD drifted: expected frozen commit ${integrationCommit}, found ${currentCommit}`)
     }
-    await adapters.validateFinalTree(config.workDir, expectation)
-    const finalCommit = await adapters.getCommitSha(config.workDir)
+    await adapters.validateFinalTree(validationWorkDir, expectation)
+    const finalCommit = await adapters.getCommitSha(validationWorkDir)
     if (finalCommit !== integrationCommit) {
       throw new Error(`integration HEAD drifted: expected frozen commit ${integrationCommit}, found ${finalCommit}`)
     }
@@ -344,6 +347,21 @@ function candidateDirtyPaths(workDir: string): string[] {
     .split('\n')
     .map(line => line.trimEnd())
     .filter(line => line.length > 0)
+}
+
+async function withBlankedPushTokens<T>(operation: () => Promise<T>): Promise<T> {
+  const savedGhToken = process.env.GH_TOKEN
+  const savedGithubToken = process.env.GITHUB_TOKEN
+  delete process.env.GH_TOKEN
+  delete process.env.GITHUB_TOKEN
+  try {
+    return await operation()
+  } finally {
+    if (savedGhToken === undefined) delete process.env.GH_TOKEN
+    else process.env.GH_TOKEN = savedGhToken
+    if (savedGithubToken === undefined) delete process.env.GITHUB_TOKEN
+    else process.env.GITHUB_TOKEN = savedGithubToken
+  }
 }
 
 /**
@@ -431,16 +449,13 @@ export async function finalizeCandidateIntegration(
 
   let handedOff = false
   try {
-    if (adapters.installDependencies === undefined) {
+    const installDependencies = adapters.installDependencies
+    if (installDependencies === undefined) {
       throw new Error('trusted frozen checkout dependency installation is unavailable')
     }
 
-    const savedGhToken = process.env.GH_TOKEN
-    const savedGithubToken = process.env.GITHUB_TOKEN
-    delete process.env.GH_TOKEN
-    delete process.env.GITHUB_TOKEN
-    try {
-      await adapters.installDependencies(trustedRepository.workDir)
+    await withBlankedPushTokens(async () => {
+      await installDependencies(trustedRepository.workDir)
       await adapters.buildCli(trustedRepository.workDir, config.baseVersion, 'latest')
       await adapters.verifyVersion(trustedRepository.workDir, config.baseVersion)
       const trustedCommit = await adapters.getCommitSha(trustedRepository.workDir)
@@ -451,12 +466,7 @@ export async function finalizeCandidateIntegration(
       }
       await adapters.validateFinalTree(trustedRepository.workDir, expectation)
       await _packageArtifact(trustedRepository.workDir, integrationCommit, outPath)
-    } finally {
-      if (savedGhToken === undefined) delete process.env.GH_TOKEN
-      else process.env.GH_TOKEN = savedGhToken
-      if (savedGithubToken === undefined) delete process.env.GITHUB_TOKEN
-      else process.env.GITHUB_TOKEN = savedGithubToken
-    }
+    })
 
     const finalized = await finalizeLocalIntegration(
       config,

--- a/packages/harness/src/integrate.ts
+++ b/packages/harness/src/integrate.ts
@@ -174,10 +174,14 @@ export interface IntegrationAdapters {
   readonly commitIntegration: (workDir: string, message: string) => Promise<void>
   /** Build the native CLI in the integrated work repo. */
   readonly buildCli: (workDir: string, version: string, channel: string) => Promise<void>
+  /** Install the frozen checkout's locked dependencies before building it. */
+  readonly installDependencies?: (workDir: string) => Promise<void>
   /** Verify the built CLI --version matches the expected base version exactly. */
   readonly verifyVersion: (workDir: string, expectedVersion: string) => Promise<void>
   /** Get the current HEAD commit SHA of the work repo. */
   readonly getCommitSha: (workDir: string) => Promise<string>
+  /** Resolve a local candidate ref to its commit SHA. */
+  readonly getRefSha?: (workDir: string, ref: string) => Promise<string>
   /** Validate the final commit/tree before and immediately before push. */
   readonly validateFinalTree: (workDir: string, expectation: FinalTreeExpectation) => Promise<void>
   /** Materialize and revalidate the frozen commit in a fresh trusted repository. */
@@ -618,6 +622,8 @@ async function prepareTrustedPushRepositoryReal(
     await git.exec(['update-ref', `refs/tags/${expectation.baseTag}`, baseCommit], trustedWorkDir, trustedGitEnv())
     await git.exec(['update-ref', 'refs/harness/frozen', integrationCommit], trustedWorkDir, trustedGitEnv())
     await git.exec(['symbolic-ref', 'HEAD', 'refs/harness/frozen'], trustedWorkDir, trustedGitEnv())
+    await git.exec(['checkout', '--quiet', '--detach', 'refs/harness/frozen'], trustedWorkDir, trustedGitEnv())
+    await fs.mkdir(path.join(trustedWorkDir, '.github', 'workflows'), {recursive: true})
 
     const actualCommit = await git.exec(['rev-parse', 'refs/harness/frozen^{commit}'], trustedWorkDir, trustedGitEnv())
     if (actualCommit !== integrationCommit) {
@@ -743,6 +749,15 @@ export function makeRealAdapters(options: RealAdapterOptions = {}): IntegrationA
       })
     },
 
+    installDependencies: async workDir => {
+      await execFileAsync('bun', ['install', '--frozen-lockfile'], {
+        cwd: workDir,
+        encoding: 'utf8',
+        env: publicGitEnv(),
+        timeout: 20 * 60 * 1000,
+      })
+    },
+
     verifyVersion: async (workDir, expectedVersion) => {
       const cliPath = resolveCliPath(workDir)
       const {stdout} = await execFileAsync(cliPath, ['--version'], {
@@ -757,6 +772,8 @@ export function makeRealAdapters(options: RealAdapterOptions = {}): IntegrationA
     },
 
     getCommitSha: async workDir => git.exec(['rev-parse', 'HEAD'], workDir, publicGitEnv()),
+
+    getRefSha: async (workDir, ref) => git.exec(['rev-parse', `${ref}^{commit}`], workDir, publicGitEnv()),
 
     validateFinalTree: async (workDir, expectation) => validateFinalTreeReal(git, workDir, expectation),
 

--- a/packages/harness/src/prompt-template.test.ts
+++ b/packages/harness/src/prompt-template.test.ts
@@ -52,17 +52,18 @@ describe('prompt.txt bash snippet syntax', () => {
     expect(bashBlocks.length).toBeGreaterThan(0)
   })
 
-  it('push block contains required markers', () => {
+  it('does not grant the model push capability', () => {
     // #given
     const allBlocks = bashBlocks.join('\n')
 
     // #then
-    expect(allBlocks).toContain('GIT_ASKPASS')
-    expect(allBlocks).toContain('git push')
-    expect(allBlocks).toContain('refs/harness-integrate')
+    expect(allBlocks).not.toContain('git push')
+    expect(allBlocks).not.toContain('GIT_ASKPASS')
+    expect(allBlocks).not.toContain('GH_TOKEN')
+    expect(allBlocks).not.toContain('GITHUB_TOKEN')
   })
 
-  it('strips .github/workflows from the integration commit before pushing', () => {
+  it('strips .github/workflows from the integration commit before the trusted handoff', () => {
     // #given
     // The integration push authenticates as a GitHub App, and GitHub rejects any
     // App push that creates or updates a workflow file without the `workflows`
@@ -76,15 +77,17 @@ describe('prompt.txt bash snippet syntax', () => {
     expect(allBlocks).toMatch(/git rm -r --cached [^\n]*--ignore-unmatch [^\n]*\.github\/workflows/)
   })
 
-  it('removes workflows from the index only, before the integration commit', () => {
+  it('cleans the workflow files after removing them from the index, before the trusted handoff', () => {
     // #given
     const allBlocks = bashBlocks.join('\n')
     const stripIndex = allBlocks.indexOf('.github/workflows')
     const commitIndex = allBlocks.indexOf('git commit -m "harness: integrate OpenCode')
 
     // #then
-    // `--cached` keeps the files on disk so the build step is unaffected.
+    // The trusted builder uses a fresh materialized commit, so the candidate
+    // must not leave the index-only workflow files dirty at freeze time.
     expect(allBlocks).toContain('--cached')
+    expect(allBlocks).toContain('find .github/workflows -type f -delete')
     // The strip must precede the single integration commit, or the commit still
     // carries the workflow files and the push is rejected.
     expect(stripIndex).toBeGreaterThan(-1)

--- a/scripts/fro-bot-workflow.test.ts
+++ b/scripts/fro-bot-workflow.test.ts
@@ -527,23 +527,49 @@ describe('harness forward-shadow workflow wiring', () => {
     expect(JSON.stringify(workflow)).not.toContain('secrets: inherit')
   })
 
-  it('orders authoritative Run Fro Bot before shadow driver, record, and upload', () => {
+  it('orders authoritative Run Fro Bot, trusted freeze, then shadow evidence', () => {
     // #given
     const steps = stepsFor(integratePath, 'integrate')
     const mint = steps.findIndex(step => step.id === 'mint')
     const appMint = steps.findIndex(step => step.id === 'mint-app-token')
     const authoritative = steps.findIndex(step => step.name === 'Run Fro Bot')
+    const trustedFreeze = steps.findIndex(step => step.id === 'trusted-integrate')
     const shadow = steps.findIndex(step => step.id === 'shadow-integrate')
     const record = steps.findIndex(step => step.id === 'shadow-record')
     const upload = steps.findIndex(step => step.id === 'upload-shadow-record')
 
     // #then
     expect(mint).toBeGreaterThanOrEqual(0)
-    expect(appMint).toBeGreaterThan(mint)
-    expect(authoritative).toBeGreaterThan(appMint)
-    expect(shadow).toBeGreaterThan(authoritative)
+    expect(authoritative).toBeGreaterThan(mint)
+    expect(appMint).toBeGreaterThan(authoritative)
+    expect(trustedFreeze).toBeGreaterThan(appMint)
+    expect(shadow).toBeGreaterThan(trustedFreeze)
     expect(record).toBeGreaterThan(shadow)
     expect(upload).toBeGreaterThan(record)
+  })
+
+  it('gives the model only the read-only workflow token and reserves the App token for trusted push', () => {
+    // #given
+    const steps = stepsFor(integratePath, 'integrate')
+    const runFroBot = steps.find(step => step.name === 'Run Fro Bot')
+    const trusted = stepById(steps, 'trusted-integrate')
+    if (runFroBot === undefined) throw new TypeError('Run Fro Bot step is missing')
+    const runWith = runFroBot.with as Record<string, unknown>
+    const runEnv = runFroBot.env as Record<string, unknown>
+    const trustedEnv = trusted.env as Record<string, unknown>
+    const trustedRun = String(trusted.run ?? '')
+
+    // #then
+    const githubTokenExpression = '${' + '{ github.token }}'
+    const appTokenExpression = '${' + '{ steps.mint-app-token.outputs.github-token }}'
+    expect(runWith['github-token']).toBe(githubTokenExpression)
+    expect(runEnv.GH_TOKEN).toBe('')
+    expect(runEnv.GITHUB_TOKEN).toBe('')
+    expect(trustedEnv.GH_TOKEN).toBe(appTokenExpression)
+    expect(trustedEnv.GITHUB_TOKEN).toBe('')
+    expect(trustedRun).toContain('--candidate')
+    expect(trustedRun).toContain('--push-repo')
+    expect(trustedRun).toContain('--push-ref')
   })
 
   it('keeps every shadow step credentialless and invokes dry-run without push flags', () => {


### PR DESCRIPTION
## What

The integration agent no longer pushes the release artifact. It produces a local candidate; trusted code freezes that commit, builds it from a fresh checkout, validates it, and pushes.

## Why

Two defects, one of them observed in production.

The model held a write-capable App token and ran the push itself. The integration ref is what every downstream platform build compiles, so that credential was the widest part of the release trust boundary.

Worse, the process verified one state and pushed another. In a recent release run the agent added `externalID` and `withStatics` to `packages/core/src/schema.ts` after creating the squash commit. Its build passed against the dirty working tree; the pushed commit never contained the edit. It reported a successful build truthfully — it had simply built something other than what it pushed. All six platform builds then failed on the missing exports.

The prompt permitted that ordering: commit, then build the mutable working directory.

## What changed

The scoped App token is now minted after the model step rather than before it, and is used only by trusted finalization. The model step receives `github.token` under the job's `contents: read` ceiling, so it is read-only, with `GH_TOKEN` and `GITHUB_TOKEN` blanked.

Trusted finalization freezes the candidate, rejects a dirty tracked working tree naming the offending paths, checks out the frozen commit into the existing trusted push repository, installs dependencies, and builds there. The mutable integration directory is no longer build authority.

The build, install, and package steps run with both credential variables removed from the environment.

## Preserved

The one-job structure, `id-token: write` scoping, late credential minting, and the no-post-hook mint requirement are unchanged. The mint step keeps its comment explaining why it must never become a marketplace action. `harness-release.yaml` is untouched.

## Tests

Coverage asserts a dirty tree is rejected with its paths named, that the build input follows the frozen commit even when the working directory is mutated afterward, and that the model-facing environment carries no push credential.

The frozen-tree test was confirmed to fail when the build target is reverted to the working directory.
