### PR TITLE
feat(harness): pin carry refs to immutable SHAs

### DIFF
--- a/packages/harness/scripts/build-platform.test.ts
+++ b/packages/harness/scripts/build-platform.test.ts
@@ -30,6 +30,7 @@ import {
   assertMuslBinary,
   assertPatchLanded,
   cloneAndCheckout,
+  emitProvenanceManifest,
   enforceBunVersion,
   main,
   parseArgs,
@@ -111,6 +112,103 @@ vi.mock('node:fs', async importOriginal => {
     readFileSync: vi.fn(),
     writeFileSync: vi.fn(),
   }
+})
+
+describe('emitProvenanceManifest', () => {
+  const mockedReadFileSync = vi.mocked(readFileSync)
+  const mockedWriteFileSync = vi.mocked(writeFileSync)
+
+  function writtenManifest(): Record<string, unknown> {
+    const call = mockedWriteFileSync.mock.calls.at(-1)
+    if (call === undefined || typeof call[1] !== 'string') throw new Error('expected provenance write')
+    const parsed: unknown = JSON.parse(call[1])
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed))
+      throw new Error('invalid written manifest')
+    return parsed as Record<string, unknown>
+  }
+
+  beforeEach(() => {
+    mockedReadFileSync.mockReset()
+    mockedWriteFileSync.mockReset()
+  })
+
+  it('preserves carry data from an existing manifest with the same integration commit', () => {
+    // #given
+    const existing = {
+      baseVersion: 'old-base',
+      carryManifest: {base: 'v1.15.13', carries: [{ref: 'carry', resolvedSha: 'a'.repeat(40)}]},
+      integrationRefs: [{ref: 'carry', resolvedSha: 'a'.repeat(40)}],
+      integrationCommit: 'commit-a',
+      buildSha: 'old-build',
+    }
+    mockedReadFileSync.mockReturnValue(JSON.stringify(existing))
+
+    // #when
+    emitProvenanceManifest('/tmp/harness', '1.15.13', 'commit-a', 'build-b')
+
+    // #then
+    expect(writtenManifest()).toEqual({
+      ...existing,
+      baseVersion: '1.15.13',
+      buildSha: 'build-b',
+    })
+  })
+
+  it('writes an empty carry set when no existing manifest is available', () => {
+    // #given
+    mockedReadFileSync.mockImplementation(() => {
+      throw new Error('missing')
+    })
+
+    // #when
+    emitProvenanceManifest('/tmp/harness', '1.15.13', 'commit-a', 'build-a')
+
+    // #then
+    expect(writtenManifest()).toEqual({
+      baseVersion: '1.15.13',
+      integrationRefs: [],
+      integrationCommit: 'commit-a',
+      buildSha: 'build-a',
+    })
+  })
+
+  it('writes an empty carry set when the existing manifest is malformed', () => {
+    // #given
+    mockedReadFileSync.mockReturnValue('{not-json')
+
+    // #when
+    emitProvenanceManifest('/tmp/harness', '1.15.13', 'commit-a', 'build-a')
+
+    // #then
+    expect(writtenManifest()).toEqual({
+      baseVersion: '1.15.13',
+      integrationRefs: [],
+      integrationCommit: 'commit-a',
+      buildSha: 'build-a',
+    })
+  })
+
+  it('clears preserved carry data when the existing integration commit is stale', () => {
+    // #given
+    mockedReadFileSync.mockReturnValue(
+      JSON.stringify({
+        carryManifest: {base: 'v1.15.13', carries: [{ref: 'stale', resolvedSha: 'b'.repeat(40)}]},
+        integrationRefs: [{ref: 'stale', resolvedSha: 'b'.repeat(40)}],
+        integrationCommit: 'commit-old',
+      }),
+    )
+
+    // #when
+    emitProvenanceManifest('/tmp/harness', '1.15.13', 'commit-new', 'build-a')
+
+    // #then
+    expect(writtenManifest()).toEqual({
+      baseVersion: '1.15.13',
+      integrationRefs: [],
+      integrationCommit: 'commit-new',
+      buildSha: 'build-a',
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/harness/scripts/build-platform.test.ts
+++ b/packages/harness/scripts/build-platform.test.ts
@@ -144,7 +144,7 @@ describe('emitProvenanceManifest', () => {
     mockedReadFileSync.mockReturnValue(JSON.stringify(existing))
 
     // #when
-    emitProvenanceManifest('/tmp/harness', '1.15.13', 'commit-a', 'build-b')
+    emitProvenanceManifest('/harness-package', '1.15.13', 'commit-a', 'build-b')
 
     // #then
     expect(writtenManifest()).toEqual({
@@ -161,7 +161,7 @@ describe('emitProvenanceManifest', () => {
     })
 
     // #when
-    emitProvenanceManifest('/tmp/harness', '1.15.13', 'commit-a', 'build-a')
+    emitProvenanceManifest('/harness-package', '1.15.13', 'commit-a', 'build-a')
 
     // #then
     expect(writtenManifest()).toEqual({
@@ -177,7 +177,7 @@ describe('emitProvenanceManifest', () => {
     mockedReadFileSync.mockReturnValue('{not-json')
 
     // #when
-    emitProvenanceManifest('/tmp/harness', '1.15.13', 'commit-a', 'build-a')
+    emitProvenanceManifest('/harness-package', '1.15.13', 'commit-a', 'build-a')
 
     // #then
     expect(writtenManifest()).toEqual({
@@ -199,7 +199,7 @@ describe('emitProvenanceManifest', () => {
     )
 
     // #when
-    emitProvenanceManifest('/tmp/harness', '1.15.13', 'commit-new', 'build-a')
+    emitProvenanceManifest('/harness-package', '1.15.13', 'commit-new', 'build-a')
 
     // #then
     expect(writtenManifest()).toEqual({

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -661,7 +661,7 @@ function emitBinary(
  * The manifest records the integration commit, base version, and build SHA
  * so the runtime getProvenance() function can serve it to `harness info`.
  */
-function emitProvenanceManifest(
+export function emitProvenanceManifest(
   harnessPackageDir: string,
   baseVersion: string,
   integrationCommit: string,
@@ -672,9 +672,12 @@ function emitProvenanceManifest(
   try {
     const existing: unknown = JSON.parse(readFileSync(path.join(harnessPackageDir, 'provenance.json'), 'utf8'))
     if (typeof existing === 'object' && existing !== null) {
-      if ('carryManifest' in existing) carryManifest = existing.carryManifest
-      if ('integrationRefs' in existing && Array.isArray(existing.integrationRefs))
-        integrationRefs = existing.integrationRefs
+      const existingIntegrationCommit = 'integrationCommit' in existing ? existing.integrationCommit : undefined
+      if (existingIntegrationCommit === integrationCommit) {
+        if ('carryManifest' in existing) carryManifest = existing.carryManifest
+        if ('integrationRefs' in existing && Array.isArray(existing.integrationRefs))
+          integrationRefs = existing.integrationRefs
+      }
     }
   } catch {
     // Build-only invocations may not have an integration manifest to preserve.

--- a/packages/harness/scripts/build-platform.ts
+++ b/packages/harness/scripts/build-platform.ts
@@ -667,9 +667,22 @@ function emitProvenanceManifest(
   integrationCommit: string,
   buildSha: string,
 ): void {
+  let carryManifest: unknown
+  let integrationRefs: readonly unknown[] = []
+  try {
+    const existing: unknown = JSON.parse(readFileSync(path.join(harnessPackageDir, 'provenance.json'), 'utf8'))
+    if (typeof existing === 'object' && existing !== null) {
+      if ('carryManifest' in existing) carryManifest = existing.carryManifest
+      if ('integrationRefs' in existing && Array.isArray(existing.integrationRefs))
+        integrationRefs = existing.integrationRefs
+    }
+  } catch {
+    // Build-only invocations may not have an integration manifest to preserve.
+  }
   const manifest = {
     baseVersion,
-    integrationRefs: [], // populated by the integration engine; preserved here as empty for build-only runs
+    ...(carryManifest === undefined ? {} : {carryManifest}),
+    integrationRefs,
     integrationCommit,
     buildSha,
   }

--- a/packages/harness/src/candidate-integration.test.ts
+++ b/packages/harness/src/candidate-integration.test.ts
@@ -1,4 +1,4 @@
-import type {IntegrationAdapters, IntegrationConfig, TrustedPushRepository} from './integrate.js'
+import type {IntegrationAdapters, IntegrationConfig, ProvenanceManifest, TrustedPushRepository} from './integrate.js'
 import {execFileSync} from 'node:child_process'
 import fs from 'node:fs/promises'
 import os from 'node:os'
@@ -78,12 +78,13 @@ describe('finalizeCandidateIntegration', () => {
     const root = await makeTmpDir()
     const previousGhToken = process.env.GH_TOKEN
     try {
-      const {workDir} = await makeCandidateRepository(root)
+      const {workDir, commit} = await makeCandidateRepository(root)
       const outPath = path.join(root, 'artifact.tar')
       const real = makeRealAdapters()
       process.env.GH_TOKEN = 'trusted-push-token'
       const originalPrepare = real.prepareTrustedPushRepository
       let pushedRepository: TrustedPushRepository | null = null
+      const preparedManifest: {value: ProvenanceManifest | null} = {value: null}
       let candidateMutated = false
       const adapters: IntegrationAdapters = {
         ...real,
@@ -93,8 +94,9 @@ describe('finalizeCandidateIntegration', () => {
           }
           await real.validateFinalTree(validationWorkDir, expectation)
         },
-        prepareTrustedPushRepository: async (...args) => {
-          const trusted = await originalPrepare(...args)
+        prepareTrustedPushRepository: async (sourceWorkDir, integrationCommit, manifest, expectation) => {
+          preparedManifest.value = manifest
+          const trusted = await originalPrepare(sourceWorkDir, integrationCommit, manifest, expectation)
           // Simulate the mutable working directory changing after freeze.
           await fs.writeFile(path.join(workDir, 'README.md'), 'mutated after freeze\n', 'utf8')
           candidateMutated = true
@@ -124,6 +126,11 @@ describe('finalizeCandidateIntegration', () => {
 
       // #then
       expect(result.ok).toBe(true)
+      if (preparedManifest.value === null) throw new Error('expected prepared provenance manifest')
+      expect(preparedManifest.value.carryManifest).toEqual({
+        base: 'v1.0.0',
+        carries: [{ref: 'candidate-ref', resolvedSha: commit}],
+      })
       expect(pushedRepository).not.toBeNull()
       expect(outPath).toBeTruthy()
       await expect(fs.stat(outPath)).resolves.toBeTruthy()

--- a/packages/harness/src/forward-shadow-command.test.ts
+++ b/packages/harness/src/forward-shadow-command.test.ts
@@ -98,6 +98,69 @@ describe('forward shadow command', () => {
     await fs.rm(directory, {recursive: true, force: true})
   })
 
+  it('passes the immutable carry manifest entries unchanged to the shadow consumer', async () => {
+    // #given
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'forward-shadow-command-test-'))
+    const resultPath = path.join(directory, 'result.json')
+    const recordPath = path.join(directory, 'record.json')
+    const carry = {ref: 'https://github.com/anomalyco/opencode/pull/30182', resolvedSha: 'c'.repeat(40)}
+    let receivedRefs: readonly {readonly ref: string; readonly resolvedSha: string}[] = []
+    await fs.writeFile(
+      resultPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        ok: true,
+        startedAt: '2026-08-14T00:00:00.000Z',
+        endedAt: '2026-08-14T00:00:01.000Z',
+        elapsedMs: 1000,
+        manifest: {
+          baseVersion: '1.15.13',
+          carryManifest: {base: 'v1.15.13', carries: [carry]},
+          integrationRefs: [carry],
+          integrationCommit: OID_A,
+          buildSha: 'build',
+        },
+      }),
+      'utf8',
+    )
+
+    // #when
+    const code = await runForwardShadowCommand(
+      [
+        '--result-out',
+        resultPath,
+        '--record-out',
+        recordPath,
+        '--base-version',
+        '1.15.13',
+        '--shadow-work-dir',
+        directory,
+        '--release-repo',
+        'anomalyco/opencode',
+        '--authoritative-repository',
+        'fro-bot/agent',
+        '--authoritative-ref',
+        'refs/harness-integrate/1.15.13',
+        '--run-identity',
+        'run-1',
+      ],
+      {
+        readFile: async file => fs.readFile(file, 'utf8'),
+        compare: async input => {
+          receivedRefs = input.integrationRefs
+          return matchRecord()
+        },
+        writeRecord: async (file, record) => fs.writeFile(file, JSON.stringify(record), 'utf8'),
+        now: () => new Date('2026-08-14T00:00:02.000Z'),
+      },
+    )
+
+    // #then
+    expect(code).toBe(0)
+    expect(receivedRefs).toEqual([carry])
+    await fs.rm(directory, {recursive: true, force: true})
+  })
+
   it('writes inconclusive evidence when the outcome is missing and never leaks its path or contents', async () => {
     // #given
     const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'forward-shadow-command-test-'))

--- a/packages/harness/src/forward-shadow-command.ts
+++ b/packages/harness/src/forward-shadow-command.ts
@@ -126,7 +126,8 @@ function parseManifest(value: unknown, baseVersion: string): ProvenanceManifest 
     return undefined
   }
   if (
-    OID_PATTERN.test(String(value.integrationCommit)) === false ||
+    typeof value.integrationCommit !== 'string' ||
+    OID_PATTERN.test(value.integrationCommit) === false ||
     isValidCarryManifest(value.carryManifest) === false ||
     value.carryManifest.base !== `v${baseVersion}` ||
     Array.isArray(value.integrationRefs) === false ||
@@ -158,7 +159,7 @@ function parseManifest(value: unknown, baseVersion: string): ProvenanceManifest 
       })),
     },
     integrationRefs,
-    integrationCommit: String(value.integrationCommit).toLowerCase(),
+    integrationCommit: value.integrationCommit.toLowerCase(),
     buildSha: value.buildSha,
   }
 }

--- a/packages/harness/src/forward-shadow-command.ts
+++ b/packages/harness/src/forward-shadow-command.ts
@@ -13,6 +13,7 @@ import fs from 'node:fs/promises'
 import process from 'node:process'
 import {buildForwardShadowRecord, compareForwardShadow, writeForwardShadowRecord} from './forward-shadow.js'
 import {isValidBaseVersion} from './integrate-command.js'
+import {isValidCarryManifest} from './sources.js'
 
 interface ParsedFlags {
   readonly resultOut: string
@@ -124,16 +125,24 @@ function parseManifest(value: unknown, baseVersion: string): ProvenanceManifest 
   if (isRecord(value) === false || value.baseVersion !== baseVersion || isString(value.buildSha) === false) {
     return undefined
   }
-  if (OID_PATTERN.test(String(value.integrationCommit)) === false || Array.isArray(value.integrationRefs) === false) {
+  if (
+    OID_PATTERN.test(String(value.integrationCommit)) === false ||
+    isValidCarryManifest(value.carryManifest) === false ||
+    value.carryManifest.base !== `v${baseVersion}` ||
+    Array.isArray(value.integrationRefs) === false ||
+    value.carryManifest.carries.length !== value.integrationRefs.length
+  ) {
     return undefined
   }
   const integrationRefs: {readonly ref: string; readonly resolvedSha: string}[] = []
-  for (const entry of value.integrationRefs) {
+  for (const [index, entry] of value.integrationRefs.entries()) {
     if (
       isRecord(entry) === false ||
       isString(entry.ref) === false ||
       typeof entry.resolvedSha !== 'string' ||
-      OID_PATTERN.test(entry.resolvedSha) === false
+      OID_PATTERN.test(entry.resolvedSha) === false ||
+      value.carryManifest.carries[index]?.ref !== entry.ref ||
+      value.carryManifest.carries[index]?.resolvedSha.toLowerCase() !== entry.resolvedSha.toLowerCase()
     ) {
       return undefined
     }
@@ -141,6 +150,13 @@ function parseManifest(value: unknown, baseVersion: string): ProvenanceManifest 
   }
   return {
     baseVersion,
+    carryManifest: {
+      base: value.carryManifest.base,
+      carries: value.carryManifest.carries.map(carry => ({
+        ref: carry.ref,
+        resolvedSha: carry.resolvedSha.toLowerCase(),
+      })),
+    },
     integrationRefs,
     integrationCommit: String(value.integrationCommit).toLowerCase(),
     buildSha: value.buildSha,
@@ -197,13 +213,15 @@ async function readOutcome(
     }
   }
   const manifest = parseManifest(parsed.manifest, baseVersion)
-  if (manifest === undefined) return invalidOutcome(dependencies.now(), 'shadow outcome manifest is invalid')
+  if (manifest === undefined || manifest.carryManifest === undefined) {
+    return invalidOutcome(dependencies.now(), 'shadow outcome manifest is invalid')
+  }
   return {
     result: {ok: true, manifest, conflictDiagnostics: []},
     conflictMetrics,
     startedAt,
     endedAt,
-    integrationRefs: manifest.integrationRefs,
+    integrationRefs: manifest.carryManifest.carries,
   }
 }
 

--- a/packages/harness/src/integrate-command.ts
+++ b/packages/harness/src/integrate-command.ts
@@ -23,6 +23,7 @@ import type {
   IntegrationStage,
   TrustedPushRepository,
 } from './integrate.js'
+import type {CarryManifest} from './sources.js'
 import {execFileSync, execSync} from 'node:child_process'
 import {copyFileSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync} from 'node:fs'
 import os from 'node:os'
@@ -426,6 +427,13 @@ export async function finalizeCandidateIntegration(
 
   const manifest = {
     baseVersion: config.baseVersion,
+    carryManifest: {
+      base: `v${config.baseVersion}`,
+      carries: sources.map((source, index) => ({
+        ref: config.integrationRefs[index] ?? source.label,
+        resolvedSha: resolvedShas[index] ?? '',
+      })),
+    } satisfies CarryManifest,
     integrationRefs: sources.map((source, index) => ({
       ref: config.integrationRefs[index] ?? source.label,
       resolvedSha: resolvedShas[index] ?? '',

--- a/packages/harness/src/integrate.test.ts
+++ b/packages/harness/src/integrate.test.ts
@@ -18,11 +18,13 @@ async function makeTmpDir(): Promise<string> {
 }
 
 function makeAdapters(overrides: Partial<IntegrationAdapters> = {}): IntegrationAdapters {
+  const sourceSha = 'a'.repeat(40)
   return {
     cloneRepo: async () => {},
     fetchTags: async () => {},
     fetchRef: async () => {},
-    captureRefSha: async () => 'resolved-source-sha',
+    resolveRefSha: async () => sourceSha,
+    captureRefSha: async () => sourceSha,
     createBranch: async () => {},
     mergeRef: async () => ({kind: 'clean'}),
     runMerge: async () => {},
@@ -79,6 +81,15 @@ describe('writeProvenanceManifest / readProvenanceManifest', () => {
     try {
       const manifest: ProvenanceManifest = {
         baseVersion: '1.15.13',
+        carryManifest: {
+          base: 'v1.15.13',
+          carries: [
+            {
+              ref: 'https://github.com/anomalyco/opencode/pull/30182',
+              resolvedSha: 'd'.repeat(40),
+            },
+          ],
+        },
         integrationRefs: [
           {
             ref: 'https://github.com/anomalyco/opencode/pull/30182',
@@ -156,6 +167,115 @@ describe('runIntegration', () => {
       expect(result.manifest.baseVersion).toBe('1.15.13')
       expect(result.manifest.integrationRefs.length).toBe(0)
       expect(typeof result.manifest.integrationCommit).toBe('string')
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+
+  it('records the carry SHA rather than the final integration commit', async () => {
+    // #given
+    const dir = await makeTmpDir()
+    const carrySha = 'b'.repeat(40)
+    const integrationCommit = 'c'.repeat(40)
+    try {
+      const result = await runIntegration(
+        {
+          baseVersion: '1.15.13',
+          releaseRepo: 'anomalyco/opencode',
+          integrationRefs: ['https://github.com/anomalyco/opencode/pull/30182'],
+          workDir: dir,
+        },
+        makeAdapters({
+          resolveRefSha: async () => carrySha,
+          captureRefSha: async () => carrySha,
+          getCommitSha: async () => integrationCommit,
+        }),
+      )
+
+      // #when
+      // The pipeline has already completed with the resolved carry.
+
+      // #then
+      expect(result.ok).toBe(true)
+      if (result.ok === false) throw new Error(result.error)
+      if (result.manifest.carryManifest === undefined) throw new Error('expected carry manifest')
+      expect(result.manifest.carryManifest.carries[0]?.resolvedSha).toBe(carrySha)
+      expect(result.manifest.integrationRefs[0]?.resolvedSha).toBe(carrySha)
+      expect(result.manifest.integrationRefs[0]?.resolvedSha).not.toBe(integrationCommit)
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+
+  it('fails closed with CarrySourceChangedError when the moving head changes before fetch completes', async () => {
+    // #given
+    const dir = await makeTmpDir()
+    const resolvedSha = 'd'.repeat(40)
+    const movedSha = 'e'.repeat(40)
+    try {
+      const result = await runIntegration(
+        {
+          baseVersion: '1.15.13',
+          releaseRepo: 'anomalyco/opencode',
+          integrationRefs: ['https://github.com/anomalyco/opencode/pull/30182'],
+          workDir: dir,
+        },
+        makeAdapters({
+          resolveRefSha: async () => resolvedSha,
+          captureRefSha: async () => movedSha,
+        }),
+      )
+
+      // #when
+      // The fetched source resolves to a different SHA than the frozen manifest.
+
+      // #then
+      expect(result.ok).toBe(false)
+      if (result.ok === true) throw new Error('expected source drift failure')
+      expect(result.error).toMatch(/CarrySourceChangedError/)
+      expect(await readProvenanceManifest(dir)).toBeNull()
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+
+  it('passes one supplied carry manifest unchanged to the integration consumer', async () => {
+    // #given
+    const dir = await makeTmpDir()
+    const carrySha = 'f'.repeat(40)
+    const carryManifest = {
+      base: 'v1.15.13',
+      carries: [{ref: 'https://github.com/anomalyco/opencode/pull/30182', resolvedSha: carrySha}],
+    } as const
+    const fetched: string[] = []
+    try {
+      const result = await runIntegration(
+        {
+          baseVersion: '1.15.13',
+          releaseRepo: 'anomalyco/opencode',
+          integrationRefs: [carryManifest.carries[0].ref],
+          carryManifest,
+          workDir: dir,
+        },
+        makeAdapters({
+          resolveRefSha: async () => {
+            throw new Error('supplied manifest must be consumed without re-resolution')
+          },
+          fetchRef: async (_workDir, _remoteUrl, _fetchRef, _localRef, expectedSha) => {
+            fetched.push(expectedSha ?? '')
+          },
+          captureRefSha: async () => carrySha,
+        }),
+      )
+
+      // #when
+      // The same manifest is supplied to the trusted integration consumer.
+
+      // #then
+      expect(result.ok).toBe(true)
+      if (result.ok === false) throw new Error(result.error)
+      expect(result.manifest.carryManifest).toEqual(carryManifest)
+      expect(fetched).toEqual([carrySha])
     } finally {
       await fs.rm(dir, {recursive: true, force: true})
     }
@@ -538,6 +658,15 @@ describe('runIntegration', () => {
     try {
       const manifest: ProvenanceManifest = {
         baseVersion: '1.15.13',
+        carryManifest: {
+          base: 'v1.15.13',
+          carries: [
+            {
+              ref: 'https://github.com/anomalyco/opencode/pull/30182',
+              resolvedSha: 'd'.repeat(40),
+            },
+          ],
+        },
         integrationRefs: [
           {
             ref: 'https://github.com/anomalyco/opencode/pull/30182',
@@ -584,9 +713,15 @@ describe('runIntegration', () => {
         'dummy {{tag}} {{branch}} {{merges}} {{sources}} {{repo}} {{version}} {{channel}} {{base}} {{release_repo}} {{release_url}} {{branches}}',
       )
       // Each ref gets a distinct SHA from captureRefSha
-      const refShas = ['aaa1111100000000', 'bbb2222200000000', 'ccc3333300000000']
+      const refShas = ['a'.repeat(40), 'b'.repeat(40), 'c'.repeat(40)]
+      let resolveCallCount = 0
       let captureCallCount = 0
       const adapters = makeAdapters({
+        resolveRefSha: async () => {
+          const sha = refShas[resolveCallCount] ?? ''
+          resolveCallCount++
+          return sha
+        },
         captureRefSha: async () => {
           const sha = refShas[captureCallCount] ?? null
           captureCallCount++
@@ -622,9 +757,9 @@ describe('runIntegration', () => {
       // All 3 are distinct
       expect(new Set(shas).size).toBe(3)
       // Each matches the captured SHA, not the integration commit
-      expect(shas[0]).toBe('aaa1111100000000')
-      expect(shas[1]).toBe('bbb2222200000000')
-      expect(shas[2]).toBe('ccc3333300000000')
+      expect(shas[0]).toBe('a'.repeat(40))
+      expect(shas[1]).toBe('b'.repeat(40))
+      expect(shas[2]).toBe('c'.repeat(40))
     } finally {
       await fs.rm(dir, {recursive: true, force: true})
     }
@@ -756,6 +891,38 @@ describe('clean-snapshot guarantees', () => {
   })
 })
 
+describe('frozen carry fetches', () => {
+  it('detects a local branch move between SHA resolution and fetch without network access', async () => {
+    // #given
+    const sourceDir = await makeTmpDir()
+    const workDir = await makeTmpDir()
+    const adapters = integrateModule.makeRealAdapters()
+    try {
+      runGit(sourceDir, ['init', '--quiet'])
+      runGit(sourceDir, ['config', 'user.name', 'harness-test'])
+      runGit(sourceDir, ['config', 'user.email', 'harness-test@example.invalid'])
+      await fs.writeFile(path.join(sourceDir, 'carry.txt'), 'first\n', 'utf8')
+      runGit(sourceDir, ['add', 'carry.txt'])
+      runGit(sourceDir, ['commit', '--quiet', '-m', 'carry'])
+      const resolvedSha = runGit(sourceDir, ['rev-parse', 'HEAD'])
+
+      runGit(sourceDir, ['checkout', '--quiet', '-b', 'carry'])
+      await fs.writeFile(path.join(sourceDir, 'carry.txt'), 'moved\n', 'utf8')
+      runGit(sourceDir, ['commit', '--quiet', '-am', 'move carry'])
+      runGit(workDir, ['init', '--quiet'])
+
+      // #when / #then
+      await expect(
+        adapters.fetchRef(workDir, sourceDir, 'refs/heads/carry', 'refs/remotes/watch/local/carry', resolvedSha),
+      ).rejects.toMatchObject({name: 'CarrySourceChangedError'})
+    } finally {
+      await adapters.dispose?.()
+      await fs.rm(sourceDir, {recursive: true, force: true})
+      await fs.rm(workDir, {recursive: true, force: true})
+    }
+  })
+})
+
 // ---------------------------------------------------------------------------
 // U5: code-owned deterministic integration driver
 // ---------------------------------------------------------------------------
@@ -776,6 +943,7 @@ describe('U5 code-owned integration driver', () => {
       runGit(sourceDir, ['tag', 'v1.15.13'])
       const manifest: ProvenanceManifest = {
         baseVersion: '1.15.13',
+        carryManifest: {base: 'v1.15.13', carries: []},
         integrationRefs: [],
         integrationCommit,
         buildSha: 'dev',

--- a/packages/harness/src/integrate.ts
+++ b/packages/harness/src/integrate.ts
@@ -10,7 +10,7 @@
 
 import type {ConflictResolutionRequest, ConflictResolverResult} from './conflict-resolver.js'
 import type {IntegrationRefRecord} from './provenance.js'
-import type {IntegrationSource} from './sources.js'
+import type {CarryManifest, IntegrationSource, ResolvedIntegrationSource} from './sources.js'
 import {Buffer} from 'node:buffer'
 import {execFile} from 'node:child_process'
 import crypto from 'node:crypto'
@@ -21,7 +21,13 @@ import process from 'node:process'
 import {promisify} from 'node:util'
 import {HARNESS_GIT_IDENTITY, resolveConflict as resolveConflictAttempt} from './conflict-resolver.js'
 import {formatPipelineError} from './format-error.js'
-import {resolveSources} from './sources.js'
+import {
+  carrySourceChangedError,
+  carrySourceFetchError,
+  isValidCarryManifest,
+  resolveCarryManifest,
+  sourcesFromCarryManifest,
+} from './sources.js'
 
 // Re-export so callers that previously imported from integrate.ts still work.
 export type {IntegrationRefRecord} from './provenance.js'
@@ -32,6 +38,8 @@ export type {IntegrationRefRecord} from './provenance.js'
 
 export interface ProvenanceManifest {
   readonly baseVersion: string
+  /** Required on manifests emitted by the current integration pipeline; optional for legacy test/build scaffolds. */
+  readonly carryManifest?: CarryManifest
   readonly integrationRefs: readonly IntegrationRefRecord[]
   readonly integrationCommit: string
   readonly buildSha: string
@@ -55,6 +63,7 @@ export interface IntegrationConfig {
   readonly releaseRepo: string
   readonly sourceRepo?: string
   readonly integrationRefs: readonly string[]
+  readonly carryManifest?: CarryManifest
   readonly workDir: string
   readonly dryRun?: boolean
   readonly pushTarget?: IntegrationPushTarget
@@ -140,8 +149,16 @@ export interface IntegrationAdapters {
   readonly cloneRepo: (repoUrl: string, workDir: string, tag?: string) => Promise<void>
   /** Fetch tags from the anonymous origin. */
   readonly fetchTags: (workDir: string) => Promise<void>
-  /** Fetch one public integration ref into a local tracking ref. */
-  readonly fetchRef: (workDir: string, remoteUrl: string, fetchRef: string, localRef: string) => Promise<void>
+  /** Fetch one public integration ref into a local tracking ref and verify its frozen SHA. */
+  readonly fetchRef: (
+    workDir: string,
+    remoteUrl: string,
+    fetchRef: string,
+    localRef: string,
+    expectedSha?: string,
+  ) => Promise<void>
+  /** Resolve one public integration ref to its current SHA before any carry fetches. */
+  readonly resolveRefSha?: (remoteUrl: string, fetchRef: string) => Promise<string>
   /** Capture the resolved upstream SHA immediately after fetchRef. */
   readonly captureRefSha: (workDir: string) => Promise<string | null>
   /** Create/reset the integration branch to the release tag. */
@@ -233,6 +250,7 @@ function isValidIntegrationRefRecord(value: unknown): value is IntegrationRefRec
 export function isValidProvenanceManifest(value: unknown): value is ProvenanceManifest {
   if (!isRecord(value)) return false
   if (typeof value.baseVersion !== 'string' || value.baseVersion.length === 0) return false
+  if (isValidCarryManifest(value.carryManifest) === false) return false
   if (!Array.isArray(value.integrationRefs)) return false
   if (!value.integrationRefs.every(isValidIntegrationRefRecord)) return false
   if (typeof value.integrationCommit !== 'string' || value.integrationCommit.length === 0) return false
@@ -671,8 +689,31 @@ export function makeRealAdapters(options: RealAdapterOptions = {}): IntegrationA
       await git.exec(['fetch', 'origin', '--tags'], workDir, publicGitEnv())
     },
 
-    fetchRef: async (workDir, remoteUrl, fetchRef, localRef) => {
-      await git.exec(['fetch', '--no-tags', remoteUrl, `${fetchRef}:${localRef}`], workDir, publicGitEnv())
+    fetchRef: async (workDir, remoteUrl, fetchRef, localRef, expectedSha) => {
+      try {
+        await git.exec(['fetch', '--no-tags', remoteUrl, `${fetchRef}:${localRef}`], workDir, publicGitEnv())
+      } catch (error) {
+        if (expectedSha !== undefined) throw carrySourceFetchError({label: fetchRef}, error)
+        throw error
+      }
+      if (expectedSha !== undefined) {
+        const actualSha = await git.exec(['rev-parse', `${localRef}^{commit}`], workDir, publicGitEnv())
+        if (actualSha !== expectedSha) {
+          throw carrySourceChangedError({label: fetchRef}, expectedSha, actualSha)
+        }
+      }
+    },
+
+    resolveRefSha: async (remoteUrl, fetchRef) => {
+      const output = await git.exec(['ls-remote', remoteUrl, fetchRef], undefined, publicGitEnv())
+      const firstLine = splitLines(output)[0]
+      const resolvedSha = firstLine?.split(/\s+/)[0]
+      if (resolvedSha === undefined || /^[0-9a-f]{40}$/i.test(resolvedSha) === false) {
+        const error = new Error(`remote ref ${fetchRef} did not resolve to a commit SHA`)
+        error.name = 'CarrySourceResolutionError'
+        throw error
+      }
+      return resolvedSha.toLowerCase()
     },
 
     captureRefSha: async workDir => {
@@ -856,6 +897,24 @@ function sourceRefForManifest(source: IntegrationSource, configuredRef: string |
   return configuredRef === undefined ? source.label : configuredRef
 }
 
+function validateCarryManifestInput(
+  manifest: CarryManifest,
+  expectedBase: string,
+  configuredRefs: readonly string[],
+): string | null {
+  if (isValidCarryManifest(manifest) === false) return 'immutable carry manifest shape is invalid'
+  if (manifest.base !== expectedBase) return 'immutable carry manifest base does not match configuration'
+  if (manifest.carries.length !== configuredRefs.length)
+    return 'immutable carry manifest ref count does not match configuration'
+  for (const [index, carry] of manifest.carries.entries()) {
+    const configuredRef = configuredRefs[index]
+    if (configuredRef === undefined || carry.ref !== configuredRef) {
+      return `immutable carry manifest ref ${index} identity does not match configuration`
+    }
+  }
+  return null
+}
+
 function resolveReleaseRepoUrl(releaseRepo: string): string {
   const candidate = releaseRepo.startsWith('https://')
     ? releaseRepo.endsWith('.git')
@@ -879,6 +938,13 @@ function validateManifest(
 ): string | null {
   if (!isValidProvenanceManifest(manifest)) return 'provenance manifest shape is invalid'
   if (manifest.baseVersion !== config.baseVersion) return 'provenance base version does not match configuration'
+  if (manifest.carryManifest === undefined) return 'provenance immutable carry manifest is missing'
+  const carryManifestError = validateCarryManifestInput(
+    manifest.carryManifest,
+    `v${config.baseVersion}`,
+    config.integrationRefs,
+  )
+  if (carryManifestError !== null) return carryManifestError
   if (manifest.integrationCommit !== integrationCommit) return 'provenance integration commit does not match HEAD'
   if (manifest.integrationRefs.length !== sources.length) {
     return 'provenance ref count does not match configured sources'
@@ -893,6 +959,10 @@ function validateManifest(
     const expectedRef = sourceRefForManifest(source, config.integrationRefs[index])
     if (record.ref !== expectedRef) return `provenance ref ${index} identity does not match configuration`
     if (record.resolvedSha !== expectedSha) return `provenance ref ${index} SHA does not match the fetched source`
+    const carry = manifest.carryManifest.carries[index]
+    if (carry === undefined || carry.ref !== record.ref || carry.resolvedSha !== record.resolvedSha) {
+      return `provenance carry ${index} does not match the immutable carry manifest`
+    }
   }
 
   return null
@@ -928,9 +998,23 @@ async function runIntegrationPipeline(
     return failure('sources', error)
   }
 
-  let sources: IntegrationSource[]
+  let sources: ResolvedIntegrationSource[]
+  let carryManifest: CarryManifest
   try {
-    sources = resolveSources(integrationRefs, sourceRepoUrl)
+    if (config.carryManifest === undefined) {
+      if (integrationRefs.length > 0 && adapters.resolveRefSha === undefined) {
+        throw new Error('immutable carry manifest resolution is unavailable')
+      }
+      carryManifest = await resolveCarryManifest(tag, integrationRefs, sourceRepoUrl, async source => {
+        if (adapters.resolveRefSha === undefined) throw new Error('immutable carry manifest resolution is unavailable')
+        return adapters.resolveRefSha(source.repo, source.fetchRef)
+      })
+    } else {
+      const manifestError = validateCarryManifestInput(config.carryManifest, tag, integrationRefs)
+      if (manifestError !== null) throw new Error(manifestError)
+      carryManifest = config.carryManifest
+    }
+    sources = sourcesFromCarryManifest(carryManifest, sourceRepoUrl)
   } catch (error) {
     return failure('sources', error)
   }
@@ -953,11 +1037,11 @@ async function runIntegrationPipeline(
     return failure('branch', error)
   }
 
-  const resolvedShas: string[] = []
+  const resolvedShas = carryManifest.carries.map(carry => carry.resolvedSha)
   const conflictDiagnostics: ConflictResolverResult[] = []
   for (const source of sources) {
     try {
-      await adapters.fetchRef(workDir, source.repo, source.fetchRef, source.fetch)
+      await adapters.fetchRef(workDir, source.repo, source.fetchRef, source.fetch, source.resolvedSha)
     } catch (error) {
       return failure('fetch', `fetch ref ${source.label} failed: ${formatPipelineError(error)}`)
     }
@@ -971,7 +1055,9 @@ async function runIntegrationPipeline(
     if (resolvedSha === null || resolvedSha.length === 0) {
       return failure('provenance', `capture SHA for ${source.label} returned no resolved source SHA`)
     }
-    resolvedShas.push(resolvedSha)
+    if (resolvedSha.toLowerCase() !== source.resolvedSha) {
+      return failure('fetch', carrySourceChangedError(source, source.resolvedSha, resolvedSha).message)
+    }
 
     let preMergeCommit: string
     try {
@@ -1138,6 +1224,7 @@ async function runIntegrationPipeline(
 
   const manifest: ProvenanceManifest = {
     baseVersion,
+    carryManifest,
     integrationRefs: sources.map((source, index) => ({
       ref: sourceRefForManifest(source, integrationRefs[index]),
       resolvedSha: resolvedShas[index] ?? '',

--- a/packages/harness/src/sources.test.ts
+++ b/packages/harness/src/sources.test.ts
@@ -1,7 +1,8 @@
 import {describe, expect, it} from 'vitest'
-import {parseSource, resolveSources} from './sources.js'
+import {parseSource, resolveCarryManifest, resolveSources, sourcesFromCarryManifest} from './sources.js'
 
 const SOURCE_REPO = 'https://github.com/anomalyco/opencode.git'
+const SOURCE_SHA = 'a'.repeat(40)
 
 // ---------------------------------------------------------------------------
 // parseSource — PR URL
@@ -146,5 +147,31 @@ describe('resolveSources', () => {
 
     // #then
     expect(sources.length).toBe(0)
+  })
+})
+
+describe('resolveCarryManifest', () => {
+  it('resolves each carry once and maps the immutable manifest back to sources', async () => {
+    // #given
+    const refs = ['https://github.com/anomalyco/opencode/pull/30182']
+    const resolved = [] as string[]
+
+    // #when
+    const manifest = await resolveCarryManifest('v1.18.18', refs, SOURCE_REPO, async source => {
+      resolved.push(source.fetchRef)
+      return SOURCE_SHA
+    })
+    const sources = sourcesFromCarryManifest(manifest, SOURCE_REPO)
+
+    // #then
+    expect(manifest).toEqual({
+      base: 'v1.18.18',
+      carries: [{ref: refs[0], resolvedSha: SOURCE_SHA}],
+    })
+    expect(resolved).toEqual(['refs/pull/30182/head'])
+    expect(sources[0]?.resolvedSha).toBe(SOURCE_SHA)
+    expect(sources[0]?.fetchRef).toBe('refs/pull/30182/head')
+    expect(Object.isFrozen(manifest)).toBe(true)
+    expect(Object.isFrozen(manifest.carries)).toBe(true)
   })
 })

--- a/packages/harness/src/sources.ts
+++ b/packages/harness/src/sources.ts
@@ -25,6 +25,76 @@ export interface IntegrationSource {
   readonly merge: string
 }
 
+export interface CarryManifestEntry {
+  readonly ref: string
+  readonly resolvedSha: string
+}
+
+/**
+ * The immutable carry input shared by the authoritative and forward-shadow paths.
+ * GitHub does not reliably serve arbitrary reachable commits by SHA, so consumers
+ * fetch the configured ref and assert that it still resolves to this SHA.
+ */
+export interface CarryManifest {
+  readonly base: string
+  readonly carries: readonly CarryManifestEntry[]
+}
+
+export interface ResolvedIntegrationSource extends IntegrationSource {
+  readonly resolvedSha: string
+}
+
+export type SourceShaResolver = (source: IntegrationSource) => Promise<string>
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/i
+
+export function isValidCarryManifest(value: unknown): value is CarryManifest {
+  if (value === null || typeof value !== 'object') return false
+  const candidate = value as {readonly base?: unknown; readonly carries?: unknown}
+  if (typeof candidate.base !== 'string' || candidate.base.length === 0 || Array.isArray(candidate.carries) === false) {
+    return false
+  }
+  return candidate.carries.every(entry => {
+    if (entry === null || typeof entry !== 'object') return false
+    const carry = entry as {readonly ref?: unknown; readonly resolvedSha?: unknown}
+    return (
+      typeof carry.ref === 'string' &&
+      carry.ref.length > 0 &&
+      typeof carry.resolvedSha === 'string' &&
+      carry.resolvedSha === carry.resolvedSha.toLowerCase() &&
+      SHA_PATTERN.test(carry.resolvedSha)
+    )
+  })
+}
+
+export function carrySourceResolutionError(source: Pick<IntegrationSource, 'label'>, cause: unknown): Error {
+  const message = cause instanceof Error ? cause.message : String(cause)
+  const error = new Error(
+    `[CarrySourceResolutionError] failed to resolve carry ${source.label} to an immutable SHA: ${message}`,
+  )
+  error.name = 'CarrySourceResolutionError'
+  return error
+}
+
+export function carrySourceChangedError(
+  source: Pick<IntegrationSource, 'label'>,
+  expectedSha: string,
+  actualSha: string,
+): Error {
+  const error = new Error(
+    `[CarrySourceChangedError] carry ${source.label} changed after resolution: expected ${expectedSha}, fetched ${actualSha}`,
+  )
+  error.name = 'CarrySourceChangedError'
+  return error
+}
+
+export function carrySourceFetchError(source: Pick<IntegrationSource, 'label'>, cause: unknown): Error {
+  const message = cause instanceof Error ? cause.message : String(cause)
+  const error = new Error(`[CarrySourceFetchError] failed to fetch frozen carry ${source.label}: ${message}`)
+  error.name = 'CarrySourceFetchError'
+  return error
+}
+
 /**
  * Maps a single integration source input to a typed IntegrationSource.
  *
@@ -92,6 +162,40 @@ export function parseSource(input: string, sourceRepo: string): IntegrationSourc
  */
 export function resolveSources(refs: readonly string[], sourceRepo: string): IntegrationSource[] {
   return refs.map(input => parseSource(input, sourceRepo))
+}
+
+export async function resolveCarryManifest(
+  base: string,
+  refs: readonly string[],
+  sourceRepo: string,
+  resolveSha: SourceShaResolver,
+): Promise<CarryManifest> {
+  if (base.trim().length === 0) throw new Error('Carry manifest base must not be empty')
+
+  const sources = resolveSources(refs, sourceRepo)
+  const carries: CarryManifestEntry[] = []
+  for (const [index, source] of sources.entries()) {
+    if (source === undefined) throw new Error(`Carry manifest source ${index} is missing`)
+    let resolvedSha: string
+    try {
+      resolvedSha = (await resolveSha(source)).trim().toLowerCase()
+    } catch (error) {
+      throw carrySourceResolutionError(source, error)
+    }
+    if (SHA_PATTERN.test(resolvedSha) === false) {
+      throw carrySourceResolutionError(source, new Error(`resolver returned invalid SHA ${resolvedSha}`))
+    }
+    carries.push(Object.freeze({ref: refs[index] ?? source.label, resolvedSha}))
+  }
+
+  return Object.freeze({base, carries: Object.freeze(carries)})
+}
+
+export function sourcesFromCarryManifest(manifest: CarryManifest, sourceRepo: string): ResolvedIntegrationSource[] {
+  return manifest.carries.map(carry => {
+    const source = parseSource(carry.ref, sourceRepo)
+    return {...source, resolvedSha: carry.resolvedSha}
+  })
 }
 
 function watchSlug(owner: string, repo: string): string {


### PR DESCRIPTION
## What

Carry refs resolve to concrete commit SHAs once, in trusted code, and both integration paths consume the same frozen manifest.

## Why

Carries are configured as PR URLs and resolved through `refs/pull/<n>/head`, which moves. Upstream can push to a PR between two runs, or between the authoritative integration and the forward shadow inside a single run.

That makes shadow comparison unsound: a divergence caused by upstream moving a head is indistinguishable from a divergence caused by different conflict resolution.

## What changed

Resolution happens once and produces a `CarryManifest` of the base plus each carry's resolved SHA. Both consumers receive the identical manifest.

Fetching an arbitrary SHA directly proved unreliable against GitHub, so each carry is fetched by ref and the resolved SHA is then asserted against the manifest. A mismatch fails closed with `CarrySourceChangedError` reporting expected and fetched SHAs, rather than silently integrating different bytes.

`emitProvenanceManifest` in the platform build script previously hardcoded `integrationRefs` to an empty array, discarding carry provenance written by the integration engine. It now preserves the existing manifest when present.

## Note

The historical defect where every carry's `resolvedSha` was populated with the final integration commit is not present in current code. Per-carry SHAs were already captured correctly; what was missing was shared resolution and drift detection.
