### PR TITLE
docs(solutions): capture the Renovate CI and dependency-major findings

### DIFF
--- a/docs/solutions/best-practices/dependency-majors-that-ci-cannot-verify-2026-08-22.md
+++ b/docs/solutions/best-practices/dependency-majors-that-ci-cannot-verify-2026-08-22.md
@@ -113,7 +113,7 @@ The types case was resolved by holding the update and capping it, alongside the 
 }
 ```
 
-Raise that only when every runtime surface has moved, not ahead of it.
+The cap tracks the runtime major rather than the version being rejected: `<25` keeps types on 24.x, where the runtime is. `<26` would admit v25 and reintroduce the same mismatch one major lower. Raise it only when every runtime surface has moved, not ahead of it.
 
 The probe pattern generalizes to any dependency whose behavior CI does not exercise. Drive the real plugins with the real configuration, once on the baseline and once on the candidate, and compare:
 

--- a/docs/solutions/best-practices/dependency-majors-that-ci-cannot-verify-2026-08-22.md
+++ b/docs/solutions/best-practices/dependency-majors-that-ci-cannot-verify-2026-08-22.md
@@ -1,0 +1,139 @@
+---
+title: A dependency major can pass every check and still break the release
+date: 2026-08-22
+category: best-practices
+module: dependency-management
+problem_type: best_practice
+component: tooling
+severity: high
+applies_when:
+  - Upgrading a dependency used by release, deploy, or other tooling that CI does not execute
+  - Upgrading a type package that can describe a newer runtime than the one actually deployed
+  - A plugin's transitive dependency imposes a compatibility floor its own manifest does not express
+  - Configuration-driven tooling renames a field or changes a default between majors
+tags:
+  - dependency-majors
+  - semantic-release
+  - conventional-changelog
+  - renovate
+  - release-pipeline
+  - types-runtime-mismatch
+  - verification
+---
+
+# A dependency major can pass every check and still break the release
+
+## Context
+
+Two dependency majors arrived together and both looked safe. Every check was green on both. Both were unsafe, for structurally different reasons, and in neither case could CI have caught it.
+
+That is the point worth keeping: these were not gaps in test coverage that more tests would close. In one case the affected code never runs in CI at all; in the other, the check succeeds *by construction* regardless of whether the code would work.
+
+## Guidance
+
+Treat dependency-major safety as a compatibility claim to be established, not a CI result to be observed. Before accepting one, answer four questions:
+
+**Where is this dependency actually exercised?** CI may never execute release-only, deploy-only, or operator-only paths. If the dependency's job happens on a branch or in a job that pull-request CI does not run, green tells you nothing about it.
+
+**What does it require from its neighbors?** A package can declare a compatible range while another package in the installed graph supplies an incompatible implementation. Peer and transitive constraints are where this hides.
+
+**Do the types describe the runtime you deploy?** Type packages must track the runtime actually in use, not the newest available. Type-checking against newer declarations succeeds by construction.
+
+**Did configuration semantics change?** Renamed fields, changed defaults, and boolean-to-enum conversions can keep a config syntactically valid while silently changing behavior.
+
+When CI cannot exercise the boundary, build a probe. It is cheaper than it sounds:
+
+1. Install the candidate dependency set.
+2. Import the real production plugins — not reimplementations of them.
+3. Feed representative inputs covering every configured type, rule, and scope.
+4. Capture both success/failure and the rendered output.
+5. Run the identical probe against the known-good baseline.
+6. Diff the results.
+
+The baseline run is the part people skip, and it is the part that makes the probe meaningful. "The new version produced output" is not a result. "The new version produced output identical to the baseline across all twelve cases" is.
+
+## Why This Matters
+
+**Case 1: the release pipeline.** `conventional-changelog-conventionalcommits` v10 requires `conventional-changelog-writer@>=9`. `@semantic-release/release-notes-generator@14.1.1` pins `^8.0.0`, and its `15.0.0-beta.1` still pins `^8.0.0`, so there is no upstream fix available. Note generation fails outright:
+
+```text
+Missing helper: "conventional-changelog-conventionalcommits requires
+conventional-changelog-writer@9 or newer (conventional-changelog@8 or newer).
+Your changelog tooling loaded an older writer which cannot render this preset.
+Update the tooling or use an older major version of the preset."
+```
+
+`semantic-release` runs only on the `release` branch, so the update PR was green on every check and would have failed at release time. Upstream tracks this as [release-notes-generator#1027](https://github.com/semantic-release/release-notes-generator/issues/1027) and [#992](https://github.com/semantic-release/release-notes-generator/issues/992) — and #992's title, "produces empty release notes," indicates some version pairings fail *silently*, which is worse than the loud error.
+
+v10 also replaced the `hidden` commit-type property and the `bumpStrict` preset option with `effect`, a string enum of `'bump' | 'changelog' | 'hidden'` that defaults to `'bump'` when omitted. It is not a boolean, so the mechanical translation of `hidden: true` is `effect: hidden`, not `effect: false`.
+
+The probe made the difference concrete by driving the real `analyzeCommits()` and `generateNotes()` with the repository's actual `presetConfig` and `releaseRules` across twelve representative commits:
+
+| configuration | result |
+| --- | --- |
+| v10, writer 8 | hard failure at `generateNotes` |
+| v10 + writer 9, stale `hidden: true` | renders, but `skip:` commits appear under **⚠ BREAKING CHANGES** |
+| v10 + writer 9 + `effect: hidden` | identical to the v9 baseline |
+
+The middle row is the one that argues for a probe rather than a smoke test. A run that merely completes looks like success; only the baseline comparison reveals that suppressed commits were being promoted to the most alarming section in the changelog.
+
+**Case 2: the type/runtime split.** `@types/node` v26 against a Node 24 runtime is the inverse failure. Every runtime surface here is Node 24 — `using: node24` in `action.yaml`, `node:24.19.0-alpine` in both deploy Dockerfiles, `node-version: '24'` in the harness release workflow, `24.19.0` in `.node-version`. Newer types describe a standard library none of them ship. A Node 26-only API would type-check cleanly and fail on the runner, and no amount of type-checking can detect that, because type-checking against newer types succeeding is the expected behavior.
+
+## When to Apply
+
+Apply this to majors involving release tooling, deployment tooling, and code generators; plugins whose peer or transitive dependencies impose undocumented compatibility floors; configuration-driven tools where a renamed field can silently alter output; and type packages or platform declarations that can outrun the deployed runtime.
+
+Where a compatibility boundary is deliberate, encode it as a version cap so the update stops being re-raised and re-analyzed. Record the reason inline — a bare cap invites removal by whoever finds it next.
+
+## Examples
+
+The changelog fix required both a dependency override and a config migration; neither alone is sufficient:
+
+```json
+{
+  "overrides": {
+    "conventional-changelog-writer": ">=9"
+  }
+}
+```
+
+```yaml
+presetConfig:
+  types:
+    - type: skip
+      effect: hidden
+```
+
+The types case was resolved by holding the update and capping it, alongside the existing OpenCode and Bun caps in the same file:
+
+```json5
+{
+  matchPackageNames: ['@types/node'],
+  allowedVersions: '<25',
+}
+```
+
+Raise that only when every runtime surface has moved, not ahead of it.
+
+The probe pattern generalizes to any dependency whose behavior CI does not exercise. Drive the real plugins with the real configuration, once on the baseline and once on the candidate, and compare:
+
+```js
+const analysis = await analyzeCommits(
+  {preset, presetConfig, releaseRules},
+  {commits: representativeCommits, logger, cwd},
+)
+
+const notes = await generateNotes(
+  {preset, presetConfig},
+  {commits: representativeCommits, lastRelease, nextRelease, options, cwd},
+)
+```
+
+A green install, build, and unit-test suite is not evidence when the probe is the first thing to actually execute the affected boundary.
+
+## Related
+
+- [A check reports clean for the part of the world it cannot observe](../workflow-issues/checks-report-clean-for-what-they-cannot-observe-2026-08-10.md) — the general form of this failure
+- [A gate that cannot fail manufactures confidence](../workflow-issues/non-failing-gates-are-worse-than-no-gates-2026-08-07.md) — why a check that cannot fail is worse than none
+- [#1420](https://github.com/fro-bot/agent/pull/1420) — the changelog preset major and its migration
+- [#1461](https://github.com/fro-bot/agent/pull/1461) — the `@types/node` cap

--- a/docs/solutions/performance-issues/renovate-duplicate-ci-work-from-git-hooks-2026-08-22.md
+++ b/docs/solutions/performance-issues/renovate-duplicate-ci-work-from-git-hooks-2026-08-22.md
@@ -1,0 +1,124 @@
+---
+title: Renovate CI duplicated work through installed git hooks
+date: 2026-08-22
+category: performance-issues
+module: ci-workflows
+problem_type: performance_issue
+component: tooling
+symptoms:
+  - Renovate workflow_run scans took roughly 24 minutes while push and workflow_dispatch scans finished in under a minute
+  - Each update branch showed an unexplained ~124s gap between the commit log line and the next branch reset
+  - Lint and build ran a second time during the branch push, immediately after postUpgradeTasks had run them
+root_cause: config_error
+resolution_type: config_change
+severity: medium
+related_components:
+  - development_workflow
+  - testing_framework
+tags:
+  - renovate
+  - github-actions
+  - ci-performance
+  - git-hooks
+  - bun
+  - postinstall
+  - dependency-updates
+---
+
+# Renovate CI duplicated work through installed git hooks
+
+## Problem
+
+Renovate `workflow_run` scans took roughly 24 minutes, while `push` and `workflow_dispatch` scans finished in under a minute. Only the full-repo scan that actually updates branches was slow, and it was slow because it ran the same lint and build work twice on every branch.
+
+## Symptoms
+
+Run `32543077755` showed a repeating ~124s gap sitting between the `git commit` log line and the next branch's `resetToCommit`, with nothing else in it, once per branch. Combined with ~129s of `postUpgradeTasks`, that produced roughly four minutes per branch across about six branches.
+
+The second execution came from the repository's own postinstall:
+
+```json
+"postinstall": "simple-git-hooks",
+"simple-git-hooks": {
+  "pre-push": "bun run lint && bun run build"
+}
+```
+
+Renovate's `postUpgradeTasks` ran `bun install`, which fired that postinstall and wrote `.git/hooks/pre-push` into Renovate's container. The push that followed then re-ran `lint && build` — exactly the work `postUpgradeTasks` had just completed.
+
+The `bun install` itself is not removable. `skipArtifactsUpdate: true` is set for the bun and npm managers, so Renovate does not update `bun.lock` itself; that install is what regenerates it.
+
+## What Didn't Work
+
+**Consolidating the four sequential ESLint invocations.** The root `fix` script chains four filtered runs, each spawning its own `bunx eslint --fix`. The hypothesis was that four process startups and four flat-config loads dominated the cost. Measured: 62s for the existing four-way sequential run against 55s for a single equivalent invocation over the same directories — about 11%. The cost is the linting itself, not startup. Rejected.
+
+**Passing arguments to scope the work.** Not possible. The `allowedCommands` allowlist in `bfra-me/renovate-action` is anchored regex admitting only bare script names from a fixed list:
+
+```
+^(?:bun|npm|pnpm|yarn)(?:\srun)?\s(?:bootstrap|build(-release)?|check|clean|fix|format|generate|lint|postupgrade|typecheck|update-snapshots)$
+```
+
+So `bun run fix --filter '*'` is rejected, and a new script name such as `fix:changed` is rejected. `postupgrade` is on that list and is the intended escape hatch for a custom command. A whole-repo `bunx eslint --fix .` is separately allowlisted but would be slower, not faster.
+
+## Solution
+
+Two changes, either sufficient on its own, shipped together:
+
+```diff
+-commands: ['bun install', 'bun run fix', 'bun run build'],
++commands: ['bun install --ignore-scripts', 'bun run build'],
+```
+
+```json5
+platformCommit: 'enabled',
+```
+
+`--ignore-scripts` means the hook is never installed. `platformCommit` makes Renovate commit through the GitHub Contents API rather than the git CLI, which cannot run hooks at all regardless of what installed them, and attributes commits to the App.
+
+A follow-up removed the remaining dominant cost. After the first fix, `bun run fix` at ~95s per branch was the largest step, and it is autofix-only. Update branches contain nothing ESLint reads — checking three open update PRs found only manifests, `bun.lock`, generated third-party notices, and workflow YAML. So `fix` now runs only for the tooling that can actually move lint output:
+
+```json5
+{
+  matchPackageNames: [
+    'eslint',
+    'prettier',
+    '@bfra.me/eslint-config',
+    '@bfra.me/prettier-config',
+    'eslint-config-prettier',
+    'eslint-plugin-prettier',
+    '@vitest/eslint-plugin',
+  ],
+  // This object replaces the top-level postUpgradeTasks rather than merging
+  // with it, so the full command list is repeated here on purpose.
+  postUpgradeTasks: {
+    commands: ['bun install --ignore-scripts', 'bun run fix', 'bun run build'],
+    executionMode: 'branch',
+  },
+},
+```
+
+`bun run build` stays unconditional — it regenerates the committed `dist/`, and a dependency bump does change bundled output.
+
+## Why This Works
+
+`bun install --ignore-scripts` still resolves dependencies and regenerates `bun.lock`, because lockfile resolution does not depend on lifecycle scripts. The only workspace postinstalls are the root `simple-git-hooks` and the harness's `node dist/postinstall.mjs || true`, which fetches a platform binary and is already failure-tolerant. Neither is needed by `fix` or `build`.
+
+Scans went from 22 minutes to 13 at comparable branch counts — six to five, so not a lighter workload — and per-branch time from roughly four minutes to 2m18s. The post-commit gap is gone. With `platformCommit` active the `Committing files to branch` log line no longer appears at all, confirming the API path. `bun install --ignore-scripts` now completes in 0.2s, logging `No updated lock file`, which means essentially all of that step's former cost was the postinstall.
+
+Two mechanics are worth knowing before editing this config. Renovate's `postUpgradeTasks` is not mergeable, so a matching `packageRules` entry replaces the top-level one wholesale rather than concatenating — which is why the lint-tooling rule repeats the full command list. And mixed groups fail safe: if a lint-tooling package is ever grouped with a non-tooling one, the lint rule wins for the whole branch under `executionMode: 'branch'`, so `fix` runs. The failure direction is "runs unnecessarily," never "skipped when needed."
+
+## Prevention
+
+- Use `--ignore-scripts` in any automation that installs dependencies and then commits, unless a lifecycle script is genuinely required. A repo whose postinstall installs git hooks will silently double the work of any such tool. This is not Renovate-specific.
+- Prefer API-based commits when automation must be immune to repository-local hooks.
+- Scope expensive autofix steps to the dependency updates that can actually change linted source.
+- Treat `postUpgradeTasks` in a `packageRules` entry as a replacement, not an addition, and repeat the full command list deliberately.
+- When a CI job is slow, measure where the time sits before restructuring how commands are invoked. Here the gap between the commit line and the next branch reset identified the duplicate immediately, while the plausible-sounding startup-overhead theory measured at 11% and was wrong.
+
+## Related Issues
+
+- [#1459](https://github.com/fro-bot/agent/pull/1459) — the `--ignore-scripts` and `platformCommit` fix
+- [#1462](https://github.com/fro-bot/agent/pull/1462) — scoping autofix to lint tooling
+- [Build pipelines: fallible work is a preflight, cleanup is a finally](../workflow-issues/build-pipeline-fallible-preflight-and-finally-cleanup-2026-06-22.md) — adjacent pipeline-sequencing guidance
+- [Tool binary caching on ephemeral runners](./tool-binary-caching-ephemeral-runners.md) — related CI overhead reduction
+- [Migrating a pnpm workspace to Bun](../workflow-issues/migrate-pnpm-to-bun-monorepo-2026-06-24.md) — Bun and Renovate interaction background


### PR DESCRIPTION
Two learnings from today's Renovate work, both non-obvious enough to be worth the disk space.

**`performance-issues/renovate-duplicate-ci-work-from-git-hooks-2026-08-22.md`**

Renovate scans took ~24 minutes because the same lint and build ran twice on every branch. The cause was this repository's own `postinstall: simple-git-hooks`, which Renovate's `postUpgradeTasks` install fired, writing a `pre-push` hook into Renovate's container — so the push that followed re-ran work that had just completed. Fixed by `--ignore-scripts` plus `platformCommit`, then by scoping autofix to lint tooling. 22min to 13min, verified at comparable branch counts.

The doc also records the theory that was wrong. Four sequential ESLint invocations looked like the obvious culprit; consolidating them measured 62s against 55s. The cost was the linting, not the startup, and the gap between the commit line and the next branch reset had already pointed at the real answer.

**`best-practices/dependency-majors-that-ci-cannot-verify-2026-08-22.md`**

Two majors arrived green and both were unsafe, for structurally different reasons. The changelog preset v10 requires a writer major its own consumer pins below, and `semantic-release` only runs on the release branch — so CI could not have caught it. `@types/node` v26 is the inverse: type-checking against newer types succeeds by construction, which is precisely why it proves nothing about a Node 24 runtime.

Neither is a coverage gap that more tests would close, which is the reason to write it down. The doc gives the probe used to establish equivalence — drive the real plugins with the real config, once on the baseline and once on the candidate, and diff. That probe is what caught the middle case, where the config renders successfully but promotes suppressed commits into BREAKING CHANGES.

Both link to the existing `checks-report-clean-for-what-they-cannot-observe` and `non-failing-gates-are-worse-than-no-gates` docs rather than restating them.

Module taxonomy test passes, 375 markdown links resolve, lint clean.
