### PR TITLE
ci(renovate): only autofix when lint tooling changes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -212,6 +212,25 @@
       allowedVersions: '<25',
     },
     {
+      // `fix` is autofix-only, and update branches touch manifests, lockfiles,
+      // and workflow YAML — none of which ESLint reads. Running it repo-wide on
+      // every branch costs ~95s to change nothing, so it runs only for the
+      // tooling that can actually move lint output.
+      matchPackageNames: [
+        'eslint',
+        'prettier',
+        '@bfra.me/eslint-config',
+        '@bfra.me/prettier-config',
+        'eslint-config-prettier',
+        'eslint-plugin-prettier',
+        '@vitest/eslint-plugin',
+      ],
+      postUpgradeTasks: {
+        commands: ['bun install --ignore-scripts', 'bun run fix', 'bun run build'],
+        executionMode: 'branch',
+      },
+    },
+    {
       // Let release-pipeline packages settle before they reach the release job. A
       // broken same-day publish (e.g. semantic-release 25.0.4 shipped a missing
       // @semantic-release/core import) would otherwise break Perform Release before
@@ -240,7 +259,7 @@
     // --ignore-scripts keeps `postinstall: simple-git-hooks` from installing the
     // pre-push hook into the runner. Lockfile resolution does not depend on
     // lifecycle scripts, and neither `fix` nor `build` needs one to have run.
-    commands: ['bun install --ignore-scripts', 'bun run fix', 'bun run build'],
+    commands: ['bun install --ignore-scripts', 'bun run build'],
     executionMode: 'branch',
   },
   vulnerabilityAlerts: {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -225,6 +225,8 @@
         'eslint-plugin-prettier',
         '@vitest/eslint-plugin',
       ],
+      // This object replaces the top-level postUpgradeTasks rather than merging
+      // with it, so the full command list is repeated here on purpose.
       postUpgradeTasks: {
         commands: ['bun install --ignore-scripts', 'bun run fix', 'bun run build'],
         executionMode: 'branch',


### PR DESCRIPTION
`bun run fix` is the dominant cost in a Renovate scan at roughly 95s per branch, and on nearly every branch it changes nothing.

Update branches touch manifests, lockfiles, and workflow YAML. ESLint reads none of those. Checking the three currently open update PRs:

- #1449 — `apps/workspace-agent/package.json`, `bun.lock`, `dist/THIRD_PARTY_NOTICES.txt`, `packages/gateway/package.json`
- #1448 — `apps/workspace-agent/package.json`, `bun.lock`, `package.json`
- #1447 — three workflow YAML files

Not one lintable file among them. So `fix` now runs only for the tooling that can actually move lint output: eslint, prettier, their shared configs, and the plugins. Everything else runs install and build.

`build` stays unconditional — it regenerates the committed `dist/`, and a dependency bump does change bundled output.

Consolidating the four sequential ESLint invocations into one was measured first and rejected: 62s to 55s. The cost is the linting itself, not process startup, so the win is skipping work that has nothing to lint rather than restructuring how it is invoked.

Expect roughly 13min to 8min on a five-branch scan. The previous cut (#1459) is already confirmed: 22min to 13min, per-branch 4min to 2min18s.

Validated with `renovate-config-validator`.
