### PR TITLE
fix(harness): create the integration workdir and stop shallow-cloning in the prompt

### DIFF
--- a/.github/workflows/harness-integrate.yaml
+++ b/.github/workflows/harness-integrate.yaml
@@ -111,6 +111,13 @@ jobs:
         id: mint
         run: node --experimental-strip-types scripts/harness/mint-broker-credential.ts
 
+      # The external-directory allowlist grants the model `<workdir>/*`, which covers paths
+      # inside the workdir but not creation of the workdir itself. Without this, `git clone`
+      # cannot create its own target and the model clones into a subdirectory instead,
+      # leaving trusted finalization pointed at a path that is not a git repository.
+      - name: Create the integration workdir
+        run: mkdir -p "${{ runner.temp }}/harness-integrate-work"
+
       # SYNC: keep the shared merge inputs in step with fro-bot.yaml's Run Fro Bot step
       - name: Run Fro Bot
         uses: ./

--- a/packages/harness/prompt.txt
+++ b/packages/harness/prompt.txt
@@ -20,10 +20,10 @@ Do not read package.json, build scripts, action.yaml, or workflow files to under
 - DO NOT USE BASH with background: true. This will cause this non-interactive tool to exit before the job is done. If bash gets auto-promoted to background, poll bash_status even when the tool says otherwise. This is IMPORTANT because you are running in non-interactive mode — if you end your response, you will not get the notification.
 
 <procedure>
-1. Clone {{release_repo}} at {{tag}} into {{repo}} and create branch {{branch}}:
+1. Clone {{release_repo}} at {{tag}} into {{repo}} and create branch {{branch}}. `{{repo}}` already exists and is empty — clone directly into it, never into a subdirectory of it, and do not use a shallow clone: a shallow history makes the later `--no-ff` merges fail with `refusing to merge unrelated histories`.
 
 ```bash
-git clone --depth 1 --branch {{tag}} https://github.com/{{release_repo}}.git {{repo}}
+git clone --branch {{tag}} https://github.com/{{release_repo}}.git {{repo}}
 cd {{repo}}
 git checkout -b {{branch}} refs/tags/{{tag}}
 ```

--- a/packages/harness/src/prompt-template.test.ts
+++ b/packages/harness/src/prompt-template.test.ts
@@ -63,6 +63,29 @@ describe('prompt.txt bash snippet syntax', () => {
     expect(allBlocks).not.toContain('GITHUB_TOKEN')
   })
 
+  it('clones the full history so the ordered --no-ff merges can find a merge base', () => {
+    // #given
+    // A shallow clone makes `git merge --no-ff` fail with `refusing to merge unrelated
+    // histories` before producing any unmerged index entries. The code-owned driver hit
+    // the same defect; see the tagged clone path in integrate.ts.
+    const allBlocks = bashBlocks.join('\n')
+
+    // #then
+    expect(allBlocks).toContain('git clone --branch')
+    expect(allBlocks).not.toContain('--depth')
+  })
+
+  it('directs the clone at the pre-created workdir rather than a subdirectory', () => {
+    // #given
+    // The model is granted `<workdir>/*`, which does not cover creating the workdir
+    // itself, so the workflow pre-creates it. Cloning one level deeper leaves trusted
+    // finalization pointed at a path that is not a git repository.
+
+    // #then
+    expect(promptContent).toContain('already exists and is empty')
+    expect(promptContent).toContain('never into a subdirectory of it')
+  })
+
   it('strips .github/workflows from the integration commit before the trusted handoff', () => {
     // #given
     // The integration push authenticates as a GitHub App, and GitHub rejects any

--- a/scripts/fro-bot-workflow.test.ts
+++ b/scripts/fro-bot-workflow.test.ts
@@ -513,6 +513,22 @@ describe('harness forward-shadow workflow wiring', () => {
     expect(shadow['timeout-minutes']).toBe(90)
   })
 
+  it('creates the integration workdir before the model step that must clone into it', () => {
+    // #given
+    // The model is granted `<workdir>/*`, which covers paths inside the workdir but not
+    // creation of the workdir itself, so `git clone` cannot create its own target.
+    const job = rawJob(integratePath, 'integrate')
+    const steps = job.steps as {readonly name?: string; readonly run?: string}[]
+    const createIndex = steps.findIndex(step => step.name === 'Create the integration workdir')
+    const modelIndex = steps.findIndex(step => step.name === 'Run Fro Bot')
+
+    // #then
+    expect(createIndex).toBeGreaterThanOrEqual(0)
+    expect(modelIndex).toBeGreaterThanOrEqual(0)
+    expect(createIndex).toBeLessThan(modelIndex)
+    expect(String(steps[createIndex]?.run)).toContain('harness-integrate-work')
+  })
+
   it('keeps harness-integrate to one job with unchanged permissions and no secret inheritance', () => {
     // #given
     const workflow = loadRawWorkflow(integratePath)


### PR DESCRIPTION
## What

The workflow now creates the integration working directory before the model runs, and the prompt clones full history directly into it.

## Why

The harness release dry run failed during trusted finalization:

```
[integrate] Command failed: git status --porcelain=v1 --untracked-files=all
fatal: not a git repository (or any of the parent directories): .git
```

The model explained the cause in its own output:

> cloned into a `repo/` subdirectory rather than the workdir root directly, due to a sandbox permission constraint requiring the target directory to pre-exist as empty

The external-directory allowlist grants the model `<workdir>/*`. That covers paths inside the working directory but not creation of the directory itself, so `git clone` could not create its own target. The model cloned one level deeper, and trusted finalization then ran its dirty-tree check against a path that was not a repository.

Pre-creating the directory resolves this without widening write permission: cloning into an existing empty directory is ordinary git behaviour, and everything the clone writes inside already matches the existing pattern.

## Shallow clone

The same run surfaced a second issue the model had been silently working around:

> Cloned `anomalyco/opencode` at `v1.18.18`, then unshallowed it (the initial `--depth 1` clone caused `refusing to merge unrelated histories` on the first PR merge — fetched full history to fix)

This is the defect already fixed in the code-owned driver, where a shallow clone makes `git merge --no-ff` fail before producing any unmerged index entries. The prompt still carried `--depth 1`, so the model detected and repaired it on every run. It now clones full history, and the instruction says why.

## Tests

Three assertions pin the behaviour: the workflow creates the workdir before the model step, the prompt no longer requests a shallow clone, and the prompt directs the clone at the pre-created directory rather than a subdirectory.

## Note

Both defects were diagnosable only because the model reported what it had worked around. Neither surfaced as a failure at the point where it occurred.