### PR TITLE
fix(harness): bound integration and forward-shadow execution

### DIFF
--- a/.github/workflows/harness-integrate.yaml
+++ b/.github/workflows/harness-integrate.yaml
@@ -63,6 +63,9 @@ jobs:
   integrate:
     name: integrate
     runs-on: ubuntu-latest
+    # INTEGRATION_JOB_TIMEOUT_MINUTES = 120. Leaves room for evidence recording
+    # while preventing the reusable job from inheriting GitHub's 360-minute default.
+    timeout-minutes: 120
 
     permissions:
       id-token: write
@@ -159,6 +162,9 @@ jobs:
         id: shadow-integrate
         if: ${{ always() }}
         continue-on-error: true
+        # FORWARD_SHADOW_STEP_TIMEOUT_MINUTES = 90. Healthy shadow runs need
+        # clone/fetch/merge/model/build headroom, but must stop before the job backstop.
+        timeout-minutes: 90
         env:
           BASE_VERSION: ${{ inputs.base-version }}
           SHADOW_WORK_DIR: ${{ runner.temp }}/harness-shadow-work

--- a/packages/harness/src/conflict-resolver.ts
+++ b/packages/harness/src/conflict-resolver.ts
@@ -36,6 +36,8 @@ export const MAX_CONFLICT_CONTEXT_BYTES = 48 * 1024
 export const MAX_CONFLICT_CONTEXT_FILES = 8
 export const MAX_CONFLICT_CONTEXT_REQUESTS = 8
 export const DEFAULT_CONFLICT_MODEL_TIMEOUT_MS = 30 * 60 * 1000
+/** Shadow evidence model deadline: enough for a repair attempt, bounded below the authoritative 30-minute budget. */
+export const DEFAULT_SHADOW_CONFLICT_MODEL_TIMEOUT_MS = 5 * 60 * 1000
 const MODEL_OUTPUT_MAX_BUFFER = 8 * 1024 * 1024
 
 const RUNTIME_ENV_KEYS = [

--- a/packages/harness/src/forward-shadow-command.ts
+++ b/packages/harness/src/forward-shadow-command.ts
@@ -68,6 +68,7 @@ const INTEGRATION_STAGES: Readonly<Record<IntegrationStage, true>> = {
   provenance: true,
   cleanup: true,
   push: true,
+  deadline: true,
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/harness/src/integrate-command.ts
+++ b/packages/harness/src/integrate-command.ts
@@ -30,6 +30,7 @@ import os from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
 import {fileURLToPath} from 'node:url'
+import {DEFAULT_SHADOW_CONFLICT_MODEL_TIMEOUT_MS} from './conflict-resolver.js'
 import {formatPipelineError} from './format-error.js'
 import {buildIntegrationOutcomeFile, writeIntegrationOutcomeFile} from './forward-shadow.js'
 import {makeRealAdapters, runIntegration, writeProvenanceManifest} from './integrate.js'
@@ -607,7 +608,9 @@ export async function cmdIntegrate(
 
   // Run the integration and package the artifact.
   try {
-    const adapters = makeRealAdapters()
+    const adapters = makeRealAdapters({
+      conflictModelTimeoutMs: config.dryRun === true ? DEFAULT_SHADOW_CONFLICT_MODEL_TIMEOUT_MS : undefined,
+    })
     if (flags.candidate) {
       const result = await finalizeCandidateIntegration(config, outPath, adapters, _packageArtifact, logger)
       if (result.ok === true) {

--- a/packages/harness/src/integrate.test.ts
+++ b/packages/harness/src/integrate.test.ts
@@ -458,6 +458,67 @@ describe('runIntegration', () => {
     }
   })
 
+  it('returns a named deadline failure when the integration pipeline exceeds its configured bound', async () => {
+    // #given a local integration run whose clone stage never completes
+    const dir = await makeTmpDir()
+    try {
+      const resultPromise = runIntegration(
+        {
+          baseVersion: '1.15.13',
+          releaseRepo: 'anomalyco/opencode',
+          integrationRefs: [],
+          workDir: dir,
+          pipelineTimeoutMs: 20,
+        },
+        makeAdapters({
+          cloneRepo: async () => new Promise<void>(() => {}),
+          dispose: async () => new Promise<void>(() => {}),
+        }),
+      )
+
+      // #when the driver deadline expires during clone
+      const result = await resultPromise
+
+      // #then the failure names both the deadline and the active stage
+      expect(result.ok).toBe(false)
+      if (result.ok) throw new Error('expected deadline failure')
+      expect(result.stage).toBe('deadline')
+      expect(result.error).toMatch(/integration pipeline deadline exceeded during clone/)
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+
+  it('reports a named timeout when a git subprocess exceeds its bound', async () => {
+    // #given a local repository and a local git shim that deliberately stalls
+    const dir = await makeTmpDir()
+    const sourceRepo = path.join(dir, 'source.git')
+    const gitShim = path.join(dir, 'git-stall.sh')
+    try {
+      execFileSync('git', ['init', '--bare', sourceRepo], {encoding: 'utf8'})
+      await fs.writeFile(gitShim, '#!/bin/sh\nsleep 1\n', {encoding: 'utf8', mode: 0o700})
+      const adapters = makeRealAdapters({hooksRoot: dir, gitBin: gitShim, gitTimeoutMs: 20})
+
+      // #when a local clone invokes the stalled git subprocess
+      const clone = adapters.cloneRepo(`file://${sourceRepo}`, path.join(dir, 'clone'))
+
+      // #then the timeout is attributable to the git subprocess rather than generic
+      let caughtError: unknown
+      try {
+        await clone
+      } catch (error) {
+        caughtError = error
+      }
+      expect(caughtError).toBeInstanceOf(Error)
+      if (!(caughtError instanceof Error)) throw new Error('expected git timeout error')
+      expect(caughtError.name).toBe('GitSubprocessTimeoutError')
+      expect(caughtError.message).toMatch(/git subprocess timed out after 20ms/)
+      await adapters.dispose?.()
+    } finally {
+      await fs.rm(dir, {recursive: true, force: true})
+    }
+  })
+
   // ---------------------------------------------------------------------------
   // Happy path: successful integration with refs
   // ---------------------------------------------------------------------------

--- a/packages/harness/src/integrate.ts
+++ b/packages/harness/src/integrate.ts
@@ -29,6 +29,11 @@ import {
   sourcesFromCarryManifest,
 } from './sources.js'
 
+/** Driver deadline: leaves the workflow backstop time to record a named failure and upload evidence. */
+export const DEFAULT_INTEGRATION_PIPELINE_TIMEOUT_MS = 75 * 60 * 1000
+/** Git command deadline: generous for a large hosted-runner clone/fetch, short enough to fail a wedged process. */
+export const GIT_SUBPROCESS_TIMEOUT_MS = 10 * 60 * 1000
+
 // Re-export so callers that previously imported from integrate.ts still work.
 export type {IntegrationRefRecord} from './provenance.js'
 
@@ -74,6 +79,8 @@ export interface IntegrationConfig {
   readonly brokerAuthJson?: string
   readonly runnerTempDir?: string
   readonly promptPath?: string
+  /** Overall driver deadline; callers may shorten it for fail-soft shadow evidence. */
+  readonly pipelineTimeoutMs?: number
 }
 
 export type MergeOutcome =
@@ -122,6 +129,7 @@ export type IntegrationStage =
   | 'provenance'
   | 'cleanup'
   | 'push'
+  | 'deadline'
 
 export type IntegrationResult =
   | {
@@ -349,6 +357,12 @@ function trustedGitEnv(): NodeJS.ProcessEnv {
 
 export interface RealAdapterOptions {
   readonly hooksRoot?: string
+  /** Test seam for exercising subprocess timeout handling without network access. */
+  readonly gitBin?: string
+  /** Test seam; production uses GIT_SUBPROCESS_TIMEOUT_MS. */
+  readonly gitTimeoutMs?: number
+  /** Shadow callers may shorten model attempts without changing authoritative integration. */
+  readonly conflictModelTimeoutMs?: number
 }
 
 interface GitSubprocess {
@@ -358,7 +372,20 @@ interface GitSubprocess {
   readonly dispose: () => Promise<void>
 }
 
-function makeGitSubprocess(hooksRoot: string): GitSubprocess {
+function isGitSubprocessTimeout(error: unknown): boolean {
+  if (error === null || typeof error !== 'object') return false
+  const record = error as Record<string, unknown>
+  return record.code === 'ETIMEDOUT' || (record.killed === true && record.signal === 'SIGTERM')
+}
+
+function gitSubprocessError(error: unknown, args: readonly string[], timeoutMs: number): unknown {
+  if (isGitSubprocessTimeout(error) === false) return error
+  const timeoutError = new Error(`git subprocess timed out after ${timeoutMs}ms: git ${args.join(' ')}`)
+  timeoutError.name = 'GitSubprocessTimeoutError'
+  return timeoutError
+}
+
+function makeGitSubprocess(hooksRoot: string, gitBin = 'git', timeoutMs = GIT_SUBPROCESS_TIMEOUT_MS): GitSubprocess {
   let hooksPathPromise: Promise<string> | undefined
   let disposePromise: Promise<void> | undefined
   let disposeRequested = false
@@ -389,21 +416,25 @@ function makeGitSubprocess(hooksRoot: string): GitSubprocess {
     begin()
     try {
       const disabledHooksPath = await hooksPath()
-      const result = await execFileAsync(
-        'git',
-        [
-          '-c',
-          'credential.helper=',
-          '-c',
-          'core.askPass=',
-          ...HARNESS_GIT_IDENTITY,
-          '-c',
-          `core.hooksPath=${disabledHooksPath}`,
-          ...args,
-        ],
-        {cwd, encoding: 'utf8', env},
-      )
-      return result.stdout.trim()
+      try {
+        const result = await execFileAsync(
+          gitBin,
+          [
+            '-c',
+            'credential.helper=',
+            '-c',
+            'core.askPass=',
+            ...HARNESS_GIT_IDENTITY,
+            '-c',
+            `core.hooksPath=${disabledHooksPath}`,
+            ...args,
+          ],
+          {cwd, encoding: 'utf8', env, timeout: timeoutMs},
+        )
+        return result.stdout.trim()
+      } catch (error) {
+        throw gitSubprocessError(error, args, timeoutMs)
+      }
     } finally {
       end()
     }
@@ -413,21 +444,25 @@ function makeGitSubprocess(hooksRoot: string): GitSubprocess {
     begin()
     try {
       const disabledHooksPath = await hooksPath()
-      const result = await execFileAsync(
-        'git',
-        [
-          '-c',
-          'credential.helper=',
-          '-c',
-          'core.askPass=',
-          ...HARNESS_GIT_IDENTITY,
-          '-c',
-          `core.hooksPath=${disabledHooksPath}`,
-          ...args,
-        ],
-        {cwd, encoding: 'buffer', env},
-      )
-      return Buffer.isBuffer(result.stdout) ? result.stdout : Buffer.from(result.stdout)
+      try {
+        const result = await execFileAsync(
+          gitBin,
+          [
+            '-c',
+            'credential.helper=',
+            '-c',
+            'core.askPass=',
+            ...HARNESS_GIT_IDENTITY,
+            '-c',
+            `core.hooksPath=${disabledHooksPath}`,
+            ...args,
+          ],
+          {cwd, encoding: 'buffer', env, timeout: timeoutMs},
+        )
+        return Buffer.isBuffer(result.stdout) ? result.stdout : Buffer.from(result.stdout)
+      } catch (error) {
+        throw gitSubprocessError(error, args, timeoutMs)
+      }
     } finally {
       end()
     }
@@ -437,12 +472,16 @@ function makeGitSubprocess(hooksRoot: string): GitSubprocess {
     begin()
     try {
       const disabledHooksPath = await hooksPath()
-      const result = await execFileAsync(
-        'git',
-        ['-c', 'credential.helper=', ...HARNESS_GIT_IDENTITY, '-c', `core.hooksPath=${disabledHooksPath}`, ...args],
-        {cwd, encoding: 'utf8', env},
-      )
-      return result.stdout.trim()
+      try {
+        const result = await execFileAsync(
+          gitBin,
+          ['-c', 'credential.helper=', ...HARNESS_GIT_IDENTITY, '-c', `core.hooksPath=${disabledHooksPath}`, ...args],
+          {cwd, encoding: 'utf8', env, timeout: timeoutMs},
+        )
+        return result.stdout.trim()
+      } catch (error) {
+        throw gitSubprocessError(error, args, timeoutMs)
+      }
     } finally {
       end()
     }
@@ -676,7 +715,7 @@ async function prepareTrustedPushRepositoryReal(
 }
 
 export function makeRealAdapters(options: RealAdapterOptions = {}): IntegrationAdapters {
-  const git = makeGitSubprocess(options.hooksRoot ?? os.tmpdir())
+  const git = makeGitSubprocess(options.hooksRoot ?? os.tmpdir(), options.gitBin, options.gitTimeoutMs)
   return {
     cloneRepo: async (repoUrl, workDir, tag) => {
       await fs.rm(workDir, {recursive: true, force: true})
@@ -743,7 +782,11 @@ export function makeRealAdapters(options: RealAdapterOptions = {}): IntegrationA
       }
     },
 
-    resolveConflict: async request => resolveConflictAttempt(request),
+    resolveConflict: async request =>
+      resolveConflictAttempt(
+        request,
+        options.conflictModelTimeoutMs === undefined ? {} : {modelTimeoutMs: options.conflictModelTimeoutMs},
+      ),
 
     stagePaths: async (workDir, paths) => {
       if (paths.length === 0) throw new Error('cannot stage an empty conflict path set')
@@ -873,6 +916,39 @@ function failure(stage: IntegrationStage, error: unknown): IntegrationResult {
   return {ok: false, kind: 'failure', stage, error: formatPipelineError(error)}
 }
 
+interface IntegrationDeadlineError extends Error {
+  readonly integrationStage: IntegrationStage
+  readonly timeoutMs: number
+}
+
+function integrationDeadlineError(stage: IntegrationStage, timeoutMs: number): IntegrationDeadlineError {
+  const error = new Error(`integration pipeline deadline exceeded during ${stage} after ${timeoutMs}ms`)
+  error.name = 'IntegrationDeadlineError'
+  Object.defineProperty(error, 'integrationStage', {value: stage})
+  Object.defineProperty(error, 'timeoutMs', {value: timeoutMs})
+  return error as IntegrationDeadlineError
+}
+
+function isIntegrationDeadlineError(error: unknown): error is IntegrationDeadlineError {
+  return error instanceof Error && error.name === 'IntegrationDeadlineError'
+}
+
+async function withIntegrationDeadline<T>(
+  operation: Promise<T>,
+  stage: () => IntegrationStage,
+  timeoutMs: number,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(integrationDeadlineError(stage(), timeoutMs)), timeoutMs)
+  })
+  try {
+    return await Promise.race([operation, deadline])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
+
 function treeExpectationFor(config: IntegrationConfig, integrationCommit: string): FinalTreeExpectation {
   return {
     baseTag: `v${config.baseVersion}`,
@@ -978,6 +1054,7 @@ function validateManifest(
 async function runIntegrationPipeline(
   config: IntegrationConfig,
   adapters: IntegrationAdapters,
+  setStage: (stage: IntegrationStage) => void,
 ): Promise<IntegrationResult> {
   const {baseVersion, releaseRepo, integrationRefs, workDir} = config
   // Callers on the pre-U5 API did not have a push target. Preserve their local
@@ -992,6 +1069,7 @@ async function runIntegrationPipeline(
   let releaseRepoUrl: string
   let sourceRepoUrl: string
   try {
+    setStage('sources')
     releaseRepoUrl = resolveReleaseRepoUrl(releaseRepo)
     sourceRepoUrl = config.sourceRepo === undefined ? releaseRepoUrl : resolveReleaseRepoUrl(config.sourceRepo)
   } catch (error) {
@@ -1001,6 +1079,7 @@ async function runIntegrationPipeline(
   let sources: ResolvedIntegrationSource[]
   let carryManifest: CarryManifest
   try {
+    setStage('sources')
     if (config.carryManifest === undefined) {
       if (integrationRefs.length > 0 && adapters.resolveRefSha === undefined) {
         throw new Error('immutable carry manifest resolution is unavailable')
@@ -1020,18 +1099,21 @@ async function runIntegrationPipeline(
   }
 
   try {
+    setStage('clone')
     await adapters.cloneRepo(releaseRepoUrl, workDir, tag)
   } catch (error) {
     return failure('clone', error)
   }
 
   try {
+    setStage('fetch-tags')
     await adapters.fetchTags(workDir)
   } catch (error) {
     return failure('fetch-tags', error)
   }
 
   try {
+    setStage('branch')
     await adapters.createBranch(workDir, branch, tag)
   } catch (error) {
     return failure('branch', error)
@@ -1041,6 +1123,7 @@ async function runIntegrationPipeline(
   const conflictDiagnostics: ConflictResolverResult[] = []
   for (const source of sources) {
     try {
+      setStage('fetch')
       await adapters.fetchRef(workDir, source.repo, source.fetchRef, source.fetch, source.resolvedSha)
     } catch (error) {
       return failure('fetch', `fetch ref ${source.label} failed: ${formatPipelineError(error)}`)
@@ -1048,6 +1131,7 @@ async function runIntegrationPipeline(
 
     let resolvedSha: string | null
     try {
+      setStage('provenance')
       resolvedSha = await adapters.captureRefSha(workDir)
     } catch (error) {
       return failure('provenance', `capture SHA for ${source.label} failed: ${formatPipelineError(error)}`)
@@ -1061,6 +1145,7 @@ async function runIntegrationPipeline(
 
     let preMergeCommit: string
     try {
+      setStage('merge')
       preMergeCommit = await adapters.getCommitSha(workDir)
     } catch (error) {
       return failure('merge', `capture pre-merge commit for ${source.label} failed: ${formatPipelineError(error)}`)
@@ -1068,6 +1153,7 @@ async function runIntegrationPipeline(
 
     let mergeOutcome: MergeOutcome
     try {
+      setStage('merge')
       mergeOutcome = await adapters.mergeRef(workDir, source.merge)
     } catch (error) {
       return failure('merge', `merge ref ${source.label} failed: ${formatPipelineError(error)}`)
@@ -1096,6 +1182,7 @@ async function runIntegrationPipeline(
 
       let resolution: ConflictResolverResult
       try {
+        setStage('merge')
         resolution = await adapters.resolveConflict({
           integrationWorkDir: workDir,
           preConflictCommit: preMergeCommit,
@@ -1145,6 +1232,7 @@ async function runIntegrationPipeline(
       }
 
       try {
+        setStage('merge')
         await adapters.stagePaths(workDir, resolution.resolvedPaths)
         await adapters.verifyStagedPaths(workDir, resolution.resolvedDigests)
         await adapters.assertNoUnmerged(workDir)
@@ -1164,18 +1252,21 @@ async function runIntegrationPipeline(
   const squashed = sources.length > 0
   if (squashed) {
     try {
+      setStage('squash')
       await adapters.resetToBase(workDir, tag)
     } catch (error) {
       return failure('squash', error)
     }
 
     try {
+      setStage('workflow-strip')
       await adapters.stripWorkflowFiles(workDir)
     } catch (error) {
       return failure('workflow-strip', error)
     }
 
     try {
+      setStage('commit')
       await adapters.commitIntegration(
         workDir,
         `harness: integrate OpenCode ${baseVersion} carrying ${sources.map(s => s.label).join(', ')}`,
@@ -1187,6 +1278,7 @@ async function runIntegrationPipeline(
 
   let integrationCommit: string
   try {
+    setStage('commit')
     integrationCommit = await adapters.getCommitSha(workDir)
   } catch (error) {
     return failure('commit', error)
@@ -1195,18 +1287,21 @@ async function runIntegrationPipeline(
   const treeExpectation = treeExpectationFor(config, integrationCommit)
 
   try {
+    setStage('tree')
     await adapters.validateFinalTree(workDir, treeExpectation)
   } catch (error) {
     return failure('tree', error)
   }
 
   try {
+    setStage('build')
     await adapters.buildCli(workDir, baseVersion, channel)
   } catch (error) {
     return failure('build', error)
   }
 
   try {
+    setStage('version')
     await adapters.verifyVersion(workDir, baseVersion)
   } catch (error) {
     return failure('version', error)
@@ -1215,6 +1310,7 @@ async function runIntegrationPipeline(
   // Recheck the frozen commit/tree after build and version verification. This is
   // the first point at which a build hook could have moved HEAD.
   try {
+    setStage('tree')
     await assertFrozenIntegrationHead(adapters, workDir, integrationCommit)
     await adapters.validateFinalTree(workDir, treeExpectation)
     await assertFrozenIntegrationHead(adapters, workDir, integrationCommit)
@@ -1237,6 +1333,7 @@ async function runIntegrationPipeline(
   if (manifestError !== null) return failure('provenance', manifestError)
 
   try {
+    setStage('provenance')
     await writeProvenanceManifest(workDir, manifest)
   } catch (error) {
     return failure('provenance', error)
@@ -1259,20 +1356,40 @@ export async function runIntegration(
   let pipelineThrew = false
   let disposeError: unknown
   let disposeThrew = false
-
+  let deadlineExceeded = false
   try {
     try {
-      pipelineResult = await runIntegrationPipeline(config, adapters)
+      let activeStage: IntegrationStage = 'sources'
+      const timeoutMs = config.pipelineTimeoutMs ?? DEFAULT_INTEGRATION_PIPELINE_TIMEOUT_MS
+      pipelineResult = await withIntegrationDeadline(
+        runIntegrationPipeline(config, adapters, stage => {
+          activeStage = stage
+        }),
+        () => activeStage,
+        timeoutMs,
+      )
     } catch (error) {
-      pipelineThrew = true
-      pipelineError = error
+      if (isIntegrationDeadlineError(error)) {
+        deadlineExceeded = true
+        pipelineResult = failure('deadline', error)
+      } else {
+        pipelineThrew = true
+        pipelineError = error
+      }
     }
   } finally {
-    try {
-      await adapters.dispose?.()
-    } catch (error) {
-      disposeThrew = true
-      disposeError = error
+    if (deadlineExceeded) {
+      // Do not let cleanup of an already-bounded subprocess hide the deadline
+      // record; the adapter owns its own subprocess timeout and best-effort cleanup.
+      const dispose = adapters.dispose
+      if (dispose !== undefined) dispose().catch(() => undefined)
+    } else {
+      try {
+        await adapters.dispose?.()
+      } catch (error) {
+        disposeThrew = true
+        disposeError = error
+      }
     }
   }
 

--- a/scripts/fro-bot-workflow.test.ts
+++ b/scripts/fro-bot-workflow.test.ts
@@ -502,6 +502,17 @@ describe('harness forward-shadow workflow wiring', () => {
   const integratePath = '.github/workflows/harness-integrate.yaml'
   const releasePath = '.github/workflows/harness-release.yaml'
 
+  it('bounds the integrate job and forward-shadow step independently', () => {
+    // #given the checked-in reusable integration workflow
+    const job = rawJob(integratePath, 'integrate')
+    const steps = stepsFor(integratePath, 'integrate')
+    const shadow = stepById(steps, 'shadow-integrate')
+
+    // #then the job backstop leaves room for the fail-soft shadow step to report evidence
+    expect(job['timeout-minutes']).toBe(120)
+    expect(shadow['timeout-minutes']).toBe(90)
+  })
+
   it('keeps harness-integrate to one job with unchanged permissions and no secret inheritance', () => {
     // #given
     const workflow = loadRawWorkflow(integratePath)


### PR DESCRIPTION
## What

Nothing in the integrate workflow had a time bound. This adds a layered set, so a wedged run fails fast with an attributable error instead of consuming a runner in silence.

## Why

A recent dry run ended with the hosted runner losing communication with the server. The job had run 63 minutes, three steps finished with null conclusions, no log blob was ever written, and no evidence artifact was uploaded. The failure is undiagnosable because nothing survived it.

Several gaps made that outcome possible. The workflow carried no `timeout-minutes` at any level, so it inherited GitHub's 360-minute default. The forward-shadow step is deliberately `continue-on-error: true`, since shadow evidence must never block a release — but combined with no timeout, a wedged resolver can consume six hours and still report the job green. The resolver's own budget of two attempts at thirty minutes across twelve carry refs is a theoretical twelve hours of model time before any clone, merge, or build. And git subprocesses had no timeout at all, so clone, tag fetch, twelve ref fetches, merges, and validation were unbounded.

## The bounds

Each is a named constant with its reasoning recorded at the definition.

Shadow model attempts get five minutes, shorter than the authoritative thirty because shadow work is evidence collection rather than the release critical path. Git subprocesses get ten minutes, generous for a large clone on a hosted runner. The driver itself gets a seventy-five minute deadline. The shadow step gets ninety, and the job gets one hundred twenty.

They nest deliberately: each inner bound expires before the one containing it, so the innermost failure is the one reported.

The driver deadline matters most for diagnosis. A workflow timeout kills the process and produces nothing — which is exactly why the runner death remains unexplained. The driver stopping on its own fails with a named stage that reaches the shadow record.

Git timeouts surface as `GitSubprocessTimeoutError` naming both the bound and the command. Non-timeout errors pass through unchanged.

## Calibration

The observed numbers are thin: one authoritative integration at roughly fifteen minutes, and one shadow run at roughly forty-eight minutes when the runner died. Before a recent fix the shadow failed in twenty-one seconds without doing real work, so there is no healthy long-run baseline. The bounds are set to give real headroom rather than to be tight, and should be revisited once successful runs provide a distribution.

## Unchanged

The shadow step keeps `continue-on-error: true`; a shadow timeout does not fail the job. The single-job structure, scoped `id-token: write`, late credential minting, blank model-facing tokens, absence of secret inheritance, and the no-post-hook mint requirement are all preserved.
