### PR TITLE
docs(harness): mark the unreachable conflict-resolver path

### DIFF
--- a/packages/harness/src/conflict-resolver.ts
+++ b/packages/harness/src/conflict-resolver.ts
@@ -6,6 +6,10 @@
  * filesystem is never artifact authority: code extracts only validated bytes
  * from the declared conflict paths, then applies those bytes to the real
  * integration merge state.
+ *
+ * This resolver is not reached by production release runs: --candidate routes
+ * around runIntegration, HARNESS_BROKER_AUTH_JSON is unset by workflows, and
+ * production conflict repair is prompt-driven; see prompt.txt:38.
  */
 
 import {execFile} from 'node:child_process'
@@ -29,6 +33,7 @@ export const HARNESS_GIT_IDENTITY = [
   'user.email=fro-bot[bot]@users.noreply.github.com',
 ] as const
 
+// Resolver-only limits; production --candidate never invokes resolveConflict.
 export const MAX_CONFLICT_RESOLUTION_ATTEMPTS = 2
 export const MAX_CONFLICT_FILE_BYTES = 1_048_576
 export const MAX_CONFLICT_PAYLOAD_BYTES = 4 * 1_048_576
@@ -231,6 +236,7 @@ function permissionRules(workDir: string, allowedPaths: readonly string[]): Reco
 /**
  * Build the smallest OpenCode config used by the resolver.
  * Object insertion order is intentional: OpenCode resolves last-match-wins.
+ * Not reached in production: --candidate bypasses the pipeline that invokes this resolver config.
  */
 export function buildConflictResolverConfig(
   workDir: string,
@@ -280,7 +286,7 @@ interface BuildEnvironmentOptions {
   readonly sourceLabel: string
 }
 
-/** Build env without copying provider keys or the caller's OpenCode config. */
+/** Resolver-only environment assembly; production --candidate never invokes it. */
 export function buildConflictResolverEnv(options: BuildEnvironmentOptions): NodeJS.ProcessEnv {
   const result = buildRuntimeEnv(options.source)
   // Model turns use the private attempt sandbox as HOME.
@@ -699,7 +705,13 @@ function failure(
   return {ok: false, attempts, error, diagnostics}
 }
 
-/** Resolves one merge conflict with at most two fresh disposable attempts. */
+/**
+ * Resolves one merge conflict with at most two fresh disposable attempts.
+ *
+ * Not reached in production: --candidate bypasses runIntegration, and the
+ * workflow never supplies HARNESS_BROKER_AUTH_JSON, so this entrypoint fails
+ * closed without it. Production repair is prompt-driven; see prompt.txt:38.
+ */
 export async function resolveConflict(
   request: ConflictResolutionRequest,
   options: ConflictResolverOptions = {},

--- a/packages/harness/src/integrate-command.ts
+++ b/packages/harness/src/integrate-command.ts
@@ -519,6 +519,9 @@ export async function cmdIntegrate(
   _packageArtifact: typeof packageArtifact = packageArtifact,
   logger: IntegrateLogger = silentIntegrateLogger,
 ): Promise<number> {
+  // Legacy conflict-resolver input. Production always uses --candidate, so it
+  // is not consumed; workflows never set it, and the resolver fails closed
+  // without it. Production conflict repair is prompt-driven; see prompt.txt:38.
   const brokerAuthJson = process.env.HARNESS_BROKER_AUTH_JSON
   delete process.env.HARNESS_BROKER_AUTH_JSON
 
@@ -588,6 +591,8 @@ export async function cmdIntegrate(
       conflictModelTimeoutMs: config.dryRun === true ? DEFAULT_DRY_RUN_CONFLICT_MODEL_TIMEOUT_MS : undefined,
     })
     if (flags.candidate) {
+      // Production release path: --candidate bypasses runIntegration and its
+      // code-owned conflict resolver. Conflict repair happens in prompt.txt:38 and :87.
       const result = await finalizeCandidateIntegration(config, outPath, adapters, _packageArtifact, logger)
       if (result.ok === true) return 0
       console.error(`[integrate] ${result.error}`)

--- a/packages/harness/src/integrate.ts
+++ b/packages/harness/src/integrate.ts
@@ -6,6 +6,9 @@
  * provenance, final-tree validation, and the late push boundary. A merge conflict
  * is returned as a typed boundary for the conflict-resolver unit; this module does
  * not invoke a model to perform deterministic work.
+ * Production release runs pass --candidate and bypass this pipeline; conflict
+ * repair there is prompt-driven. The resolver also fails closed without the
+ * workflow-unset HARNESS_BROKER_AUTH_JSON; see prompt.txt:38.
  */
 
 import type {ConflictResolutionRequest, ConflictResolverResult} from './conflict-resolver.js'
@@ -29,7 +32,7 @@ import {
   sourcesFromCarryManifest,
 } from './sources.js'
 
-/** Driver deadline: leaves the workflow backstop time to record a named failure and upload evidence. */
+/** Used only by runIntegration, which production --candidate runs bypass. */
 export const DEFAULT_INTEGRATION_PIPELINE_TIMEOUT_MS = 75 * 60 * 1000
 /** Git command deadline: generous for a large hosted-runner clone/fetch, short enough to fail a wedged process. */
 export const GIT_SUBPROCESS_TIMEOUT_MS = 10 * 60 * 1000
@@ -77,7 +80,7 @@ export interface IntegrationConfig {
   readonly agent?: string
   readonly model?: string
   readonly opencodeBin?: string
-  /** Short-lived broker-minted model auth JSON, supplied via HARNESS_BROKER_AUTH_JSON when set. */
+  /** Used only by the non-candidate conflict-resolver path; --candidate never consumes it. */
   readonly brokerAuthJson?: string
   readonly runnerTempDir?: string
   readonly promptPath?: string
@@ -175,7 +178,7 @@ export interface IntegrationAdapters {
   readonly createBranch: (workDir: string, branch: string, tag: string) => Promise<void>
   /** Run one deterministic no-ff merge. Conflicts are returned, not thrown. */
   readonly mergeRef: (workDir: string, mergeRef: string) => Promise<MergeOutcome>
-  /** Resolve one actual merge conflict in a disposable broker-scoped checkout. */
+  /** Resolve one actual merge conflict; only runIntegration's non-candidate path invokes this. */
   readonly resolveConflict?: (request: ConflictResolutionRequest) => Promise<ConflictResolverResult>
   /** Stage only the validated regular-file conflict paths. */
   readonly stagePaths?: (workDir: string, paths: readonly string[]) => Promise<void>
@@ -256,7 +259,7 @@ function isValidIntegrationRefRecord(value: unknown): value is IntegrationRefRec
   return true
 }
 
-/** Type guard for complete, non-partial integration provenance. */
+/** Type guard used by the non-candidate pipeline; candidate finalization does not validate manifests here. */
 export function isValidProvenanceManifest(value: unknown): value is ProvenanceManifest {
   if (!isRecord(value)) return false
   if (typeof value.baseVersion !== 'string' || value.baseVersion.length === 0) return false
@@ -268,7 +271,7 @@ export function isValidProvenanceManifest(value: unknown): value is ProvenanceMa
   return true
 }
 
-/** Reads a complete manifest, returning null for missing or malformed data. */
+/** Reads a complete manifest for the non-candidate pipeline; candidate finalization only writes it. */
 export async function readProvenanceManifest(dir: string): Promise<ProvenanceManifest | null> {
   const manifestPath = path.join(dir, MANIFEST_FILENAME)
   try {
@@ -1106,6 +1109,8 @@ function validateManifest(
  * A clean merge never crosses the model boundary. A conflict returns before
  * squash/build so U6 can own the bounded contextual repair contract. Artifact
  * packaging and the credentialed trusted push are owned by the command layer.
+ * Production --candidate runs bypass this pipeline; its conflict branch is
+ * test-covered but not production-reachable.
  */
 async function runIntegrationPipeline(
   config: IntegrationConfig,
@@ -1403,6 +1408,10 @@ async function runIntegrationPipeline(
   return {ok: true, manifest: persistedManifest, dryRun, pushed: false, conflictDiagnostics}
 }
 
+/**
+ * Not reached by production release runs: --candidate routes to
+ * finalizeCandidateIntegration before this path. Its conflict branch remains test-covered.
+ */
 export async function runIntegration(
   config: IntegrationConfig,
   adapters: IntegrationAdapters,


### PR DESCRIPTION
The harness carries a code-owned conflict-resolution subsystem — disposable attempt workspaces, symlink and encoding validation, a two-attempt bound — that never executes in production. Tests are green, so nothing signals the gap, and a reader reasonably assumes it guards the release pipeline.

It is blocked two independent ways:

1. `harness-integrate.yaml:168` always passes `--candidate`, and `integrate-command.ts` routes to `finalizeCandidateIntegration` before reaching `runIntegration`.
2. `integrate-command.ts:522` reads `HARNESS_BROKER_AUTH_JSON`, which no workflow sets. The only occurrences in the repo are that read, a doc comment, and the tests that set it for themselves. `conflict-resolver.ts:713` fails closed without it.

So removing `--candidate` to activate the code-owned path would not activate it — the first merge conflict would hard-fail the release. Prior audits recorded the triplication debt but not the second lock.

Production conflict repair is `prompt.txt:38` and `:87`: prose instructing the model to resolve conflicts. No isolated checkout, no allowed-path extraction, no symlink rejection, no attempt bound.

This annotates the affected symbols in place. Reachability was established per symbol rather than per file, because both files are mixed — `finalizeCandidateIntegration` and `makeRealAdapters` are live, and `conflict-resolver.ts` exports two values (`HARNESS_GIT_IDENTITY`, `DEFAULT_DRY_RUN_CONFLICT_MODEL_TIMEOUT_MS`) that production does use despite its resolver being unreachable.

Comments only. No code, control flow, types, tests, workflows, or prompts changed. Whether to delete this subsystem is a separate decision, and the tests still pin its contract.
