### PR TITLE
ci(renovate): stop re-running lint and build on every branch push

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,12 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['github>fro-bot/.github'],
+  // Commit through the GitHub Contents API instead of the git CLI. The CLI path
+  // runs local hooks, and `postinstall: simple-git-hooks` installs a pre-push
+  // hook that re-runs `lint && build` — repeating work postUpgradeTasks already
+  // did, at roughly two minutes per branch. The API path cannot run hooks at
+  // all, and attributes commits to the App rather than a synthesized author.
+  platformCommit: 'enabled',
   // dist/ is bundled vendor code (committed for the GitHub Action runtime).
   // ignorePaths excludes it from dependency extraction only — it does NOT
   // suppress the hidden-Unicode safety scan, which runs on these files
@@ -221,7 +227,10 @@
   postUpgradeTasks: {
     // `build` escapes dist hidden Unicode as its final step, so a rebuilt dist on
     // update branches stays free of characters Renovate would otherwise flag.
-    commands: ['bun install', 'bun run fix', 'bun run build'],
+    // --ignore-scripts keeps `postinstall: simple-git-hooks` from installing the
+    // pre-push hook into the runner. Lockfile resolution does not depend on
+    // lifecycle scripts, and neither `fix` nor `build` needs one to have run.
+    commands: ['bun install --ignore-scripts', 'bun run fix', 'bun run build'],
     executionMode: 'branch',
   },
   vulnerabilityAlerts: {


### PR DESCRIPTION
A Renovate scan that updates six branches takes about 24 minutes. Roughly half of that is the same work done twice.

`postUpgradeTasks` runs `bun install`, `bun run fix`, `bun run build` — around 129s per branch, and legitimately needed, since `skipArtifactsUpdate: true` means that install is what regenerates `bun.lock`.

But `bun install` triggers `postinstall: simple-git-hooks`, which writes a `pre-push` hook into the runner. The push that follows then runs `bun run lint && bun run build` all over again. In run 32543077755 that shows up as a ~124s gap sitting between the `git commit` log line and the next branch's `resetToCommit`, with nothing else in it, repeating once per branch.

Two changes, either sufficient alone:

- `bun install --ignore-scripts` in `postUpgradeTasks` — the hook is never installed. Lockfile resolution does not depend on lifecycle scripts, and the only workspace postinstalls are `simple-git-hooks` and the harness binary fetch, neither of which `fix` or `build` needs. The action's `allowedCommands` already permits the flag.
- `platformCommit: 'enabled'` — Renovate commits through the GitHub Contents API rather than the git CLI, which cannot run hooks at all regardless of what installed them, and attributes commits to the App.

Validated with `renovate-config-validator` (exit 0). The proof is the next scheduled `workflow_run` scan: if the per-branch gap after `git commit` disappears, this is right.
