### PR TITLE
refactor(harness): drop forward-shadow naming remnants

### DIFF
--- a/packages/harness/src/conflict-resolver.ts
+++ b/packages/harness/src/conflict-resolver.ts
@@ -36,8 +36,8 @@ export const MAX_CONFLICT_CONTEXT_BYTES = 48 * 1024
 export const MAX_CONFLICT_CONTEXT_FILES = 8
 export const MAX_CONFLICT_CONTEXT_REQUESTS = 8
 export const DEFAULT_CONFLICT_MODEL_TIMEOUT_MS = 30 * 60 * 1000
-/** Shadow evidence model deadline: enough for a repair attempt, bounded below the authoritative 30-minute budget. */
-export const DEFAULT_SHADOW_CONFLICT_MODEL_TIMEOUT_MS = 5 * 60 * 1000
+/** Default model timeout for conflict resolution during a dry run. */
+export const DEFAULT_DRY_RUN_CONFLICT_MODEL_TIMEOUT_MS = 5 * 60 * 1000
 const MODEL_OUTPUT_MAX_BUFFER = 8 * 1024 * 1024
 
 const RUNTIME_ENV_KEYS = [

--- a/packages/harness/src/integrate-command.ts
+++ b/packages/harness/src/integrate-command.ts
@@ -30,7 +30,7 @@ import os from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
 import {fileURLToPath} from 'node:url'
-import {DEFAULT_SHADOW_CONFLICT_MODEL_TIMEOUT_MS} from './conflict-resolver.js'
+import {DEFAULT_DRY_RUN_CONFLICT_MODEL_TIMEOUT_MS} from './conflict-resolver.js'
 import {formatPipelineError} from './format-error.js'
 import {makeRealAdapters, runIntegration, writeProvenanceManifest} from './integrate.js'
 import {resolveSources} from './sources.js'
@@ -585,7 +585,7 @@ export async function cmdIntegrate(
   // Run the integration and package the artifact.
   try {
     const adapters = makeRealAdapters({
-      conflictModelTimeoutMs: config.dryRun === true ? DEFAULT_SHADOW_CONFLICT_MODEL_TIMEOUT_MS : undefined,
+      conflictModelTimeoutMs: config.dryRun === true ? DEFAULT_DRY_RUN_CONFLICT_MODEL_TIMEOUT_MS : undefined,
     })
     if (flags.candidate) {
       const result = await finalizeCandidateIntegration(config, outPath, adapters, _packageArtifact, logger)

--- a/packages/harness/src/integrate.ts
+++ b/packages/harness/src/integrate.ts
@@ -77,11 +77,11 @@ export interface IntegrationConfig {
   readonly agent?: string
   readonly model?: string
   readonly opencodeBin?: string
-  /** Short-lived broker-minted model auth JSON; U7 wires the production input. */
+  /** Short-lived broker-minted model auth JSON, supplied via HARNESS_BROKER_AUTH_JSON when set. */
   readonly brokerAuthJson?: string
   readonly runnerTempDir?: string
   readonly promptPath?: string
-  /** Overall driver deadline; callers may shorten it for fail-soft shadow evidence. */
+  /** Overall driver deadline; callers may shorten it. */
   readonly pipelineTimeoutMs?: number
 }
 


### PR DESCRIPTION
#1439 deleted the forward-shadow integration. Three references to it survived in names and comments.

- `DEFAULT_SHADOW_CONFLICT_MODEL_TIMEOUT_MS` is renamed to `DEFAULT_DRY_RUN_CONFLICT_MODEL_TIMEOUT_MS`. Its only remaining use is the dry-run conflict-model timeout in `cmdIntegrate`, so the old name pointed at machinery that no longer exists.
- `IntegrationConfig.pipelineTimeoutMs` no longer claims callers shorten it "for fail-soft shadow evidence".
- `IntegrationConfig.brokerAuthJson` no longer carries a stale "U7 wires the production input" forward-reference. U7 is closed — U7c shipped in #1431 and U7b was abandoned. The comment now states what actually happens: the value comes from `HARNESS_BROKER_AUTH_JSON` when set.

No behavior change. Rename only, plus two comment corrections. `dist/` is unaffected — nothing here is bundled into the Action.
