### PR TITLE
ci(renovate): keep @types/node on the runtime major

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -196,6 +196,16 @@
       allowedVersions: '<=1.3.14',
     },
     {
+      // Keep @types/node on the major the code actually runs on. Every runtime
+      // surface is Node 24 — `using: node24` in action.yaml, node:24 in both
+      // deploy Dockerfiles, and node-version 24 in harness-release. Newer types
+      // describe a stdlib none of them have, and type-checking against them
+      // succeeds by construction, so CI cannot catch the mismatch. Raise this
+      // together with the runtime, not ahead of it.
+      matchPackageNames: ['@types/node'],
+      allowedVersions: '<25',
+    },
+    {
       // Let release-pipeline packages settle before they reach the release job. A
       // broken same-day publish (e.g. semantic-release 25.0.4 shipped a missing
       // @semantic-release/core import) would otherwise break Perform Release before


### PR DESCRIPTION
`@types/node` currently tracks the runtime at 24.x. Renovate #1412 proposes v26.

Nothing here runs Node 26. `action.yaml` declares `using: node24`, both deploy Dockerfiles pin `node:24.19.0-alpine`, and `harness-release.yaml` sets `node-version: '24'`. Newer types describe a stdlib none of those ship, so a Node 26-only API would type-check clean and fail on the runner.

CI cannot catch this. Type-checking against newer types succeeds by construction — that is what makes the mismatch invisible rather than merely untested.

So this caps `@types/node` at `<25`, matching how OpenCode and Bun are already capped in this file, with the reasoning recorded inline. Raise it together with the runtime, not ahead of it — and note `action.yaml` cannot move until GitHub Actions ships a `using: node26` runtime.

#1412 stays open; Renovate will retire it once this lands.
