### PR TITLE
docs(plans): reconcile status metadata with shipped reality

### DIFF
--- a/docs/plans/2026-03-22-feat-agent-cohesion-session-continuity-plan.md
+++ b/docs/plans/2026-03-22-feat-agent-cohesion-session-continuity-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Agent Cohesion via Deterministic Session Continuity"
 type: feat
-status: completed
+status: done
 date: 2026-03-22
 origin: docs/brainstorms/2026-03-22-agent-cohesion-session-context-brainstorm.md
 shipped: 2026-03-22 onward (buildLogicalKey + deterministic 'fro-bot: {key}' titles + session continuation are in packages/runtime/src/session/logical-key.ts and src/harness/phases/session-prep.ts)

--- a/docs/plans/2026-04-06-001-feat-prompt-content-to-file-attachments-plan.md
+++ b/docs/plans/2026-04-06-001-feat-prompt-content-to-file-attachments-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Move external prompt content to file attachments"
 type: feat
-status: completed
+status: done
 date: 2026-04-06
 deepened: 2026-04-06
 ---

--- a/docs/plans/2026-04-07-001-refactor-prompt-xml-architecture-plan.md
+++ b/docs/plans/2026-04-07-001-refactor-prompt-xml-architecture-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "refactor: Migrate prompt structure to XML-tagged architecture"
 type: refactor
-status: completed
+status: done
 date: 2026-04-07
 origin: docs/brainstorms/2026-04-07-prompt-xml-architecture-requirements.md
 deepened: 2026-04-07

--- a/docs/plans/2026-04-13-001-feat-compounding-wiki-plan.md
+++ b/docs/plans/2026-04-13-001-feat-compounding-wiki-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Add compounding project wiki maintained by Fro Bot"
 type: feat
-status: completed
+status: done
 date: 2026-04-13
 origin: docs/brainstorms/2026-04-13-compounding-wiki-requirements.md
 deepened: 2026-04-13

--- a/docs/plans/2026-04-15-001-feat-durable-object-storage-plan.md
+++ b/docs/plans/2026-04-15-001-feat-durable-object-storage-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Durable S3-compatible object storage as canonical persistence backend"
 type: feat
-status: completed
+status: done
 date: 2026-04-15
 deepened: 2026-04-15
 origin: docs/brainstorms/2026-04-15-durable-object-storage-requirements.md

--- a/docs/plans/2026-04-17-001-fix-manual-delivery-mode-plan.md
+++ b/docs/plans/2026-04-17-001-fix-manual-delivery-mode-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: Add explicit delivery mode for manual file-edit runs"
 type: fix
-status: completed
+status: done
 date: 2026-04-17
 gap_review: 2026-04-17 (Metis — critical + important gaps closed)
 deepened: 2026-04-17 (research-grounded — repo verification, prompt-priority research, system-wide impact, pattern alignment)

--- a/docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
+++ b/docs/plans/2026-04-18-001-feat-fro-bot-gateway-discord-v1-plan.md
@@ -9,6 +9,8 @@ revised: 2026-06-01 (Units 5-6 reconciled; remote-attach MVP) / 2026-05-20 (Unit
 review_coverage: full (coherence + feasibility + scope-guardian, 3 reviewers)
 ---
 
+Open: Unit 8 remains; `docs/SETUP.md`, `docs/KNOWN-LIMITS.md`, and `docs/OPERATIONS.md` are absent.
+
 # feat: Fro Bot Gateway — Discord-first action-taking agent (v1)
 
 ## Overview

--- a/docs/plans/2026-04-30-001-feat-disable-omo-by-default-plan.md
+++ b/docs/plans/2026-04-30-001-feat-disable-omo-by-default-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Disable oMo by default"
 type: feat
-status: completed
+status: done
 date: 2026-04-30
 completed: 2026-05-09
 origin: docs/brainstorms/2026-04-29-disable-omo-by-default-requirements.md

--- a/docs/plans/2026-05-30-001-unit-0-spike-findings.md
+++ b/docs/plans/2026-05-30-001-unit-0-spike-findings.md
@@ -1,6 +1,6 @@
 ---
 title: Unit 0 spike findings — remote-attach streaming + bearer-token proxy
-status: complete
+status: done
 date: 2026-05-30
 plan: docs/plans/2026-05-30-001-feat-gateway-unit-6-mention-loop-plan.md
 verdict: GO

--- a/docs/plans/2026-06-05-001-feat-harness-integrate-build-bridge-plan.md
+++ b/docs/plans/2026-06-05-001-feat-harness-integrate-build-bridge-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Harness integrate→build bridge via CI artifact handoff"
 type: feat
-status: completed
+status: done
 date: 2026-06-05
 ---
 

--- a/docs/plans/2026-06-06-002-fix-approval-visible-output-race-plan.md
+++ b/docs/plans/2026-06-06-002-fix-approval-visible-output-race-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: Resolve gateway approval/status visible-output race in timeout classification"
 type: fix
-status: completed
+status: done
 date: 2026-06-06
 completed: 2026-06-06
 ---

--- a/docs/plans/2026-06-06-003-fix-review-event-reconciliation-plan.md
+++ b/docs/plans/2026-06-06-003-fix-review-event-reconciliation-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: Reconcile PR review approval event when the agent delivers a verdict as a comment"
 type: fix
-status: completed
+status: done
 date: 2026-06-06
 completed: 2026-06-06
 ---

--- a/docs/plans/2026-06-07-003-feat-mention-loop-rendering-persona-plan.md
+++ b/docs/plans/2026-06-07-003-feat-mention-loop-rendering-persona-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Mention-loop clean rendering + Discord persona (Phase 1)"
 type: feat
-status: completed
+status: done
 date: 2026-06-07
 origin: docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md
 deepened: 2026-06-07

--- a/docs/plans/2026-06-07-004-feat-mention-loop-working-state-ux-plan.md
+++ b/docs/plans/2026-06-07-004-feat-mention-loop-working-state-ux-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Mention-loop working-state UX (live status + typing)"
 type: feat
-status: completed
+status: done
 date: 2026-06-07
 origin: docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md
 deepened: 2026-06-07

--- a/docs/plans/2026-06-07-005-fix-workspace-gateway-reliability-hardening-plan.md
+++ b/docs/plans/2026-06-07-005-fix-workspace-gateway-reliability-hardening-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: Workspace/gateway reliability hardening (#763)"
 type: fix
-status: completed
+status: done
 date: 2026-06-07
 deepened: 2026-06-07
 completed: 2026-06-09

--- a/docs/plans/2026-06-09-002-feat-mention-loop-serial-queue-plan.md
+++ b/docs/plans/2026-06-09-002-feat-mention-loop-serial-queue-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Serial per-channel queue for mention loop"
 type: feat
-status: completed
+status: done
 date: 2026-06-09
 origin: docs/brainstorms/2026-06-07-mention-loop-production-ready-requirements.md
 deepened: 2026-06-09

--- a/docs/plans/2026-06-09-003-feat-mention-loop-operator-commands-plan.md
+++ b/docs/plans/2026-06-09-003-feat-mention-loop-operator-commands-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Mention-loop operator commands — /fro-bot force-release-lock + run reactions"
 type: feat
-status: completed
+status: done
 date: 2026-06-09
 deepened: 2026-06-09
 completed: 2026-06-09

--- a/docs/plans/2026-06-09-004-refactor-gateway-discord-io-helper-plan.md
+++ b/docs/plans/2026-06-09-004-refactor-gateway-discord-io-helper-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "refactor: Centralized fail-soft Discord I/O helper (discord/io.ts)"
 type: refactor
-status: completed
+status: done
 date: 2026-06-09
 deepened: 2026-06-09
 completed: 2026-06-09

--- a/docs/plans/2026-06-10-001-refactor-gateway-guild-command-pipeline-plan.md
+++ b/docs/plans/2026-06-10-001-refactor-gateway-guild-command-pipeline-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "refactor: Shared guild-command pipeline (makeGuildCommand)"
 type: refactor
-status: completed
+status: done
 date: 2026-06-10
 deepened: 2026-06-10
 completed: 2026-06-10

--- a/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
+++ b/docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Gateway web operator API surface'
 type: feat
-status: completed
+status: done
 completed: 2026-06-23
 date: 2026-06-15
 origin: docs/brainstorms/2026-06-15-gateway-control-surface-phase-b-requirements.md

--- a/docs/plans/2026-06-19-002-feat-gateway-redaction-gate-plan.md
+++ b/docs/plans/2026-06-19-002-feat-gateway-redaction-gate-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Gateway metadata/repos.yaml redaction gate (denylist-before-query)"
 type: feat
-status: completed
+status: done
 date: 2026-06-19
 completed: 2026-06-19
 origin: https://github.com/fro-bot/agent/issues/950 (Fro Bot triage comment as requirements)

--- a/docs/plans/2026-06-19-003-feat-sse-run-observation-core-plan.md
+++ b/docs/plans/2026-06-19-003-feat-sse-run-observation-core-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Inert SSE run-observation core (Unit 4a)"
 type: feat
-status: completed
+status: done
 date: 2026-06-19
 deepened: 2026-06-19
 completed: 2026-06-19

--- a/docs/plans/2026-06-20-001-feat-authenticated-sse-run-stream-route-plan.md
+++ b/docs/plans/2026-06-20-001-feat-authenticated-sse-run-stream-route-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Authenticated SSE run-stream route (Unit 4b)"
 type: feat
-status: completed
+status: done
 date: 2026-06-20
 deepened: 2026-06-20
 completed: 2026-06-20

--- a/docs/plans/2026-06-23-001-feat-operator-surface-docs-smoke-plan.md
+++ b/docs/plans/2026-06-23-001-feat-operator-surface-docs-smoke-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Operator control-surface documentation and smoke coverage (Unit 8)"
 type: feat
-status: completed
+status: done
 date: 2026-06-23
 origin: docs/plans/2026-06-15-002-feat-gateway-web-operator-control-surface-plan.md
 ---

--- a/docs/plans/2026-07-03-001-feat-operator-run-cancellation-plan.md
+++ b/docs/plans/2026-07-03-001-feat-operator-run-cancellation-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: operator-initiated run cancellation'
 type: feat
-status: active
+status: done
 date: 2026-07-03
 origin: docs/brainstorms/2026-07-03-operator-run-cancellation-requirements.md
 deepened: 2026-07-03
@@ -102,7 +102,7 @@ Traceability to the origin doc's requirements:
 
 ## Implementation Units
 
-- [ ] **Unit 1: Cancel signal seam — abort registry + `'cancelled'` error kind + CANCELLED error path**
+- [x] **Unit 1: Cancel signal seam — abort registry + `'cancelled'` error kind + CANCELLED error path**
 
 **Goal:** An in-flight run can be aborted by runId, and the run lifecycle settles it as `CANCELLED` (not `FAILED`) with partial output preserved.
 
@@ -135,7 +135,7 @@ Traceability to the origin doc's requirements:
 
 **Verification:** gateway `tsc` + full gateway suite green; a simulated in-flight run cancelled via the registry lands `CANCELLED` with all resources released (asserted via fakes, not sleeps).
 
-- [ ] **Unit 2: Cancel orchestrator — queue removal, approval cascade, thread notice, attribution**
+- [x] **Unit 2: Cancel orchestrator — queue removal, approval cascade, thread notice, attribution**
 
 **Goal:** A single transport-neutral `cancelRun(runId, actor, deps)` entry point that resolves the run's phase and executes the correct cancellation path.
 
@@ -170,7 +170,7 @@ Traceability to the origin doc's requirements:
 
 **Verification:** every origin acceptance example AE1–AE7 that is orchestrator-scoped has a corresponding passing test; queue removal is race-checked against concurrent `takeNext` in a deterministic test.
 
-- [ ] **Unit 3: Operator cancel route + contract 1.6.0 + pins + audit**
+- [x] **Unit 3: Operator cancel route + contract 1.6.0 + pins + audit**
 
 **Goal:** `POST /operator/runs/:runId/cancel` exposed on the operator surface with full guard parity, typed response, audit events, and the contract bump.
 
@@ -202,7 +202,7 @@ Traceability to the origin doc's requirements:
 
 **Verification:** ingress-pin, smoke, and full gateway suite green; the SSE ready-frame carries 1.6.0.
 
-- [ ] **Unit 4: Crash-consistency recovery — reconcile CANCELLED runs holding live locks**
+- [x] **Unit 4: Crash-consistency recovery — reconcile CANCELLED runs holding live locks**
 
 **Goal:** A crash between the `CANCELLED` transition and resource cleanup cannot strand the per-repo lock (origin R9).
 

--- a/docs/plans/2026-07-04-001-feat-operator-failure-reason-plan.md
+++ b/docs/plans/2026-07-04-001-feat-operator-failure-reason-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: expose sanitized operator failure reason on the run status contract'
 type: feat
-status: active
+status: done
 date: 2026-07-04
 deepened: 2026-07-04
 ---
@@ -84,7 +84,7 @@ A dashboard-launched run can end `failed` while the gateway knows the sanitized 
 
 ## Implementation Units
 
-- [ ] **Unit 1: Contract type + allowlist mapping**
+- [x] **Unit 1: Contract type + allowlist mapping**
 
 **Goal:** Define `OperatorFailureKind` and the closed `RunCoreErrorKind → OperatorFailureKind` allowlist gate; export from the contract barrel. No projection changes yet.
 
@@ -112,7 +112,7 @@ A dashboard-launched run can end `failed` while the gateway knows the sanitized 
 
 **Verification:** the mapping is total over `RunCoreErrorKind`, falls back to `'unknown'` for everything else, and reads no other detail.
 
-- [ ] **Unit 2: Populate both projections + closed-DTO tests**
+- [x] **Unit 2: Populate both projections + closed-DTO tests**
 
 **Goal:** Add `failureKind?` to `OperatorRunStatus` and `RunSummary`, populate it (FAILED-only) in both projectors and the SSE copy-through, and update the closed-DTO guards.
 
@@ -144,7 +144,7 @@ A dashboard-launched run can end `failed` while the gateway knows the sanitized 
 
 > Write-path caveat (deepen/#1109): these tests use populated run-state fakes and prove only the *reader*. The write is proven in Unit 3's end-to-end scenario — do not treat a green Unit 2 as evidence production populates the field.
 
-- [ ] **Unit 3: Persist the failure kind on the in-flight FAILED transition**
+- [x] **Unit 3: Persist the failure kind on the in-flight FAILED transition**
 
 **Goal:** Classify the in-flight run failure and write it to run-state so the projections (Unit 2) can read it.
 
@@ -174,7 +174,7 @@ A dashboard-launched run can end `failed` while the gateway knows the sanitized 
 
 **Verification:** the FAILED transition persists the classified kind; a full inactivity-timeout path surfaces the sanitized reason on the operator contract with no raw detail leak.
 
-- [ ] **Unit 4: Pre-ACK workspace-unreachable coverage**
+- [x] **Unit 4: Pre-ACK workspace-unreachable coverage**
 
 **Goal:** Surface `workspace-unreachable` for pre-ACK workspace-startup failures; leave other pre-ACK failures without a `failureKind`.
 

--- a/docs/plans/2026-07-08-001-fix-scrub-agent-env-secrets-plan.md
+++ b/docs/plans/2026-07-08-001-fix-scrub-agent-env-secrets-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: scrub raw secrets from the OpenCode agent environment"
 type: fix
-status: active
+status: done
 date: 2026-07-08
 ---
 
@@ -80,7 +80,7 @@ The leak vector is confirmed from a downstream consumer's run artifact (see #114
 
 ## Implementation Units
 
-- [ ] **Unit 1: Env allowlist filter helper**
+- [x] **Unit 1: Env allowlist filter helper**
 
 **Goal:** A pure, tested helper that takes an environment record and returns a filtered copy containing only allowlisted keys (deny-by-default), dropping all secret-shaped vars.
 
@@ -108,7 +108,7 @@ The leak vector is confirmed from a downstream consumer's run artifact (see #114
 
 **Verification:** Filter returns only allowlisted keys; every token/secret-shaped key (incl. any `GITHUB_*` secret) is absent; `OPENCODE_CONFIG_CONTENT` is retained.
 
-- [ ] **Unit 2: Scope the env scrub to the OpenCode spawn (snapshot → scrub → spawn → restore)**
+- [x] **Unit 2: Scope the env scrub to the OpenCode spawn (snapshot → scrub → spawn → restore)**
 
 **Goal:** At each `createOpencode` call, `process.env` is temporarily reduced to the allowlisted set so the synchronously-spawned child captures a clean env, then `process.env` is restored so the harness keeps its full env (S3 `AWS_*`, proxy vars, etc.). The model's bash never inherits `GH_TOKEN`/`GITHUB_TOKEN`; the harness's own later phases (cache save/restore) are unaffected.
 
@@ -141,7 +141,7 @@ The leak vector is confirmed from a downstream consumer's run artifact (see #114
 - Restore `process.env` in `afterEach` (snapshot in `beforeEach`) so tests don't leak.
 **Verification:** Inside `withScrubbedEnv`'s `fn`, `process.env` provably lacks `GH_TOKEN`/`GITHUB_TOKEN` (test fails otherwise) while `OPENCODE_CONFIG_CONTENT` is retained; after it resolves (or throws), `process.env` is fully restored including `AWS_*`; both `server.ts` and `execution.ts` seams wrap their `createOpencode` call.
 
-- [ ] **Unit 3: Off-environment `gh` authentication**
+- [x] **Unit 3: Off-environment `gh` authentication**
 
 **Goal:** `gh` is authenticated for the model's bash via a persisted config in a temp `GH_CONFIG_DIR`, not via `GH_TOKEN` in the child env — so delegated `gh` works with the raw token scrubbed.
 

--- a/docs/plans/2026-07-08-002-feat-operator-push-gateway-plan.md
+++ b/docs/plans/2026-07-08-002-feat-operator-push-gateway-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: add Gateway-owned operator push notifications"
 type: feat
-status: active
+status: done
 date: 2026-07-08
 deepened: 2026-07-09
 origin: "fro-bot/dashboard:docs/brainstorms/2026-07-08-operator-push-notifications-requirements.md"

--- a/docs/plans/2026-07-11-001-fix-remove-agent-credential-comment-review-flows-plan.md
+++ b/docs/plans/2026-07-11-001-fix-remove-agent-credential-comment-review-flows-plan.md
@@ -8,6 +8,8 @@ origin: docs/brainstorms/2026-07-11-remove-agent-github-credential-requirements.
 issue: fro-bot/agent#1167
 ---
 
+Open: Unit 6 remains; `detectArtifacts` and `detectArtifactsFromMessageParts` still have six occurrences in `src/features/agent/streaming.ts`, although affected-flow delivery uses the response file.
+
 # fix: Remove the agent's GitHub credential for comment/review flows
 
 ## Overview

--- a/docs/plans/2026-07-11-001-fix-remove-agent-credential-comment-review-flows-plan.md
+++ b/docs/plans/2026-07-11-001-fix-remove-agent-credential-comment-review-flows-plan.md
@@ -1,14 +1,14 @@
 ---
 title: "fix: Remove the agent's GitHub credential for comment/review flows"
 type: fix
-status: active
+status: done
 date: 2026-07-11
 deepened: 2026-07-11
 origin: docs/brainstorms/2026-07-11-remove-agent-github-credential-requirements.md
 issue: fro-bot/agent#1167
 ---
 
-Open: Unit 6 remains; `detectArtifacts` and `detectArtifactsFromMessageParts` still have six occurrences in `src/features/agent/streaming.ts`, although affected-flow delivery uses the response file.
+Open: Unit 7's documentation landed, but its verification evidence is a live run against a real PR and issue, so it leaves no tree artifact to confirm.
 
 # fix: Remove the agent's GitHub credential for comment/review flows
 
@@ -115,7 +115,7 @@ bootstrap: resolveResponseDelivery(eventName, responseMode) -> { delivery, crede
 
 ## Implementation Units
 
-- [ ] **Unit 1: Two-axis delivery resolver (single source of truth, in runtime)**
+- [x] **Unit 1: Two-axis delivery resolver (single source of truth, in runtime)**
 
 **Goal:** `resolveResponseDelivery(eventName, responseMode) → {delivery, credential}` — one decision consumed by the credential gate, prompt builder, and finalize.
 
@@ -138,7 +138,7 @@ bootstrap: resolveResponseDelivery(eventName, responseMode) -> { delivery, crede
 - Edge case (the trap): `pull_request` + `responseMode:'none'` → `{delivery:'none', credential:'withhold'}` (credential still withheld).
 - Edge case: exhaustiveness guard trips for an unhandled event name (compile-time).
 
-- [ ] **Unit 2: Response-file — out-of-checkout path helper, strict schema, validating reader**
+- [x] **Unit 2: Response-file — out-of-checkout path helper, strict schema, validating reader**
 
 **Goal:** One module owning the run-scoped `$RUNNER_TEMP` path and a strict parse/validate returning `{body, verdict?}`.
 
@@ -161,7 +161,7 @@ bootstrap: resolveResponseDelivery(eventName, responseMode) -> { delivery, crede
 - Security (R3): file with `number: 999` / `repo: other/x` / `surface:` / any unknown key → hard error; result never carries a target field; a body containing "PASS"/"approved" prose with `verdict: request-changes` → parsed verdict is `request-changes` (body never consulted).
 - Error path: missing/empty → typed error; malformed frontmatter → error; verdict on a comment surface → error; unknown verdict value → error; oversize body → error.
 
-- [ ] **Unit 3: Credential suppression (BOTH token-write sites) — [ATOMIC CUTOVER with Units 4-5]**
+- [x] **Unit 3: Credential suppression (BOTH token-write sites) — [ATOMIC CUTOVER with Units 4-5]**
 
 **Goal:** For affected triggers, withhold the token everywhere the child can read it; unchanged for autonomous triggers.
 
@@ -185,7 +185,7 @@ bootstrap: resolveResponseDelivery(eventName, responseMode) -> { delivery, crede
 - Security: with `persist-credentials:false`, `.git/config` has no extraheader/embedded token for affected flows (assert); a fixture with an extraheader fails the preflight.
 - Regression (R6): #1147 env-scrub still holds.
 
-- [ ] **Unit 4: Response Protocol prompt rewrite (per-delivery) — [ATOMIC CUTOVER with Units 3, 5]**
+- [x] **Unit 4: Response Protocol prompt rewrite (per-delivery) — [ATOMIC CUTOVER with Units 3, 5]**
 
 **Goal:** For `file-convention` delivery, instruct the model to write the file **synchronously** at the exact path and state `gh` is unavailable; `model-gh` keeps current instructions; `none` renders neither.
 
@@ -206,7 +206,7 @@ bootstrap: resolveResponseDelivery(eventName, responseMode) -> { delivery, crede
 - Edge: `responseMode:none` → neither file nor `gh` posting instruction.
 - Regression: `<!-- fro-bot-agent -->` marker + Run Summary guidance survive.
 
-- [ ] **Unit 5: Finalize response-delivery — post, guard, assert, reconciliation skip — [ATOMIC CUTOVER with Units 3-4]**
+- [x] **Unit 5: Finalize response-delivery — post, guard, assert, reconciliation skip — [ATOMIC CUTOVER with Units 3-4]**
 
 **Goal:** Read/validate/post with trusted-context binding, apply review guards, fail-closed with a delivery assertion, and make reconciliation skip file-convention runs.
 
@@ -234,7 +234,9 @@ bootstrap: resolveResponseDelivery(eventName, responseMode) -> { delivery, crede
 - Edge: `responseMode:none` → no read, no post, assertion expects zero; dedup marker not saved when delivery fails.
 - Integration: real write-path (fixture file in a temp `$RUNNER_TEMP`, real finalize read → stubbed Octokit asserting body+target), not a pre-seeded parse result; re-review (second invocation, fresh nonce path) → one new review, reconciliation does not double-submit.
 
-- [ ] **Unit 6: Retire dead artifact-scraping for affected flows + metrics**
+- [x] **Unit 6: Retire dead artifact-scraping for affected flows + metrics**
+
+Done by re-sourcing, not deletion. `metrics.incrementComments()` fires at `src/harness/phases/finalize.ts:347` once the file-convention response is delivered, and `detectArtifacts`/`detectArtifactsFromMessageParts` stay in `src/features/agent/streaming.ts` for autonomous flows that self-post via `gh`. The two sources are mutually exclusive per run.
 
 **Goal:** Remove/neutralize the `gh`-output URL scraping that no longer fires for affected flows; re-source the posted-comment metric.
 

--- a/docs/plans/2026-07-13-001-feat-native-session-tools-plan.md
+++ b/docs/plans/2026-07-13-001-feat-native-session-tools-plan.md
@@ -1,6 +1,6 @@
 ---
 title: 'Native session tools: always-on session_list/read/search/info'
-status: active
+status: done
 created: 2026-07-13
 issue: https://github.com/fro-bot/agent/issues/1188
 requirements: none (issue #1188 + operator directive are the requirements)

--- a/docs/plans/2026-07-15-001-feat-run-state-object-tagging-plan.md
+++ b/docs/plans/2026-07-15-001-feat-run-state-object-tagging-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Tag run-state objects for S3 lifecycle retention"
 type: feat
-status: active
+status: done
 date: 2026-07-15
 issue: https://github.com/fro-bot/agent/issues/1192
 depth: standard

--- a/docs/plans/2026-07-15-002-fix-quota-limit-fail-fast-plan.md
+++ b/docs/plans/2026-07-15-002-fix-quota-limit-fail-fast-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: Fail fast on provider quota exhaustion"
 type: fix
-status: active
+status: done
 date: 2026-07-15
 issue: https://github.com/fro-bot/agent/issues/1206
 depth: deep
@@ -555,7 +555,7 @@ The diagram expresses intended boundaries, not exact method signatures.
   - **Verification:** Finalization tests assert response count, bound surface, failure status, and no duplicate
     delivery.
 
-- [ ] **Unit 7: Verify and release**
+- [x] **Unit 7: Verify and release**
   - **Goal:** Prove the exact production failure mode is fixed and ship through the normal Action release process.
   - **Requirements:** R1 through R11
   - **Dependencies:** Units 1 and 3 through 6. Unit 2 is skipped/no-op.

--- a/docs/plans/2026-07-16-001-feat-skip-agent-review-label-plan.md
+++ b/docs/plans/2026-07-16-001-feat-skip-agent-review-label-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Skip PR reviews via opt-out label'
 type: feat
-status: active
+status: done
 date: 2026-07-16
 origin: docs/brainstorms/2026-07-15-skip-agent-review-label-requirements.md
 ---

--- a/docs/plans/2026-07-17-001-feat-two-phase-release-notes-narration-plan.md
+++ b/docs/plans/2026-07-17-001-feat-two-phase-release-notes-narration-plan.md
@@ -176,6 +176,8 @@ Release narratives are shallow reformats of commit subjects (e.g. v0.92.1) becau
 
 - [ ] **Unit 5: Docs + live verification**
 
+Open: verification evidence is a live release dry-run, so it leaves no tree artifact to confirm. The narration flow itself ships and is documented in `AGENTS.md`.
+
 **Goal:** Update operational docs and prove the pipeline on a real tag without mutating a real release incorrectly.
 
 **Requirements:** R4, R5, R8

--- a/docs/plans/2026-07-17-001-feat-two-phase-release-notes-narration-plan.md
+++ b/docs/plans/2026-07-17-001-feat-two-phase-release-notes-narration-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Two-phase release-notes narration (read-only generate, trusted apply)'
 type: feat
-status: active
+status: done
 date: 2026-07-17
 ---
 
@@ -77,7 +77,7 @@ Release narratives are shallow reformats of commit subjects (e.g. v0.92.1) becau
 
 ## Implementation Units
 
-- [ ] **Unit 1: Trusted assembly module**
+- [x] **Unit 1: Trusted assembly module**
 
 **Goal:** Pure validation + assembly logic for the apply phase, plus its CLI entry.
 
@@ -104,7 +104,7 @@ Release narratives are shallow reformats of commit subjects (e.g. v0.92.1) becau
 
 **Verification:** New test file green under `bun run test:scripts`; no behavior change anywhere (module unused until Unit 3).
 
-- [ ] **Unit 2: Generation prompt rewrite**
+- [x] **Unit 2: Generation prompt rewrite**
 
 **Goal:** `buildNarrationPrompt` produces the gather/synthesize/candidate contract instead of rewrite/apply.
 
@@ -127,7 +127,7 @@ Release narratives are shallow reformats of commit subjects (e.g. v0.92.1) becau
 
 **Verification:** `test:scripts` green; prompt snapshot readable end-to-end.
 
-- [ ] **Unit 3: Workflow split — read-only generate job + trusted apply job**
+- [x] **Unit 3: Workflow split — read-only generate job + trusted apply job**
 
 **Goal:** Wire the credential boundary and candidate handoff in `.github/workflows/fro-bot.yaml`.
 
@@ -150,7 +150,7 @@ Release narratives are shallow reformats of commit subjects (e.g. v0.92.1) becau
 
 **Verification:** `bun run lint` green (workflow lint included); YAML parses; a plain `workflow_dispatch` without `release-tag` runs exactly as today (no apply job, PAT provisioned).
 
-- [ ] **Unit 4: Dispatcher passes the tag + monitoring update**
+- [x] **Unit 4: Dispatcher passes the tag + monitoring update**
 
 **Goal:** `dispatch-release-notes.ts` sends `release-tag` as a structured input and monitors the two-job outcome.
 

--- a/docs/plans/2026-07-20-001-feat-opencode-1.18.4-harness-release-plan.md
+++ b/docs/plans/2026-07-20-001-feat-opencode-1.18.4-harness-release-plan.md
@@ -1,7 +1,7 @@
 ---
 title: 'feat: Rebase @fro.bot/harness to OpenCode 1.18.4'
 type: feat
-status: completed
+status: done
 date: 2026-07-20
 ---
 

--- a/docs/plans/2026-07-24-001-fix-provider-auth-fast-fail-plan.md
+++ b/docs/plans/2026-07-24-001-fix-provider-auth-fast-fail-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: Fail fast on model-provider authentication failures"
 type: fix
-status: completed
+status: done
 date: 2026-07-24
 deepened: 2026-07-24
 ---

--- a/docs/plans/2026-07-30-001-feat-brokered-push-trusted-mention-plan.md
+++ b/docs/plans/2026-07-30-001-feat-brokered-push-trusted-mention-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Brokered push for trusted same-repo mention runs"
 type: feat
-status: active
+status: done
 date: 2026-07-30
 deepened: 2026-07-30
 origin: docs/brainstorms/2026-07-30-brokered-push-trusted-mention-requirements.md
@@ -133,7 +133,7 @@ finalize: after outputs/summary
 
 ## Implementation Units
 
-- [ ] **Unit 1: Extend the delegated commit primitive for deletions and regular-file mode policy**
+- [x] **Unit 1: Extend the delegated commit primitive for deletions and regular-file mode policy**
 
 **Goal:** `createCommit` can remove files and enforces regular-file-only entries, so a reconstructed change set writes a correct, safe tree.
 
@@ -164,7 +164,7 @@ finalize: after outputs/summary
 
 **Verification:** deletions and modifications co-exist in one commit; non-regular entries rejected; existing add/modify tests still pass; `force:false` preserved.
 
-- [ ] **Unit 2: Change-reconstruction bridge (workspace → FileChange[])**
+- [x] **Unit 2: Change-reconstruction bridge (workspace → FileChange[])**
 
 **Goal:** Turn the net difference between the checked-out workspace and the trusted head SHA into a validated `FileChange[]` (adds, modifies, deletes), branch- and history-agnostic, trusting no local git metadata.
 
@@ -199,7 +199,7 @@ finalize: after outputs/summary
 
 **Verification:** correct `FileChange[]` for add/modify/delete regardless of the model's local git state; non-regular entries rejected; clean "nothing to deliver" on no difference; no reliance on local git config for target/base.
 
-- [ ] **Unit 3: Brokered-push allowlist validation**
+- [x] **Unit 3: Brokered-push allowlist validation**
 
 **Goal:** A brokered-push-specific validation that admits only allowlisted product/docs/test paths, on top of the existing size/sensitive rules — without touching global `validateFiles`.
 
@@ -231,7 +231,7 @@ finalize: after outputs/summary
 
 **Verification:** only allowlisted paths pass; global delegated-commit behavior unchanged.
 
-- [ ] **Unit 4: Brokered-push authorization + target derivation gate**
+- [x] **Unit 4: Brokered-push authorization + target derivation gate**
 
 **Goal:** A gate that decides, from trusted event context and live GitHub state only, whether a brokered push is allowed and what branch it targets — with an event-time early filter and a delivery-time live check.
 
@@ -263,7 +263,7 @@ finalize: after outputs/summary
 
 **Verification:** admits exactly the trusted same-repo PR case with live write permission and a matching live head; every other context bypasses or fails per policy, using only event-derived + live GitHub state.
 
-- [ ] **Unit 5a: Brokered-push finalize state machine**
+- [x] **Unit 5a: Brokered-push finalize state machine**
 
 **Goal:** finalize runs the brokered-push decision for the eligible surface and returns a typed outcome, with precise sequencing against existing branches and no response mutation yet.
 
@@ -298,7 +298,7 @@ finalize: after outputs/summary
 
 **Verification:** each state yields the correct typed outcome and the push is attempted only in the precise eligible+successful state.
 
-- [ ] **Unit 5b: Single-response composition**
+- [x] **Unit 5b: Single-response composition**
 
 **Goal:** Fold the push outcome into exactly one response — model reply plus push footer on success, one error comment on fail-loud — preserving one-response-per-run.
 
@@ -326,7 +326,7 @@ finalize: after outputs/summary
 
 **Verification:** one response in every outcome; success reports the branch and paths; failures never post the model's "fixed it" reply.
 
-- [ ] **Unit 6: Workflow + docs**
+- [x] **Unit 6: Workflow + docs**
 
 **Goal:** Supply the trusted head SHA to the action and document the trusted-push behavior.
 

--- a/docs/plans/2026-08-03-001-fix-review-session-overflow-recovery-plan.md
+++ b/docs/plans/2026-08-03-001-fix-review-session-overflow-recovery-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "fix: recoverable ContextOverflowError for the PR review session"
 type: fix
-status: active
+status: done
 date: 2026-08-03
 origin: docs/brainstorms/2026-08-03-review-session-overflow-recovery-requirements.md
 deepened: 2026-08-03
@@ -101,7 +101,7 @@ Key research reframe (see origin R4): the overflow comes from the **continued se
 
 ## Implementation Units
 
-- [ ] **Unit 1: Classify `ContextOverflowError` distinctly**
+- [x] **Unit 1: Classify `ContextOverflowError` distinctly**
 
 **Goal:** Produce a distinct `context_overflow` `ErrorInfo` when the session emits `ContextOverflowError`, at the same streaming boundary that already classifies auth/quota.
 
@@ -134,7 +134,7 @@ Key research reframe (see origin R4): the overflow comes from the **continued se
 
 **Verification:** A `ContextOverflowError` session event yields a distinct `context_overflow` `ErrorInfo`; auth/quota/generic classification unchanged.
 
-- [ ] **Unit 2: Session primitives — archive, resolver eligibility fix, prior-work exclusion**
+- [x] **Unit 2: Session primitives — archive, resolver eligibility fix, prior-work exclusion**
 
 **Goal:** Provide the three session-layer mechanisms recovery needs: archive a session so it is never re-continued, make the resolver pick the eligible (non-archived) same-title session, and exclude a session from prior-work search.
 
@@ -170,7 +170,7 @@ Key research reframe (see origin R4): the overflow comes from the **continued se
 
 **Verification:** Archiving a session makes `resolveSessionForLogicalKey` skip it; a newer archived same-title session no longer masks an eligible fresh one; `searchSessions` can exclude a given session and is unchanged when the option is omitted.
 
-- [ ] **Unit 3: Phase-level recovery orchestration (bounded single restart)**
+- [x] **Unit 3: Phase-level recovery orchestration (bounded single restart)**
 
 **Goal:** On a classified overflow, archive the overflowed session and restart the review once — from a fresh, bounded session-prep — within the same run and the same execution budget; bound to exactly one restart.
 
@@ -209,7 +209,7 @@ Key research reframe (see origin R4): the overflow comes from the **continued se
 
 **Verification:** An overflowing review run recovers in-run without admin override; the second overflow fails cleanly; the second attempt shares the original budget; a delivered overflow attempt never double-posts; non-overflow errors are unaffected.
 
-- [ ] **Unit 4: Suppress ENOENT cascade + surface the recovery marker**
+- [x] **Unit 4: Suppress ENOENT cascade + surface the recovery marker**
 
 **Goal:** Stop the confusing `failed to read response file … ENOENT` secondary on session-error failures, and make overflow recovery visible in the run output, without regressing the #1252 fallback.
 

--- a/docs/plans/2026-08-22-001-feat-gateway-dispatch-command-plan.md
+++ b/docs/plans/2026-08-22-001-feat-gateway-dispatch-command-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: /fro-bot dispatch — trigger Action runs from Discord"
 type: feat
-status: active
+status: done
 date: 2026-08-22
 origin: docs/brainstorms/2026-04-17-fro-bot-gateway-discord-requirements.md
 ---
@@ -114,7 +114,7 @@ The Discord mapping must use an exhaustive `switch` with a `const exhaustiveChec
 
 ## Implementation Units
 
-- [ ] **Unit 1: Add scoped workflow-dispatch capability to the GitHub App client**
+- [x] **Unit 1: Add scoped workflow-dispatch capability to the GitHub App client**
 
 **Files:** modify `packages/gateway/src/github/app-client.ts`, `packages/gateway/src/github/app-client.test.ts`.
 
@@ -128,7 +128,7 @@ Extend the App client with a dispatch-specific authorization path. Keep ordinary
 - Token minting or discovery fails → returns a safe auth error without logging credentials.
 - Ordinary `authForRepo` with `contents: read` → remains successful without requiring Actions write.
 
-- [ ] **Unit 2: Implement the typed GitHub workflow-dispatch adapter**
+- [x] **Unit 2: Implement the typed GitHub workflow-dispatch adapter**
 
 **Files:** create `packages/gateway/src/github/dispatch.ts` and `packages/gateway/src/github/dispatch.test.ts`.
 
@@ -147,7 +147,7 @@ Create the gateway-level dispatch primitive. It resolves the binding's owner/rep
 - Successful request payload inspection → confirms the ref is the resolved default branch, inputs contain only `prompt`, and `correlation-id` is never sent.
 - `200` response with a malformed or missing nested `workflow_run` → returns `dispatch-rejected` rather than fabricating a run link.
 
-- [ ] **Unit 3: Wire `/fro-bot dispatch`, program injection, and deployment documentation**
+- [x] **Unit 3: Wire `/fro-bot dispatch`, program injection, and deployment documentation**
 
 **Files:** create `packages/gateway/src/discord/commands/dispatch.ts` and `packages/gateway/src/discord/commands/dispatch.test.ts`; modify `packages/gateway/src/discord/commands/fro-bot.ts`, `packages/gateway/src/discord/commands/fro-bot.test.ts`, `packages/gateway/src/discord/commands/index.test.ts`, `packages/gateway/src/program.ts`, `packages/gateway/src/program.test.ts`, and `deploy/README.md`.
 


### PR DESCRIPTION
Plan frontmatter `status:` was the field triage relies on, and it was wrong 14 times out of 14. Twelve plans marked `active` had fully shipped; the vocabulary had drifted into four spellings of "finished" (`done`, `completed`, `complete`, plus plans with no status at all).

Yesterday's audit spent most of its effort re-deriving what had already shipped, because neither metadata field could be trusted. `status:` claimed active for delivered work, while unit checkboxes sat unticked for code that demonstrably exists.

Every box ticked here was verified against a named artifact in the current tree — a real symbol, file, or route — not against a plan's own claims or a merged PR title.

**`2026-07-11-001` (remove-agent-credential) closes too, and the reason is worth recording.** Unit 6 reads "Retire dead artifact-scraping," and `detectArtifacts`/`detectArtifactsFromMessageParts` still have six occurrences in `src/features/agent/streaming.ts` — which looks like unfinished work and was cited as such three separate times. It is not. The unit's own approach says to re-source `commentsPosted` from the finalize post and *keep autonomous-flow scraping intact*. Both halves shipped: `metrics.incrementComments()` fires at `src/harness/phases/finalize.ts:347` once the file-convention response is delivered, and the scraper is deliberately retained for `workflow_dispatch`/`schedule` runs that keep the credential and self-post via `gh`. The two metric sources are mutually exclusive per run. Unit 6 now carries a line saying so, because a symbol count is not evidence of dead code.

One plan deliberately stays `active`: **`2026-04-18-001` gateway v1**, whose Unit 8 is real open work — `docs/SETUP.md`, `docs/KNOWN-LIMITS.md`, and `docs/OPERATIONS.md` are absent. It carries a line naming what remains.

Two boxes are left unticked on purpose. `2026-07-17` Unit 5 and `2026-07-11-001` Unit 7 both specify live-run verification, and that evidence does not exist as a tree artifact. Ticking either would assert something unverifiable, so each says why it stays open.

Final distribution: `done` 93, `active` 1, `superseded` 1.

Documentation only — all changes under `docs/plans/`.