### PR TITLE
fix(build): stop running every package's tests from the action workspace

### DIFF
--- a/apps/action/package.json
+++ b/apps/action/package.json
@@ -10,7 +10,7 @@
     "check-types": "bunx tsc --noEmit -p ../../tsconfig.json",
     "fix": "bunx eslint --fix ../../src ../../scripts ../../tsdown.config.ts ../../eslint.config.ts",
     "lint": "bunx eslint ../../src ../../scripts ../../evals ../../tsdown.config.ts ../../eslint.config.ts",
-    "test": "bunx vitest run --root ../.. src"
+    "test": "bunx vitest run --root ../.. --dir ../../src"
   },
   "dependencies": {
     "@fro-bot/runtime": "workspace:*"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fix": "bun run --filter @fro-bot/runtime fix && bun run --filter @fro-bot/action fix && bun run --filter @fro.bot/harness fix && bun run --filter @fro-bot/gateway fix",
     "postinstall": "simple-git-hooks",
     "lint": "bun run --filter @fro-bot/runtime lint && bun run --filter @fro-bot/action lint && bun run --filter @fro.bot/harness lint && bun run --filter @fro-bot/gateway lint && bun run dist:check-hidden-unicode && bun run check:md-links",
-    "test": "bun run --filter @fro-bot/runtime test && bun run --filter @fro-bot/action test && bun run --filter @fro.bot/harness test && bun run --filter @fro-bot/gateway test && bun run test:evals",
+    "test": "bun run --filter @fro-bot/runtime test && bun run --filter @fro-bot/action test && bun run --filter @fro-bot/workspace-agent test && bun run --filter @fro.bot/harness test && bun run --filter @fro-bot/gateway test && bun run test:evals",
     "evals:baseline:update": "bun run evals/update-baseline.ts",
     "evals:presearch": "bun run evals/presearch-differential.ts",
     "test:evals": "vitest run evals/",


### PR DESCRIPTION
`apps/action`'s test script passed `src` as a positional argument. Vitest treats that as a filename substring filter, not a directory path, so it matched every workspace package's `src/` directory — the action's run was executing the entire monorepo.

The root chain then ran runtime, harness, and gateway a second time each. 41% of the reported suite was duplicate execution, and driving 5,821 tests in parallel — including the gateway's heavy integration tests — starved timing-sensitive tests of CPU. `packages/gateway/src/program.test.ts` took 25s and failed in a full run earlier today while passing isolated in 327ms; an operator-route test flaked the same way.

Scoping the filter alone would have quietly dropped coverage: `apps/workspace-agent` has a test script but was never in the root chain, so its 208 tests only ran as a side effect of the over-broad match. It is now invoked explicitly.

Verified per package, before and after:

| package | before | after |
| --- | --- | --- |
| runtime | 640 | 640 |
| action | 5,821 | 1,517 |
| workspace-agent | via action only | 208 |
| harness | 318 | 318 |
| gateway | 3,216 | 3,216 |
| evals | 170 | 170 |

Total drops from 10,165 to 6,069. No individual package's count fell — the difference is entirely duplicate execution.

Two consecutive full runs passed clean with no gateway timeout. That is consistent with contention being the cause but does not prove the flake is gone, since it was intermittent to begin with.
