### PR TITLE
build: exempt first-party @bfra.me packages from the release-age gate

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -12,3 +12,9 @@ linker = "hoisted"
 # Supply-chain age gate: refuse dependency versions published within this window.
 # Mirrors the prior pnpm minimumReleaseAge policy. Seconds (3 days).
 minimumReleaseAge = 259200
+
+# First-party packages, published from bfra-me/works under the same ownership as
+# this repo. The age gate buys a cooling-off period against a compromised upstream
+# publish; it has nothing to buy here, and it blocks Renovate's own update PRs from
+# installing for three days. Bun matches these exactly — no glob support.
+minimumReleaseAgeExcludes = ["@bfra.me/es", "@bfra.me/eslint-config", "@bfra.me/prettier-config", "@bfra.me/tsconfig"]


### PR DESCRIPTION
Renovate's own `@bfra.me/*` update PRs cannot install. `bunfig.toml` sets a three-day `minimumReleaseAge`, so PR #1476 fails at Setup:

```
error: No version matching "@bfra.me/tsconfig" found for specifier "0.13.2" (blocked by minimum-release-age: 259200 seconds)
error: No version matching "@bfra.me/prettier-config" found for specifier "0.16.11" (blocked by minimum-release-age: 259200 seconds)
error: No version matching "@bfra.me/eslint-config" found for specifier "0.51.3" (blocked by minimum-release-age: 259200 seconds)
```

The gate exists to buy a cooling-off period against a compromised upstream publish. These four packages are published from `bfra-me/works` under the same ownership as this repo, so there is no third party to cool off from — the gate only delays first-party updates by three days and red-lights their PRs in the meantime.

Bun matches `minimumReleaseAgeExcludes` on exact package names; the documentation describes it as "an array of package names" with no wildcard support, and OpenCode's own `bunfig.toml` uses a long explicit list rather than globs. All four are named individually.

Verified both directions against the real resolver rather than the config parsing:

- **With the exemption**, `bun install` resolves `@bfra.me/tsconfig@0.13.2` and `@bfra.me/prettier-config@0.16.11` — the exact versions CI reported as blocked.
- **Without it**, the same install reproduces the CI error verbatim.

The gate stays at three days for every third-party dependency.
