### PR TITLE
fix(ci): allow pkg.pr.new egress for the harness integration build

### DIFF
--- a/.github/workflows/harness-integrate.yaml
+++ b/.github/workflows/harness-integrate.yaml
@@ -78,6 +78,8 @@ jobs:
           egress-policy: block
           disable-telemetry: true
           disable-sudo-and-containers: true
+          # Upstream OpenCode pins @solidjs/start to a pkg.pr.new preview build in its root
+          # package.json, so bun install --frozen-lockfile cannot complete without it.
           allowed-endpoints: >-
             api.github.com:443
             broker.fro.bot:443
@@ -87,6 +89,7 @@ jobs:
             github.com:443
             models.dev:443
             nodejs.org:443
+            pkg.pr.new:443
             registry.npmjs.org:443
             *.actions.githubusercontent.com:443
             *.githubusercontent.com:443

--- a/scripts/fro-bot-workflow.test.ts
+++ b/scripts/fro-bot-workflow.test.ts
@@ -538,6 +538,38 @@ describe('harness forward-shadow workflow wiring', () => {
     expect(JSON.stringify(workflow)).not.toContain('secrets: inherit')
   })
 
+  it('allows only the pinned OpenCode preview dependency host in the blocked egress list', () => {
+    // #given the checked-in runner hardening step
+    const job = rawJob(integratePath, 'integrate')
+    const harden = stepsFor(integratePath, 'integrate').find(step => step.name === 'Harden runner egress')
+    if (harden === undefined) throw new TypeError('Harden runner egress step is missing')
+    const hardenWith = harden.with as Record<string, unknown>
+
+    // #then the policy remains blocked and the allowlist changes only by adding pkg.pr.new
+    expect(hardenWith['egress-policy']).toBe('block')
+    expect(hardenWith['allowed-endpoints']).toBe(
+      [
+        'api.github.com:443',
+        'broker.fro.bot:443',
+        'bun.sh:443',
+        'codeload.github.com:443',
+        'cliproxy.fro.bot:443',
+        'github.com:443',
+        'models.dev:443',
+        'nodejs.org:443',
+        'pkg.pr.new:443',
+        'registry.npmjs.org:443',
+        '*.actions.githubusercontent.com:443',
+        '*.githubusercontent.com:443',
+      ].join(' '),
+    )
+
+    const raw = readFileSync(integratePath, 'utf8')
+    expect(raw).toContain('# Upstream OpenCode pins @solidjs/start to a pkg.pr.new preview build in its root')
+    expect(raw).toContain('# package.json, so bun install --frozen-lockfile cannot complete without it.')
+    expect(job.permissions).toEqual({'id-token': 'write', contents: 'read'})
+  })
+
   it('orders authoritative Run Fro Bot, trusted freeze, then shadow evidence', () => {
     // #given
     const steps = stepsFor(integratePath, 'integrate')


### PR DESCRIPTION
## What

Adds `pkg.pr.new:443` to the integrate workflow's egress allowlist.

## Why

The trusted build fails during dependency installation:

```
error: failed to download @solidjs/start@https://[REDACTED]@dfb2020: ConnectionRefused
```

Upstream OpenCode pins that dependency to a preview build in its root manifest:

```json
"@solidjs/start": "https://pkg.pr.new/@solidjs/start@dfb2020"
```

The workflow runs with `egress-policy: block`, and `pkg.pr.new` was not on the allowlist, so the connection was refused at the network layer after 539 packages had already resolved.

The egress hardening predates this by six weeks; it is not a regression. The install simply moved from the model to trusted code, which is where it now surfaces.

Worth noting what this reveals about the run that motivated the trusted-build change: the model was instructed to run `bun install` and reported that the build succeeded and the smoke test passed. That install could not have completed with this host blocked. It joins a non-compiling pushed tree and a build against a dirty working directory as the third unreliable claim from that single run.

## Scope

Every non-registry dependency specifier across upstream's manifests was audited rather than fixing one blocked host per failed run. Two exist: this one, and `ghostty-web`, which resolves through `github.com` and `codeload.github.com` and was already allowed. The lockfile records `pkg.pr.new` as the only non-registry host, which corroborates that. Remaining URLs in those manifests are metadata — schema, homepage, bugs, repository — and are never fetched during install.

`egress-policy: block` is unchanged and no other host was added. A workflow assertion now pins the exact allowlist, so future additions are deliberate rather than incidental.

## Tradeoff

`pkg.pr.new` serves continuous preview builds published from pull requests, so allowing it widens the trusted build's egress to community-published artifacts. That is unavoidable while building upstream's tree as pinned — the dependency is upstream's choice, fixed at a specific build. Vendoring it would diverge from the lockfile and require maintenance on every base version bump.
