### PR TITLE
fix(harness): restore force semantics to the trusted integration push

### DIFF
--- a/packages/harness/src/format-error.test.ts
+++ b/packages/harness/src/format-error.test.ts
@@ -221,6 +221,28 @@ describe('formatPipelineError', () => {
     expect(result).toBe('short error')
   })
 
+  it('keeps useful multi-line git rejection details visible', () => {
+    // #given
+    const err = new Error(
+      [
+        'Command failed: git push --no-verify https://github.com/fro-bot/agent.git',
+        '! [rejected] c9fda554:refs/harness-integrate/1.18.18 (stale info)',
+        'error: failed to push some refs to https://github.com/fro-bot/agent.git',
+        'hint: Updates were rejected because the remote ref moved underneath this run.',
+        'hint: Verify the integration ref before retrying the release.',
+      ].join('\n'),
+    )
+
+    // #when
+    const result = formatPipelineError(err)
+
+    // #then
+    expect(result).toContain('stale info')
+    expect(result).toContain('remote ref moved underneath this run')
+    expect(result.length).toBeGreaterThan(300)
+    expect(result.endsWith('...')).toBe(false)
+  })
+
   it('handles null safely', () => {
     // #given / #when
     const result = formatPipelineError(null)

--- a/packages/harness/src/format-error.ts
+++ b/packages/harness/src/format-error.ts
@@ -13,7 +13,7 @@
  */
 
 /** Maximum length of the formatted error message (characters). */
-export const FORMAT_ERROR_MAX_LENGTH = 300
+export const FORMAT_ERROR_MAX_LENGTH = 2000
 
 /** Placeholder substituted for each redacted secret. */
 const REDACTED = '[REDACTED]'

--- a/packages/harness/src/integrate.test.ts
+++ b/packages/harness/src/integrate.test.ts
@@ -70,6 +70,60 @@ async function withEnvironment<T>(
   }
 }
 
+async function makeGitUrlWrapper(targetUrl: string, remoteDir: string): Promise<string> {
+  const wrapperPath = path.join(await makeTmpDir(), 'git-wrapper.mjs')
+  await fs.writeFile(
+    wrapperPath,
+    String.raw`#!/usr/bin/env node
+import {appendFileSync} from 'node:fs'
+import {spawnSync} from 'node:child_process'
+
+const args = process.argv.slice(2)
+const logPath = process.env.TEST_GIT_LOG
+if (logPath !== undefined) appendFileSync(logPath, JSON.stringify(args) + '\n')
+
+if (args.includes('push') && process.env.TEST_MOVE_SHA !== undefined) {
+  const update = spawnSync('git', ['--git-dir', ${JSON.stringify(remoteDir)}, 'update-ref', process.env.TEST_MOVE_REF ?? '', process.env.TEST_MOVE_SHA], {
+    encoding: 'utf8',
+  })
+  if (update.status !== 0) {
+    process.stderr.write(update.stderr ?? '')
+    process.exit(update.status ?? 1)
+  }
+}
+
+const rewritten = args.map(arg => (arg === ${JSON.stringify(targetUrl)} ? ${JSON.stringify(remoteDir)} : arg))
+const result = spawnSync('git', rewritten, {stdio: 'inherit'})
+if (result.error !== undefined) {
+  process.stderr.write(String(result.error))
+  process.exit(1)
+}
+process.exit(result.status ?? 1)
+`,
+    {encoding: 'utf8', mode: 0o700},
+  )
+  return wrapperPath
+}
+
+async function makeGitSourceRepository(): Promise<{
+  readonly dir: string
+  readonly firstSha: string
+  readonly headSha: string
+}> {
+  const dir = await makeTmpDir()
+  runGit(dir, ['init', '--quiet'])
+  runGit(dir, ['config', 'user.name', 'harness-test'])
+  runGit(dir, ['config', 'user.email', 'harness-test@example.invalid'])
+  await fs.writeFile(path.join(dir, 'file.txt'), 'first\n', 'utf8')
+  runGit(dir, ['add', 'file.txt'])
+  runGit(dir, ['commit', '--quiet', '-m', 'first'])
+  const firstSha = runGit(dir, ['rev-parse', 'HEAD'])
+  await fs.writeFile(path.join(dir, 'file.txt'), 'second\n', 'utf8')
+  runGit(dir, ['commit', '--quiet', '-am', 'second'])
+  const headSha = runGit(dir, ['rev-parse', 'HEAD'])
+  return {dir, firstSha, headSha}
+}
+
 // ---------------------------------------------------------------------------
 // Provenance round-trip
 // ---------------------------------------------------------------------------
@@ -980,6 +1034,150 @@ describe('frozen carry fetches', () => {
       await adapters.dispose?.()
       await fs.rm(sourceDir, {recursive: true, force: true})
       await fs.rm(workDir, {recursive: true, force: true})
+    }
+  })
+})
+
+describe('trusted integration push leases', () => {
+  it('pushes when the remote ref matches the lease expectation', async () => {
+    // #given
+    const source = await makeGitSourceRepository()
+    const remoteDir = await makeTmpDir()
+    const logPath = path.join(await makeTmpDir(), 'git-args.log')
+    const targetUrl = 'https://local.test/fro-bot/agent.git'
+    const targetRef = 'refs/harness-integrate/test'
+    runGit(remoteDir, ['init', '--bare', '--quiet'])
+    runGit(source.dir, ['push', '--quiet', remoteDir, `${source.firstSha}:${targetRef}`])
+    runGit(source.dir, ['push', '--quiet', remoteDir, `${source.headSha}:refs/hidden/source`])
+    const gitBin = await makeGitUrlWrapper(targetUrl, remoteDir)
+    const adapters = makeRealAdapters({gitBin})
+
+    try {
+      // #when
+      await withEnvironment({TEST_GIT_LOG: logPath}, async () => {
+        await adapters.pushIntegration(
+          {workDir: source.dir, integrationCommit: source.headSha, cleanup: async () => {}},
+          source.headSha,
+          {repository: targetUrl, ref: targetRef},
+          {token: 'test-token'},
+        )
+      })
+
+      // #then
+      expect(runGit(remoteDir, [`rev-parse`, `${targetRef}^{commit}`])).toBe(source.headSha)
+      const loggedArgs = (await fs.readFile(logPath, 'utf8'))
+        .trim()
+        .split('\n')
+        .map(line => JSON.parse(line) as string[])
+        .find(args => args.includes('push'))
+      if (loggedArgs === undefined) throw new Error('expected wrapper to log a push')
+      const pushIndex = loggedArgs.indexOf('push')
+      expect(loggedArgs.slice(pushIndex)).toEqual([
+        'push',
+        '--no-verify',
+        `--force-with-lease=${targetRef}:${source.firstSha}`,
+        targetUrl,
+        `${source.headSha}:${targetRef}`,
+      ])
+    } finally {
+      await adapters.dispose?.()
+      await fs.rm(source.dir, {recursive: true, force: true})
+      await fs.rm(remoteDir, {recursive: true, force: true})
+      await fs.rm(path.dirname(gitBin), {recursive: true, force: true})
+      await fs.rm(path.dirname(logPath), {recursive: true, force: true})
+    }
+  })
+
+  it('rejects a ref that moved underneath the run with a named lease error', async () => {
+    // #given
+    const source = await makeGitSourceRepository()
+    const remoteDir = await makeTmpDir()
+    const logPath = path.join(await makeTmpDir(), 'git-args.log')
+    const targetUrl = 'https://local.test/fro-bot/agent.git'
+    const targetRef = 'refs/harness-integrate/test'
+    runGit(remoteDir, ['init', '--bare', '--quiet'])
+    runGit(source.dir, ['push', '--quiet', remoteDir, `${source.firstSha}:${targetRef}`])
+    await fs.writeFile(path.join(source.dir, 'file.txt'), 'moved\n', 'utf8')
+    runGit(source.dir, ['commit', '--quiet', '-am', 'moved'])
+    const movedSha = runGit(source.dir, ['rev-parse', 'HEAD'])
+    runGit(source.dir, ['push', '--quiet', remoteDir, `${movedSha}:refs/hidden/moved`])
+    const gitBin = await makeGitUrlWrapper(targetUrl, remoteDir)
+    const adapters = makeRealAdapters({gitBin})
+
+    try {
+      // #when / #then
+      const rejection: unknown = await withEnvironment<unknown>(
+        {TEST_GIT_LOG: logPath, TEST_MOVE_REF: targetRef, TEST_MOVE_SHA: movedSha},
+        async (): Promise<unknown> => {
+          try {
+            await adapters.pushIntegration(
+              {workDir: source.dir, integrationCommit: source.headSha, cleanup: async () => {}},
+              source.headSha,
+              {repository: targetUrl, ref: targetRef},
+              {token: 'test-token'},
+            )
+            return undefined
+          } catch (error) {
+            return error
+          }
+        },
+      )
+      expect(rejection).toBeInstanceOf(Error)
+      if (!(rejection instanceof Error)) throw new Error('expected trusted push to reject')
+      expect(rejection.name).toBe('TrustedPushLeaseRejectedError')
+      expect(rejection.message).toMatch(/moved underneath/)
+      expect(runGit(remoteDir, [`rev-parse`, `${targetRef}^{commit}`])).toBe(movedSha)
+    } finally {
+      await adapters.dispose?.()
+      await fs.rm(source.dir, {recursive: true, force: true})
+      await fs.rm(remoteDir, {recursive: true, force: true})
+      await fs.rm(path.dirname(gitBin), {recursive: true, force: true})
+      await fs.rm(path.dirname(logPath), {recursive: true, force: true})
+    }
+  })
+
+  it('pushes the first release when the target ref does not exist', async () => {
+    // #given
+    const source = await makeGitSourceRepository()
+    const remoteDir = await makeTmpDir()
+    const logPath = path.join(await makeTmpDir(), 'git-args.log')
+    const targetUrl = 'https://local.test/fro-bot/agent.git'
+    const targetRef = 'refs/harness-integrate/first-release'
+    runGit(remoteDir, ['init', '--bare', '--quiet'])
+    const gitBin = await makeGitUrlWrapper(targetUrl, remoteDir)
+    const adapters = makeRealAdapters({gitBin})
+
+    try {
+      // #when
+      await withEnvironment({TEST_GIT_LOG: logPath}, async () => {
+        await adapters.pushIntegration(
+          {workDir: source.dir, integrationCommit: source.headSha, cleanup: async () => {}},
+          source.headSha,
+          {repository: targetUrl, ref: targetRef},
+          {token: 'test-token'},
+        )
+      })
+
+      // #then
+      expect(runGit(remoteDir, [`rev-parse`, `${targetRef}^{commit}`])).toBe(source.headSha)
+      const loggedArgs = (await fs.readFile(logPath, 'utf8'))
+        .trim()
+        .split('\n')
+        .map(line => JSON.parse(line) as string[])
+        .find(args => args.includes('push'))
+      if (loggedArgs === undefined) throw new Error('expected wrapper to log a push')
+      const pushIndex = loggedArgs.indexOf('push')
+      expect(loggedArgs.slice(pushIndex, pushIndex + 3)).toEqual([
+        'push',
+        '--no-verify',
+        `--force-with-lease=${targetRef}:`,
+      ])
+    } finally {
+      await adapters.dispose?.()
+      await fs.rm(source.dir, {recursive: true, force: true})
+      await fs.rm(remoteDir, {recursive: true, force: true})
+      await fs.rm(path.dirname(gitBin), {recursive: true, force: true})
+      await fs.rm(path.dirname(logPath), {recursive: true, force: true})
     }
   })
 })

--- a/packages/harness/src/integrate.test.ts
+++ b/packages/harness/src/integrate.test.ts
@@ -6,7 +6,13 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import {describe, expect, it} from 'vitest'
-import {makeRealAdapters, readProvenanceManifest, runIntegration, writeProvenanceManifest} from './integrate.js'
+import {
+  makeRealAdapters,
+  readProvenanceManifest,
+  runIntegration,
+  TRUSTED_PUSH_LEASE_REJECTED_ERROR_NAME,
+  writeProvenanceManifest,
+} from './integrate.js'
 import * as integrateModule from './integrate.js'
 
 // ---------------------------------------------------------------------------
@@ -1124,7 +1130,7 @@ describe('trusted integration push leases', () => {
       )
       expect(rejection).toBeInstanceOf(Error)
       if (!(rejection instanceof Error)) throw new Error('expected trusted push to reject')
-      expect(rejection.name).toBe('TrustedPushLeaseRejectedError')
+      expect(rejection.name).toBe(TRUSTED_PUSH_LEASE_REJECTED_ERROR_NAME)
       expect(rejection.message).toMatch(/moved underneath/)
       expect(runGit(remoteDir, [`rev-parse`, `${targetRef}^{commit}`])).toBe(movedSha)
     } finally {

--- a/packages/harness/src/integrate.ts
+++ b/packages/harness/src/integrate.ts
@@ -656,6 +656,9 @@ function errorText(error: unknown): string {
   return String(error)
 }
 
+// `stale info` is git's authoritative marker for a rejected `--force-with-lease`. The second
+// pattern is a defensive fallback only: it would not survive git abbreviating the expected SHA
+// or localizing the message, so it must never be relied on as the primary signal.
 function isTrustedPushLeaseRejection(error: unknown): boolean {
   const text = errorText(error)
   return /stale info/i.test(text) || /cannot lock ref .*expected [0-9a-f]{40}/i.test(text)
@@ -669,6 +672,10 @@ function trustedPushLeaseRejectedError(targetRef: string, cause: unknown): Error
   return error
 }
 
+// The expected value is captured out-of-band because the trusted repository is materialized fresh
+// and has no local tracking ref for the target, so git has nothing to lease against implicitly.
+// A ref that moves between this lookup and the push is not a race: the lease rejects that push,
+// which is precisely the protection being bought here.
 async function resolvePushLeaseExpectation(
   git: GitSubprocess,
   target: IntegrationPushTarget,

--- a/packages/harness/src/integrate.ts
+++ b/packages/harness/src/integrate.ts
@@ -33,6 +33,8 @@ import {
 export const DEFAULT_INTEGRATION_PIPELINE_TIMEOUT_MS = 75 * 60 * 1000
 /** Git command deadline: generous for a large hosted-runner clone/fetch, short enough to fail a wedged process. */
 export const GIT_SUBPROCESS_TIMEOUT_MS = 10 * 60 * 1000
+/** Error name used when the trusted integration ref changed after lease capture. */
+export const TRUSTED_PUSH_LEASE_REJECTED_ERROR_NAME = 'TrustedPushLeaseRejectedError'
 
 // Re-export so callers that previously imported from integrate.ts still work.
 export type {IntegrationRefRecord} from './provenance.js'
@@ -645,6 +647,44 @@ function assertPushTarget(target: IntegrationPushTarget): void {
   }
 }
 
+function errorText(error: unknown): string {
+  if (error instanceof Error) {
+    const record = error as Error & {readonly stderr?: unknown}
+    const stderr = typeof record.stderr === 'string' ? record.stderr : ''
+    return `${error.message}\n${stderr}`
+  }
+  return String(error)
+}
+
+function isTrustedPushLeaseRejection(error: unknown): boolean {
+  const text = errorText(error)
+  return /stale info/i.test(text) || /cannot lock ref .*expected [0-9a-f]{40}/i.test(text)
+}
+
+function trustedPushLeaseRejectedError(targetRef: string, cause: unknown): Error {
+  const error = new Error(
+    `trusted integration ref moved underneath this run: ${targetRef}; ${formatPipelineError(cause)}`,
+  )
+  error.name = TRUSTED_PUSH_LEASE_REJECTED_ERROR_NAME
+  return error
+}
+
+async function resolvePushLeaseExpectation(
+  git: GitSubprocess,
+  target: IntegrationPushTarget,
+  workDir: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string> {
+  const output = await git.authExec(['ls-remote', '--refs', target.repository, target.ref], workDir, env)
+  const firstLine = splitLines(output)[0]
+  if (firstLine === undefined || firstLine.length === 0) return ''
+  const [sha, ref] = firstLine.split(/\s+/)
+  if (sha === undefined || ref !== target.ref || /^[0-9a-f]{40}$/i.test(sha) === false) {
+    throw new Error(`push target ref ${target.ref} did not resolve to a commit SHA`)
+  }
+  return sha.toLowerCase()
+}
+
 function assertCommitSha(commit: string): void {
   if (!/^[0-9a-f]{40}$/i.test(commit)) throw new Error('integration commit must be a full hexadecimal SHA')
 }
@@ -894,11 +934,20 @@ export function makeRealAdapters(options: RealAdapterOptions = {}): IntegrationA
         env.HARNESS_PUSH_TOKEN = credential.token
         env.GIT_ASKPASS = askpass
         env.GIT_TERMINAL_PROMPT = '0'
-        await git.authExec(
-          ['push', '--no-verify', target.repository, `${sourceRef}:${target.ref}`],
-          trustedRepository.workDir,
-          env,
-        )
+        const expectedOldValue = await resolvePushLeaseExpectation(git, target, trustedRepository.workDir, env)
+        const pushArgs = [
+          'push',
+          '--no-verify',
+          `--force-with-lease=${target.ref}:${expectedOldValue}`,
+          target.repository,
+          `${sourceRef}:${target.ref}`,
+        ] as const
+        try {
+          await git.authExec(pushArgs, trustedRepository.workDir, env)
+        } catch (error) {
+          if (isTrustedPushLeaseRejection(error)) throw trustedPushLeaseRejectedError(target.ref, error)
+          throw error
+        }
       } finally {
         await fs.rm(tempDir, {recursive: true, force: true})
       }


### PR DESCRIPTION
## What

The trusted push now uses `--force-with-lease` against an explicitly captured expected value, and failed git commands report enough of their output to be diagnosable.

## Why

The harness release dry run failed at the push:

```
push --no-verify https://github.com/fro-bot/agent.git c9fda554…:refs/harness-integrate/1.18.18; T...
```

Moving the push from the model into trusted code dropped the force flag the prompt had always carried. Each run integrates independently from the same base tag, so a new candidate is never a descendant of the previous one, and `refs/harness-integrate/1.18.18` already pointed at an earlier integration. The push was a non-fast-forward and was rejected.

Everything ahead of the push now works: dependency installation completes, the frozen tree builds, and version verification passes. This was the last blocker.

## Approach

A blind `--force` would contradict this project's standing rule against forced ref updates. That rule protects user-facing refs; the integration ref is machine-managed and deliberately replaced each run. Rather than treat that as an exemption, the push captures the ref's current value with an authenticated `ls-remote` and passes it as a lease, so it refuses to clobber a ref that changed underneath the run.

A first release for a base version has no existing ref, which the lease expresses as an empty expectation — the ref must not exist. A lease failure raises a named error distinguishing "the ref moved" from any other push failure.

The credential path is untouched: the token stays in the askpass helper, never in arguments or URLs, and the rule rejecting URL credentials still applies.

## Diagnosability

The failure above ends in `T…` because failed command output was truncated at 300 characters, cutting off git's message entirely and costing a full diagnostic cycle. The cap is now 2000, which fits multi-line git output such as a rejected push while remaining bounded.

Widening this cannot surface a credential: URL credentials are rejected before any push runs, and the token is only ever passed through the askpass helper.
