### PR TITLE
feat(gateway): dispatch Action runs from Discord

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,7 +9,7 @@ This document describes the system design, invariants, and data flows for the fr
 This monorepo ships three distinct deployable surfaces from one codebase:
 
 - **GitHub Action** — a CI harness that runs OpenCode agents in response to GitHub webhook events (issues, PRs, comments, reviews, scheduled runs, workflow dispatches). The Action entry points are `src/main.ts` and `src/post.ts`; the real logic lives in the 4-layer `src/` tree and `packages/runtime/`. Sessions persist across CI runs via GitHub Actions cache and an S3-compatible object store.
-- **`@fro-bot/gateway`** (`packages/gateway/`) — a Discord-first daemon that listens for `@fro-bot` mentions in bound guild channels and runs OpenCode inside a sandboxed workspace container. Includes an operator web surface (Hono, gateway-net only), an inbound announce webhook, and an S3-backed coordination layer.
+- **`@fro-bot/gateway`** (`packages/gateway/`) — a Discord-first daemon that listens for `@fro-bot` mentions in bound guild channels and runs OpenCode inside a sandboxed workspace container. Includes an operator web surface (Hono, gateway-net only), an inbound announce webhook, and an S3-backed coordination layer. The `/fro-bot dispatch` slash command is a separate, simpler path: it asks the bound repo's `fro-bot.yaml` workflow to run via the GitHub Actions API and returns the run URL — it never touches the gateway's queue, concurrency cap, or run-state.
 - **`@fro.bot/harness`** (`packages/harness/`) — a patched OpenCode binary built via an LLM-merge integration pipeline. Published to npm and GitHub Releases; consumed by the Action setup phase as the default OpenCode binary.
 
 Supporting packages: `@fro-bot/runtime` (`packages/runtime/`) owns shared runtime primitives and version-pin constants; `@fro-bot/action` (`apps/action/`) is a thin workspace wrapper whose build produces the committed root `dist/`; `@fro-bot/workspace-agent` (`apps/workspace-agent/`) is the Hono HTTP sidecar inside the workspace container.
@@ -56,17 +56,18 @@ Symbols verified against the live source tree. Where a symbol has moved to `pack
 | `processEventStream` | Function | `src/features/agent/streaming.ts` | Process SDK event stream |
 | `bootstrapOpenCodeServer` | Function | `src/features/agent/server.ts` | Initialize SDK server lifecycle |
 | `TriggerDirective` | Interface | `packages/runtime/src/agent/prompt.ts` | Directive + appendMode for triggers |
-| `DEFAULT_SYSTEMATIC_VERSION` | Constant | `packages/runtime/src/shared/constants.ts` | Pinned Systematic version (`3.6.0`) |
-| `DEFAULT_OPENCODE_VERSION` | Constant | `packages/runtime/src/shared/constants.ts` | Pinned harness version (`1.18.14+harness.202732ae`) |
+| `DEFAULT_SYSTEMATIC_VERSION` | Constant | `packages/runtime/src/shared/constants.ts` | Pinned Systematic version (`3.12.4`) |
+| `DEFAULT_OPENCODE_VERSION` | Constant | `packages/runtime/src/shared/constants.ts` | Pinned harness version (`1.18.21+harness.22dee0ee`) |
 
 ### `packages/gateway/`
 
-| Symbol               | Type     | Location                                 | Role                             |
-| -------------------- | -------- | ---------------------------------------- | -------------------------------- |
-| `runMention`         | Function | `packages/gateway/src/execute/run.ts`    | Full mention execution lifecycle |
-| `launchWork`         | Function | `packages/gateway/src/execute/run.ts`    | Fire-and-return web launch path  |
-| `buildDiscordPrompt` | Function | `packages/gateway/src/execute/prompt.ts` | Discord-specific prompt builder  |
-| `buildOperatorApp`   | Function | `packages/gateway/src/web/server.ts`     | Operator Hono app factory        |
+| Symbol | Type | Location | Role |
+| --- | --- | --- | --- |
+| `runMention` | Function | `packages/gateway/src/execute/run.ts` | Full mention execution lifecycle |
+| `launchWork` | Function | `packages/gateway/src/execute/run.ts` | Fire-and-return web launch path |
+| `buildDiscordPrompt` | Function | `packages/gateway/src/execute/prompt.ts` | Discord-specific prompt builder |
+| `buildOperatorApp` | Function | `packages/gateway/src/web/server.ts` | Operator Hono app factory |
+| `createWorkflowDispatcher` | Function | `packages/gateway/src/github/dispatch.ts` | `/fro-bot dispatch` GitHub Actions workflow-dispatch adapter (fire-and-forget; no queue, concurrency, or local run-state) |
 
 ## Invariants
 
@@ -120,6 +121,9 @@ main.ts
         ├─→ execute phase
         │     executeOpenCode → bootstrapOpenCodeServer → sendPromptToSession
         │       → runPromptAttempt → processEventStream (SSE)
+        │     (onPermissionAsked auto-denies any permission.asked event immediately —
+        │      there is no interactive approval path in CI, so an unanswered ask must
+        │      never be left to block the run until the execution deadline)
         │
         ├─→ review-reconciliation phase
         │     reconcile formal review state after agent execution

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -34,6 +34,7 @@ fro-bot/agent/
 │   ├── gateway/                # @fro-bot/gateway — Discord daemon + operator web surface
 │   │   └── src/
 │   │       ├── discord/        # Discord client, mentions, commands, streaming
+│   │       ├── github/         # GitHub App client, Actions workflow-dispatch adapter
 │   │       ├── execute/        # run-core, queue, concurrency, recovery
 │   │       ├── web/            # Operator HTTP routes, SSE, audit
 │   │       ├── workspace-api/  # Workspace API surface

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -218,7 +218,7 @@ When a new optional secret is added to `compose.yaml` in the future, add a row h
 
 ## GitHub App
 
-The gateway uses a GitHub App to authenticate against repositories. This is required for the `/add-project` command and any feature that reads repository content.
+The gateway uses a GitHub App to authenticate against repositories. This is required for the `/add-project` command, `/fro-bot dispatch`, and any feature that reads repository content.
 
 ### Creating the App
 
@@ -226,6 +226,7 @@ The gateway uses a GitHub App to authenticate against repositories. This is requ
 2. Set the App name, homepage URL, and webhook URL (webhook is not used by the gateway — set it to any valid URL).
 3. Under **Permissions → Repository permissions**, grant:
    - **Contents**: Read-only (minimum required)
+   - **Actions**: Read and write (required for `/fro-bot dispatch`)
    - Grant only the minimum permissions needed. Over-privileged installations produce a `WARN` log entry at runtime but do not block operation. Under-privileged installations fail fast at `/add-project` time with a clear error message.
 4. Disable **Webhook** (the gateway does not receive webhooks from GitHub).
 5. Click **Create GitHub App**.
@@ -255,8 +256,18 @@ The gateway auto-discovers the installation ID at runtime — you do not need to
 
 ### Permission behaviour
 
-- **Under-privileged** (e.g. `contents: none`): the gateway returns an error at `/add-project` time with a message naming the missing permissions and a link to the installation settings page.
+- **Under-privileged** (e.g. `contents: none` or missing `actions: write`): the gateway returns an error with a link to the installation settings page. `/fro-bot dispatch` specifically requires `Actions: write`.
 - **Over-privileged** (e.g. `contents: write` when only `read` is required): the gateway logs a `WARN` entry listing the over-privileged scopes but does not block the request. Operators should review and reduce permissions to the minimum needed.
+
+### Dispatching an Action run
+
+In a channel bound with `/fro-bot add-project`, an authorized member can request an Action run with:
+
+```text
+/fro-bot dispatch task:<task>
+```
+
+The gateway dispatches the fixed `.github/workflows/fro-bot.yaml` workflow on the repository's default branch and replies with GitHub's accepted run link. Acceptance does not mean the run has completed successfully; GitHub Actions may still skip or fail it, including when another surface holds the repository lock.
 
 ## Operator OAuth (Web Surface)
 

--- a/docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
+++ b/docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
@@ -830,6 +830,8 @@ The Action and gateway both import from `@fro-bot/runtime` (the name is internal
 
 - [ ] **Unit 7: Cloud dispatch + summaries bridge**
 
+**Superseded by [2026-08-22-001-feat-gateway-dispatch-command-plan.md](2026-08-22-001-feat-gateway-dispatch-command-plan.md).** The design below predates the operator web surface, the object-store key builder, run-state coordination, and the release-notes narration flow that gave `correlation-id` its current meaning; several of its file paths and premises are no longer accurate. The command is now `/fro-bot dispatch`. Dispatch acceptance is scoped as Unit 7A; completion notification and the summaries bridge are deferred there with reasons. The box stays unchecked because the work has not shipped — read the superseding plan, not the design below.
+
 **Goal:** Implement `/fro-bot cloud <task>` to dispatch the Action via `workflow_dispatch` with a typed schema. Write the summaries bridge: Action writes a condensed summary to `summaries/` prefix; gateway reads it when users ask about prior Action work.
 
 **Requirements:** R3 (summaries bridge), R4 (cloud dispatch), S4 + S7 (cross-surface context)

--- a/docs/plans/2026-08-22-001-feat-gateway-dispatch-command-plan.md
+++ b/docs/plans/2026-08-22-001-feat-gateway-dispatch-command-plan.md
@@ -14,6 +14,12 @@ Ship Unit 7A of the gateway roadmap: a Discord `/fro-bot dispatch task:<task>` s
 
 This plan supersedes Unit 7, “Cloud dispatch + summaries bridge,” in `docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md`. The implementation scope is deliberately limited to dispatch acceptance. Completion notification and the summaries bridge remain separate tasks.
 
+## Problem Frame
+
+Work that needs the Action's environment — matrix CI, secrets-heavy operations, long-running jobs — currently has no path from Discord. A user in a bound channel can mention the bot for local execution in the gateway's workspace, but cannot reach the Action at all without leaving Discord for the GitHub UI.
+
+The April plan specified this capability and it never shipped. Its design predates the operator web surface, the object-store key builder, run-state coordination, and the release-notes narration flow that gave `correlation-id` its current meaning, so the original unit is no longer implementable as written.
+
 ## Requirements Trace
 
 - **R3:** Reuse the channel binding as the authoritative repo context. The task is user-authored session content and must be treated as untrusted input by the Action. No cross-surface session resume is introduced.
@@ -96,7 +102,7 @@ The dispatch adapter exposes an exhaustive outcome set:
 
 The Discord mapping must use an exhaustive `switch` with a `const exhaustiveCheck: never` guard. Unexpected throws still fall through the shared `INTERNAL_ERROR_COPY` path.
 
-### Key Technical Decisions
+## Key Technical Decisions
 
 - **Use `/fro-bot dispatch`, not `/fro-bot cloud`:** explicit owner decision; the implementation and documentation use one name consistently.
 - **Never send `correlation-id`:** `.github/workflows/fro-bot.yaml` treats any non-empty value as release-notes mode, which changes output mode to `working-dir`, suppresses GitHub response delivery with `response-mode: none`, and applies a 600-second timeout. A dispatch command must not accidentally enter that mode.
@@ -106,9 +112,9 @@ The Discord mapping must use an exhaustive `switch` with a `const exhaustiveChec
 - **No local queue or slot participation:** dispatch consumes no local execution resources. The Action owns the authoritative per-repo lock; a successful API acceptance can still lead to a skipped run if another surface holds that lock.
 - **Say accepted, not succeeded:** the reply describes GitHub's acceptance of the dispatch and includes the run link. It does not imply the Action completed successfully.
 
-## Implementation Plan
+## Implementation Units
 
-### Unit 1 — Add scoped workflow-dispatch capability to the GitHub App client
+- [ ] **Unit 1: Add scoped workflow-dispatch capability to the GitHub App client**
 
 **Files:** modify `packages/gateway/src/github/app-client.ts`, `packages/gateway/src/github/app-client.test.ts`.
 
@@ -122,7 +128,7 @@ Extend the App client with a dispatch-specific authorization path. Keep ordinary
 - Token minting or discovery fails → returns a safe auth error without logging credentials.
 - Ordinary `authForRepo` with `contents: read` → remains successful without requiring Actions write.
 
-### Unit 2 — Implement the typed GitHub workflow-dispatch adapter
+- [ ] **Unit 2: Implement the typed GitHub workflow-dispatch adapter**
 
 **Files:** create `packages/gateway/src/github/dispatch.ts` and `packages/gateway/src/github/dispatch.test.ts`.
 
@@ -141,7 +147,7 @@ Create the gateway-level dispatch primitive. It resolves the binding's owner/rep
 - Successful request payload inspection → confirms the ref is the resolved default branch, inputs contain only `prompt`, and `correlation-id` is never sent.
 - `200` response with a malformed or missing nested `workflow_run` → returns `dispatch-rejected` rather than fabricating a run link.
 
-### Unit 3 — Wire `/fro-bot dispatch`, program injection, and deployment documentation
+- [ ] **Unit 3: Wire `/fro-bot dispatch`, program injection, and deployment documentation**
 
 **Files:** create `packages/gateway/src/discord/commands/dispatch.ts` and `packages/gateway/src/discord/commands/dispatch.test.ts`; modify `packages/gateway/src/discord/commands/fro-bot.ts`, `packages/gateway/src/discord/commands/fro-bot.test.ts`, `packages/gateway/src/discord/commands/index.test.ts`, `packages/gateway/src/program.ts`, `packages/gateway/src/program.test.ts`, and `deploy/README.md`.
 

--- a/docs/plans/2026-08-22-001-feat-gateway-dispatch-command-plan.md
+++ b/docs/plans/2026-08-22-001-feat-gateway-dispatch-command-plan.md
@@ -1,0 +1,189 @@
+---
+title: "feat: /fro-bot dispatch — trigger Action runs from Discord"
+type: feat
+status: active
+date: 2026-08-22
+origin: docs/brainstorms/2026-04-17-fro-bot-gateway-discord-requirements.md
+---
+
+# feat: /fro-bot dispatch — trigger Action runs from Discord
+
+## Overview
+
+Ship Unit 7A of the gateway roadmap: a Discord `/fro-bot dispatch task:<task>` subcommand that triggers the repository's fixed GitHub Action workflow for the repo bound to the invoking channel and returns the accepted run's URL.
+
+This plan supersedes Unit 7, “Cloud dispatch + summaries bridge,” in `docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md`. The implementation scope is deliberately limited to dispatch acceptance. Completion notification and the summaries bridge remain separate tasks.
+
+## Requirements Trace
+
+- **R3:** Reuse the channel binding as the authoritative repo context. The task is user-authored session content and must be treated as untrusted input by the Action. No cross-surface session resume is introduced.
+- **R4:** Preserve local execution as the default gateway behavior while adding explicit cloud dispatch. Unit 7A reports acceptance and a run link only; progress reporting is deferred because it needs durable dispatch state plus webhook ingress or a background reconciler. R4 is therefore only partially satisfied by this unit.
+- **S4:** Implement `/fro-bot dispatch` → `workflow_dispatch` with the fixed `.github/workflows/fro-bot.yaml` workflow and `{prompt: task}` input. The origin requirement names `/fro-bot cloud`; the shipped command intentionally uses `/fro-bot dispatch` by owner decision. Unit 7A returns the run URL only, not Action progress updates, so S4 is only partially satisfied.
+- **S7:** Keep the feature self-hostable. The gateway remains the caller, the GitHub App remains the credential boundary, and deployment documentation must describe the additional narrowly scoped App permission.
+
+### Deliberate Deviations from Origin
+
+1. **Command name:** The command is `/fro-bot dispatch`, not `/fro-bot cloud`. This is an explicit owner decision.
+2. **Acceptance-only delivery:** Unit 7A returns the accepted run link only, not progress updates. Discord interaction tokens expire after 15 minutes while Action runs routinely exceed that window; durable `DispatchRecord` state and either signed `workflow_run` webhook ingress or a background reconciler are required for reliable later updates. R4/S4 are only partially satisfied until that work ships.
+
+## Scope Boundaries
+
+### In Scope
+
+- Add the `dispatch` subcommand to the existing `/fro-bot` parent command.
+- Require a non-empty, trimmed `task` string.
+- Resolve the repo only from `bindingsStore.getBindingByChannelId(channelId)`.
+- Authorize with the existing `userIsAuthorized` trigger-role gate: the configured trigger role, or guild-level ManageChannels when no trigger role is configured.
+- Resolve the repository default branch through `GET /repos/{owner}/{repo}`.
+- Dispatch the fixed `.github/workflows/fro-bot.yaml` workflow on that default branch with only the `prompt` input.
+- Return typed outcomes and a user-facing reply that says GitHub **accepted** the dispatch, never that the work succeeded.
+- Keep dispatch outside the local execution slot and per-channel `RunTask` queue. GitHub Actions performs authoritative per-repo lock acquisition through the existing Action routing.
+- Add the dedicated GitHub App workflow-dispatch capability, tests, command wiring, program injection, and deployment documentation.
+
+### Out of Scope
+
+- Arbitrary repo, ref, workflow path, task type, model, PR/issue number, or `correlation-id` options.
+- Completion notifications, progress updates, polling, webhook ingress, or durable dispatch records.
+- Summaries publication, storage, or reading.
+- Changes to `packages/gateway/src/execute/*`.
+- Changes to `.github/workflows/fro-bot.yaml`; its existing `prompt` input is sufficient.
+
+### Deferred to Separate Tasks
+
+- **7B — completion notification** (~5–7 days plus ingress configuration). Prefer a signed `workflow_run` webhook only if public ingress becomes a supported deployment requirement. The Hono listener is currently gateway-net only. Add a dedicated durable `DispatchRecord`; do not overload `RunState`, because the Action deliberately creates no `RunState` and GitHub is canonical for Action status.
+- **7C — summaries bridge** (~5–8 days). It currently has no consumer: it was designed to feed `/fro-bot review <pr>`, which does not exist. Building publisher, storage, and reader now would create dead code. `writeSessionSummary` at `packages/runtime/src/session/writeback.ts:56` is not this bridge; it appends a synthetic message to the current OpenCode session and serves a different purpose. If the bridge is built later, route keys through `buildObjectStoreKey` at `packages/runtime/src/object-store/key-builder.ts:22` rather than the April plan's raw `summaries/{owner}/{repo}/...` scheme so configured prefixes, identity namespacing, and validation remain intact.
+
+## Prior-Art Survey
+
+```json
+{
+  "schema_version": 2,
+  "verdict": "extend",
+  "scope": "packages/gateway",
+  "freshness": {"vcs_reference": "main"},
+  "budget": {"max_search_passes": 1, "max_candidate_inspections": 3, "exhausted": false},
+  "candidates": [
+    {"path_or_symbol": "packages/gateway/src/github/app-client.ts", "description": "GitHub App installation token minting, currently contents:read only", "disposition": "extend"},
+    {"path_or_symbol": "packages/gateway/src/discord/commands/fro-bot.ts", "description": "parent slash command with subcommand routing and makeGuildCommand executors", "disposition": "extend"},
+    {"path_or_symbol": "packages/gateway/src/execute/run.ts", "description": "local OpenCode execution with queue and concurrency", "disposition": "insufficient"}
+  ]
+}
+```
+
+## High-Level Technical Design
+
+The feature has three boundaries:
+
+1. **Capability boundary — `packages/gateway/src/github/app-client.ts`:** retain `REQUIRED_PERMISSIONS` as the ordinary `contents: read` minimum. Add a dedicated `authForWorkflowDispatch()` capability that verifies the installation has `Actions: write`, mints a repository-scoped token with only the permissions required for dispatch, and preserves the existing installation cache and secret-redaction invariants. A missing permission must retain the App install URL for the Discord outcome.
+2. **GitHub adapter — `packages/gateway/src/github/dispatch.ts`:** authenticate, resolve the default branch, and call the workflow dispatch endpoint for `.github/workflows/fro-bot.yaml`. Use a raw Octokit request with `X-GitHub-Api-Version: 2026-03-10`, a local minimal response type, and runtime shape parsing. Do not use `@octokit/rest`, the typed plugin endpoint, or the obsolete `return_run_details: true` flag. Do not send `correlation-id`.
+3. **Discord adapter — `packages/gateway/src/discord/commands/dispatch.ts`:** use `makeGuildCommand` for the normal defer/auth/work pipeline, resolve the binding, call the injected `dispatchWorkflow` primitive, and map every typed outcome to safe reply copy. Extend `FroBotDeps` and construct the primitive in `program.ts`; do not use module globals.
+
+The parent command remains the single registered command. `packages/gateway/src/discord/commands/index.ts` is intentionally unchanged because it already registers the parent returned by `createFroBotCommand()`.
+
+### Typed Outcomes
+
+The dispatch adapter exposes an exhaustive outcome set:
+
+- `accepted` — repository, run ID, and run HTML URL.
+- `invalid-task` — the command input is empty after trimming.
+- `channel-unbound` — no binding exists for the interaction channel.
+- `app-not-installed` — repository plus App installation URL.
+- `missing-actions-permission` — repository plus App installation URL.
+- `repo-not-found` — the repository lookup or default-branch resolution cannot find the repo.
+- `workflow-not-found` — the fixed workflow is absent on the repository's default branch.
+- `dispatch-rejected` — GitHub rejected the request with a non-success response or malformed success payload.
+- `github-unavailable` — GitHub API/network failure, including 5xx responses.
+
+The Discord mapping must use an exhaustive `switch` with a `const exhaustiveCheck: never` guard. Unexpected throws still fall through the shared `INTERNAL_ERROR_COPY` path.
+
+### Key Technical Decisions
+
+- **Use `/fro-bot dispatch`, not `/fro-bot cloud`:** explicit owner decision; the implementation and documentation use one name consistently.
+- **Never send `correlation-id`:** `.github/workflows/fro-bot.yaml` treats any non-empty value as release-notes mode, which changes output mode to `working-dir`, suppresses GitHub response delivery with `response-mode: none`, and applies a 600-second timeout. A dispatch command must not accidentally enter that mode.
+- **Dispatch the default branch only:** resolve it from `GET /repos/{owner}/{repo}` and do not expose an arbitrary ref. The workflow runs repository-local actions and scripts while holding secrets and minting App credentials.
+- **Use raw API request and parse the response locally:** the installed Octokit stack types the dispatch endpoint as `204` with no body, while the current API returns `200` with nested `workflow_run` details. The local parser isolates this API/version mismatch and rejects malformed shapes.
+- **Keep ordinary App auth narrow:** Actions: write is required only for dispatch. Add it through `authForWorkflowDispatch()` rather than widening the shared `REQUIRED_PERMISSIONS` constant, so ordinary gateway tokens continue requesting only `contents: read`.
+- **No local queue or slot participation:** dispatch consumes no local execution resources. The Action owns the authoritative per-repo lock; a successful API acceptance can still lead to a skipped run if another surface holds that lock.
+- **Say accepted, not succeeded:** the reply describes GitHub's acceptance of the dispatch and includes the run link. It does not imply the Action completed successfully.
+
+## Implementation Plan
+
+### Unit 1 — Add scoped workflow-dispatch capability to the GitHub App client
+
+**Files:** modify `packages/gateway/src/github/app-client.ts`, `packages/gateway/src/github/app-client.test.ts`.
+
+Extend the App client with a dispatch-specific authorization path. Keep ordinary repository authentication behavior and `REQUIRED_PERMISSIONS` unchanged. Verify `Actions: write` separately, retain the installation URL in the typed error, and mint a token scoped to the requested repository. Keep token, private key, and JWT values out of logs.
+
+**Required test scenarios:**
+
+- Installation grants `contents: read` and `actions: write` → dispatch capability returns an authenticated client/token and the repository scope is preserved.
+- Installation grants `contents: read` but no Actions write permission → returns the typed insufficient-permission error with the install URL and does not cache an unusable dispatch capability.
+- Installation is absent → returns `AppNotInstalledError` with the install URL.
+- Token minting or discovery fails → returns a safe auth error without logging credentials.
+- Ordinary `authForRepo` with `contents: read` → remains successful without requiring Actions write.
+
+### Unit 2 — Implement the typed GitHub workflow-dispatch adapter
+
+**Files:** create `packages/gateway/src/github/dispatch.ts` and `packages/gateway/src/github/dispatch.test.ts`.
+
+Create the gateway-level dispatch primitive. It resolves the binding's owner/repo through the repository endpoint, uses the repository's default branch, calls the fixed workflow with `prompt: task`, sends the explicit API-version header, parses the nested `workflow_run` response, and maps GitHub/App failures to the closed outcome set. The adapter must not accept or synthesize arbitrary refs or correlation IDs.
+
+**Required test scenarios:**
+
+- Valid task, repository metadata with default branch, and a `200` response containing nested `workflow_run` → returns `accepted` with repo, run ID, and HTML URL.
+- Whitespace-only task → returns `invalid-task` and makes no GitHub request.
+- Missing repository metadata → returns `repo-not-found`.
+- Fixed workflow absent on the default branch → returns `workflow-not-found`.
+- App absent → returns `app-not-installed` with install URL.
+- App lacks Actions write → returns `missing-actions-permission` with install URL.
+- GitHub 5xx or transport failure → returns `github-unavailable`.
+- GitHub returns a non-success dispatch response → returns `dispatch-rejected`.
+- Successful request payload inspection → confirms the ref is the resolved default branch, inputs contain only `prompt`, and `correlation-id` is never sent.
+- `200` response with a malformed or missing nested `workflow_run` → returns `dispatch-rejected` rather than fabricating a run link.
+
+### Unit 3 — Wire `/fro-bot dispatch`, program injection, and deployment documentation
+
+**Files:** create `packages/gateway/src/discord/commands/dispatch.ts` and `packages/gateway/src/discord/commands/dispatch.test.ts`; modify `packages/gateway/src/discord/commands/fro-bot.ts`, `packages/gateway/src/discord/commands/fro-bot.test.ts`, `packages/gateway/src/discord/commands/index.test.ts`, `packages/gateway/src/program.ts`, `packages/gateway/src/program.test.ts`, and `deploy/README.md`.
+
+Add the required `task` option to the parent builder and route `dispatch` through a factory-built executor. Extend `FroBotDeps` with the injected `dispatchWorkflow` primitive, construct it once in `program.ts`, and keep the existing parent registry path unchanged. Resolve the channel binding inside the command, apply the normal trigger authorization bar, and map all outcomes with exhaustive handling. Document the command, the accepted-only behavior, and the GitHub App Actions: write requirement in `deploy/README.md`.
+
+The command must not enqueue a `RunTask`, acquire the gateway concurrency slot, create local `RunState`, or call local execution code. It should defer, authorize, dispatch, and edit the interaction with the final acceptance or failure copy.
+
+**Required test scenarios:**
+
+- Bound channel plus authorized user plus successful adapter result → replies that GitHub accepted the dispatch and includes the run URL; does not claim success.
+- Unbound channel → replies with the channel-unbound guidance and does not call the adapter.
+- Whitespace-only task → replies with invalid-task guidance and does not call the adapter.
+- User without the configured trigger role → denied; with no trigger role, a user with ManageChannels is authorized.
+- Adapter returns `app-not-installed` or `missing-actions-permission` → reply includes the repository and install URL without exposing tokens or internal errors.
+- Adapter returns `workflow-not-found`, `repo-not-found`, `dispatch-rejected`, or `github-unavailable` → each maps to the intended safe copy.
+- Parent builder exposes `dispatch` with required `task`, while the existing parent command remains the sole registered command.
+- Injected primitive is constructed and passed through program wiring; tests do not require real GitHub or Discord network calls.
+- Exhaustiveness guard remains present and catches an unhandled outcome at type-check time.
+- Regression coverage confirms the command path does not add the `correlation-id` input or enter the local queue/concurrency path.
+
+## Deployment and Operational Notes
+
+- The GitHub App installation must grant Actions: write in addition to the existing contents: read capability. The implementation requests this through the dispatch-specific capability only.
+- The workflow remains `.github/workflows/fro-bot.yaml`; no workflow change is needed because its existing `prompt` input is sufficient.
+- The command is self-hosted with the existing gateway deployment. `deploy/README.md` must state the setup requirement and show `/fro-bot dispatch task:<task>`.
+- Rate limiting is not included in Unit 7A. Repeated dispatches consume GitHub Actions minutes and currently have no gateway-side guard.
+
+## Risks
+
+- **Actions: write broadens the gateway App capability.** Mitigate with the dedicated `authForWorkflowDispatch()` path and repository-scoped tokens; do not widen `REQUIRED_PERMISSIONS`.
+- **`correlation-id` misuse silently creates a no-response run.** Mitigate by omitting the input entirely and keeping a request-payload regression test.
+- **Users may read “accepted” as “succeeded.”** Mitigate with explicit reply copy that names GitHub acceptance and links the run without claiming completion.
+- **Unbounded Actions spend.** Repeated dispatches are currently possible. The command should be observable and documented as a future rate-limit concern.
+- **Run lookup or response-shape drift.** Mitigate with the explicit API version, raw request, local response parser, and malformed-response tests.
+- **Lock contention after acceptance.** A dispatch can be accepted and later skipped when another surface owns the repository lock. Mitigate by describing acceptance rather than execution success; completion semantics belong to 7B.
+
+## Open Questions — Deferred to Implementation
+
+- **Rate limiting:** raised during scoping. Add a per-user or per-channel dispatch limit before broadening usage, because every accepted request can consume GitHub Actions minutes. Decide the initial budget, window, and whether a successful API acceptance or only a completed run counts against it.
+
+## Verification
+
+- Run `bun run check:md-links` after writing the plan.
+- Confirm every cited repository-relative path resolves.
+- No source files, workflow files, generated files, or lockfiles are changed by this plan.

--- a/packages/gateway/src/discord/commands/dispatch.test.ts
+++ b/packages/gateway/src/discord/commands/dispatch.test.ts
@@ -1,0 +1,252 @@
+import type {CoordinationConfig} from '@fro-bot/runtime'
+import type {ChatInputCommandInteraction, Guild} from 'discord.js'
+import type {ChannelQueue} from '../../execute/queue.js'
+import type {RunTask} from '../../execute/run.js'
+import type {DispatchOutcome, DispatchWorkflow} from '../../github/dispatch.js'
+import type {FroBotDeps} from './fro-bot.js'
+
+import {Effect} from 'effect'
+import {describe, expect, it, vi} from 'vitest'
+
+import {executeDispatch} from './dispatch.js'
+
+const INSTALL_URL = 'https://github.com/apps/fro-bot-agent/installations/new'
+
+function makeGuild(opts: {hasRole?: boolean; hasManageChannels?: boolean} = {}): Guild {
+  const {hasRole = true, hasManageChannels = true} = opts
+  return {
+    members: {
+      fetch: vi.fn().mockResolvedValue({
+        roles: {cache: {has: vi.fn().mockReturnValue(hasRole)}},
+        permissions: {has: vi.fn().mockReturnValue(hasManageChannels)},
+      }),
+    },
+  } as unknown as Guild
+}
+
+function makeQueue(): ChannelQueue<RunTask> {
+  return {
+    enqueue: vi.fn(),
+    pendingCount: vi.fn(),
+    takeNext: vi.fn(),
+    clear: vi.fn(),
+    removeBy: vi.fn(),
+  }
+}
+
+function makeDeps(
+  dispatchWorkflow: DispatchWorkflow,
+  binding: {readonly owner: string; readonly repo: string} | null = {owner: 'acme', repo: 'widget'},
+  overrides: Partial<FroBotDeps> = {},
+): FroBotDeps {
+  return {
+    bindingsStore: {
+      createBinding: vi.fn(),
+      getBindingByRepo: vi.fn(),
+      getBindingByChannelId: vi.fn().mockResolvedValue(
+        binding === null
+          ? {success: true, data: null}
+          : {
+              success: true,
+              data: {
+                owner: binding.owner,
+                repo: binding.repo,
+                channelId: 'channel-1',
+                channelName: 'widget',
+                workspacePath: '/workspace/repos/acme/widget',
+                createdAt: new Date().toISOString(),
+                createdByDiscordId: 'user-1',
+              },
+            },
+      ),
+      listBindings: vi.fn(),
+    },
+    appClient: {
+      authForRepo: vi.fn(),
+      authForWorkflowDispatch: vi.fn(),
+      getRepoIdentity: vi.fn(),
+      invalidateCache: vi.fn(),
+    },
+    workspaceClient: {clone: vi.fn(), readyz: vi.fn()},
+    installUrl: INSTALL_URL,
+    logger: {info: vi.fn(), warn: vi.fn(), error: vi.fn()},
+    queue: makeQueue(),
+    triggerRoleId: 'trigger-role',
+    gatewayLogger: {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()},
+    coordinationConfig: {} as CoordinationConfig,
+    identity: 'discord-gateway',
+    forceReleaseStaleLock: vi.fn(),
+    dispatchWorkflow,
+    ...overrides,
+  }
+}
+
+function makeInteraction(
+  task: string,
+  guild: Guild = makeGuild(),
+  channelId = 'channel-1',
+): {
+  readonly interaction: ChatInputCommandInteraction
+  readonly deferReply: ReturnType<typeof vi.fn>
+  readonly editReply: ReturnType<typeof vi.fn>
+} {
+  const deferReply = vi.fn().mockResolvedValue(undefined)
+  const editReply = vi.fn().mockResolvedValue(undefined)
+  return {
+    interaction: {
+      channelId,
+      guild,
+      user: {id: 'user-1'},
+      deferReply,
+      editReply,
+      options: {getString: vi.fn().mockReturnValue(task)},
+    } as unknown as ChatInputCommandInteraction,
+    deferReply,
+    editReply,
+  }
+}
+
+function getReplyContent(editReply: ReturnType<typeof vi.fn>): string {
+  const firstCall = editReply.mock.calls[0]
+  const options: unknown = firstCall?.[0]
+  if (typeof options !== 'object' || options === null || 'content' in options === false) return ''
+  const content = options.content
+  return typeof content === 'string' ? content : ''
+}
+
+describe('executeDispatch', () => {
+  it('reports GitHub acceptance and the run link without claiming the run succeeded', async () => {
+    // #given — an authorized user in a bound channel and an accepted workflow dispatch
+    const dispatchWorkflow = vi.fn().mockResolvedValue({
+      outcome: 'accepted',
+      owner: 'acme',
+      repo: 'widget',
+      runId: 1234,
+      runUrl: 'https://github.com/acme/widget/actions/runs/1234',
+    } satisfies DispatchOutcome)
+    const deps = makeDeps(dispatchWorkflow)
+    const {interaction, deferReply, editReply} = makeInteraction('run the checks')
+
+    // #when
+    await Effect.runPromise(executeDispatch(interaction, deps))
+
+    // #then
+    expect(deferReply).toHaveBeenCalledExactlyOnceWith({ephemeral: true})
+    expect(dispatchWorkflow).toHaveBeenCalledExactlyOnceWith('acme', 'widget', 'run the checks')
+    const content = getReplyContent(editReply)
+    expect(content).toContain('accepted')
+    expect(content).toContain('https://github.com/acme/widget/actions/runs/1234')
+    expect(content).not.toMatch(/succeeded|completed|finished/i)
+    expect(deps.queue.enqueue).not.toHaveBeenCalled()
+    expect(deps.queue.takeNext).not.toHaveBeenCalled()
+    expect(deps.forceReleaseStaleLock).not.toHaveBeenCalled()
+  })
+
+  it('reports acceptance without inventing a run link when GitHub omits run details', async () => {
+    // #given — GitHub accepted the dispatch but returned no run details
+    const dispatchWorkflow = vi.fn<DispatchWorkflow>().mockResolvedValue({
+      outcome: 'accepted',
+      owner: 'acme',
+      repo: 'widget',
+    })
+    const deps = makeDeps(dispatchWorkflow)
+    const {interaction, editReply} = makeInteraction('run the checks')
+
+    // #when
+    await Effect.runPromise(executeDispatch(interaction, deps))
+
+    // #then
+    const content = getReplyContent(editReply)
+    expect(content).toContain('accepted')
+    expect(content).toContain('run link is unavailable')
+    expect(content).not.toContain('undefined')
+  })
+
+  it('reports an unbound channel without calling the dispatch adapter', async () => {
+    // #given
+    const dispatchWorkflow = vi.fn()
+    const deps = makeDeps(dispatchWorkflow, null)
+    const {interaction, editReply} = makeInteraction('run it')
+
+    // #when
+    await Effect.runPromise(executeDispatch(interaction, deps))
+
+    // #then
+    expect(dispatchWorkflow).not.toHaveBeenCalled()
+    expect(getReplyContent(editReply)).toMatch(/not bound|add-project/i)
+  })
+
+  it('reports invalid-task without calling the dispatch adapter for whitespace-only input', async () => {
+    // #given
+    const dispatchWorkflow = vi.fn()
+    const deps = makeDeps(dispatchWorkflow)
+    const {interaction, editReply} = makeInteraction(' \n\t ')
+
+    // #when
+    await Effect.runPromise(executeDispatch(interaction, deps))
+
+    // #then
+    expect(dispatchWorkflow).not.toHaveBeenCalled()
+    expect(getReplyContent(editReply)).toMatch(/task|empty|provide/i)
+  })
+
+  it('denies an unauthorized user before binding lookup or dispatch', async () => {
+    // #given
+    const dispatchWorkflow = vi.fn()
+    const deps = makeDeps(dispatchWorkflow)
+    const getBindingByChannelId = deps.bindingsStore.getBindingByChannelId as ReturnType<typeof vi.fn>
+    const {interaction, editReply} = makeInteraction('run it', makeGuild({hasRole: false, hasManageChannels: false}))
+
+    // #when
+    await Effect.runPromise(executeDispatch(interaction, deps))
+
+    // #then
+    expect(getBindingByChannelId).not.toHaveBeenCalled()
+    expect(dispatchWorkflow).not.toHaveBeenCalled()
+    expect(getReplyContent(editReply)).toMatch(/permission|authorized/i)
+  })
+
+  it('uses ManageChannels when no trigger role is configured', async () => {
+    // #given
+    const dispatchWorkflow = vi.fn().mockResolvedValue({outcome: 'dispatch-rejected', owner: 'acme', repo: 'widget'})
+    const deps = makeDeps(dispatchWorkflow, {owner: 'acme', repo: 'widget'}, {triggerRoleId: null})
+    const {interaction} = makeInteraction('run it', makeGuild({hasRole: false, hasManageChannels: true}))
+
+    // #when
+    await Effect.runPromise(executeDispatch(interaction, deps))
+
+    // #then
+    expect(dispatchWorkflow).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    ['app-not-installed', INSTALL_URL],
+    ['missing-actions-permission', `Actions: write`],
+    ['missing-permissions', 'permissions'],
+    ['workflow-not-found', 'repository or workflow'],
+    ['repo-not-found', 'repository'],
+    ['dispatch-rejected', 'rejected'],
+    ['github-unavailable', 'Please try again'],
+  ] as const)('maps %s to safe user-facing copy', async (outcome, expectedCopy) => {
+    // #given
+    const dispatchWorkflow = vi.fn().mockResolvedValue(
+      outcome === 'app-not-installed' || outcome === 'missing-actions-permission' || outcome === 'missing-permissions'
+        ? {
+            outcome,
+            owner: 'acme',
+            repo: 'widget',
+            installUrl: INSTALL_URL,
+            ...(outcome === 'missing-permissions' ? {missingPermissions: ['contents: read']} : {}),
+          }
+        : {outcome, owner: 'acme', repo: 'widget'},
+    )
+    const deps = makeDeps(dispatchWorkflow)
+    const {interaction, editReply} = makeInteraction('run it')
+
+    // #when
+    await Effect.runPromise(executeDispatch(interaction, deps))
+
+    // #then
+    expect(getReplyContent(editReply)).toContain(expectedCopy)
+  })
+})

--- a/packages/gateway/src/discord/commands/dispatch.ts
+++ b/packages/gateway/src/discord/commands/dispatch.ts
@@ -1,0 +1,127 @@
+/**
+ * `/fro-bot dispatch` subcommand.
+ *
+ * This command only asks GitHub Actions to accept a workflow dispatch. It does
+ * not enter the gateway queue, acquire a local execution slot, or create local
+ * run state.
+ */
+
+import type {ChatInputCommandInteraction} from 'discord.js'
+import type {DispatchOutcome} from '../../github/dispatch.js'
+import type {FroBotDeps} from './fro-bot.js'
+import type {AuthDecision, GuildCommandCtx} from './guild-command.js'
+
+import {Effect} from 'effect'
+
+import {editInteraction} from '../io.js'
+import {userIsAuthorized} from '../mentions.js'
+import {INTERNAL_ERROR_COPY, makeGuildCommand} from './guild-command.js'
+
+function invalidTaskCopy(): string {
+  return 'Provide a non-empty task with `/fro-bot dispatch task:<task>`.'
+}
+
+function repoSlug(owner: string, repo: string): string {
+  return `${owner}/${repo}`
+}
+
+function acceptedCopy(owner: string, repo: string, runUrl: string | undefined): string {
+  if (runUrl === undefined) {
+    return `✅ GitHub accepted the dispatch for \`${repoSlug(owner, repo)}\`, but the run link is unavailable. Check GitHub Actions for the run.`
+  }
+  return `✅ GitHub accepted the dispatch for \`${repoSlug(owner, repo)}\`. Track the run here: ${runUrl}`
+}
+
+function outcomeCopy(outcome: DispatchOutcome): string {
+  switch (outcome.outcome) {
+    case 'accepted':
+      return acceptedCopy(outcome.owner, outcome.repo, outcome.runUrl)
+    case 'invalid-task':
+      return invalidTaskCopy()
+    case 'app-not-installed':
+      return `The fro-bot GitHub App is not installed on \`${repoSlug(outcome.owner, outcome.repo)}\`. Install it at: ${outcome.installUrl}`
+    case 'missing-actions-permission':
+      return `The GitHub App needs **Actions: write** for \`${repoSlug(outcome.owner, outcome.repo)}\`. Update the installation at: ${outcome.installUrl}`
+    case 'missing-permissions':
+      return `The GitHub App is missing permissions (${outcome.missingPermissions.join(', ')}) for \`${repoSlug(outcome.owner, outcome.repo)}\`. Update the installation at: ${outcome.installUrl}`
+    case 'repo-not-found':
+      return `GitHub could not find repository \`${repoSlug(outcome.owner, outcome.repo)}\`.`
+    case 'workflow-not-found':
+      return `GitHub could not dispatch the fixed workflow for \`${repoSlug(outcome.owner, outcome.repo)}\`. The repository or workflow may no longer be available.`
+    case 'dispatch-rejected':
+      return `GitHub rejected the workflow dispatch for \`${repoSlug(outcome.owner, outcome.repo)}\`. Please try again.`
+    case 'github-unavailable':
+      return 'GitHub is temporarily unavailable. Please try again.'
+    default: {
+      const exhaustiveCheck: never = outcome
+      return exhaustiveCheck
+    }
+  }
+}
+
+export function buildDispatchSpec(deps: FroBotDeps): {
+  readonly authorize: (ctx: GuildCommandCtx) => Effect.Effect<AuthDecision, never>
+  readonly work: (ctx: GuildCommandCtx) => Effect.Effect<void, Error>
+} {
+  const authorize = (ctx: GuildCommandCtx): Effect.Effect<AuthDecision, never> =>
+    Effect.promise(async () => {
+      const authorized = await userIsAuthorized(ctx.guild, ctx.interaction.user.id, deps.triggerRoleId, ctx.log)
+      if (authorized === true) return {authorized: true as const}
+      return {authorized: false as const, copy: 'You are not authorized to dispatch tasks here.'}
+    })
+
+  const work = (ctx: GuildCommandCtx): Effect.Effect<void, Error> =>
+    Effect.gen(function* () {
+      const task = ctx.interaction.options.getString('task', true)
+      if (task.trim().length === 0) {
+        yield* editInteraction(ctx.interaction, {content: invalidTaskCopy()}, ctx.log)
+        return
+      }
+
+      const channelId = ctx.interaction.channelId
+      const bindingResult = yield* Effect.tryPromise({
+        try: async () => deps.bindingsStore.getBindingByChannelId(channelId),
+        catch: error => (error instanceof Error ? error : new Error(String(error))),
+      })
+
+      if (bindingResult.success === false) {
+        ctx.log.error({channelId, err: bindingResult.error.message}, 'dispatch: binding lookup failed')
+        yield* editInteraction(ctx.interaction, {content: INTERNAL_ERROR_COPY}, ctx.log)
+        return
+      }
+
+      if (bindingResult.data === null) {
+        yield* editInteraction(
+          ctx.interaction,
+          {content: 'This channel is not bound to a repository. Use `/fro-bot add-project` first.'},
+          ctx.log,
+        )
+        return
+      }
+
+      const {owner, repo} = bindingResult.data
+      const outcome = yield* Effect.tryPromise({
+        try: async () => deps.dispatchWorkflow(owner, repo, task),
+        catch: error => (error instanceof Error ? error : new Error(String(error))),
+      })
+      yield* editInteraction(ctx.interaction, {content: outcomeCopy(outcome)}, ctx.log)
+    })
+
+  return {authorize, work}
+}
+
+export function executeDispatch(
+  interaction: ChatInputCommandInteraction,
+  deps: FroBotDeps,
+): Effect.Effect<void, Error> {
+  const {authorize, work} = buildDispatchSpec(deps)
+  return makeGuildCommand(
+    {
+      name: 'dispatch',
+      authorize,
+      work,
+      serverOnlyCopy: 'This command can only be used in a server.',
+    },
+    deps,
+  )(interaction)
+}

--- a/packages/gateway/src/discord/commands/fro-bot.test.ts
+++ b/packages/gateway/src/discord/commands/fro-bot.test.ts
@@ -14,6 +14,7 @@ import type {CoordinationConfig, ForceReleaseStaleLockResult} from '@fro-bot/run
 import type {ChatInputCommandInteraction, Guild} from 'discord.js'
 import type {ChannelQueue} from '../../execute/queue.js'
 import type {RunTask} from '../../execute/run.js'
+import type {DispatchWorkflow} from '../../github/dispatch.js'
 import type {FroBotDeps} from './fro-bot.js'
 
 import {Effect} from 'effect'
@@ -74,6 +75,7 @@ function makeDeps(overrides?: Partial<FroBotDeps>): FroBotDeps {
     },
     appClient: {
       authForRepo: vi.fn(),
+      authForWorkflowDispatch: vi.fn(),
       getRepoIdentity: vi.fn(),
       invalidateCache: vi.fn(),
     },
@@ -105,6 +107,7 @@ function makeDeps(overrides?: Partial<FroBotDeps>): FroBotDeps {
     },
     identity: 'discord-gateway',
     forceReleaseStaleLock: defaultForceRelease,
+    dispatchWorkflow: vi.fn<DispatchWorkflow>(),
     ...overrides,
   }
 }
@@ -133,6 +136,7 @@ function makeInteraction(
     editReply,
     options: {
       getSubcommand: vi.fn().mockReturnValue(subcommand),
+      getString: vi.fn().mockReturnValue('run the checks'),
     },
   } as unknown as ChatInputCommandInteraction
   return {interaction, reply, deferReply, editReply}
@@ -155,6 +159,11 @@ describe('createFroBotCommand — builder registration', () => {
     expect(subNames).toContain('ping')
     expect(subNames).toContain('add-project')
     expect(subNames).toContain('clear-queue')
+    expect(subNames).toContain('dispatch')
+
+    const dispatch = (json.options ?? []).find((o: {name: string}) => o.name === 'dispatch') as
+      {options?: readonly {name: string; required?: boolean}[]} | undefined
+    expect(dispatch?.options).toEqual(expect.arrayContaining([expect.objectContaining({name: 'task', required: true})]))
   })
 })
 
@@ -189,6 +198,44 @@ describe('createFroBotCommand — dispatch', () => {
     expect(reply).toHaveBeenCalledWith(
       expect.objectContaining({content: 'pong', ephemeral: true, allowedMentions: {parse: []}}),
     )
+  })
+
+  it('routes dispatch to the injected workflow dispatcher', async () => {
+    // #given — a bound channel, authorized user, and accepted dispatch result
+    const dispatchWorkflow = vi.fn<DispatchWorkflow>().mockResolvedValue({
+      outcome: 'accepted',
+      owner: 'acme',
+      repo: 'widget',
+      runId: 1234,
+      runUrl: 'https://github.com/acme/widget/actions/runs/1234',
+    })
+    const bindingsStore = {
+      createBinding: vi.fn(),
+      getBindingByRepo: vi.fn(),
+      getBindingByChannelId: vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          owner: 'acme',
+          repo: 'widget',
+          channelId: 'ch-test-123',
+          channelName: 'widget',
+          workspacePath: '/workspace/repos/acme/widget',
+          createdAt: new Date().toISOString(),
+          createdByDiscordId: 'user-authorized-123',
+        },
+      }),
+      listBindings: vi.fn(),
+    }
+    const deps = makeDeps({bindingsStore, dispatchWorkflow})
+    const cmd = createFroBotCommand(deps)
+    const {interaction} = makeInteraction('dispatch')
+
+    // #when
+    const result = await Effect.runPromise(Effect.either(cmd.execute(interaction)))
+
+    // #then
+    expect(result._tag).toBe('Right')
+    expect(dispatchWorkflow).toHaveBeenCalledExactlyOnceWith('acme', 'widget', 'run the checks')
   })
 
   it('returns Effect.fail for an unknown subcommand', async () => {

--- a/packages/gateway/src/discord/commands/fro-bot.ts
+++ b/packages/gateway/src/discord/commands/fro-bot.ts
@@ -9,12 +9,14 @@
  * - `add-project` — bind a GitHub repo to a Discord channel
  * - `clear-queue` — drop pending queued tasks for the invoking channel
  * - `force-release-lock` — dead-run-verified force-release of a stuck per-repo lock
+ * - `dispatch` — ask GitHub Actions to run the fixed repository workflow
  */
 
 import type {CoordinationConfig, ForceReleaseStaleLockResult} from '@fro-bot/runtime'
 import type {ChatInputCommandInteraction} from 'discord.js'
 import type {ChannelQueue} from '../../execute/queue.js'
 import type {RunTask} from '../../execute/run.js'
+import type {DispatchWorkflow} from '../../github/dispatch.js'
 import type {CoordinationLogger} from '../../runtime-effect.js'
 import type {GatewayLogger} from '../client.js'
 import type {AddProjectDeps} from './add-project.js'
@@ -26,6 +28,7 @@ import {Effect} from 'effect'
 import {editInteraction} from '../io.js'
 import {userIsAuthorized} from '../mentions.js'
 import {executeAddProject} from './add-project.js'
+import {buildDispatchSpec} from './dispatch.js'
 import {INTERNAL_ERROR_COPY, makeGuildCommand} from './guild-command.js'
 import {executePing} from './ping.js'
 
@@ -75,6 +78,8 @@ export interface FroBotDeps extends AddProjectDeps {
     identity: string,
     logger: CoordinationLogger,
   ) => Effect.Effect<ForceReleaseStaleLockResult, Error>
+  /** GitHub Actions dispatch primitive, constructed once in program.ts. */
+  readonly dispatchWorkflow: DispatchWorkflow
 }
 
 // ---------------------------------------------------------------------------
@@ -118,6 +123,12 @@ export function createFroBotCommand(deps: FroBotDeps): SlashCommand {
         .setDescription(
           'Force-release a stuck per-repo coordination lock (dead-run-verified; requires ManageChannels)',
         ),
+    )
+    .addSubcommand(sub =>
+      sub
+        .setName('dispatch')
+        .setDescription('Ask GitHub Actions to run the repository workflow')
+        .addStringOption(opt => opt.setName('task').setDescription('Task to send to the Action').setRequired(true)),
     ) as SlashCommandBuilder
 
   // Build pipeline executors once per factory call, closing over deps.
@@ -295,6 +306,16 @@ export function createFroBotCommand(deps: FroBotDeps): SlashCommand {
     deps,
   )
 
+  const executeDispatchCommand = makeGuildCommand(
+    {
+      name: 'dispatch',
+      ...buildDispatchSpec(deps),
+      denialCopy: 'You are not authorized to dispatch tasks here.',
+      serverOnlyCopy: 'This command can only be used in a server.',
+    },
+    deps,
+  )
+
   const execute = (interaction: ChatInputCommandInteraction): Effect.Effect<void, Error> => {
     const subcommand = interaction.options.getSubcommand(true)
 
@@ -312,6 +333,10 @@ export function createFroBotCommand(deps: FroBotDeps): SlashCommand {
 
     if (subcommand === 'force-release-lock') {
       return executeForceReleaseLock(interaction)
+    }
+
+    if (subcommand === 'dispatch') {
+      return executeDispatchCommand(interaction)
     }
 
     return Effect.fail(new Error(`Unknown subcommand: ${subcommand}`))

--- a/packages/gateway/src/discord/commands/index.test.ts
+++ b/packages/gateway/src/discord/commands/index.test.ts
@@ -1,5 +1,6 @@
 import type {CoordinationConfig} from '@fro-bot/runtime'
 import type {ChatInputCommandInteraction} from 'discord.js'
+import type {DispatchWorkflow} from '../../github/dispatch.js'
 import type {FroBotDeps} from './fro-bot.js'
 
 import {Routes} from 'discord.js'
@@ -22,6 +23,7 @@ function makeMockDeps(): FroBotDeps {
     },
     appClient: {
       authForRepo: vi.fn(),
+      authForWorkflowDispatch: vi.fn(),
       getRepoIdentity: vi.fn(),
       invalidateCache: vi.fn(),
     },
@@ -62,6 +64,7 @@ function makeMockDeps(): FroBotDeps {
       success: true,
       data: {outcome: 'no-lock', holderId: null, runId: null, lockAgeMs: null, heartbeatAgeMs: null},
     }),
+    dispatchWorkflow: vi.fn<DispatchWorkflow>(),
   }
 }
 

--- a/packages/gateway/src/github/app-client.test.ts
+++ b/packages/gateway/src/github/app-client.test.ts
@@ -68,6 +68,14 @@ interface InstallationAuthCallArg {
   readonly type: string
   readonly repositoryNames?: string[]
   readonly permissions?: Record<string, string>
+  readonly request?: {readonly signal?: AbortSignal}
+}
+
+function makeAbortedTimeout(): {readonly signal: AbortSignal; readonly restore: () => void} {
+  const controller = new AbortController()
+  controller.abort(new Error('workflow dispatch timeout'))
+  const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal)
+  return {signal: controller.signal, restore: () => timeoutSpy.mockRestore()}
 }
 
 function getInstallationCalls(): InstallationAuthCallArg[] {
@@ -120,6 +128,9 @@ describe('createAppClient', () => {
     expect(result.data.installationId).toBe(99)
     expect(result.data.token).toBe('installation-token-value')
     expect(result.data.octokit).toBeDefined()
+    const [installationCallArg] = getInstallationCalls()
+    expect(installationCallArg?.repositoryNames).toEqual(['repo'])
+    expect(installationCallArg?.permissions).toEqual({contents: 'read'})
   })
 
   it('happy path: second call for same (owner, repo) reuses cached installationId', async () => {
@@ -313,6 +324,142 @@ describe('createAppClient', () => {
       expect(arg.repositoryNames).toEqual(['myrepo'])
       expect(arg.permissions).toEqual({contents: 'read'})
     }
+  })
+
+  describe('authForWorkflowDispatch', () => {
+    it('bounds installation discovery with an abort signal', async () => {
+      // #given — the discovery request is aborted by the workflow-dispatch timeout
+      const timeout = makeAbortedTimeout()
+      let receivedSignal: AbortSignal | undefined
+      mockRequest.mockImplementation(async (_route: string, options: InstallationAuthCallArg) => {
+        receivedSignal = options.request?.signal
+        throw timeout.signal.reason
+      })
+      const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY, installUrl: INSTALL_URL})
+
+      // #when
+      const result = await client.authForWorkflowDispatch('myorg', 'myrepo')
+
+      // #then
+      expect(receivedSignal).toBe(timeout.signal)
+      expect(result.success).toBe(false)
+      if (result.success === true) return
+      expect(result.error).toBeInstanceOf(AuthError)
+      timeout.restore()
+    })
+
+    it('bounds installation token minting with an abort signal', async () => {
+      // #given — discovery succeeds but installation-token minting is aborted
+      const timeout = makeAbortedTimeout()
+      let receivedSignal: AbortSignal | undefined
+      mockRequest.mockResolvedValue({data: {id: 99, permissions: {contents: 'read', actions: 'write'}}})
+      mockAuth.mockImplementation(async (options: InstallationAuthCallArg) => {
+        if (options.type === 'app') return {token: 'jwt-token-value'}
+        receivedSignal = options.request?.signal
+        throw timeout.signal.reason
+      })
+      const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY, installUrl: INSTALL_URL})
+
+      // #when
+      const result = await client.authForWorkflowDispatch('myorg', 'myrepo')
+
+      // #then
+      expect(receivedSignal).toBe(timeout.signal)
+      expect(result.success).toBe(false)
+      if (result.success === true) return
+      expect(result.error).toBeInstanceOf(AuthError)
+      timeout.restore()
+    })
+
+    it('returns a repository-scoped dispatch client when Actions: write is granted', async () => {
+      // #given — the installation grants the ordinary contents permission and Actions: write
+      mockRequest.mockResolvedValue({data: {id: 99, permissions: {contents: 'read', actions: 'write'}}})
+      const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY, installUrl: INSTALL_URL})
+
+      // #when
+      const result = await client.authForWorkflowDispatch('myorg', 'myrepo')
+
+      // #then — dispatch auth succeeds and the token is scoped to this repository with only Actions: write
+      expect(result.success).toBe(true)
+      expect(getInstallationCalls()).toHaveLength(1)
+      const [installationCallArg] = getInstallationCalls()
+      expect(installationCallArg?.repositoryNames).toEqual(['myrepo'])
+      expect(installationCallArg?.permissions).toEqual({actions: 'write'})
+    })
+
+    it('returns InsufficientPermissionsError with the install URL when Actions: write is missing', async () => {
+      // #given — the installation has contents:read but no Actions:write
+      mockRequest
+        .mockResolvedValueOnce({data: {id: 99, permissions: {contents: 'read'}}})
+        .mockResolvedValueOnce({data: {id: 99, permissions: {contents: 'read', actions: 'write'}}})
+      const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY, installUrl: INSTALL_URL})
+
+      // #when
+      const result = await client.authForWorkflowDispatch('myorg', 'myrepo')
+
+      // #then
+      expect(result.success).toBe(false)
+      if (result.success === true) return
+      expect(result.error).toBeInstanceOf(InsufficientPermissionsError)
+      if (result.error instanceof InsufficientPermissionsError === false) return
+      expect(result.error.message).toContain('actions: write')
+      expect(result.error.installUrl).toBe(INSTALL_URL)
+      expect(getInstallationCalls()).toHaveLength(0)
+
+      // #when — the installation is fixed and the capability is requested again
+      const retry = await client.authForWorkflowDispatch('myorg', 'myrepo')
+
+      // #then — the unusable permission result was not cached
+      expect(retry.success).toBe(true)
+      expect(mockRequest).toHaveBeenCalledTimes(2)
+    })
+
+    it('returns AppNotInstalledError with the install URL when dispatch auth cannot find an installation', async () => {
+      // #given
+      mockRequest.mockRejectedValueOnce(Object.assign(new Error('Not Found'), {status: 404}))
+      const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY, installUrl: INSTALL_URL})
+
+      // #when
+      const result = await client.authForWorkflowDispatch('myorg', 'myrepo')
+
+      // #then
+      expect(result.success).toBe(false)
+      if (result.success === true) return
+      expect(result.error).toBeInstanceOf(AppNotInstalledError)
+      if (result.error instanceof AppNotInstalledError === false) return
+      expect(result.error.installUrl).toBe(INSTALL_URL)
+    })
+
+    it('returns a safe AuthError when dispatch token minting fails', async () => {
+      // #given
+      mockRequest.mockResolvedValue({data: {id: 99, permissions: {contents: 'read', actions: 'write'}}})
+      mockAuth.mockImplementation(async ({type}: {type: string}) => {
+        if (type === 'app') return {token: 'jwt-token-value'}
+        throw new Error('installation token mint failed')
+      })
+      const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY, installUrl: INSTALL_URL})
+
+      // #when
+      const result = await client.authForWorkflowDispatch('myorg', 'myrepo')
+
+      // #then
+      expect(result.success).toBe(false)
+      if (result.success === true) return
+      expect(result.error).toBeInstanceOf(AuthError)
+      expect(result.error.message).not.toContain('installation-token-value')
+    })
+
+    it('does not require Actions: write for ordinary repository auth', async () => {
+      // #given — the ordinary installation permission remains contents:read only
+      mockRequest.mockResolvedValue({data: {id: 99, permissions: {contents: 'read'}}})
+      const client = createAppClient({appId: APP_ID, privateKey: PRIVATE_KEY})
+
+      // #when
+      const result = await client.authForRepo('myorg', 'myrepo')
+
+      // #then
+      expect(result.success).toBe(true)
+    })
   })
 
   it('security: repositoryNames uses the repo name, not the owner/repo path', async () => {

--- a/packages/gateway/src/github/app-client.ts
+++ b/packages/gateway/src/github/app-client.ts
@@ -29,6 +29,9 @@ import {isOctokitNotFound, safeErrorMessage} from './errors.js'
  */
 export const REPO_IDENTITY_REQUEST_TIMEOUT_MS = 10_000
 
+/** Maximum duration for each network operation in workflow-dispatch App auth. */
+export const WORKFLOW_DISPATCH_AUTH_TIMEOUT_MS = 5_000
+
 // ---------------------------------------------------------------------------
 // Error types
 // ---------------------------------------------------------------------------
@@ -132,6 +135,18 @@ export interface AppClient {
   ) => Promise<Result<AppClientAuthResult, AppNotInstalledError | InsufficientPermissionsError | AuthError>>
 
   /**
+   * Return an authenticated, repository-scoped Octokit instance for workflow dispatch.
+   *
+   * This capability separately requires Actions: write and mints a token with only
+   * `{actions: 'write'}`. It intentionally does not widen the ordinary authForRepo
+   * permission contract.
+   */
+  readonly authForWorkflowDispatch: (
+    owner: string,
+    repo: string,
+  ) => Promise<Result<AppClientAuthResult, AppNotInstalledError | InsufficientPermissionsError | AuthError>>
+
+  /**
    * Fetch the repo's immutable numeric id and node_id via GET /repos/{owner}/{repo}.
    *
    * Uses the authenticated octokit from authForRepo — no extra auth round-trip.
@@ -187,87 +202,127 @@ export interface AppClientOptions {
 export function createAppClient(options: AppClientOptions): AppClient {
   const {appId, privateKey, installUrl = 'https://github.com/apps/fro-bot-agent/installations/new', logger} = options
 
-  // In-memory cache: "owner/repo" → installationId
-  const installationCache = new Map<string, number>()
+  interface InstallationData {
+    readonly id: number
+    readonly permissions: Record<string, string>
+  }
+
+  // In-memory cache: "owner/repo" → verified installation data
+  const installationCache = new Map<string, InstallationData>()
 
   const cacheKey = (owner: string, repo: string): string => `${owner}/${repo}`
+
+  async function discoverInstallation(
+    owner: string,
+    repo: string,
+    requestSignal?: AbortSignal,
+  ): Promise<Result<InstallationData, AppNotInstalledError | InsufficientPermissionsError | AuthError>> {
+    const key = cacheKey(owner, repo)
+    const cached = installationCache.get(key)
+    if (cached !== undefined) return ok(cached)
+
+    try {
+      // Mint a JWT-scoped auth (no installationId) to call the discovery endpoint.
+      const jwtAuth = createAppAuth({appId, privateKey})
+      const {token: jwtToken} = await jwtAuth({type: 'app'})
+      const discoveryOctokit = new Octokit({auth: jwtToken})
+
+      let installationData: InstallationData
+      try {
+        const requestOptions =
+          requestSignal === undefined ? {owner, repo} : {owner, repo, request: {signal: requestSignal}}
+        const response = await discoveryOctokit.request('GET /repos/{owner}/{repo}/installation', requestOptions)
+        installationData = {
+          id: response.data.id,
+          permissions: response.data.permissions ?? {},
+        }
+      } catch (discoveryError) {
+        if (isOctokitNotFound(discoveryError)) {
+          return err(new AppNotInstalledError(owner, repo, installUrl))
+        }
+        return err(new AuthError(safeErrorMessage(discoveryError)))
+      }
+
+      // The ordinary contents:read minimum remains a prerequisite for every cached installation.
+      const permissionResult = verifyPermissions(installationData.permissions, REQUIRED_PERMISSIONS, installUrl, logger)
+      if (permissionResult !== null) return err(permissionResult)
+
+      installationCache.set(key, installationData)
+      logger?.debug('Discovered GitHub App installation', {
+        owner,
+        repo,
+        installationId: installationData.id,
+      })
+      return ok(installationData)
+    } catch (error) {
+      return err(new AuthError(safeErrorMessage(error)))
+    }
+  }
+
+  async function mintToken(
+    owner: string,
+    repo: string,
+    installation: InstallationData,
+    permissions: Record<string, string>,
+    requestSignal?: AbortSignal,
+  ): Promise<Result<AppClientAuthResult, AuthError>> {
+    try {
+      const installAuth = createAppAuth({appId, privateKey, installationId: installation.id})
+      const requestOptions = requestSignal === undefined ? {} : {request: {signal: requestSignal}}
+      const {token} = await installAuth({
+        type: 'installation',
+        repositoryNames: [repo],
+        permissions,
+        ...requestOptions,
+      })
+      const octokit = new Octokit({auth: token})
+      return ok({octokit, installationId: installation.id, token})
+    } catch (mintError) {
+      // A mint failure means the cached installation may no longer be usable.
+      installationCache.delete(cacheKey(owner, repo))
+      return err(new AuthError(safeErrorMessage(mintError)))
+    }
+  }
 
   async function authForRepo(
     owner: string,
     repo: string,
   ): Promise<Result<AppClientAuthResult, AppNotInstalledError | InsufficientPermissionsError | AuthError>> {
-    try {
-      // Stage 1: JWT-level auth — discover installation ID if not cached.
-      let installationId = installationCache.get(cacheKey(owner, repo))
+    const installationResult = await discoverInstallation(owner, repo)
+    if (installationResult.success === false) return installationResult
+    return mintToken(owner, repo, installationResult.data, {contents: 'read'})
+  }
 
-      if (installationId === undefined) {
-        // Note: the over-privileged WARN in verifyPermissions only fires during
-        // discovery (cache miss). Cache-hit calls skip this block entirely, so
-        // the WARN will not repeat on subsequent calls — this is intentional.
-        // Mint a JWT-scoped auth (no installationId) to call the discovery endpoint.
-        const jwtAuth = createAppAuth({appId, privateKey})
+  async function authForWorkflowDispatch(
+    owner: string,
+    repo: string,
+  ): Promise<Result<AppClientAuthResult, AppNotInstalledError | InsufficientPermissionsError | AuthError>> {
+    const installationResult = await discoverInstallation(
+      owner,
+      repo,
+      AbortSignal.timeout(WORKFLOW_DISPATCH_AUTH_TIMEOUT_MS),
+    )
+    if (installationResult.success === false) return installationResult
 
-        // Get a JWT token for the App-level request.
-        const {token: jwtToken} = await jwtAuth({type: 'app'})
-
-        const discoveryOctokit = new Octokit({auth: jwtToken})
-
-        let installationData: {id: number; permissions: Record<string, string>}
-        try {
-          const response = await discoveryOctokit.request('GET /repos/{owner}/{repo}/installation', {owner, repo})
-          installationData = {
-            id: response.data.id,
-            permissions: response.data.permissions ?? {},
-          }
-        } catch (discoveryError) {
-          if (isOctokitNotFound(discoveryError)) {
-            return err(new AppNotInstalledError(owner, repo, installUrl))
-          }
-          return err(new AuthError(safeErrorMessage(discoveryError)))
-        }
-
-        // Verify permissions.
-        const permissionResult = verifyPermissions(installationData.permissions, installUrl, logger)
-        if (permissionResult !== null) {
-          return err(permissionResult)
-        }
-
-        installationId = installationData.id
-        installationCache.set(cacheKey(owner, repo), installationId)
-
-        logger?.debug('Discovered GitHub App installation', {
-          owner,
-          repo,
-          installationId,
-        })
-      }
-
-      // Stage 2: Mint a repository-scoped installation token.
-      // Narrow the token to the requested repository and the minimum required
-      // permissions (contents:read) so a compromised token cannot be used to
-      // access other repositories in the same installation.
-      const installAuth = createAppAuth({appId, privateKey, installationId})
-      let token: string
-      try {
-        ;({token} = await installAuth({
-          type: 'installation',
-          repositoryNames: [repo],
-          permissions: {contents: 'read'},
-        }))
-      } catch (mintError) {
-        // Stage-2 failure means the cached installationId is no longer usable
-        // (e.g. revoked installation, rotated key, transient API error).
-        // Evict it so the next call re-discovers rather than failing indefinitely.
-        installationCache.delete(cacheKey(owner, repo))
-        return err(new AuthError(safeErrorMessage(mintError)))
-      }
-
-      const octokit = new Octokit({auth: token})
-
-      return ok({octokit, installationId, token})
-    } catch (error) {
-      return err(new AuthError(safeErrorMessage(error)))
+    const permissionResult = verifyPermissions(
+      installationResult.data.permissions,
+      {actions: 'write'},
+      installUrl,
+      logger,
+    )
+    if (permissionResult !== null) {
+      // Do not retain an installation that cannot satisfy this dedicated capability.
+      installationCache.delete(cacheKey(owner, repo))
+      return err(permissionResult)
     }
+
+    return mintToken(
+      owner,
+      repo,
+      installationResult.data,
+      {actions: 'write'},
+      AbortSignal.timeout(WORKFLOW_DISPATCH_AUTH_TIMEOUT_MS),
+    )
   }
 
   async function getRepoIdentity(
@@ -317,7 +372,7 @@ export function createAppClient(options: AppClientOptions): AppClient {
     installationCache.delete(cacheKey(owner, repo))
   }
 
-  return {authForRepo, getRepoIdentity, invalidateCache}
+  return {authForRepo, authForWorkflowDispatch, getRepoIdentity, invalidateCache}
 }
 
 // ---------------------------------------------------------------------------
@@ -331,13 +386,14 @@ export function createAppClient(options: AppClientOptions): AppClient {
  */
 function verifyPermissions(
   granted: Record<string, string>,
+  requiredPermissions: Record<string, string>,
   installUrl: string,
   logger?: AppClientOptions['logger'],
 ): InsufficientPermissionsError | null {
   const missing: string[] = []
   const overPrivileged: string[] = []
 
-  for (const [permission, requiredLevel] of Object.entries(REQUIRED_PERMISSIONS)) {
+  for (const [permission, requiredLevel] of Object.entries(requiredPermissions)) {
     const grantedLevel = granted[permission] ?? 'none'
     const grantedIdx = permissionLevel(grantedLevel)
     const requiredIdx = permissionLevel(requiredLevel)

--- a/packages/gateway/src/github/dispatch.test.ts
+++ b/packages/gateway/src/github/dispatch.test.ts
@@ -1,0 +1,301 @@
+import type {Octokit} from '@octokit/core'
+import type {AppClient} from './app-client.js'
+
+import {ok} from '@fro-bot/runtime'
+import {describe, expect, it, vi} from 'vitest'
+
+import {AppNotInstalledError, InsufficientPermissionsError} from './app-client.js'
+import {createWorkflowDispatcher} from './dispatch.js'
+
+const INSTALL_URL = 'https://github.com/apps/fro-bot-agent/installations/new'
+
+function makeLogger() {
+  return {debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()}
+}
+
+function makeAppClient(request: ReturnType<typeof vi.fn>): AppClient {
+  return {
+    authForRepo: vi.fn(),
+    authForWorkflowDispatch: vi
+      .fn()
+      .mockResolvedValue(ok({octokit: {request} as unknown as Octokit, installationId: 99, token: 'ghs-test-token'})),
+    getRepoIdentity: vi.fn(),
+    invalidateCache: vi.fn(),
+  }
+}
+
+function makeRepoResponse(defaultBranch = 'main') {
+  return {status: 200, data: {default_branch: defaultBranch}}
+}
+
+function makeWorkflowResponse() {
+  return {status: 200, data: {workflow_run: {id: 1234, html_url: 'https://github.com/acme/widget/actions/runs/1234'}}}
+}
+
+interface RequestOptions {
+  readonly request?: {readonly signal?: AbortSignal}
+}
+
+function makeAbortedTimeout(): {readonly signal: AbortSignal; readonly restore: () => void} {
+  const controller = new AbortController()
+  controller.abort(new Error('workflow dispatch timeout'))
+  const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal)
+  return {signal: controller.signal, restore: () => timeoutSpy.mockRestore()}
+}
+
+describe('createWorkflowDispatcher', () => {
+  it('returns accepted with the run link and dispatches the resolved default branch', async () => {
+    // #given — repository metadata and a current workflow-run response
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(makeRepoResponse('trunk'))
+      .mockResolvedValueOnce(makeWorkflowResponse())
+    const dispatch = createWorkflowDispatcher({appClient: makeAppClient(request), logger: makeLogger()})
+
+    // #when
+    const result = await dispatch('acme', 'widget', 'run the checks')
+
+    // #then
+    expect(result).toEqual({
+      outcome: 'accepted',
+      owner: 'acme',
+      repo: 'widget',
+      runId: 1234,
+      runUrl: 'https://github.com/acme/widget/actions/runs/1234',
+    })
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      'GET /repos/{owner}/{repo}',
+      expect.objectContaining({
+        owner: 'acme',
+        repo: 'widget',
+        headers: {'X-GitHub-Api-Version': '2026-03-10'},
+      }),
+    )
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      'POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches',
+      expect.objectContaining({
+        owner: 'acme',
+        repo: 'widget',
+        workflow_id: '.github/workflows/fro-bot.yaml',
+        ref: 'trunk',
+        return_run_details: true,
+        inputs: {prompt: 'run the checks'},
+        headers: {'X-GitHub-Api-Version': '2026-03-10'},
+      }),
+    )
+    const dispatchOptions = request.mock.calls[1]?.[1] as {
+      readonly inputs: Record<string, string>
+      readonly return_run_details: boolean
+    }
+    expect(dispatchOptions.return_run_details).toBe(true)
+    expect(dispatchOptions.inputs).toEqual({prompt: 'run the checks'})
+  })
+
+  it('returns accepted without run details when GitHub accepts with a 204 empty response', async () => {
+    // #given — GitHub accepts the dispatch but returns no response body
+    const request = vi.fn().mockResolvedValueOnce(makeRepoResponse()).mockResolvedValueOnce({status: 204})
+    const dispatch = createWorkflowDispatcher({appClient: makeAppClient(request), logger: makeLogger()})
+
+    // #when
+    const result = await dispatch('acme', 'widget', 'run it')
+
+    // #then — acceptance is established by the 2xx status, not response details
+    expect(result).toEqual({outcome: 'accepted', owner: 'acme', repo: 'widget'})
+  })
+
+  it('returns invalid-task without making a GitHub request for whitespace-only task text', async () => {
+    // #given
+    const request = vi.fn()
+    const dispatch = createWorkflowDispatcher({appClient: makeAppClient(request), logger: makeLogger()})
+
+    // #when
+    const result = await dispatch('acme', 'widget', '  \n\t  ')
+
+    // #then
+    expect(result).toEqual({outcome: 'invalid-task'})
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('returns repo-not-found when repository metadata is not found', async () => {
+    // #given
+    const request = vi.fn().mockRejectedValue(Object.assign(new Error('Not Found'), {status: 404}))
+    const dispatch = createWorkflowDispatcher({appClient: makeAppClient(request), logger: makeLogger()})
+
+    // #when
+    const result = await dispatch('acme', 'missing', 'run it')
+
+    // #then
+    expect(result).toEqual({outcome: 'repo-not-found', owner: 'acme', repo: 'missing'})
+  })
+
+  it('returns github-unavailable when a successful repository response has malformed default-branch metadata', async () => {
+    // #given — GitHub returned 200 but violated the expected repository response shape
+    const request = vi.fn().mockResolvedValue({status: 200, data: {default_branch: 42}})
+    const dispatch = createWorkflowDispatcher({appClient: makeAppClient(request), logger: makeLogger()})
+
+    // #when
+    const result = await dispatch('acme', 'widget', 'run it')
+
+    // #then — malformed metadata is not reported as a missing repository
+    expect(result).toEqual({outcome: 'github-unavailable', owner: 'acme', repo: 'widget'})
+  })
+
+  it('returns workflow-not-found when the fixed workflow is absent', async () => {
+    // #given
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(makeRepoResponse())
+      .mockRejectedValueOnce(Object.assign(new Error('Not Found'), {status: 404}))
+    const dispatch = createWorkflowDispatcher({appClient: makeAppClient(request), logger: makeLogger()})
+
+    // #when
+    const result = await dispatch('acme', 'widget', 'run it')
+
+    // #then
+    expect(result).toEqual({outcome: 'workflow-not-found', owner: 'acme', repo: 'widget'})
+  })
+
+  it('returns github-unavailable when default-branch lookup is aborted', async () => {
+    // #given — the repository lookup receives an already-aborted timeout signal
+    const timeout = makeAbortedTimeout()
+    const request = vi.fn().mockImplementation(async (_route: string, options: RequestOptions) => {
+      if (options.request?.signal !== timeout.signal) return Promise.reject(new Error('missing timeout signal'))
+      return Promise.reject(timeout.signal.reason)
+    })
+    const dispatch = createWorkflowDispatcher({appClient: makeAppClient(request), logger: makeLogger()})
+
+    // #when
+    const result = await dispatch('acme', 'widget', 'run it')
+
+    // #then
+    expect(result).toEqual({outcome: 'github-unavailable', owner: 'acme', repo: 'widget'})
+    expect(request).toHaveBeenCalledWith(
+      'GET /repos/{owner}/{repo}',
+      expect.objectContaining({request: {signal: timeout.signal}}),
+    )
+    timeout.restore()
+  })
+
+  it('returns github-unavailable when workflow dispatch POST is aborted', async () => {
+    // #given — repository lookup succeeds but the dispatch POST receives an aborted timeout signal
+    const timeout = makeAbortedTimeout()
+    const request = vi.fn().mockImplementation(async (route: string, options: RequestOptions) => {
+      if (route.startsWith('GET ')) return Promise.resolve(makeRepoResponse())
+      if (options.request?.signal !== timeout.signal) return Promise.reject(new Error('missing timeout signal'))
+      return Promise.reject(timeout.signal.reason)
+    })
+    const dispatch = createWorkflowDispatcher({appClient: makeAppClient(request), logger: makeLogger()})
+
+    // #when
+    const result = await dispatch('acme', 'widget', 'run it')
+
+    // #then
+    expect(result).toEqual({outcome: 'github-unavailable', owner: 'acme', repo: 'widget'})
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      'POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches',
+      expect.objectContaining({request: {signal: timeout.signal}}),
+    )
+    timeout.restore()
+  })
+
+  it('returns app-not-installed with the install URL', async () => {
+    // #given
+    const appClient = makeAppClient(vi.fn())
+    vi.mocked(appClient.authForWorkflowDispatch).mockResolvedValueOnce(
+      Object.assign({success: false as const}, {error: new AppNotInstalledError('acme', 'widget', INSTALL_URL)}),
+    )
+    const dispatch = createWorkflowDispatcher({appClient, logger: makeLogger()})
+
+    // #when
+    const result = await dispatch('acme', 'widget', 'run it')
+
+    // #then
+    expect(result).toEqual({outcome: 'app-not-installed', owner: 'acme', repo: 'widget', installUrl: INSTALL_URL})
+  })
+
+  it('returns missing-actions-permission with the install URL', async () => {
+    // #given
+    const appClient = makeAppClient(vi.fn())
+    vi.mocked(appClient.authForWorkflowDispatch).mockResolvedValueOnce(
+      Object.assign(
+        {success: false as const},
+        {error: new InsufficientPermissionsError(['actions: write'], INSTALL_URL)},
+      ),
+    )
+    const dispatch = createWorkflowDispatcher({appClient, logger: makeLogger()})
+
+    // #when
+    const result = await dispatch('acme', 'widget', 'run it')
+
+    // #then
+    expect(result).toEqual({
+      outcome: 'missing-actions-permission',
+      owner: 'acme',
+      repo: 'widget',
+      installUrl: INSTALL_URL,
+    })
+  })
+
+  it('returns missing-permissions with the install URL for non-actions permission failures', async () => {
+    // #given — the App lacks a deterministic non-actions permission
+    const appClient = makeAppClient(vi.fn())
+    vi.mocked(appClient.authForWorkflowDispatch).mockResolvedValueOnce(
+      Object.assign(
+        {success: false as const},
+        {error: new InsufficientPermissionsError(['contents: read'], INSTALL_URL)},
+      ),
+    )
+    const dispatch = createWorkflowDispatcher({appClient, logger: makeLogger()})
+
+    // #when
+    const result = await dispatch('acme', 'widget', 'run it')
+
+    // #then — configuration failure is actionable, not a transient outage
+    expect(result).toEqual({
+      outcome: 'missing-permissions',
+      owner: 'acme',
+      repo: 'widget',
+      missingPermissions: ['contents: read'],
+      installUrl: INSTALL_URL,
+    })
+  })
+
+  it('returns github-unavailable for GitHub 5xx responses', async () => {
+    // #given
+    const request = vi.fn().mockRejectedValue(Object.assign(new Error('GitHub unavailable'), {status: 503}))
+    const dispatch = createWorkflowDispatcher({appClient: makeAppClient(request), logger: makeLogger()})
+
+    // #when
+    const result = await dispatch('acme', 'widget', 'run it')
+
+    // #then
+    expect(result).toEqual({outcome: 'github-unavailable', owner: 'acme', repo: 'widget'})
+  })
+
+  it('returns dispatch-rejected for a non-success dispatch response', async () => {
+    // #given
+    const request = vi.fn().mockResolvedValueOnce(makeRepoResponse()).mockResolvedValueOnce({status: 400, data: {}})
+    const dispatch = createWorkflowDispatcher({appClient: makeAppClient(request), logger: makeLogger()})
+
+    // #when
+    const result = await dispatch('acme', 'widget', 'run it')
+
+    // #then
+    expect(result).toEqual({outcome: 'dispatch-rejected', owner: 'acme', repo: 'widget'})
+  })
+
+  it('returns accepted without run details for a malformed workflow_run response', async () => {
+    // #given
+    const request = vi.fn().mockResolvedValueOnce(makeRepoResponse()).mockResolvedValueOnce({status: 200, data: {}})
+    const dispatch = createWorkflowDispatcher({appClient: makeAppClient(request), logger: makeLogger()})
+
+    // #when
+    const result = await dispatch('acme', 'widget', 'run it')
+
+    // #then — a successful status still establishes acceptance
+    expect(result).toEqual({outcome: 'accepted', owner: 'acme', repo: 'widget'})
+  })
+})

--- a/packages/gateway/src/github/dispatch.ts
+++ b/packages/gateway/src/github/dispatch.ts
@@ -1,0 +1,225 @@
+/**
+ * GitHub Actions workflow-dispatch adapter for the gateway.
+ *
+ * The adapter owns the fixed workflow, default-branch resolution, raw Octokit
+ * request shape, and closed outcome mapping. It deliberately has no queue,
+ * concurrency, or local run-state participation.
+ */
+
+import type {Octokit} from '@octokit/core'
+import type {GatewayLogger} from '../discord/client.js'
+
+import {AppNotInstalledError, InsufficientPermissionsError, type AppClient, type AuthError} from './app-client.js'
+import {isOctokitNotFound, safeErrorMessage} from './errors.js'
+
+export const WORKFLOW_PATH = '.github/workflows/fro-bot.yaml'
+export const GITHUB_API_VERSION = '2026-03-10'
+export const WORKFLOW_DISPATCH_REQUEST_TIMEOUT_MS = 5_000
+
+export type DispatchOutcome =
+  | {
+      readonly outcome: 'accepted'
+      readonly owner: string
+      readonly repo: string
+      readonly runId?: number
+      readonly runUrl?: string
+    }
+  | {readonly outcome: 'invalid-task'}
+  | {readonly outcome: 'app-not-installed'; readonly owner: string; readonly repo: string; readonly installUrl: string}
+  | {
+      readonly outcome: 'missing-actions-permission'
+      readonly owner: string
+      readonly repo: string
+      readonly installUrl: string
+    }
+  | {
+      readonly outcome: 'missing-permissions'
+      readonly owner: string
+      readonly repo: string
+      readonly missingPermissions: readonly string[]
+      readonly installUrl: string
+    }
+  | {readonly outcome: 'repo-not-found'; readonly owner: string; readonly repo: string}
+  | {readonly outcome: 'workflow-not-found'; readonly owner: string; readonly repo: string}
+  | {readonly outcome: 'dispatch-rejected'; readonly owner: string; readonly repo: string}
+  | {readonly outcome: 'github-unavailable'; readonly owner: string; readonly repo: string}
+
+export type DispatchWorkflow = (owner: string, repo: string, task: string) => Promise<DispatchOutcome>
+
+export interface WorkflowDispatcherDeps {
+  readonly appClient: AppClient
+  readonly logger: GatewayLogger
+}
+
+interface WorkflowRun {
+  readonly id: number
+  readonly html_url: string
+}
+
+interface WorkflowDispatchResponse {
+  readonly workflow_run: WorkflowRun
+}
+
+const API_HEADERS = {'X-GitHub-Api-Version': GITHUB_API_VERSION}
+
+function responseStatus(response: unknown): number | undefined {
+  if (typeof response !== 'object' || response === null || !('status' in response)) return undefined
+  const status = response.status
+  return typeof status === 'number' ? status : undefined
+}
+
+function errorStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null || !('status' in error)) return undefined
+  const status = error.status
+  return typeof status === 'number' ? status : undefined
+}
+
+function isSuccessStatus(status: number | undefined): boolean {
+  return status === undefined || (status >= 200 && status < 300)
+}
+
+function isServerError(status: number | undefined): boolean {
+  return status !== undefined && status >= 500 && status < 600
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function parseDefaultBranch(response: unknown): string | null {
+  if (!isRecord(response) || !isRecord(response.data)) return null
+  const defaultBranch = response.data.default_branch
+  if (typeof defaultBranch !== 'string' || defaultBranch.length === 0) return null
+  return defaultBranch
+}
+
+function parseWorkflowRun(response: unknown): WorkflowDispatchResponse | null {
+  if (!isRecord(response) || !isRecord(response.data) || !isRecord(response.data.workflow_run)) return null
+  const workflowRun = response.data.workflow_run
+  const id = workflowRun.id
+  const htmlUrl = workflowRun.html_url
+  if (typeof id !== 'number' || Number.isInteger(id) === false || id <= 0) return null
+  if (typeof htmlUrl !== 'string' || htmlUrl.length === 0) return null
+  return {workflow_run: {id, html_url: htmlUrl}}
+}
+
+function logGithubFailure(logger: GatewayLogger, owner: string, repo: string, error: unknown, message: string): void {
+  logger.warn({owner, repo, status: errorStatus(error), err: safeErrorMessage(error)}, message)
+}
+
+async function resolveDefaultBranch(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  logger: GatewayLogger,
+): Promise<
+  | {readonly outcome: 'ok'; readonly branch: string}
+  | {readonly outcome: 'repo-not-found'}
+  | {readonly outcome: 'github-unavailable'}
+> {
+  try {
+    const response = await octokit.request('GET /repos/{owner}/{repo}', {
+      owner,
+      repo,
+      headers: API_HEADERS,
+      request: {signal: AbortSignal.timeout(WORKFLOW_DISPATCH_REQUEST_TIMEOUT_MS)},
+    })
+    const status = responseStatus(response)
+    if (status === 404) return {outcome: 'repo-not-found'}
+    if (isServerError(status)) return {outcome: 'github-unavailable'}
+    if (isSuccessStatus(status) === false) return {outcome: 'github-unavailable'}
+
+    const branch = parseDefaultBranch(response)
+    return branch === null ? {outcome: 'github-unavailable'} : {outcome: 'ok', branch}
+  } catch (error) {
+    if (errorStatus(error) === 404 || isOctokitNotFound(error)) return {outcome: 'repo-not-found'}
+    if (isServerError(errorStatus(error))) return {outcome: 'github-unavailable'}
+    logGithubFailure(logger, owner, repo, error, 'workflow dispatch: repository metadata lookup failed')
+    return {outcome: 'github-unavailable'}
+  }
+}
+
+async function dispatchWorkflowRequest(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  branch: string,
+  task: string,
+  logger: GatewayLogger,
+): Promise<DispatchOutcome> {
+  try {
+    const response = await octokit.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
+      owner,
+      repo,
+      workflow_id: WORKFLOW_PATH,
+      ref: branch,
+      return_run_details: true,
+      inputs: {prompt: task},
+      headers: API_HEADERS,
+      request: {signal: AbortSignal.timeout(WORKFLOW_DISPATCH_REQUEST_TIMEOUT_MS)},
+    })
+    const status = responseStatus(response)
+    if (status === 404) return {outcome: 'workflow-not-found', owner, repo}
+    if (isServerError(status)) return {outcome: 'github-unavailable', owner, repo}
+    if (isSuccessStatus(status) === false) return {outcome: 'dispatch-rejected', owner, repo}
+
+    const parsedResponse = parseWorkflowRun(response)
+    if (parsedResponse === null) return {outcome: 'accepted', owner, repo}
+    return {
+      outcome: 'accepted',
+      owner,
+      repo,
+      runId: parsedResponse.workflow_run.id,
+      runUrl: parsedResponse.workflow_run.html_url,
+    }
+  } catch (error) {
+    const status = errorStatus(error)
+    if (status === 404 || isOctokitNotFound(error)) return {outcome: 'workflow-not-found', owner, repo}
+    if (isServerError(status)) return {outcome: 'github-unavailable', owner, repo}
+    if (status !== undefined) return {outcome: 'dispatch-rejected', owner, repo}
+    logGithubFailure(logger, owner, repo, error, 'workflow dispatch: GitHub request failed')
+    return {outcome: 'github-unavailable', owner, repo}
+  }
+}
+
+function mapAuthFailure(
+  owner: string,
+  repo: string,
+  error: AppNotInstalledError | InsufficientPermissionsError | AuthError,
+): DispatchOutcome {
+  if (error instanceof AppNotInstalledError) {
+    return {outcome: 'app-not-installed', owner, repo, installUrl: error.installUrl}
+  }
+  if (
+    error instanceof InsufficientPermissionsError &&
+    error.missingPermissions.some(permission => permission.startsWith('actions:'))
+  ) {
+    return {outcome: 'missing-actions-permission', owner, repo, installUrl: error.installUrl}
+  }
+  if (error instanceof InsufficientPermissionsError) {
+    return {
+      outcome: 'missing-permissions',
+      owner,
+      repo,
+      missingPermissions: error.missingPermissions,
+      installUrl: error.installUrl,
+    }
+  }
+  return {outcome: 'github-unavailable', owner, repo}
+}
+
+export function createWorkflowDispatcher(deps: WorkflowDispatcherDeps): DispatchWorkflow {
+  return async (owner: string, repo: string, task: string): Promise<DispatchOutcome> => {
+    const trimmedTask = task.trim()
+    if (trimmedTask.length === 0) return {outcome: 'invalid-task'}
+
+    const authResult = await deps.appClient.authForWorkflowDispatch(owner, repo)
+    if (authResult.success === false) return mapAuthFailure(owner, repo, authResult.error)
+
+    const branchResult = await resolveDefaultBranch(authResult.data.octokit, owner, repo, deps.logger)
+    if (branchResult.outcome === 'repo-not-found') return {outcome: 'repo-not-found', owner, repo}
+    if (branchResult.outcome === 'github-unavailable') return {outcome: 'github-unavailable', owner, repo}
+
+    return dispatchWorkflowRequest(authResult.data.octokit, owner, repo, branchResult.branch, trimmedTask, deps.logger)
+  }
+}

--- a/packages/gateway/src/program.test.ts
+++ b/packages/gateway/src/program.test.ts
@@ -23,6 +23,7 @@ vi.mock('./discord/commands/index.js', async importOriginal => {
   const actual = await importOriginal<typeof import('./discord/commands/index.js')>()
   return {
     ...actual,
+    getCommandRegistry: vi.fn(actual.getCommandRegistry),
     registerSlashCommands: vi.fn().mockResolvedValue(undefined),
   }
 })
@@ -117,7 +118,9 @@ vi.mock('./web/operator-push/subscription-store.js', async importOriginal => {
 
 const {makeDiscordClientFromConfig, makeGatewayProgram, makeLogger} = await import('./program.js')
 const {createDiscordClient} = await import('./discord/client.js')
+const {getCommandRegistry} = await import('./discord/commands/index.js')
 const createDiscordClientSpy = vi.mocked(createDiscordClient)
+const getCommandRegistrySpy = vi.mocked(getCommandRegistry)
 
 const stubLogger: GatewayLogger = {
   debug: vi.fn(),
@@ -550,6 +553,28 @@ describe('makeGatewayProgram', () => {
     expect(callOrder).toContain('runProviderSelfTest')
     expect(callOrder).toContain('login')
     expect(callOrder.indexOf('runProviderSelfTest')).toBeLessThan(callOrder.indexOf('login'))
+  })
+
+  it('constructs and injects the workflow dispatch primitive into the command registry', async () => {
+    // #given — a bootable gateway with no announce server required
+    const fakeConfig = makeFakeConfig({announce: undefined})
+    const fakeClient = makeFakeClient()
+    const deps = {
+      makeClient: () => fakeClient as unknown as import('discord.js').Client,
+      setupReadinessFlag: vi.fn(),
+      login: vi.fn().mockResolvedValue(undefined),
+      startAnnounceServer: vi.fn(),
+      startOperatorServer: vi.fn(),
+      runProviderSelfTest: vi.fn(async () => {}),
+    }
+
+    // #when
+    await Effect.runPromise(makeGatewayProgram(deps, fakeConfig))
+
+    // #then — program wiring passes a callable dispatcher without using module-global state
+    expect(getCommandRegistrySpy).toHaveBeenCalledOnce()
+    const commandDeps = getCommandRegistrySpy.mock.calls[0]?.[0] as {dispatchWorkflow?: unknown} | undefined
+    expect(typeof commandDeps?.dispatchWorkflow).toBe('function')
   })
 
   it('boot fails fast when provider self-test rejects', async () => {

--- a/packages/gateway/src/program.ts
+++ b/packages/gateway/src/program.ts
@@ -40,6 +40,7 @@ import {recoverStaleRuns} from './execute/recovery.js'
 import {createRunIndex} from './execute/run-index.js'
 import {getInFlightRuns} from './execute/run.js'
 import {createAppClient} from './github/app-client.js'
+import {createWorkflowDispatcher} from './github/dispatch.js'
 import {createRateLimiter} from './http/rate-limit.js'
 import {createDenylistCache} from './redaction/denylist.js'
 import {createAppClientMetadataReader} from './redaction/reader-app-client.js'
@@ -420,6 +421,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
       installUrl: config.gatewayGitHubAppInstallUrl,
       logger: addProjectLogger,
     })
+    const dispatchWorkflow = createWorkflowDispatcher({appClient, logger})
     const workspaceClient = createWorkspaceClient({baseUrl: config.workspaceAgentUrl})
 
     const commandDeps = {
@@ -439,6 +441,7 @@ export function makeGatewayProgram(deps: GatewayProgramDeps, config: GatewayConf
       // forceReleaseStaleLockEffect so it reads run-state under the correct key segment.
       identity: config.identity,
       forceReleaseStaleLock: forceReleaseStaleLockEffect,
+      dispatchWorkflow,
     }
 
     const registry = getCommandRegistry(commandDeps)

--- a/packages/gateway/src/redaction/reader-app-client.test.ts
+++ b/packages/gateway/src/redaction/reader-app-client.test.ts
@@ -51,6 +51,7 @@ function makeFakeAppClient(octokit: {request: ReturnType<typeof vi.fn>}): AppCli
   }
   return {
     authForRepo: vi.fn().mockResolvedValue({success: true, data: authResult}),
+    authForWorkflowDispatch: vi.fn(),
     getRepoIdentity: vi.fn().mockResolvedValue({success: false, error: new Error('not used')}),
     invalidateCache: vi.fn(),
   }
@@ -60,6 +61,7 @@ function makeFakeAppClient(octokit: {request: ReturnType<typeof vi.fn>}): AppCli
 function makeFakeFailingAppClient(error: Error): AppClient {
   return {
     authForRepo: vi.fn().mockResolvedValue({success: false, error}),
+    authForWorkflowDispatch: vi.fn(),
     getRepoIdentity: vi.fn().mockResolvedValue({success: false, error: new Error('not used')}),
     invalidateCache: vi.fn(),
   }

--- a/packages/gateway/src/workspace-api/ensure-clone.test.ts
+++ b/packages/gateway/src/workspace-api/ensure-clone.test.ts
@@ -47,6 +47,7 @@ function makeAppClient(
 ): AppClient {
   return {
     authForRepo: vi.fn().mockResolvedValue(authResult),
+    authForWorkflowDispatch: vi.fn(),
     getRepoIdentity: vi.fn().mockResolvedValue(ok({databaseId: 1, nodeId: 'node-1'})),
     invalidateCache: vi.fn(),
   }
@@ -394,6 +395,7 @@ describe('ensureWorkspaceClone', () => {
       const repo = 'testrepo'
       const appClient: AppClient = {
         authForRepo: vi.fn().mockRejectedValue(new Error('unexpected crash')),
+        authForWorkflowDispatch: vi.fn(),
         getRepoIdentity: vi.fn().mockResolvedValue(ok({databaseId: 1, nodeId: 'node-1'})),
         invalidateCache: vi.fn(),
       }
@@ -415,6 +417,7 @@ describe('ensureWorkspaceClone', () => {
       const repo = 'testrepo'
       const appClient: AppClient = {
         authForRepo: vi.fn().mockRejectedValue(new Error('sensitive internal detail')),
+        authForWorkflowDispatch: vi.fn(),
         getRepoIdentity: vi.fn().mockResolvedValue(ok({databaseId: 1, nodeId: 'node-1'})),
         invalidateCache: vi.fn(),
       }
@@ -443,6 +446,7 @@ describe('ensureWorkspaceClone', () => {
       const repo = 'testrepo'
       const appClient: AppClient = {
         authForRepo: vi.fn().mockReturnValue(new Promise<never>(() => {})), // never resolves
+        authForWorkflowDispatch: vi.fn(),
         getRepoIdentity: vi.fn().mockResolvedValue(ok({databaseId: 1, nodeId: 'node-1'})),
         invalidateCache: vi.fn(),
       }


### PR DESCRIPTION
Unit 7 of the April gateway plan — "Cloud dispatch + summaries bridge" — was the last unshipped feature in that plan. This replaces it with a scoped increment: `/fro-bot dispatch task:<text>` resolves the repo bound to the invoking channel, authorizes, dispatches `fro-bot.yaml` on the default branch, and returns the run link.

The plan is committed alongside the work. Completion notification and the summaries bridge are deferred with reasons — the first needs durable state because Discord interaction tokens expire long before Action runs finish, and the second has no consumer, since it was designed to feed a `/fro-bot review` command that does not exist.

**Permissions stay narrow.** `workflow_dispatch` requires Actions: write, which arrives through a dedicated `authForWorkflowDispatch()` capability. The shared `REQUIRED_PERMISSIONS` constant remains `{contents: 'read'}`, so ordinary gateway tokens are unchanged.

**`correlation-id` is never sent.** Any non-empty value flips the workflow into release-notes mode — `response-mode: none`, working-directory output, 600s timeout. A regression test asserts the exact `inputs` shape so the payload cannot regress into that behavior.

**Dispatch takes no local resources.** No execution slot, no per-channel queue. The Action owns the authoritative per-repo lock, and the reply says GitHub *accepted* the dispatch rather than claiming the work succeeded — a run can still skip if another surface holds that lock.

A pre-push review caught a P0 worth recording. The original implementation followed the plan's instruction to drop `return_run_details: true` as obsolete. That instruction was wrong: GitHub returns 204 with an empty body without it, so `parseWorkflowRun` failed and every successful dispatch reported as `dispatch-rejected`. The feature would have shipped green and failed on first use. Acceptance is now established by the status code, with run details used when present.

Six further findings were fixed: unbounded GitHub calls that could outlive Discord's interaction window, permission failures reported as transient outages instead of actionable config problems, a malformed `default_branch` masked as a missing repository, an unreachable `channel-unbound` variant, and two thin tests.

Four reviewers re-ran against the corrected code and returned clean.
